### PR TITLE
refactor(internal-adapter): remove duplicate findAccountByUserId

### DIFF
--- a/.changeset/remove-find-account-by-user-id.md
+++ b/.changeset/remove-find-account-by-user-id.md
@@ -1,0 +1,6 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+---
+
+Remove duplicate `internalAdapter.findAccountByUserId`. It was identical to `findAccounts(userId)`. Use `findAccounts` instead.

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1066,20 +1066,6 @@ export const createInternalAdapter = (
 			);
 			return account;
 		},
-		findAccountByUserId: async (userId: string) => {
-			const account = await (
-				await getCurrentAdapter(adapter)
-			).findMany<Account>({
-				model: "account",
-				where: [
-					{
-						field: "userId",
-						value: userId,
-					},
-				],
-			});
-			return account;
-		},
 		updateAccount: async (id: string, data: Partial<Account>) => {
 			const account = await updateWithHooks<Account>(
 				data,

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -141,9 +141,7 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 					);
 				}
 			}
-			const accounts = await ctx.context.internalAdapter.findAccountByUserId(
-				user.id,
-			);
+			const accounts = await ctx.context.internalAdapter.findAccounts(user.id);
 			const credentialAccount = accounts.find(
 				(a) => a.providerId === "credential",
 			);

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -209,8 +209,6 @@ export interface InternalAdapter<
 		providerId: string,
 	): Promise<Account | null>;
 
-	findAccountByUserId(userId: string): Promise<Account[]>;
-
 	updateAccount(id: string, data: Partial<Account>): Promise<Account>;
 
 	createVerificationValue(


### PR DESCRIPTION
## Summary
- Remove duplicate `internalAdapter.findAccountByUserId` - it was identical to `findAccounts(userId)`. Migrates the single caller (phone-number plugin) and drops the method from the public adapter type.
- Part of #9496.

## Test plan
- [x] `vitest packages/better-auth/src/db/internal-adapter.test.ts packages/better-auth/src/plugins/phone-number/phone-number.test.ts -t "account"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicate `internalAdapter.findAccountByUserId` in `better-auth` and switched the phone-number plugin to use `findAccounts(userId)`, reducing API surface and redundancy. This also removes the method from the `InternalAdapter` type in `@better-auth/core` (part of #9496).

<sup>Written for commit e7b3822a3a97cea57e7ac3e05dc69fc0c80522c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

