### PR TITLE
fix(kysely-adapter): use native Postgres arrays for string[]/number[]

### DIFF
--- a/packages/better-auth/src/db/get-migration-schema.test.ts
+++ b/packages/better-auth/src/db/get-migration-schema.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
-import type { BetterAuthOptions } from "@better-auth/core";
+import type { BetterAuthOptions, BetterAuthPlugin } from "@better-auth/core";
+import { kyselyAdapter } from "@better-auth/kysely-adapter";
 import { CamelCasePlugin, Kysely, PostgresDialect } from "kysely";
 import { Pool } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -685,5 +686,87 @@ describe("index generation for columns added to existing tables", () => {
 		expect(apikeyAdded!.fields).toHaveProperty("referenceId");
 
 		await expect(runMigrations()).resolves.not.toThrow();
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9853
+ */
+describe.runIf(isPostgresAvailable)("PostgreSQL native array columns", () => {
+	const pool = new Pool({ connectionString: CONNECTION_STRING });
+	const db = new Kysely({ dialect: new PostgresDialect({ pool }) });
+
+	const arrayTestPlugin = {
+		id: "array-roundtrip-test",
+		schema: {
+			testModel: {
+				fields: {
+					stringArray: {
+						type: "string[]",
+						required: true,
+					},
+					numberArray: {
+						type: "number[]",
+						required: true,
+					},
+				},
+			},
+		},
+	} satisfies BetterAuthPlugin;
+
+	const options = {
+		database: pool,
+		emailAndPassword: {
+			enabled: true,
+		},
+		plugins: [arrayTestPlugin],
+	} satisfies BetterAuthOptions;
+
+	const adapter = kyselyAdapter(db, { type: "postgres" })(options);
+
+	beforeAll(async () => {
+		await pool.query(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`);
+		const { runMigrations } = await getMigrations(options);
+		await runMigrations();
+	});
+
+	afterAll(async () => {
+		await db.destroy();
+	});
+
+	it("round-trips string[] and number[] through the kysely adapter", async () => {
+		const created = await adapter.create<{
+			id: string;
+			stringArray: string[];
+			numberArray: number[];
+		}>({
+			model: "testModel",
+			data: {
+				stringArray: ["a", "b"],
+				numberArray: [1, 2, 3],
+			},
+		});
+
+		expect(created.stringArray).toEqual(["a", "b"]);
+		expect(created.numberArray).toEqual([1, 2, 3]);
+
+		const found = await adapter.findOne<{
+			stringArray: string[];
+			numberArray: number[];
+		}>({
+			model: "testModel",
+			where: [{ field: "id", value: created.id }],
+		});
+
+		expect(found?.stringArray).toEqual(["a", "b"]);
+		expect(found?.numberArray).toEqual([1, 2, 3]);
+	});
+
+	it("does not re-migrate native array columns (_text / _int4 introspection)", async () => {
+		const { toBeAdded, toBeCreated } = await getMigrations(options);
+		const testModelPending =
+			toBeCreated.find((t) => t.table === "testModel") ??
+			toBeAdded.find((t) => t.table === "testModel");
+		expect(testModelPending).toBeUndefined();
 	});
 });

--- a/packages/better-auth/src/db/get-migration.test.ts
+++ b/packages/better-auth/src/db/get-migration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { matchType } from "./get-migration";
+
+describe("matchType", () => {
+	describe("postgres array fields", () => {
+		it("accepts native text[] for string[]", () => {
+			expect(matchType("text[]", "string[]", "postgres")).toBe(true);
+			expect(matchType("character varying[]", "string[]", "postgres")).toBe(
+				true,
+			);
+			expect(matchType("_text", "string[]", "postgres")).toBe(true);
+		});
+
+		it("accepts native integer[] for number[]", () => {
+			expect(matchType("integer[]", "number[]", "postgres")).toBe(true);
+			expect(matchType("bigint[]", "number[]", "postgres")).toBe(true);
+			expect(matchType("_int4", "number[]", "postgres")).toBe(true);
+		});
+
+		it("accepts legacy jsonb for string[] and number[]", () => {
+			expect(matchType("jsonb", "string[]", "postgres")).toBe(true);
+			expect(matchType("json", "number[]", "postgres")).toBe(true);
+		});
+
+		it("rejects unrelated postgres types", () => {
+			expect(matchType("text", "string[]", "postgres")).toBe(false);
+			expect(matchType("integer", "number[]", "postgres")).toBe(false);
+		});
+	});
+
+	describe("non-postgres array fields", () => {
+		it("matches json storage types", () => {
+			expect(matchType("json", "string[]", "mysql")).toBe(true);
+			expect(matchType("jsonb", "number[]", "mysql")).toBe(true);
+			expect(matchType("TEXT", "string[]", "sqlite")).toBe(false);
+		});
+	});
+});

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -73,6 +73,45 @@ const map = {
 	mssql: mssqlMap,
 };
 
+// cspell:ignore bpchar
+function matchesPostgresArrayColumn(
+	columnDataType: string,
+	fieldType: "string[]" | "number[]",
+) {
+	const lower = columnDataType.toLowerCase();
+	if (lower.includes("json")) {
+		return true;
+	}
+	// Kysely/pg introspection reports internal array type names (e.g. _text, _int4).
+	if (fieldType === "string[]") {
+		return (
+			lower === "_text" ||
+			lower === "_varchar" ||
+			lower === "_bpchar" ||
+			(lower.includes("[]") &&
+				(lower.includes("text") ||
+					lower.includes("char") ||
+					lower.includes("varchar"))) ||
+			lower === "array"
+		);
+	}
+	return (
+		lower === "_int4" ||
+		lower === "_int2" ||
+		lower === "_int8" ||
+		lower === "_numeric" ||
+		lower === "_float4" ||
+		lower === "_float8" ||
+		(lower.includes("[]") &&
+			(lower.includes("int") ||
+				lower.includes("numeric") ||
+				lower.includes("bigint") ||
+				lower.includes("smallint") ||
+				lower.includes("double") ||
+				lower.includes("real")))
+	);
+}
+
 export function matchType(
 	columnDataType: string,
 	fieldType: DBFieldType,
@@ -82,6 +121,9 @@ export function matchType(
 		return type.toLowerCase().split("(")[0]!.trim();
 	}
 	if (fieldType === "string[]" || fieldType === "number[]") {
+		if (dbType === "postgres") {
+			return matchesPostgresArrayColumn(columnDataType, fieldType);
+		}
 		return columnDataType.toLowerCase().includes("json");
 	}
 	const types = map[dbType]!;
@@ -373,13 +415,13 @@ export async function getMigrations(config: BetterAuthOptions) {
 			},
 			"string[]": {
 				sqlite: "text",
-				postgres: "jsonb",
+				postgres: sql`text[]`,
 				mysql: "json",
 				mssql: "varchar(8000)",
 			},
 			"number[]": {
 				sqlite: "text",
-				postgres: "jsonb",
+				postgres: sql`integer[]`,
 				mysql: "json",
 				mssql: "varchar(8000)",
 			},

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -9,6 +9,7 @@ import type {
 } from "@better-auth/core/db/adapter";
 import { createAdapterFactory } from "@better-auth/core/db/adapter";
 import { logger } from "@better-auth/core/env";
+import { safeJSONParse } from "@better-auth/core/utils/json";
 import { capitalizeFirstLetter } from "@better-auth/core/utils/string";
 import type {
 	InsertQueryBuilder,
@@ -51,6 +52,36 @@ interface KyselyAdapterConfig {
 	 * @default false
 	 */
 	transaction?: boolean | undefined;
+}
+
+function transformPostgresArrayInput(
+	data: unknown,
+	fieldType: "string[]" | "number[]",
+) {
+	if (typeof data === "string") {
+		return safeJSONParse<unknown[]>(data) ?? data;
+	}
+	if (fieldType === "number[]" && Array.isArray(data)) {
+		return data.map((value) =>
+			value === null ? null : typeof value === "number" ? value : Number(value),
+		);
+	}
+	return data;
+}
+
+function transformPostgresArrayOutput(
+	data: unknown,
+	fieldType: "string[]" | "number[]",
+) {
+	if (typeof data === "string") {
+		return safeJSONParse<unknown[]>(data) ?? data;
+	}
+	if (fieldType === "number[]" && Array.isArray(data)) {
+		return data.map((value) =>
+			value === null ? null : typeof value === "number" ? value : Number(value),
+		);
+	}
+	return data;
 }
 
 export const kyselyAdapter = (
@@ -818,6 +849,7 @@ export const kyselyAdapter = (
 		};
 	};
 	let adapterOptions: AdapterFactoryOptions | null = null;
+	const isPostgres = config?.type === "postgres";
 	adapterOptions = {
 		config: {
 			adapterId: "kysely",
@@ -839,8 +871,30 @@ export const kyselyAdapter = (
 				config?.type === "postgres"
 					? true // even if there is JSON support, only pg supports passing direct json, all others must stringify
 					: false,
-			supportsArrays: false, // Even if field supports JSON, we must pass stringified arrays to the database.
-			supportsUUIDs: config?.type === "postgres" ? true : false,
+			supportsArrays: isPostgres,
+			customTransformInput: isPostgres
+				? ({ data, fieldAttributes }) => {
+						if (
+							fieldAttributes.type === "string[]" ||
+							fieldAttributes.type === "number[]"
+						) {
+							return transformPostgresArrayInput(data, fieldAttributes.type);
+						}
+						return data;
+					}
+				: undefined,
+			customTransformOutput: isPostgres
+				? ({ data, fieldAttributes }) => {
+						if (
+							fieldAttributes.type === "string[]" ||
+							fieldAttributes.type === "number[]"
+						) {
+							return transformPostgresArrayOutput(data, fieldAttributes.type);
+						}
+						return data;
+					}
+				: undefined,
+			supportsUUIDs: isPostgres,
 			transaction: config?.transaction
 				? (cb) =>
 						db.transaction().execute((trx) => {


### PR DESCRIPTION
## Summary
- Closes #9853.
- Aligns the Kysely adapter and migrations with Drizzle/Prisma on PostgreSQL: `string[]` / `number[]` fields use native `text[]` / `integer[]` instead of `jsonb`, and JS arrays round-trip without JSON stringification (fixed `malformed array literal: "[\"test\"]"` when binding to native array columns).

## Test plan
- [x] `npx vitest run packages/better-auth/src/db/get-migration.test.ts`
- [x] `npx vitest run packages/better-auth/src/db/get-migration-schema.test.ts -t "PostgreSQL native array"`
- [x] `npx vitest run e2e/adapter/test/kysely-adapter/adapter.kysely.pg.test.ts -t "should support arrays"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `@better-auth/kysely-adapter` on Postgres to native `text[]`/`integer[]` for `string[]`/`number[]`, so JS arrays round-trip without JSON. Fixes the malformed array literal error and aligns migrations with Drizzle/Prisma.

- **Bug Fixes**
  - Pass and return Postgres arrays as real arrays; no JSON stringification.
  - Enable array support in the adapter with input/output transforms for `string[]`/`number[]`.
  - Update `matchType` to recognize native array types (`text[]`, `integer[]`, `_text`, `_int4`) and legacy `jsonb`.
  - Add tests for migration schema and array round-trip.

- **Migration**
  - No manual changes needed; existing `jsonb` columns are still recognized.
  - New migrations emit `text[]` and `integer[]` for `string[]` and `number[]`.

<sup>Written for commit b73c842046644a4aa01226e426abc55fc076c429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

