### PR TITLE
fix(admin-plugin): revoke sessions by default and allow opting out in admin.setUserPassword

### DIFF
--- a/.changeset/five-owls-bet.md
+++ b/.changeset/five-owls-bet.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+When admins change a user’s password with admin.setUserPassword, that user’s active sessions are now revoked by default. You can optionally disable this if you want to keep existing sessions active.

--- a/.changeset/five-owls-bet.md
+++ b/.changeset/five-owls-bet.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": patch
+"better-auth": minor
 ---
 
 When admins change a user’s password with admin.setUserPassword, that user’s active sessions are now revoked by default. You can optionally disable this if you want to keep existing sessions active.

--- a/.changeset/optional-fields-accept-null.md
+++ b/.changeset/optional-fields-accept-null.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+Optional fields (`required: false`) now accept `null`, not just omission. The
+generated input validation previously rejected `null` even though the column is
+nullable, so a nullable field could not be cleared by passing `null`.

--- a/.changeset/session-cookie-secure-prefix.md
+++ b/.changeset/session-cookie-secure-prefix.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+`getSessionCookie` now prefers the `__Secure-` cookie when both it and a non-secure cookie are present, so the non-secure cookie no longer shadows the current session cookie.

--- a/.postmortem/rsc-header-detection.md
+++ b/.postmortem/rsc-header-detection.md
@@ -1,0 +1,112 @@
+# Postmortem: Detecting RSC Context via Request Headers in Next.js
+
+## Issue Reference
+
+* [PR #7625](https://github.com/better-auth/better-auth/pull/7625) - first header-based detection
+* [PR #7763](https://github.com/better-auth/better-auth/pull/7763) - replaced it with a cookie probe
+* [PR #9059](https://github.com/better-auth/better-auth/pull/9059) - reverted to header-based detection
+* [PR #9851](https://github.com/better-auth/better-auth/pull/9851) - tried to forward the header from a proxy
+
+## Summary
+
+You cannot detect an RSC request by reading the `RSC` header in Next.js.
+The browser sends `RSC: 1` on a soft navigation, but Next.js classifies
+`rsc`, `next-router-state-tree`, `next-router-prefetch`, etc. as internal
+Flight headers and strips them from every user-accessible surface before
+user code runs. Both a Server Component's `headers()` and a proxy's
+`request.headers` see `null`. Any RSC detection built on reading these
+headers is dead on arrival, and contributors keep reintroducing it.
+
+## Recurrence History
+
+This logic has cycled through four PRs, each trading one real problem
+for another:
+
+1. **#7625** introduced header-based detection (`RSC: 1`).
+2. **#7763** found the header inaccessible and switched to a cookie
+   probe: `cookies().set()` then `delete()` to test writability.
+3. **#9059** reverted to header-based detection because the probe's
+   `cookies().set()` unconditionally invalidates the router cache,
+   causing infinite refresh loops (#8464) and a leaked probe cookie
+   (#8828). It assumed `RSC: 1` is present on client-side flight
+   requests. On Next.js 16 it is not.
+4. **#9851** (external contributor) assumed the header is only stripped
+   when a proxy/middleware is present, and tried to forward it into a
+   custom `x-better-auth-is-rsc` header. The proxy never sees it either.
+
+## Root Cause
+
+### Next.js strips Flight headers on every surface
+
+`FLIGHT_HEADERS` is deleted in two independent places, both before user
+code runs (pinned to Next.js `v16.3.0-canary.36`, SHA `58e8c0b`):
+
+* Proxy path, before building `NextRequestHint`:
+  [`server/web/adapter.ts`](https://github.com/vercel/next.js/blob/58e8c0b4457f8f7cb737158efc543f3708f3e6e3/packages/next/src/server/web/adapter.ts#L164-L172)
+* `headers()` path, in `getHeaders()`:
+  [`server/async-storage/request-store.ts`](https://github.com/vercel/next.js/blob/58e8c0b4457f8f7cb737158efc543f3708f3e6e3/packages/next/src/server/async-storage/request-store.ts#L29-L36)
+
+Next.js does this on purpose, so an RSC request is never handled
+differently from its HTML counterpart. The behavior is documented under
+[RSC requests and rewrites](https://nextjs.org/docs/app/api-reference/file-conventions/proxy#rsc-requests-and-rewrites).
+
+```ts
+// WRONG - always null in RSC, with or without a proxy
+const isRSC = (await headers()).get("RSC") === "1"
+
+// ALSO WRONG - the proxy strips it too, nothing to forward
+requestHeaders.set("x-better-auth-is-rsc", request.headers.get("RSC"))
+```
+
+### Why both fixes fail differently
+
+* **Cookie probe (#7763)**: works as a signal, but `cookies().set()`
+  invalidates the router cache on every call. Unacceptable side effect.
+* **Header read (#7625, #9059)**: zero side effects, but the header is
+  never there. Silent no-op.
+
+### Why the tests pass anyway
+
+The regression tests in `next-js.test.ts` mock `next/headers`:
+
+```ts
+headers: vi.fn(async () => new Headers({ RSC: "1" }))
+```
+
+`new Headers({ RSC: "1" })` is an input the real Next.js runtime never
+produces, because it strips the header first. A mock returns whatever
+the test feeds it, so the suite only proves the code agrees with the
+mock, never that the mock matches the runtime. It is the inherent limit
+of mocking a boundary: you stub the boundary's output instead of exercising
+the rule that produces it.
+
+## How to Verify
+
+Run a real Next.js app, not a unit test. A Server Component that dumps
+`(await headers()).get("RSC")` on a soft navigation prints `null`, even
+though DevTools shows `RSC: 1` on the `?_rsc=...` request. A `proxy.ts`
+logging `request.headers.get("RSC")` also prints `null`.
+
+## Lesson Learned
+
+1. **Internal Flight headers are not user-accessible.** Reading `RSC`
+   from `headers()` or `request.headers` always returns `null`.
+2. **A mock cannot validate an assumption about the real module.** The
+   tests stubbed `headers()` to return a value the runtime never emits,
+   so a green suite only proved the code agreed with the mock. Mocking a
+   boundary stubs its output, it does not exercise the rule that strips
+   the header. Behavior that depends on that rule belongs in a real-app
+   or e2e check.
+3. **Both directions are dead ends.** Header read is a no-op, proxy
+   forward is a no-op, cookie probe has unacceptable side effects.
+4. **Detection is the wrong goal.** It existed only to skip session
+   refresh when cookies cannot be written. Make refresh idempotent so it
+   is harmless in that case, instead of detecting the context.
+5. **This is a recurring contributor assumption.** Link this document
+   in review when a PR reads the `RSC` header.
+
+## Prevention
+
+1. Add a code comment at the detection site pointing to this postmortem.
+2. Reject PRs that read `RSC` / `next-router-*` from `headers()` or a
+   proxy. Link the two Next.js source lines above.

--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -263,6 +263,10 @@ Changes the password of a user.
        * The user id which you want to set the password for.
        */
       userId: string = 'user-id'
+      /**
+      * Whether to revoke all user sessions after setting the password. Defaults to `true`.
+      */
+      revokeSessions?: boolean = true
   }
   ```
 </APIMethod>

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -85,7 +85,7 @@ Once you've installed the plugin, you can start using the organization plugin to
     /**
     * The organization logo.
     */
-    logo?: string = "https://example.com/logo.png"
+    logo?: string | null = "https://example.com/logo.png"
     /**
     * The metadata of the organization.
     */
@@ -775,9 +775,9 @@ To update organization info, you can use `organization.update`
            */
           slug?: string = "updated-slug"
           /**
-           * The logo of the organization. 
+           * The logo of the organization.
            */
-          logo?: string = "new-logo.url"
+          logo?: string | null = "new-logo.url"
           /**
            * The metadata of the organization. 
            */

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -538,6 +538,30 @@ describe("getSessionCookie", async () => {
 		});
 	});
 
+	it("prefers the __Secure- cookie when a non-secure leftover is also present", () => {
+		const headers = new Headers();
+		headers.set(
+			"cookie",
+			"better-auth.session_token=stale; __Secure-better-auth.session_token=current",
+		);
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+		expect(getSessionCookie(request)).toBe("current");
+	});
+
+	it("does not fall back to a non-secure cookie when the __Secure- value is empty", () => {
+		const headers = new Headers();
+		headers.set(
+			"cookie",
+			"better-auth.session_token=stale; __Secure-better-auth.session_token=",
+		);
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+		expect(getSessionCookie(request)).toBeNull();
+	});
+
 	it("should allow override cookie prefix with secure cookies", async () => {
 		const { client, testUser, cookieSetter } = await getTestInstance({
 			advanced: {

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -443,9 +443,10 @@ export const getSessionCookie = (
 	const { cookieName = "session_token", cookiePrefix = "better-auth" } =
 		config || {};
 	const parsedCookie = parseCookies(cookies);
+	// Prefer __Secure- (HTTPS-only) over a non-secure leftover.
 	const getCookie = (name: string) =>
-		parsedCookie.get(name) ||
-		parsedCookie.get(`${SECURE_COOKIE_PREFIX}${name}`);
+		parsedCookie.get(`${SECURE_COOKIE_PREFIX}${name}`) ??
+		parsedCookie.get(name);
 
 	const sessionToken =
 		getCookie(`${cookiePrefix}.${cookieName}`) ||

--- a/packages/better-auth/src/db/to-zod.test.ts
+++ b/packages/better-auth/src/db/to-zod.test.ts
@@ -32,4 +32,31 @@ describe("toZodSchema", () => {
 			expect(schema.shape).not.toHaveProperty("secretField");
 		});
 	});
+
+	describe("required: false field nullability", () => {
+		it("should accept null, undefined, and a value for an optional field", () => {
+			const schema = toZodSchema({
+				fields: {
+					logo: { type: "string", required: false },
+				},
+				isClientSide: true,
+			});
+
+			expect(schema.parse({ logo: null })).toEqual({ logo: null });
+			expect(schema.safeParse({ logo: undefined }).success).toBe(true);
+			expect(schema.parse({})).toEqual({});
+			expect(schema.parse({ logo: "value" })).toEqual({ logo: "value" });
+		});
+
+		it("should reject null for a required field", () => {
+			const schema = toZodSchema({
+				fields: {
+					name: { type: "string", required: true },
+				},
+				isClientSide: true,
+			});
+
+			expect(schema.safeParse({ name: null }).success).toBe(false);
+		});
+	});
 });

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -36,7 +36,7 @@ export function toZodSchema<
 		}
 
 		if (field?.required === false) {
-			schema = schema.optional();
+			schema = schema.nullish();
 		}
 		if (!isClientSide && field?.returned === false) {
 			return acc;
@@ -78,11 +78,9 @@ type GetType<F extends DBFieldAttribute> = F extends {
 type GetRequired<
 	F extends DBFieldAttribute,
 	Schema extends z.core.SomeType,
-> = F extends {
-	required: true;
-}
-	? Schema
-	: z.ZodOptional<Schema>;
+> = F extends { required: false }
+	? z.ZodOptional<z.ZodNullable<Schema>>
+	: Schema;
 
 type GetInput<
 	isClientSide extends boolean,

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -1207,6 +1207,133 @@ describe("Admin plugin", async () => {
 		});
 		expect(res2.data?.user).toBeDefined();
 	});
+
+	it("should revoke user sessions by default when admin sets user password", async () => {
+		const email = "revoke-default@test.com";
+		const password = "password";
+		const newPassword = "updatedPassword";
+		const signUpRes = await client.signUp.email({
+			email,
+			password,
+			name: "Revoke Default User",
+		});
+		const userId = signUpRes.data?.user.id || "";
+
+		await signInWithUser(email, password);
+
+		const sessionsBefore = await client.admin.listUserSessions(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(sessionsBefore.data?.sessions.length).toBeGreaterThan(0);
+
+		const res = await client.admin.setUserPassword(
+			{
+				userId,
+				newPassword,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.status).toBe(true);
+
+		const sessionsAfter = await client.admin.listUserSessions(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(sessionsAfter.data?.sessions.length).toBe(0);
+
+		const signInRes = await client.signIn.email({
+			email,
+			password: newPassword,
+		});
+		expect(signInRes.data?.user.id).toBe(userId);
+
+		await client.admin.removeUser(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+	});
+
+	it("should keep user sessions when revokeSessions is false", async () => {
+		const email = "keep-sessions@test.com";
+		const password = "password";
+		const newPassword = "updatedPassword";
+		const signUpRes = await client.signUp.email({
+			email,
+			password,
+			name: "Keep Sessions User",
+		});
+		const userId = signUpRes.data?.user.id || "";
+		const { headers: userSessionHeaders } = await signInWithUser(
+			email,
+			password,
+		);
+
+		const sessionsBefore = await client.admin.listUserSessions(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(sessionsBefore.data?.sessions.length).toBeGreaterThan(0);
+
+		const res = await client.admin.setUserPassword(
+			{
+				userId,
+				newPassword,
+				revokeSessions: false,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.status).toBe(true);
+
+		const sessionsAfter = await client.admin.listUserSessions(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(sessionsAfter.data?.sessions.length).toBe(
+			sessionsBefore.data?.sessions.length,
+		);
+
+		const sessionRes = await client.getSession({
+			fetchOptions: {
+				headers: userSessionHeaders,
+			},
+		});
+		expect(sessionRes.data?.session).toBeDefined();
+
+		await client.admin.removeUser(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+	});
+
 	it("should not allow admin to set user password with empty userId", async () => {
 		const res = await client.admin.setUserPassword(
 			{

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1475,6 +1475,14 @@ const setUserPasswordBodySchema = z.object({
 	userId: z.coerce.string().nonempty("userId cannot be empty").meta({
 		description: "The user id",
 	}),
+	revokeSessions: z
+		.boolean()
+		.default(true)
+		.meta({
+			description:
+				"Whether to revoke all user sessions after setting the password. Default is `true`.",
+		})
+		.optional(),
 });
 
 /**
@@ -1540,7 +1548,7 @@ export const setUserPassword = (opts: AdminOptions) =>
 				);
 			}
 
-			const { newPassword, userId } = ctx.body;
+			const { newPassword, userId, revokeSessions } = ctx.body;
 			const minPasswordLength = ctx.context.password.config.minPasswordLength;
 			if (newPassword.length < minPasswordLength) {
 				ctx.context.logger.error("Password is too short");
@@ -1553,6 +1561,11 @@ export const setUserPassword = (opts: AdminOptions) =>
 			}
 			const hashedPassword = await ctx.context.password.hash(newPassword);
 			await ctx.context.internalAdapter.updatePassword(userId, hashedPassword);
+
+			if (revokeSessions) {
+				await ctx.context.internalAdapter.deleteUserSessions(userId);
+			}
+
 			return ctx.json({
 				status: true,
 			});


### PR DESCRIPTION
- `admin.setUserPassword` now revokes a user’s active sessions by default when an admin changes their password. Previously, changing a password through this API did not revoke existing sessions. If needed, you can keep sessions active with revokeSessions: false.
- Add test cases for this feature
- Update docs to match API spec changes

Related Issue: #9855 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `revokeSessions` flag to `admin.setUserPassword` so admins can choose to revoke user sessions after a password change. Defaults to true for stronger security, with an opt-out to keep sessions.

- **New Features**
  - `revokeSessions?: boolean` accepted by `admin.setUserPassword` (default `true` when omitted).
  - When `true`, all user sessions are revoked after the password update; when `false`, sessions remain valid.
  - Docs updated to include the new param and default; tests cover default revoke and opt-out, verifying session list and active session behavior.

<sup>Written for commit 0af68ff74d4c4d1a137c1576ef9c04228a3228c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



