### PR TITLE
refactor(oauth)!: verify provider `id_tokens` with a single shared verifier

### DIFF
--- a/.changeset/oauth-idtoken-verifier.md
+++ b/.changeset/oauth-idtoken-verifier.md
@@ -9,7 +9,7 @@ Client-submitted id_token sign-in (`signIn.social({ idToken })` and account link
 
 PayPal previously accepted any decodable id_token without verifying its signature. PayPal derives identity from the access token, so it now declares no `idToken` config, and the client id_token path returns `ID_TOKEN_NOT_SUPPORTED`. PayPal sign-in through the redirect flow is unchanged.
 
-Custom providers that implement `OAuthProvider` directly replace the removed `verifyIdToken` method with an `idToken` config:
+Custom providers that implement `UpstreamProvider` directly replace the removed `verifyIdToken` method with an `idToken` config:
 
 ```ts
 idToken: {

--- a/.changeset/oauth-idtoken-verifier.md
+++ b/.changeset/oauth-idtoken-verifier.md
@@ -1,0 +1,22 @@
+---
+"@better-auth/core": minor
+"better-auth": minor
+---
+
+Verify social-provider id_tokens with a single shared verifier.
+
+Client-submitted id_token sign-in (`signIn.social({ idToken })` and account linking) is verified by one function instead of a per-provider `verifyIdToken` method. Each provider declares an `idToken` config with a JWKS source, issuer, and audience, and the core verifier runs the signature, issuer, audience, and nonce checks. A provider that declares no config rejects the client id_token path.
+
+PayPal previously accepted any decodable id_token without verifying its signature. PayPal derives identity from the access token, so it now declares no `idToken` config, and the client id_token path returns `ID_TOKEN_NOT_SUPPORTED`. PayPal sign-in through the redirect flow is unchanged.
+
+Custom providers that implement `OAuthProvider` directly replace the removed `verifyIdToken` method with an `idToken` config:
+
+```ts
+idToken: {
+	jwks: createRemoteJWKSet(new URL("https://issuer.example/.well-known/jwks.json")),
+	issuer: "https://issuer.example",
+	audience: clientId,
+},
+```
+
+For verification that cannot use a local JWKS, pass `idToken: { verify: async (token, nonce) => boolean }`. The `verifyIdToken` and `disableIdTokenSignIn` provider options are unchanged.

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -66,12 +66,15 @@ afterEach(() => {
 afterAll(() => server.close());
 
 describe("account", async () => {
+	const googleVerifyIdTokenMock =
+		vi.fn<(token: string, nonce?: string) => Promise<boolean>>();
 	const { auth, signInWithTestUser, client } = await getTestInstance({
 		socialProviders: {
 			google: {
 				clientId: "test",
 				clientSecret: "test",
 				enabled: true,
+				verifyIdToken: googleVerifyIdTokenMock,
 			},
 		},
 		account: {
@@ -84,13 +87,11 @@ describe("account", async () => {
 
 	const ctx = await auth.$context;
 
-	let googleVerifyIdTokenMock: MockInstance;
 	let googleGetUserInfoMock: MockInstance;
 	beforeAll(() => {
 		const googleProvider = ctx.socialProviders.find((v) => v.id === "google")!;
 		expect(googleProvider).toBeTruthy();
 
-		googleVerifyIdTokenMock = vi.spyOn(googleProvider, "verifyIdToken");
 		googleGetUserInfoMock = vi.spyOn(googleProvider, "getUserInfo");
 	});
 

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -6,6 +6,8 @@ import type { OAuth2Tokens } from "@better-auth/core/oauth2";
 import {
 	additionalAuthorizationParamsSchema,
 	readGrantedScopes,
+	supportsIdTokenSignIn,
+	verifyProviderIdToken,
 } from "@better-auth/core/oauth2";
 import { SocialProviderListEnum } from "@better-auth/core/social-providers";
 
@@ -253,7 +255,7 @@ export const linkSocialAccount = createAuthEndpoint(
 
 		// Handle ID Token flow if provided
 		if (c.body.idToken) {
-			if (!provider.verifyIdToken) {
+			if (!supportsIdTokenSignIn(provider)) {
 				c.context.logger.error(
 					"Provider does not support id token verification",
 					{
@@ -267,7 +269,7 @@ export const linkSocialAccount = createAuthEndpoint(
 			}
 
 			const { token, nonce } = c.body.idToken;
-			const valid = await provider.verifyIdToken(token, nonce);
+			const valid = await verifyProviderIdToken(provider, token, nonce);
 			if (!valid) {
 				c.context.logger.error("Invalid id token", {
 					provider: c.body.provider,

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -2,7 +2,11 @@ import type { BetterAuthOptions } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import type { User } from "@better-auth/core/db";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
-import { additionalAuthorizationParamsSchema } from "@better-auth/core/oauth2";
+import {
+	additionalAuthorizationParamsSchema,
+	supportsIdTokenSignIn,
+	verifyProviderIdToken,
+} from "@better-auth/core/oauth2";
 import { SocialProviderListEnum } from "@better-auth/core/social-providers";
 import * as z from "zod";
 import { getAwaitableValue } from "../../context/helpers";
@@ -269,7 +273,7 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 			}
 
 			if (c.body.idToken) {
-				if (!provider.verifyIdToken) {
+				if (!supportsIdTokenSignIn(provider)) {
 					c.context.logger.error(
 						"Provider does not support id token verification",
 						{
@@ -282,7 +286,7 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 					);
 				}
 				const { token, nonce } = c.body.idToken;
-				const valid = await provider.verifyIdToken(token, nonce);
+				const valid = await verifyProviderIdToken(provider, token, nonce);
 				if (!valid) {
 					c.context.logger.error("Invalid id token", {
 						provider: c.body.provider,

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -2167,7 +2167,7 @@ describe("Microsoft Provider", async () => {
 		expect(data.user.name).toBe("IdToken User");
 	});
 
-	it("should return false when disableIdTokenSignIn is true", async () => {
+	it("should report id_token sign-in unsupported when disableIdTokenSignIn is true", async () => {
 		const microsoftProfile: Partial<MicrosoftEntraIDProfile> = {
 			sub: "ms-disabled-user",
 			email: "disabled@outlook.com",
@@ -2217,7 +2217,11 @@ describe("Microsoft Provider", async () => {
 			},
 		});
 
-		expect(res.error?.status).toBe(401);
+		// A disabled provider reports the id_token path as unsupported, the same as a provider
+		// that declares no idToken config, instead of the misleading "invalid id token" (401)
+		// that implies the token was verified and rejected.
+		expect(res.error?.status).toBe(404);
+		expect(res.error?.code).toBe("ID_TOKEN_NOT_SUPPORTED");
 	});
 
 	it("should verify issuer when specific tenant is configured", async () => {

--- a/packages/core/src/oauth2/index.ts
+++ b/packages/core/src/oauth2/index.ts
@@ -31,6 +31,7 @@ export type {
 	GrantAuthority,
 	OAuth2Tokens,
 	OAuth2UserInfo,
+	OAuthIdTokenConfig,
 	ProviderGrantAuthority,
 	ProviderOptions,
 	UpstreamProvider,
@@ -68,3 +69,7 @@ export {
 	verifyAccessToken,
 	verifyJwsAccessToken,
 } from "./verify";
+export {
+	supportsIdTokenSignIn,
+	verifyProviderIdToken,
+} from "./verify-id-token";

--- a/packages/core/src/oauth2/oauth-provider.ts
+++ b/packages/core/src/oauth2/oauth-provider.ts
@@ -1,4 +1,50 @@
+import type { JWTVerifyGetKey } from "jose";
 import type { Awaitable, LiteralString } from "../types";
+
+/**
+ * id_token verification config for a social provider.
+ *
+ * Declares how a client-submitted id_token is verified. The shared verifier
+ * (`verifyProviderIdToken`) consumes this instead of each provider implementing its own
+ * boolean check, so verification is centralized and fail-closed: a provider without a config
+ * cannot accept a forged token by omission.
+ */
+export type OAuthIdTokenConfig =
+	| {
+			/**
+			 * JWKS resolver used to verify the JWS signature. Accepts a jose
+			 * `createRemoteJWKSet` resolver or a key-resolving function
+			 * `(protectedHeader) => key`.
+			 */
+			jwks: JWTVerifyGetKey;
+			/** Expected `iss`. Omit for providers whose issuer varies per tenant. */
+			issuer?: (string | string[]) | undefined;
+			/** Expected `aud`, usually the client ID. */
+			audience: string | string[];
+			/** Permitted JWS algorithms. Defaults to the token's `alg` header. */
+			algorithms?: string[] | undefined;
+			/** Maximum token age passed to jose (e.g. `"1h"`). */
+			maxTokenAge?: string | undefined;
+			/**
+			 * How the `nonce` claim is compared to the expected nonce.
+			 * - `"exact"` (default): strict equality.
+			 * - `"exact-or-sha256"`: matches the raw nonce or its SHA-256 hex digest (Apple).
+			 */
+			nonceComparison?: ("exact" | "exact-or-sha256") | undefined;
+			/**
+			 * Accept non-JWS (opaque) tokens without signature verification. Identity is then
+			 * resolved by getUserInfo from the access token via the provider userinfo endpoint,
+			 * which validates it (e.g. Facebook Graph access tokens).
+			 */
+			allowOpaqueToken?: boolean | undefined;
+	  }
+	| {
+			/**
+			 * Custom verifier for providers that cannot verify against a local JWKS, such as a
+			 * remote verification endpoint (e.g. LINE).
+			 */
+			verify: (token: string, nonce?: string) => Promise<boolean>;
+	  };
 
 export interface OAuth2Tokens {
 	tokenType?: string | undefined;
@@ -130,14 +176,11 @@ export interface UpstreamProvider<
 		| ((refreshToken: string) => Promise<OAuth2Tokens>)
 		| undefined;
 	/**
-	 * Verify the id token
-	 * @param token - The id token
-	 * @param nonce - The nonce
-	 * @returns True if the id token is valid, false otherwise
+	 * Declarative id_token verification config consumed by the shared
+	 * `verifyProviderIdToken` verifier. Providers set this instead of implementing a boolean
+	 * verify method, which keeps verification centralized and fail-closed.
 	 */
-	verifyIdToken?:
-		| ((token: string, nonce?: string) => Promise<boolean>)
-		| undefined;
+	idToken?: OAuthIdTokenConfig | undefined;
 	/**
 	 * The expected issuer identifier for this provider (RFC 9207).
 	 * When set, the callback handler validates the `iss` query parameter

--- a/packages/core/src/oauth2/verify-id-token.test.ts
+++ b/packages/core/src/oauth2/verify-id-token.test.ts
@@ -149,9 +149,28 @@ describe("verifyProviderIdToken", () => {
 			{ jwks, issuer: ISSUER, audience: AUDIENCE },
 			{ disableIdTokenSignIn: true },
 		);
+		expect(supportsIdTokenSignIn(provider)).toBe(false);
 		expect(
 			await verifyProviderIdToken(provider, await sign({ sub: "u1" })),
 		).toBe(false);
+	});
+
+	it("is fail-closed when a custom verifier throws", async () => {
+		const overrideThrows = providerWith(undefined, {
+			verifyIdToken: async () => {
+				throw new Error("override boom");
+			},
+		});
+		expect(await verifyProviderIdToken(overrideThrows, "token")).toBe(false);
+
+		const remoteVerifyThrows = providerWith({
+			verify: async () => {
+				throw new Error("remote boom");
+			},
+		});
+		expect(await verifyProviderIdToken(remoteVerifyThrows, "token")).toBe(
+			false,
+		);
 	});
 
 	it("gates opaque (non-JWS) tokens behind allowOpaqueToken", async () => {

--- a/packages/core/src/oauth2/verify-id-token.test.ts
+++ b/packages/core/src/oauth2/verify-id-token.test.ts
@@ -189,7 +189,7 @@ describe("verifyProviderIdToken", () => {
 			const provider = facebook({ clientId: "c", clientSecret: "s" });
 			expect(supportsIdTokenSignIn(provider)).toBe(true);
 			expect(
-				await verifyProviderIdToken(provider, "EAAGopaqueGraphAccessToken"),
+				await verifyProviderIdToken(provider, "opaque-graph-access-token"),
 			).toBe(true);
 		});
 	});

--- a/packages/core/src/oauth2/verify-id-token.test.ts
+++ b/packages/core/src/oauth2/verify-id-token.test.ts
@@ -1,0 +1,183 @@
+import { createHash } from "node:crypto";
+import type { JWK } from "jose";
+import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT } from "jose";
+import { describe, expect, it } from "vitest";
+import { facebook } from "../social-providers/facebook";
+import { paypal } from "../social-providers/paypal";
+import type { OAuthIdTokenConfig, UpstreamProvider } from "./oauth-provider";
+import {
+	supportsIdTokenSignIn,
+	verifyProviderIdToken,
+} from "./verify-id-token";
+
+const ISSUER = "https://issuer.test";
+const AUDIENCE = "client-123";
+
+async function makeKeyset() {
+	const { publicKey, privateKey } = await generateKeyPair("RS256", {
+		extractable: true,
+	});
+	const jwk: JWK = await exportJWK(publicKey);
+	jwk.kid = "test-key";
+	jwk.alg = "RS256";
+	jwk.use = "sig";
+	const jwks = createLocalJWKSet({ keys: [jwk] });
+	const sign = (claims: Record<string, unknown>, key = privateKey) =>
+		new SignJWT(claims)
+			.setProtectedHeader({ alg: "RS256", kid: "test-key" })
+			.setIssuer(ISSUER)
+			.setAudience(AUDIENCE)
+			.setIssuedAt()
+			.setExpirationTime("1h")
+			.sign(key);
+	return { jwks, sign };
+}
+
+function providerWith(
+	idToken: OAuthIdTokenConfig | undefined,
+	options: Record<string, unknown> = {},
+): UpstreamProvider<any, any> {
+	return { idToken, options } as UpstreamProvider<any, any>;
+}
+
+const sha256Hex = (value: string) =>
+	createHash("sha256").update(value).digest("hex");
+
+describe("verifyProviderIdToken", () => {
+	it("accepts a correctly signed token with matching issuer, audience, and nonce", async () => {
+		const { jwks, sign } = await makeKeyset();
+		const token = await sign({ sub: "u1", nonce: "n1" });
+		const provider = providerWith({ jwks, issuer: ISSUER, audience: AUDIENCE });
+		expect(await verifyProviderIdToken(provider, token, "n1")).toBe(true);
+	});
+
+	it("rejects a token signed by a different key (forgery)", async () => {
+		const { jwks } = await makeKeyset();
+		const attacker = await generateKeyPair("RS256", { extractable: true });
+		const forged = await new SignJWT({ sub: "victim" })
+			.setProtectedHeader({ alg: "RS256", kid: "test-key" })
+			.setIssuer(ISSUER)
+			.setAudience(AUDIENCE)
+			.setIssuedAt()
+			.setExpirationTime("1h")
+			.sign(attacker.privateKey);
+		const provider = providerWith({ jwks, issuer: ISSUER, audience: AUDIENCE });
+		expect(await verifyProviderIdToken(provider, forged)).toBe(false);
+	});
+
+	it("rejects an unsigned alg:none token", async () => {
+		const { jwks } = await makeKeyset();
+		const seg = (o: unknown) =>
+			Buffer.from(JSON.stringify(o)).toString("base64url");
+		const none = `${seg({ alg: "none", kid: "test-key" })}.${seg({
+			sub: "victim",
+			iss: ISSUER,
+			aud: AUDIENCE,
+		})}.`;
+		const provider = providerWith({ jwks, issuer: ISSUER, audience: AUDIENCE });
+		expect(await verifyProviderIdToken(provider, none)).toBe(false);
+	});
+
+	it("rejects a wrong issuer or audience", async () => {
+		const { jwks, sign } = await makeKeyset();
+		const token = await sign({ sub: "u1" });
+		expect(
+			await verifyProviderIdToken(
+				providerWith({ jwks, issuer: "https://evil.test", audience: AUDIENCE }),
+				token,
+			),
+		).toBe(false);
+		expect(
+			await verifyProviderIdToken(
+				providerWith({ jwks, issuer: ISSUER, audience: "other-client" }),
+				token,
+			),
+		).toBe(false);
+	});
+
+	it("enforces nonce and supports exact-or-sha256 comparison", async () => {
+		const { jwks, sign } = await makeKeyset();
+		const raw = "raw-nonce";
+		const exact = providerWith({ jwks, issuer: ISSUER, audience: AUDIENCE });
+		const t1 = await sign({ sub: "u1", nonce: raw });
+		expect(await verifyProviderIdToken(exact, t1, raw)).toBe(true);
+		expect(await verifyProviderIdToken(exact, t1, "mismatch")).toBe(false);
+
+		const hashed = providerWith({
+			jwks,
+			issuer: ISSUER,
+			audience: AUDIENCE,
+			nonceComparison: "exact-or-sha256",
+		});
+		const t2 = await sign({ sub: "u1", nonce: sha256Hex(raw) });
+		expect(await verifyProviderIdToken(hashed, t2, raw)).toBe(true);
+	});
+
+	it("is fail-closed when no config and no override are present", async () => {
+		const { sign } = await makeKeyset();
+		const provider = providerWith(undefined);
+		expect(supportsIdTokenSignIn(provider)).toBe(false);
+		expect(
+			await verifyProviderIdToken(provider, await sign({ sub: "u1" })),
+		).toBe(false);
+	});
+
+	it("honors an options.verifyIdToken override", async () => {
+		const provider = providerWith(undefined, {
+			verifyIdToken: async () => true,
+		});
+		expect(supportsIdTokenSignIn(provider)).toBe(true);
+		expect(await verifyProviderIdToken(provider, "anything")).toBe(true);
+	});
+
+	it("honors disableIdTokenSignIn even with a valid config", async () => {
+		const { jwks, sign } = await makeKeyset();
+		const provider = providerWith(
+			{ jwks, issuer: ISSUER, audience: AUDIENCE },
+			{ disableIdTokenSignIn: true },
+		);
+		expect(
+			await verifyProviderIdToken(provider, await sign({ sub: "u1" })),
+		).toBe(false);
+	});
+
+	it("gates opaque (non-JWS) tokens behind allowOpaqueToken", async () => {
+		const { jwks } = await makeKeyset();
+		const opaque = "opaque-access-token";
+		expect(
+			await verifyProviderIdToken(
+				providerWith({
+					jwks,
+					issuer: ISSUER,
+					audience: AUDIENCE,
+					allowOpaqueToken: true,
+				}),
+				opaque,
+			),
+		).toBe(true);
+		expect(
+			await verifyProviderIdToken(
+				providerWith({ jwks, issuer: ISSUER, audience: AUDIENCE }),
+				opaque,
+			),
+		).toBe(false);
+	});
+
+	describe("provider regressions", () => {
+		it("PayPal no longer accepts client id_token sign-in", () => {
+			// Previously verifyIdToken returned true for any decodable token without
+			// checking the signature. PayPal resolves identity from the access token, so
+			// it now declares no id_token config and the client path is fail-closed.
+			const provider = paypal({ clientId: "c", clientSecret: "s" });
+			expect(supportsIdTokenSignIn(provider)).toBe(false);
+		});
+
+		it("Facebook supports id_token sign-in and still accepts opaque Graph tokens", async () => {
+			const provider = facebook({ clientId: "c", clientSecret: "s" });
+			expect(supportsIdTokenSignIn(provider)).toBe(true);
+			expect(
+				await verifyProviderIdToken(provider, "EAAGopaqueGraphAccessToken"),
+			).toBe(true);
+		});
+	});
+});

--- a/packages/core/src/oauth2/verify-id-token.test.ts
+++ b/packages/core/src/oauth2/verify-id-token.test.ts
@@ -30,7 +30,7 @@ async function makeKeyset() {
 			.setIssuedAt()
 			.setExpirationTime("1h")
 			.sign(key);
-	return { jwks, sign };
+	return { jwks, sign, privateKey };
 }
 
 function providerWith(
@@ -49,6 +49,19 @@ describe("verifyProviderIdToken", () => {
 		const token = await sign({ sub: "u1", nonce: "n1" });
 		const provider = providerWith({ jwks, issuer: ISSUER, audience: AUDIENCE });
 		expect(await verifyProviderIdToken(provider, token, "n1")).toBe(true);
+	});
+
+	it("accepts a signed token without a kid header when the JWKS resolves it", async () => {
+		const { jwks, privateKey } = await makeKeyset();
+		const token = await new SignJWT({ sub: "u1" })
+			.setProtectedHeader({ alg: "RS256" })
+			.setIssuer(ISSUER)
+			.setAudience(AUDIENCE)
+			.setIssuedAt()
+			.setExpirationTime("1h")
+			.sign(privateKey);
+		const provider = providerWith({ jwks, issuer: ISSUER, audience: AUDIENCE });
+		expect(await verifyProviderIdToken(provider, token)).toBe(true);
 	});
 
 	it("rejects a token signed by a different key (forgery)", async () => {

--- a/packages/core/src/oauth2/verify-id-token.ts
+++ b/packages/core/src/oauth2/verify-id-token.ts
@@ -76,14 +76,14 @@ export async function verifyProviderIdToken(
 		return config.allowOpaqueToken === true;
 	}
 	try {
-		const header = decodeProtectedHeader(token);
-		if (!header.kid || !header.alg) {
-			return false;
-		}
+		// `kid` is optional in JWS: a JWKS resolver can still select a key by algorithm, so
+		// key selection is left to config.jwks. The token's `alg` only seeds the default
+		// allowed-algorithms list when the provider does not pin one.
+		const { alg } = decodeProtectedHeader(token);
 		const { payload } = await jwtVerify(token, config.jwks, {
 			issuer: config.issuer,
 			audience: config.audience,
-			algorithms: config.algorithms ?? [header.alg],
+			algorithms: config.algorithms ?? (alg ? [alg] : undefined),
 			maxTokenAge: config.maxTokenAge,
 		});
 		if (

--- a/packages/core/src/oauth2/verify-id-token.ts
+++ b/packages/core/src/oauth2/verify-id-token.ts
@@ -1,0 +1,99 @@
+import { decodeProtectedHeader, jwtVerify } from "jose";
+import type { ProviderOptions, UpstreamProvider } from "./oauth-provider";
+
+async function sha256Hex(value: string) {
+	const data = new TextEncoder().encode(value);
+	const digest = await crypto.subtle.digest("SHA-256", data);
+	return Array.from(new Uint8Array(digest))
+		.map((byte) => byte.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+async function nonceMatches(
+	claimNonce: unknown,
+	nonce: string,
+	comparison: "exact" | "exact-or-sha256" = "exact",
+) {
+	if (typeof claimNonce !== "string") {
+		return false;
+	}
+	if (claimNonce === nonce) {
+		return true;
+	}
+	if (comparison === "exact-or-sha256") {
+		return claimNonce === (await sha256Hex(nonce));
+	}
+	return false;
+}
+
+/**
+ * Whether a provider can verify a client-submitted id_token.
+ *
+ * A provider supports id_token sign-in when it declares an {@link UpstreamProvider.idToken}
+ * verification config, or when the integrator supplies a `verifyIdToken` override on the
+ * provider options. Providers without either reject the client id_token sign-in path with
+ * `ID_TOKEN_NOT_SUPPORTED`.
+ */
+export function supportsIdTokenSignIn(provider: UpstreamProvider<any, any>) {
+	const options = (provider.options ?? {}) as Partial<ProviderOptions>;
+	return Boolean(provider.idToken || options.verifyIdToken);
+}
+
+/**
+ * Verify a client-submitted id_token against a provider's verification config.
+ *
+ * This is the single id_token verifier for every social provider. Providers no longer
+ * implement their own boolean `verifyIdToken`; they declare an {@link UpstreamProvider.idToken}
+ * config and this function performs the cryptographic check. The contract is fail-closed: a
+ * provider without a config (and without an integrator `verifyIdToken` override) returns
+ * `false`, so a forged token can never be accepted by omission.
+ *
+ * @returns `true` only when the token is authentic for the provider.
+ */
+export async function verifyProviderIdToken(
+	provider: UpstreamProvider<any, any>,
+	token: string,
+	nonce?: string,
+): Promise<boolean> {
+	const options = (provider.options ?? {}) as Partial<ProviderOptions>;
+	if (options.disableIdTokenSignIn) {
+		return false;
+	}
+	if (options.verifyIdToken) {
+		return options.verifyIdToken(token, nonce);
+	}
+	const config = provider.idToken;
+	if (!config) {
+		return false;
+	}
+	if ("verify" in config) {
+		return config.verify(token, nonce);
+	}
+	// Opaque (non-JWS) tokens carry no signature to check. They are accepted only when the
+	// provider opts in, in which case getUserInfo resolves identity from the access token via
+	// the provider's userinfo endpoint, which validates it (e.g. Facebook Graph access tokens).
+	if (token.split(".").length !== 3) {
+		return config.allowOpaqueToken === true;
+	}
+	try {
+		const header = decodeProtectedHeader(token);
+		if (!header.kid || !header.alg) {
+			return false;
+		}
+		const { payload } = await jwtVerify(token, config.jwks, {
+			issuer: config.issuer,
+			audience: config.audience,
+			algorithms: config.algorithms ?? [header.alg],
+			maxTokenAge: config.maxTokenAge,
+		});
+		if (
+			nonce &&
+			!(await nonceMatches(payload.nonce, nonce, config.nonceComparison))
+		) {
+			return false;
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/core/src/oauth2/verify-id-token.ts
+++ b/packages/core/src/oauth2/verify-id-token.ts
@@ -31,11 +31,14 @@ async function nonceMatches(
  *
  * A provider supports id_token sign-in when it declares an {@link UpstreamProvider.idToken}
  * verification config, or when the integrator supplies a `verifyIdToken` override on the
- * provider options. Providers without either reject the client id_token sign-in path with
- * `ID_TOKEN_NOT_SUPPORTED`.
+ * provider options. A provider whose options set `disableIdTokenSignIn`, or that declares
+ * neither, rejects the client id_token sign-in path with `ID_TOKEN_NOT_SUPPORTED`.
  */
 export function supportsIdTokenSignIn(provider: UpstreamProvider<any, any>) {
 	const options = (provider.options ?? {}) as Partial<ProviderOptions>;
+	if (options.disableIdTokenSignIn) {
+		return false;
+	}
 	return Boolean(provider.idToken || options.verifyIdToken);
 }
 
@@ -59,23 +62,26 @@ export async function verifyProviderIdToken(
 	if (options.disableIdTokenSignIn) {
 		return false;
 	}
-	if (options.verifyIdToken) {
-		return options.verifyIdToken(token, nonce);
-	}
-	const config = provider.idToken;
-	if (!config) {
-		return false;
-	}
-	if ("verify" in config) {
-		return config.verify(token, nonce);
-	}
-	// Opaque (non-JWS) tokens carry no signature to check. They are accepted only when the
-	// provider opts in, in which case getUserInfo resolves identity from the access token via
-	// the provider's userinfo endpoint, which validates it (e.g. Facebook Graph access tokens).
-	if (token.split(".").length !== 3) {
-		return config.allowOpaqueToken === true;
-	}
+	// Every verification path is fail-closed: a throw from the integrator override, a custom
+	// remote verifier, the JWKS resolver, or signature checking resolves to `false` instead of
+	// escaping to the caller as a server error.
 	try {
+		if (options.verifyIdToken) {
+			return await options.verifyIdToken(token, nonce);
+		}
+		const config = provider.idToken;
+		if (!config) {
+			return false;
+		}
+		if ("verify" in config) {
+			return await config.verify(token, nonce);
+		}
+		// Opaque (non-JWS) tokens carry no signature to check. They are accepted only when the
+		// provider opts in, in which case getUserInfo resolves identity from the access token via
+		// the provider's userinfo endpoint, which validates it (e.g. Facebook Graph access tokens).
+		if (token.split(".").length !== 3) {
+			return config.allowOpaqueToken === true;
+		}
 		// `kid` is optional in JWS: a JWKS resolver can still select a key by algorithm, so
 		// key selection is left to config.jwks. The token's `alg` only seeds the default
 		// allowed-algorithms list when the provider does not pin one.

--- a/packages/core/src/social-providers/apple.test.ts
+++ b/packages/core/src/social-providers/apple.test.ts
@@ -10,6 +10,7 @@ vi.mock("@better-fetch/fetch", () => ({
 
 import { betterFetch } from "@better-fetch/fetch";
 
+import { verifyProviderIdToken } from "../oauth2";
 import { apple } from "./apple";
 
 const mockedBetterFetch = vi.mocked(betterFetch);
@@ -46,7 +47,7 @@ function mockAppleJwks(publicJWK: JWK) {
 	} as Awaited<ReturnType<typeof betterFetch>>);
 }
 
-describe("apple.verifyIdToken", () => {
+describe("apple id_token verification", () => {
 	beforeEach(() => {
 		mockedBetterFetch.mockReset();
 	});
@@ -62,7 +63,9 @@ describe("apple.verifyIdToken", () => {
 			appBundleIdentifier: "com.example.app",
 		});
 
-		await expect(provider.verifyIdToken(token, rawNonce)).resolves.toBe(true);
+		await expect(
+			verifyProviderIdToken(provider, token, rawNonce),
+		).resolves.toBe(true);
 	});
 
 	it("accepts a hashed token nonce when the request provides the raw native iOS nonce", async () => {
@@ -77,7 +80,9 @@ describe("apple.verifyIdToken", () => {
 			appBundleIdentifier: "com.example.app",
 		});
 
-		await expect(provider.verifyIdToken(token, rawNonce)).resolves.toBe(true);
+		await expect(
+			verifyProviderIdToken(provider, token, rawNonce),
+		).resolves.toBe(true);
 	});
 
 	it("rejects a mismatched nonce", async () => {
@@ -93,7 +98,7 @@ describe("apple.verifyIdToken", () => {
 		});
 
 		await expect(
-			provider.verifyIdToken(token, "different-nonce"),
+			verifyProviderIdToken(provider, token, "different-nonce"),
 		).resolves.toBe(false);
 	});
 });

--- a/packages/core/src/social-providers/apple.ts
+++ b/packages/core/src/social-providers/apple.ts
@@ -1,6 +1,6 @@
 import { betterFetch } from "@better-fetch/fetch";
 
-import { decodeJwt, decodeProtectedHeader, importJWK, jwtVerify } from "jose";
+import { decodeJwt, importJWK } from "jose";
 import { logger } from "../env";
 import { APIError, BetterAuthError } from "../error";
 import type { ProviderOptions, UpstreamProvider } from "../oauth2";
@@ -78,24 +78,6 @@ export interface AppleOptions extends ProviderOptions<AppleProfile> {
 	audience?: (string | string[]) | undefined;
 }
 
-async function sha256Hex(value: string) {
-	const data = new TextEncoder().encode(value);
-	const digest = await crypto.subtle.digest("SHA-256", data);
-	return Array.from(new Uint8Array(digest))
-		.map((byte) => byte.toString(16).padStart(2, "0"))
-		.join("");
-}
-
-async function nonceMatches(jwtNonce: unknown, nonce: string) {
-	if (typeof jwtNonce !== "string") {
-		return false;
-	}
-	if (jwtNonce === nonce) {
-		return true;
-	}
-	return jwtNonce === (await sha256Hex(nonce));
-}
-
 const APPLE_DEFAULT_SCOPES = ["email", "name"];
 
 export const apple = (options: AppleOptions) => {
@@ -142,41 +124,17 @@ export const apple = (options: AppleOptions) => {
 				tokenEndpoint,
 			});
 		},
-		async verifyIdToken(token, nonce) {
-			if (options.disableIdTokenSignIn) {
-				return false;
-			}
-			if (options.verifyIdToken) {
-				return options.verifyIdToken(token, nonce);
-			}
-			try {
-				const decodedHeader = decodeProtectedHeader(token);
-				const { kid, alg: jwtAlg } = decodedHeader;
-				if (!kid || !jwtAlg) return false;
-				const publicKey = await getApplePublicKey(kid);
-				const { payload: jwtClaims } = await jwtVerify(token, publicKey, {
-					algorithms: [jwtAlg],
-					issuer: "https://appleid.apple.com",
-					audience:
-						options.audience && options.audience.length
-							? options.audience
-							: options.appBundleIdentifier
-								? options.appBundleIdentifier
-								: options.clientId,
-					maxTokenAge: "1h",
-				});
-				["email_verified", "is_private_email"].forEach((field) => {
-					if (jwtClaims[field] !== undefined) {
-						jwtClaims[field] = Boolean(jwtClaims[field]);
-					}
-				});
-				if (nonce && !(await nonceMatches(jwtClaims.nonce, nonce))) {
-					return false;
-				}
-				return !!jwtClaims;
-			} catch {
-				return false;
-			}
+		idToken: {
+			jwks: (header) => getApplePublicKey(header.kid!),
+			issuer: "https://appleid.apple.com",
+			audience:
+				options.audience && options.audience.length
+					? options.audience
+					: options.appBundleIdentifier
+						? options.appBundleIdentifier
+						: options.clientId,
+			maxTokenAge: "1h",
+			nonceComparison: "exact-or-sha256",
 		},
 		refreshAccessToken: options.refreshAccessToken
 			? options.refreshAccessToken

--- a/packages/core/src/social-providers/cognito.ts
+++ b/packages/core/src/social-providers/cognito.ts
@@ -1,5 +1,5 @@
 import { betterFetch } from "@better-fetch/fetch";
-import { decodeJwt, decodeProtectedHeader, importJWK, jwtVerify } from "jose";
+import { decodeJwt, importJWK } from "jose";
 import { logger } from "../env";
 import { APIError, BetterAuthError } from "../error";
 import type { ProviderOptions, UpstreamProvider } from "../oauth2";
@@ -162,41 +162,12 @@ export const cognito = (options: CognitoOptions) => {
 					});
 				},
 
-		async verifyIdToken(token, nonce) {
-			if (options.disableIdTokenSignIn) {
-				return false;
-			}
-			if (options.verifyIdToken) {
-				return options.verifyIdToken(token, nonce);
-			}
-
-			try {
-				const decodedHeader = decodeProtectedHeader(token);
-				const { kid, alg: jwtAlg } = decodedHeader;
-				if (!kid || !jwtAlg) return false;
-
-				const publicKey = await getCognitoPublicKey(
-					kid,
-					options.region,
-					options.userPoolId,
-				);
-				const expectedIssuer = `https://cognito-idp.${options.region}.amazonaws.com/${options.userPoolId}`;
-
-				const { payload: jwtClaims } = await jwtVerify(token, publicKey, {
-					algorithms: [jwtAlg],
-					issuer: expectedIssuer,
-					audience: options.clientId,
-					maxTokenAge: "1h",
-				});
-
-				if (nonce && jwtClaims.nonce !== nonce) {
-					return false;
-				}
-				return true;
-			} catch (error) {
-				logger.error("Failed to verify ID token:", error);
-				return false;
-			}
+		idToken: {
+			jwks: (header) =>
+				getCognitoPublicKey(header.kid!, options.region, options.userPoolId),
+			issuer: `https://cognito-idp.${options.region}.amazonaws.com/${options.userPoolId}`,
+			audience: options.clientId,
+			maxTokenAge: "1h",
 		},
 
 		async getUserInfo(token) {

--- a/packages/core/src/social-providers/facebook.ts
+++ b/packages/core/src/social-providers/facebook.ts
@@ -1,5 +1,5 @@
 import { betterFetch } from "@better-fetch/fetch";
-import { createRemoteJWKSet, decodeJwt, jwtVerify } from "jose";
+import { createRemoteJWKSet, decodeJwt } from "jose";
 import { logger } from "../env";
 import { BetterAuthError } from "../error";
 import type { ProviderOptions, UpstreamProvider } from "../oauth2";
@@ -87,46 +87,17 @@ export const facebook = (options: FacebookOptions) => {
 				tokenEndpoint: "https://graph.facebook.com/v24.0/oauth/access_token",
 			});
 		},
-		async verifyIdToken(token, nonce) {
-			if (options.disableIdTokenSignIn) {
-				return false;
-			}
-
-			if (options.verifyIdToken) {
-				return options.verifyIdToken(token, nonce);
-			}
-
-			/* limited login */
-			// check is limited token
-			if (token.split(".").length === 3) {
-				try {
-					const { payload: jwtClaims } = await jwtVerify(
-						token,
-						createRemoteJWKSet(
-							// https://developers.facebook.com/docs/facebook-login/limited-login/token/#jwks
-							new URL(
-								"https://limited.facebook.com/.well-known/oauth/openid/jwks/",
-							),
-						),
-						{
-							algorithms: ["RS256"],
-							audience: options.clientId,
-							issuer: "https://www.facebook.com",
-						},
-					);
-
-					if (nonce && jwtClaims.nonce !== nonce) {
-						return false;
-					}
-
-					return !!jwtClaims;
-				} catch {
-					return false;
-				}
-			}
-
-			/* access_token */
-			return true;
+		idToken: {
+			// https://developers.facebook.com/docs/facebook-login/limited-login/token/#jwks
+			jwks: createRemoteJWKSet(
+				new URL("https://limited.facebook.com/.well-known/oauth/openid/jwks/"),
+			),
+			issuer: "https://www.facebook.com",
+			audience: options.clientId,
+			algorithms: ["RS256"],
+			// Facebook also accepts an opaque Graph access token on the client sign-in path;
+			// identity is then resolved by getUserInfo via the Graph API, which validates it.
+			allowOpaqueToken: true,
 		},
 		refreshAccessToken: options.refreshAccessToken
 			? options.refreshAccessToken

--- a/packages/core/src/social-providers/google.ts
+++ b/packages/core/src/social-providers/google.ts
@@ -1,5 +1,5 @@
 import { betterFetch } from "@better-fetch/fetch";
-import { decodeJwt, decodeProtectedHeader, importJWK, jwtVerify } from "jose";
+import { decodeJwt, importJWK } from "jose";
 import { logger } from "../env";
 import { APIError, BetterAuthError } from "../error";
 import type { ProviderOptions, UpstreamProvider } from "../oauth2";
@@ -141,37 +141,12 @@ export const google = (options: GoogleOptions) => {
 						tokenEndpoint: "https://oauth2.googleapis.com/token",
 					});
 				},
-		async verifyIdToken(token, nonce) {
-			if (options.disableIdTokenSignIn) {
-				return false;
-			}
-			if (options.verifyIdToken) {
-				return options.verifyIdToken(token, nonce);
-			}
-
-			// Verify JWT integrity
-			// See https://developers.google.com/identity/sign-in/web/backend-auth#verify-the-integrity-of-the-id-token
-
-			try {
-				const { kid, alg: jwtAlg } = decodeProtectedHeader(token);
-				if (!kid || !jwtAlg) return false;
-
-				const publicKey = await getGooglePublicKey(kid);
-				const { payload: jwtClaims } = await jwtVerify(token, publicKey, {
-					algorithms: [jwtAlg],
-					issuer: ["https://accounts.google.com", "accounts.google.com"],
-					audience: options.clientId,
-					maxTokenAge: "1h",
-				});
-
-				if (nonce && jwtClaims.nonce !== nonce) {
-					return false;
-				}
-
-				return true;
-			} catch {
-				return false;
-			}
+		idToken: {
+			// https://developers.google.com/identity/sign-in/web/backend-auth#verify-the-integrity-of-the-id-token
+			jwks: (header) => getGooglePublicKey(header.kid!),
+			issuer: ["https://accounts.google.com", "accounts.google.com"],
+			audience: options.clientId,
+			maxTokenAge: "1h",
 		},
 		async getUserInfo(token) {
 			if (options.getUserInfo) {

--- a/packages/core/src/social-providers/line.ts
+++ b/packages/core/src/social-providers/line.ts
@@ -100,34 +100,30 @@ export const line = (options: LineOptions) => {
 						tokenEndpoint,
 					});
 				},
-		async verifyIdToken(token, nonce) {
-			if (options.disableIdTokenSignIn) {
-				return false;
-			}
-			if (options.verifyIdToken) {
-				return options.verifyIdToken(token, nonce);
-			}
-			const body = new URLSearchParams();
-			body.set("id_token", token);
-			body.set("client_id", options.clientId);
-			if (nonce) body.set("nonce", nonce);
-			const { data, error } = await betterFetch<LineIdTokenPayload>(
-				verifyIdTokenEndpoint,
-				{
-					method: "POST",
-					headers: {
-						"content-type": "application/x-www-form-urlencoded",
+		idToken: {
+			verify: async (token, nonce) => {
+				const body = new URLSearchParams();
+				body.set("id_token", token);
+				body.set("client_id", options.clientId);
+				if (nonce) body.set("nonce", nonce);
+				const { data, error } = await betterFetch<LineIdTokenPayload>(
+					verifyIdTokenEndpoint,
+					{
+						method: "POST",
+						headers: {
+							"content-type": "application/x-www-form-urlencoded",
+						},
+						body,
 					},
-					body,
-				},
-			);
-			if (error || !data) {
-				return false;
-			}
-			// aud must match clientId; nonce (if provided) must also match nonce
-			if (data.aud !== options.clientId) return false;
-			if (data.nonce && data.nonce !== nonce) return false;
-			return true;
+				);
+				if (error || !data) {
+					return false;
+				}
+				// aud must match clientId; nonce (if provided) must also match nonce
+				if (data.aud !== options.clientId) return false;
+				if (data.nonce && data.nonce !== nonce) return false;
+				return true;
+			},
 		},
 		async getUserInfo(token) {
 			if (options.getUserInfo) {

--- a/packages/core/src/social-providers/microsoft-entra-id.ts
+++ b/packages/core/src/social-providers/microsoft-entra-id.ts
@@ -1,6 +1,6 @@
 import { base64 } from "@better-auth/utils/base64";
 import { betterFetch } from "@better-fetch/fetch";
-import { decodeJwt, decodeProtectedHeader, importJWK, jwtVerify } from "jose";
+import { decodeJwt, importJWK } from "jose";
 import { logger } from "../env";
 import { APIError, BetterAuthError } from "../error";
 import type { ProviderOptions, UpstreamProvider } from "../oauth2";
@@ -196,55 +196,21 @@ export const microsoft = (options: MicrosoftOptions) => {
 				tokenEndpoint,
 			});
 		},
-		async verifyIdToken(token, nonce) {
-			if (options.disableIdTokenSignIn) {
-				return false;
-			}
-			if (options.verifyIdToken) {
-				return options.verifyIdToken(token, nonce);
-			}
-
-			try {
-				const { kid, alg: jwtAlg } = decodeProtectedHeader(token);
-				if (!kid || !jwtAlg) return false;
-
-				const publicKey = await getMicrosoftPublicKey(kid, tenant, authority);
-				const verifyOptions: {
-					algorithms: [string];
-					audience: string | string[];
-					maxTokenAge: string;
-					issuer?: string;
-				} = {
-					algorithms: [jwtAlg],
-					audience: options.clientId,
-					maxTokenAge: "1h",
-				};
-				/**
-				 * Issuer varies per user's tenant for multi-tenant endpoints, so only validate for specific tenants.
-				 * @see https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols#endpoints
-				 */
-				if (
-					tenant !== "common" &&
-					tenant !== "organizations" &&
-					tenant !== "consumers"
-				) {
-					verifyOptions.issuer = `${authority}/${tenant}/v2.0`;
-				}
-				const { payload: jwtClaims } = await jwtVerify(
-					token,
-					publicKey,
-					verifyOptions,
-				);
-
-				if (nonce && jwtClaims.nonce !== nonce) {
-					return false;
-				}
-
-				return true;
-			} catch (error) {
-				logger.error("Failed to verify ID token:", error);
-				return false;
-			}
+		idToken: {
+			jwks: (header) => getMicrosoftPublicKey(header.kid!, tenant, authority),
+			audience: options.clientId,
+			maxTokenAge: "1h",
+			/**
+			 * Issuer varies per tenant for multi-tenant endpoints, so only validate it for
+			 * specific tenants.
+			 * @see https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols#endpoints
+			 */
+			issuer:
+				tenant !== "common" &&
+				tenant !== "organizations" &&
+				tenant !== "consumers"
+					? `${authority}/${tenant}/v2.0`
+					: undefined,
 		},
 		async getUserInfo(token) {
 			if (options.getUserInfo) {

--- a/packages/core/src/social-providers/paypal.ts
+++ b/packages/core/src/social-providers/paypal.ts
@@ -1,6 +1,5 @@
 import { base64 } from "@better-auth/utils/base64";
 import { betterFetch } from "@better-fetch/fetch";
-import { decodeJwt } from "jose";
 import { logger } from "../env";
 import { BetterAuthError } from "../error";
 import type { ProviderOptions, UpstreamProvider } from "../oauth2";
@@ -197,22 +196,6 @@ export const paypal = (options: PayPalOptions) => {
 						throw new BetterAuthError("FAILED_TO_REFRESH_ACCESS_TOKEN");
 					}
 				},
-
-		async verifyIdToken(token, nonce) {
-			if (options.disableIdTokenSignIn) {
-				return false;
-			}
-			if (options.verifyIdToken) {
-				return options.verifyIdToken(token, nonce);
-			}
-			try {
-				const payload = decodeJwt(token);
-				return !!payload.sub;
-			} catch (error) {
-				logger.error("Failed to verify PayPal ID token:", error);
-				return false;
-			}
-		},
 
 		async getUserInfo(token) {
 			if (options.getUserInfo) {


### PR DESCRIPTION
Every social provider verified client-submitted id_tokens with its own `verifyIdToken` method. The method returned a boolean, so a provider could return `true` without checking the signature, and the verification logic was duplicated across providers. This change replaces the per-provider method with a declarative `idToken` config that one core verifier consumes. A provider supplies a JWKS source, issuer, and audience, and the verifier runs the signature, issuer, audience, and nonce checks. A provider that declares no config rejects the client id_token path instead of accepting the token.

The PayPal provider's `verifyIdToken` decoded the token and returned `true` whenever it carried a `sub` claim, without verifying the signature. PayPal derives identity from the access token rather than the id_token, so it now declares no `idToken` config, and the client id_token path returns `ID_TOKEN_NOT_SUPPORTED`. PayPal sign-in through the redirect flow is unchanged. Facebook accepted opaque Graph access tokens on the same path through an unconditional `return true`; that case is now an explicit `allowOpaqueToken` flag.

This removes `OAuthProvider.verifyIdToken`. A custom provider that implements `OAuthProvider` directly replaces the method with an `idToken` config: `{ jwks, issuer, audience }` for JWKS verification, or `{ verify }` for verification against a remote endpoint. The `verifyIdToken` and `disableIdTokenSignIn` options on provider configs are unchanged.
