### PR TITLE
feat(stripe): add locale param to cancel subscription

### DIFF
--- a/.changeset/happy-things-dig.md
+++ b/.changeset/happy-things-dig.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/stripe": patch
+---
+
+Add locale param to the Stripe subscription cancel api

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -427,6 +427,11 @@ To cancel a subscription:
        * URL to take customers to when they click on the billing portal's link to return to your website.
        */
       returnUrl: string = '/account'
+      /**
+       * The IETF language tag of the locale Checkout is displayed in.
+       * If not provided or set to `auto`, the browser's locale is used.
+       */
+      locale?: string
   }
   ```
 </APIMethod>

--- a/packages/stripe/src/routes.ts
+++ b/packages/stripe/src/routes.ts
@@ -966,6 +966,7 @@ export const upgradeSubscription = (options: StripeOptions) => {
 					({ url: upgradeUrl } = await client.billingPortal.sessions
 						.create({
 							customer: customerId,
+							locale: ctx.body.locale,
 							return_url: getUrl(ctx, ctx.body.returnUrl || "/"),
 							flow_data: {
 								type: "subscription_update_confirm",
@@ -1225,6 +1226,19 @@ const cancelSubscriptionBodySchema = z.object({
 				"Disable redirect after successful subscription cancellation. Eg: true",
 		})
 		.default(false),
+	/**
+	 * The IETF language tag of the locale Checkout is displayed in.
+	 * If not provided or set to `auto`, the browser's locale is used.
+	 */
+	locale: z
+		.custom<CheckoutSessionLocale>((localization) => {
+			return typeof localization === "string";
+		})
+		.meta({
+			description:
+				"The locale to display Checkout in. Eg: 'en', 'ko'. If not provided or set to `auto`, the browser's locale is used.",
+		})
+		.optional(),
 });
 
 /**
@@ -1333,6 +1347,7 @@ export const cancelSubscription = (options: StripeOptions) => {
 			const { url } = await client.billingPortal.sessions
 				.create({
 					customer: subscription.stripeCustomerId,
+					locale: ctx.body.locale,
 					return_url: getUrl(ctx, ctx.body?.returnUrl || "/"),
 					flow_data: {
 						type: "subscription_cancel",

--- a/packages/stripe/test/subscription.test.ts
+++ b/packages/stripe/test/subscription.test.ts
@@ -2961,4 +2961,64 @@ describe("stripe subscription", () => {
 		// Should still proceed with the upgrade via billing portal
 		expect(stripeMock.billingPortal.sessions.create).toHaveBeenCalled();
 	});
+
+	describe("cancel stripe subscription", () => {
+		test("should pass locale when canceling", async ({
+			stripeMock,
+			memory,
+			stripeOptions,
+		}) => {
+			const { client, auth, sessionSetter } = await getTestInstance(
+				{
+					database: memory,
+					plugins: [stripe(stripeOptions)],
+				},
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [stripeClient({ subscription: true })],
+					},
+				},
+			);
+			const ctx = await auth.$context;
+
+			const userRes = await client.signUp.email(testUser, {
+				throw: true,
+			});
+
+			const headers = new Headers();
+			await client.signIn.email(testUser, {
+				throw: true,
+				onSuccess: sessionSetter(headers),
+			});
+
+			const subscriptionId = "sub_delete_test";
+			await client.subscription.upgrade({
+				plan: "starter",
+				fetchOptions: { headers },
+			});
+			await ctx.adapter.update({
+				model: "subscription",
+				update: { status: "active", stripeSubscriptionId: subscriptionId },
+				where: [{ field: "referenceId", value: userRes.user.id }],
+			});
+
+			stripeMock.subscriptions.list.mockResolvedValue({
+				data: [{ id: subscriptionId, status: "active" }],
+			});
+
+			const locale = "fr";
+
+			await client.subscription.cancel({
+				locale: locale,
+				fetchOptions: { headers },
+				referenceId: userRes.user.id,
+				returnUrl: "",
+			});
+
+			expect(stripeMock.billingPortal.sessions.create).toHaveBeenCalledWith(
+				expect.objectContaining({ locale: locale }),
+			);
+		});
+	});
 });


### PR DESCRIPTION
Added a locale param to the Stripe cancel subscription api.
Also fixed a create billing portal call that was missing the locale param in the upgrade subscription api.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional locale parameter to the cancel subscription API in `@better-auth/stripe`, passed to Stripe’s Billing Portal for a localized UI. Also wires locale through the upgrade subscription flow.

- New Features
  - Add optional locale to cancelSubscription; forwarded to Billing Portal (defaults to browser locale if omitted). Docs updated and tests added.

- Bug Fixes
  - upgradeSubscription now passes locale when creating a Billing Portal session.

<sup>Written for commit 063180cecfd3cda701cd5b55c7426f998af76ed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

