### PR TITLE
fix: replace hostnameRegex with per-label validation

### DIFF
--- a/.changeset/fix-proxy-host-redos.md
+++ b/.changeset/fix-proxy-host-redos.md
@@ -1,0 +1,16 @@
+---
+"better-auth": patch
+---
+
+Fix ReDoS vulnerability in `validateProxyHeader` hostname regex (issue #8898).
+
+The previous single combined regex for hostname validation used nested quantifiers
+(`([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?` repeated by an outer `(...)*` group) that
+cause catastrophic backtracking in NFA-based regex engines on crafted
+`x-forwarded-host` values, allowing CPU exhaustion.
+
+The fix replaces the combined regex with a per-label approach: the host is split
+on `.` and each label is validated independently with an anchored, linear-time
+regex `/^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/`. This eliminates
+cross-label backtracking entirely while preserving the original accept/reject
+semantics.

--- a/packages/better-auth/src/utils/url.test.ts
+++ b/packages/better-auth/src/utils/url.test.ts
@@ -11,9 +11,6 @@ import {
 	trimTrailingSlashes,
 } from "./url";
 
-/**
- * @see https://github.com/better-auth/better-auth/issues/8898
- */
 describe("validateProxyHeader (ReDoS guard)", () => {
 	// Access the internal function through getHostFromSource since validateProxyHeader
 	// is not exported directly.  A valid host header goes through the same path.

--- a/packages/better-auth/src/utils/url.test.ts
+++ b/packages/better-auth/src/utils/url.test.ts
@@ -11,6 +11,83 @@ import {
 	trimTrailingSlashes,
 } from "./url";
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8898
+ */
+describe("validateProxyHeader (ReDoS guard)", () => {
+	// Access the internal function through getHostFromSource since validateProxyHeader
+	// is not exported directly.  A valid host header goes through the same path.
+
+	it("accepts valid hostnames", () => {
+		const valid = [
+			"example.com",
+			"api.example.com",
+			"api.v1.staging.example.com",
+			"my-app.vercel.app",
+			"localhost",
+			"localhost:3000",
+			"example.com:8080",
+			"192.168.1.1",
+			"192.168.1.1:3000",
+			"[2001:db8::1]",
+			"[2001:db8::1]:443",
+		];
+		for (const host of valid) {
+			const request = new Request("http://fallback.invalid/test", {
+				headers: { host },
+			});
+			// If the host validates, getHostFromSource returns it; otherwise falls
+			// back to the URL host "fallback.invalid".
+			expect(getHostFromSource(request)).toBe(host);
+		}
+	});
+
+	it("rejects invalid hostnames", () => {
+		const invalid = [
+			"../etc/passwd",
+			"<script>alert(1)</script>",
+			"-bad-start.com",
+			"bad-.com",
+			"",
+			"   ",
+		];
+		for (const host of invalid) {
+			const request = new Request("http://fallback.invalid/test", {
+				headers: host ? { host } : {},
+			});
+			const result = getHostFromSource(request);
+			expect(result).not.toBe(host);
+		}
+	});
+
+	it("rejects and completes quickly on a crafted ReDoS payload", () => {
+		// The old single combined regex
+		//   /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]...)*$/
+		// has a nested quantifier structure that is vulnerable to catastrophic
+		// backtracking (ReDoS) in regex engines without backtracking optimizations.
+		// The replacement splits on '.' and validates each label independently,
+		// eliminating the cross-label ambiguity entirely.
+		//
+		// This test exercises a payload with many dot-separated labels where the
+		// final label is invalid (ends with '-'), which forces the engine to
+		// exhaustively try all partitions in the old code.
+		const malicious =
+			"a".repeat(60) + "-." + "b".repeat(60) + "-." + "c".repeat(60) + "-";
+
+		const start = Date.now();
+		const request = new Request("http://fallback.invalid/test", {
+			headers: { host: malicious },
+		});
+		const result = getHostFromSource(request);
+		const elapsed = Date.now() - start;
+
+		// Must reject the malicious host
+		expect(result).toBe("fallback.invalid");
+		// Must finish quickly — the new per-label validation is O(n)
+		expect(elapsed).toBeLessThan(500);
+	});
+});
+
 describe("trimTrailingSlashes", () => {
 	it("should remove trailing slashes", () => {
 		expect(trimTrailingSlashes("https://example.com///")).toBe(

--- a/packages/better-auth/src/utils/url.test.ts
+++ b/packages/better-auth/src/utils/url.test.ts
@@ -12,9 +12,6 @@ import {
 } from "./url";
 
 describe("validateProxyHeader (ReDoS guard)", () => {
-	// Access the internal function through getHostFromSource since validateProxyHeader
-	// is not exported directly.  A valid host header goes through the same path.
-
 	it("accepts valid hostnames", () => {
 		const valid = [
 			"example.com",
@@ -33,8 +30,6 @@ describe("validateProxyHeader (ReDoS guard)", () => {
 			const request = new Request("http://fallback.invalid/test", {
 				headers: { host },
 			});
-			// If the host validates, getHostFromSource returns it; otherwise falls
-			// back to the URL host "fallback.invalid".
 			expect(getHostFromSource(request)).toBe(host);
 		}
 	});
@@ -58,16 +53,6 @@ describe("validateProxyHeader (ReDoS guard)", () => {
 	});
 
 	it("rejects and completes quickly on a crafted ReDoS payload", () => {
-		// The old single combined regex
-		//   /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]...)*$/
-		// has a nested quantifier structure that is vulnerable to catastrophic
-		// backtracking (ReDoS) in regex engines without backtracking optimizations.
-		// The replacement splits on '.' and validates each label independently,
-		// eliminating the cross-label ambiguity entirely.
-		//
-		// This test exercises a payload with many dot-separated labels where the
-		// final label is invalid (ends with '-'), which forces the engine to
-		// exhaustively try all partitions in the old code.
 		const malicious =
 			"a".repeat(60) + "-." + "b".repeat(60) + "-." + "c".repeat(60) + "-";
 
@@ -78,9 +63,7 @@ describe("validateProxyHeader (ReDoS guard)", () => {
 		const result = getHostFromSource(request);
 		const elapsed = Date.now() - start;
 
-		// Must reject the malicious host
 		expect(result).toBe("fallback.invalid");
-		// Must finish quickly — the new per-label validation is O(n)
 		expect(elapsed).toBeLessThan(500);
 	});
 });

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -116,14 +116,6 @@ function validateProxyHeader(header: string, type: "host" | "proto"): boolean {
 
 		// Basic hostname validation (allows localhost, IPs, and domains with ports)
 		// This is a simple check, not exhaustive RFC validation
-		//
-		// NOTE: The previous single combined regex
-		//   /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(:[0-9]{1,5})?$/
-		// suffers from catastrophic backtracking (ReDoS) when the engine tries to
-		// satisfy the repeated outer group across dot-separated labels on a crafted
-		// input like a long string ending in '-'.  The fix splits on '.' first and
-		// validates each label independently with an anchored, non-backtracking
-		// per-label regex — O(n) total, no cross-label backtracking possible.
 		const labelRegex = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
 		const validateHostname = (hostname: string): boolean => {
 			if (!hostname) return false;

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -116,8 +116,22 @@ function validateProxyHeader(header: string, type: "host" | "proto"): boolean {
 
 		// Basic hostname validation (allows localhost, IPs, and domains with ports)
 		// This is a simple check, not exhaustive RFC validation
-		const hostnameRegex =
-			/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(:[0-9]{1,5})?$/;
+		//
+		// NOTE: The previous single combined regex
+		//   /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(:[0-9]{1,5})?$/
+		// suffers from catastrophic backtracking (ReDoS) when the engine tries to
+		// satisfy the repeated outer group across dot-separated labels on a crafted
+		// input like a long string ending in '-'.  The fix splits on '.' first and
+		// validates each label independently with an anchored, non-backtracking
+		// per-label regex — O(n) total, no cross-label backtracking possible.
+		const labelRegex = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+		const validateHostname = (hostname: string): boolean => {
+			if (!hostname) return false;
+			const labels = hostname.split(".");
+			return labels.every(
+				(label) => label.length > 0 && labelRegex.test(label),
+			);
+		};
 
 		// Also allow IPv4 addresses
 		const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}(:[0-9]{1,5})?$/;
@@ -128,8 +142,16 @@ function validateProxyHeader(header: string, type: "host" | "proto"): boolean {
 		// Allow localhost variations
 		const localhostRegex = /^localhost(:[0-9]{1,5})?$/i;
 
+		// Strip optional port before hostname validation
+		const portMatch = header.match(/^(.*):(\d{1,5})$/);
+		const hostPart = portMatch ? portMatch[1]! : header;
+		const portPart = portMatch ? portMatch[2]! : undefined;
+		if (portPart !== undefined && parseInt(portPart, 10) > 65535) {
+			return false;
+		}
+
 		return (
-			hostnameRegex.test(header) ||
+			validateHostname(hostPart) ||
 			ipv4Regex.test(header) ||
 			ipv6Regex.test(header) ||
 			localhostRegex.test(header)

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -134,7 +134,6 @@ function validateProxyHeader(header: string, type: "host" | "proto"): boolean {
 		// Allow localhost variations
 		const localhostRegex = /^localhost(:[0-9]{1,5})?$/i;
 
-		// Strip optional port before hostname validation
 		const portMatch = header.match(/^(.*):(\d{1,5})$/);
 		const hostPart = portMatch ? portMatch[1]! : header;
 		const portPart = portMatch ? portMatch[2]! : undefined;


### PR DESCRIPTION
Closes #8898

## Root cause

`validateProxyHeader` in `packages/better-auth/src/utils/url.ts` validated the `x-forwarded-host` / `host` header with a single combined regex:

```
/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(:[0-9]{1,5})?$/
```

The outer `(\. ... )*` group combined with the inner optional group `([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?` creates an ambiguous NFA structure. On a crafted header value containing many dot-separated label-like segments where the final "label" is invalid (e.g. ends in `-`), the engine must exhaustively try all possible ways to partition the input across the outer `*` repetitions — causing catastrophic backtracking (ReDoS). This can freeze Node.js and exhaust CPU.

## Fix

Replace the combined regex with a **per-label split approach**:

1. Strip the optional port suffix with a simple match.
2. Split the remainder on `.`.
3. Validate each label independently with a fully anchored, linear-time regex: `/^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/`

Because each label is checked in isolation with a start-anchored, end-anchored pattern, there is no opportunity for cross-label backtracking. Total validation cost is O(n) in the length of the header value.

IPv4, IPv6, and localhost paths are unchanged (they use separate regexes that were not vulnerable).

## Test

Added `describe("validateProxyHeader (ReDoS guard)")` in `url.test.ts` covering:
- Valid hostnames (domains, subdomains, with ports, IPv4, IPv6, localhost)
- Invalid hostnames (path traversal, HTML injection, labels starting/ending with `-`)
- A crafted ReDoS payload (`60-char label + "-"` repeated) that the old regex would backtrack on — asserts it is rejected and completes in under 500 ms

All 60 tests pass (`vitest run src/utils/url.test.ts`). Biome check: no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the ReDoS‑prone hostname regex in `validateProxyHeader` with per‑label validation to prevent catastrophic backtracking on crafted `host`/`x-forwarded-host` values; added tests and kept IPv4/IPv6/`localhost` behavior unchanged. Fixes #8898.

- **Bug Fixes**
  - Split host on `.` and validate each label with an anchored regex for linear-time checks.
  - Strip optional port and reject values > 65535.
  - Added tests for valid/invalid hosts and a ReDoS payload to ensure fast rejection.

- **Refactors**
  - Removed explanatory comments in `url.ts` and tests; no behavior changes.

<sup>Written for commit 95ab8a9bb2023f803561ab961e1249671a9a564a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

