### PR TITLE
fix(oauth-provider): run configured hooks when authorize resumes

### DIFF
--- a/.changeset/oauth-authorize-resume-hooks.md
+++ b/.changeset/oauth-authorize-resume-hooks.md
@@ -1,0 +1,12 @@
+---
+"better-auth": minor
+"@better-auth/oauth-provider": patch
+---
+
+Run configured hooks when OAuth authorize resumes after sign-in
+
+Configured `hooks.before` / `hooks.after` now run when the OAuth provider resumes `/oauth2/authorize` after a fresh sign-in, account selection, or consent. The resume previously called the authorize function directly and skipped the hook pipeline, so a hook registered on the auth instance ran for a standalone authorize request but not the post-login resume.
+
+The hook pipeline is now a shared `dispatchAuthEndpoint` primitive, exported from `better-auth/api`. A plugin re-runs the configured hooks for one endpoint by dispatching it, rather than calling it as a plain function. Internal endpoint-to-endpoint calls (for example resolving the session through the `getSession` endpoint) still skip hooks, so a single request does not fire them twice.
+
+This also corrects two hook header cases. A `hooks.before` that sets response headers or cookies before short-circuiting now keeps them on the response instead of dropping them. A `hooks.after` that throws an `APIError` now merges the cookies it accumulated with the error's explicit headers, so neither side is lost.

--- a/.changeset/oauth-authorize-resume-hooks.md
+++ b/.changeset/oauth-authorize-resume-hooks.md
@@ -1,12 +1,10 @@
 ---
-"better-auth": minor
+"better-auth": patch
 "@better-auth/oauth-provider": patch
 ---
 
-Run configured hooks when OAuth authorize resumes after sign-in
+Run configured hooks through the whole OAuth sign-in flow
 
-Configured `hooks.before` / `hooks.after` now run when the OAuth provider resumes `/oauth2/authorize` after a fresh sign-in, account selection, or consent. The resume previously called the authorize function directly and skipped the hook pipeline, so a hook registered on the auth instance ran for a standalone authorize request but not the post-login resume.
+`hooks.before` / `hooks.after` configured on the auth instance now run for the OAuth authorization that continues after a user signs in, selects an account, or consents. They were being skipped there.
 
-The hook pipeline is now a shared `dispatchAuthEndpoint` primitive, exported from `better-auth/api`. A plugin re-runs the configured hooks for one endpoint by dispatching it, rather than calling it as a plain function. Internal endpoint-to-endpoint calls (for example resolving the session through the `getSession` endpoint) still skip hooks, so a single request does not fire them twice.
-
-This also corrects two hook header cases. A `hooks.before` that sets response headers or cookies before short-circuiting now keeps them on the response instead of dropping them. A `hooks.after` that throws an `APIError` now merges the cookies it accumulated with the error's explicit headers, so neither side is lost.
+Headers or cookies a `hooks.before` sets before returning its own response are no longer dropped, and a `hooks.after` that throws an `APIError` no longer loses either its cookies or the error's headers.

--- a/packages/better-auth/src/api/dispatch.ts
+++ b/packages/better-auth/src/api/dispatch.ts
@@ -1,0 +1,476 @@
+import type { AuthContext, HookEndpointContext } from "@better-auth/core";
+import type { AuthMiddleware } from "@better-auth/core/api";
+import { runWithEndpointContext } from "@better-auth/core/context";
+import { shouldPublishLog } from "@better-auth/core/env";
+import { APIError } from "@better-auth/core/error";
+import {
+	ATTR_CONTEXT,
+	ATTR_HOOK_TYPE,
+	ATTR_HTTP_ROUTE,
+	ATTR_OPERATION_ID,
+	withSpan,
+} from "@better-auth/core/instrumentation";
+import type { Endpoint, EndpointContext, InputContext } from "better-call";
+import { kAPIErrorHeaderSymbol, toResponse } from "better-call";
+import { createDefu } from "defu";
+import { isAPIError } from "../utils/is-api-error";
+import { isRequestLike } from "../utils/url";
+
+/**
+ * Input accepted by {@link dispatchAuthEndpoint}. `context` must already be a
+ * resolved `AuthContext`; the caller owns `baseURL` resolution. A fresh
+ * dispatch carries no `session` (the shared context has none), while a resumed
+ * dispatch carries the in-flight request's `session` through.
+ */
+export type DispatchContext = Partial<
+	InputContext<string, any> & EndpointContext<string, any>
+> & {
+	context: AuthContext & {
+		returned?: unknown | undefined;
+		responseHeaders?: Headers | undefined;
+	};
+	operationId?: string | undefined;
+};
+
+/**
+ * The working context a dispatch runs against: the input plus the resolved
+ * `path` and the `asResponse` decision.
+ */
+type InternalContext = DispatchContext & {
+	path?: string | undefined;
+	asResponse?: boolean | undefined;
+};
+
+const defuReplaceArrays = createDefu((obj, key, value) => {
+	if (Array.isArray(obj[key]) && Array.isArray(value)) {
+		obj[key] = value;
+		return true;
+	}
+});
+
+type Hook = {
+	matcher: (context: HookEndpointContext) => boolean;
+	handler: AuthMiddleware;
+};
+
+const hooksSourceWeakMap = new WeakMap<
+	AuthMiddleware,
+	`user` | `plugin:${string}`
+>();
+
+/**
+ * Resolves the operation id used for spans, preferring an explicit
+ * `operationId`, then the OpenAPI one, then the caller's `fallback` (the
+ * `auth.api.*` map key), and finally the route path.
+ */
+export function getOperationId(endpoint: Endpoint, fallback?: string): string {
+	const opts = endpoint.options as
+		| {
+				operationId?: string;
+				metadata?: { openapi?: { operationId?: string } };
+		  }
+		| undefined;
+	return (
+		opts?.operationId ??
+		opts?.metadata?.openapi?.operationId ??
+		fallback ??
+		endpoint.path ??
+		"/:virtual"
+	);
+}
+
+/**
+ * Merge a set of response headers onto the dispatch's accumulator, appending
+ * `set-cookie` (multiple cookies are legal) and replacing everything else.
+ */
+function mergeResponseHeaders(
+	context: InternalContext["context"],
+	headers: Headers | null | undefined,
+) {
+	if (!headers) return;
+	headers.forEach((value, key) => {
+		if (!context.responseHeaders) {
+			context.responseHeaders = new Headers({ [key]: value });
+		} else if (key.toLowerCase() === "set-cookie") {
+			context.responseHeaders.append(key, value);
+		} else {
+			context.responseHeaders.set(key, value);
+		}
+	});
+}
+
+/**
+ * Combine the two header sources an `APIError` can carry into one set:
+ * - `kAPIErrorHeaderSymbol`: `ctx.responseHeaders` accumulated via
+ *   `c.setCookie` / `c.setHeader` before the throw.
+ * - `e.headers`: explicit headers on the error (e.g. `location` from
+ *   `c.redirect`).
+ *
+ * `c.redirect()` reuses `ctx.responseHeaders` as `e.headers`, so when both
+ * point at the same object iterating each would duplicate every `set-cookie`;
+ * the identity check skips that copy. Explicit error headers override
+ * accumulated ones, while cookies from both accumulate.
+ */
+function mergeAPIErrorHeaders(error: APIError): Headers | null {
+	const ctxHeaders = (
+		error as APIError & { [kAPIErrorHeaderSymbol]?: Headers }
+	)[kAPIErrorHeaderSymbol];
+	const errHeaders =
+		error.headers && error.headers !== ctxHeaders
+			? new Headers(error.headers)
+			: null;
+	if (!ctxHeaders && !errHeaders) return null;
+	const headers = new Headers();
+	ctxHeaders?.forEach((value, key) => {
+		headers.append(key, value);
+	});
+	errHeaders?.forEach((value, key) => {
+		if (key.toLowerCase() === "set-cookie") {
+			headers.append(key, value);
+		} else {
+			headers.set(key, value);
+		}
+	});
+	return headers;
+}
+
+async function runBeforeHooks(
+	context: InternalContext,
+	hooks: Hook[],
+	endpoint: Endpoint,
+	operationId: string,
+) {
+	let modifiedContext: Partial<InternalContext> = {};
+
+	for (const hook of hooks) {
+		let matched = false;
+		try {
+			matched = hook.matcher(context as HookEndpointContext);
+		} catch (error) {
+			// Surface which plugin's matcher failed in the logs without leaking
+			// internal details to the caller.
+			const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
+			context.context.logger.error(
+				`An error occurred during ${hookSource} hook matcher execution:`,
+				error,
+			);
+			throw new APIError("INTERNAL_SERVER_ERROR", {
+				message:
+					"An error occurred during hook matcher execution. Check the logs for more details.",
+			});
+		}
+		if (!matched) continue;
+
+		const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
+		const route = endpoint.path ?? "/:virtual";
+		// `returnHeaders: true` so headers the hook sets via `c.setHeader` /
+		// `c.setCookie` come back to us instead of being discarded; the hook's
+		// own return value arrives as `result.response`.
+		const result = (await withSpan(
+			`hook before ${route} ${hookSource}`,
+			{
+				[ATTR_HOOK_TYPE]: "before",
+				[ATTR_HTTP_ROUTE]: route,
+				[ATTR_CONTEXT]: hookSource,
+				[ATTR_OPERATION_ID]: operationId,
+			},
+			() =>
+				hook.handler({
+					...context,
+					returnHeaders: true,
+				}),
+		).catch((e: unknown) => {
+			if (
+				isAPIError(e) &&
+				shouldPublishLog(context.context.logger.level, "debug")
+			) {
+				e.stack = e.errorStack;
+			}
+			throw e;
+		})) as { response?: unknown; headers?: Headers | null } | undefined;
+
+		mergeResponseHeaders(context.context, result?.headers);
+
+		const hookReturn = result?.response;
+		if (hookReturn && typeof hookReturn === "object") {
+			if (
+				"context" in hookReturn &&
+				typeof (hookReturn as { context?: unknown }).context === "object"
+			) {
+				const { headers, ...rest } = (
+					hookReturn as { context: Partial<InternalContext> }
+				).context;
+				if (headers instanceof Headers) {
+					if (modifiedContext.headers) {
+						headers.forEach((value, key) => {
+							modifiedContext.headers?.set(key, value);
+						});
+					} else {
+						modifiedContext.headers = headers;
+					}
+				}
+				modifiedContext = defuReplaceArrays(rest, modifiedContext);
+				continue;
+			}
+			return hookReturn;
+		}
+	}
+	return { context: modifiedContext };
+}
+
+async function runAfterHooks(
+	context: InternalContext,
+	hooks: Hook[],
+	endpoint: Endpoint,
+	operationId: string,
+) {
+	for (const hook of hooks) {
+		if (!hook.matcher(context as HookEndpointContext)) continue;
+
+		const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
+		const route = endpoint.path ?? "/:virtual";
+		const result = (await withSpan(
+			`hook after ${route} ${hookSource}`,
+			{
+				[ATTR_HOOK_TYPE]: "after",
+				[ATTR_HTTP_ROUTE]: route,
+				[ATTR_CONTEXT]: hookSource,
+				[ATTR_OPERATION_ID]: operationId,
+			},
+			() => hook.handler(context),
+		).catch((e) => {
+			if (isAPIError(e)) {
+				if (shouldPublishLog(context.context.logger.level, "debug")) {
+					e.stack = e.errorStack;
+				}
+				return {
+					response: e,
+					headers: mergeAPIErrorHeaders(e),
+				};
+			}
+			throw e;
+		})) as {
+			response: unknown;
+			headers?: Headers | null;
+		};
+		mergeResponseHeaders(context.context, result.headers);
+		if (result.response !== undefined) {
+			context.context.returned = result.response;
+		}
+	}
+	return {
+		response: context.context.returned,
+		headers: context.context.responseHeaders,
+	};
+}
+
+function getHooks(authContext: AuthContext) {
+	const plugins = authContext.options.plugins || [];
+	const beforeHooks: Hook[] = [];
+	const afterHooks: Hook[] = [];
+	const beforeHookHandler = authContext.options.hooks?.before;
+	if (beforeHookHandler) {
+		hooksSourceWeakMap.set(beforeHookHandler, "user");
+		beforeHooks.push({
+			matcher: () => true,
+			handler: beforeHookHandler,
+		});
+	}
+	const afterHookHandler = authContext.options.hooks?.after;
+	if (afterHookHandler) {
+		hooksSourceWeakMap.set(afterHookHandler, "user");
+		afterHooks.push({
+			matcher: () => true,
+			handler: afterHookHandler,
+		});
+	}
+	const pluginBeforeHooks = plugins.flatMap((plugin) =>
+		(plugin.hooks?.before ?? []).map((h) => {
+			hooksSourceWeakMap.set(h.handler, `plugin:${plugin.id}`);
+			return h;
+		}),
+	);
+	const pluginAfterHooks = plugins.flatMap((plugin) =>
+		(plugin.hooks?.after ?? []).map((h) => {
+			hooksSourceWeakMap.set(h.handler, `plugin:${plugin.id}`);
+			return h;
+		}),
+	);
+
+	// Plugin hooks run after the user-configured hooks.
+	if (pluginBeforeHooks.length) beforeHooks.push(...pluginBeforeHooks);
+	if (pluginAfterHooks.length) afterHooks.push(...pluginAfterHooks);
+
+	return { beforeHooks, afterHooks };
+}
+
+/**
+ * Run a single endpoint through the configured `hooks.before` / `hooks.after`
+ * pipeline, normalizing the response, headers, and `APIError`s the same way a
+ * router or `auth.api.*` dispatch does.
+ *
+ * This is the canonical hook runner. The HTTP router and `auth.api.*` reach it
+ * through {@link toAuthEndpoints}. Plugins call it directly when they need to
+ * re-enter the pipeline on purpose, such as resuming `/oauth2/authorize` after
+ * a fresh sign-in. Calling an endpoint as a plain function deliberately skips
+ * hooks; `dispatchAuthEndpoint` is the supported way to opt back in.
+ *
+ * @param endpoint The endpoint to dispatch.
+ * @param input Input context whose `context` is an already-resolved `AuthContext`.
+ */
+export async function dispatchAuthEndpoint(
+	endpoint: Endpoint,
+	input: DispatchContext,
+): Promise<unknown> {
+	const operationId = input.operationId ?? getOperationId(endpoint);
+	const route = endpoint.path ?? "/:virtual";
+	const endpointMethod = endpoint.options?.method;
+	const defaultMethod = Array.isArray(endpointMethod)
+		? endpointMethod[0]
+		: endpointMethod;
+	const methodName =
+		input.method ?? input.request?.method ?? defaultMethod ?? "?";
+	const shouldReturnResponse = input.asResponse ?? isRequestLike(input.request);
+
+	let internalContext: InternalContext = {
+		...input,
+		context: {
+			...input.context,
+			returned: undefined,
+			responseHeaders: undefined,
+			// A fresh dispatch (shared context) has no session; a resumed dispatch
+			// carries the in-flight request's session through.
+			session: input.context.session ?? null,
+		},
+		path: endpoint.path,
+		headers: input.headers ? new Headers(input.headers) : undefined,
+	};
+
+	return withSpan(
+		`${methodName} ${route}`,
+		{
+			[ATTR_HTTP_ROUTE]: route,
+			[ATTR_OPERATION_ID]: operationId,
+		},
+		async () =>
+			runWithEndpointContext(internalContext, async () => {
+				const { beforeHooks, afterHooks } = getHooks(internalContext.context);
+				const before = await runBeforeHooks(
+					internalContext,
+					beforeHooks,
+					endpoint,
+					operationId,
+				);
+				if (
+					"context" in before &&
+					before.context &&
+					typeof before.context === "object"
+				) {
+					const { headers, ...rest } = before.context as { headers: Headers };
+					// Request-header overrides from the hook merge into the request
+					// headers; response headers are already accumulated separately.
+					if (headers) {
+						headers.forEach((value, key) => {
+							(internalContext.headers as Headers).set(key, value);
+						});
+					}
+					internalContext = defuReplaceArrays(rest, internalContext);
+				} else if (before) {
+					// A before hook short-circuited. Serialize the response headers it
+					// accumulated (`c.setHeader` / `c.setCookie`), not the request headers.
+					const responseHeaders = internalContext.context.responseHeaders;
+					return shouldReturnResponse
+						? toResponse(before, { headers: responseHeaders })
+						: input.returnHeaders
+							? { headers: responseHeaders, response: before }
+							: before;
+				}
+
+				internalContext.asResponse = false;
+				internalContext.returnHeaders = true;
+				internalContext.returnStatus = true;
+				const result = (await runWithEndpointContext(internalContext, () =>
+					withSpan(
+						`handler ${route}`,
+						{
+							[ATTR_HTTP_ROUTE]: route,
+							[ATTR_OPERATION_ID]: operationId,
+						},
+						() => (endpoint as any)(internalContext as any),
+					),
+				).catch((e: unknown) => {
+					if (isAPIError(e)) {
+						return {
+							response: e,
+							status: e.statusCode,
+							headers: mergeAPIErrorHeaders(e),
+						};
+					}
+					throw e;
+				})) as
+					| Response
+					| { headers: Headers | null; response: any; status?: number };
+
+				// A raw Response skips after hooks and post-processing.
+				if (result instanceof Response) {
+					return result;
+				}
+
+				internalContext.context.returned = result.response;
+				internalContext.context.responseHeaders = result.headers ?? undefined;
+
+				const after = await runAfterHooks(
+					internalContext,
+					afterHooks,
+					endpoint,
+					operationId,
+				);
+				if (after.response !== undefined) {
+					result.response = after.response;
+				}
+				result.headers = after.headers ?? result.headers;
+
+				if (
+					isAPIError(result.response) &&
+					shouldPublishLog(internalContext.context.logger.level, "debug")
+				) {
+					result.response.stack = result.response.errorStack;
+				}
+
+				if (isAPIError(result.response) && !shouldReturnResponse) {
+					// Non-response path: re-throw the raw APIError to `auth.api.*`
+					// callers, attaching the merged headers so an outer pipeline sees
+					// the same set we would have written on a response.
+					if (result.headers) {
+						Object.defineProperty(result.response, kAPIErrorHeaderSymbol, {
+							enumerable: false,
+							configurable: true,
+							writable: false,
+							value: result.headers,
+						});
+					}
+					throw result.response;
+				}
+
+				return shouldReturnResponse
+					? toResponse(result.response, {
+							headers: result.headers ?? undefined,
+							status: result.status,
+						})
+					: input.returnHeaders
+						? input.returnStatus
+							? {
+									headers: result.headers,
+									response: result.response,
+									status: result.status,
+								}
+							: {
+									headers: result.headers,
+									response: result.response,
+								}
+						: input.returnStatus
+							? { response: result.response, status: result.status }
+							: result.response;
+			}),
+	);
+}

--- a/packages/better-auth/src/api/dispatch.ts
+++ b/packages/better-auth/src/api/dispatch.ts
@@ -370,8 +370,12 @@ export async function dispatchAuthEndpoint(
 					// Request-header overrides from the hook merge into the request
 					// headers; response headers are already accumulated separately.
 					if (headers) {
+						if (!internalContext.headers) {
+							internalContext.headers = new Headers();
+						}
+						const requestHeaders = internalContext.headers;
 						headers.forEach((value, key) => {
-							(internalContext.headers as Headers).set(key, value);
+							requestHeaders.set(key, value);
 						});
 					}
 					internalContext = defuReplaceArrays(rest, internalContext);

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -411,6 +411,7 @@ export {
 export { APIError } from "@better-auth/core/error";
 export { getIp } from "../utils/get-request-ip";
 export { isAPIError } from "../utils/is-api-error";
+export { type DispatchContext, dispatchAuthEndpoint } from "./dispatch";
 export * from "./middlewares";
 export * from "./routes";
 export { getOAuthState } from "./state/oauth";

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -1331,3 +1331,99 @@ describe("response headers on APIError", async () => {
 		expect(setCookies.some((c) => c.startsWith("session_data="))).toBe(true);
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9887
+ *
+ * Configured hooks run once per dispatch boundary (the HTTP router or an
+ * `auth.api.*` call), not once per endpoint invocation. Internal
+ * endpoint-to-endpoint calls, such as `sessionMiddleware` resolving the
+ * session through the `getSession` endpoint, must not re-run them.
+ */
+describe("hook dispatch boundary", async () => {
+	it("does not re-run configured hooks for internal getSession calls", async () => {
+		const beforePaths: string[] = [];
+		const afterPaths: string[] = [];
+		const { auth, signInWithTestUser } = await getTestInstance({
+			hooks: {
+				before: createAuthMiddleware(async (ctx) => {
+					beforePaths.push(ctx.path);
+				}),
+				after: createAuthMiddleware(async (ctx) => {
+					afterPaths.push(ctx.path);
+				}),
+			},
+		});
+		const { headers } = await signInWithTestUser();
+
+		// `/list-sessions` resolves the session via `sessionMiddleware`, which
+		// calls the `getSession` endpoint internally.
+		beforePaths.length = 0;
+		afterPaths.length = 0;
+		await auth.api.listSessions({ headers });
+
+		expect(beforePaths).toContain("/list-sessions");
+		expect(afterPaths).toContain("/list-sessions");
+		expect(beforePaths).not.toContain("/get-session");
+		expect(afterPaths).not.toContain("/get-session");
+
+		// Sanity: hooks do run when `getSession` is the dispatched endpoint, so
+		// the assertions above reflect the boundary, not a disabled hook.
+		beforePaths.length = 0;
+		await auth.api.getSession({ headers });
+		expect(beforePaths).toContain("/get-session");
+	});
+});
+
+describe("before hook response headers", async () => {
+	const endpoints = {
+		guarded: createAuthEndpoint("/guarded", { method: "GET" }, async () => ({
+			handler: true,
+		})),
+	};
+	const authContext = init({
+		hooks: {
+			before: createAuthMiddleware(async (c) => {
+				c.setHeader("x-before", "yes");
+				c.setCookie("from_before", "1");
+				return { shortCircuited: true };
+			}),
+		},
+	});
+	const api = toAuthEndpoints(endpoints, authContext);
+
+	it("serializes the response headers a short-circuiting before hook set", async () => {
+		const response = await api.guarded({ asResponse: true });
+		expect(await response.json()).toMatchObject({ shortCircuited: true });
+		expect(response.headers.get("x-before")).toBe("yes");
+		expect(response.headers.get("set-cookie")).toContain("from_before=1");
+	});
+});
+
+describe("after hook error headers", async () => {
+	const endpoints = {
+		ok: createAuthEndpoint("/ok", { method: "GET" }, async () => ({
+			ok: true,
+		})),
+	};
+	const authContext = init({
+		hooks: {
+			after: createAuthMiddleware(async (c) => {
+				c.setCookie("from_after", "1");
+				throw c.error(
+					"BAD_REQUEST",
+					{ message: "after rejected" },
+					new Headers({ location: "/login" }),
+				);
+			}),
+		},
+	});
+	const api = toAuthEndpoints(endpoints, authContext);
+
+	it("merges accumulated cookies with explicit APIError headers from an after hook", async () => {
+		const response = await api.ok({ asResponse: true });
+		expect(response.status).toBe(400);
+		expect(response.headers.get("location")).toBe("/login");
+		expect(response.headers.get("set-cookie")).toContain("from_after=1");
+	});
+});

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -1427,3 +1427,30 @@ describe("after hook error headers", async () => {
 		expect(response.headers.get("set-cookie")).toContain("from_after=1");
 	});
 });
+
+describe("before hook request headers", async () => {
+	const endpoints = {
+		echoHeaders: createAuthEndpoint(
+			"/echo-headers",
+			{ method: "GET" },
+			async (c) => Object.fromEntries(c.headers?.entries() ?? []),
+		),
+	};
+	const authContext = init({
+		hooks: {
+			before: createAuthMiddleware(async (c) => {
+				if (c.path === "/echo-headers") {
+					return { context: { headers: new Headers({ injected: "yes" }) } };
+				}
+			}),
+		},
+	});
+	const api = toAuthEndpoints(endpoints, authContext);
+
+	it("merges hook-provided request headers when the call has none", async () => {
+		// No request headers, so the dispatch context starts with `headers`
+		// undefined; the merge must not throw.
+		const res = await api.echoHeaders();
+		expect(res).toMatchObject({ injected: "yes" });
+	});
+});

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -1,72 +1,22 @@
-import type { AuthContext, HookEndpointContext } from "@better-auth/core";
-import type { AuthMiddleware } from "@better-auth/core/api";
+import type { AuthContext } from "@better-auth/core";
 import {
 	hasRequestState,
-	runWithEndpointContext,
 	runWithRequestState,
 } from "@better-auth/core/context";
-import { shouldPublishLog } from "@better-auth/core/env";
 import { APIError, BetterAuthError } from "@better-auth/core/error";
-import {
-	ATTR_CONTEXT,
-	ATTR_HOOK_TYPE,
-	ATTR_HTTP_ROUTE,
-	ATTR_OPERATION_ID,
-	withSpan,
-} from "@better-auth/core/instrumentation";
 import type {
 	Endpoint,
 	EndpointContext,
 	EndpointOptions,
 	InputContext,
 } from "better-call";
-import { kAPIErrorHeaderSymbol, toResponse } from "better-call";
-import { createDefu } from "defu";
 import {
 	pickSource,
 	resolveDynamicTrustedProxyHeaders,
 	resolveRequestContext,
 } from "../context/helpers";
-import { isAPIError } from "../utils/is-api-error";
 import { isDynamicBaseURLConfig, isRequestLike } from "../utils/url";
-
-type InternalContext = Partial<
-	InputContext<string, any> & EndpointContext<string, any>
-> & {
-	path: string;
-	asResponse?: boolean | undefined;
-	context: AuthContext & {
-		logger: AuthContext["logger"];
-		returned?: unknown | undefined;
-		responseHeaders?: Headers | undefined;
-	};
-};
-
-const defuReplaceArrays = createDefu((obj, key, value) => {
-	if (Array.isArray(obj[key]) && Array.isArray(value)) {
-		obj[key] = value;
-		return true;
-	}
-});
-
-type Hook = {
-	matcher: (context: HookEndpointContext) => boolean;
-	handler: AuthMiddleware;
-};
-
-const hooksSourceWeakMap = new WeakMap<
-	AuthMiddleware,
-	`user` | `plugin:${string}`
->();
-
-function getOperationId(endpoint: Endpoint | undefined, key: string): string {
-	if (!endpoint?.options) return key;
-	const opts = endpoint.options as {
-		operationId?: string;
-		metadata?: { openapi?: { operationId?: string } };
-	};
-	return opts.operationId ?? opts.metadata?.openapi?.operationId ?? key;
-}
+import { dispatchAuthEndpoint, getOperationId } from "./dispatch";
 
 type UserInputContext = Partial<
 	InputContext<string, any> & EndpointContext<string, any>
@@ -114,6 +64,12 @@ async function resolveDynamicContext(
 	}
 }
 
+/**
+ * Wraps each raw endpoint so a router or `auth.api.*` call runs it through the
+ * configured hook pipeline. Per-call work that is specific to this entry point
+ * (dynamic `baseURL` resolution, request-state initialization) happens here;
+ * the hook pipeline itself lives in {@link dispatchAuthEndpoint}.
+ */
 export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 	endpoints: E,
 	ctx: AuthContext | Promise<AuthContext>,
@@ -131,434 +87,29 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 	for (const [key, endpoint] of Object.entries(endpoints)) {
 		api[key] = async (context?: UserInputContext) => {
 			const operationId = getOperationId(endpoint, key);
-			const endpointMethod = endpoint?.options?.method;
-			const defaultMethod = Array.isArray(endpointMethod)
-				? endpointMethod[0]
-				: endpointMethod;
 
 			const run = async () => {
 				const rawContext = await ctx;
-				const methodName =
-					context?.method ?? context?.request?.method ?? defaultMethod ?? "?";
-				const route = endpoint.path ?? "/:virtual";
-
 				const authContext = isDynamicBaseURLConfig(rawContext.options.baseURL)
 					? await resolveDynamicContext(rawContext, context)
 					: rawContext;
 
-				let internalContext: InternalContext = {
+				return dispatchAuthEndpoint(endpoint, {
 					...context,
-					context: {
-						...authContext,
-						returned: undefined,
-						responseHeaders: undefined,
-						session: null,
-					},
-					path: endpoint.path,
-					headers: context?.headers ? new Headers(context?.headers) : undefined,
-				};
-				const hasRequest = isRequestLike(context?.request);
-				const shouldReturnResponse = context?.asResponse ?? hasRequest;
-				return withSpan(
-					`${methodName} ${route}`,
-					{
-						[ATTR_HTTP_ROUTE]: route,
-						[ATTR_OPERATION_ID]: operationId,
-					},
-					async () =>
-						runWithEndpointContext(internalContext, async () => {
-							const { beforeHooks, afterHooks } = getHooks(authContext);
-							const before = await runBeforeHooks(
-								internalContext,
-								beforeHooks,
-								endpoint,
-								operationId,
-							);
-							/**
-							 * If `before.context` is returned, it should
-							 * get merged with the original context
-							 */
-							if (
-								"context" in before &&
-								before.context &&
-								typeof before.context === "object"
-							) {
-								const { headers, ...rest } = before.context as {
-									headers: Headers;
-								};
-								/**
-								 * Headers should be merged differently
-								 * so the hook doesn't override the whole
-								 * header
-								 */
-								if (headers) {
-									headers.forEach((value, key) => {
-										(internalContext.headers as Headers).set(key, value);
-									});
-								}
-								internalContext = defuReplaceArrays(rest, internalContext);
-							} else if (before) {
-								/* Return before hook response if it's anything other than a context return */
-								return shouldReturnResponse
-									? toResponse(before, {
-											headers: context?.headers,
-										})
-									: context?.returnHeaders
-										? {
-												headers: context?.headers,
-												response: before,
-											}
-										: before;
-							}
-
-							internalContext.asResponse = false;
-							internalContext.returnHeaders = true;
-							internalContext.returnStatus = true;
-							const result = (await runWithEndpointContext(
-								internalContext,
-								() =>
-									withSpan(
-										`handler ${route}`,
-										{
-											[ATTR_HTTP_ROUTE]: route,
-											[ATTR_OPERATION_ID]: operationId,
-										},
-										() => (endpoint as any)(internalContext as any),
-									),
-							).catch((e: any) => {
-								if (isAPIError(e)) {
-									/**
-									 * API Errors from response are caught
-									 * and returned to hooks.
-									 *
-									 * Headers come from two sources that must both
-									 * survive:
-									 * - `kAPIErrorHeaderSymbol`: ctx.responseHeaders
-									 *   accumulated via c.setCookie / c.setHeader
-									 *   before the throw.
-									 * - `e.headers`: explicit headers on the APIError
-									 *   (e.g. `location` from c.redirect).
-									 *
-									 * Start from the accumulated ctx headers, then
-									 * apply e.headers on top — appending `set-cookie`
-									 * and setting others — so explicit APIError
-									 * headers override while cookies accumulate.
-									 */
-									const ctxHeaders = (
-										e as {
-											[kAPIErrorHeaderSymbol]?: Headers;
-										}
-									)[kAPIErrorHeaderSymbol];
-									/**
-									 * `c.redirect()` (and similar APIError throws) reuse
-									 * `ctx.responseHeaders` as `e.headers`, so when both sources
-									 * reference the same Headers, iterating both duplicates every
-									 * `set-cookie`. Skip the `errHeaders` copy in that case.
-									 */
-									const errHeaders =
-										e.headers && e.headers !== ctxHeaders
-											? new Headers(e.headers)
-											: null;
-									let headers: Headers | null = null;
-									if (ctxHeaders || errHeaders) {
-										headers = new Headers();
-										ctxHeaders?.forEach((value, key) => {
-											headers!.append(key, value);
-										});
-										errHeaders?.forEach((value, key) => {
-											if (key.toLowerCase() === "set-cookie") {
-												headers!.append(key, value);
-											} else {
-												headers!.set(key, value);
-											}
-										});
-									}
-									return {
-										response: e,
-										status: e.statusCode,
-										headers,
-									};
-								}
-								throw e;
-							})) as {
-								headers: Headers;
-								response: any;
-								status: number;
-							};
-
-							//if response object is returned we skip after hooks and post processing
-							if (result && result instanceof Response) {
-								return result;
-							}
-
-							internalContext.context.returned = result.response;
-							internalContext.context.responseHeaders = result.headers;
-
-							const after = await runAfterHooks(
-								internalContext,
-								afterHooks,
-								endpoint,
-								operationId,
-							);
-
-							if (after.response) {
-								result.response = after.response;
-							}
-
-							if (
-								isAPIError(result.response) &&
-								shouldPublishLog(authContext.logger.level, "debug")
-							) {
-								// inherit stack from errorStack if debug mode is enabled
-								result.response.stack = result.response.errorStack;
-							}
-
-							if (isAPIError(result.response) && !shouldReturnResponse) {
-								/**
-								 * Non-response path: we re-throw the raw APIError
-								 * to callers of `auth.api.*`. `result.headers`
-								 * holds the merged ctx + explicit headers (see
-								 * catch block above) — rewrite
-								 * `kAPIErrorHeaderSymbol` with the merged set so
-								 * downstream pipelines (e.g. better-call's
-								 * response builder, or an outer hook catch) see
-								 * the same headers we'd have written on the
-								 * response.
-								 */
-								if (result.headers) {
-									Object.defineProperty(
-										result.response,
-										kAPIErrorHeaderSymbol,
-										{
-											enumerable: false,
-											configurable: true,
-											writable: false,
-											value: result.headers,
-										},
-									);
-								}
-								throw result.response;
-							}
-
-							const response = shouldReturnResponse
-								? toResponse(result.response, {
-										headers: result.headers,
-										status: result.status,
-									})
-								: context?.returnHeaders
-									? context?.returnStatus
-										? {
-												headers: result.headers,
-												response: result.response,
-												status: result.status,
-											}
-										: {
-												headers: result.headers,
-												response: result.response,
-											}
-									: context?.returnStatus
-										? { response: result.response, status: result.status }
-										: result.response;
-							return response;
-						}),
-				);
+					context: authContext,
+					operationId,
+					asResponse: context?.asResponse ?? isRequestLike(context?.request),
+				});
 			};
+
 			if (await hasRequestState()) {
 				return run();
-			} else {
-				const store = new WeakMap();
-				return runWithRequestState(store, run);
 			}
+			const store = new WeakMap();
+			return runWithRequestState(store, run);
 		};
 		api[key].path = endpoint.path;
 		api[key].options = endpoint.options;
 	}
 	return api as unknown as E;
-}
-
-async function runBeforeHooks(
-	context: InternalContext,
-	hooks: Hook[],
-	endpoint: Endpoint,
-	operationId: string,
-) {
-	let modifiedContext: Partial<InternalContext> = {};
-
-	for (const hook of hooks) {
-		let matched = false;
-		try {
-			matched = hook.matcher(context);
-		} catch (error) {
-			// manually handle unexpected errors during hook matcher execution to prevent accidental exposure of internal details
-			// Also provides debug information about which plugin the hook failed and error info
-			const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
-			context.context.logger.error(
-				`An error occurred during ${hookSource} hook matcher execution:`,
-				error,
-			);
-			throw new APIError("INTERNAL_SERVER_ERROR", {
-				message: `An error occurred during hook matcher execution. Check the logs for more details.`,
-			});
-		}
-		if (matched) {
-			const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
-			const route = endpoint.path ?? "/:virtual";
-			const result = await withSpan(
-				`hook before ${route} ${hookSource}`,
-				{
-					[ATTR_HOOK_TYPE]: "before",
-					[ATTR_HTTP_ROUTE]: route,
-					[ATTR_CONTEXT]: hookSource,
-					[ATTR_OPERATION_ID]: operationId,
-				},
-				() =>
-					hook.handler({
-						...context,
-						returnHeaders: false,
-					}),
-			).catch((e: unknown) => {
-				if (
-					isAPIError(e) &&
-					shouldPublishLog(context.context.logger.level, "debug")
-				) {
-					// inherit stack from errorStack if debug mode is enabled
-					e.stack = e.errorStack;
-				}
-				throw e;
-			});
-			if (result && typeof result === "object") {
-				if ("context" in result && typeof result.context === "object") {
-					const { headers, ...rest } =
-						result.context as Partial<InternalContext>;
-					if (headers instanceof Headers) {
-						if (modifiedContext.headers) {
-							headers.forEach((value, key) => {
-								modifiedContext.headers?.set(key, value);
-							});
-						} else {
-							modifiedContext.headers = headers;
-						}
-					}
-					modifiedContext = defuReplaceArrays(rest, modifiedContext);
-
-					continue;
-				}
-				return result;
-			}
-		}
-	}
-	return { context: modifiedContext };
-}
-
-async function runAfterHooks(
-	context: InternalContext,
-	hooks: Hook[],
-	endpoint: Endpoint,
-	operationId: string,
-) {
-	for (const hook of hooks) {
-		if (hook.matcher(context)) {
-			const hookSource = hooksSourceWeakMap.get(hook.handler) ?? "unknown";
-			const route = endpoint.path ?? "/:virtual";
-			const result = (await withSpan(
-				`hook after ${route} ${hookSource}`,
-				{
-					[ATTR_HOOK_TYPE]: "after",
-					[ATTR_HTTP_ROUTE]: route,
-					[ATTR_CONTEXT]: hookSource,
-					[ATTR_OPERATION_ID]: operationId,
-				},
-				() => hook.handler(context),
-			).catch((e) => {
-				if (isAPIError(e)) {
-					const headers = (e as any)[kAPIErrorHeaderSymbol] as
-						| Headers
-						| undefined;
-					if (shouldPublishLog(context.context.logger.level, "debug")) {
-						// inherit stack from errorStack if debug mode is enabled
-						e.stack = e.errorStack;
-					}
-					return {
-						response: e,
-						headers: headers
-							? headers
-							: e.headers
-								? new Headers(e.headers)
-								: null,
-					};
-				}
-				throw e;
-			})) as {
-				response: any;
-				headers: Headers;
-			};
-			if (result.headers) {
-				result.headers.forEach((value, key) => {
-					if (!context.context.responseHeaders) {
-						context.context.responseHeaders = new Headers({
-							[key]: value,
-						});
-					} else {
-						if (key.toLowerCase() === "set-cookie") {
-							context.context.responseHeaders.append(key, value);
-						} else {
-							context.context.responseHeaders.set(key, value);
-						}
-					}
-				});
-			}
-			if (result.response) {
-				context.context.returned = result.response;
-			}
-		}
-	}
-	return {
-		response: context.context.returned,
-		headers: context.context.responseHeaders,
-	};
-}
-
-function getHooks(authContext: AuthContext) {
-	const plugins = authContext.options.plugins || [];
-	const beforeHooks: Hook[] = [];
-	const afterHooks: Hook[] = [];
-	const beforeHookHandler = authContext.options.hooks?.before;
-	if (beforeHookHandler) {
-		hooksSourceWeakMap.set(beforeHookHandler, "user");
-		beforeHooks.push({
-			matcher: () => true,
-			handler: beforeHookHandler,
-		});
-	}
-	const afterHookHandler = authContext.options.hooks?.after;
-	if (afterHookHandler) {
-		hooksSourceWeakMap.set(afterHookHandler, "user");
-		afterHooks.push({
-			matcher: () => true,
-			handler: afterHookHandler,
-		});
-	}
-	const pluginBeforeHooks = plugins.flatMap((plugin) =>
-		(plugin.hooks?.before ?? []).map((h) => {
-			hooksSourceWeakMap.set(h.handler, `plugin:${plugin.id}`);
-			return h;
-		}),
-	);
-	const pluginAfterHooks = plugins.flatMap((plugin) =>
-		(plugin.hooks?.after ?? []).map((h) => {
-			hooksSourceWeakMap.set(h.handler, `plugin:${plugin.id}`);
-			return h;
-		}),
-	);
-
-	/**
-	 * Add plugin added hooks at last
-	 */
-	if (pluginBeforeHooks.length) beforeHooks.push(...pluginBeforeHooks);
-	if (pluginAfterHooks.length) afterHooks.push(...pluginAfterHooks);
-
-	return {
-		beforeHooks,
-		afterHooks,
-	};
 }

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -149,13 +149,15 @@ function getErrorURL(
 	return formattedURL;
 }
 
+export type AuthorizeEndpointSettings = {
+	isAuthorize?: boolean;
+	postLogin?: boolean;
+};
+
 export async function authorizeEndpoint(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
-	settings?: {
-		isAuthorize?: boolean;
-		postLogin?: boolean;
-	},
+	settings?: AuthorizeEndpointSettings,
 ) {
 	// Grant type must include authorization_code to use this endpoint
 	if (opts.grantTypes && !opts.grantTypes.includes("authorization_code")) {

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -1,6 +1,7 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError, getSessionFromCtx } from "better-auth/api";
-import { authorizeEndpoint, formatErrorURL, getIssuer } from "./authorize";
+import { formatErrorURL, getIssuer } from "./authorize";
+import type { AuthorizeEndpointCaller } from "./continue";
 import { oAuthState } from "./oauth";
 import type { OAuthConsent, OAuthOptions, Scope } from "./types";
 import {
@@ -10,9 +11,10 @@ import {
 	searchParamsToQuery,
 } from "./utils";
 
-export async function consentEndpoint(
+export async function consentEndpoint<Result>(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
+	authorize: AuthorizeEndpointCaller<Result>,
 ) {
 	// Obtain oauth query
 	const oauthRequest = await oAuthState.get();
@@ -72,11 +74,7 @@ export async function consentEndpoint(
 	if (hasLoginPrompt && !hasSatisfiedLoginPrompt) {
 		ctx?.headers?.set("accept", "application/json");
 		ctx.query = searchParamsToQuery(query);
-		const { url } = await authorizeEndpoint(ctx, opts);
-		return {
-			redirect: true,
-			url,
-		};
+		return await authorize(ctx);
 	}
 
 	const referenceId = await opts.postLogin?.consentReferenceId?.({
@@ -151,13 +149,9 @@ export async function consentEndpoint(
 	const postLoginClearedForThisSession =
 		oauthRequest?.postLoginClearedForSession !== undefined &&
 		oauthRequest.postLoginClearedForSession === session?.session.id;
-	const { url } = await authorizeEndpoint(ctx, opts, {
+	return await authorize(ctx, {
 		postLogin: postLoginClearedForThisSession,
 	});
-	return {
-		redirect: true,
-		url,
-	};
 }
 
 // Relies on session.createdAt being immutable for the session's lifetime; a

--- a/packages/oauth-provider/src/continue.ts
+++ b/packages/oauth-provider/src/continue.ts
@@ -1,21 +1,30 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError } from "better-auth/api";
-import { authorizeEndpoint } from "./authorize";
+import type { AuthorizeEndpointSettings } from "./authorize";
 import { oAuthState } from "./oauth";
-import type { OAuthOptions, Scope } from "./types";
 import { removePromptFromQuery, searchParamsToQuery } from "./utils";
 
-export async function continueEndpoint(
+/**
+ * Re-enters `/oauth2/authorize` through the hook pipeline. Injected so the
+ * resume paths dispatch the endpoint (running configured hooks) instead of
+ * calling the raw `authorizeEndpoint` function, which would skip them.
+ */
+export type AuthorizeEndpointCaller<Result = unknown> = (
 	ctx: GenericEndpointContext,
-	opts: OAuthOptions<Scope[]>,
+	settings?: AuthorizeEndpointSettings,
+) => Promise<Result>;
+
+export async function continueEndpoint<Result>(
+	ctx: GenericEndpointContext,
+	authorize: AuthorizeEndpointCaller<Result>,
 ) {
 	// Continue login flow (ensure it's strictly boolean true)
 	if (ctx.body.selected === true) {
-		return await selected(ctx, opts);
+		return await selected(ctx, authorize);
 	} else if (ctx.body.created === true) {
-		return await created(ctx, opts);
+		return await created(ctx, authorize);
 	} else if (ctx.body.postLogin === true) {
-		return await postLogin(ctx, opts);
+		return await postLogin(ctx, authorize);
 	} else {
 		throw new APIError("BAD_REQUEST", {
 			error_description: "Missing parameters",
@@ -24,9 +33,9 @@ export async function continueEndpoint(
 	}
 }
 
-async function selected(
+async function selected<Result>(
 	ctx: GenericEndpointContext,
-	opts: OAuthOptions<Scope[]>,
+	authorize: AuthorizeEndpointCaller<Result>,
 ) {
 	const _query = (await oAuthState.get())?.query as string | undefined;
 	if (!_query) {
@@ -40,16 +49,12 @@ async function selected(
 	ctx.query = searchParamsToQuery(
 		removePromptFromQuery(query, "select_account"),
 	);
-	const { url } = await authorizeEndpoint(ctx, opts);
-	return {
-		redirect: true,
-		url,
-	};
+	return await authorize(ctx);
 }
 
-async function created(
+async function created<Result>(
 	ctx: GenericEndpointContext,
-	opts: OAuthOptions<Scope[]>,
+	authorize: AuthorizeEndpointCaller<Result>,
 ) {
 	const _query = (await oAuthState.get())?.query as string | undefined;
 	if (!_query) {
@@ -61,16 +66,12 @@ async function created(
 	const query = new URLSearchParams(_query);
 	ctx.headers?.set("accept", "application/json");
 	ctx.query = searchParamsToQuery(removePromptFromQuery(query, "create"));
-	const { url } = await authorizeEndpoint(ctx, opts);
-	return {
-		redirect: true,
-		url,
-	};
+	return await authorize(ctx);
 }
 
-async function postLogin(
+async function postLogin<Result>(
 	ctx: GenericEndpointContext,
-	opts: OAuthOptions<Scope[]>,
+	authorize: AuthorizeEndpointCaller<Result>,
 ) {
 	const _query = (await oAuthState.get())?.query as string | undefined;
 	if (!_query) {
@@ -82,11 +83,7 @@ async function postLogin(
 	const query = new URLSearchParams(_query);
 	ctx.headers?.set("accept", "application/json");
 	ctx.query = searchParamsToQuery(query);
-	const { url } = await authorizeEndpoint(ctx, opts, {
+	return await authorize(ctx, {
 		postLogin: true,
 	});
-	return {
-		redirect: true,
-		url,
-	};
 }

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -1,3 +1,4 @@
+import { createAuthMiddleware } from "better-auth/api";
 import { createAuthClient } from "better-auth/client";
 import {
 	genericOAuthClient,
@@ -1002,6 +1003,7 @@ describe("oauth - prompt", async () => {
 	let forcePostLoginRedirect = false;
 	let bypassReferenceIdCheck = false;
 	let isUserRegistered = true;
+	let authorizeBeforeHookCount = 0;
 	const {
 		auth: authorizationServer,
 		customFetchImpl,
@@ -1009,6 +1011,13 @@ describe("oauth - prompt", async () => {
 		cookieSetter,
 	} = await getTestInstance({
 		baseURL: authServerBaseUrl,
+		hooks: {
+			before: createAuthMiddleware(async (ctx) => {
+				if (ctx.path === "/oauth2/authorize") {
+					authorizeBeforeHookCount++;
+				}
+			}),
+		},
 		plugins: [
 			jwt(),
 			multiSession(),
@@ -1832,6 +1841,82 @@ describe("oauth - prompt", async () => {
 		expect(selectedAccountRedirectUri).toContain(`code=`);
 
 		enableSelectAccount = false;
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9887
+	 *
+	 * The resumed `/oauth2/authorize` step must run configured hooks. Before the
+	 * fix it called the raw authorize function directly, skipping the dispatch
+	 * pipeline, so hooks ran for the standalone request but not the resume.
+	 */
+	it("runs configured hooks when authorize resumes from continue", async ({
+		onTestFinished,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		enableSelectAccount = true;
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+			enableSelectAccount = false;
+		});
+		const { customFetchImpl: customFetchImplRP, cookieSetter } =
+			await createTestInstance();
+		const client = createAuthClient({
+			baseURL: rpBaseUrl,
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+
+		const data = await client.signIn.social(
+			{
+				provider: providerId,
+				callbackURL: "/success",
+			},
+			{
+				throw: true,
+				headers,
+				onSuccess: cookieSetter(headers),
+			},
+		);
+
+		let selectAccountRedirectUri = "";
+		await serverClient.$fetch(data.url, {
+			method: "GET",
+			headers,
+			onError(ctx) {
+				selectAccountRedirectUri = ctx.response.headers.get("Location") || "";
+				cookieSetter(headers)(ctx);
+				headers.append("Cookie", headers.get("Cookie") || "");
+			},
+		});
+		expect(selectAccountRedirectUri).toContain(`/select-account`);
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(selectAccountRedirectUri, authServerBaseUrl).search,
+			},
+		});
+
+		// The standalone authorize request already ran the hook; the resume must
+		// run it again rather than calling the raw authorize function.
+		const countBeforeResume = authorizeBeforeHookCount;
+		expect(countBeforeResume).toBeGreaterThan(0);
+
+		const selectedAccountRes = await serverClient.oauth2.continue(
+			{
+				selected: true,
+			},
+			{
+				headers,
+				throw: true,
+			},
+		);
+		// Whether the resume lands on consent or the callback, it re-dispatched
+		// `/oauth2/authorize`, so the configured hook must have run once more.
+		expect(selectedAccountRes.redirect).toBeTruthy();
+		expect(authorizeBeforeHookCount).toBe(countBeforeResume + 1);
 	});
 
 	it("none - should return account_selection_required when account selection is required", async () => {

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -6,6 +6,8 @@ import {
 	APIError,
 	createAuthEndpoint,
 	createAuthMiddleware,
+	type DispatchContext,
+	dispatchAuthEndpoint,
 	getOAuthState,
 	sessionMiddleware,
 } from "better-auth/api";
@@ -13,7 +15,7 @@ import { parseSetCookieHeader } from "better-auth/cookies";
 import { mergeSchema } from "better-auth/db";
 import type { BetterAuthPlugin } from "better-auth/types";
 import * as z from "zod";
-import { authorizeEndpoint } from "./authorize";
+import { type AuthorizeEndpointSettings, authorizeEndpoint } from "./authorize";
 import { consentEndpoint } from "./consent";
 import { continueEndpoint } from "./continue";
 import { introspectEndpoint } from "./introspect";
@@ -257,6 +259,163 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 			};
 		}
 	};
+	type OAuth2AuthorizeContext = GenericEndpointContext & {
+		authorizeSettings?: AuthorizeEndpointSettings | undefined;
+	};
+	type OAuth2AuthorizeResult = Awaited<ReturnType<typeof authorizeEndpoint>>;
+
+	const oauth2AuthorizeEndpoint = createAuthEndpoint(
+		"/oauth2/authorize",
+		{
+			method: "GET",
+			query: z.object({
+				response_type: z.enum(["code"]).optional(),
+				client_id: z.string(),
+				redirect_uri: SafeUrlSchema.optional(),
+				scope: z.string().optional(),
+				state: z.string().optional(),
+				request_uri: z.string().optional(),
+				code_challenge: z.string().optional(),
+				code_challenge_method: z.enum(["S256"]).optional(),
+				nonce: z.string().optional(),
+				prompt: z
+					.enum([
+						"none",
+						"consent",
+						"login",
+						"create",
+						"select_account",
+						"login consent",
+						"select_account consent",
+					])
+					.optional(),
+			}),
+			metadata: {
+				openapi: {
+					description: "Authorize an OAuth2 request",
+					parameters: [
+						{
+							name: "response_type",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "OAuth2 response type (e.g., 'code')",
+						},
+						{
+							name: "client_id",
+							in: "query",
+							required: true,
+							schema: { type: "string" },
+							description: "OAuth2 client ID",
+						},
+						{
+							name: "redirect_uri",
+							in: "query",
+							required: false,
+							schema: { type: "string", format: "uri" },
+							description: "OAuth2 redirect URI",
+						},
+						{
+							name: "scope",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "OAuth2 scopes (space-separated)",
+						},
+						{
+							name: "state",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "OAuth2 state parameter",
+						},
+						{
+							name: "request_uri",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description:
+								"Pushed Authorization Request URI referencing stored parameters",
+						},
+						{
+							name: "code_challenge",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "PKCE code challenge",
+						},
+						{
+							name: "code_challenge_method",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "PKCE code challenge method",
+						},
+						{
+							name: "nonce",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "OpenID Connect nonce",
+						},
+						{
+							name: "prompt",
+							in: "query",
+							required: false,
+							schema: { type: "string" },
+							description: "OAuth2 prompt parameter",
+						},
+					],
+					responses: {
+						"302": {
+							description: "Redirect to client with code or error",
+							headers: {
+								Location: {
+									description: "Redirect URI with code or error",
+									schema: { type: "string", format: "uri" },
+								},
+							},
+						},
+						"400": {
+							description: "Invalid request",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											error: { type: "string" },
+											error_description: { type: "string" },
+											state: { type: "string" },
+										},
+										required: ["error"],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx): Promise<OAuth2AuthorizeResult> => {
+			const settings = (ctx as OAuth2AuthorizeContext).authorizeSettings ?? {
+				isAuthorize: true,
+			};
+			return authorizeEndpoint(ctx, opts, settings);
+		},
+	);
+
+	const runOAuth2Authorize = (
+		ctx: GenericEndpointContext,
+		settings?: AuthorizeEndpointSettings,
+	): Promise<OAuth2AuthorizeResult> =>
+		dispatchAuthEndpoint(oauth2AuthorizeEndpoint, {
+			...ctx,
+			asResponse: false,
+			returnHeaders: false,
+			returnStatus: false,
+			authorizeSettings: settings ?? {},
+		} as DispatchContext & OAuth2AuthorizeContext) as Promise<OAuth2AuthorizeResult>;
+
 	return {
 		id: "oauth-provider",
 		version: PACKAGE_VERSION,
@@ -407,7 +566,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						ctx.query = searchParamsToQuery(
 							removePromptFromQuery(query, "login"),
 						);
-						return await authorizeEndpoint(ctx, opts);
+						return await runOAuth2Authorize(ctx);
 					}),
 				},
 			],
@@ -473,144 +632,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					return metadata;
 				},
 			),
-			oauth2Authorize: createAuthEndpoint(
-				"/oauth2/authorize",
-				{
-					method: "GET",
-					query: z.object({
-						response_type: z.enum(["code"]).optional(),
-						client_id: z.string(),
-						redirect_uri: SafeUrlSchema.optional(),
-						scope: z.string().optional(),
-						state: z.string().optional(),
-						request_uri: z.string().optional(),
-						code_challenge: z.string().optional(),
-						code_challenge_method: z.enum(["S256"]).optional(),
-						nonce: z.string().optional(),
-						prompt: z
-							.enum([
-								"none",
-								"consent",
-								"login",
-								"create",
-								"select_account",
-								"login consent",
-								"select_account consent",
-							])
-							.optional(),
-					}),
-					metadata: {
-						openapi: {
-							description: "Authorize an OAuth2 request",
-							parameters: [
-								{
-									name: "response_type",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "OAuth2 response type (e.g., 'code')",
-								},
-								{
-									name: "client_id",
-									in: "query",
-									required: true,
-									schema: { type: "string" },
-									description: "OAuth2 client ID",
-								},
-								{
-									name: "redirect_uri",
-									in: "query",
-									required: false,
-									schema: { type: "string", format: "uri" },
-									description: "OAuth2 redirect URI",
-								},
-								{
-									name: "scope",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "OAuth2 scopes (space-separated)",
-								},
-								{
-									name: "state",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "OAuth2 state parameter",
-								},
-								{
-									name: "request_uri",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description:
-										"Pushed Authorization Request URI referencing stored parameters",
-								},
-								{
-									name: "code_challenge",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "PKCE code challenge",
-								},
-								{
-									name: "code_challenge_method",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "PKCE code challenge method",
-								},
-								{
-									name: "nonce",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "OpenID Connect nonce",
-								},
-								{
-									name: "prompt",
-									in: "query",
-									required: false,
-									schema: { type: "string" },
-									description: "OAuth2 prompt parameter",
-								},
-							],
-							responses: {
-								"302": {
-									description: "Redirect to client with code or error",
-									headers: {
-										Location: {
-											description: "Redirect URI with code or error",
-											schema: { type: "string", format: "uri" },
-										},
-									},
-								},
-								"400": {
-									description: "Invalid request",
-									content: {
-										"application/json": {
-											schema: {
-												type: "object",
-												properties: {
-													error: { type: "string" },
-													error_description: { type: "string" },
-													state: { type: "string" },
-												},
-												required: ["error"],
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				async (ctx) => {
-					return authorizeEndpoint(ctx, opts, {
-						isAuthorize: true,
-					});
-				},
-			),
+			oauth2Authorize: oauth2AuthorizeEndpoint,
 			oauth2Consent: createAuthEndpoint(
 				"/oauth2/consent",
 				{
@@ -656,7 +678,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					},
 				},
 				async (ctx) => {
-					return consentEndpoint(ctx, opts);
+					return consentEndpoint(ctx, opts, runOAuth2Authorize);
 				},
 			),
 			oauth2Continue: createAuthEndpoint(
@@ -707,7 +729,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					},
 				},
 				async (ctx) => {
-					return continueEndpoint(ctx, opts);
+					return continueEndpoint(ctx, runOAuth2Authorize);
 				},
 			),
 			oauth2Token: createAuthEndpoint(

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -2,11 +2,11 @@ import type { GenericEndpointContext } from "@better-auth/core";
 import { defineRequestState } from "@better-auth/core/context";
 import { logger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
+import type { DispatchContext } from "better-auth/api";
 import {
 	APIError,
 	createAuthEndpoint,
 	createAuthMiddleware,
-	type DispatchContext,
 	dispatchAuthEndpoint,
 	getOAuthState,
 	sessionMiddleware,
@@ -15,7 +15,8 @@ import { parseSetCookieHeader } from "better-auth/cookies";
 import { mergeSchema } from "better-auth/db";
 import type { BetterAuthPlugin } from "better-auth/types";
 import * as z from "zod";
-import { type AuthorizeEndpointSettings, authorizeEndpoint } from "./authorize";
+import type { AuthorizeEndpointSettings } from "./authorize";
+import { authorizeEndpoint } from "./authorize";
 import { consentEndpoint } from "./consent";
 import { continueEndpoint } from "./continue";
 import { introspectEndpoint } from "./introspect";
@@ -414,7 +415,8 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 			returnHeaders: false,
 			returnStatus: false,
 			authorizeSettings: settings ?? {},
-		} as DispatchContext & OAuth2AuthorizeContext) as Promise<OAuth2AuthorizeResult>;
+		} as DispatchContext &
+			OAuth2AuthorizeContext) as Promise<OAuth2AuthorizeResult>;
 
 	return {
 		id: "oauth-provider",


### PR DESCRIPTION
Resumed `/oauth2/authorize` flows (post-login, account selection, consent) skipped the configured hook pipeline because they called the authorize function directly.

#9894 fixed this by running hooks on every endpoint call, which also fired global hooks on internal `getSession` calls (i.e. most authenticated requests). This instead adds one shared `dispatchAuthEndpoint` primitive and routes the resume paths through it explicitly, keeping hooks at one run per dispatch boundary while internal endpoint calls stay hook-free. Also fixes two latent hook-header cases (before-hook short-circuit, after-hook APIError headers).

Supersedes #9894, built on @GautamBytes's diagnosis and implementation. Boundary decision tracked in #9918.

Fixes #9887
Closes #9894
