### PR TITLE
docs(two-factor): mark `viewBackupCodes` as server-only in its API comment

### DIFF
--- a/.changeset/two-factor-view-backup-codes-jsdoc.md
+++ b/.changeset/two-factor-view-backup-codes-jsdoc.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+Document `viewBackupCodes` as a server-only function so its API comment no longer reads like an HTTP route.
+
+The JSDoc above `auth.api.viewBackupCodes` advertised `POST /two-factor/view-backup-codes`, but the endpoint is server-only: it is not registered on the HTTP router and has no client method. The comment now states that it is callable only from trusted server code and that the `userId` should come from an authenticated session.

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -507,9 +507,10 @@ export const backupCode2fa = (opts: BackupCodeOptions) => {
 				},
 			),
 			/**
-			 * ### Endpoint
-			 *
-			 * POST `/two-factor/view-backup-codes`
+			 * A server-only function that returns a user's decrypted two-factor
+			 * backup codes. It is not exposed over HTTP and has no client method;
+			 * call it from trusted server code with a `userId` taken from an
+			 * authenticated session.
 			 *
 			 * ### API Methods
 			 *


### PR DESCRIPTION
The JSDoc above `auth.api.viewBackupCodes` advertised `POST /two-factor/view-backup-codes`, which reads like a live HTTP route. The endpoint is server-only: it uses the no-path form of `createAuthEndpoint`, so it is never added to the HTTP router, and it has no client method. A reader following the comment could believe it is an authenticated HTTP endpoint and wire it up as one.

The comment now describes it as a server-only function, callable only from trusted server code, and notes that the `userId` should come from an authenticated session, matching the existing 2FA docs. There is no behavior change; this is a comment-only clarification that ships in the published type declarations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update JSDoc to mark `auth.api.viewBackupCodes` as server-only and not an HTTP route, preventing misuse as `POST /two-factor/view-backup-codes`. The comment now says to call it from trusted server code with a session-derived `userId`; no behavior change, docs-only patch to `better-auth`.

<sup>Written for commit 5c6b9e043bd88f698b3e87371dd33dc84219e0ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

