### PR TITLE
fix(account): scope OAuth account identity and fix buggy internalAdapter helpers

### DIFF
--- a/.changeset/internal-adapter-helpers.md
+++ b/.changeset/internal-adapter-helpers.md
@@ -1,0 +1,10 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+---
+
+Fix two buggy `internalAdapter` helpers.
+
+Remove `findAccount(accountId)`. It looked accounts up by account ID alone, which is unique neither across providers nor across users, so it returned a non-deterministic match. All callers now use a user-scoped or provider-scoped lookup.
+
+Replace the ambiguous `deleteSessions(string | string[])` with two explicit methods. `deleteUserSessions(userId)` revokes every session for a user, and `deleteSessions(tokens)` revokes sessions by token. The old single-string overload silently treated its argument as a user ID, so a caller that meant to delete one session token could instead wipe all of a user's sessions or quietly match nothing.

--- a/.changeset/oauth-account-identity.md
+++ b/.changeset/oauth-account-identity.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+Fix Google One Tap signing in the wrong user when the presented Google account is already linked to someone else. One Tap now resolves identity through the shared OAuth path, so the user who owns the Google subject is signed in, matching the redirect and `signIn.social` flows. Previously it matched a local user by the token's email and used the subject only to decide linking, so a Google credential owned by one user could authenticate a different user who happened to share that email.
+
+`/account-info` now resolves the account from the signed-in user's own linked accounts and accepts an optional `providerId` to disambiguate when two providers issue the same account ID. A colliding account ID returns a distinct `AMBIGUOUS_ACCOUNT` error instead of a misleading "not found", and an account with no configured social provider returns a 400 rather than a 500.

--- a/.changeset/provider-scoped-account-lookups.md
+++ b/.changeset/provider-scoped-account-lookups.md
@@ -1,5 +1,0 @@
----
-"better-auth": patch
----
-
-Avoid ambiguous provider account lookups in account info and Google One Tap flows when different providers issue the same account ID.

--- a/.changeset/provider-scoped-account-lookups.md
+++ b/.changeset/provider-scoped-account-lookups.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Avoid ambiguous provider account lookups in account info and Google One Tap flows when different providers issue the same account ID.

--- a/.changeset/saml-slo-session-revocation.md
+++ b/.changeset/saml-slo-session-revocation.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+Fix SAML Single Logout leaving the user signed in. The logout handlers passed the session row id to a delete that matches on the session token, so the session was never removed. The stored SAML session record now carries the session token, and all three logout paths revoke the session by token.

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -405,7 +405,7 @@ describe("account", async () => {
 			});
 
 			expect(ambiguousInfo.error?.message).toBe(
-				BASE_ERROR_CODES.ACCOUNT_NOT_FOUND.message,
+				"Multiple accounts share this account ID. Pass a providerId to disambiguate.",
 			);
 			expect(googleGetUserInfoMock).not.toHaveBeenCalled();
 			expect(githubGetUserInfoMock).not.toHaveBeenCalled();
@@ -430,6 +430,124 @@ describe("account", async () => {
 			});
 			expect(githubGetUserInfoMock).toHaveBeenCalledWith(
 				expect.objectContaining({ accessToken: "github-access-token" }),
+			);
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9502
+	 */
+	it("should disambiguate by providerId on the server-side userId path without a session", async () => {
+		const { auth } = await getTestInstance({
+			socialProviders: {
+				google: { clientId: "test", clientSecret: "test", enabled: true },
+				github: { clientId: "test", clientSecret: "test", enabled: true },
+			},
+			account: {
+				accountLinking: {
+					allowDifferentEmails: true,
+				},
+			},
+		});
+		const ctx = await auth.$context;
+		const githubProvider = ctx.socialProviders.find((v) => v.id === "github")!;
+		const githubGetUserInfoMock = vi.spyOn(githubProvider, "getUserInfo");
+		const sharedAccountId = "shared-server-side-account-id";
+
+		const user = await ctx.internalAdapter.createUser({
+			name: "Server Side User",
+			email: "server-side-disambiguate@example.com",
+		});
+		await ctx.internalAdapter.createAccount({
+			userId: user.id,
+			providerId: "google",
+			accountId: sharedAccountId,
+			accessToken: "google-access-token",
+		});
+		await ctx.internalAdapter.createAccount({
+			userId: user.id,
+			providerId: "github",
+			accountId: sharedAccountId,
+			accessToken: "github-access-token",
+		});
+
+		githubGetUserInfoMock.mockResolvedValueOnce({
+			user: {
+				id: user.id,
+				name: user.name,
+				email: user.email,
+				emailVerified: user.emailVerified,
+			},
+			data: { source: "github" },
+		});
+
+		// No headers: the trusted server-side caller names the user via userId,
+		// and providerId disambiguates the colliding accountId.
+		const info = await auth.api.accountInfo({
+			query: {
+				accountId: sharedAccountId,
+				userId: user.id,
+				providerId: "github",
+			},
+		});
+
+		expect(info).toMatchObject({ data: { source: "github" } });
+		expect(githubGetUserInfoMock).toHaveBeenCalledWith(
+			expect.objectContaining({ accessToken: "github-access-token" }),
+		);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9502
+	 */
+	it("should not find an account when providerId matches none of the user's accounts", async () => {
+		const { auth, signInWithTestUser, client } = await getTestInstance({
+			socialProviders: {
+				google: { clientId: "test", clientSecret: "test", enabled: true },
+				github: { clientId: "test", clientSecret: "test", enabled: true },
+			},
+			account: {
+				accountLinking: {
+					allowDifferentEmails: true,
+				},
+			},
+		});
+		const ctx = await auth.$context;
+		const accountId = "github-only-account-id";
+
+		const { runWithUser, user } = await signInWithTestUser();
+		await ctx.internalAdapter.createAccount({
+			userId: user.id,
+			providerId: "github",
+			accountId,
+			accessToken: "github-access-token",
+		});
+
+		await runWithUser(async () => {
+			const info = await client.$fetch("/account-info", {
+				query: { accountId, providerId: "google" },
+				method: "GET",
+			});
+
+			expect(info.error?.message).toBe(
+				BASE_ERROR_CODES.ACCOUNT_NOT_FOUND.message,
+			);
+		});
+	});
+
+	it("should reject account info for a non-social (credential) account", async () => {
+		// A credential account stores its accountId as the user id. Asking for its
+		// provider info is a client error (400), not a server error (500).
+		const { runWithUser, user } = await signInWithTestUser();
+		await runWithUser(async () => {
+			const info = await client.$fetch("/account-info", {
+				query: { accountId: user.id },
+				method: "GET",
+			});
+
+			expect(info.error?.status).toBe(400);
+			expect(info.error?.message).toBe(
+				"Account is not associated with a configured social provider.",
 			);
 		});
 	});

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -357,6 +357,83 @@ describe("account", async () => {
 		});
 	});
 
+	it("should require providerId when a current user's provider account IDs collide", async () => {
+		const { auth, signInWithTestUser, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+				github: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			account: {
+				accountLinking: {
+					allowDifferentEmails: true,
+				},
+			},
+		});
+		const ctx = await auth.$context;
+		const googleProvider = ctx.socialProviders.find((v) => v.id === "google")!;
+		const githubProvider = ctx.socialProviders.find((v) => v.id === "github")!;
+		const googleGetUserInfoMock = vi.spyOn(googleProvider, "getUserInfo");
+		const githubGetUserInfoMock = vi.spyOn(githubProvider, "getUserInfo");
+		const sharedAccountId = "shared-provider-account-id";
+
+		const { runWithUser, user } = await signInWithTestUser();
+		await ctx.internalAdapter.createAccount({
+			userId: user.id,
+			providerId: "google",
+			accountId: sharedAccountId,
+			accessToken: "google-access-token",
+		});
+		await ctx.internalAdapter.createAccount({
+			userId: user.id,
+			providerId: "github",
+			accountId: sharedAccountId,
+			accessToken: "github-access-token",
+		});
+
+		await runWithUser(async () => {
+			const ambiguousInfo = await client.$fetch("/account-info", {
+				query: { accountId: sharedAccountId },
+				method: "GET",
+			});
+
+			expect(ambiguousInfo.error?.message).toBe(
+				BASE_ERROR_CODES.ACCOUNT_NOT_FOUND.message,
+			);
+			expect(googleGetUserInfoMock).not.toHaveBeenCalled();
+			expect(githubGetUserInfoMock).not.toHaveBeenCalled();
+
+			githubGetUserInfoMock.mockResolvedValueOnce({
+				user: {
+					id: user.id,
+					name: user.name,
+					email: user.email,
+					emailVerified: user.emailVerified,
+				},
+				data: { source: "github" },
+			});
+			const githubInfo = await client.$fetch("/account-info", {
+				query: { accountId: sharedAccountId, providerId: "github" },
+				method: "GET",
+			});
+
+			expect(githubInfo.error).toBeNull();
+			expect(githubInfo.data).toMatchObject({
+				data: { source: "github" },
+			});
+			expect(githubGetUserInfoMock).toHaveBeenCalledWith(
+				expect.objectContaining({ accessToken: "github-access-token" }),
+			);
+		});
+	});
+
 	it("should pass custom scopes to authorization URL", async () => {
 		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async () => {

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -289,6 +289,74 @@ describe("account", async () => {
 		expect(info.error?.status).toBe(401);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9502
+	 */
+	it("should resolve account info from the current user's accounts when provider account IDs collide", async () => {
+		const { auth, signInWithTestUser, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			account: {
+				accountLinking: {
+					allowDifferentEmails: true,
+				},
+				encryptOAuthTokens: true,
+			},
+		});
+		const ctx = await auth.$context;
+		const googleProvider = ctx.socialProviders.find((v) => v.id === "google")!;
+		const getUserInfoMock = vi.spyOn(googleProvider, "getUserInfo");
+		const sharedAccountId = "shared-provider-account-id";
+		const otherUser = await ctx.internalAdapter.createUser({
+			name: "Other User",
+			email: "other-account-info@example.com",
+		});
+		await ctx.internalAdapter.createAccount({
+			userId: otherUser.id,
+			providerId: "google",
+			accountId: sharedAccountId,
+			accessToken: "other-access-token",
+		});
+
+		const { runWithUser, user } = await signInWithTestUser();
+		await ctx.internalAdapter.createAccount({
+			userId: user.id,
+			providerId: "google",
+			accountId: sharedAccountId,
+			accessToken: "current-access-token",
+		});
+
+		getUserInfoMock.mockResolvedValueOnce({
+			user: {
+				id: user.id,
+				name: user.name,
+				email: user.email,
+				emailVerified: user.emailVerified,
+			},
+			data: { source: "current-user" },
+		});
+
+		await runWithUser(async () => {
+			const info = await client.$fetch("/account-info", {
+				query: { accountId: sharedAccountId },
+				method: "GET",
+			});
+
+			expect(info.error).toBeNull();
+			expect(info.data).toMatchObject({
+				data: { source: "current-user" },
+			});
+			expect(getUserInfoMock).toHaveBeenCalledWith(
+				expect.objectContaining({ accessToken: "current-access-token" }),
+			);
+		});
+	});
+
 	it("should pass custom scopes to authorization URL", async () => {
 		const { runWithUser: runWithClient2 } = await signInWithTestUser();
 		await runWithClient2(async () => {

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -853,6 +853,13 @@ const accountInfoQuerySchema = z.optional(
 					"The provider given account id for which to get the account info",
 			})
 			.optional(),
+		providerId: z
+			.string()
+			.meta({
+				description:
+					"The provider ID to disambiguate provider-issued account IDs",
+			})
+			.optional(),
 		userId: z
 			.string()
 			.meta({
@@ -916,7 +923,11 @@ export const accountInfo = createAuthEndpoint(
 		query: accountInfoQuerySchema,
 	},
 	async (ctx) => {
-		const { accountId: providedAccountId, userId } = ctx.query || {};
+		const {
+			accountId: providedAccountId,
+			providerId: providedProviderId,
+			userId,
+		} = ctx.query || {};
 		const resolvedUserId = await resolveUserId(ctx, userId);
 
 		let account: Account | undefined = undefined;
@@ -928,10 +939,15 @@ export const accountInfo = createAuthEndpoint(
 				}
 			}
 		} else {
-			const accountData =
-				await ctx.context.internalAdapter.findAccount(providedAccountId);
-			if (accountData) {
-				account = accountData;
+			const accounts =
+				await ctx.context.internalAdapter.findAccounts(resolvedUserId);
+			const matchingAccounts = accounts.filter(
+				(acc) =>
+					acc.accountId === providedAccountId &&
+					(!providedProviderId || acc.providerId === providedProviderId),
+			);
+			if (matchingAccounts.length === 1) {
+				account = matchingAccounts[0];
 			}
 		}
 

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -486,7 +486,18 @@ async function getValidAccessToken(
 		resolvedUserId,
 		providerId,
 		accountId,
-	}: { resolvedUserId: string; providerId: string; accountId?: string },
+		account: resolvedAccount,
+	}: {
+		resolvedUserId: string;
+		providerId: string;
+		accountId?: string;
+		/**
+		 * An already-resolved account. When provided, skips the cookie and
+		 * database lookup so a caller that has the account in hand does not
+		 * re-query for it.
+		 */
+		account?: Account;
+	},
 ) {
 	const provider = await getAwaitableValue(ctx.context.socialProviders, {
 		value: providerId,
@@ -497,23 +508,25 @@ async function getValidAccessToken(
 			code: "PROVIDER_NOT_SUPPORTED",
 		});
 	}
-	const accountData = await getAccountCookie(ctx);
-	let account: Account | undefined = undefined;
-	if (
-		accountData &&
-		accountData.userId === resolvedUserId &&
-		providerId === accountData.providerId &&
-		(!accountId || accountData.accountId === accountId)
-	) {
-		account = accountData;
-	} else {
-		const accounts =
-			await ctx.context.internalAdapter.findAccounts(resolvedUserId);
-		account = accounts.find((acc) =>
-			accountId
-				? acc.accountId === accountId && acc.providerId === providerId
-				: acc.providerId === providerId,
-		);
+	let account: Account | undefined = resolvedAccount;
+	if (!account) {
+		const accountData = await getAccountCookie(ctx);
+		if (
+			accountData &&
+			accountData.userId === resolvedUserId &&
+			providerId === accountData.providerId &&
+			(!accountId || accountData.accountId === accountId)
+		) {
+			account = accountData;
+		} else {
+			const accounts =
+				await ctx.context.internalAdapter.findAccounts(resolvedUserId);
+			account = accounts.find((acc) =>
+				accountId
+					? acc.accountId === accountId && acc.providerId === providerId
+					: acc.providerId === providerId,
+			);
+		}
 	}
 
 	if (!account) {
@@ -946,9 +959,14 @@ export const accountInfo = createAuthEndpoint(
 					acc.accountId === providedAccountId &&
 					(!providedProviderId || acc.providerId === providedProviderId),
 			);
-			if (matchingAccounts.length === 1) {
-				account = matchingAccounts[0];
+			if (matchingAccounts.length > 1) {
+				throw APIError.from("BAD_REQUEST", {
+					message:
+						"Multiple accounts share this account ID. Pass a providerId to disambiguate.",
+					code: "AMBIGUOUS_ACCOUNT",
+				});
 			}
+			account = matchingAccounts[0];
 		}
 
 		if (!account || account.userId !== resolvedUserId) {
@@ -960,8 +978,8 @@ export const accountInfo = createAuthEndpoint(
 		});
 
 		if (!provider) {
-			throw APIError.from("INTERNAL_SERVER_ERROR", {
-				message: `Provider account provider is ${account.providerId} but it is not configured`,
+			throw APIError.from("BAD_REQUEST", {
+				message: "Account is not associated with a configured social provider.",
 				code: "PROVIDER_NOT_CONFIGURED",
 			});
 		}
@@ -969,6 +987,7 @@ export const accountInfo = createAuthEndpoint(
 			resolvedUserId,
 			providerId: account.providerId,
 			accountId: account.accountId,
+			account,
 		});
 		if (!tokens.accessToken) {
 			throw APIError.from("BAD_REQUEST", {

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -323,7 +323,7 @@ export const resetPassword = createAuthEndpoint(
 			}
 		}
 		if (ctx.context.options.emailAndPassword?.revokeSessionsOnPasswordReset) {
-			await ctx.context.internalAdapter.deleteSessions(userId);
+			await ctx.context.internalAdapter.deleteUserSessions(userId);
 		}
 		return ctx.json({
 			status: true,

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -824,7 +824,7 @@ export const revokeSessions = createAuthEndpoint(
 	},
 	async (ctx) => {
 		try {
-			await ctx.context.internalAdapter.deleteSessions(
+			await ctx.context.internalAdapter.deleteUserSessions(
 				ctx.context.session.user.id,
 			);
 		} catch (error) {

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -288,7 +288,7 @@ export const changePassword = createAuthEndpoint(
 		});
 		let token = null;
 		if (revokeOtherSessions) {
-			await ctx.context.internalAdapter.deleteSessions(session.user.id);
+			await ctx.context.internalAdapter.deleteUserSessions(session.user.id);
 			const newSession = await ctx.context.internalAdapter.createSession(
 				session.user.id,
 			);
@@ -549,7 +549,7 @@ export const deleteUser = createAuthEndpoint(
 			await beforeDelete(session.user, ctx.request);
 		}
 		await ctx.context.internalAdapter.deleteUser(session.user.id);
-		await ctx.context.internalAdapter.deleteSessions(session.user.id);
+		await ctx.context.internalAdapter.deleteUserSessions(session.user.id);
 		deleteSessionCookie(ctx);
 		const afterDelete = ctx.context.options.user.deleteUser?.afterDelete;
 		if (afterDelete) {
@@ -640,7 +640,7 @@ export const deleteUserCallback = createAuthEndpoint(
 			await beforeDelete(session.user, ctx.request);
 		}
 		await ctx.context.internalAdapter.deleteUser(session.user.id);
-		await ctx.context.internalAdapter.deleteSessions(session.user.id);
+		await ctx.context.internalAdapter.deleteUserSessions(session.user.id);
 		await ctx.context.internalAdapter.deleteAccounts(session.user.id);
 		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 			`delete-account-${ctx.query.token}`,

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -721,12 +721,18 @@ describe("internal adapter test", async () => {
 			accountId: "test-account-id-1",
 		});
 
-		let foundAccount = await internalAdapter.findAccount(account.accountId);
+		let foundAccount = await internalAdapter.findAccountByProviderId(
+			account.accountId,
+			"test-provider",
+		);
 		expect(foundAccount).toBeDefined();
 
 		await internalAdapter.deleteAccount(account.id);
 
-		foundAccount = await internalAdapter.findAccount(account.accountId);
+		foundAccount = await internalAdapter.findAccountByProviderId(
+			account.accountId,
+			"test-provider",
+		);
 		expect(foundAccount).toBeNull();
 	});
 

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -776,28 +776,44 @@ export const createInternalAdapter = (
 				undefined,
 			);
 		},
-		deleteSessions: async (userIdOrSessionTokens: string | string[]) => {
+		deleteUserSessions: async (userId: string) => {
 			if (secondaryStorage) {
-				if (typeof userIdOrSessionTokens === "string") {
-					const activeSession = await secondaryStorage.get(
-						`active-sessions-${userIdOrSessionTokens}`,
-					);
-					const sessions = activeSession
-						? safeJSONParse<{ token: string }[]>(activeSession)
-						: [];
-					if (!sessions) return;
-					for (const session of sessions) {
-						await secondaryStorage.delete(session.token);
-					}
-					await secondaryStorage.delete(
-						`active-sessions-${userIdOrSessionTokens}`,
-					);
-				} else {
-					for (const sessionToken of userIdOrSessionTokens) {
-						const session = await secondaryStorage.get(sessionToken);
-						if (session) {
-							await secondaryStorage.delete(sessionToken);
-						}
+				const activeSession = await secondaryStorage.get(
+					`active-sessions-${userId}`,
+				);
+				const sessions = activeSession
+					? safeJSONParse<{ token: string }[]>(activeSession)
+					: [];
+				if (!sessions) return;
+				for (const session of sessions) {
+					await secondaryStorage.delete(session.token);
+				}
+				await secondaryStorage.delete(`active-sessions-${userId}`);
+
+				if (
+					!options.session?.storeSessionInDatabase ||
+					ctx.options.session?.preserveSessionInDatabase
+				) {
+					return;
+				}
+			}
+			await deleteManyWithHooks(
+				[
+					{
+						field: "userId",
+						value: userId,
+					},
+				],
+				"session",
+				undefined,
+			);
+		},
+		deleteSessions: async (sessionTokens: string[]) => {
+			if (secondaryStorage) {
+				for (const sessionToken of sessionTokens) {
+					const session = await secondaryStorage.get(sessionToken);
+					if (session) {
+						await secondaryStorage.delete(sessionToken);
 					}
 				}
 
@@ -811,9 +827,9 @@ export const createInternalAdapter = (
 			await deleteManyWithHooks(
 				[
 					{
-						field: Array.isArray(userIdOrSessionTokens) ? "token" : "userId",
-						value: userIdOrSessionTokens,
-						operator: Array.isArray(userIdOrSessionTokens) ? "in" : undefined,
+						field: "token",
+						value: sessionTokens,
+						operator: "in",
 					},
 				],
 				"session",
@@ -1031,20 +1047,6 @@ export const createInternalAdapter = (
 				],
 			});
 			return accounts;
-		},
-		findAccount: async (accountId: string) => {
-			const account = await (await getCurrentAdapter(adapter)).findOne<Account>(
-				{
-					model: "account",
-					where: [
-						{
-							field: "accountId",
-							value: accountId,
-						},
-					],
-				},
-			);
-			return account;
 		},
 		findAccountByProviderId: async (accountId: string, providerId: string) => {
 			const account = await (await getCurrentAdapter(adapter)).findOne<Account>(

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -946,8 +946,8 @@ describe("oauth2 - override user info on sign-in", async () => {
 /**
  * @see https://github.com/better-auth/better-auth/issues/8906
  *
- * Regression: linkSocial callback used findAccount(accountId) without
- * filtering by providerId. When two different providers share the same
+ * Regression: linkSocial callback looked up the account by accountId
+ * alone, without filtering by providerId. When two different providers share the same
  * numeric account ID, the wrong account could be matched, causing a
  * spurious "account_already_linked_to_different_user" error or silently
  * updating the wrong account record.
@@ -1059,7 +1059,7 @@ describe("oauth2 - link-social uses provider-scoped account lookup", async () =>
 		);
 
 		// User B tries to link GitHub — GitHub returns the SAME accountId
-		// as User A's Google account. Without the fix, findAccount(SHARED_ACCOUNT_ID)
+		// as User A's Google account. Without the fix, an accountId-only lookup
 		// would find User A's Google account and return "account_already_linked_to_different_user".
 		mockGithubToken("user-b-gh", Number(SHARED_ACCOUNT_ID), userBEmail);
 

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -983,7 +983,7 @@ export const banUser = (opts: AdminOptions) =>
 				},
 			);
 			//revoke all sessions
-			await ctx.context.internalAdapter.deleteSessions(ctx.body.userId);
+			await ctx.context.internalAdapter.deleteUserSessions(ctx.body.userId);
 			return ctx.json({
 				user: parseUserOutput(ctx.context.options, user) as UserWithRole,
 			});
@@ -1367,7 +1367,7 @@ export const revokeUserSessions = (opts: AdminOptions) =>
 				);
 			}
 
-			await ctx.context.internalAdapter.deleteSessions(ctx.body.userId);
+			await ctx.context.internalAdapter.deleteUserSessions(ctx.body.userId);
 			return ctx.json({
 				success: true,
 			});
@@ -1460,7 +1460,7 @@ export const removeUser = (opts: AdminOptions) =>
 				throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.USER_NOT_FOUND);
 			}
 
-			await ctx.context.internalAdapter.deleteSessions(ctx.body.userId);
+			await ctx.context.internalAdapter.deleteUserSessions(ctx.body.userId);
 			await ctx.context.internalAdapter.deleteUser(ctx.body.userId);
 			return ctx.json({
 				success: true,

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -439,11 +439,11 @@ describe("anonymous", async () => {
 		function createMiddlewareContext({
 			newSessionUser,
 			deleteUser,
-			deleteSessions,
+			deleteUserSessions,
 		}: {
 			newSessionUser: Record<string, any>;
 			deleteUser: ReturnType<typeof vi.fn>;
-			deleteSessions?: ReturnType<typeof vi.fn>;
+			deleteUserSessions?: ReturnType<typeof vi.fn>;
 		}) {
 			return {
 				path: "/sign-in/anonymous",
@@ -474,7 +474,7 @@ describe("anonymous", async () => {
 					},
 					internalAdapter: {
 						deleteUser,
-						deleteSessions: deleteSessions ?? vi.fn(),
+						deleteUserSessions: deleteUserSessions ?? vi.fn(),
 					},
 					options: {},
 					secret: "secret",
@@ -521,14 +521,14 @@ describe("anonymous", async () => {
 			const plugin = anonymous();
 			const handler = plugin.hooks?.after?.[0]?.handler;
 			const deleteUser = vi.fn();
-			const deleteSessions = vi.fn();
+			const deleteUserSessions = vi.fn();
 			const ctx = createMiddlewareContext({
 				newSessionUser: {
 					id: "linked-user",
 					isAnonymous: false,
 				},
 				deleteUser,
-				deleteSessions,
+				deleteUserSessions,
 			});
 
 			vi.spyOn(apiModule, "getSessionFromCtx").mockResolvedValue({
@@ -543,7 +543,7 @@ describe("anonymous", async () => {
 
 			await handler?.(ctx);
 
-			expect(deleteSessions).toHaveBeenCalledWith("anon-user");
+			expect(deleteUserSessions).toHaveBeenCalledWith("anon-user");
 			expect(deleteUser).toHaveBeenCalledWith("anon-user");
 		});
 	});

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -219,7 +219,9 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 					}
 
 					try {
-						await ctx.context.internalAdapter.deleteSessions(session.user.id);
+						await ctx.context.internalAdapter.deleteUserSessions(
+							session.user.id,
+						);
 					} catch (error) {
 						ctx.context.logger.error(
 							"Failed to delete anonymous user sessions",
@@ -337,7 +339,9 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 							return;
 						}
 						try {
-							await ctx.context.internalAdapter.deleteSessions(session.user.id);
+							await ctx.context.internalAdapter.deleteUserSessions(
+								session.user.id,
+							);
 							await ctx.context.internalAdapter.deleteUser(session.user.id);
 						} catch (error) {
 							// TODO: collapse session+user cleanup into `internalAdapter.deleteUser`

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -982,7 +982,7 @@ export const resetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			}
 
 			if (ctx.context.options.emailAndPassword?.revokeSessionsOnPasswordReset) {
-				await ctx.context.internalAdapter.deleteSessions(user.user.id);
+				await ctx.context.internalAdapter.deleteUserSessions(user.user.id);
 			}
 			return ctx.json({
 				success: true,

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -5,6 +5,7 @@ import * as z from "zod";
 import { APIError } from "../../api";
 import { setSessionCookie } from "../../cookies";
 import { parseUserOutput } from "../../db/schema";
+import { handleOAuthUserInfo } from "../../oauth2/link-account";
 import { toBoolean } from "../../utils/boolean";
 import { PACKAGE_VERSION } from "../../version";
 
@@ -117,92 +118,41 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 					}
 					const email = rawEmail.toLowerCase();
 
-					const user = await ctx.context.internalAdapter.findUserByEmail(email);
-					if (!user) {
-						if (options?.disableSignup) {
-							throw new APIError("BAD_GATEWAY", {
-								message: "User not found",
-							});
-						}
-						const newUser = await ctx.context.internalAdapter.createOAuthUser(
-							{
-								email,
-								emailVerified:
-									typeof email_verified === "boolean"
-										? email_verified
-										: toBoolean(email_verified),
-								name,
-								image: picture,
-							},
-							{
-								providerId: "google",
-								accountId: sub,
-							},
-						);
-						if (!newUser) {
-							throw new APIError("INTERNAL_SERVER_ERROR", {
-								message: "Could not create user",
-							});
-						}
-						const session = await ctx.context.internalAdapter.createSession(
-							newUser.user.id,
-						);
-						await setSessionCookie(ctx, {
-							user: newUser.user,
-							session,
-						});
-						return ctx.json({
-							token: session.token,
-							user: parseUserOutput(ctx.context.options, newUser.user),
-						});
-					}
-					const account =
-						await ctx.context.internalAdapter.findAccountByProviderId(
-							sub,
-							"google",
-						);
-					if (!account) {
-						const accountLinking = ctx.context.options.account?.accountLinking;
-						const providerEmailVerified =
-							typeof email_verified === "boolean"
-								? email_verified
-								: toBoolean(email_verified);
-						// FIXME(next-minor): drop `requireLocalEmailVerified` option and
-						// make the gate unconditional.
-						const requireLocalEmailVerified =
-							accountLinking?.requireLocalEmailVerified ?? true;
-						const shouldLinkAccount =
-							accountLinking?.enabled !== false &&
-							accountLinking?.disableImplicitLinking !== true &&
-							(!requireLocalEmailVerified || user.user.emailVerified) &&
-							(ctx.context.trustedProviders.includes("google") ||
-								providerEmailVerified);
-						if (shouldLinkAccount) {
-							await ctx.context.internalAdapter.linkAccount({
-								userId: user.user.id,
-								providerId: "google",
-								accountId: sub,
-								scope: "openid,profile,email",
-								idToken,
-							});
-						} else {
-							throw new APIError("UNAUTHORIZED", {
-								message:
-									"Google identity cannot be linked: implicit account-linking is disabled, the local email is not verified, or the Google email_verified claim is false and Google is not a trusted provider",
-							});
-						}
-					}
-					const session = await ctx.context.internalAdapter.createSession(
-						user.user.id,
-					);
+					const emailVerified =
+						typeof email_verified === "boolean"
+							? email_verified
+							: toBoolean(email_verified);
 
-					await setSessionCookie(ctx, {
-						user: user.user,
-						session,
+					// Resolve identity through the shared OAuth path so One Tap matches
+					// the redirect and `signIn.social` flows: the account that owns the
+					// Google `sub` wins, never whichever local user happens to share the
+					// token's email.
+					const result = await handleOAuthUserInfo(ctx, {
+						userInfo: {
+							id: sub,
+							email,
+							emailVerified,
+							name: name ?? "",
+							image: picture,
+						},
+						account: {
+							providerId: "google",
+							accountId: sub,
+							idToken,
+							scope: "openid,profile,email",
+						},
+						disableSignUp: options?.disableSignup,
 					});
+					if (result.error) {
+						throw new APIError("UNAUTHORIZED", {
+							message: result.error,
+						});
+					}
+
+					await setSessionCookie(ctx, result.data!);
 					return ctx.json({
-						token: session.token,
-						user: parseUserOutput(ctx.context.options, user.user),
+						token: result.data!.session.token,
+						user: parseUserOutput(ctx.context.options, result.data!.user),
 					});
 				},
 			),

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -156,7 +156,11 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 							user: parseUserOutput(ctx.context.options, newUser.user),
 						});
 					}
-					const account = await ctx.context.internalAdapter.findAccount(sub);
+					const account =
+						await ctx.context.internalAdapter.findAccountByProviderId(
+							sub,
+							"google",
+						);
 					if (!account) {
 						const accountLinking = ctx.context.options.account?.accountLinking;
 						const providerEmailVerified =

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -220,6 +220,98 @@ describe("one-tap implicit linking gate", async () => {
 		expect(googleAccounts).toHaveLength(1);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9502
+	 */
+	it("does not duplicate the Google account when the same user signs in again", async () => {
+		verifiedPayload.email = "one-tap-returning-user@example.com";
+		verifiedPayload.sub = "returning-user-google-sub";
+
+		const { auth, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+				},
+			},
+			plugins: [oneTap()],
+		});
+		const ctx = await auth.$context;
+
+		const callOneTap = () =>
+			client.$fetch<{ token?: string }>("/one-tap/callback", {
+				method: "POST",
+				body: { idToken: "stub-id-token" },
+			});
+
+		const first = await callOneTap();
+		expect(first.error).toBeFalsy();
+		expect(first.data?.token).toBeTruthy();
+
+		// Second sign-in finds the user's own Google account and skips re-linking.
+		const second = await callOneTap();
+		expect(second.error).toBeFalsy();
+		expect(second.data?.token).toBeTruthy();
+
+		const googleAccounts = await ctx.adapter.findMany<{ providerId: string }>({
+			model: "account",
+			where: [
+				{ field: "providerId", value: "google" },
+				{ field: "accountId", value: verifiedPayload.sub },
+			],
+		});
+		expect(googleAccounts).toHaveLength(1);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9502
+	 *
+	 * Identity must resolve by the Google `sub`, not the token email. A Google
+	 * credential already linked to user A must sign in A, even when the token's
+	 * email matches a different local user B.
+	 */
+	it("signs in the account that owns the Google sub, not the email-matched user", async () => {
+		const sharedSub = "one-tap-sub-owned-by-user-a";
+		verifiedPayload.email = "one-tap-email-collision-b@example.com";
+		verifiedPayload.sub = sharedSub;
+
+		const { auth, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+				},
+			},
+			plugins: [oneTap()],
+		});
+		const ctx = await auth.$context;
+
+		const userA = await ctx.internalAdapter.createUser({
+			name: "Sub Owner A",
+			email: "one-tap-sub-owner-a@example.com",
+		});
+		await ctx.internalAdapter.createAccount({
+			userId: userA.id,
+			providerId: "google",
+			accountId: sharedSub,
+		});
+		const userB = await ctx.internalAdapter.createUser({
+			name: "Email Match B",
+			email: verifiedPayload.email,
+		});
+
+		const res = await client.$fetch<{ user?: { id: string } }>(
+			"/one-tap/callback",
+			{ method: "POST", body: { idToken: "stub-id-token" } },
+		);
+
+		expect(res.error).toBeFalsy();
+		expect(res.data?.user?.id).toBe(userA.id);
+		expect(res.data?.user?.id).not.toBe(userB.id);
+	});
+
 	it("honors accountLinking.disableImplicitLinking even when the local user is verified", async () => {
 		const { auth, client } = await getTestInstance({
 			socialProviders: {

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -2,13 +2,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { oneTap } from "./index";
 
-const verifiedPayload = {
+const defaultVerifiedPayload = {
 	email: "one-tap-user@example.com",
 	email_verified: true,
 	name: "One Tap User",
 	picture: "https://example.com/photo.jpg",
 	sub: "google_oauth_sub_one_tap",
 };
+
+const verifiedPayload = { ...defaultVerifiedPayload };
 
 vi.mock("jose", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("jose")>();
@@ -24,7 +26,7 @@ vi.mock("jose", async (importOriginal) => {
 
 describe("one-tap implicit linking gate", async () => {
 	afterEach(() => {
-		verifiedPayload.email_verified = true;
+		Object.assign(verifiedPayload, defaultVerifiedPayload);
 	});
 
 	/**
@@ -157,6 +159,65 @@ describe("one-tap implicit linking gate", async () => {
 			],
 		});
 		expect(accounts.length).toBeGreaterThanOrEqual(1);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9502
+	 */
+	it("links Google One Tap when another provider has the same account ID", async () => {
+		verifiedPayload.email = "one-tap-provider-collision@example.com";
+		verifiedPayload.sub = "shared-one-tap-provider-account-id";
+
+		const { auth, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+				},
+			},
+			account: {
+				accountLinking: {
+					requireLocalEmailVerified: false,
+				},
+			},
+			plugins: [oneTap()],
+		});
+
+		const ctx = await auth.$context;
+		const otherUser = await ctx.internalAdapter.createUser({
+			name: "Other Provider User",
+			email: "one-tap-other-provider@example.com",
+		});
+		await ctx.internalAdapter.createAccount({
+			userId: otherUser.id,
+			providerId: "github",
+			accountId: verifiedPayload.sub,
+		});
+
+		await client.signUp.email({
+			email: verifiedPayload.email,
+			password: "password123",
+			name: "Pre-existing Local User",
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error).toBeFalsy();
+		const googleAccounts = await ctx.adapter.findMany<{ providerId: string }>({
+			model: "account",
+			where: [
+				{ field: "providerId", value: "google" },
+				{ field: "accountId", value: verifiedPayload.sub },
+			],
+		});
+		expect(googleAccounts).toHaveLength(1);
 	});
 
 	it("honors accountLinking.disableImplicitLinking even when the local user is verified", async () => {

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -907,7 +907,7 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			}
 
 			if (ctx.context.options.emailAndPassword?.revokeSessionsOnPasswordReset) {
-				await ctx.context.internalAdapter.deleteSessions(user.id);
+				await ctx.context.internalAdapter.deleteUserSessions(user.id);
 			}
 
 			return ctx.json({

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -158,7 +158,15 @@ export interface InternalAdapter<
 	 */
 	deleteAccount(id: string): Promise<void>;
 
-	deleteSessions(userIdOrSessionTokens: string | string[]): Promise<void>;
+	/**
+	 * Delete every session belonging to a user.
+	 */
+	deleteUserSessions(userId: string): Promise<void>;
+
+	/**
+	 * Delete sessions by their session tokens.
+	 */
+	deleteSessions(sessionTokens: string[]): Promise<void>;
 
 	findOAuthUser(
 		email: string,
@@ -195,8 +203,6 @@ export interface InternalAdapter<
 	updatePassword(userId: string, password: string): Promise<void>;
 
 	findAccounts(userId: string): Promise<Account[]>;
-
-	findAccount(accountId: string): Promise<Account | null>;
 
 	findAccountByProviderId(
 		accountId: string,

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -1050,7 +1050,7 @@ export const deleteSCIMUser = (authMiddleware: AuthMiddleware) =>
 				});
 			}
 
-			await ctx.context.internalAdapter.deleteSessions(userId);
+			await ctx.context.internalAdapter.deleteUserSessions(userId);
 			await ctx.context.internalAdapter.deleteUser(userId);
 
 			ctx.setStatus(204);

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -502,6 +502,7 @@ export async function processSAMLResponse(
 		const samlSessionKey = `${constants.SAML_SESSION_KEY_PREFIX}${providerId}:${extract.nameID}`;
 		const samlSessionData: SAMLSessionRecord = {
 			sessionId: session.id,
+			sessionToken: session.token,
 			providerId,
 			nameID: extract.nameID,
 			sessionIndex: (extract as SAMLAssertionExtract).sessionIndex,

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -2189,7 +2189,7 @@ async function handleLogoutRequest(
 				sessionIndex === data.sessionIndex
 			) {
 				await ctx.context.internalAdapter
-					.deleteSession(data.sessionId)
+					.deleteSession(data.sessionToken)
 					.catch((e: unknown) =>
 						ctx.context.logger.warn("Failed to delete session during SLO", {
 							error: e,
@@ -2228,7 +2228,9 @@ async function handleLogoutRequest(
 
 	const currentSession = await getSessionFromCtx(ctx);
 	if (currentSession?.session) {
-		await ctx.context.internalAdapter.deleteSession(currentSession.session.id);
+		await ctx.context.internalAdapter.deleteSession(
+			currentSession.session.token,
+		);
 	}
 
 	deleteSessionCookie(ctx);
@@ -2371,7 +2373,7 @@ export const initiateSLO = (options?: SSOOptions) => {
 					),
 				);
 
-			await ctx.context.internalAdapter.deleteSession(session.session.id);
+			await ctx.context.internalAdapter.deleteSession(session.session.token);
 
 			deleteSessionCookie(ctx);
 

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -5293,6 +5293,10 @@ describe("SAML Single Logout (SLO)", () => {
 			const location = initSloRes.headers.get("location");
 			expect(location).toContain("http://localhost:8081/api/sso/saml2/idp/slo");
 			expect(location).toContain("SAMLRequest=");
+
+			// SP-initiated logout must revoke the local session, not just redirect.
+			const sessionAfter = await auth.api.getSession({ headers });
+			expect(sessionAfter).toBeNull();
 		});
 	});
 

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -97,7 +97,10 @@ export interface AuthnRequestRecord {
 
 /** Session data stored during SAML login for Single Logout */
 export interface SAMLSessionRecord {
+	/** Session row id, used to key the by-id lookup index. */
 	sessionId: string;
+	/** Session token, used to revoke the session during Single Logout. */
+	sessionToken: string;
 	providerId: string;
 	nameID: string;
 	sessionIndex?: string;


### PR DESCRIPTION
Supersedes #9664 and closes #9502. This fixes a Google One Tap bug that could authenticate the wrong user. It also tightens how `/account-info` resolves accounts and removes two unsafe `internalAdapter` helpers. A SAML logout bug, found while auditing those helpers, is fixed too.

## Google One Tap could sign in the wrong user

One Tap looked up the local user by the ID token's email. It used the Google subject (`sub`) only to decide whether to link an account. Suppose that `sub` was already linked to user A, but the token's email matched a different local user B. One Tap signed in B, not A, the account that actually owns the Google identity. Every other OAuth entry point avoids this by resolving through `handleOAuthUserInfo`, which is subject-first. One Tap now calls that same resolver, so the owning user is signed in. The plugin's duplicated link-eligibility gate is gone too.

## `/account-info` resolved accounts globally and reported confusing errors

The endpoint looked accounts up across all users by account ID, then re-checked ownership. When another user shared that account ID, the legitimate owner saw a misleading "account not found". It now resolves the account from the signed-in user's own linked accounts. An optional `providerId` disambiguates when two providers issue the same ID. A genuinely ambiguous lookup now returns a distinct `AMBIGUOUS_ACCOUNT` error rather than "not found". An account with no configured social provider returns 400 instead of 500. The account is resolved once and passed into the token helper, which removes a duplicate database lookup.

## Two unsafe `internalAdapter` helpers

`findAccount(accountId)` matched on account ID alone, which is unique neither across providers nor across users. It returned a non-deterministic first row. The helper is removed, and every caller now uses a user-scoped or provider-scoped lookup. `deleteSessions(string | string[])` treated a lone string as a user ID. A caller that meant to delete one session token could instead wipe every session for that user, or match nothing. It is now split into `deleteUserSessions(userId)` and `deleteSessions(tokens)`.

## SAML Single Logout never revoked the session

The logout handlers passed the session row id to a delete that matches on the session token. The match never hit, so the session survived logout and the user stayed signed in. The stored SAML session record now carries the token, and all three logout paths revoke by token.

## Attribution

The provider-scoping commits and their regression tests are @kgarg2468's. They are rebased onto current `main` and reconciled with the server-side `accountInfo` refactor that landed since.

Closes #9664
Closes #9502
