### PR TITLE
fix(open-api): generate requestBody for intersection body schemas

### DIFF
--- a/.changeset/open-api-intersection-request-body.md
+++ b/.changeset/open-api-intersection-request-body.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The OpenAPI spec now includes the `requestBody` for endpoints whose body schema is an intersection (e.g. `/sign-in/email-otp`). Previously these operations were generated without a request body, so the documented fields were missing from the schema.

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -191,7 +191,72 @@ function getRequestBody(options: EndpointOptions): any {
 			},
 		};
 	}
+	if (options.body instanceof z.ZodIntersection) {
+		const { properties, required, additionalProperties } =
+			resolveIntersectionSchema(options.body);
+		return {
+			required: true,
+			content: {
+				"application/json": {
+					schema: {
+						type: "object",
+						properties,
+						required,
+						...(additionalProperties ? { additionalProperties: true } : {}),
+					},
+				},
+			},
+		};
+	}
 	return undefined;
+}
+
+/**
+ * Resolves a `ZodIntersection` body schema (e.g. `z.object({...}).and(z.record(...))`)
+ * into a flat object schema. The object members are merged into `properties`, while a
+ * record member (catch-all) is represented as `additionalProperties`. Without this the
+ * generator would skip the `requestBody` entirely for endpoints using intersections.
+ */
+function resolveIntersectionSchema(zodType: z.ZodType<any>): {
+	properties: Record<string, any>;
+	required: string[];
+	additionalProperties: boolean;
+} {
+	const result = {
+		properties: {} as Record<string, any>,
+		required: [] as string[],
+		additionalProperties: false,
+	};
+	const merge = (schema: z.ZodType<any>) => {
+		if (schema instanceof z.ZodOptional) {
+			merge(schema.unwrap() as z.ZodType<any>);
+			return;
+		}
+		if (schema instanceof z.ZodIntersection) {
+			const def = (schema as any)._def;
+			merge(def.left);
+			merge(def.right);
+			return;
+		}
+		if (schema instanceof z.ZodRecord) {
+			result.additionalProperties = true;
+			return;
+		}
+		if (schema instanceof z.ZodObject) {
+			const shape = (schema as any).shape;
+			if (!shape) return;
+			Object.entries(shape).forEach(([key, value]) => {
+				if (value instanceof z.ZodType) {
+					result.properties[key] = processZodType(value as z.ZodType<any>);
+					if (!(value instanceof z.ZodOptional)) {
+						result.required.push(key);
+					}
+				}
+			});
+		}
+	};
+	merge(zodType);
+	return result;
 }
 
 function processZodType(zodType: z.ZodType<any>): any {

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -202,7 +202,7 @@ function getRequestBody(options: EndpointOptions): any {
 						type: "object",
 						properties,
 						required,
-						...(additionalProperties ? { additionalProperties: true } : {}),
+						...(additionalProperties ? { additionalProperties } : {}),
 					},
 				},
 			},
@@ -214,18 +214,20 @@ function getRequestBody(options: EndpointOptions): any {
 /**
  * Resolves a `ZodIntersection` body schema (e.g. `z.object({...}).and(z.record(...))`)
  * into a flat object schema. The object members are merged into `properties`, while a
- * record member (catch-all) is represented as `additionalProperties`. Without this the
- * generator would skip the `requestBody` entirely for endpoints using intersections.
+ * record member (catch-all) is represented as `additionalProperties` — preserving the
+ * record's value type, or `true` when the value type is unconstrained (`z.any()`/
+ * `z.unknown()`). Without this the generator would skip the `requestBody` entirely for
+ * endpoints using intersections.
  */
 function resolveIntersectionSchema(zodType: z.ZodType<any>): {
 	properties: Record<string, any>;
 	required: string[];
-	additionalProperties: boolean;
+	additionalProperties: boolean | Record<string, any>;
 } {
 	const result = {
 		properties: {} as Record<string, any>,
 		required: [] as string[],
-		additionalProperties: false,
+		additionalProperties: false as boolean | Record<string, any>,
 	};
 	const merge = (schema: z.ZodType<any>) => {
 		if (schema instanceof z.ZodOptional) {
@@ -239,7 +241,11 @@ function resolveIntersectionSchema(zodType: z.ZodType<any>): {
 			return;
 		}
 		if (schema instanceof z.ZodRecord) {
-			result.additionalProperties = true;
+			const valueType = (schema as any)._def.valueType as z.ZodType<any>;
+			result.additionalProperties =
+				valueType instanceof z.ZodAny || valueType instanceof z.ZodUnknown
+					? true
+					: processZodType(valueType);
 			return;
 		}
 		if (schema instanceof z.ZodObject) {
@@ -256,6 +262,9 @@ function resolveIntersectionSchema(zodType: z.ZodType<any>): {
 		}
 	};
 	merge(zodType);
+	// `required` must be a set of unique property names (JSON Schema); intersecting
+	// objects that share a key would otherwise produce duplicates.
+	result.required = [...new Set(result.required)];
 	return result;
 }
 

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
+import { emailOTP } from "../email-otp";
 import { openAPI } from ".";
 
 describe("open-api", async () => {
@@ -314,5 +315,45 @@ describe("open-api", async () => {
 		expect(signUpProps.rememberMe).toBeDefined();
 		const baseTypes = getBaseType(signUpProps.rememberMe.type);
 		expect(baseTypes).toContain("boolean");
+	});
+});
+
+describe("open-api request body for intersection schemas", async () => {
+	const { auth } = await getTestInstance({
+		plugins: [
+			openAPI(),
+			emailOTP({
+				async sendVerificationOTP() {},
+			}),
+		],
+	});
+
+	/**
+	 * Endpoints whose body uses `z.object({...}).and(z.record(...))` (a `ZodIntersection`)
+	 * used to be skipped by the generator, leaving the operation without a `requestBody`.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/9679
+	 */
+	it("should generate a requestBody for endpoints using intersection body schemas", async () => {
+		const schema = await auth.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, any>;
+
+		const signInEmailOTP = paths["/sign-in/email-otp"];
+		expect(signInEmailOTP).toBeDefined();
+
+		const requestBody = signInEmailOTP.post.requestBody;
+		expect(requestBody).toBeDefined();
+
+		const bodySchema = requestBody.content["application/json"].schema;
+		expect(bodySchema.type).toBe("object");
+		// Defined members of the intersected object are exposed as properties.
+		expect(bodySchema.properties.email).toBeDefined();
+		expect(bodySchema.properties.otp).toBeDefined();
+		expect(bodySchema.required).toContain("email");
+		expect(bodySchema.required).toContain("otp");
+		// Optional members are not required.
+		expect(bodySchema.required).not.toContain("name");
+		// The `z.record(...)` catch-all is represented as additionalProperties.
+		expect(bodySchema.additionalProperties).toBe(true);
 	});
 });


### PR DESCRIPTION
## Description

Endpoints whose request body is built with an intersection — `z.object({...}).and(z.record(z.string(), z.any()))` — produce a Zod `ZodIntersection`. The OpenAPI generator's `getRequestBody` only handled `ZodObject` / `ZodOptional`, so for these endpoints it fell through and returned `undefined`, emitting the operation **without a `requestBody`**.

The most visible case is `POST /sign-in/email-otp` (the `emailOTP` plugin), whose body is:

```ts
z.object({ email, otp, name?, image? }).and(z.record(z.string(), z.any()))
```

Its generated spec was missing the `requestBody` entirely.

## Fix

Add a `ZodIntersection` branch to `getRequestBody`, backed by a small `resolveIntersectionSchema` helper that:

- merges the defined object members into `properties` (preserving `required` for non-optional fields), and
- represents a `z.record(...)` catch-all member as `additionalProperties: true`.

The existing `ZodObject` / `ZodOptional` path is left untouched, so no other operation's output changes. Endpoints that already declare an explicit `metadata.openapi.requestBody` (e.g. `/sign-up/email`) continue to short-circuit as before.

## Tests

Added a regression test (`open-api.test.ts`) that registers the `emailOTP` plugin and asserts `/sign-in/email-otp` now has a `requestBody` with `email`/`otp` required, `name` optional, and `additionalProperties: true`.

```
Test Files  1 passed (1)
     Tests  13 passed (13)
```

`pnpm typecheck` and biome both pass.

Closes #9679

<sub>Note: the linked duplicate #9298 is closed but no fix has landed on `main`/`next`.</sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the OpenAPI generator to include requestBody for intersection body schemas (`z.object(...).and(z.record(...))`), so endpoints like `POST /sign-in/email-otp` are documented correctly. Also dedupes required keys and preserves record value types in `additionalProperties`.

- **Bug Fixes**
  - Handle `ZodIntersection` in `getRequestBody` via `resolveIntersectionSchema`.
  - Merge object members into `properties` with accurate, deduped `required`; map `z.record(...)` to `additionalProperties` using the processed value type (fallback to `true` for `z.any()`/`z.unknown()`).
  - Keep existing `ZodObject`/`ZodOptional` behavior and explicit `metadata.openapi.requestBody` overrides unchanged.
  - Add a regression test ensuring `/sign-in/email-otp` now emits a proper `requestBody`.

<sup>Written for commit ddaeae59dff8b5814f4f38b2552be012294755e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

