### PR TITLE
fix: deprecated import from 'kysely'

### DIFF
--- a/packages/kysely-adapter/src/bun-sqlite-dialect.ts
+++ b/packages/kysely-adapter/src/bun-sqlite-dialect.ts
@@ -25,6 +25,15 @@ import {
 	DefaultQueryCompiler,
 	sql,
 } from "kysely";
+import {
+	CompiledQuery,
+	DefaultQueryCompiler,
+	sql,
+} from "kysely";
+import {
+	DEFAULT_MIGRATION_LOCK_TABLE,
+	DEFAULT_MIGRATION_TABLE,
+} from "kysely/migration";
 
 class BunSqliteAdapter implements DialectAdapterBase {
 	get supportsCreateIfNotExists(): boolean {

--- a/packages/kysely-adapter/src/d1-sqlite-dialect.ts
+++ b/packages/kysely-adapter/src/d1-sqlite-dialect.ts
@@ -15,11 +15,14 @@ import type {
 	TableMetadata,
 } from "kysely";
 import {
+	CompiledQuery,
+	DefaultQueryCompiler,
+	sql,
+} from "kysely";
+import {
 	DEFAULT_MIGRATION_LOCK_TABLE,
 	DEFAULT_MIGRATION_TABLE,
-	SqliteAdapter,
-	SqliteQueryCompiler,
-} from "kysely";
+} from "kysely/migration";
 
 class D1SqliteAdapter extends SqliteAdapter {}
 

--- a/packages/kysely-adapter/src/node-sqlite-dialect.ts
+++ b/packages/kysely-adapter/src/node-sqlite-dialect.ts
@@ -20,11 +20,13 @@ import type {
 } from "kysely";
 import {
 	CompiledQuery,
-	DEFAULT_MIGRATION_LOCK_TABLE,
-	DEFAULT_MIGRATION_TABLE,
 	DefaultQueryCompiler,
 	sql,
 } from "kysely";
+import {
+	DEFAULT_MIGRATION_LOCK_TABLE,
+	DEFAULT_MIGRATION_TABLE,
+} from "kysely/migration";
 
 class NodeSqliteAdapter implements DialectAdapterBase {
 	get supportsCreateIfNotExists(): boolean {


### PR DESCRIPTION
MIGRATION consts from 'kysely' are depreacted and cause error in esbuild so i fixed to import from 'kysely/migration'

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch migration constant imports to `kysely/migration` to remove esbuild errors and match Kysely’s current API. Affects the SQLite dialect adapters in the `kysely-adapter` package.

- Bug Fixes
  - Updated `bun-sqlite-dialect.ts`, `d1-sqlite-dialect.ts`, and `node-sqlite-dialect.ts` to import `DEFAULT_MIGRATION_TABLE` and `DEFAULT_MIGRATION_LOCK_TABLE` from `kysely/migration`.
  - Standardized other imports to use `kysely` for `CompiledQuery`, `DefaultQueryCompiler`, and `sql`.

<sup>Written for commit d01168de03bf10312a2e257076761409a52ef1e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

