### PR TITLE
fix(core): throw on non-numeric deleteMany in `consumeOne` fallback

### DIFF
--- a/.changeset/short-steaks-add.md
+++ b/.changeset/short-steaks-add.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Surface a clear error when an adapter's `deleteMany` returns a non-numeric value in the `consumeOne` fallback, instead of silently failing the consume.

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -143,4 +143,29 @@ describe("createAdapterFactory consumeOne fallback", () => {
 
 		expect(result).toBeNull();
 	});
+
+	it("throws when deleteMany returns a non-numeric value", async () => {
+		const adapter = createTestAdapter({
+			adapter: createCustomAdapter({
+				findMany: async <T>() =>
+					[
+						{
+							id: "verification-id",
+							identifier_text: "stored-token",
+						},
+					] as T[],
+				// A misbehaving adapter (e.g. a document store returning the raw
+				// delete response) breaks the count-based race gate. The fallback
+				// must surface this instead of reporting a spurious miss.
+				deleteMany: async () => ({ deleted: true }) as unknown as number,
+			}),
+		});
+
+		await expect(
+			adapter.consumeOne({
+				model: "verification",
+				where: [{ field: "identifier", value: "token" }],
+			}),
+		).rejects.toThrowError(/non-numeric value from deleteMany/);
+	});
 });

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -1391,6 +1391,12 @@ export const createAdapterFactory =
 										},
 									],
 								});
+								// A non-numeric count coerces to a false miss, so fail loud.
+								if (typeof deleted !== "number") {
+									throw new BetterAuthError(
+										`Adapter "${config.adapterId}" returned a non-numeric value from deleteMany during the consumeOne fallback. Return the number of deleted rows, or implement a native consumeOne for atomic single-use consumption.`,
+									);
+								}
 								return deleted > 0 ? (target as T) : null;
 							}),
 					);


### PR DESCRIPTION
Related to #9819 (closed)

The guidance around this contract has existed for a long time, but I think it's better to make it explicit rather than failing silently.

cc @gustavovalverde 