### PR TITLE
fix(next-js): restore RSC detection when Next.js middleware is present

### DIFF
--- a/.changeset/major-grapes-beg.md
+++ b/.changeset/major-grapes-beg.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+`nextCookies()` plugin now correctly skips session refresh during RSC navigation when Next.js middleware is present. Previously, middleware caused Next.js to strip the `RSC` header before the plugin could read it, resulting in unnecessary database writes. Use the new `nextCookiesMiddleware` helper in your middleware to forward RSC context headers.

--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -122,6 +122,38 @@ const signIn = async () => {
 }
 ```
 
+### Usage with Next.js Middleware
+
+When your app includes Next.js middleware (even a minimal pass-through), Next.js strips internal routing headers (`RSC`, `next-action`, etc.) before forwarding requests to the app router. This prevents `nextCookies()` from detecting RSC navigation, causing unnecessary session refreshes that cannot be reflected back in cookies.
+
+To fix this, use the `nextCookiesMiddleware` helper in your middleware to forward the necessary context headers:
+
+```ts title="middleware.ts"
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { nextCookiesMiddleware } from "better-auth/next-js";
+
+export function middleware(request: NextRequest) {
+    // ... your middleware logic
+    return NextResponse.next(nextCookiesMiddleware(request));
+}
+```
+
+If you need to combine it with other response options, spread the result:
+
+```ts title="middleware.ts"
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { nextCookiesMiddleware } from "better-auth/next-js";
+
+export function middleware(request: NextRequest) {
+    return NextResponse.next({
+        ...nextCookiesMiddleware(request),
+        // other NextResponse.next() options...
+    });
+}
+```
+
 ## Auth Protection
 
 In Next.js proxy/middleware, it's recommended to only check for the existence of a session cookie to handle redirection to avoid blocking requests by making API or database calls.

--- a/packages/better-auth/src/integrations/next-js.test.ts
+++ b/packages/better-auth/src/integrations/next-js.test.ts
@@ -160,4 +160,70 @@ describe("next-js integration", () => {
 
 		expect(session).not.toBeNull();
 	});
+
+	/**
+	 * When Next.js middleware is present (even a pass-through `NextResponse.next()`),
+	 * it strips internal routing headers (RSC, next-action, etc.) before forwarding
+	 * to the app router. The nextCookiesMiddleware() helper maps them to custom
+	 * x-better-auth-* headers that survive the middleware→app transition.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/9776
+	 */
+	it("should skip refresh when x-better-auth-is-rsc header is set (middleware scenario)", async () => {
+		// Simulates a request that went through nextCookiesMiddleware():
+		// RSC header was stripped by Next.js but x-better-auth-is-rsc was forwarded.
+		const { cookiesMock, headersMock, session } =
+			await getSessionWithNextHeaders({
+				"x-better-auth-is-rsc": "1",
+			});
+
+		expect(headersMock).toHaveBeenCalledTimes(1);
+		expect(cookiesMock).not.toHaveBeenCalled();
+		expect(session).not.toBeNull();
+		expect(session?.needsRefresh).toBe(false);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9776
+	 */
+	it("should not skip refresh when x-better-auth-is-server-action is set (middleware + server action scenario)", async () => {
+		const { session } = await getSessionWithNextHeaders({
+			"x-better-auth-is-rsc": "1",
+			"x-better-auth-is-server-action": "1",
+		});
+
+		expect(session).not.toBeNull();
+		expect(session?.needsRefresh).toBe(true);
+	});
+
+	describe("nextCookiesMiddleware", () => {
+		it("should map RSC header to x-better-auth-is-rsc", async () => {
+			const { nextCookiesMiddleware } = await import("./next-js");
+			const request = { headers: new Headers({ RSC: "1" }) };
+			const result = nextCookiesMiddleware(request);
+			expect(result.request.headers.get("x-better-auth-is-rsc")).toBe("1");
+		});
+
+		it("should map next-action header to x-better-auth-is-server-action", async () => {
+			const { nextCookiesMiddleware } = await import("./next-js");
+			const request = {
+				headers: new Headers({ RSC: "1", "next-action": "abc123" }),
+			};
+			const result = nextCookiesMiddleware(request);
+			expect(result.request.headers.get("x-better-auth-is-rsc")).toBe("1");
+			expect(result.request.headers.get("x-better-auth-is-server-action")).toBe(
+				"1",
+			);
+		});
+
+		it("should not set custom headers when RSC headers are absent", async () => {
+			const { nextCookiesMiddleware } = await import("./next-js");
+			const request = { headers: new Headers({}) };
+			const result = nextCookiesMiddleware(request);
+			expect(result.request.headers.get("x-better-auth-is-rsc")).toBeNull();
+			expect(
+				result.request.headers.get("x-better-auth-is-server-action"),
+			).toBeNull();
+		});
+	});
 });

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -5,6 +5,41 @@ import { parseSetCookieHeader, toCookieOptions } from "../cookies";
 import { PACKAGE_VERSION } from "../version";
 import { warnIfCookiePluginNotLast } from "./cookie-plugin-guard";
 
+/**
+ * Returns Next.js middleware request options that forward RSC context headers.
+ *
+ * Next.js middleware strips internal routing headers (`RSC`, `next-action`,
+ * etc.) before forwarding requests to the app router. Without these headers,
+ * the `nextCookies()` plugin cannot detect RSC navigation and will perform
+ * unnecessary session refreshes (extra DB writes) that cannot be reflected
+ * back in cookies.
+ *
+ * Pass the return value to `NextResponse.next()` in your middleware:
+ *
+ * @example
+ * ```ts
+ * import { NextResponse } from "next/server";
+ * import type { NextRequest } from "next/server";
+ * import { nextCookiesMiddleware } from "better-auth/next-js";
+ *
+ * export function middleware(request: NextRequest) {
+ *   return NextResponse.next(nextCookiesMiddleware(request));
+ * }
+ * ```
+ */
+export function nextCookiesMiddleware(request: { headers: Headers }): {
+	request: { headers: Headers };
+} {
+	const headers = new Headers(request.headers);
+	if (headers.get("RSC") === "1") {
+		headers.set("x-better-auth-is-rsc", "1");
+	}
+	if (headers.has("next-action")) {
+		headers.set("x-better-auth-is-server-action", "1");
+	}
+	return { request: { headers } };
+}
+
 export function toNextJsHandler(
 	auth:
 		| {
@@ -66,8 +101,15 @@ export const nextCookies = () => {
 						 *
 						 * @see https://github.com/vercel/next.js/blob/8c5af211d580/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts#L112-L157
 						 */
-						const isRSC = headersStore.get("RSC") === "1";
-						const isServerAction = !!headersStore.get("next-action");
+						// Also check x-better-auth-is-rsc / x-better-auth-is-server-action
+						// for apps using nextCookiesMiddleware() — Next.js strips the
+						// native RSC/next-action headers during the middleware→app transition.
+						const isRSC =
+							headersStore.get("RSC") === "1" ||
+							headersStore.get("x-better-auth-is-rsc") === "1";
+						const isServerAction =
+							!!headersStore.get("next-action") ||
+							!!headersStore.get("x-better-auth-is-server-action");
 						if (isRSC && !isServerAction) {
 							await setShouldSkipSessionRefresh(true);
 						}


### PR DESCRIPTION
Closes #9776

## Problem

The `nextCookies()` plugin detects RSC navigation by checking for the
`RSC: 1` request header, and calls `setShouldSkipSessionRefresh(true)`
to avoid a DB write that can't be reflected back in cookies (RSC context
is read-only for cookies).

When any Next.js middleware is present — even a bare `NextResponse.next()`
— Next.js strips its own internal routing headers (`RSC`, `next-action`,
etc.) during the middleware → app router transition. By the time the
plugin's `before` hook runs, `headersStore.get("RSC")` is always `null`,
so the skip-refresh optimization never activates for these apps.

Result: every RSC navigation causes a wasted DB write and a growing
expiry drift between the DB session record and the browser cookie.
No functional harm to users, but unnecessary load.

## Solution

Two-part fix:

**1. `nextCookiesMiddleware()` export** — a helper users call in their
`middleware.ts` that copies `RSC: 1` to `x-better-auth-is-rsc: 1` (and
`next-action` to `x-better-auth-is-server-action: 1`) *before* Next.js
strips the originals. Custom `x-*` headers survive the middleware → app
transition.

**2. Updated detection in the `before` hook** — checks both the native
headers (no-middleware path) and the custom forwarded headers
(middleware path). Fully backwards-compatible.

## Usage

```ts
// middleware.ts
import { NextResponse } from "next/server";
import type { NextRequest } from "next/server";
import { nextCookiesMiddleware } from "better-auth/next-js";

export function middleware(request: NextRequest) {
  return NextResponse.next(nextCookiesMiddleware(request));
}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores RSC detection in `nextCookies()` when Next.js middleware is present to prevent unnecessary session refresh DB writes. Adds `nextCookiesMiddleware` to forward RSC context headers through middleware.

- **Bug Fixes**
  - Exported `nextCookiesMiddleware` from `better-auth/next-js` to map `RSC`/`next-action` to `x-better-auth-*` before Next.js strips them.
  - Updated `nextCookies()` to read both native and forwarded headers, skipping refresh on RSC (but not during server actions).
  - Usage: `return NextResponse.next(nextCookiesMiddleware(request))` in `middleware.ts`.
  - Added docs, tests, and a patch changeset.

<sup>Written for commit bb5114ade0fb8eadf13a69a05b21e361cd841094. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

