### PR TITLE
docs: add FAQ for Kysely migration lock export error

### DIFF
--- a/docs/content/docs/reference/faq.mdx
+++ b/docs/content/docs/reference/faq.mdx
@@ -121,6 +121,28 @@ This page contains frequently asked questions, common issues, and other helpful 
     You can learn more in our <Link href="/docs/concepts/typescript#typescript-config">TypeScript docs</Link>.
   </Accordion>
 
+  <Accordion id="default-migration-lock-table-export-error" title="Export DEFAULT_MIGRATION_LOCK_TABLE doesn't exist">
+    If you see `Export DEFAULT_MIGRATION_LOCK_TABLE doesn't exist` while building a project that uses `better-auth@1.6.13` with Kysely 0.29, upgrade Better Auth and `@better-auth/kysely-adapter` to `1.6.14` or later.
+
+    This was caused by Kysely 0.29 moving migration constants out of the root `kysely` export. Better Auth `1.6.14` imports those constants from Kysely's migration subpath.
+
+    If you can't upgrade immediately, pin Kysely to `0.28.17` as a temporary workaround and reinstall your dependencies:
+
+    ```json title="package.json"
+    {
+      "overrides": {
+        "kysely": "0.28.17"
+      }
+    }
+    ```
+
+    ```bash
+    npm install
+    ```
+
+    Remove the override after upgrading Better Auth.
+  </Accordion>
+
   <Accordion id="can-i-remove-name-image-or-email-fields-from-the-user-table" title="Can I remove `name`, `image`, or `email` fields from the user table?">
     At this time, you can't remove the `name`, `image`, or `email` fields from the user table.
 


### PR DESCRIPTION
## Summary
- add an FAQ entry for the `DEFAULT_MIGRATION_LOCK_TABLE` export error with `better-auth@1.6.13` and Kysely 0.29
- recommend upgrading to `1.6.14+`, with a temporary `kysely@0.28.17` override for projects that cannot upgrade immediately

## Testing
- `git diff --check`
- Not run: docs remark check. `pnpm install --frozen-lockfile --ignore-scripts` failed locally while linking dependencies after registry download timeouts/ENOENT, so `remark` was not available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an FAQ entry to help fix the `Export DEFAULT_MIGRATION_LOCK_TABLE doesn't exist` error when using Kysely 0.29 with `better-auth@1.6.13`. Recommends upgrading to `1.6.14+` and offers a temporary `kysely@0.28.17` override.

- **Migration**
  - Upgrade `better-auth` and `@better-auth/kysely-adapter` to `1.6.14+`.
  - If you can’t upgrade now, pin `kysely` to `0.28.17`, reinstall, and remove the override after upgrading.

<sup>Written for commit 11f4a2d3a4edab5d778aadd6e9bbfdfa300f7c70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

