### PR TITLE
fix(admin-plugin): `admin.setUserPassword` now revokes sessions by default, with an option to keep sessions active

### DIFF
--- a/.changeset/five-owls-bet.md
+++ b/.changeset/five-owls-bet.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+When admins change a user’s password with admin.setUserPassword, that user’s active sessions are now revoked by default. You can optionally disable this if you want to keep existing sessions active.

--- a/docs/content/docs/plugins/admin.mdx
+++ b/docs/content/docs/plugins/admin.mdx
@@ -271,6 +271,10 @@ Changes the password of a user.
        * The user id which you want to set the password for.
        */
       userId: string = 'user-id'
+      /**
+      * Whether to revoke all user sessions after setting the password. Defaults to `true`.
+      */
+      revokeSessions?: boolean = true
   }
   ```
 </APIMethod>

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -1207,6 +1207,133 @@ describe("Admin plugin", async () => {
 		});
 		expect(res2.data?.user).toBeDefined();
 	});
+
+	it("should revoke user sessions by default when admin sets user password", async () => {
+		const email = "revoke-default@test.com";
+		const password = "password";
+		const newPassword = "updatedPassword";
+		const signUpRes = await client.signUp.email({
+			email,
+			password,
+			name: "Revoke Default User",
+		});
+		const userId = signUpRes.data?.user.id || "";
+
+		await signInWithUser(email, password);
+
+		const sessionsBefore = await client.admin.listUserSessions(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(sessionsBefore.data?.sessions.length).toBeGreaterThan(0);
+
+		const res = await client.admin.setUserPassword(
+			{
+				userId,
+				newPassword,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.status).toBe(true);
+
+		const sessionsAfter = await client.admin.listUserSessions(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(sessionsAfter.data?.sessions.length).toBe(0);
+
+		const signInRes = await client.signIn.email({
+			email,
+			password: newPassword,
+		});
+		expect(signInRes.data?.user.id).toBe(userId);
+
+		await client.admin.removeUser(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+	});
+
+	it("should keep user sessions when revokeSessions is false", async () => {
+		const email = "keep-sessions@test.com";
+		const password = "password";
+		const newPassword = "updatedPassword";
+		const signUpRes = await client.signUp.email({
+			email,
+			password,
+			name: "Keep Sessions User",
+		});
+		const userId = signUpRes.data?.user.id || "";
+		const { headers: userSessionHeaders } = await signInWithUser(
+			email,
+			password,
+		);
+
+		const sessionsBefore = await client.admin.listUserSessions(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(sessionsBefore.data?.sessions.length).toBeGreaterThan(0);
+
+		const res = await client.admin.setUserPassword(
+			{
+				userId,
+				newPassword,
+				revokeSessions: false,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.status).toBe(true);
+
+		const sessionsAfter = await client.admin.listUserSessions(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(sessionsAfter.data?.sessions.length).toBe(
+			sessionsBefore.data?.sessions.length,
+		);
+
+		const sessionRes = await client.getSession({
+			fetchOptions: {
+				headers: userSessionHeaders,
+			},
+		});
+		expect(sessionRes.data?.session).toBeDefined();
+
+		await client.admin.removeUser(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+	});
+
 	it("should not allow admin to set user password with empty userId", async () => {
 		const res = await client.admin.setUserPassword(
 			{

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1475,6 +1475,14 @@ const setUserPasswordBodySchema = z.object({
 	userId: z.coerce.string().nonempty("userId cannot be empty").meta({
 		description: "The user id",
 	}),
+	revokeSessions: z
+		.boolean()
+		.default(true)
+		.meta({
+			description:
+				"Whether to revoke all user sessions after setting the password. Default is `true`.",
+		})
+		.optional(),
 });
 
 /**
@@ -1540,7 +1548,7 @@ export const setUserPassword = (opts: AdminOptions) =>
 				);
 			}
 
-			const { newPassword, userId } = ctx.body;
+			const { newPassword, userId, revokeSessions } = ctx.body;
 			const minPasswordLength = ctx.context.password.config.minPasswordLength;
 			if (newPassword.length < minPasswordLength) {
 				ctx.context.logger.error("Password is too short");
@@ -1553,6 +1561,11 @@ export const setUserPassword = (opts: AdminOptions) =>
 			}
 			const hashedPassword = await ctx.context.password.hash(newPassword);
 			await ctx.context.internalAdapter.updatePassword(userId, hashedPassword);
+
+			if (revokeSessions) {
+				await ctx.context.internalAdapter.deleteUserSessions(userId);
+			}
+
 			return ctx.json({
 				status: true,
 			});


### PR DESCRIPTION
Related issue: #9855 

- `admin.setUserPassword` now revokes a user’s active sessions by default when an admin changes their password. Previously, changing a password through this API did not revoke existing sessions. If needed, you can keep sessions active with
```typescript
const { data, error } = await authClient.admin.setUserPassword({
    newPassword: 'new-password',
    userId: 'user-id',
    revokeSessions: false,  // <--
});
```
- Add test cases for this feature
- Update docs to match API spec changes:
<img width="891" height="570" alt="image" src="https://github.com/user-attachments/assets/4f7e7b16-2745-4634-8124-00e740153ee4" />
<img width="880" height="642" alt="image" src="https://github.com/user-attachments/assets/d7d592be-5292-4c2d-a906-3a80a0c93e49" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admin password changes in `better-auth` now revoke the user’s active sessions by default to close a security gap. Set `revokeSessions: false` to keep sessions active when needed.

- **Migration**
  - If you relied on sessions staying active after `admin.setUserPassword`, pass `revokeSessions: false`.

<sup>Written for commit c6b7a5834cd95b560253df5442a7e84069d4b5b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

