### PR TITLE
fix(oauth-provider): run hooks for authorize resume paths

### DIFF
--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -11,6 +11,102 @@ import { getTestInstance } from "../test-utils/test-instance";
 import { isAPIError } from "../utils/is-api-error";
 import { toAuthEndpoints } from "./to-auth-endpoints";
 
+function createHookPipelineOptions(calls: string[]) {
+	return {
+		hooks: {
+			before: createAuthMiddleware(async (ctx) => {
+				if (ctx.path !== "/hook-pipeline") return;
+				calls.push("before");
+				return {
+					context: {
+						body: {
+							name: "from-before",
+						},
+					},
+				};
+			}),
+			after: createAuthMiddleware(async (ctx) => {
+				if (ctx.path !== "/hook-pipeline") return;
+				calls.push(`after:${(ctx.context.returned as { name: string }).name}`);
+				return {
+					name: "from-after",
+				};
+			}),
+		},
+	};
+}
+
+function createHookPipelineEndpoint(calls: string[]) {
+	return createAuthEndpoint(
+		"/hook-pipeline",
+		{
+			method: "POST",
+			body: z.object({
+				name: z.string(),
+			}),
+		},
+		async (ctx) => {
+			calls.push(`handler:${ctx.body.name}`);
+			return {
+				name: ctx.body.name,
+			};
+		},
+	);
+}
+
+describe("endpoint hook pipeline", () => {
+	it("runs hooks exactly once through auth.api calls", async () => {
+		const calls: string[] = [];
+		const endpoint = createHookPipelineEndpoint(calls);
+		const authContext = init(createHookPipelineOptions(calls));
+		const api = toAuthEndpoints({ hookPipeline: endpoint }, authContext);
+
+		const response = await api.hookPipeline({
+			body: {},
+		} as any);
+
+		expect(response).toEqual({ name: "from-after" });
+		expect(calls).toEqual([
+			"before",
+			"handler:from-before",
+			"after:from-before",
+		]);
+	});
+
+	it("runs hooks exactly once through the HTTP router", async () => {
+		const calls: string[] = [];
+		const endpoint = createHookPipelineEndpoint(calls);
+		const { auth } = await getTestInstance({
+			...createHookPipelineOptions(calls),
+			plugins: [
+				{
+					id: "hook-pipeline-test",
+					endpoints: {
+						hookPipeline: endpoint,
+					},
+				},
+			],
+		});
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/api/auth/hook-pipeline", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({}),
+			}),
+		);
+
+		expect(await response.json()).toEqual({ name: "from-after" });
+		expect(calls).toEqual([
+			"before",
+			"handler:from-before",
+			"after:from-before",
+		]);
+	});
+});
+
 describe("before hook", async () => {
 	describe("context", async () => {
 		const endpoints = {

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -296,11 +296,24 @@ describe("before hook", async () => {
 					return { response: true };
 				},
 			),
+			jsonWithHeaders: createAuthEndpoint(
+				"/json-with-headers",
+				{
+					method: "GET",
+				},
+				async (c) => {
+					return { response: true };
+				},
+			),
 		};
 
 		const authContext = init({
 			hooks: {
 				before: createAuthMiddleware(async (c) => {
+					if (c.path === "/json-with-headers") {
+						c.setHeader("x-before-hook", "set");
+						return { before: true };
+					}
 					if (c.path === "/json") {
 						return { before: true };
 					}
@@ -318,6 +331,32 @@ describe("before hook", async () => {
 		it("should return the hook response", async () => {
 			const response = await authEndpoints.json();
 			expect(response).toMatchObject({ before: true });
+		});
+
+		it("should preserve response headers from short-circuited before hooks", async () => {
+			const response = await authEndpoints.jsonWithHeaders({
+				asResponse: true,
+				headers: new Headers({
+					cookie: "session=request",
+				}),
+			});
+
+			expect(await response.json()).toEqual({ before: true });
+			expect(response.headers.get("x-before-hook")).toBe("set");
+			expect(response.headers.get("cookie")).toBeNull();
+		});
+
+		it("should return response headers from short-circuited before hooks", async () => {
+			const result = await authEndpoints.jsonWithHeaders({
+				returnHeaders: true,
+				headers: new Headers({
+					cookie: "session=request",
+				}),
+			});
+
+			expect(result.response).toEqual({ before: true });
+			expect(result.headers?.get("x-before-hook")).toBe("set");
+			expect(result.headers?.get("cookie")).toBeNull();
 		});
 	});
 });

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -1,15 +1,10 @@
-import type { AuthContext, HookEndpointContext } from "@better-auth/core";
-import type { AuthMiddleware } from "@better-auth/core/api";
+import type { AuthContext } from "@better-auth/core";
 import {
 	hasRequestState,
-	runWithEndpointContext,
 	runWithRequestState,
 } from "@better-auth/core/context";
-import { shouldPublishLog } from "@better-auth/core/env";
 import { APIError, BetterAuthError } from "@better-auth/core/error";
 import {
-	ATTR_CONTEXT,
-	ATTR_HOOK_TYPE,
 	ATTR_HTTP_ROUTE,
 	ATTR_OPERATION_ID,
 	withSpan,
@@ -20,15 +15,12 @@ import type {
 	EndpointOptions,
 	InputContext,
 } from "better-call";
-import { kAPIErrorHeaderSymbol, toResponse } from "better-call";
-import { createDefu } from "defu";
 import {
 	pickSource,
 	resolveDynamicTrustedProxyHeaders,
 	resolveRequestContext,
 } from "../context/helpers";
-import { isAPIError } from "../utils/is-api-error";
-import { isDynamicBaseURLConfig, isRequestLike } from "../utils/url";
+import { isDynamicBaseURLConfig } from "../utils/url";
 
 type InternalContext = Partial<
 	InputContext<string, any> & EndpointContext<string, any>
@@ -40,24 +32,8 @@ type InternalContext = Partial<
 		returned?: unknown | undefined;
 		responseHeaders?: Headers | undefined;
 	};
+	operationId?: string | undefined;
 };
-
-const defuReplaceArrays = createDefu((obj, key, value) => {
-	if (Array.isArray(obj[key]) && Array.isArray(value)) {
-		obj[key] = value;
-		return true;
-	}
-});
-
-type Hook = {
-	matcher: (context: HookEndpointContext) => boolean;
-	handler: AuthMiddleware;
-};
-
-const hooksSourceWeakMap = new WeakMap<
-	AuthMiddleware,
-	`user` | `plugin:${string}`
->();
 
 function getOperationId(endpoint: Endpoint | undefined, key: string): string {
 	if (!endpoint?.options) return key;
@@ -146,7 +122,7 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 					? await resolveDynamicContext(rawContext, context)
 					: rawContext;
 
-				let internalContext: InternalContext = {
+				const internalContext: InternalContext = {
 					...context,
 					context: {
 						...authContext,
@@ -156,211 +132,15 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 					},
 					path: endpoint.path,
 					headers: context?.headers ? new Headers(context?.headers) : undefined,
+					operationId,
 				};
-				const hasRequest = isRequestLike(context?.request);
-				const shouldReturnResponse = context?.asResponse ?? hasRequest;
 				return withSpan(
 					`${methodName} ${route}`,
 					{
 						[ATTR_HTTP_ROUTE]: route,
 						[ATTR_OPERATION_ID]: operationId,
 					},
-					async () =>
-						runWithEndpointContext(internalContext, async () => {
-							const { beforeHooks, afterHooks } = getHooks(authContext);
-							const before = await runBeforeHooks(
-								internalContext,
-								beforeHooks,
-								endpoint,
-								operationId,
-							);
-							/**
-							 * If `before.context` is returned, it should
-							 * get merged with the original context
-							 */
-							if (
-								"context" in before &&
-								before.context &&
-								typeof before.context === "object"
-							) {
-								const { headers, ...rest } = before.context as {
-									headers: Headers;
-								};
-								/**
-								 * Headers should be merged differently
-								 * so the hook doesn't override the whole
-								 * header
-								 */
-								if (headers) {
-									headers.forEach((value, key) => {
-										(internalContext.headers as Headers).set(key, value);
-									});
-								}
-								internalContext = defuReplaceArrays(rest, internalContext);
-							} else if (before) {
-								/* Return before hook response if it's anything other than a context return */
-								return shouldReturnResponse
-									? toResponse(before, {
-											headers: context?.headers,
-										})
-									: context?.returnHeaders
-										? {
-												headers: context?.headers,
-												response: before,
-											}
-										: before;
-							}
-
-							internalContext.asResponse = false;
-							internalContext.returnHeaders = true;
-							internalContext.returnStatus = true;
-							const result = (await runWithEndpointContext(
-								internalContext,
-								() =>
-									withSpan(
-										`handler ${route}`,
-										{
-											[ATTR_HTTP_ROUTE]: route,
-											[ATTR_OPERATION_ID]: operationId,
-										},
-										() => (endpoint as any)(internalContext as any),
-									),
-							).catch((e: any) => {
-								if (isAPIError(e)) {
-									/**
-									 * API Errors from response are caught
-									 * and returned to hooks.
-									 *
-									 * Headers come from two sources that must both
-									 * survive:
-									 * - `kAPIErrorHeaderSymbol`: ctx.responseHeaders
-									 *   accumulated via c.setCookie / c.setHeader
-									 *   before the throw.
-									 * - `e.headers`: explicit headers on the APIError
-									 *   (e.g. `location` from c.redirect).
-									 *
-									 * Start from the accumulated ctx headers, then
-									 * apply e.headers on top — appending `set-cookie`
-									 * and setting others — so explicit APIError
-									 * headers override while cookies accumulate.
-									 */
-									const ctxHeaders = (
-										e as {
-											[kAPIErrorHeaderSymbol]?: Headers;
-										}
-									)[kAPIErrorHeaderSymbol];
-									/**
-									 * `c.redirect()` (and similar APIError throws) reuse
-									 * `ctx.responseHeaders` as `e.headers`, so when both sources
-									 * reference the same Headers, iterating both duplicates every
-									 * `set-cookie`. Skip the `errHeaders` copy in that case.
-									 */
-									const errHeaders =
-										e.headers && e.headers !== ctxHeaders
-											? new Headers(e.headers)
-											: null;
-									let headers: Headers | null = null;
-									if (ctxHeaders || errHeaders) {
-										headers = new Headers();
-										ctxHeaders?.forEach((value, key) => {
-											headers!.append(key, value);
-										});
-										errHeaders?.forEach((value, key) => {
-											if (key.toLowerCase() === "set-cookie") {
-												headers!.append(key, value);
-											} else {
-												headers!.set(key, value);
-											}
-										});
-									}
-									return {
-										response: e,
-										status: e.statusCode,
-										headers,
-									};
-								}
-								throw e;
-							})) as {
-								headers: Headers;
-								response: any;
-								status: number;
-							};
-
-							//if response object is returned we skip after hooks and post processing
-							if (result && result instanceof Response) {
-								return result;
-							}
-
-							internalContext.context.returned = result.response;
-							internalContext.context.responseHeaders = result.headers;
-
-							const after = await runAfterHooks(
-								internalContext,
-								afterHooks,
-								endpoint,
-								operationId,
-							);
-
-							if (after.response) {
-								result.response = after.response;
-							}
-
-							if (
-								isAPIError(result.response) &&
-								shouldPublishLog(authContext.logger.level, "debug")
-							) {
-								// inherit stack from errorStack if debug mode is enabled
-								result.response.stack = result.response.errorStack;
-							}
-
-							if (isAPIError(result.response) && !shouldReturnResponse) {
-								/**
-								 * Non-response path: we re-throw the raw APIError
-								 * to callers of `auth.api.*`. `result.headers`
-								 * holds the merged ctx + explicit headers (see
-								 * catch block above) — rewrite
-								 * `kAPIErrorHeaderSymbol` with the merged set so
-								 * downstream pipelines (e.g. better-call's
-								 * response builder, or an outer hook catch) see
-								 * the same headers we'd have written on the
-								 * response.
-								 */
-								if (result.headers) {
-									Object.defineProperty(
-										result.response,
-										kAPIErrorHeaderSymbol,
-										{
-											enumerable: false,
-											configurable: true,
-											writable: false,
-											value: result.headers,
-										},
-									);
-								}
-								throw result.response;
-							}
-
-							const response = shouldReturnResponse
-								? toResponse(result.response, {
-										headers: result.headers,
-										status: result.status,
-									})
-								: context?.returnHeaders
-									? context?.returnStatus
-										? {
-												headers: result.headers,
-												response: result.response,
-												status: result.status,
-											}
-										: {
-												headers: result.headers,
-												response: result.response,
-											}
-									: context?.returnStatus
-										? { response: result.response, status: result.status }
-										: result.response;
-							return response;
-						}),
+					() => (endpoint as any)(internalContext as any),
 				);
 			};
 			if (await hasRequestState()) {
@@ -374,191 +154,4 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 		api[key].options = endpoint.options;
 	}
 	return api as unknown as E;
-}
-
-async function runBeforeHooks(
-	context: InternalContext,
-	hooks: Hook[],
-	endpoint: Endpoint,
-	operationId: string,
-) {
-	let modifiedContext: Partial<InternalContext> = {};
-
-	for (const hook of hooks) {
-		let matched = false;
-		try {
-			matched = hook.matcher(context);
-		} catch (error) {
-			// manually handle unexpected errors during hook matcher execution to prevent accidental exposure of internal details
-			// Also provides debug information about which plugin the hook failed and error info
-			const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
-			context.context.logger.error(
-				`An error occurred during ${hookSource} hook matcher execution:`,
-				error,
-			);
-			throw new APIError("INTERNAL_SERVER_ERROR", {
-				message: `An error occurred during hook matcher execution. Check the logs for more details.`,
-			});
-		}
-		if (matched) {
-			const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
-			const route = endpoint.path ?? "/:virtual";
-			const result = await withSpan(
-				`hook before ${route} ${hookSource}`,
-				{
-					[ATTR_HOOK_TYPE]: "before",
-					[ATTR_HTTP_ROUTE]: route,
-					[ATTR_CONTEXT]: hookSource,
-					[ATTR_OPERATION_ID]: operationId,
-				},
-				() =>
-					hook.handler({
-						...context,
-						returnHeaders: false,
-					}),
-			).catch((e: unknown) => {
-				if (
-					isAPIError(e) &&
-					shouldPublishLog(context.context.logger.level, "debug")
-				) {
-					// inherit stack from errorStack if debug mode is enabled
-					e.stack = e.errorStack;
-				}
-				throw e;
-			});
-			if (result && typeof result === "object") {
-				if ("context" in result && typeof result.context === "object") {
-					const { headers, ...rest } =
-						result.context as Partial<InternalContext>;
-					if (headers instanceof Headers) {
-						if (modifiedContext.headers) {
-							headers.forEach((value, key) => {
-								modifiedContext.headers?.set(key, value);
-							});
-						} else {
-							modifiedContext.headers = headers;
-						}
-					}
-					modifiedContext = defuReplaceArrays(rest, modifiedContext);
-
-					continue;
-				}
-				return result;
-			}
-		}
-	}
-	return { context: modifiedContext };
-}
-
-async function runAfterHooks(
-	context: InternalContext,
-	hooks: Hook[],
-	endpoint: Endpoint,
-	operationId: string,
-) {
-	for (const hook of hooks) {
-		if (hook.matcher(context)) {
-			const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
-			const route = endpoint.path ?? "/:virtual";
-			const result = (await withSpan(
-				`hook after ${route} ${hookSource}`,
-				{
-					[ATTR_HOOK_TYPE]: "after",
-					[ATTR_HTTP_ROUTE]: route,
-					[ATTR_CONTEXT]: hookSource,
-					[ATTR_OPERATION_ID]: operationId,
-				},
-				() => hook.handler(context),
-			).catch((e) => {
-				if (isAPIError(e)) {
-					const headers = (e as any)[kAPIErrorHeaderSymbol] as
-						| Headers
-						| undefined;
-					if (shouldPublishLog(context.context.logger.level, "debug")) {
-						// inherit stack from errorStack if debug mode is enabled
-						e.stack = e.errorStack;
-					}
-					return {
-						response: e,
-						headers: headers
-							? headers
-							: e.headers
-								? new Headers(e.headers)
-								: null,
-					};
-				}
-				throw e;
-			})) as {
-				response: any;
-				headers: Headers;
-			};
-			if (result.headers) {
-				result.headers.forEach((value, key) => {
-					if (!context.context.responseHeaders) {
-						context.context.responseHeaders = new Headers({
-							[key]: value,
-						});
-					} else {
-						if (key.toLowerCase() === "set-cookie") {
-							context.context.responseHeaders.append(key, value);
-						} else {
-							context.context.responseHeaders.set(key, value);
-						}
-					}
-				});
-			}
-			if (result.response) {
-				context.context.returned = result.response;
-			}
-		}
-	}
-	return {
-		response: context.context.returned,
-		headers: context.context.responseHeaders,
-	};
-}
-
-function getHooks(authContext: AuthContext) {
-	const plugins = authContext.options.plugins || [];
-	const beforeHooks: Hook[] = [];
-	const afterHooks: Hook[] = [];
-	const beforeHookHandler = authContext.options.hooks?.before;
-	if (beforeHookHandler) {
-		hooksSourceWeakMap.set(beforeHookHandler, "user");
-		beforeHooks.push({
-			matcher: () => true,
-			handler: beforeHookHandler,
-		});
-	}
-	const afterHookHandler = authContext.options.hooks?.after;
-	if (afterHookHandler) {
-		hooksSourceWeakMap.set(afterHookHandler, "user");
-		afterHooks.push({
-			matcher: () => true,
-			handler: afterHookHandler,
-		});
-	}
-	const pluginBeforeHooks = plugins.flatMap((plugin) =>
-		(plugin.hooks?.before ?? []).map((h) => {
-			hooksSourceWeakMap.set(h.handler, `plugin:${plugin.id}`);
-			return h;
-		}),
-	);
-	const pluginAfterHooks = plugins.flatMap((plugin) =>
-		(plugin.hooks?.after ?? []).map((h) => {
-			hooksSourceWeakMap.set(h.handler, `plugin:${plugin.id}`);
-			return h;
-		}),
-	);
-
-	/**
-	 * Add plugin added hooks at last
-	 */
-	if (pluginBeforeHooks.length) beforeHooks.push(...pluginBeforeHooks);
-	if (pluginAfterHooks.length) afterHooks.push(...pluginAfterHooks);
-
-	return {
-		beforeHooks,
-		afterHooks,
-	};
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -310,7 +310,7 @@ async function runBeforeHooks(
 
 		const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
 		const route = endpoint.path ?? "/:virtual";
-		const result = await withSpan(
+		const result = (await withSpan(
 			`hook before ${route} ${hookSource}`,
 			{
 				[ATTR_HOOK_TYPE]: "before",
@@ -321,7 +321,7 @@ async function runBeforeHooks(
 			() =>
 				hook.handler({
 					...context,
-					returnHeaders: false,
+					returnHeaders: true,
 				}),
 		).catch((e: unknown) => {
 			if (
@@ -331,13 +331,18 @@ async function runBeforeHooks(
 				e.stack = e.errorStack;
 			}
 			throw e;
-		});
-		if (!result || typeof result !== "object") continue;
-		if ("context" in result && typeof result.context === "object") {
-			mergeHookContext(context, result.context);
+		})) as {
+			headers?: Headers | null | undefined;
+			response?: unknown;
+		};
+		mergeResponseHeaders(context.context, result.headers);
+		const response = result.response;
+		if (!response || typeof response !== "object") continue;
+		if ("context" in response && typeof response.context === "object") {
+			mergeHookContext(context, response.context);
 			continue;
 		}
-		return result;
+		return response;
 	}
 }
 
@@ -450,14 +455,15 @@ function withHookPipeline<T extends Endpoint>(endpoint: T): T {
 				operationId,
 			);
 			if (before) {
+				const headers = endpointContext.context.responseHeaders;
 				mergeEndpointHeadersBack(parentAuthContext!, endpointContext.context);
 				return shouldReturnResponse
 					? toResponse(before, {
-							headers: endpointContext.headers,
+							headers,
 						})
 					: context?.returnHeaders
 						? {
-								headers: endpointContext.headers,
+								headers,
 								response: before,
 							}
 						: before;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,15 +1,27 @@
 import type {
+	Endpoint,
 	EndpointContext,
 	EndpointOptions,
+	InputContext,
 	StrictEndpoint,
 } from "better-call";
 import {
 	createEndpoint,
 	createMiddleware,
 	kAPIErrorHeaderSymbol,
+	toResponse,
 } from "better-call";
 import { runWithEndpointContext } from "../context";
-import type { AuthContext } from "../types";
+import { shouldPublishLog } from "../env";
+import { APIError } from "../error";
+import {
+	ATTR_CONTEXT,
+	ATTR_HOOK_TYPE,
+	ATTR_HTTP_ROUTE,
+	ATTR_OPERATION_ID,
+	withSpan,
+} from "../instrumentation";
+import type { AuthContext, HookEndpointContext } from "../types";
 import { isAPIError } from "../utils/is-api-error";
 
 /**
@@ -57,6 +69,491 @@ export const createAuthMiddleware = createMiddleware.create({
 });
 
 const use = [optionsMiddleware];
+
+type InternalContext = Partial<
+	InputContext<string, any> & EndpointContext<string, any>
+> & {
+	path: string;
+	asResponse?: boolean | undefined;
+	context: AuthContext & {
+		logger: AuthContext["logger"];
+		returned?: unknown | undefined;
+		responseHeaders?: Headers | undefined;
+	};
+	operationId?: string | undefined;
+};
+
+type Hook = {
+	matcher: (context: HookEndpointContext) => boolean;
+	handler: AuthMiddleware;
+};
+
+const hooksSourceWeakMap = new WeakMap<
+	AuthMiddleware,
+	`user` | `plugin:${string}`
+>();
+
+function getOperationId(
+	endpoint: Endpoint | undefined,
+	context: Partial<InternalContext> | undefined,
+): string {
+	if (context?.operationId) return context.operationId;
+	if (!endpoint?.options) return endpoint?.path ?? "/:virtual";
+	const opts = endpoint.options as {
+		operationId?: string;
+		metadata?: { openapi?: { operationId?: string } };
+	};
+	return (
+		opts.operationId ??
+		opts.metadata?.openapi?.operationId ??
+		endpoint.path ??
+		"/:virtual"
+	);
+}
+
+function isRequestLike(value: unknown): value is Request {
+	if (value instanceof Request) return true;
+	if (
+		typeof value !== "object" ||
+		value === null ||
+		Object.prototype.toString.call(value) !== "[object Request]"
+	) {
+		return false;
+	}
+	const v = value as { url?: unknown; headers?: unknown };
+	return (
+		typeof v.url === "string" &&
+		typeof v.headers === "object" &&
+		v.headers !== null &&
+		typeof (v.headers as { get?: unknown }).get === "function"
+	);
+}
+
+function isAuthContext(value: unknown): value is AuthContext {
+	return (
+		!!value &&
+		typeof value === "object" &&
+		"options" in value &&
+		"logger" in value
+	);
+}
+
+function makeEndpointContext(
+	context: Partial<InternalContext> | undefined,
+	endpoint: Endpoint,
+): InternalContext | null {
+	const authContext = context?.context;
+	if (!isAuthContext(authContext)) {
+		return null;
+	}
+	return {
+		...context,
+		context: {
+			...authContext,
+			returned: undefined,
+			responseHeaders: undefined,
+			session: authContext.session ?? null,
+		},
+		path: endpoint.path ?? context?.path ?? "/:virtual",
+		headers: context?.headers ? new Headers(context.headers) : undefined,
+	};
+}
+
+function mergeResponseHeaders(
+	target: AuthContext & { responseHeaders?: Headers | undefined },
+	headers: Headers | null | undefined,
+) {
+	if (!headers) return;
+	headers.forEach((value, key) => {
+		if (!target.responseHeaders) {
+			target.responseHeaders = new Headers({ [key]: value });
+		} else if (key.toLowerCase() === "set-cookie") {
+			target.responseHeaders.append(key, value);
+		} else {
+			target.responseHeaders.set(key, value);
+		}
+	});
+}
+
+function mergeEndpointHeadersBack(
+	parent: AuthContext,
+	current: AuthContext & { responseHeaders?: Headers | undefined },
+) {
+	if (parent === current) return;
+	mergeResponseHeaders(parent, current.responseHeaders);
+}
+
+function mergeHookContext(ctx: InternalContext, hookContext: unknown) {
+	if (!hookContext || typeof hookContext !== "object") return;
+	const { headers, ...rest } = hookContext as Partial<InternalContext>;
+	if (headers instanceof Headers) {
+		if (!ctx.headers) {
+			ctx.headers = new Headers();
+		}
+		headers.forEach((value, key) => {
+			ctx.headers?.set(key, value);
+		});
+	}
+	mergeContextValue(ctx, rest);
+}
+
+function mergeContextValue(
+	ctx: InternalContext,
+	hookContext: Partial<InternalContext>,
+) {
+	for (const [key, value] of Object.entries(hookContext)) {
+		if (value === undefined) continue;
+		const target = ctx as Record<string, unknown>;
+		target[key] = mergeHookValue(target[key], value);
+	}
+}
+
+function mergeHookValue(target: unknown, value: unknown): unknown {
+	if (isMergeableRecord(target) && isMergeableRecord(value)) {
+		const merged = { ...target };
+		for (const [key, childValue] of Object.entries(value)) {
+			merged[key] = mergeHookValue(merged[key], childValue);
+		}
+		return merged;
+	}
+	return value;
+}
+
+function isMergeableRecord(value: unknown): value is Record<string, unknown> {
+	return (
+		!!value &&
+		typeof value === "object" &&
+		!Array.isArray(value) &&
+		!(value instanceof Headers) &&
+		!(value instanceof Request) &&
+		!(value instanceof Response) &&
+		!(value instanceof URLSearchParams) &&
+		!(value instanceof Date)
+	);
+}
+
+function getAPIErrorHeaders(apiError: unknown) {
+	if (!isAPIError(apiError)) return null;
+	const headersFromSymbol = (
+		apiError as typeof apiError & { [kAPIErrorHeaderSymbol]?: Headers }
+	)[kAPIErrorHeaderSymbol];
+	if (headersFromSymbol) {
+		return headersFromSymbol;
+	}
+	if (apiError.headers) {
+		return new Headers(apiError.headers);
+	}
+	return null;
+}
+
+function mergeAPIErrorHeaders(apiError: unknown) {
+	if (!isAPIError(apiError)) return null;
+	const ctxHeaders = (
+		apiError as typeof apiError & { [kAPIErrorHeaderSymbol]?: Headers }
+	)[kAPIErrorHeaderSymbol];
+	const errHeaders =
+		apiError.headers && apiError.headers !== ctxHeaders
+			? new Headers(apiError.headers)
+			: null;
+	let headers: Headers | null = null;
+	if (ctxHeaders || errHeaders) {
+		headers = new Headers();
+		ctxHeaders?.forEach((value, key) => {
+			headers!.append(key, value);
+		});
+		errHeaders?.forEach((value, key) => {
+			if (key.toLowerCase() === "set-cookie") {
+				headers!.append(key, value);
+			} else {
+				headers!.set(key, value);
+			}
+		});
+	}
+	return headers;
+}
+
+function attachMergedHeadersToAPIError(
+	error: unknown,
+	headers?: Headers | null,
+) {
+	if (!isAPIError(error) || !headers) return;
+	Object.defineProperty(error, kAPIErrorHeaderSymbol, {
+		enumerable: false,
+		configurable: true,
+		writable: false,
+		value: headers,
+	});
+}
+
+async function runBeforeHooks(
+	context: InternalContext,
+	hooks: Hook[],
+	endpoint: Endpoint,
+	operationId: string,
+) {
+	for (const hook of hooks) {
+		let matched = false;
+		try {
+			matched = hook.matcher(context);
+		} catch (error) {
+			const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
+			context.context.logger.error(
+				`An error occurred during ${hookSource} hook matcher execution:`,
+				error,
+			);
+			throw new APIError("INTERNAL_SERVER_ERROR", {
+				message:
+					"An error occurred during hook matcher execution. Check the logs for more details.",
+			});
+		}
+		if (!matched) continue;
+
+		const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
+		const route = endpoint.path ?? "/:virtual";
+		const result = await withSpan(
+			`hook before ${route} ${hookSource}`,
+			{
+				[ATTR_HOOK_TYPE]: "before",
+				[ATTR_HTTP_ROUTE]: route,
+				[ATTR_CONTEXT]: hookSource,
+				[ATTR_OPERATION_ID]: operationId,
+			},
+			() =>
+				hook.handler({
+					...context,
+					returnHeaders: false,
+				}),
+		).catch((e: unknown) => {
+			if (
+				isAPIError(e) &&
+				shouldPublishLog(context.context.logger.level, "debug")
+			) {
+				e.stack = e.errorStack;
+			}
+			throw e;
+		});
+		if (!result || typeof result !== "object") continue;
+		if ("context" in result && typeof result.context === "object") {
+			mergeHookContext(context, result.context);
+			continue;
+		}
+		return result;
+	}
+}
+
+async function runAfterHooks(
+	context: InternalContext,
+	hooks: Hook[],
+	endpoint: Endpoint,
+	operationId: string,
+) {
+	for (const hook of hooks) {
+		if (!hook.matcher(context)) continue;
+
+		const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
+		const route = endpoint.path ?? "/:virtual";
+		const result = (await withSpan(
+			`hook after ${route} ${hookSource}`,
+			{
+				[ATTR_HOOK_TYPE]: "after",
+				[ATTR_HTTP_ROUTE]: route,
+				[ATTR_CONTEXT]: hookSource,
+				[ATTR_OPERATION_ID]: operationId,
+			},
+			() => hook.handler(context),
+		).catch((e) => {
+			if (isAPIError(e)) {
+				if (shouldPublishLog(context.context.logger.level, "debug")) {
+					e.stack = e.errorStack;
+				}
+				return {
+					response: e,
+					headers: getAPIErrorHeaders(e),
+				};
+			}
+			throw e;
+		})) as {
+			response: unknown;
+			headers?: Headers | null;
+		};
+		mergeResponseHeaders(context.context, result.headers);
+		if (result.response !== undefined) {
+			context.context.returned = result.response;
+		}
+	}
+	return {
+		response: context.context.returned,
+		headers: context.context.responseHeaders,
+	};
+}
+
+function getHooks(authContext: AuthContext) {
+	const plugins = authContext.options.plugins || [];
+	const beforeHooks: Hook[] = [];
+	const afterHooks: Hook[] = [];
+	const beforeHookHandler = authContext.options.hooks?.before;
+	if (beforeHookHandler) {
+		hooksSourceWeakMap.set(beforeHookHandler, "user");
+		beforeHooks.push({
+			matcher: () => true,
+			handler: beforeHookHandler,
+		});
+	}
+	const afterHookHandler = authContext.options.hooks?.after;
+	if (afterHookHandler) {
+		hooksSourceWeakMap.set(afterHookHandler, "user");
+		afterHooks.push({
+			matcher: () => true,
+			handler: afterHookHandler,
+		});
+	}
+	const pluginBeforeHooks = plugins.flatMap((plugin) =>
+		(plugin.hooks?.before ?? []).map((h) => {
+			hooksSourceWeakMap.set(h.handler, `plugin:${plugin.id}`);
+			return h;
+		}),
+	);
+	const pluginAfterHooks = plugins.flatMap((plugin) =>
+		(plugin.hooks?.after ?? []).map((h) => {
+			hooksSourceWeakMap.set(h.handler, `plugin:${plugin.id}`);
+			return h;
+		}),
+	);
+
+	if (pluginBeforeHooks.length) beforeHooks.push(...pluginBeforeHooks);
+	if (pluginAfterHooks.length) afterHooks.push(...pluginAfterHooks);
+
+	return {
+		beforeHooks,
+		afterHooks,
+	};
+}
+
+function withHookPipeline<T extends Endpoint>(endpoint: T): T {
+	const hooked = (async (context?: Partial<InternalContext>) => {
+		const endpointContext = makeEndpointContext(context, endpoint);
+		if (!endpointContext) {
+			return endpoint(context as never);
+		}
+
+		const parentAuthContext = context?.context;
+		const operationId = getOperationId(endpoint, endpointContext);
+		const route = endpoint.path ?? "/:virtual";
+		const hasRequest = isRequestLike(context?.request);
+		const shouldReturnResponse = context?.asResponse ?? hasRequest;
+		return runWithEndpointContext(endpointContext, async () => {
+			const { beforeHooks, afterHooks } = getHooks(endpointContext.context);
+			const before = await runBeforeHooks(
+				endpointContext,
+				beforeHooks,
+				endpoint,
+				operationId,
+			);
+			if (before) {
+				mergeEndpointHeadersBack(parentAuthContext!, endpointContext.context);
+				return shouldReturnResponse
+					? toResponse(before, {
+							headers: endpointContext.headers,
+						})
+					: context?.returnHeaders
+						? {
+								headers: endpointContext.headers,
+								response: before,
+							}
+						: before;
+			}
+
+			endpointContext.asResponse = false;
+			endpointContext.returnHeaders = true;
+			endpointContext.returnStatus = true;
+			const result = (await runWithEndpointContext(endpointContext, () =>
+				withSpan(
+					`handler ${route}`,
+					{
+						[ATTR_HTTP_ROUTE]: route,
+						[ATTR_OPERATION_ID]: operationId,
+					},
+					() => endpoint(endpointContext as never),
+				),
+			).catch((e: unknown) => {
+				if (isAPIError(e)) {
+					const headers = mergeAPIErrorHeaders(e);
+					return {
+						response: e,
+						status: e.statusCode,
+						headers,
+					};
+				}
+				throw e;
+			})) as
+				| Response
+				| {
+						headers: Headers | null;
+						response: unknown;
+						status?: number;
+				  };
+
+			if (result instanceof Response) {
+				mergeEndpointHeadersBack(parentAuthContext!, endpointContext.context);
+				return result;
+			}
+
+			endpointContext.context.returned = result.response;
+			endpointContext.context.responseHeaders = result.headers ?? undefined;
+
+			const after = await runAfterHooks(
+				endpointContext,
+				afterHooks,
+				endpoint,
+				operationId,
+			);
+
+			if (after.response !== undefined) {
+				result.response = after.response;
+			}
+			if (after.headers) {
+				result.headers = after.headers;
+			}
+
+			if (
+				isAPIError(result.response) &&
+				shouldPublishLog(endpointContext.context.logger.level, "debug")
+			) {
+				result.response.stack = result.response.errorStack;
+			}
+
+			mergeEndpointHeadersBack(parentAuthContext!, endpointContext.context);
+
+			if (isAPIError(result.response) && !shouldReturnResponse) {
+				attachMergedHeadersToAPIError(result.response, result.headers);
+				throw result.response;
+			}
+
+			return shouldReturnResponse
+				? toResponse(result.response, {
+						headers: result.headers ?? undefined,
+						status: result.status,
+					})
+				: context?.returnHeaders
+					? context?.returnStatus
+						? {
+								headers: result.headers,
+								response: result.response,
+								status: result.status,
+							}
+						: {
+								headers: result.headers,
+								response: result.response,
+							}
+					: context?.returnStatus
+						? { response: result.response, status: result.status }
+						: result.response;
+		});
+	}) as T;
+	hooked.path = endpoint.path;
+	hooked.options = endpoint.options;
+	return hooked;
+}
 
 type EndpointHandler<
 	Path extends string,
@@ -113,22 +610,26 @@ export function createAuthEndpoint<
 	};
 
 	if (path) {
-		return createEndpoint(
-			path,
+		return withHookPipeline(
+			createEndpoint(
+				path,
+				{
+					...options,
+					use: [...(options?.use || []), ...use],
+				},
+				wrapped,
+			),
+		);
+	}
+
+	return withHookPipeline(
+		createEndpoint(
 			{
 				...options,
 				use: [...(options?.use || []), ...use],
 			},
 			wrapped,
-		);
-	}
-
-	return createEndpoint(
-		{
-			...options,
-			use: [...(options?.use || []), ...use],
-		},
-		wrapped,
+		),
 	);
 }
 

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -1,10 +1,10 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { isBrowserFetchRequest } from "@better-auth/core/utils/fetch-metadata";
 import { isLoopbackHost, isLoopbackIP } from "@better-auth/core/utils/host";
-import { getSessionFromCtx, isAPIError } from "better-auth/api";
+import { getSessionFromCtx } from "better-auth/api";
 import { generateRandomString, makeSignature } from "better-auth/crypto";
 import type { Verification } from "better-auth/db";
-import { APIError, kAPIErrorHeaderSymbol } from "better-call";
+import { APIError } from "better-call";
 import { oAuthState } from "./oauth";
 import type { OAuthErrorCode, OAuthRedirectOnError } from "./oauth-endpoint";
 import type {
@@ -278,10 +278,7 @@ export function authorizeRedirectOnError(
 export async function authorizeEndpoint(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
-	settings?: {
-		isAuthorize?: boolean;
-		postLogin?: boolean;
-	},
+	settings?: AuthorizeEndpointSettings,
 ) {
 	// Grant type must include authorization_code to use this endpoint
 	if (opts.grantTypes && !opts.grantTypes.includes("authorization_code")) {
@@ -688,200 +685,10 @@ export async function authorizeEndpoint(
 	});
 }
 
-export async function authorizeEndpointWithHooks(
-	ctx: GenericEndpointContext,
-	opts: OAuthOptions<Scope[]>,
-	settings?: {
-		isAuthorize?: boolean;
-		postLogin?: boolean;
-	},
-): Promise<Awaited<ReturnType<typeof authorizeEndpoint>>> {
-	const beforeHook = ctx.context.options.hooks?.before;
-	const afterHook = ctx.context.options.hooks?.after;
-	if (!beforeHook && !afterHook) {
-		return authorizeEndpoint(ctx, opts, settings);
-	}
-
-	const originalPath = ctx.path;
-	ctx.path = "/oauth2/authorize";
-	try {
-		if (beforeHook) {
-			const before = await beforeHook({
-				...ctx,
-				returnHeaders: false,
-			});
-			if (before && typeof before === "object" && "context" in before) {
-				applyHookContext(ctx, before.context);
-			} else if (before) {
-				return before as Awaited<ReturnType<typeof authorizeEndpoint>>;
-			}
-		}
-
-		try {
-			const response = await authorizeEndpoint(ctx, opts, settings);
-			return (await runAfterAuthorizeHook(ctx, response)) as Awaited<
-				ReturnType<typeof authorizeEndpoint>
-			>;
-		} catch (error) {
-			if (!isAPIError(error)) {
-				throw error;
-			}
-			syncResponseHeadersFromAPIError(ctx, error as APIError);
-			const response = await runAfterAuthorizeHook(ctx, error);
-			if (response !== error) {
-				return response as Awaited<ReturnType<typeof authorizeEndpoint>>;
-			}
-			attachResponseHeadersToAPIError(ctx, error as APIError);
-			throw error;
-		}
-	} finally {
-		ctx.path = originalPath;
-	}
-
-	async function runAfterAuthorizeHook(
-		ctx: GenericEndpointContext,
-		response: unknown,
-	) {
-		if (!afterHook) {
-			return response;
-		}
-		ensureResponseHeaders(ctx);
-		ctx.context.returned = response;
-		let after:
-			| {
-					headers?: Headers | null;
-					response?: unknown;
-			  }
-			| undefined;
-		try {
-			after = (await afterHook({
-				...ctx,
-				returnHeaders: true,
-			})) as typeof after;
-		} catch (error) {
-			if (!isAPIError(error)) {
-				throw error;
-			}
-			syncResponseHeadersFromAPIError(ctx, error as APIError);
-			ctx.context.returned = error;
-			attachResponseHeadersToAPIError(ctx, error as APIError);
-			throw error;
-		}
-		if (after?.headers) {
-			mergeResponseHeaders(ctx, after.headers);
-		}
-		if (after?.response !== undefined) {
-			ctx.context.returned = after.response;
-		}
-		return ctx.context.returned;
-	}
-}
-
-function applyHookContext(ctx: GenericEndpointContext, hookContext: unknown) {
-	if (!hookContext || typeof hookContext !== "object") return;
-	const { headers, ...rest } = hookContext as Partial<GenericEndpointContext>;
-	if (headers instanceof Headers) {
-		if (!ctx.headers) {
-			ctx.headers = new Headers();
-		}
-		headers.forEach((value, key) => {
-			ctx.headers?.set(key, value);
-		});
-	}
-	mergeHookContext(ctx, rest);
-}
-
-function mergeHookContext(
-	ctx: GenericEndpointContext,
-	hookContext: Partial<GenericEndpointContext>,
-) {
-	for (const [key, value] of Object.entries(hookContext)) {
-		if (value === undefined) continue;
-		const target = ctx as Record<string, unknown>;
-		target[key] = mergeHookValue(target[key], value);
-	}
-}
-
-function mergeHookValue(target: unknown, value: unknown): unknown {
-	if (isMergeableRecord(target) && isMergeableRecord(value)) {
-		const merged = { ...target };
-		for (const [key, childValue] of Object.entries(value)) {
-			merged[key] = mergeHookValue(merged[key], childValue);
-		}
-		return merged;
-	}
-	return value;
-}
-
-function isMergeableRecord(value: unknown): value is Record<string, unknown> {
-	return (
-		!!value &&
-		typeof value === "object" &&
-		!Array.isArray(value) &&
-		!(value instanceof Headers) &&
-		!(value instanceof Request) &&
-		!(value instanceof Response) &&
-		!(value instanceof URLSearchParams) &&
-		!(value instanceof Date)
-	);
-}
-
-function ensureResponseHeaders(ctx: GenericEndpointContext) {
-	const responseHeaders = (
-		ctx as GenericEndpointContext & {
-			responseHeaders?: Headers;
-		}
-	).responseHeaders;
-	if (!ctx.context.responseHeaders && responseHeaders) {
-		ctx.context.responseHeaders = responseHeaders;
-	}
-}
-
-function syncResponseHeadersFromAPIError(
-	ctx: GenericEndpointContext,
-	error: APIError,
-) {
-	const headers = getAPIErrorHeaders(error);
-	if (!headers || headers === ctx.context.responseHeaders) return;
-	mergeResponseHeaders(ctx, headers);
-}
-
-function attachResponseHeadersToAPIError(
-	ctx: GenericEndpointContext,
-	error: APIError,
-) {
-	if (!ctx.context.responseHeaders) return;
-	Object.defineProperty(error, kAPIErrorHeaderSymbol, {
-		enumerable: false,
-		configurable: true,
-		value: ctx.context.responseHeaders,
-		writable: false,
-	});
-}
-
-function getAPIErrorHeaders(error: APIError) {
-	const headersFromSymbol = (
-		error as APIError & { [kAPIErrorHeaderSymbol]?: Headers }
-	)[kAPIErrorHeaderSymbol];
-	if (headersFromSymbol) {
-		return headersFromSymbol;
-	}
-	if (error.headers) {
-		return new Headers(error.headers);
-	}
-}
-
-function mergeResponseHeaders(ctx: GenericEndpointContext, headers: Headers) {
-	headers.forEach((value, key) => {
-		if (!ctx.context.responseHeaders) {
-			ctx.context.responseHeaders = new Headers({ [key]: value });
-		} else if (key.toLowerCase() === "set-cookie") {
-			ctx.context.responseHeaders.append(key, value);
-		} else {
-			ctx.context.responseHeaders.set(key, value);
-		}
-	});
-}
+export type AuthorizeEndpointSettings = {
+	isAuthorize?: boolean;
+	postLogin?: boolean;
+};
 
 function serializeAuthorizationQuery(query: OAuthAuthorizationQuery) {
 	const params = new URLSearchParams();

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -1,10 +1,10 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { isBrowserFetchRequest } from "@better-auth/core/utils/fetch-metadata";
 import { isLoopbackHost, isLoopbackIP } from "@better-auth/core/utils/host";
-import { getSessionFromCtx } from "better-auth/api";
+import { getSessionFromCtx, isAPIError } from "better-auth/api";
 import { generateRandomString, makeSignature } from "better-auth/crypto";
 import type { Verification } from "better-auth/db";
-import { APIError } from "better-call";
+import { APIError, kAPIErrorHeaderSymbol } from "better-call";
 import { oAuthState } from "./oauth";
 import type { OAuthErrorCode, OAuthRedirectOnError } from "./oauth-endpoint";
 import type {
@@ -685,6 +685,201 @@ export async function authorizeEndpoint(
 		authTime: new Date(session.session.createdAt).getTime(),
 		referenceId,
 		resource: requestedResources,
+	});
+}
+
+export async function authorizeEndpointWithHooks(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	settings?: {
+		isAuthorize?: boolean;
+		postLogin?: boolean;
+	},
+): Promise<Awaited<ReturnType<typeof authorizeEndpoint>>> {
+	const beforeHook = ctx.context.options.hooks?.before;
+	const afterHook = ctx.context.options.hooks?.after;
+	if (!beforeHook && !afterHook) {
+		return authorizeEndpoint(ctx, opts, settings);
+	}
+
+	const originalPath = ctx.path;
+	ctx.path = "/oauth2/authorize";
+	try {
+		if (beforeHook) {
+			const before = await beforeHook({
+				...ctx,
+				returnHeaders: false,
+			});
+			if (before && typeof before === "object" && "context" in before) {
+				applyHookContext(ctx, before.context);
+			} else if (before) {
+				return before as Awaited<ReturnType<typeof authorizeEndpoint>>;
+			}
+		}
+
+		try {
+			const response = await authorizeEndpoint(ctx, opts, settings);
+			return (await runAfterAuthorizeHook(ctx, response)) as Awaited<
+				ReturnType<typeof authorizeEndpoint>
+			>;
+		} catch (error) {
+			if (!isAPIError(error)) {
+				throw error;
+			}
+			syncResponseHeadersFromAPIError(ctx, error as APIError);
+			const response = await runAfterAuthorizeHook(ctx, error);
+			if (response !== error) {
+				return response as Awaited<ReturnType<typeof authorizeEndpoint>>;
+			}
+			attachResponseHeadersToAPIError(ctx, error as APIError);
+			throw error;
+		}
+	} finally {
+		ctx.path = originalPath;
+	}
+
+	async function runAfterAuthorizeHook(
+		ctx: GenericEndpointContext,
+		response: unknown,
+	) {
+		if (!afterHook) {
+			return response;
+		}
+		ensureResponseHeaders(ctx);
+		ctx.context.returned = response;
+		let after:
+			| {
+					headers?: Headers | null;
+					response?: unknown;
+			  }
+			| undefined;
+		try {
+			after = (await afterHook({
+				...ctx,
+				returnHeaders: true,
+			})) as typeof after;
+		} catch (error) {
+			if (!isAPIError(error)) {
+				throw error;
+			}
+			syncResponseHeadersFromAPIError(ctx, error as APIError);
+			ctx.context.returned = error;
+			attachResponseHeadersToAPIError(ctx, error as APIError);
+			throw error;
+		}
+		if (after?.headers) {
+			mergeResponseHeaders(ctx, after.headers);
+		}
+		if (after?.response !== undefined) {
+			ctx.context.returned = after.response;
+		}
+		return ctx.context.returned;
+	}
+}
+
+function applyHookContext(ctx: GenericEndpointContext, hookContext: unknown) {
+	if (!hookContext || typeof hookContext !== "object") return;
+	const { headers, ...rest } = hookContext as Partial<GenericEndpointContext>;
+	if (headers instanceof Headers) {
+		if (!ctx.headers) {
+			ctx.headers = new Headers();
+		}
+		headers.forEach((value, key) => {
+			ctx.headers?.set(key, value);
+		});
+	}
+	mergeHookContext(ctx, rest);
+}
+
+function mergeHookContext(
+	ctx: GenericEndpointContext,
+	hookContext: Partial<GenericEndpointContext>,
+) {
+	for (const [key, value] of Object.entries(hookContext)) {
+		if (value === undefined) continue;
+		const target = ctx as Record<string, unknown>;
+		target[key] = mergeHookValue(target[key], value);
+	}
+}
+
+function mergeHookValue(target: unknown, value: unknown): unknown {
+	if (isMergeableRecord(target) && isMergeableRecord(value)) {
+		const merged = { ...target };
+		for (const [key, childValue] of Object.entries(value)) {
+			merged[key] = mergeHookValue(merged[key], childValue);
+		}
+		return merged;
+	}
+	return value;
+}
+
+function isMergeableRecord(value: unknown): value is Record<string, unknown> {
+	return (
+		!!value &&
+		typeof value === "object" &&
+		!Array.isArray(value) &&
+		!(value instanceof Headers) &&
+		!(value instanceof Request) &&
+		!(value instanceof Response) &&
+		!(value instanceof URLSearchParams) &&
+		!(value instanceof Date)
+	);
+}
+
+function ensureResponseHeaders(ctx: GenericEndpointContext) {
+	const responseHeaders = (
+		ctx as GenericEndpointContext & {
+			responseHeaders?: Headers;
+		}
+	).responseHeaders;
+	if (!ctx.context.responseHeaders && responseHeaders) {
+		ctx.context.responseHeaders = responseHeaders;
+	}
+}
+
+function syncResponseHeadersFromAPIError(
+	ctx: GenericEndpointContext,
+	error: APIError,
+) {
+	const headers = getAPIErrorHeaders(error);
+	if (!headers || headers === ctx.context.responseHeaders) return;
+	mergeResponseHeaders(ctx, headers);
+}
+
+function attachResponseHeadersToAPIError(
+	ctx: GenericEndpointContext,
+	error: APIError,
+) {
+	if (!ctx.context.responseHeaders) return;
+	Object.defineProperty(error, kAPIErrorHeaderSymbol, {
+		enumerable: false,
+		configurable: true,
+		value: ctx.context.responseHeaders,
+		writable: false,
+	});
+}
+
+function getAPIErrorHeaders(error: APIError) {
+	const headersFromSymbol = (
+		error as APIError & { [kAPIErrorHeaderSymbol]?: Headers }
+	)[kAPIErrorHeaderSymbol];
+	if (headersFromSymbol) {
+		return headersFromSymbol;
+	}
+	if (error.headers) {
+		return new Headers(error.headers);
+	}
+}
+
+function mergeResponseHeaders(ctx: GenericEndpointContext, headers: Headers) {
+	headers.forEach((value, key) => {
+		if (!ctx.context.responseHeaders) {
+			ctx.context.responseHeaders = new Headers({ [key]: value });
+		} else if (key.toLowerCase() === "set-cookie") {
+			ctx.context.responseHeaders.append(key, value);
+		} else {
+			ctx.context.responseHeaders.set(key, value);
+		}
 	});
 }
 

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -1,6 +1,10 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError, getSessionFromCtx } from "better-auth/api";
-import { authorizeEndpoint, formatErrorURL, getIssuer } from "./authorize";
+import {
+	authorizeEndpointWithHooks,
+	formatErrorURL,
+	getIssuer,
+} from "./authorize";
 import { oAuthState } from "./oauth";
 import type { OAuthConsent, OAuthOptions, Scope } from "./types";
 import {
@@ -72,11 +76,7 @@ export async function consentEndpoint(
 	if (hasLoginPrompt && !hasSatisfiedLoginPrompt) {
 		ctx?.headers?.set("accept", "application/json");
 		ctx.query = searchParamsToQuery(query);
-		const { url } = await authorizeEndpoint(ctx, opts);
-		return {
-			redirect: true,
-			url,
-		};
+		return await authorizeEndpointWithHooks(ctx, opts);
 	}
 
 	const referenceId = await opts.postLogin?.consentReferenceId?.({
@@ -154,13 +154,9 @@ export async function consentEndpoint(
 	const postLoginClearedForThisSession =
 		oauthRequest?.postLoginClearedForSession !== undefined &&
 		oauthRequest.postLoginClearedForSession === session?.session.id;
-	const { url } = await authorizeEndpoint(ctx, opts, {
+	return await authorizeEndpointWithHooks(ctx, opts, {
 		postLogin: postLoginClearedForThisSession,
 	});
-	return {
-		redirect: true,
-		url,
-	};
 }
 
 // Relies on session.createdAt being immutable for the session's lifetime; a

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -1,10 +1,7 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError, getSessionFromCtx } from "better-auth/api";
-import {
-	authorizeEndpointWithHooks,
-	formatErrorURL,
-	getIssuer,
-} from "./authorize";
+import { formatErrorURL, getIssuer } from "./authorize";
+import type { AuthorizeEndpointCaller } from "./continue";
 import { oAuthState } from "./oauth";
 import type { OAuthConsent, OAuthOptions, Scope } from "./types";
 import {
@@ -14,9 +11,10 @@ import {
 	searchParamsToQuery,
 } from "./utils";
 
-export async function consentEndpoint(
+export async function consentEndpoint<Result>(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
+	authorize: AuthorizeEndpointCaller<Result>,
 ) {
 	// Obtain oauth query
 	const oauthRequest = await oAuthState.get();
@@ -76,7 +74,7 @@ export async function consentEndpoint(
 	if (hasLoginPrompt && !hasSatisfiedLoginPrompt) {
 		ctx?.headers?.set("accept", "application/json");
 		ctx.query = searchParamsToQuery(query);
-		return await authorizeEndpointWithHooks(ctx, opts);
+		return await authorize(ctx);
 	}
 
 	const referenceId = await opts.postLogin?.consentReferenceId?.({
@@ -154,7 +152,7 @@ export async function consentEndpoint(
 	const postLoginClearedForThisSession =
 		oauthRequest?.postLoginClearedForSession !== undefined &&
 		oauthRequest.postLoginClearedForSession === session?.session.id;
-	return await authorizeEndpointWithHooks(ctx, opts, {
+	return await authorize(ctx, {
 		postLogin: postLoginClearedForThisSession,
 	});
 }

--- a/packages/oauth-provider/src/continue.ts
+++ b/packages/oauth-provider/src/continue.ts
@@ -1,21 +1,25 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError } from "better-auth/api";
-import { authorizeEndpointWithHooks } from "./authorize";
+import type { AuthorizeEndpointSettings } from "./authorize";
 import { oAuthState } from "./oauth";
-import type { OAuthOptions, Scope } from "./types";
 import { removePromptFromQuery, searchParamsToQuery } from "./utils";
 
-export async function continueEndpoint(
+export type AuthorizeEndpointCaller<Result = unknown> = (
 	ctx: GenericEndpointContext,
-	opts: OAuthOptions<Scope[]>,
+	settings?: AuthorizeEndpointSettings,
+) => Promise<Result>;
+
+export async function continueEndpoint<Result>(
+	ctx: GenericEndpointContext,
+	authorize: AuthorizeEndpointCaller<Result>,
 ) {
 	// Continue login flow (ensure it's strictly boolean true)
 	if (ctx.body.selected === true) {
-		return await selected(ctx, opts);
+		return await selected(ctx, authorize);
 	} else if (ctx.body.created === true) {
-		return await created(ctx, opts);
+		return await created(ctx, authorize);
 	} else if (ctx.body.postLogin === true) {
-		return await postLogin(ctx, opts);
+		return await postLogin(ctx, authorize);
 	} else {
 		throw new APIError("BAD_REQUEST", {
 			error_description: "Missing parameters",
@@ -24,9 +28,9 @@ export async function continueEndpoint(
 	}
 }
 
-async function selected(
+async function selected<Result>(
 	ctx: GenericEndpointContext,
-	opts: OAuthOptions<Scope[]>,
+	authorize: AuthorizeEndpointCaller<Result>,
 ) {
 	const _query = (await oAuthState.get())?.query as string | undefined;
 	if (!_query) {
@@ -40,12 +44,12 @@ async function selected(
 	ctx.query = searchParamsToQuery(
 		removePromptFromQuery(query, "select_account"),
 	);
-	return await authorizeEndpointWithHooks(ctx, opts);
+	return await authorize(ctx);
 }
 
-async function created(
+async function created<Result>(
 	ctx: GenericEndpointContext,
-	opts: OAuthOptions<Scope[]>,
+	authorize: AuthorizeEndpointCaller<Result>,
 ) {
 	const _query = (await oAuthState.get())?.query as string | undefined;
 	if (!_query) {
@@ -57,12 +61,12 @@ async function created(
 	const query = new URLSearchParams(_query);
 	ctx.headers?.set("accept", "application/json");
 	ctx.query = searchParamsToQuery(removePromptFromQuery(query, "create"));
-	return await authorizeEndpointWithHooks(ctx, opts);
+	return await authorize(ctx);
 }
 
-async function postLogin(
+async function postLogin<Result>(
 	ctx: GenericEndpointContext,
-	opts: OAuthOptions<Scope[]>,
+	authorize: AuthorizeEndpointCaller<Result>,
 ) {
 	const _query = (await oAuthState.get())?.query as string | undefined;
 	if (!_query) {
@@ -74,7 +78,7 @@ async function postLogin(
 	const query = new URLSearchParams(_query);
 	ctx.headers?.set("accept", "application/json");
 	ctx.query = searchParamsToQuery(query);
-	return await authorizeEndpointWithHooks(ctx, opts, {
+	return await authorize(ctx, {
 		postLogin: true,
 	});
 }

--- a/packages/oauth-provider/src/continue.ts
+++ b/packages/oauth-provider/src/continue.ts
@@ -1,6 +1,6 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError } from "better-auth/api";
-import { authorizeEndpoint } from "./authorize";
+import { authorizeEndpointWithHooks } from "./authorize";
 import { oAuthState } from "./oauth";
 import type { OAuthOptions, Scope } from "./types";
 import { removePromptFromQuery, searchParamsToQuery } from "./utils";
@@ -40,11 +40,7 @@ async function selected(
 	ctx.query = searchParamsToQuery(
 		removePromptFromQuery(query, "select_account"),
 	);
-	const { url } = await authorizeEndpoint(ctx, opts);
-	return {
-		redirect: true,
-		url,
-	};
+	return await authorizeEndpointWithHooks(ctx, opts);
 }
 
 async function created(
@@ -61,11 +57,7 @@ async function created(
 	const query = new URLSearchParams(_query);
 	ctx.headers?.set("accept", "application/json");
 	ctx.query = searchParamsToQuery(removePromptFromQuery(query, "create"));
-	const { url } = await authorizeEndpoint(ctx, opts);
-	return {
-		redirect: true,
-		url,
-	};
+	return await authorizeEndpointWithHooks(ctx, opts);
 }
 
 async function postLogin(
@@ -82,11 +74,7 @@ async function postLogin(
 	const query = new URLSearchParams(_query);
 	ctx.headers?.set("accept", "application/json");
 	ctx.query = searchParamsToQuery(query);
-	const { url } = await authorizeEndpoint(ctx, opts, {
+	return await authorizeEndpointWithHooks(ctx, opts, {
 		postLogin: true,
 	});
-	return {
-		redirect: true,
-		url,
-	};
 }

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -11,7 +11,7 @@ import { jwt } from "better-auth/plugins/jwt";
 import { multiSession } from "better-auth/plugins/multi-session";
 import type { Organization } from "better-auth/plugins/organization";
 import { organization } from "better-auth/plugins/organization";
-import { getTestInstance } from "better-auth/test";
+import { getHttpTestInstance, getTestInstance } from "better-auth/test";
 import { APIError } from "better-call";
 import { createLocalJWKSet, jwtVerify } from "jose";
 import type { Listener } from "listhen";
@@ -984,17 +984,6 @@ describe("oauth", async () => {
 });
 
 describe("oauth - authorize resume hooks", async () => {
-	const tempServer = await listen(
-		toNodeHandler(async () => new Response("temp")),
-		{ port: 0 },
-	);
-	const allocatedPort = tempServer.address?.port;
-	await tempServer.close();
-	if (!allocatedPort) {
-		throw new Error("Expected test server port");
-	}
-	const port = allocatedPort;
-	const authServerBaseUrl = `http://localhost:${port}`;
 	const rpBaseUrl = "http://localhost:5000";
 	const providerId = "test";
 	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
@@ -1011,8 +1000,9 @@ describe("oauth - authorize resume hooks", async () => {
 		customFetchImpl,
 		cookieSetter,
 		testUser,
-	} = await getTestInstance({
+		server,
 		baseURL: authServerBaseUrl,
+	} = await getHttpTestInstance({
 		hooks: {
 			before: createAuthMiddleware(async (ctx) => {
 				if (ctx.path === "/oauth2/authorize") {
@@ -1072,14 +1062,6 @@ describe("oauth - authorize resume hooks", async () => {
 		fetchOptions: {
 			customFetchImpl,
 		},
-	});
-
-	let server: Listener;
-
-	beforeAll(async () => {
-		server = await listen(toNodeHandler(authorizationServer.handler), {
-			port,
-		});
 	});
 
 	afterEach(() => {

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -1,3 +1,4 @@
+import { createAuthMiddleware } from "better-auth/api";
 import { createAuthClient } from "better-auth/client";
 import {
 	multiSessionClient,
@@ -979,6 +980,333 @@ describe("oauth", async () => {
 			},
 		});
 		expect(callbackURL).toContain("/success");
+	});
+});
+
+describe("oauth - authorize resume hooks", async () => {
+	const tempServer = await listen(
+		toNodeHandler(async () => new Response("temp")),
+		{ port: 0 },
+	);
+	const allocatedPort = tempServer.address?.port;
+	await tempServer.close();
+	if (!allocatedPort) {
+		throw new Error("Expected test server port");
+	}
+	const port = allocatedPort;
+	const authServerBaseUrl = `http://localhost:${port}`;
+	const rpBaseUrl = "http://localhost:5000";
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	const hookCalls: string[] = [];
+	let afterHookAction:
+		| "replace-thrown-error"
+		| "throw-api-error"
+		| "return-null"
+		| undefined;
+
+	const {
+		auth: authorizationServer,
+		signInWithTestUser,
+		customFetchImpl,
+		cookieSetter,
+		testUser,
+	} = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		hooks: {
+			before: createAuthMiddleware(async (ctx) => {
+				if (ctx.path === "/oauth2/authorize") {
+					hookCalls.push("before");
+				}
+			}),
+			after: createAuthMiddleware(async (ctx) => {
+				if (ctx.path === "/oauth2/authorize") {
+					hookCalls.push("after");
+					if (
+						afterHookAction === "replace-thrown-error" &&
+						ctx.context.returned instanceof APIError
+					) {
+						ctx.setHeader("x-after-hook", "replaced");
+						return {
+							redirect: true,
+							url: `${rpBaseUrl}/after-hook-replaced`,
+						};
+					}
+					if (
+						afterHookAction === "throw-api-error" &&
+						ctx.context.returned instanceof APIError
+					) {
+						ctx.setHeader("x-after-hook", "thrown");
+						throw new APIError("BAD_REQUEST", {
+							message: "after hook rejected",
+						});
+					}
+					if (afterHookAction === "return-null") {
+						return null;
+					}
+				}
+			}),
+		},
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				selectAccount: {
+					page: "/select-account",
+					shouldRedirect() {
+						return false;
+					},
+				},
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const serverClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	let server: Listener;
+
+	beforeAll(async () => {
+		server = await listen(toNodeHandler(authorizationServer.handler), {
+			port,
+		});
+	});
+
+	afterEach(() => {
+		hookCalls.length = 0;
+		afterHookAction = undefined;
+		vi.unstubAllGlobals();
+	});
+
+	afterAll(async () => {
+		await server.close();
+	});
+
+	async function createOAuthClient(skipConsent: boolean) {
+		const { headers } = await signInWithTestUser();
+		const client = await authorizationServer.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: skipConsent,
+			},
+		});
+		expect(client?.client_id).toBeDefined();
+		expect(client?.client_secret).toBeDefined();
+		return { client: client!, headers };
+	}
+
+	function createAuthorizeUrl(client: OAuthClient, prompt?: string) {
+		const url = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("client_id", client.client_id);
+		url.searchParams.set("redirect_uri", redirectUri);
+		url.searchParams.set("scope", "openid profile email");
+		url.searchParams.set("state", "state");
+		url.searchParams.set("code_challenge", "test-code-challenge");
+		url.searchParams.set("code_challenge_method", "S256");
+		if (prompt) {
+			url.searchParams.set("prompt", prompt);
+		}
+		return url.toString();
+	}
+
+	function expectHookCalls(count: number) {
+		expect(hookCalls).toEqual(Array(count).fill(["before", "after"]).flat());
+	}
+
+	async function getRedirect(url: string, headers?: Headers) {
+		let redirectUri = "";
+		await serverClient.$fetch(url, {
+			method: "GET",
+			headers,
+			onError(ctx) {
+				redirectUri = ctx.response.headers.get("Location") || "";
+				if (headers) {
+					cookieSetter(headers)(ctx);
+				}
+			},
+		});
+		return redirectUri;
+	}
+
+	function stubWindowSearch(redirectUri: string) {
+		vi.stubGlobal("window", {
+			location: {
+				href: "",
+				search: new URL(redirectUri, authServerBaseUrl).search,
+			},
+		});
+	}
+
+	function expectCallback(url: string) {
+		expect(url).toContain(redirectUri);
+		expect(url).toContain("code=");
+	}
+
+	it("runs configured hooks when authorize resumes after navigation sign-in", async () => {
+		const { client: oauthClient } = await createOAuthClient(true);
+		const authorizeUrl = createAuthorizeUrl(oauthClient);
+		const loginRedirectUri = await getRedirect(authorizeUrl);
+		expect(loginRedirectUri).toContain("/login");
+		expectHookCalls(1);
+		stubWindowSearch(loginRedirectUri);
+
+		let signInLocationHeader = "";
+		await serverClient.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				headers: {
+					"Sec-Fetch-Mode": "navigate",
+				},
+				onResponse(ctx) {
+					signInLocationHeader = ctx.response.headers.get("Location") || "";
+				},
+			},
+		);
+		expectCallback(signInLocationHeader);
+		expectHookCalls(2);
+	});
+
+	it("runs configured hooks when authorize resumes from continue", async () => {
+		const { client: oauthClient, headers } = await createOAuthClient(true);
+		const selectAccountRedirectUri = await getRedirect(
+			createAuthorizeUrl(oauthClient, "select_account"),
+			headers,
+		);
+		expect(selectAccountRedirectUri).toContain("/select-account");
+		expectHookCalls(1);
+		stubWindowSearch(selectAccountRedirectUri);
+
+		const continueResponse = await serverClient.oauth2.continue(
+			{
+				selected: true,
+			},
+			{
+				headers,
+				throw: true,
+			},
+		);
+		expectCallback(continueResponse.url);
+		expectHookCalls(2);
+	});
+
+	it("allows after hook to replace a thrown authorize redirect", async () => {
+		const { client: oauthClient } = await createOAuthClient(true);
+		const loginRedirectUri = await getRedirect(createAuthorizeUrl(oauthClient));
+		expect(loginRedirectUri).toContain("/login");
+		expectHookCalls(1);
+		stubWindowSearch(loginRedirectUri);
+		afterHookAction = "replace-thrown-error";
+
+		const signInResponse = await serverClient.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				headers: {
+					"Sec-Fetch-Mode": "navigate",
+				},
+				throw: true,
+			},
+		);
+		expect(signInResponse).toMatchObject({
+			redirect: true,
+			url: `${rpBaseUrl}/after-hook-replaced`,
+		});
+		expectHookCalls(2);
+	});
+
+	it("propagates after hook APIErrors from a thrown authorize redirect", async () => {
+		const { client: oauthClient } = await createOAuthClient(true);
+		const loginRedirectUri = await getRedirect(createAuthorizeUrl(oauthClient));
+		expect(loginRedirectUri).toContain("/login");
+		expectHookCalls(1);
+		stubWindowSearch(loginRedirectUri);
+		afterHookAction = "throw-api-error";
+
+		let responseStatus = 0;
+		let afterHookHeader = "";
+		const signInResponse = await serverClient.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				headers: {
+					"Sec-Fetch-Mode": "navigate",
+				},
+				onResponse(ctx) {
+					responseStatus = ctx.response.status;
+					afterHookHeader = ctx.response.headers.get("x-after-hook") || "";
+				},
+			},
+		);
+		expect(responseStatus).toBe(400);
+		expect(afterHookHeader).toBe("thrown");
+		expect(signInResponse.error?.message).toBe("after hook rejected");
+		expectHookCalls(2);
+	});
+
+	it("allows after hook to replace a resumed authorize response with null", async () => {
+		const { client: oauthClient, headers } = await createOAuthClient(true);
+		const selectAccountRedirectUri = await getRedirect(
+			createAuthorizeUrl(oauthClient, "select_account"),
+			headers,
+		);
+		expect(selectAccountRedirectUri).toContain("/select-account");
+		expectHookCalls(1);
+		stubWindowSearch(selectAccountRedirectUri);
+		afterHookAction = "return-null";
+
+		const continueResponse = await serverClient.oauth2.continue(
+			{
+				selected: true,
+			},
+			{
+				headers,
+				throw: true,
+			},
+		);
+		expect(continueResponse).toBeNull();
+		expectHookCalls(2);
+	});
+
+	it("runs configured hooks when authorize resumes after consent", async () => {
+		const { client: oauthClient, headers } = await createOAuthClient(false);
+		const consentRedirectUri = await getRedirect(
+			createAuthorizeUrl(oauthClient, "consent"),
+			headers,
+		);
+		expect(consentRedirectUri).toContain("/consent");
+		expectHookCalls(1);
+		stubWindowSearch(consentRedirectUri);
+
+		const consentResponse = await serverClient.oauth2.consent(
+			{
+				accept: true,
+			},
+			{
+				headers,
+				throw: true,
+			},
+		);
+		expectCallback(consentResponse.url);
+		expectHookCalls(2);
 	});
 });
 

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -13,7 +13,11 @@ import { parseSetCookieHeader } from "better-auth/cookies";
 import { mergeSchema } from "better-auth/db";
 import type { BetterAuthPlugin } from "better-auth/types";
 import * as z from "zod";
-import { authorizeEndpoint, authorizeRedirectOnError } from "./authorize";
+import {
+	authorizeEndpoint,
+	authorizeEndpointWithHooks,
+	authorizeRedirectOnError,
+} from "./authorize";
 import { consentEndpoint } from "./consent";
 import { continueEndpoint } from "./continue";
 import { introspectEndpoint } from "./introspect";
@@ -412,7 +416,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						ctx.query = searchParamsToQuery(
 							removePromptFromQuery(query, "login"),
 						);
-						return await authorizeEndpoint(ctx, opts);
+						return await authorizeEndpointWithHooks(ctx, opts);
 					}),
 				},
 			],

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -13,11 +13,8 @@ import { parseSetCookieHeader } from "better-auth/cookies";
 import { mergeSchema } from "better-auth/db";
 import type { BetterAuthPlugin } from "better-auth/types";
 import * as z from "zod";
-import {
-	authorizeEndpoint,
-	authorizeEndpointWithHooks,
-	authorizeRedirectOnError,
-} from "./authorize";
+import type { AuthorizeEndpointSettings } from "./authorize";
+import { authorizeEndpoint, authorizeRedirectOnError } from "./authorize";
 import { consentEndpoint } from "./consent";
 import { continueEndpoint } from "./continue";
 import { introspectEndpoint } from "./introspect";
@@ -139,6 +136,192 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		claims: Array.from(claims),
 		clientRegistrationAllowedScopes,
 	};
+
+	type OAuth2AuthorizeContext = GenericEndpointContext & {
+		authorizeSettings?: AuthorizeEndpointSettings | undefined;
+	};
+	type OAuth2AuthorizeResult = Awaited<ReturnType<typeof authorizeEndpoint>>;
+
+	const oauth2AuthorizeEndpoint = createOAuthEndpoint(
+		"/oauth2/authorize",
+		{
+			method: "GET",
+			query: z.object({
+				response_type: z
+					.string()
+					.pipe(z.enum(["code"]))
+					.optional(),
+				client_id: z.string(),
+				redirect_uri: SafeUrlSchema.optional(),
+				scope: z.string().optional(),
+				state: z.string().optional(),
+				request_uri: z.string().optional(),
+				code_challenge: z.string().optional(),
+				code_challenge_method: z
+					.string()
+					.pipe(z.enum(["S256"]))
+					.optional(),
+				nonce: z.string().optional(),
+				resource: z
+					.union([ResourceUriSchema, z.array(ResourceUriSchema).min(1)])
+					.optional(),
+				prompt: z
+					.string()
+					.pipe(
+						z.enum([
+							"none",
+							"consent",
+							"login",
+							"create",
+							"select_account",
+							"login consent",
+							"select_account consent",
+						]),
+					)
+					.optional(),
+			}),
+			redirectOnError: authorizeRedirectOnError(opts),
+			errorCodesByField: {
+				response_type: { invalid: "unsupported_response_type" },
+				resource: { invalid: "invalid_target" },
+			},
+			metadata: {
+				openapi: {
+					description: "Authorize an OAuth2 request",
+					parameters: [
+						{
+							name: "response_type",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "OAuth2 response type (e.g., 'code')",
+						},
+						{
+							name: "client_id",
+							in: "query",
+							required: true,
+							schema: { type: "string" },
+							description: "OAuth2 client ID",
+						},
+						{
+							name: "redirect_uri",
+							in: "query",
+							required: false,
+							schema: { type: "string", format: "uri" },
+							description: "OAuth2 redirect URI",
+						},
+						{
+							name: "scope",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "OAuth2 scopes (space-separated)",
+						},
+						{
+							name: "state",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "OAuth2 state parameter",
+						},
+						{
+							name: "request_uri",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description:
+								"Pushed Authorization Request URI referencing stored parameters",
+						},
+						{
+							name: "code_challenge",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "PKCE code challenge",
+						},
+						{
+							name: "code_challenge_method",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "PKCE code challenge method",
+						},
+						{
+							name: "nonce",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "OpenID Connect nonce",
+						},
+						{
+							name: "resource",
+							in: "query",
+							required: false,
+							schema: { type: "array", items: { type: "string" } },
+							description:
+								"Requested token resource(s) (ie audience) to obtain a JWT formatted access token. May be supplied multiple times as repeated 'resource' query parameters (RFC 8707) or as an array of strings.",
+						},
+						{
+							name: "prompt",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "OAuth2 prompt parameter",
+						},
+					],
+					responses: {
+						"302": {
+							description: "Redirect to client with code or error",
+							headers: {
+								Location: {
+									description: "Redirect URI with code or error",
+									schema: { type: "string", format: "uri" },
+								},
+							},
+						},
+						"400": {
+							description: "Invalid request",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											error: { type: "string" },
+											error_description: { type: "string" },
+											state: { type: "string" },
+										},
+										required: ["error"],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx): Promise<OAuth2AuthorizeResult> => {
+			const authorizeCtx = ctx as OAuth2AuthorizeContext;
+			return authorizeEndpoint(
+				ctx,
+				opts,
+				"authorizeSettings" in authorizeCtx
+					? authorizeCtx.authorizeSettings
+					: { isAuthorize: true },
+			);
+		},
+	);
+
+	const runOAuth2Authorize = (
+		ctx: GenericEndpointContext,
+		settings?: AuthorizeEndpointSettings,
+	): Promise<OAuth2AuthorizeResult> =>
+		oauth2AuthorizeEndpoint({
+			...ctx,
+			asResponse: false,
+			returnHeaders: false,
+			returnStatus: false,
+			authorizeSettings: settings ?? {},
+		} as OAuth2AuthorizeContext) as Promise<OAuth2AuthorizeResult>;
 
 	// Validate pairwiseSecret minimum length
 	if (opts.pairwiseSecret && opts.pairwiseSecret.length < 32) {
@@ -416,7 +599,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						ctx.query = searchParamsToQuery(
 							removePromptFromQuery(query, "login"),
 						);
-						return await authorizeEndpointWithHooks(ctx, opts);
+						return await runOAuth2Authorize(ctx);
 					}),
 				},
 			],
@@ -486,169 +669,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					return metadata;
 				},
 			),
-			oauth2Authorize: createOAuthEndpoint(
-				"/oauth2/authorize",
-				{
-					method: "GET",
-					query: z.object({
-						response_type: z
-							.string()
-							.pipe(z.enum(["code"]))
-							.optional(),
-						client_id: z.string(),
-						redirect_uri: SafeUrlSchema.optional(),
-						scope: z.string().optional(),
-						state: z.string().optional(),
-						request_uri: z.string().optional(),
-						code_challenge: z.string().optional(),
-						code_challenge_method: z
-							.string()
-							.pipe(z.enum(["S256"]))
-							.optional(),
-						nonce: z.string().optional(),
-						resource: z
-							.union([ResourceUriSchema, z.array(ResourceUriSchema).min(1)])
-							.optional(),
-						prompt: z
-							.string()
-							.pipe(
-								z.enum([
-									"none",
-									"consent",
-									"login",
-									"create",
-									"select_account",
-									"login consent",
-									"select_account consent",
-								]),
-							)
-							.optional(),
-					}),
-					redirectOnError: authorizeRedirectOnError(opts),
-					errorCodesByField: {
-						response_type: { invalid: "unsupported_response_type" },
-						resource: { invalid: "invalid_target" },
-					},
-					metadata: {
-						openapi: {
-							description: "Authorize an OAuth2 request",
-							parameters: [
-								{
-									name: "response_type",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "OAuth2 response type (e.g., 'code')",
-								},
-								{
-									name: "client_id",
-									in: "query",
-									required: true,
-									schema: { type: "string" },
-									description: "OAuth2 client ID",
-								},
-								{
-									name: "redirect_uri",
-									in: "query",
-									required: false,
-									schema: { type: "string", format: "uri" },
-									description: "OAuth2 redirect URI",
-								},
-								{
-									name: "scope",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "OAuth2 scopes (space-separated)",
-								},
-								{
-									name: "state",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "OAuth2 state parameter",
-								},
-								{
-									name: "request_uri",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description:
-										"Pushed Authorization Request URI referencing stored parameters",
-								},
-								{
-									name: "code_challenge",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "PKCE code challenge",
-								},
-								{
-									name: "code_challenge_method",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "PKCE code challenge method",
-								},
-								{
-									name: "nonce",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "OpenID Connect nonce",
-								},
-								{
-									name: "resource",
-									in: "query",
-									required: false,
-									schema: { type: "array", items: { type: "string" } },
-									description:
-										"Requested token resource(s) (ie audience) to obtain a JWT formatted access token. May be supplied multiple times as repeated 'resource' query parameters (RFC 8707) or as an array of strings.",
-								},
-								{
-									name: "prompt",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "OAuth2 prompt parameter",
-								},
-							],
-							responses: {
-								"302": {
-									description: "Redirect to client with code or error",
-									headers: {
-										Location: {
-											description: "Redirect URI with code or error",
-											schema: { type: "string", format: "uri" },
-										},
-									},
-								},
-								"400": {
-									description: "Invalid request",
-									content: {
-										"application/json": {
-											schema: {
-												type: "object",
-												properties: {
-													error: { type: "string" },
-													error_description: { type: "string" },
-													state: { type: "string" },
-												},
-												required: ["error"],
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				async (ctx) => {
-					return authorizeEndpoint(ctx, opts, {
-						isAuthorize: true,
-					});
-				},
-			),
+			oauth2Authorize: oauth2AuthorizeEndpoint,
 			oauth2Consent: createAuthEndpoint(
 				"/oauth2/consent",
 				{
@@ -694,7 +715,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					},
 				},
 				async (ctx) => {
-					return consentEndpoint(ctx, opts);
+					return consentEndpoint(ctx, opts, runOAuth2Authorize);
 				},
 			),
 			oauth2Continue: createAuthEndpoint(
@@ -745,7 +766,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					},
 				},
 				async (ctx) => {
-					return continueEndpoint(ctx, opts);
+					return continueEndpoint(ctx, runOAuth2Authorize);
 				},
 			),
 			oauth2Token: createOAuthEndpoint(


### PR DESCRIPTION
## Summary
- run configured auth hooks around internal OAuth authorize resume paths
- preserve normal endpoint-dispatch behavior for the public /oauth2/authorize endpoint
- cover post-login, continue/select-account, and consent resume flows

## Root cause
OAuth-provider resume paths called authorizeEndpoint() directly, bypassing the framework endpoint pipeline that normally runs user-configured hooks.before and hooks.after.

Fixes #9887


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs configured auth hooks around OAuth authorize resume paths and moves the hook pipeline into the core endpoint layer so hooks run for both HTTP requests and internal `auth.api` calls. Keeps `/oauth2/authorize` behavior unchanged while preserving before-hook response headers and cookies across redirects and errors.

- **Bug Fixes**
  - Implemented core hook pipeline in `createAuthEndpoint`; runs `hooks.before`/`hooks.after` once per call for `auth.api.*` and router; preserves response headers from short-circuited before hooks, merges `Set-Cookie`, and propagates APIError headers via `kAPIErrorHeaderSymbol`.
  - Refactored resume flows to call the `oauth2Authorize` endpoint via an internal runner so hooks execute consistently: continue/select-account, created/post-login, consent, and `prompt=login`.
  - Added tests for the endpoint hook pipeline and OAuth resumes; verified before-hook header preservation (no request cookie leaks) and after-hook behaviors (replace redirects, throw APIErrors, return null).

<sup>Written for commit 11a81aea299ca2569e749b7990df3efe0c3bb873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



