### PR TITLE
fix(oauth-provider): enforce clientPrivileges on dynamic client registration

### DIFF
--- a/.changeset/oauth-provider-dcr-privilege-gate.md
+++ b/.changeset/oauth-provider-dcr-privilege-gate.md
@@ -1,0 +1,9 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Enforce the `clientPrivileges` create check on dynamic client registration.
+
+`POST /oauth2/register` reached OAuth client persistence without the create gate that `/oauth2/create-client` and `/admin/oauth2/create-client` enforced. A deployment that restricted client creation through `clientPrivileges` could still let any authenticated user register a confidential client and receive a `client_secret`. The create check now runs at the single client-creation chokepoint, so every registration route enforces it by construction.
+
+Unauthenticated public-client registration through `allowUnauthenticatedClientRegistration` is unchanged.

--- a/packages/oauth-provider/src/oauthClient/endpoints-privileges.test.ts
+++ b/packages/oauth-provider/src/oauthClient/endpoints-privileges.test.ts
@@ -352,4 +352,135 @@ describe("oauthClient", async () => {
 
 		expect(clientPrivileges).toHaveBeenCalledTimes(1);
 	});
+
+	it("should not create client via admin api without a session", async () => {
+		try {
+			await auth.api.adminCreateOAuthClient({
+				body: {
+					...testClientInput,
+					redirect_uris: [redirectUri],
+				},
+			});
+			throw new Error("should have thrown");
+		} catch (error) {
+			expect(error).toBeInstanceOf(APIError);
+			if (error instanceof APIError) {
+				expect(error.statusCode).toBe(401);
+				expect(error.status).toBe("UNAUTHORIZED");
+			}
+		}
+	});
+});
+
+/**
+ * Dynamic Client Registration must enforce the same clientPrivileges "create"
+ * gate as the create-client endpoints. The gate lives in the shared creation
+ * chokepoint, so every creation route inherits it; a forbidden authenticated
+ * user cannot mint a client through registration, while the unauthenticated
+ * public-client path stays open and never consults the hook.
+ *
+ * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-jmcv-4jfc-6qqj
+ */
+describe("oauthClient dynamic registration privileges", async () => {
+	const baseUrl = "http://localhost:3000";
+	const redirectUri = "http://localhost:5000/callback";
+	const allowedUser = {
+		email: "dcr-allowed@test.com",
+		password: "test123456",
+		name: "dcr allowed user",
+	};
+	const forbiddenUser = {
+		email: "dcr-forbidden@test.com",
+		password: "test123456",
+		name: "dcr forbidden user",
+	};
+	const clientPrivileges = vi.fn(({ user }) => {
+		if (user?.email === allowedUser.email) {
+			return true;
+		}
+		return false;
+	});
+	const { auth, customFetchImpl, signInWithUser } = await getTestInstance({
+		baseURL: baseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				allowUnauthenticatedClientRegistration: true,
+				clientPrivileges,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	await auth.api.signUpEmail({ body: allowedUser });
+	await auth.api.signUpEmail({ body: forbiddenUser });
+	const { headers: allowedUserHeaders } = await signInWithUser(
+		allowedUser.email,
+		allowedUser.password,
+	);
+	const { headers: forbiddenUserHeaders } = await signInWithUser(
+		forbiddenUser.email,
+		forbiddenUser.password,
+	);
+
+	const allowedAuthClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: baseUrl,
+		fetchOptions: { customFetchImpl, headers: allowedUserHeaders },
+	});
+	const forbiddenAuthClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: baseUrl,
+		fetchOptions: { customFetchImpl, headers: forbiddenUserHeaders },
+	});
+	const unauthedAuthClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: baseUrl,
+		fetchOptions: { customFetchImpl },
+	});
+
+	beforeEach(() => {
+		clientPrivileges.mockClear();
+	});
+
+	it("should not register a client for a forbidden user", async () => {
+		const client = await forbiddenAuthClient.oauth2.register({
+			redirect_uris: [redirectUri],
+		});
+		expect(client.error).toMatchObject({
+			status: 401,
+			statusText: "UNAUTHORIZED",
+		});
+		expect(client.data?.client_secret).toBeUndefined();
+		expect(clientPrivileges).toHaveBeenCalledWith(
+			expect.objectContaining({ action: "create" }),
+		);
+	});
+
+	it("should register a client for an allowed user", async () => {
+		const client = await allowedAuthClient.oauth2.register({
+			redirect_uris: [redirectUri],
+		});
+		expect(client.data?.client_id).toBeDefined();
+		expect(client.data?.client_secret).toBeDefined();
+		expect(clientPrivileges).toHaveBeenCalledWith(
+			expect.objectContaining({ action: "create" }),
+		);
+	});
+
+	it("should allow unauthenticated public registration without invoking the gate", async () => {
+		const client = await unauthedAuthClient.oauth2.register({
+			token_endpoint_auth_method: "none",
+			redirect_uris: [redirectUri],
+		});
+		expect(client.data?.client_id).toBeDefined();
+		expect(client.data?.client_secret).toBeUndefined();
+		expect(client.data?.public).toBe(true);
+		expect(clientPrivileges).not.toHaveBeenCalled();
+	});
 });

--- a/packages/oauth-provider/src/oauthClient/endpoints.ts
+++ b/packages/oauth-provider/src/oauthClient/endpoints.ts
@@ -5,6 +5,7 @@ import { checkOAuthClient, oauthToSchema, schemaToOAuth } from "../register";
 import type { OAuthOptions, SchemaClient, Scope } from "../types";
 import type { OAuthClient } from "../types/oauth";
 import { getClient, storeClientSecret } from "../utils";
+import { assertClientPrivileges } from "./privileges";
 
 export async function getClientEndpoint(
 	ctx: GenericEndpointContext & { query: { client_id: string } },
@@ -317,25 +318,4 @@ export async function rotateClientSecretEndpoint(
 		...updatedClient,
 		clientSecret: (opts.prefix?.clientSecret ?? "") + clientSecret,
 	});
-}
-
-export async function assertClientPrivileges(
-	ctx: GenericEndpointContext,
-	session: Awaited<ReturnType<typeof getSessionFromCtx>>,
-	opts: OAuthOptions<Scope[]>,
-	action: "create" | "read" | "update" | "delete" | "list" | "rotate",
-) {
-	if (!session) throw new APIError("UNAUTHORIZED");
-	if (!ctx.headers) throw new APIError("BAD_REQUEST");
-	if (
-		opts.clientPrivileges &&
-		!(await opts.clientPrivileges({
-			headers: ctx.headers,
-			action,
-			session: session.session,
-			user: session.user,
-		}))
-	) {
-		throw new APIError("UNAUTHORIZED");
-	}
 }

--- a/packages/oauth-provider/src/oauthClient/index.ts
+++ b/packages/oauth-provider/src/oauthClient/index.ts
@@ -1,15 +1,10 @@
-import {
-	createAuthEndpoint,
-	getSessionFromCtx,
-	sessionMiddleware,
-} from "better-auth/api";
+import { createAuthEndpoint, sessionMiddleware } from "better-auth/api";
 import * as z from "zod";
 import { publicSessionMiddleware } from "../middleware";
 import { createOAuthClientEndpoint } from "../register";
 import type { OAuthOptions, Scope } from "../types";
 import { SafeUrlSchema } from "../types/zod";
 import {
-	assertClientPrivileges,
 	deleteClientEndpoint,
 	getClientEndpoint,
 	getClientPublicEndpoint,
@@ -224,8 +219,6 @@ export const adminCreateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 			},
 		},
 		async (ctx) => {
-			const session = await getSessionFromCtx(ctx);
-			await assertClientPrivileges(ctx, session, opts, "create");
 			return createOAuthClientEndpoint(ctx, opts, {
 				isRegister: false,
 			});
@@ -422,8 +415,6 @@ export const createOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 			},
 		},
 		async (ctx) => {
-			const session = await getSessionFromCtx(ctx);
-			await assertClientPrivileges(ctx, session, opts, "create");
 			return createOAuthClientEndpoint(ctx, opts, {
 				isRegister: false,
 			});

--- a/packages/oauth-provider/src/oauthClient/privileges.ts
+++ b/packages/oauth-provider/src/oauthClient/privileges.ts
@@ -1,0 +1,35 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import type { getSessionFromCtx } from "better-auth/api";
+import { APIError } from "better-auth/api";
+import type { OAuthOptions, Scope } from "../types";
+
+/**
+ * Authorizes a client action against the configured `clientPrivileges` hook.
+ *
+ * This is the single authorization helper for every OAuth client mutation. The
+ * create path enforces it at the shared creation chokepoint so that no
+ * registration route can reach client persistence without it.
+ *
+ * @throws APIError UNAUTHORIZED when there is no session or the hook denies the action.
+ * @throws APIError BAD_REQUEST when the request carries no headers.
+ */
+export async function assertClientPrivileges(
+	ctx: GenericEndpointContext,
+	session: Awaited<ReturnType<typeof getSessionFromCtx>>,
+	opts: OAuthOptions<Scope[]>,
+	action: "create" | "read" | "update" | "delete" | "list" | "rotate",
+) {
+	if (!session) throw new APIError("UNAUTHORIZED");
+	if (!ctx.headers) throw new APIError("BAD_REQUEST");
+	if (
+		opts.clientPrivileges &&
+		!(await opts.clientPrivileges({
+			headers: ctx.headers,
+			action,
+			session: session.session,
+			user: session.user,
+		}))
+	) {
+		throw new APIError("UNAUTHORIZED");
+	}
+}

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -2,6 +2,7 @@ import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError, getSessionFromCtx } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
 import { toExpJWT } from "better-auth/plugins";
+import { assertClientPrivileges } from "./oauthClient/privileges";
 import type { OAuthOptions, SchemaClient, Scope } from "./types";
 import type { OAuthClient, TokenEndpointAuthMethod } from "./types/oauth";
 import { parseClientMetadata, storeClientSecret } from "./utils";
@@ -204,6 +205,21 @@ export async function createOAuthClientEndpoint(
 ) {
 	const body = ctx.body as OAuthClient;
 	const session = await getSessionFromCtx(ctx);
+
+	// Single authorization chokepoint for OAuth client creation. Every creation
+	// route reaches this function, so the create gate lives here rather than in
+	// each caller. Dynamic registration may be anonymous when
+	// allowUnauthenticatedClientRegistration is enabled, and registerEndpoint
+	// constrains that path to public clients, so it is authorized only when a
+	// session is present. Every other creation route requires an authorized
+	// session; assertClientPrivileges throws when none is present.
+	if (settings.isRegister) {
+		if (session) {
+			await assertClientPrivileges(ctx, session, opts, "create");
+		}
+	} else {
+		await assertClientPrivileges(ctx, session, opts, "create");
+	}
 
 	// Determine whether registration request for public client
 	// https://datatracker.ietf.org/doc/html/rfc7591#section-2


### PR DESCRIPTION
Dynamic client registration (`POST /oauth2/register`) now enforces the `clientPrivileges` create check that `/oauth2/create-client` and `/admin/oauth2/create-client` already applied. The three OAuth client creation routes share one persistence path. The create authorization check lived in only two of the three callers, so registration reached client creation without it. A deployment that configured `clientPrivileges` to restrict who can create clients did not have that restriction applied to registration.

This moves the check into `createOAuthClientEndpoint`, the single function all three routes call and the only place a client row is written. Every route now enforces the check by construction. Dynamic registration may be anonymous when `allowUnauthenticatedClientRegistration` is enabled, so it authorizes only when a session is present; every other creation route requires an authorized session. The two create-client handlers drop their now-redundant pre-call checks. The privilege helper moves to its own module, so the create path no longer forms an import cycle.

Unauthenticated public-client registration is unchanged. Deployments that do not configure `clientPrivileges` see no behavior change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the `clientPrivileges` create gate for dynamic client registration in `@better-auth/oauth-provider` by moving the check into `createOAuthClientEndpoint`. This prevents forbidden users from registering confidential clients; unauthenticated public-client registration is unchanged.

- **Bug Fixes**
  - Authorization now runs at the single client-creation chokepoint used by all routes.
  - Registration invokes the gate only when a session exists; other creation routes always require it.
  - No change when `allowUnauthenticatedClientRegistration` is used for public clients.

- **Refactors**
  - Moved `assertClientPrivileges` to `oauthClient/privileges.ts` to avoid import cycles.
  - Removed redundant pre-call checks in `createOAuthClient` and `adminCreateOAuthClient`.
  - Added tests covering dynamic registration privilege enforcement.

<sup>Written for commit e376af06a4d7a961a1980ecbeb6f958ee0ca677f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

