### PR TITLE
fix(ci): resolve the latest Node patch for the smoke matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,9 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: ${{ matrix.node-version }}
+          # Use the latest patch per major: the smoke specs run `node --test` on .ts,
+          # which needs native type-stripping (default-on at 22.18+/24), not the cached 22.13.0.
+          check-latest: true
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 


### PR DESCRIPTION
`Smoke test (22.x)` has been failing on every PR while `Smoke test (24.x)` passes on the same commit. The job runs `node --test` directly on the `.ts` specs, which needs Node's native type-stripping (default-on only on Node 22.18+ and 24). The `[22.x, 24.x]` matrix should test the latest patch per major, but `setup-node` defaults to `check-latest: false` and reused the runner's cached 22.13.0, which predates type-stripping, so every spec failed with `ERR_UNKNOWN_FILE_EXTENSION`.

`check-latest: true` resolves `22.x` to the current latest (22.22.x), where the unchanged command works. Scoped to the smoke job; the other e2e jobs pin Node via `.nvmrc`. Verified locally: `node --test` fails on 22.13.0 and passes on 22.22.3 and 24.
