### PR TITLE
feat(docs): update installation guide to include Prisma adapter configuration.

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -135,11 +135,18 @@ description: Learn how to configure Better Auth in your project.
       <Tab value="prisma">
         ```ts title="auth.ts"
         import { betterAuth } from "better-auth";
+        import { PrismaPg } from "@prisma/adapter-pg";
         import { prismaAdapter } from "better-auth/adapters/prisma";
         // If your Prisma file is located elsewhere, you can change the path
         import { PrismaClient } from "@/generated/prisma/client";
 
-        const prisma = new PrismaClient();
+        const adapter = new PrismaPg({
+          connectionString: process.env.DATABASE_URL,
+        });
+
+        const prisma = new PrismaClient({
+          adapter,
+        });
         export const auth = betterAuth({
             database: prismaAdapter(prisma, {
                 provider: "sqlite", // or "mysql", "postgresql", ...etc

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -134,7 +134,7 @@ description: Learn how to configure Better Auth in your project.
 
       <Tab value="prisma">
         ```ts title="auth.ts"
-        import { betterAuth } from "better-auth";
+        import { betterAuth } from "better-auth/minimal";
         import { PrismaPg } from "@prisma/adapter-pg";
         import { prismaAdapter } from "better-auth/adapters/prisma";
         // If your Prisma file is located elsewhere, you can change the path


### PR DESCRIPTION
# Improve Better Auth Prisma Setup with PrismaPg Adapter

## Summary

This PR updates the Better Auth Prisma installation example to use the `PrismaPg` adapter from `@prisma/adapter-pg` for PostgreSQL connections instead of relying on the default Prisma client configuration.

## Changes

* Added `PrismaPg` adapter configuration.
* Configured Prisma Client to use the PostgreSQL adapter.
* Switched to importing `betterAuth` from `better-auth/minimal` for better bundle size optimization.
* Retained the existing `prismaAdapter` integration with Better Auth.
* Updated the Prisma example to reflect modern PostgreSQL adapter usage.

## Before

```ts
import { betterAuth } from "better-auth";
import { prismaAdapter } from "better-auth/adapters/prisma";
// If your Prisma file is located elsewhere, you can change the path
import { PrismaClient } from "@/generated/prisma/client";

const prisma = new PrismaClient();

export const auth = betterAuth({
  database: prismaAdapter(prisma, {
    provider: "sqlite",
  }),
});
```

## After

```ts
 import { betterAuth } from "better-auth/minimal";
import { PrismaPg } from "@prisma/adapter-pg";
import { prismaAdapter } from "better-auth/adapters/prisma";
// If your Prisma file is located elsewhere, you can change the path
import { PrismaClient } from "@/generated/prisma/client";

const adapter = new PrismaPg({
  connectionString: process.env.DATABASE_URL,
});

const prisma = new PrismaClient({
  adapter,
});

export const auth = betterAuth({
  database: prismaAdapter(prisma, {
    provider: "sqlite",
  }),
});
```

## Benefits

* Improved PostgreSQL integration using Prisma's native adapter system.
* Better compatibility with serverless and modern deployment environments.
* Reduced bundle size by using `better-auth/minimal`.
* Provides a more production-ready Prisma setup for PostgreSQL users.

## Documentation

Updated the Prisma installation example in the Better Auth documentation to demonstrate how to configure Better Auth with Prisma and `@prisma/adapter-pg`. Based on the existing Prisma installation section in the Better Auth installation guide.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the installation guide to use `PrismaPg` from `@prisma/adapter-pg` with `PrismaClient` and switch the import to `better-auth/minimal`. This improves PostgreSQL setup and reduces bundle size while keeping the existing `prismaAdapter` integration.

<sup>Written for commit fffcb5256fd460cf9545b90e830d11be29cceb1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

