### PR TITLE
refactor: unify AuthorizeResponse to { error: string | null }

### DIFF
--- a/.changeset/unify-authorize-response.md
+++ b/.changeset/unify-authorize-response.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+`AuthorizeResponse` from `role().authorize()` is now `{ error: string | null }` instead of a discriminated union with `success`. A `null` error means authorized; a non-null error means denied. Replace `result.success` checks with `result.error === null` (or `result.error !== null` for failures).

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -125,7 +125,7 @@ export async function validateApiKey({
 		}
 		const r = role(apiKeyPermissions as any);
 		const result = r.authorize(permissions);
-		if (!result.success) {
+		if (result.error !== null) {
 			throw APIError.from("UNAUTHORIZED", ERROR_CODES.KEY_NOT_FOUND);
 		}
 	}

--- a/packages/better-auth/src/plugins/access/access.test.ts
+++ b/packages/better-auth/src/plugins/access/access.test.ts
@@ -18,7 +18,7 @@ describe("access", () => {
 		const response = role2.authorize({
 			project: ["create"],
 		});
-		expect(response.success).toBe(true);
+		expect(response.error).toBeNull();
 	});
 
 	it("should preserve exact role statement types", () => {
@@ -35,7 +35,7 @@ describe("access", () => {
 		const failedResponse = role2.authorize({
 			project: ["delete-many"],
 		});
-		expect(failedResponse.success).toBe(false);
+		expect(failedResponse.error).not.toBeNull();
 	});
 
 	it("should reject invalid role statements at type level", () => {
@@ -57,19 +57,19 @@ describe("access", () => {
 		const response = dynamicRole.authorize({
 			project: ["create"],
 		});
-		expect(response.success).toBe(true);
+		expect(response.error).toBeNull();
 	});
 
 	it("should validate permissions", async () => {
 		const response = role1.authorize({
 			project: ["create"],
 		});
-		expect(response.success).toBe(true);
+		expect(response.error).toBeNull();
 
 		const failedResponse = role1.authorize({
 			project: ["delete-many"],
 		});
-		expect(failedResponse.success).toBe(false);
+		expect(failedResponse.error).not.toBeNull();
 	});
 
 	it("should validate multiple resource permissions", async () => {
@@ -77,13 +77,13 @@ describe("access", () => {
 			project: ["create"],
 			ui: ["view"],
 		});
-		expect(response.success).toBe(true);
+		expect(response.error).toBeNull();
 
 		const failedResponse = role1.authorize({
 			project: ["delete-many"],
 			ui: ["view"],
 		});
-		expect(failedResponse.success).toBe(false);
+		expect(failedResponse.error).not.toBeNull();
 	});
 
 	it("should validate multiple resource multiple permissions", async () => {
@@ -91,12 +91,12 @@ describe("access", () => {
 			project: ["create", "delete"],
 			ui: ["view", "edit"],
 		});
-		expect(response.success).toBe(true);
+		expect(response.error).toBeNull();
 		const failedResponse = role1.authorize({
 			project: ["create", "delete-many"],
 			ui: ["view", "edit"],
 		});
-		expect(failedResponse.success).toBe(false);
+		expect(failedResponse.error).not.toBeNull();
 	});
 
 	it("should validate using or connector", () => {
@@ -107,7 +107,7 @@ describe("access", () => {
 			},
 			"OR",
 		);
-		expect(response.success).toBe(true);
+		expect(response.error).toBeNull();
 	});
 
 	it("should validate using or connector for a specific resource", () => {
@@ -118,7 +118,7 @@ describe("access", () => {
 			},
 			ui: ["view", "edit"],
 		});
-		expect(response.success).toBe(true);
+		expect(response.error).toBeNull();
 
 		const failedResponse = role1.authorize({
 			project: {
@@ -127,32 +127,32 @@ describe("access", () => {
 			},
 			ui: ["view", "edit", "hide"],
 		});
-		expect(failedResponse.success).toBe(false);
+		expect(failedResponse.error).not.toBeNull();
 	});
 
 	it("should fail when a resource is requested with an empty action list (array form)", () => {
 		const responseAnd = role1.authorize({ project: [] });
-		expect(responseAnd.success).toBe(false);
+		expect(responseAnd.error).not.toBeNull();
 
 		const responseOr = role1.authorize({ project: [] }, "OR");
-		expect(responseOr.success).toBe(false);
+		expect(responseOr.error).not.toBeNull();
 	});
 
 	it("should fail when a resource is requested with an empty action list (object form)", () => {
 		const responseAnd = role1.authorize({
 			project: { actions: [], connector: "AND" },
 		});
-		expect(responseAnd.success).toBe(false);
+		expect(responseAnd.error).not.toBeNull();
 
 		const responseOr = role1.authorize({
 			project: { actions: [], connector: "OR" },
 		});
-		expect(responseOr.success).toBe(false);
+		expect(responseOr.error).not.toBeNull();
 	});
 
 	it("should fail when every requested resource is empty under OR across multiple resources", () => {
 		const response = role1.authorize({ project: [], ui: [] }, "OR");
-		expect(response.success).toBe(false);
+		expect(response.error).not.toBeNull();
 	});
 
 	const looseStatements: Record<string, readonly string[]> = {
@@ -166,7 +166,7 @@ describe("access", () => {
 			{ audit: ["read"], project: ["create"] },
 			"OR",
 		);
-		expect(response.success).toBe(true);
+		expect(response.error).toBeNull();
 	});
 
 	it("should still fail under OR when no resource matches, including unknown ones", () => {
@@ -174,7 +174,7 @@ describe("access", () => {
 			{ audit: ["read"], project: ["delete-many"] },
 			"OR",
 		);
-		expect(response.success).toBe(false);
+		expect(response.error).not.toBeNull();
 	});
 
 	it("should fail under AND when a resource is unknown to the role", () => {
@@ -182,9 +182,7 @@ describe("access", () => {
 			audit: ["read"],
 			project: ["create"],
 		});
-		expect(response.success).toBe(false);
-		if (!response.success) {
-			expect(response.error).toContain("audit");
-		}
+		expect(response.error).not.toBeNull();
+		expect(response.error).toContain("audit");
 	});
 });

--- a/packages/better-auth/src/plugins/access/access.ts
+++ b/packages/better-auth/src/plugins/access/access.ts
@@ -7,9 +7,7 @@ import type {
 	Statements,
 } from "./types";
 
-export type AuthorizeResponse =
-	| { success: false; error: string }
-	| { success: true; error?: never | undefined };
+export type AuthorizeResponse = { error: string | null };
 
 export function role<
 	const TRoleStatements extends Statements,
@@ -30,7 +28,6 @@ export function role<
 				if (!allowedActions) {
 					if (connector === "AND") {
 						return {
-							success: false,
 							error: `You are not allowed to access resource: ${requestedResource}`,
 						};
 					}
@@ -68,22 +65,18 @@ export function role<
 					}
 				}
 				if (success && connector === "OR") {
-					return { success };
+					return { error: null };
 				}
 				if (!success && connector === "AND") {
 					return {
-						success: false,
 						error: `unauthorized to access resource "${requestedResource}"`,
 					};
 				}
 			}
 			if (success) {
-				return {
-					success,
-				};
+				return { error: null };
 			}
 			return {
-				success: false,
 				error: "Not authorized",
 			};
 		},

--- a/packages/better-auth/src/plugins/admin/has-permission.ts
+++ b/packages/better-auth/src/plugins/admin/has-permission.ts
@@ -23,7 +23,7 @@ export const hasPermission = (
 	for (const role of roles) {
 		const _role = acRoles[role as keyof typeof acRoles];
 		const result = _role?.authorize(input.permissions);
-		if (result?.success) {
+		if (result?.error === null) {
 			return true;
 		}
 	}

--- a/packages/better-auth/src/plugins/organization/permission.ts
+++ b/packages/better-auth/src/plugins/organization/permission.ts
@@ -19,7 +19,7 @@ export const hasPermissionFn = (
 	for (const role of roles) {
 		const _role = acRoles[role as keyof typeof acRoles];
 		const result = _role?.authorize(input.permissions);
-		if (result?.success) {
+		if (result?.error === null) {
 			return true;
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes #9675 
- `role().authorize()` used to return different shapes depending on pass or fail: success had `{ success: true }`, failure had `{ success: false, error: "..." }`. That made the type awkward, we had to check success before we could safely use error. So, now it always returns the same shape: `{ error: string | null }`. If `error` is `null`, the check passed. If `error` is a string, it failed and that string explains why.

## What changed
- Updated `AuthorizeResponse` and all return paths in the access plugin
- Updated internal callers in organization, admin, and api-key plugins
- Updated access plugin tests

## Breaking change
If we call `role().authorize()` directly and use `result.success`, switch to `result.error === null` (allowed) or `result.error !== null` (denied).
Not affected: `hasPermission`, `userHasPermission`, and `checkRolePermission` - those still use `{ success: boolean }` or a plain boolean.

## Testing
- `access.test.ts` - direct `authorize()` behavior
- Rebuild `better-auth`, then vitest on admin/org/api-key permission suites
- Smoke typecheck fixtures (org + admin plugins compile)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the access check result to a single shape: `AuthorizeResponse` now returns `{ error: string | null }` instead of a success/failure union in `better-auth`. This simplifies checks and removes the need to branch on `success`.

- **Migration**
  - Replace `result.success` checks with `result.error === null` (allowed) or `result.error !== null` (denied).
  - No changes needed if you use helpers like `hasPermission`, `userHasPermission`, or `checkRolePermission` (their public return shapes are unchanged).

<sup>Written for commit 9536860b7408ddabf43a870789a997bb3abe62d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

