### PR TITLE
fix(next-js)!: auto-enable deferSessionRefresh in nextCookies

### DIFF
--- a/.changeset/next-cookies-defer-session-refresh.md
+++ b/.changeset/next-cookies-defer-session-refresh.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+`nextCookies()` now auto-enables `deferSessionRefresh`, so reading the session in a React Server Component no longer triggers redundant database writes or drifts the session's expiry on each navigation. Apps that read the session only on the server can opt out with `session: { deferSessionRefresh: false }`.

--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -122,6 +122,12 @@ const signIn = async () => {
 }
 ```
 
+<Callout type="info">
+  `nextCookies()` auto-enables [`deferSessionRefresh`](/docs/concepts/session-management), so `GET` session reads stay write-free and RSC navigation never drifts the database session ahead of the cookie. The client re-issues the refresh as a writable `POST`.
+
+  Reading the session only on the server (no `createAuthClient`)? Set `session: { deferSessionRefresh: false }` to keep refreshing on `GET`.
+</Callout>
+
 ## Auth Protection
 
 In Next.js proxy/middleware, it's recommended to only check for the existence of a session cookie to handle redirection to avoid blocking requests by making API or database calls.

--- a/docs/content/docs/integrations/next.mdx
+++ b/docs/content/docs/integrations/next.mdx
@@ -123,7 +123,7 @@ const signIn = async () => {
 ```
 
 <Callout type="info">
-  `nextCookies()` auto-enables [`deferSessionRefresh`](/docs/concepts/session-management), so `GET` session reads stay write-free and RSC navigation never drifts the database session ahead of the cookie. The client re-issues the refresh as a writable `POST`.
+  `nextCookies()` auto-enables [`deferSessionRefresh`](/docs/concepts/session-management#defer-session-refresh), so `GET` session reads stay write-free and RSC navigation never drifts the database session ahead of the cookie. The client re-issues the refresh as a writable `POST`.
 
   Reading the session only on the server (no `createAuthClient`)? Set `session: { deferSessionRefresh: false }` to keep refreshing on `GET`.
 </Callout>

--- a/packages/better-auth/src/integrations/next-js.test.ts
+++ b/packages/better-auth/src/integrations/next-js.test.ts
@@ -1,163 +1,63 @@
+import type { BetterAuthOptions } from "@better-auth/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getTestInstance } from "../test-utils/test-instance";
+import { nextCookies } from "./next-js";
 
 describe("next-js integration", () => {
 	afterEach(() => {
 		vi.useRealTimers();
-		vi.clearAllMocks();
-		vi.resetModules();
-		vi.doUnmock("next/headers.js");
+		vi.restoreAllMocks();
 	});
 
-	async function getSessionWithNextHeaders(
-		nextHeaders: HeadersInit | "unavailable",
-	) {
-		const cookiesMock = vi.fn(async () => ({
-			set: vi.fn(),
-			delete: vi.fn(),
-			get: vi.fn(),
-		}));
-		const headersMock =
-			nextHeaders === "unavailable"
-				? vi.fn(async () => {
-						throw new Error("`headers` was called outside a request scope.");
-					})
-				: vi.fn(async () => new Headers(nextHeaders));
+	it("auto-enables deferSessionRefresh when it is unset", async () => {
+		const { auth } = await getTestInstance({ plugins: [nextCookies()] });
+		const ctx = await auth.$context;
+		expect(
+			(ctx.options as BetterAuthOptions).session?.deferSessionRefresh,
+		).toBe(true);
+	});
 
-		vi.doMock("next/headers.js", () => ({
-			cookies:
-				nextHeaders === "unavailable"
-					? vi.fn(async () => {
-							throw new Error("`cookies` was called outside a request scope.");
-						})
-					: cookiesMock,
-			headers: headersMock,
-		}));
+	it("respects an explicit deferSessionRefresh value", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [nextCookies()],
+			session: { deferSessionRefresh: false },
+		});
+		const ctx = await auth.$context;
+		expect(ctx.options.session?.deferSessionRefresh).toBe(false);
+	});
 
-		const [{ getTestInstance }, { nextCookies }] = await Promise.all([
-			import("../test-utils/test-instance"),
-			import("./next-js"),
-		]);
-
+	/**
+	 * A GET read must not advance the DB session, since RSC renders cannot write
+	 * the matching cookie. The refresh is signaled to the client, which re-issues
+	 * it as a POST where cookies are writable.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/9776
+	 */
+	it("defers session refresh on GET instead of writing", async () => {
 		const { auth, testUser } = await getTestInstance({
 			plugins: [nextCookies()],
-			session: {
-				deferSessionRefresh: true,
-				updateAge: 0,
-			},
+			session: { updateAge: 0 },
 		});
+		const ctx = await auth.$context;
+		const updateSession = vi.spyOn(ctx.internalAdapter, "updateSession");
 
 		const signInRes = await auth.api.signInEmail({
-			body: {
-				email: testUser.email,
-				password: testUser.password,
-			},
+			body: { email: testUser.email, password: testUser.password },
 			returnHeaders: true,
 		});
 		const requestHeaders = new Headers();
 		requestHeaders.set("cookie", signInRes.headers.getSetCookie()[0]!);
-
-		cookiesMock.mockClear();
-		headersMock.mockClear();
 
 		vi.useFakeTimers();
 		await vi.advanceTimersByTimeAsync(1000);
 
-		const session = await auth.api.getSession({
+		const session = (await auth.api.getSession({
 			headers: requestHeaders,
-		});
+		})) as { needsRefresh?: boolean } | null;
 
-		return {
-			cookiesMock,
-			headersMock,
-			session: session as { needsRefresh?: boolean } | null,
-		};
-	}
-
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/8464
-	 */
-	it("should not probe cookies in server action context", async () => {
-		const { cookiesMock, headersMock, session } =
-			await getSessionWithNextHeaders({
-				RSC: "1",
-				"next-action": "abc123",
-			});
-
-		expect(headersMock).toHaveBeenCalledTimes(1);
-		expect(cookiesMock).not.toHaveBeenCalled();
 		expect(session).not.toBeNull();
 		expect(session?.needsRefresh).toBe(true);
-	});
-
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/8464
-	 */
-	it("should skip refresh in server component context", async () => {
-		const { cookiesMock, headersMock, session } =
-			await getSessionWithNextHeaders({ RSC: "1" });
-
-		expect(headersMock).toHaveBeenCalledTimes(1);
-		expect(cookiesMock).not.toHaveBeenCalled();
-		expect(session).not.toBeNull();
-		expect(session?.needsRefresh).toBe(false);
-	});
-
-	it("should allow refresh in route handler context", async () => {
-		const { cookiesMock, session } = await getSessionWithNextHeaders({});
-
-		expect(cookiesMock).not.toHaveBeenCalled();
-		expect(session).not.toBeNull();
-		expect(session?.needsRefresh).toBe(true);
-	});
-
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/8828
-	 */
-	it("should not leak __better-auth-cookie-store cookie", async () => {
-		vi.doMock("next/headers.js", () => ({
-			cookies: vi.fn(async () => ({
-				set: vi.fn(),
-				delete: vi.fn(),
-				get: vi.fn(),
-			})),
-			headers: vi.fn(async () => new Headers({ RSC: "1" })),
-		}));
-
-		const [{ getTestInstance }, { nextCookies }] = await Promise.all([
-			import("../test-utils/test-instance"),
-			import("./next-js"),
-		]);
-
-		const { auth, testUser } = await getTestInstance({
-			plugins: [nextCookies()],
-		});
-
-		const signInRes = await auth.api.signInEmail({
-			body: {
-				email: testUser.email,
-				password: testUser.password,
-			},
-			returnHeaders: true,
-		});
-		const requestHeaders = new Headers();
-		requestHeaders.set("cookie", signInRes.headers.getSetCookie()[0]!);
-
-		const res = await auth.handler(
-			new Request("http://localhost:3000/api/auth/get-session", {
-				headers: requestHeaders,
-			}),
-		);
-
-		const setCookies = res.headers.getSetCookie();
-		const hasProbeCookie = setCookies.some((c) =>
-			c.includes("__better-auth-cookie-store"),
-		);
-		expect(hasProbeCookie).toBe(false);
-	});
-
-	it("should handle unavailable headers gracefully", async () => {
-		const { session } = await getSessionWithNextHeaders("unavailable");
-
-		expect(session).not.toBeNull();
+		// The GET must signal a refresh without performing the DB write.
+		expect(updateSession).not.toHaveBeenCalled();
 	});
 });

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -1,6 +1,5 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
-import { setShouldSkipSessionRefresh } from "../api/state/should-session-refresh";
 import { parseSetCookieHeader, toCookieOptions } from "../cookies";
 import { PACKAGE_VERSION } from "../version";
 import { warnIfCookiePluginNotLast } from "./cookie-plugin-guard";
@@ -30,6 +29,19 @@ export const nextCookies = () => {
 	return {
 		id: "next-cookies",
 		version: PACKAGE_VERSION,
+		// Keep GET /get-session read-only so RSC navigation never writes to the
+		// DB. Cookies cannot be written during an RSC render, so a GET-side
+		// refresh would only drift the DB ahead of the stale cookie. The client
+		// re-issues the refresh as a POST, where cookies are writable. The RSC
+		// context cannot be detected from request headers.
+		// @see .postmortem/rsc-header-detection.md
+		init() {
+			// `defu` preserves an explicit user value, so this applies only when
+			// `deferSessionRefresh` is unset. Escape hatch: set it to `false`.
+			return {
+				options: { session: { deferSessionRefresh: true } },
+			};
+		},
 		hooks: {
 			before: [
 				{
@@ -40,36 +52,6 @@ export const nextCookies = () => {
 						if (!hasWarned) {
 							warnIfCookiePluginNotLast(ctx.context, "next-cookies");
 							hasWarned = true;
-						}
-						// Real HTTP requests (via router) set cookies through
-						// response headers -- no need to skip refresh.
-						if ("_flag" in ctx && ctx._flag === "router") {
-							return;
-						}
-						let headersStore: Awaited<
-							ReturnType<typeof import("next/headers.js").headers>
-						>;
-						try {
-							const { headers } = await import("next/headers.js");
-							headersStore = await headers();
-						} catch {
-							return;
-						}
-						/**
-						 * Detect RSC via headers, NOT by probing cookies().set().
-						 * In Next.js, cookies().set() unconditionally triggers router
-						 * cache invalidation -- even if the value is unchanged.
-						 *
-						 * RSC sends `RSC: 1` without `next-action`. Only in that
-						 * context cookies cannot be written -- skip session refresh
-						 * to avoid DB/cookie mismatch.
-						 *
-						 * @see https://github.com/vercel/next.js/blob/8c5af211d580/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts#L112-L157
-						 */
-						const isRSC = headersStore.get("RSC") === "1";
-						const isServerAction = !!headersStore.get("next-action");
-						if (isRSC && !isServerAction) {
-							await setShouldSkipSessionRefresh(true);
 						}
 					}),
 				},

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -34,7 +34,7 @@ export const nextCookies = () => {
 		// refresh would only drift the DB ahead of the stale cookie. The client
 		// re-issues the refresh as a POST, where cookies are writable. The RSC
 		// context cannot be detected from request headers.
-		// @see .postmortem/rsc-header-detection.md
+		// @see https://github.com/better-auth/better-auth/issues/9776
 		init() {
 			// `defu` preserves an explicit user value, so this applies only when
 			// `deferSessionRefresh` is unset. Escape hatch: set it to `false`.


### PR DESCRIPTION
- Closes #9776
- Related to https://github.com/better-auth/better-auth/blob/main/.postmortem/rsc-header-detection.md