### PR TITLE
fix: accept null for optional fields in generated schema

### DIFF
--- a/.changeset/optional-fields-accept-null.md
+++ b/.changeset/optional-fields-accept-null.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+Optional fields (`required: false`) now accept `null`, not just omission. The
+generated input validation previously rejected `null` even though the column is
+nullable, so a nullable field could not be cleared by passing `null`.

--- a/packages/better-auth/src/db/to-zod.test.ts
+++ b/packages/better-auth/src/db/to-zod.test.ts
@@ -33,9 +33,6 @@ describe("toZodSchema", () => {
 		});
 	});
 
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/9829
-	 */
 	describe("required: false field nullability", () => {
 		it("should accept null, undefined, and a value for an optional field", () => {
 			const schema = toZodSchema({

--- a/packages/better-auth/src/db/to-zod.test.ts
+++ b/packages/better-auth/src/db/to-zod.test.ts
@@ -32,4 +32,33 @@ describe("toZodSchema", () => {
 			expect(schema.shape).not.toHaveProperty("secretField");
 		});
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9829
+	 */
+	describe("required: false field nullability", () => {
+		it("should accept null, undefined, and a value for an optional field", () => {
+			const schema = toZodSchema({
+				fields: {
+					logo: { type: "string", required: false },
+				},
+				isClientSide: true,
+			});
+
+			expect(schema.parse({ logo: null })).toEqual({ logo: null });
+			expect(schema.parse({ logo: undefined })).toEqual({});
+			expect(schema.parse({ logo: "value" })).toEqual({ logo: "value" });
+		});
+
+		it("should reject null for a required field", () => {
+			const schema = toZodSchema({
+				fields: {
+					name: { type: "string", required: true },
+				},
+				isClientSide: true,
+			});
+
+			expect(schema.safeParse({ name: null }).success).toBe(false);
+		});
+	});
 });

--- a/packages/better-auth/src/db/to-zod.test.ts
+++ b/packages/better-auth/src/db/to-zod.test.ts
@@ -43,7 +43,8 @@ describe("toZodSchema", () => {
 			});
 
 			expect(schema.parse({ logo: null })).toEqual({ logo: null });
-			expect(schema.parse({ logo: undefined })).toEqual({});
+			expect(schema.safeParse({ logo: undefined }).success).toBe(true);
+			expect(schema.parse({})).toEqual({});
 			expect(schema.parse({ logo: "value" })).toEqual({ logo: "value" });
 		});
 

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -36,7 +36,7 @@ export function toZodSchema<
 		}
 
 		if (field?.required === false) {
-			schema = schema.optional();
+			schema = schema.nullish();
 		}
 		if (!isClientSide && field?.returned === false) {
 			return acc;
@@ -82,7 +82,7 @@ type GetRequired<
 	required: true;
 }
 	? Schema
-	: z.ZodOptional<Schema>;
+	: z.ZodOptional<z.ZodNullable<Schema>>;
 
 type GetInput<
 	isClientSide extends boolean,

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -78,11 +78,9 @@ type GetType<F extends DBFieldAttribute> = F extends {
 type GetRequired<
 	F extends DBFieldAttribute,
 	Schema extends z.core.SomeType,
-> = F extends {
-	required: true;
-}
-	? Schema
-	: z.ZodOptional<z.ZodNullable<Schema>>;
+> = F extends { required: false }
+	? z.ZodOptional<z.ZodNullable<Schema>>
+	: Schema;
 
 type GetInput<
 	isClientSide extends boolean,


### PR DESCRIPTION
- Companion PR https://github.com/better-auth/better-auth/pull/9842