### PR TITLE
fix(logger): downgrade auth validation logs

### DIFF
--- a/.changeset/auth-log-levels.md
+++ b/.changeset/auth-log-levels.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Downgrade expected auth validation failures from error logs to warnings.

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -246,7 +246,7 @@ export const linkSocialAccount = createAuthEndpoint(
 			const { token, nonce } = c.body.idToken;
 			const valid = await provider.verifyIdToken(token, nonce);
 			if (!valid) {
-				c.context.logger.error("Invalid id token", {
+				c.context.logger.warn("Invalid id token", {
 					provider: c.body.provider,
 				});
 				throw APIError.from("UNAUTHORIZED", BASE_ERROR_CODES.INVALID_TOKEN);

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -95,7 +95,7 @@ export const callbackOAuth = createAuthEndpoint(
 		}
 
 		if (!code) {
-			c.context.logger.error("Code not found");
+			c.context.logger.warn("Code not found");
 			redirectOnError(c, resolvedErrorURL, "no_code");
 		}
 
@@ -104,11 +104,9 @@ export const callbackOAuth = createAuthEndpoint(
 		});
 
 		if (!provider) {
-			c.context.logger.error(
-				"Oauth provider with id",
-				c.params.id,
-				"not found",
-			);
+			c.context.logger.warn("OAuth provider not found", {
+				providerId: c.params.id,
+			});
 			redirectOnError(c, resolvedErrorURL, "oauth_provider_not_found");
 		}
 

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -110,7 +110,7 @@ export const requestPasswordReset = createAuthEndpoint(
 			await ctx.context.internalAdapter.findVerificationValue(
 				"dummy-verification-token",
 			);
-			ctx.context.logger.error("Reset Password: User not found", { email });
+			ctx.context.logger.warn("Reset Password: User not found");
 			return ctx.json({
 				status: true,
 				message:

--- a/packages/better-auth/src/api/routes/sign-in.test.ts
+++ b/packages/better-auth/src/api/routes/sign-in.test.ts
@@ -103,6 +103,83 @@ describe("sign-in", async () => {
 
 		expect(sendVerificationEmail).toHaveBeenCalledTimes(1);
 	});
+
+	it("logs expected auth validation failures below error level", async () => {
+		const log = vi.fn();
+		const { auth, testUser } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				async sendResetPassword() {},
+			},
+			logger: {
+				level: "info",
+				log,
+			},
+		});
+		const expectWarnWithoutError = (message: string) => {
+			expect(
+				log.mock.calls.some(
+					([level, loggedMessage]) =>
+						level === "warn" &&
+						typeof loggedMessage === "string" &&
+						loggedMessage.includes(message),
+				),
+			).toBe(true);
+			expect(log.mock.calls.some(([level]) => level === "error")).toBe(false);
+		};
+
+		log.mockClear();
+
+		await expect(
+			auth.api.signInEmail({
+				body: {
+					email: testUser.email,
+					password: "wrong-password",
+				},
+			}),
+		).rejects.toThrowError(
+			APIError.from("UNAUTHORIZED", BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD),
+		);
+
+		expectWarnWithoutError("Invalid password");
+
+		log.mockClear();
+		await expect(
+			auth.api.signInEmail({
+				body: {
+					email: "missing-sign-in@test.com",
+					password: "password",
+				},
+			}),
+		).rejects.toThrowError(
+			APIError.from("UNAUTHORIZED", BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD),
+		);
+
+		expectWarnWithoutError("User not found");
+
+		log.mockClear();
+		await expect(
+			auth.api.signUpEmail({
+				body: {
+					email: "short-password@test.com",
+					password: "short",
+					name: "Short Password",
+				},
+			}),
+		).rejects.toThrowError(
+			APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT),
+		);
+		expectWarnWithoutError("Password is too short");
+
+		log.mockClear();
+		const resetRes = await auth.api.requestPasswordReset({
+			body: {
+				email: "reset-missing@test.com",
+			},
+		});
+		expect(resetRes.status).toBe(true);
+		expectWarnWithoutError("Reset Password: User not found");
+	});
 });
 
 describe("url checks", async () => {

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -267,7 +267,7 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 				const { token, nonce } = c.body.idToken;
 				const valid = await provider.verifyIdToken(token, nonce);
 				if (!valid) {
-					c.context.logger.error("Invalid id token", {
+					c.context.logger.warn("Invalid id token", {
 						provider: c.body.provider,
 					});
 					throw APIError.from("UNAUTHORIZED", BASE_ERROR_CODES.INVALID_TOKEN);
@@ -492,7 +492,7 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 				// Hash password to prevent timing attacks from revealing valid email addresses
 				// By hashing passwords for invalid emails, we ensure consistent response times
 				await ctx.context.password.hash(password);
-				ctx.context.logger.error("User not found", { email });
+				ctx.context.logger.warn("User not found");
 				throw APIError.from(
 					"UNAUTHORIZED",
 					BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD,
@@ -504,7 +504,7 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 			);
 			if (!credentialAccount) {
 				await ctx.context.password.hash(password);
-				ctx.context.logger.error("Credential account not found", { email });
+				ctx.context.logger.warn("Credential account not found");
 				throw APIError.from(
 					"UNAUTHORIZED",
 					BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD,
@@ -513,7 +513,7 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 			const currentPassword = credentialAccount?.password;
 			if (!currentPassword) {
 				await ctx.context.password.hash(password);
-				ctx.context.logger.error("Password not found", { email });
+				ctx.context.logger.warn("Password not found");
 				throw APIError.from(
 					"UNAUTHORIZED",
 					BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD,
@@ -524,7 +524,7 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 				password,
 			});
 			if (!validPassword) {
-				ctx.context.logger.error("Invalid password");
+				ctx.context.logger.warn("Invalid password");
 				throw APIError.from(
 					"UNAUTHORIZED",
 					BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD,

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -217,7 +217,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 
 				const minPasswordLength = ctx.context.password.config.minPasswordLength;
 				if (password.length < minPasswordLength) {
-					ctx.context.logger.error("Password is too short");
+					ctx.context.logger.warn("Password is too short");
 					throw APIError.from(
 						"BAD_REQUEST",
 						BASE_ERROR_CODES.PASSWORD_TOO_SHORT,
@@ -226,7 +226,7 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 
 				const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
 				if (password.length > maxPasswordLength) {
-					ctx.context.logger.error("Password is too long");
+					ctx.context.logger.warn("Password is too long");
 					throw APIError.from(
 						"BAD_REQUEST",
 						BASE_ERROR_CODES.PASSWORD_TOO_LONG,

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -252,14 +252,14 @@ export const changePassword = createAuthEndpoint(
 		const session = ctx.context.session;
 		const minPasswordLength = ctx.context.password.config.minPasswordLength;
 		if (newPassword.length < minPasswordLength) {
-			ctx.context.logger.error("Password is too short");
+			ctx.context.logger.warn("Password is too short");
 			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
 		}
 
 		const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
 
 		if (newPassword.length > maxPasswordLength) {
-			ctx.context.logger.error("Password is too long");
+			ctx.context.logger.warn("Password is too long");
 			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
 		}
 
@@ -331,14 +331,14 @@ export const setPassword = createAuthEndpoint(
 		const session = ctx.context.session;
 		const minPasswordLength = ctx.context.password.config.minPasswordLength;
 		if (newPassword.length < minPasswordLength) {
-			ctx.context.logger.error("Password is too short");
+			ctx.context.logger.warn("Password is too short");
 			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
 		}
 
 		const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
 
 		if (newPassword.length > maxPasswordLength) {
-			ctx.context.logger.error("Password is too long");
+			ctx.context.logger.warn("Password is too long");
 			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
 		}
 
@@ -726,7 +726,7 @@ export const changeEmail = createAuthEndpoint(
 		const newEmail = ctx.body.newEmail.toLowerCase();
 
 		if (newEmail === ctx.context.session.user.email) {
-			ctx.context.logger.error("Email is the same");
+			ctx.context.logger.warn("Email is the same");
 			throw APIError.fromStatus("BAD_REQUEST", {
 				message: "Email is the same",
 			});

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1543,12 +1543,12 @@ export const setUserPassword = (opts: AdminOptions) =>
 			const { newPassword, userId } = ctx.body;
 			const minPasswordLength = ctx.context.password.config.minPasswordLength;
 			if (newPassword.length < minPasswordLength) {
-				ctx.context.logger.error("Password is too short");
+				ctx.context.logger.warn("Password is too short");
 				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
 			}
 			const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
 			if (newPassword.length > maxPasswordLength) {
-				ctx.context.logger.error("Password is too long");
+				ctx.context.logger.warn("Password is too long");
 				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
 			}
 			const hashedPassword = await ctx.context.password.hash(newPassword);

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -417,7 +417,7 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 						}
 
 						if (!code) {
-							ctx.context.logger.error(
+							ctx.context.logger.warn(
 								"OAuth callback missing authorization code",
 							);
 							throw redirectOnError(ctx, errorURL, "no_code");
@@ -429,7 +429,9 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							(p) => p.id === providerId,
 						);
 						if (!provider) {
-							ctx.context.logger.error("OAuth provider not found", providerId);
+							ctx.context.logger.warn("OAuth provider not found", {
+								providerId,
+							});
 							throw redirectOnError(ctx, errorURL, "oauth_provider_not_found");
 						}
 

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -148,9 +148,7 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				(a) => a.providerId === "credential",
 			);
 			if (!credentialAccount) {
-				ctx.context.logger.error("Credential account not found", {
-					phoneNumber,
-				});
+				ctx.context.logger.warn("Credential account not found");
 				throw APIError.from(
 					"UNAUTHORIZED",
 					PHONE_NUMBER_ERROR_CODES.INVALID_PHONE_NUMBER_OR_PASSWORD,
@@ -158,7 +156,7 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			}
 			const currentPassword = credentialAccount?.password;
 			if (!currentPassword) {
-				ctx.context.logger.error("Password not found", { phoneNumber });
+				ctx.context.logger.warn("Password not found");
 				throw APIError.from(
 					"UNAUTHORIZED",
 					PHONE_NUMBER_ERROR_CODES.UNEXPECTED_ERROR,
@@ -169,7 +167,7 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				password,
 			});
 			if (!validPassword) {
-				ctx.context.logger.error("Invalid password");
+				ctx.context.logger.warn("Invalid password");
 				throw APIError.from(
 					"UNAUTHORIZED",
 					PHONE_NUMBER_ERROR_CODES.INVALID_PHONE_NUMBER_OR_PASSWORD,

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -379,7 +379,7 @@ export const username = (options?: UsernameOptions | undefined) => {
 				},
 				async (ctx) => {
 					if (!ctx.body.username || !ctx.body.password) {
-						ctx.context.logger.error("Username or password not found");
+						ctx.context.logger.warn("Username or password not found");
 						throw APIError.from(
 							"UNAUTHORIZED",
 							ERROR_CODES.INVALID_USERNAME_OR_PASSWORD,
@@ -395,9 +395,7 @@ export const username = (options?: UsernameOptions | undefined) => {
 					const maxUsernameLength = options?.maxUsernameLength || 30;
 
 					if (username.length < minUsernameLength) {
-						ctx.context.logger.error("Username too short", {
-							username,
-						});
+						ctx.context.logger.warn("Username too short");
 						throw APIError.from(
 							"UNPROCESSABLE_ENTITY",
 							ERROR_CODES.USERNAME_TOO_SHORT,
@@ -405,9 +403,7 @@ export const username = (options?: UsernameOptions | undefined) => {
 					}
 
 					if (username.length > maxUsernameLength) {
-						ctx.context.logger.error("Username too long", {
-							username,
-						});
+						ctx.context.logger.warn("Username too long");
 						throw APIError.from(
 							"UNPROCESSABLE_ENTITY",
 							ERROR_CODES.USERNAME_TOO_LONG,
@@ -440,9 +436,7 @@ export const username = (options?: UsernameOptions | undefined) => {
 						// Hash password to prevent timing attacks from revealing valid usernames
 						// By hashing passwords for invalid usernames, we ensure consistent response times
 						await ctx.context.password.hash(ctx.body.password);
-						ctx.context.logger.error("User not found", {
-							username,
-						});
+						ctx.context.logger.warn("User not found");
 						throw APIError.from(
 							"UNAUTHORIZED",
 							ERROR_CODES.INVALID_USERNAME_OR_PASSWORD,
@@ -470,9 +464,7 @@ export const username = (options?: UsernameOptions | undefined) => {
 					}
 					const currentPassword = account?.password;
 					if (!currentPassword) {
-						ctx.context.logger.error("Password not found", {
-							username,
-						});
+						ctx.context.logger.warn("Password not found");
 						throw APIError.from(
 							"UNAUTHORIZED",
 							ERROR_CODES.INVALID_USERNAME_OR_PASSWORD,
@@ -483,7 +475,7 @@ export const username = (options?: UsernameOptions | undefined) => {
 						password: ctx.body.password,
 					});
 					if (!validPassword) {
-						ctx.context.logger.error("Invalid password");
+						ctx.context.logger.warn("Invalid password");
 						throw APIError.from(
 							"UNAUTHORIZED",
 							ERROR_CODES.INVALID_USERNAME_OR_PASSWORD,


### PR DESCRIPTION
## Summary

- Downgrade expected auth validation failures from `error` to `warn` logs.
- Cover credential sign-in, password validation, reset-password unknown users, invalid ID tokens, and missing OAuth callback/provider inputs.
- Keep operational and configuration failures at `error`, and add regression coverage .

## Why

Closes #9785.

Expected validation failures such as invalid credentials, short passwords, or unknown reset-password emails are normal auth outcomes. Logging them at `error` pollutes application error monitoring and makes it harder to alert on real failures.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded expected auth validation failures to warn-level across `better-auth` core and plugins to cut error noise. Also removed user identifiers from these logs and added tests to lock this behavior.

- **Bug Fixes**
  - Switched error → warn for normal validation outcomes: invalid/missing credentials, short/long passwords, unknown users, invalid ID tokens, missing OAuth code/provider, username/phone credential issues, and same-email changes across `sign-in`, `sign-up`, `password` (reset/change/set), `account` (ID token), `update-user`, OAuth callback/proxy, `phone-number`, `username`, and `admin` routes; includes a patch changeset for `better-auth`.
  - Redacted PII (email/phone/username) from warn logs and added tests asserting warn-only logging for invalid password, missing user, short password, and reset-password unknown email.

<sup>Written for commit 9150e54532361b8ee50a20298b68cb3fb3cd4b74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



