### PR TITLE
fix(core): make redirect-uri validation runtime-safe and reject fragments

### DIFF
--- a/.changeset/safe-url-runtime-fragment.md
+++ b/.changeset/safe-url-runtime-fragment.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/oauth-provider": patch
+"@better-auth/core": patch
+"better-auth": patch
+---
+
+Harden redirect-URI validation across the OAuth provider plugins. `isSafeUrlScheme` and `SafeUrlSchema` no longer call `URL.canParse`, which is absent on some supported runtimes and could throw or silently disable the dangerous-scheme check. They now parse with a `try`/`catch` fallback. `SafeUrlSchema` also rejects redirect URIs that contain a fragment component, per RFC 6749 §3.1.2.

--- a/packages/core/src/utils/redirect-uri.ts
+++ b/packages/core/src/utils/redirect-uri.ts
@@ -7,6 +7,7 @@ import { DANGEROUS_URL_SCHEMES } from "./url";
  * server stores and later hands back to a browser.
  *
  * - Rejects dangerous schemes (`javascript:`, `data:`, `vbscript:`).
+ * - Rejects URIs with a fragment component (`#...`) per RFC 6749 §3.1.2.
  * - Requires HTTPS, except for loopback hosts (`127.0.0.0/8`, `[::1]`,
  *   `*.localhost` per RFC 6761), where HTTP is allowed for local development.
  * - Allows custom schemes for mobile apps (e.g. `myapp://callback`).
@@ -16,7 +17,10 @@ import { DANGEROUS_URL_SCHEMES } from "./url";
  * rather than re-implementing the scheme policy per plugin.
  */
 export const SafeUrlSchema = z.url().superRefine((val, ctx) => {
-	if (!URL.canParse(val)) {
+	let u: URL;
+	try {
+		u = new URL(val);
+	} catch {
 		ctx.addIssue({
 			code: "custom",
 			message: "URL must be parseable",
@@ -25,14 +29,19 @@ export const SafeUrlSchema = z.url().superRefine((val, ctx) => {
 		return z.NEVER;
 	}
 
-	const u = new URL(val);
-
 	if (DANGEROUS_URL_SCHEMES.includes(u.protocol)) {
 		ctx.addIssue({
 			code: "custom",
 			message: "URL cannot use javascript:, data:, or vbscript: scheme",
 		});
 		return;
+	}
+
+	if (val.includes("#")) {
+		ctx.addIssue({
+			code: "custom",
+			message: "Redirect URI must not contain a fragment component",
+		});
 	}
 
 	if (u.protocol === "http:" && !isLoopbackHost(u.host)) {

--- a/packages/core/src/utils/url.test.ts
+++ b/packages/core/src/utils/url.test.ts
@@ -46,4 +46,16 @@ describe("SafeUrlSchema", () => {
 		);
 		expect(SafeUrlSchema.safeParse("http://127.0.0.1/cb").success).toBe(true);
 	});
+
+	it("rejects redirect URIs with a fragment component", () => {
+		expect(
+			SafeUrlSchema.safeParse("https://example.com/cb#token").success,
+		).toBe(false);
+		expect(SafeUrlSchema.safeParse("https://example.com/cb#").success).toBe(
+			false,
+		);
+		expect(SafeUrlSchema.safeParse("https://example.com/cb").success).toBe(
+			true,
+		);
+	});
 });

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -60,9 +60,12 @@ export const DANGEROUS_URL_SCHEMES = ["javascript:", "data:", "vbscript:"];
  * execution schemes without rejecting relative paths or mobile deep links.
  */
 export function isSafeUrlScheme(value: string): boolean {
-	if (!URL.canParse(value)) {
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch {
 		// Relative URLs carry no scheme to abuse.
 		return true;
 	}
-	return !DANGEROUS_URL_SCHEMES.includes(new URL(value).protocol);
+	return !DANGEROUS_URL_SCHEMES.includes(parsed.protocol);
 }


### PR DESCRIPTION
`redirect_uri` validation shipped in v1.6.13 (#9838) calls `URL.canParse`, which isn't present on every runtime Better Auth targets. On those runtimes the call throws, and in `isSafeUrlScheme` a missing `URL.canParse` would have turned the `javascript:`/`data:`/`vbscript:` block into a silent no-op. Both `isSafeUrlScheme` and `SafeUrlSchema` now parse with a `try`/`catch` fallback, which behaves identically where `URL.canParse` exists and stays safe where it doesn't.

This also tightens `SafeUrlSchema` to reject redirect URIs that contain a fragment component, per RFC 6749 §3.1.2. Both points came out of review on the main-to-next sync (#9844); fixing them here on main means the corrected validation flows to next through the normal sync.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make redirect-URI validation runtime-safe and spec-compliant. Replaces `URL.canParse` with safe parsing and rejects redirect URIs with fragments to align with RFC 6749.

- **Bug Fixes**
  - `isSafeUrlScheme` and `SafeUrlSchema` now use try/catch parsing, ensuring dangerous schemes are blocked on runtimes without `URL.canParse`.
  - `SafeUrlSchema` rejects redirect URIs containing a fragment (`#...`) per RFC 6749 §3.1.2.
  - Added tests for fragment rejection.

<sup>Written for commit f02919769ee5619119623d78ca92f8959008c7c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

