### PR TITLE
feat(oauth-provider): add OIDC front-channel logout

### DIFF
--- a/.changeset/oauth-provider-frontchannel-logout.md
+++ b/.changeset/oauth-provider-frontchannel-logout.md
@@ -1,0 +1,18 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+Add OIDC Front-Channel Logout 1.0 support to `@better-auth/oauth-provider`.
+
+When the end-user terminates their session with a browser navigation to `/oauth2/end-session`, the provider now responds with a logout page containing one hidden iframe per OAuth client that holds tokens on the session and has registered a `frontchannel_logout_uri`. The browser fans the logout out by loading each RP's URI so the RP can clear its own session cookies; once every iframe has settled — or after a 3-second safety timeout — the page redirects to the validated `post_logout_redirect_uri` when one was provided. Clients opt in by registering `frontchannel_logout_uri` (and optionally `frontchannel_logout_session_required`, which makes the provider append `iss` and `sid` query parameters) via DCR or the admin client endpoints.
+
+The URI is validated at registration with the same rules as `backchannel_logout_uri` (absolute http/https URL, no fragment, https for confidential clients with a loopback carve-out, non-public hosts rejected), but unlike back-channel logout it works with `disableJwtPlugin: true`, since nothing is signed.
+
+Behavior is unchanged when no front-channel client holds tokens on the session (immediate redirect, as before) and for fetch-style requests to `/oauth2/end-session`, which keep the JSON contract.
+
+Discovery documents at `/.well-known/openid-configuration` and `/.well-known/oauth-authorization-server` now advertise `frontchannel_logout_supported: true` and `frontchannel_logout_session_supported: true`.
+
+Schema changes on `@better-auth/oauth-provider`:
+
+- `oauthClient.frontchannelLogoutUri: string | null`
+- `oauthClient.frontchannelLogoutSessionRequired: boolean`

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -706,6 +706,42 @@ The Logout Token carries the §2.4 claims (`iss`, `aud`, `iat`, `exp`, `jti`, `e
   The OP advertises `backchannel_logout_supported: true` and `backchannel_logout_session_supported: true` on both `.well-known/openid-configuration` and `.well-known/oauth-authorization-server`. RPs use these fields during dynamic client registration to decide whether to register a `backchannel_logout_uri`.
 </Callout>
 
+### Front-Channel Logout
+
+[Front-Channel Logout](https://openid.net/specs/openid-connect-frontchannel-1_0.html) is the browser-based sibling of Back-Channel Logout: when the end-user navigates to `/oauth2/end-session`, the OP responds with a page containing one hidden iframe per opted-in Relying Party, and the user's browser fans the logout out by loading each RP's `frontchannel_logout_uri`. The RP endpoint clears its own session cookies in the browser context — no server-to-server call is involved.
+
+To opt a client in, register a `frontchannel_logout_uri`:
+
+```ts title="admin-create-oauth.ts"
+await auth.api.adminCreateOAuthClient({
+  headers,
+  body: {
+    redirect_uris: [redirectUri],
+    enable_end_session: true,
+    frontchannel_logout_uri: "https://rp.example.com/logout/frontchannel", // [!code highlight]
+    frontchannel_logout_session_required: true, // [!code highlight]
+  }
+});
+```
+
+When `frontchannel_logout_session_required` is `true`, the OP appends `iss` and `sid` query parameters to the iframe URL so the RP can validate the request and terminate the right session.
+
+The `frontchannel_logout_uri` is validated at registration with the same rules as `backchannel_logout_uri`: absolute `http`/`https` URL, no fragment, `https` for confidential clients (loopback `http` such as `http://127.0.0.1:<port>` is allowed for local development), and non-public hosts (private, reserved, tunneled, cloud-metadata) are rejected. Unlike the back-channel URI it has no `jwt` plugin requirement, since nothing is signed.
+
+After the OP terminates the session (and back-channel notifications fire), it renders the iframe page; once every iframe has settled — or after a 3-second safety timeout, so a hung RP cannot stall the user — the page redirects to the validated `post_logout_redirect_uri` when one was provided. When no front-channel client holds tokens on the session, `/oauth2/end-session` redirects immediately, exactly as before.
+
+<Callout type="warn">
+  Browsers that partition or block third-party cookies (Safari ITP, Chrome's third-party-cookie phase-out) may hide the RP's session cookie inside the iframe, which makes front-channel logout best-effort by design. Pair it with Back-Channel Logout when you need reliable session termination.
+</Callout>
+
+<Callout type="info">
+  The iframe page is only rendered for browser navigation requests. Fetch-style requests to `/oauth2/end-session` (e.g. `authClient.oauth2.endSession()`) keep the JSON contract: the session still ends and back-channel notifications still fire, but no front-channel fan-out occurs.
+</Callout>
+
+<Callout type="info">
+  The OP advertises `frontchannel_logout_supported: true` and `frontchannel_logout_session_supported: true` on both `.well-known/openid-configuration` and `.well-known/oauth-authorization-server`. Support does not depend on the `jwt` plugin.
+</Callout>
+
 ### UserInfo Endpoint
 
 The UserInfo Endpoint provides [OIDC](https://openid.net/specs/openid-connect-core-1_0.html)-compliant user information. Available at `/oauth2/userinfo`, the endpoint requires a valid access token with at least the scope `openid`. An access token that is expired, revoked, or bound to a session that has ended is rejected with `invalid_token` (401), per [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1).
@@ -1915,6 +1951,20 @@ export const oauthClientTableFields = [
     type: "boolean",
     description:
       "When true, the RP requires a `sid` claim in every Logout Token and user-scoped logouts are skipped",
+    isOptional: true,
+  },
+  {
+    name: "frontchannelLogoutUri",
+    type: "string",
+    description:
+      "RP URL rendered in a hidden iframe on the OP's logout page when the user's session ends (OIDC Front-Channel Logout 1.0)",
+    isOptional: true,
+  },
+  {
+    name: "frontchannelLogoutSessionRequired",
+    type: "boolean",
+    description:
+      "When true, the OP appends `iss` and `sid` query parameters to the front-channel logout URI",
     isOptional: true,
   },
   {

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -777,6 +777,42 @@ The Logout Token carries the §2.4 claims (`iss`, `aud`, `iat`, `exp`, `jti`, `e
   The OP advertises `backchannel_logout_supported: true` and `backchannel_logout_session_supported: true` on both `.well-known/openid-configuration` and `.well-known/oauth-authorization-server`. RPs use these fields during dynamic client registration to decide whether to register a `backchannel_logout_uri`.
 </Callout>
 
+### Front-Channel Logout
+
+[Front-Channel Logout](https://openid.net/specs/openid-connect-frontchannel-1_0.html) is the browser-based sibling of Back-Channel Logout: when the end-user navigates to `/oauth2/end-session`, the OP responds with a page containing one hidden iframe per opted-in Relying Party, and the user's browser fans the logout out by loading each RP's `frontchannel_logout_uri`. The RP endpoint clears its own session cookies in the browser context — no server-to-server call is involved.
+
+To opt a client in, register a `frontchannel_logout_uri`:
+
+```ts title="admin-create-oauth.ts"
+await auth.api.adminCreateOAuthClient({
+  headers,
+  body: {
+    redirect_uris: [redirectUri],
+    enable_end_session: true,
+    frontchannel_logout_uri: "https://rp.example.com/logout/frontchannel", // [!code highlight]
+    frontchannel_logout_session_required: true, // [!code highlight]
+  }
+});
+```
+
+When `frontchannel_logout_session_required` is `true`, the OP appends `iss` and `sid` query parameters to the iframe URL so the RP can validate the request and terminate the right session.
+
+The `frontchannel_logout_uri` is validated at registration with the same rules as `backchannel_logout_uri`: absolute `http`/`https` URL, no fragment, `https` for confidential clients (loopback `http` such as `http://127.0.0.1:<port>` is allowed for local development), and non-public hosts (private, reserved, tunneled, cloud-metadata) are rejected. Unlike the back-channel URI it has no `jwt` plugin requirement, since nothing is signed.
+
+After the OP terminates the session (and back-channel notifications fire), it renders the iframe page; once every iframe has settled — or after a 3-second safety timeout, so a hung RP cannot stall the user — the page redirects to the validated `post_logout_redirect_uri` when one was provided. When no front-channel client holds tokens on the session, `/oauth2/end-session` redirects immediately, exactly as before.
+
+<Callout type="warn">
+  Browsers that partition or block third-party cookies (Safari ITP, Chrome's third-party-cookie phase-out) may hide the RP's session cookie inside the iframe, which makes front-channel logout best-effort by design. Pair it with Back-Channel Logout when you need reliable session termination.
+</Callout>
+
+<Callout type="info">
+  The iframe page is only rendered for browser navigation requests. Fetch-style requests to `/oauth2/end-session` (e.g. `authClient.oauth2.endSession()`) keep the JSON contract: the session still ends and back-channel notifications still fire, but no front-channel fan-out occurs.
+</Callout>
+
+<Callout type="info">
+  The OP advertises `frontchannel_logout_supported: true` and `frontchannel_logout_session_supported: true` on both `.well-known/openid-configuration` and `.well-known/oauth-authorization-server`. Support does not depend on the `jwt` plugin.
+</Callout>
+
 ### UserInfo Endpoint
 
 The UserInfo Endpoint provides [OIDC](https://openid.net/specs/openid-connect-core-1_0.html)-compliant user information. Available at `/oauth2/userinfo`, the endpoint requires a valid access token with at least the scope `openid`. An access token that is expired, revoked, or bound to a session that has ended is rejected with `invalid_token` (401), per [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1).
@@ -1994,6 +2030,20 @@ export const oauthClientTableFields = [
     type: "boolean",
     description:
       "When true, the RP requires a `sid` claim in every Logout Token and user-scoped logouts are skipped",
+    isOptional: true,
+  },
+  {
+    name: "frontchannelLogoutUri",
+    type: "string",
+    description:
+      "RP URL rendered in a hidden iframe on the OP's logout page when the user's session ends (OIDC Front-Channel Logout 1.0)",
+    isOptional: true,
+  },
+  {
+    name: "frontchannelLogoutSessionRequired",
+    type: "boolean",
+    description:
+      "When true, the OP appends `iss` and `sid` query parameters to the front-channel logout URI",
     isOptional: true,
   },
   {

--- a/packages/oauth-provider/src/client-metadata.ts
+++ b/packages/oauth-provider/src/client-metadata.ts
@@ -30,6 +30,8 @@ const OAUTH_CLIENT_RECORD_FIELDS = {
 	postLogoutRedirectUris: true,
 	backchannelLogoutUri: true,
 	backchannelLogoutSessionRequired: true,
+	frontchannelLogoutUri: true,
+	frontchannelLogoutSessionRequired: true,
 	tokenEndpointAuthMethod: true,
 	grantTypes: true,
 	responseTypes: true,

--- a/packages/oauth-provider/src/frontchannel-logout.test.ts
+++ b/packages/oauth-provider/src/frontchannel-logout.test.ts
@@ -1,0 +1,412 @@
+import {
+	authorizationCodeRequest,
+	createAuthorizationURL,
+} from "@better-auth/core/oauth2";
+import { createAuthClient } from "better-auth/client";
+import { generateRandomString } from "better-auth/crypto";
+import { toNodeHandler } from "better-auth/node";
+import { jwt } from "better-auth/plugins/jwt";
+import { getTestInstance } from "better-auth/test";
+import { decodeJwt } from "jose";
+import type { Listener } from "listhen";
+import { listen } from "listhen";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { oauthProviderClient } from "./client";
+import { oauthProvider } from "./oauth";
+
+type MakeRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
+
+/**
+ * Extracts iframe `src` attribute values from the rendered logout page, with
+ * HTML attribute entities decoded back to the raw URL.
+ */
+function extractIframeSources(html: string): string[] {
+	return [...html.matchAll(/<iframe[^>]*\ssrc="([^"]*)"/g)].map((m) =>
+		m[1]!.replaceAll("&amp;", "&"),
+	);
+}
+
+describe("oauth front-channel logout", async () => {
+	const port = 3011;
+	const baseUrl = `http://localhost:${port}`;
+	const issuer = `${baseUrl}/api/auth`;
+	const rpBaseUrl = "http://localhost:5001";
+	const state = "123";
+	const scopes = ["openid", "email", "profile"];
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: baseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+				scopes,
+			}),
+			jwt(),
+		],
+	});
+	let { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: baseUrl,
+		fetchOptions: { customFetchImpl },
+	});
+	let server: Listener;
+
+	beforeAll(async () => {
+		server = await listen(toNodeHandler(auth.handler), { port });
+	});
+	afterAll(async () => {
+		if (server) await server.close();
+	});
+	beforeEach(async () => {
+		const signed = await signInWithTestUser();
+		headers = signed.headers;
+	});
+
+	async function registerClient(
+		overrides: Partial<{
+			enable_end_session: boolean;
+			frontchannel_logout_uri: string | undefined;
+			frontchannel_logout_session_required: boolean;
+			post_logout_redirect_uris: string[];
+		}> = {},
+	) {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [`${rpBaseUrl}/callback`],
+				skip_consent: true,
+				enable_end_session: true,
+				frontchannel_logout_uri: `${rpBaseUrl}/logout/frontchannel`,
+				...overrides,
+			},
+		});
+		if (!response?.client_id || !response?.client_secret) {
+			throw new Error("client registration failed");
+		}
+		return response;
+	}
+
+	async function issueTokens(params: {
+		client: Awaited<ReturnType<typeof registerClient>>;
+	}) {
+		const { client: oauthClient } = params;
+		const redirectUri = `${rpBaseUrl}/callback`;
+		const codeVerifier = generateRandomString(32);
+		const { url: authUrl } = await createAuthorizationURL({
+			id: "test",
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret!,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${baseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			headers,
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const code = new URL(callbackRedirectUrl).searchParams.get("code");
+		if (!code) {
+			throw new Error(`no authorization code in ${callbackRedirectUrl}`);
+		}
+
+		const { body, headers: tokenHeaders } = await authorizationCodeRequest({
+			code,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret!,
+				redirectURI: redirectUri,
+			},
+		} satisfies MakeRequired<
+			Parameters<typeof authorizationCodeRequest>[0],
+			"code"
+		>);
+
+		const tokens = await client.$fetch<{
+			access_token: string;
+			id_token: string;
+		}>("/oauth2/token", { method: "POST", body, headers: tokenHeaders });
+		return tokens.data!;
+	}
+
+	/**
+	 * Hits the end-session endpoint the way a browser navigation does (no
+	 * `sec-fetch-mode: cors`, no `accept: application/json`), which is the only
+	 * request shape that can render the iframe fan-out page.
+	 */
+	async function endSessionNavigation(
+		query: Record<string, string>,
+		init?: RequestInit,
+	) {
+		const params = new URLSearchParams(query);
+		return auth.handler(
+			new Request(`${baseUrl}/api/auth/oauth2/end-session?${params}`, init),
+		);
+	}
+
+	it("renders one hidden iframe per front-channel client and ends the session", async () => {
+		const fcClient = await registerClient();
+		const plainClient = await registerClient({
+			frontchannel_logout_uri: undefined,
+		});
+		const tokens = await issueTokens({ client: fcClient });
+		await issueTokens({ client: plainClient });
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+		});
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/html");
+		// The page is per-session state and must never be cached
+		expect(response.headers.get("cache-control")).toContain("no-store");
+
+		const html = await response.text();
+		const sources = extractIframeSources(html);
+		expect(sources).toEqual([`${rpBaseUrl}/logout/frontchannel`]);
+
+		// Spec §3: the OP terminates the session before rendering the iframes
+		const session = await client.getSession({ fetchOptions: { headers } });
+		expect(session.data).toBeNull();
+	});
+
+	it("appends iss and sid only for clients with frontchannel_logout_session_required", async () => {
+		const requiredClient = await registerClient({
+			frontchannel_logout_uri: `${rpBaseUrl}/logout/fc-required`,
+			frontchannel_logout_session_required: true,
+		});
+		const optionalClient = await registerClient({
+			frontchannel_logout_uri: `${rpBaseUrl}/logout/fc-optional`,
+		});
+		const tokens = await issueTokens({ client: requiredClient });
+		await issueTokens({ client: optionalClient });
+
+		const sid = decodeJwt(tokens.id_token).sid;
+		expect(sid).toBeDefined();
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+		});
+		const sources = extractIframeSources(await response.text()).map(
+			(src) => new URL(src),
+		);
+		expect(sources).toHaveLength(2);
+
+		// Spec §2: when the RP requires session matching, the OP includes both
+		// `iss` and `sid` (if either is included, both MUST be)
+		const required = sources.find((u) => u.pathname === "/logout/fc-required")!;
+		expect(required.searchParams.get("iss")).toBe(issuer);
+		expect(required.searchParams.get("sid")).toBe(sid);
+
+		const optional = sources.find((u) => u.pathname === "/logout/fc-optional")!;
+		expect(optional.searchParams.get("iss")).toBeNull();
+		expect(optional.searchParams.get("sid")).toBeNull();
+	});
+
+	it("carries the validated post_logout_redirect_uri into the page redirect", async () => {
+		const fcClient = await registerClient({
+			post_logout_redirect_uris: [`${rpBaseUrl}/logout/callback`],
+		});
+		const tokens = await issueTokens({ client: fcClient });
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+			post_logout_redirect_uri: `${rpBaseUrl}/logout/callback`,
+			state,
+		});
+		expect(response.status).toBe(200);
+		const html = await response.text();
+		expect(html).toContain(`${rpBaseUrl}/logout/callback?state=${state}`);
+	});
+
+	it("drops an unregistered post_logout_redirect_uri from the page", async () => {
+		const fcClient = await registerClient();
+		const tokens = await issueTokens({ client: fcClient });
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+			post_logout_redirect_uri: `${rpBaseUrl}/evil`,
+		});
+		expect(response.status).toBe(200);
+		expect(await response.text()).not.toContain(`${rpBaseUrl}/evil`);
+	});
+
+	it("keeps the immediate redirect when no front-channel client holds tokens on the session", async () => {
+		const plainClient = await registerClient({
+			frontchannel_logout_uri: undefined,
+			post_logout_redirect_uris: [`${rpBaseUrl}/logout/callback`],
+		});
+		const tokens = await issueTokens({ client: plainClient });
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+			post_logout_redirect_uri: `${rpBaseUrl}/logout/callback`,
+			state,
+		});
+		expect(response.status).toBe(302);
+		const location = response.headers.get("location")!;
+		expect(location).toContain(`${rpBaseUrl}/logout/callback`);
+		expect(location).toContain(`state=${state}`);
+	});
+
+	it("escapes HTML metacharacters in iframe sources", async () => {
+		const fcClient = await registerClient({
+			frontchannel_logout_uri: `${rpBaseUrl}/logout/frontchannel?a=1&b=2`,
+		});
+		const tokens = await issueTokens({ client: fcClient });
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+		});
+		const html = await response.text();
+		// Raw `&` must be entity-encoded inside the attribute value
+		expect(html).toContain("a=1&amp;b=2");
+		expect(extractIframeSources(html)).toEqual([
+			`${rpBaseUrl}/logout/frontchannel?a=1&b=2`,
+		]);
+	});
+
+	it("preserves the JSON contract for fetch-style requests", async () => {
+		const fcClient = await registerClient({
+			post_logout_redirect_uris: [`${rpBaseUrl}/logout/callback`],
+		});
+		const tokens = await issueTokens({ client: fcClient });
+
+		// Browser `fetch()` calls cannot render iframes, so the response must
+		// stay on the pre-existing JSON shape even when front-channel clients
+		// hold tokens on the session.
+		const response = await endSessionNavigation(
+			{
+				id_token_hint: tokens.id_token,
+				post_logout_redirect_uri: `${rpBaseUrl}/logout/callback`,
+			},
+			{ headers: { accept: "application/json" } },
+		);
+		expect(response.headers.get("content-type")).toContain("application/json");
+		const body = (await response.json()) as { redirect: boolean; url: string };
+		expect(body.redirect).toBe(true);
+		expect(body.url).toContain(`${rpBaseUrl}/logout/callback`);
+	});
+});
+
+describe("oauth front-channel logout (jwt plugin disabled)", async () => {
+	const port = 3022;
+	const baseUrl = `http://localhost:${port}`;
+	const rpBaseUrl = "http://localhost:5001";
+	const state = "123";
+	const scopes = ["openid", "email", "profile"];
+
+	// Front-channel logout never signs anything — the iframe URLs carry plain
+	// `iss`/`sid` query parameters — so it must keep working with HS256 ID
+	// tokens when the jwt plugin is disabled.
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: baseUrl,
+		plugins: [
+			oauthProvider({
+				disableJwtPlugin: true,
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+				scopes,
+			}),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: baseUrl,
+		fetchOptions: { customFetchImpl },
+	});
+
+	it("renders the front-channel logout page when the jwt plugin is disabled", async () => {
+		const redirectUri = `${rpBaseUrl}/callback`;
+		const oauthClient = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+				enable_end_session: true,
+				frontchannel_logout_uri: `${rpBaseUrl}/logout/frontchannel`,
+			},
+		});
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw new Error("client registration failed");
+		}
+
+		const codeVerifier = generateRandomString(32);
+		const { url: authUrl } = await createAuthorizationURL({
+			id: "test",
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${baseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes,
+			codeVerifier,
+		});
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			headers,
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const code = new URL(callbackRedirectUrl).searchParams.get("code");
+		if (!code) {
+			throw new Error(`no authorization code in ${callbackRedirectUrl}`);
+		}
+		const { body, headers: tokenHeaders } = await authorizationCodeRequest({
+			code,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		} satisfies MakeRequired<
+			Parameters<typeof authorizationCodeRequest>[0],
+			"code"
+		>);
+		const tokens = await client.$fetch<{ id_token: string }>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+
+		const response = await auth.handler(
+			new Request(
+				`${baseUrl}/api/auth/oauth2/end-session?${new URLSearchParams({
+					id_token_hint: tokens.data!.id_token,
+				})}`,
+			),
+		);
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/html");
+		expect(extractIframeSources(await response.text())).toEqual([
+			`${rpBaseUrl}/logout/frontchannel`,
+		]);
+	});
+});

--- a/packages/oauth-provider/src/frontchannel-logout.test.ts
+++ b/packages/oauth-provider/src/frontchannel-logout.test.ts
@@ -1,0 +1,443 @@
+import {
+	authorizationCodeRequest,
+	createAuthorizationURL,
+} from "@better-auth/core/oauth2";
+import { createAuthClient } from "better-auth/client";
+import { generateRandomString } from "better-auth/crypto";
+import { toNodeHandler } from "better-auth/node";
+import { jwt } from "better-auth/plugins/jwt";
+import { getTestInstance } from "better-auth/test";
+import { decodeJwt } from "jose";
+import type { Listener } from "listhen";
+import { listen } from "listhen";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { oauthProviderClient } from "./client";
+import { oauthProvider } from "./oauth";
+
+type MakeRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
+
+/**
+ * Extracts iframe `src` attribute values from the rendered logout page, with
+ * HTML attribute entities decoded back to the raw URL.
+ */
+function extractIframeSources(html: string): string[] {
+	return [...html.matchAll(/<iframe[^>]*\ssrc="([^"]*)"/g)].map((m) =>
+		m[1]!.replaceAll("&amp;", "&"),
+	);
+}
+
+describe("oauth front-channel logout", async () => {
+	const port = 3011;
+	const baseUrl = `http://localhost:${port}`;
+	const issuer = `${baseUrl}/api/auth`;
+	const rpBaseUrl = "http://localhost:5001";
+	const fcBaseUrl = "https://rp.example.com";
+	const state = "123";
+	const scopes = ["openid", "email", "profile"];
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: baseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+				scopes,
+			}),
+			jwt(),
+		],
+	});
+	let { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: baseUrl,
+		fetchOptions: { customFetchImpl },
+	});
+	let server: Listener;
+
+	beforeAll(async () => {
+		server = await listen(toNodeHandler(auth.handler), { port });
+	});
+	afterAll(async () => {
+		if (server) await server.close();
+	});
+	beforeEach(async () => {
+		const signed = await signInWithTestUser();
+		headers = signed.headers;
+	});
+
+	async function registerClient(
+		overrides: Partial<{
+			enable_end_session: boolean;
+			frontchannel_logout_uri: string | undefined;
+			frontchannel_logout_session_required: boolean;
+			post_logout_redirect_uris: string[];
+		}> = {},
+	) {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [`${rpBaseUrl}/callback`],
+				// http loopback redirect URIs are only valid for native clients;
+				// web clients require https on a non-loopback host.
+				application_type: "native",
+				token_endpoint_auth_method: "client_secret_post",
+				skip_consent: true,
+				enable_end_session: true,
+				frontchannel_logout_uri: `${fcBaseUrl}/logout/frontchannel`,
+				...overrides,
+			},
+		});
+		if (!response?.client_id || !response?.client_secret) {
+			throw new Error("client registration failed");
+		}
+		return response;
+	}
+
+	async function issueTokens(params: {
+		client: Awaited<ReturnType<typeof registerClient>>;
+	}) {
+		const { client: oauthClient } = params;
+		const redirectUri = `${rpBaseUrl}/callback`;
+		const codeVerifier = generateRandomString(32);
+		const authUrl = await createAuthorizationURL({
+			id: "test",
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret!,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${baseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			headers,
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const code = new URL(callbackRedirectUrl).searchParams.get("code");
+		if (!code) {
+			throw new Error(`no authorization code in ${callbackRedirectUrl}`);
+		}
+
+		const { body, headers: tokenHeaders } = await authorizationCodeRequest({
+			code,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret!,
+				redirectURI: redirectUri,
+			},
+		} satisfies MakeRequired<
+			Parameters<typeof authorizationCodeRequest>[0],
+			"code"
+		>);
+
+		const tokens = await client.$fetch<{
+			access_token: string;
+			id_token: string;
+		}>("/oauth2/token", { method: "POST", body, headers: tokenHeaders });
+		return tokens.data!;
+	}
+
+	/**
+	 * Hits the end-session endpoint the way a top-level browser navigation does.
+	 * `isBrowserNavigation` requires `sec-fetch-mode: navigate` or an HTML
+	 * `accept`, and that is the only request shape that renders the iframe
+	 * fan-out page — anything else keeps the redirect/JSON contract.
+	 */
+	async function endSessionNavigation(
+		query: Record<string, string>,
+		init?: RequestInit,
+	) {
+		const params = new URLSearchParams(query);
+		return auth.handler(
+			new Request(`${baseUrl}/api/auth/oauth2/end-session?${params}`, {
+				...init,
+				headers: {
+					accept: "text/html,application/xhtml+xml",
+					"sec-fetch-mode": "navigate",
+					...(init?.headers as Record<string, string> | undefined),
+				},
+			}),
+		);
+	}
+
+	it("renders one hidden iframe per front-channel client and ends the session", async () => {
+		const fcClient = await registerClient();
+		const plainClient = await registerClient({
+			frontchannel_logout_uri: undefined,
+		});
+		const tokens = await issueTokens({ client: fcClient });
+		await issueTokens({ client: plainClient });
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+		});
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/html");
+		// The page is per-session state and must never be cached
+		expect(response.headers.get("cache-control")).toContain("no-store");
+
+		const html = await response.text();
+		const sources = extractIframeSources(html);
+		expect(sources).toEqual([`${fcBaseUrl}/logout/frontchannel`]);
+
+		// Spec §3: the OP terminates the session before rendering the iframes
+		const session = await client.getSession({ fetchOptions: { headers } });
+		expect(session.data).toBeNull();
+	});
+
+	it("appends iss and sid only for clients with frontchannel_logout_session_required", async () => {
+		const requiredClient = await registerClient({
+			frontchannel_logout_uri: `${fcBaseUrl}/logout/fc-required`,
+			frontchannel_logout_session_required: true,
+		});
+		const optionalClient = await registerClient({
+			frontchannel_logout_uri: `${fcBaseUrl}/logout/fc-optional`,
+		});
+		const tokens = await issueTokens({ client: requiredClient });
+		await issueTokens({ client: optionalClient });
+
+		const sid = decodeJwt(tokens.id_token).sid;
+		expect(sid).toBeDefined();
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+		});
+		const sources = extractIframeSources(await response.text()).map(
+			(src) => new URL(src),
+		);
+		expect(sources).toHaveLength(2);
+
+		// Spec §2: when the RP requires session matching, the OP includes both
+		// `iss` and `sid` (if either is included, both MUST be)
+		const required = sources.find((u) => u.pathname === "/logout/fc-required")!;
+		expect(required.searchParams.get("iss")).toBe(issuer);
+		expect(required.searchParams.get("sid")).toBe(sid);
+
+		const optional = sources.find((u) => u.pathname === "/logout/fc-optional")!;
+		expect(optional.searchParams.get("iss")).toBeNull();
+		expect(optional.searchParams.get("sid")).toBeNull();
+	});
+
+	it("carries the validated post_logout_redirect_uri into the page redirect", async () => {
+		const fcClient = await registerClient({
+			post_logout_redirect_uris: [`${rpBaseUrl}/logout/callback`],
+		});
+		const tokens = await issueTokens({ client: fcClient });
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+			post_logout_redirect_uri: `${rpBaseUrl}/logout/callback`,
+			state,
+		});
+		expect(response.status).toBe(200);
+		const html = await response.text();
+		expect(html).toContain(`${rpBaseUrl}/logout/callback?state=${state}`);
+	});
+
+	it("drops an unregistered post_logout_redirect_uri from the page", async () => {
+		const fcClient = await registerClient();
+		const tokens = await issueTokens({ client: fcClient });
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+			post_logout_redirect_uri: `${rpBaseUrl}/evil`,
+		});
+		expect(response.status).toBe(200);
+		expect(await response.text()).not.toContain(`${rpBaseUrl}/evil`);
+	});
+
+	it("keeps the immediate redirect when no front-channel client holds tokens on the session", async () => {
+		const plainClient = await registerClient({
+			frontchannel_logout_uri: undefined,
+			post_logout_redirect_uris: [`${rpBaseUrl}/logout/callback`],
+		});
+		const tokens = await issueTokens({ client: plainClient });
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+			post_logout_redirect_uri: `${rpBaseUrl}/logout/callback`,
+			state,
+		});
+		expect(response.status).toBe(302);
+		const location = response.headers.get("location")!;
+		expect(location).toContain(`${rpBaseUrl}/logout/callback`);
+		expect(location).toContain(`state=${state}`);
+	});
+
+	it("escapes HTML metacharacters in iframe sources", async () => {
+		const fcClient = await registerClient({
+			frontchannel_logout_uri: `${fcBaseUrl}/logout/frontchannel?a=1&b=2`,
+		});
+		const tokens = await issueTokens({ client: fcClient });
+
+		const response = await endSessionNavigation({
+			id_token_hint: tokens.id_token,
+		});
+		const html = await response.text();
+		// Raw `&` must be entity-encoded inside the attribute value
+		expect(html).toContain("a=1&amp;b=2");
+		expect(extractIframeSources(html)).toEqual([
+			`${fcBaseUrl}/logout/frontchannel?a=1&b=2`,
+		]);
+	});
+
+	it("preserves the JSON contract for fetch-style requests", async () => {
+		const fcClient = await registerClient({
+			post_logout_redirect_uris: [`${rpBaseUrl}/logout/callback`],
+		});
+		const tokens = await issueTokens({ client: fcClient });
+
+		// Browser `fetch()` calls cannot render iframes, so the response must
+		// stay on the pre-existing JSON shape even when front-channel clients
+		// hold tokens on the session.
+		const response = await auth.handler(
+			new Request(
+				`${baseUrl}/api/auth/oauth2/end-session?${new URLSearchParams({
+					id_token_hint: tokens.id_token,
+					post_logout_redirect_uri: `${rpBaseUrl}/logout/callback`,
+				})}`,
+				{
+					headers: {
+						accept: "application/json",
+						"sec-fetch-mode": "cors",
+						"sec-fetch-dest": "empty",
+						"sec-fetch-site": "same-origin",
+					},
+				},
+			),
+		);
+		expect(response.headers.get("content-type")).toContain("application/json");
+		const body = (await response.json()) as { redirect: boolean; url: string };
+		expect(body.redirect).toBe(true);
+		expect(body.url).toContain(`${rpBaseUrl}/logout/callback`);
+	});
+});
+
+describe("oauth front-channel logout (jwt plugin disabled)", async () => {
+	const port = 3022;
+	const baseUrl = `http://localhost:${port}`;
+	const rpBaseUrl = "http://localhost:5001";
+	const fcBaseUrl = "https://rp.example.com";
+	const state = "123";
+	const scopes = ["openid", "email", "profile"];
+
+	// Front-channel logout never signs anything — the iframe URLs carry plain
+	// `iss`/`sid` query parameters — so it must keep working with HS256 ID
+	// tokens when the jwt plugin is disabled.
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: baseUrl,
+		plugins: [
+			oauthProvider({
+				disableJwtPlugin: true,
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+				scopes,
+			}),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: baseUrl,
+		fetchOptions: { customFetchImpl },
+	});
+
+	it("renders the front-channel logout page when the jwt plugin is disabled", async () => {
+		const redirectUri = `${rpBaseUrl}/callback`;
+		const oauthClient = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				application_type: "native",
+				token_endpoint_auth_method: "client_secret_post",
+				skip_consent: true,
+				enable_end_session: true,
+				frontchannel_logout_uri: `${fcBaseUrl}/logout/frontchannel`,
+			},
+		});
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw new Error("client registration failed");
+		}
+
+		const codeVerifier = generateRandomString(32);
+		const authUrl = await createAuthorizationURL({
+			id: "test",
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${baseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes,
+			codeVerifier,
+		});
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			headers,
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const code = new URL(callbackRedirectUrl).searchParams.get("code");
+		if (!code) {
+			throw new Error(`no authorization code in ${callbackRedirectUrl}`);
+		}
+		const { body, headers: tokenHeaders } = await authorizationCodeRequest({
+			code,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		} satisfies MakeRequired<
+			Parameters<typeof authorizationCodeRequest>[0],
+			"code"
+		>);
+		const tokens = await client.$fetch<{ id_token: string }>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+
+		const response = await auth.handler(
+			new Request(
+				`${baseUrl}/api/auth/oauth2/end-session?${new URLSearchParams({
+					id_token_hint: tokens.data!.id_token,
+				})}`,
+				{
+					headers: {
+						accept: "text/html,application/xhtml+xml",
+						"sec-fetch-mode": "navigate",
+					},
+				},
+			),
+		);
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/html");
+		expect(extractIframeSources(await response.text())).toEqual([
+			`${fcBaseUrl}/logout/frontchannel`,
+		]);
+	});
+});

--- a/packages/oauth-provider/src/logout.ts
+++ b/packages/oauth-provider/src/logout.ts
@@ -1,4 +1,5 @@
 import type { GenericEndpointContext } from "@better-auth/core";
+import { isBrowserFetchRequest } from "@better-auth/core/utils/fetch-metadata";
 import { generateRandomString } from "better-auth/crypto";
 import { getJwks } from "better-auth/oauth2";
 import { resolveSigningKey, signJWT } from "better-auth/plugins";
@@ -27,6 +28,11 @@ const LOGOUT_TOKEN_LIFETIME_SECONDS = 120;
 // Spec §2.5: "the OP SHOULD NOT retransmit", so a single attempt within the
 // window is enough.
 const BACKCHANNEL_DISPATCH_TIMEOUT_MS = 5_000;
+
+// OIDC Front-Channel Logout 1.0 gives no normative timeout for the iframe
+// fan-out; 3 seconds keeps a hung RP iframe from stalling the user-facing
+// redirect while still letting typical logout endpoints complete.
+const FRONTCHANNEL_IFRAME_TIMEOUT_MS = 3_000;
 
 interface TokenRow {
 	id: string;
@@ -292,6 +298,146 @@ async function deliverBackchannelLogoutTokens(
 
 export { revokeAndPlanBackchannelLogout, deliverBackchannelLogoutTokens };
 
+/** Escapes a string for safe interpolation into an HTML attribute value. */
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
+/**
+ * Enumerates clients holding tokens on the session being terminated that have
+ * registered a `frontchannel_logout_uri`, and builds the iframe URL for each.
+ * Must run before the session row is deleted: token rows reference the
+ * session with `onDelete: "set null"`, so the linkage disappears with the
+ * row.
+ *
+ * Per OIDC Front-Channel Logout 1.0 §2, when a client registered
+ * `frontchannel_logout_session_required: true` the OP appends `iss` and `sid`
+ * query parameters (if either is included, both MUST be).
+ *
+ * Returns `null` when no client opted in, so the endpoint keeps the
+ * pre-existing immediate-redirect behavior. Enumeration failures are logged
+ * and treated as "no targets" — front-channel notification is best-effort and
+ * must not block the user-facing logout.
+ */
+async function planFrontchannelLogout(
+	ctx: GenericEndpointContext,
+	input: { sessionId: string; issuer: string },
+): Promise<string[] | null> {
+	const logger = ctx.context.logger;
+	try {
+		const where = [{ field: "sessionId", value: input.sessionId }];
+
+		const [accessTokens, refreshTokens] = await Promise.all([
+			ctx.context.adapter.findMany<TokenRow>({
+				model: "oauthAccessToken",
+				where,
+			}),
+			ctx.context.adapter.findMany<TokenRow>({
+				model: "oauthRefreshToken",
+				where,
+			}),
+		]);
+
+		const affectedClientIds = new Set<string>();
+		for (const t of accessTokens) affectedClientIds.add(t.clientId);
+		for (const t of refreshTokens) affectedClientIds.add(t.clientId);
+		if (affectedClientIds.size === 0) return null;
+
+		const clients = await ctx.context.adapter.findMany<SchemaClient<Scope[]>>({
+			model: "oauthClient",
+			where: [
+				{
+					field: "clientId",
+					operator: "in",
+					value: Array.from(affectedClientIds),
+				},
+			],
+		});
+
+		const urls = clients
+			.filter((c) => Boolean(c.frontchannelLogoutUri) && !c.disabled)
+			.map((client) => {
+				const url = new URL(client.frontchannelLogoutUri!);
+				if (client.frontchannelLogoutSessionRequired) {
+					url.searchParams.set("iss", input.issuer);
+					url.searchParams.set("sid", input.sessionId);
+				}
+				return url.toString();
+			});
+		return urls.length > 0 ? urls : null;
+	} catch (error) {
+		logger.error("front-channel logout enumeration failed", error);
+		return null;
+	}
+}
+
+/**
+ * Renders the OIDC Front-Channel Logout 1.0 §3 logout page: one hidden iframe
+ * per front-channel RP, plus an inline script that redirects to the validated
+ * `post_logout_redirect_uri` once every iframe has settled (or after
+ * `FRONTCHANNEL_IFRAME_TIMEOUT_MS`, so a hung RP cannot stall the user). The
+ * iframes are plain HTML and fire without JavaScript; a meta-refresh covers
+ * the redirect when scripting is disabled.
+ */
+function renderFrontchannelLogoutPage(input: {
+	urls: string[];
+	redirectUri?: string;
+}): string {
+	const iframes = input.urls
+		.map(
+			(url) =>
+				`<iframe src="${escapeHtml(url)}" width="0" height="0" style="display:none" aria-hidden="true"></iframe>`,
+		)
+		.join("\n\t\t");
+	// `<` is additionally escaped so the URL can never break out of the inline
+	// <script> context (e.g. via a crafted `</script>` path segment).
+	const redirectTo = input.redirectUri
+		? JSON.stringify(input.redirectUri).replaceAll("<", "\\u003c")
+		: "null";
+	const metaRefresh = input.redirectUri
+		? `\n\t\t<meta http-equiv="refresh" content="${Math.ceil(FRONTCHANNEL_IFRAME_TIMEOUT_MS / 1000) + 2};url=${escapeHtml(input.redirectUri)}">`
+		: "";
+	return `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="robots" content="noindex">${metaRefresh}
+		<title>Signing out</title>
+	</head>
+	<body>
+		<p>Signing out&hellip;</p>
+		${iframes}
+		<script>
+			(function () {
+				var redirectTo = ${redirectTo};
+				var frames = document.querySelectorAll("iframe");
+				var pending = frames.length;
+				var finished = false;
+				function finish() {
+					if (finished) return;
+					finished = true;
+					if (redirectTo) window.location.replace(redirectTo);
+				}
+				function settle() {
+					pending -= 1;
+					if (pending <= 0) finish();
+				}
+				for (var i = 0; i < frames.length; i++) {
+					frames[i].addEventListener("load", settle);
+					frames[i].addEventListener("error", settle);
+				}
+				setTimeout(finish, ${FRONTCHANNEL_IFRAME_TIMEOUT_MS});
+			})();
+		</script>
+	</body>
+</html>`;
+}
+
 /**
  * RP-Initiated Logout (OIDC RP-Initiated Logout 1.0). The RP presents a signed
  * `id_token_hint`; after verification, the OP terminates the matching session
@@ -437,6 +583,19 @@ export async function rpInitiatedLogoutEndpoint(
 		});
 	}
 
+	// Front-channel logout needs a browser to render the iframe fan-out, so it
+	// only applies to navigation requests; fetch-style requests (SPA clients)
+	// keep the JSON contract. Mirrors the channel selection in
+	// `handleRedirect`. Enumeration must also happen before the session row is
+	// deleted, because token rows reference it with `onDelete: "set null"`.
+	const isNavigationRequest = !(
+		isBrowserFetchRequest(ctx.request?.headers) ||
+		ctx.headers?.get("accept")?.includes("application/json")
+	);
+	const frontchannelUrls = isNavigationRequest
+		? await planFrontchannelLogout(ctx, { sessionId, issuer })
+		: null;
+
 	try {
 		const session = await ctx.context.adapter.findOne<Session>({
 			model: "session",
@@ -459,6 +618,10 @@ export async function rpInitiatedLogoutEndpoint(
 		// Session already gone; nothing further to do.
 	}
 
+	// Resolve the post-logout redirect once; it feeds the immediate redirect
+	// and, when front-channel clients are present, the logout page's deferred
+	// redirect. Unregistered URIs are dropped (no need to fail).
+	let postLogoutRedirect: string | undefined;
 	if (post_logout_redirect_uri) {
 		const registeredUris = client.postLogoutRedirectUris;
 		if (registeredUris?.includes(post_logout_redirect_uri)) {
@@ -466,7 +629,33 @@ export async function rpInitiatedLogoutEndpoint(
 			if (state) {
 				redirectUri.searchParams.set("state", state);
 			}
-			return handleRedirect(ctx, redirectUri.toString());
+			postLogoutRedirect = redirectUri.toString();
 		}
+	}
+
+	if (frontchannelUrls) {
+		// Spec §3: the session is already terminated; render one hidden iframe
+		// per RP and redirect (when validated) after they settle.
+		return new Response(
+			renderFrontchannelLogoutPage({
+				urls: frontchannelUrls,
+				redirectUri: postLogoutRedirect,
+			}),
+			{
+				headers: {
+					"Content-Type": "text/html",
+					// Per-session content; also keeps id_token_hint-bearing URLs out
+					// of shared caches.
+					"Cache-Control": "no-store",
+					// The page embeds RP iframes; never leak the id_token_hint-bearing
+					// page URL to them via Referer.
+					"Referrer-Policy": "no-referrer",
+				},
+			},
+		);
+	}
+
+	if (postLogoutRedirect) {
+		return handleRedirect(ctx, postLogoutRedirect);
 	}
 }

--- a/packages/oauth-provider/src/logout.ts
+++ b/packages/oauth-provider/src/logout.ts
@@ -32,6 +32,11 @@ const LOGOUT_TOKEN_LIFETIME_SECONDS = 120;
 // window is enough.
 const BACKCHANNEL_DISPATCH_TIMEOUT_MS = 5_000;
 
+// OIDC Front-Channel Logout 1.0 gives no normative timeout for the iframe
+// fan-out; 3 seconds keeps a hung RP iframe from stalling the user-facing
+// redirect while still letting typical logout endpoints complete.
+const FRONTCHANNEL_IFRAME_TIMEOUT_MS = 3_000;
+
 interface TokenRow {
 	id: string;
 	clientId: string;
@@ -327,6 +332,147 @@ async function deliverBackchannelLogoutTokens(
 }
 
 export { applyBackchannelLogoutPlan, prepareBackchannelLogoutPlan };
+
+/**
+ * Enumerates clients holding tokens on the session being terminated that have
+ * registered a `frontchannel_logout_uri`, and builds the iframe URL for each.
+ * Must run before the session row is deleted: token rows reference the session
+ * with `onDelete: "set null"`, so the linkage disappears with the row.
+ *
+ * Per OIDC Front-Channel Logout 1.0 §2, when a client registered
+ * `frontchannel_logout_session_required: true` the OP appends `iss` and `sid`
+ * query parameters (if either is included, both MUST be).
+ *
+ * Returns `null` when no client opted in, so the endpoint keeps its
+ * pre-existing redirect behavior. Enumeration failures are logged and treated
+ * as "no targets" — front-channel notification is best-effort and must not
+ * block the user-facing logout.
+ */
+async function planFrontchannelLogout(
+	ctx: GenericEndpointContext,
+	input: { sessionId: string; issuer: string },
+): Promise<string[] | null> {
+	const logger = ctx.context.logger;
+	try {
+		const adapter = await getCurrentAdapter(ctx.context.adapter);
+		const where = [{ field: "sessionId", value: input.sessionId }];
+
+		const [accessTokens, refreshTokens] = await Promise.all([
+			adapter.findMany<TokenRow>({
+				model: "oauthAccessToken",
+				where,
+			}),
+			adapter.findMany<TokenRow>({
+				model: "oauthRefreshToken",
+				where,
+			}),
+		]);
+
+		const affectedClientIds = new Set<string>();
+		for (const t of accessTokens) affectedClientIds.add(t.clientId);
+		for (const t of refreshTokens) affectedClientIds.add(t.clientId);
+		if (affectedClientIds.size === 0) return null;
+
+		const clients = await adapter.findMany<SchemaClient<Scope[]>>({
+			model: "oauthClient",
+			where: [
+				{
+					field: "clientId",
+					operator: "in",
+					value: Array.from(affectedClientIds),
+				},
+			],
+		});
+
+		const urls = clients
+			.filter((c) => Boolean(c.frontchannelLogoutUri) && !c.disabled)
+			.map((client) => {
+				const url = new URL(client.frontchannelLogoutUri!);
+				if (client.frontchannelLogoutSessionRequired) {
+					url.searchParams.set("iss", input.issuer);
+					url.searchParams.set("sid", input.sessionId);
+				}
+				return url.toString();
+			});
+		return urls.length > 0 ? urls : null;
+	} catch (error) {
+		logger.error("front-channel logout enumeration failed", error);
+		return null;
+	}
+}
+
+/**
+ * Renders the OIDC Front-Channel Logout 1.0 §3 logout page: one hidden iframe
+ * per front-channel RP, plus an inline script that redirects to the validated
+ * `post_logout_redirect_uri` once every iframe has settled (or after
+ * `FRONTCHANNEL_IFRAME_TIMEOUT_MS`, so a hung RP cannot stall the user). The
+ * iframes are plain HTML and fire without JavaScript; a meta-refresh covers
+ * the redirect when scripting is disabled.
+ */
+function renderFrontchannelLogoutPage(input: {
+	urls: string[];
+	redirectUri?: string;
+}): Response {
+	const iframes = input.urls
+		.map(
+			(url) =>
+				`<iframe src="${escapeHtml(url)}" width="0" height="0" style="display:none" aria-hidden="true"></iframe>`,
+		)
+		.join("\n\t\t");
+	// `<` is additionally escaped so the URL can never break out of the inline
+	// <script> context (e.g. via a crafted `</script>` path segment).
+	const redirectTo = input.redirectUri
+		? JSON.stringify(input.redirectUri).replaceAll("<", "\\u003c")
+		: "null";
+	const metaRefresh = input.redirectUri
+		? `\n\t\t<meta http-equiv="refresh" content="${Math.ceil(FRONTCHANNEL_IFRAME_TIMEOUT_MS / 1000) + 2};url=${escapeHtml(input.redirectUri)}">`
+		: "";
+	const html = `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="robots" content="noindex">${metaRefresh}
+		<title>Signing out</title>
+	</head>
+	<body>
+		<p>Signing out&hellip;</p>
+		${iframes}
+		<script>
+			(function () {
+				var redirectTo = ${redirectTo};
+				var frames = document.querySelectorAll("iframe");
+				var pending = frames.length;
+				var finished = false;
+				function finish() {
+					if (finished) return;
+					finished = true;
+					if (redirectTo) window.location.replace(redirectTo);
+				}
+				function settle() {
+					pending -= 1;
+					if (pending <= 0) finish();
+				}
+				for (var i = 0; i < frames.length; i++) {
+					frames[i].addEventListener("load", settle);
+					frames[i].addEventListener("error", settle);
+				}
+				setTimeout(finish, ${FRONTCHANNEL_IFRAME_TIMEOUT_MS});
+			})();
+		</script>
+	</body>
+</html>`;
+	return new Response(html, {
+		headers: {
+			"Content-Type": "text/html; charset=utf-8",
+			// Per-session content; also keeps id_token_hint-bearing URLs out of
+			// shared caches.
+			"Cache-Control": "no-store",
+			// The page embeds RP iframes; never leak the id_token_hint-bearing
+			// page URL to them via Referer.
+			"Referrer-Policy": "no-referrer",
+		},
+	});
+}
 
 const LOGOUT_CONFIRMATION_TTL_SECONDS = 5 * 60;
 const LOGOUT_CONFIRMATION_COOKIE_SUFFIX = ".oauth_logout_confirmation";
@@ -858,9 +1004,26 @@ async function completeConfirmedLogout(
 		);
 	}
 
+	// Enumerate front-channel RPs before the session row goes away: token rows
+	// reference it with `onDelete: "set null"`, so the linkage is lost with it.
+	const frontchannelUrls = isBrowserNavigation(ctx)
+		? await planFrontchannelLogout(ctx, {
+				sessionId: currentSession.session.id,
+				issuer: getIssuer(ctx, opts),
+			})
+		: null;
+
 	await deleteLogoutSession(ctx, currentSession.session);
 	deleteSessionCookie(ctx);
 	clearLogoutConfirmationState(ctx);
+	if (frontchannelUrls) {
+		// Spec §3: the session is already terminated; render one hidden iframe
+		// per RP and redirect (when validated) after they settle.
+		return renderFrontchannelLogoutPage({
+			urls: frontchannelUrls,
+			redirectUri: redirect.uri,
+		});
+	}
 	if (redirect.uri) return handleRedirect(ctx, redirect.uri);
 	return isBrowserNavigation(ctx)
 		? logoutSuccessPage(
@@ -1002,6 +1165,14 @@ export async function rpInitiatedLogoutEndpoint(
 	);
 	const sessionToDelete =
 		hintedSession ?? (matchesCurrentSession ? currentSession?.session : null);
+	// Same ordering constraint as the confirmed path: enumerate before delete.
+	const frontchannelUrls =
+		sessionToDelete && isBrowserNavigation(ctx)
+			? await planFrontchannelLogout(ctx, {
+					sessionId: sessionToDelete.id,
+					issuer: getIssuer(ctx, opts),
+				})
+			: null;
 	if (sessionToDelete) {
 		// internalAdapter.deleteSession triggers the normal before/after session
 		// hooks, including revocation and back-channel dispatch for every RP.
@@ -1010,6 +1181,12 @@ export async function rpInitiatedLogoutEndpoint(
 	if (matchesCurrentSession) deleteSessionCookie(ctx);
 	clearLogoutConfirmationState(ctx);
 
+	if (frontchannelUrls) {
+		return renderFrontchannelLogoutPage({
+			urls: frontchannelUrls,
+			redirectUri: redirect.uri,
+		});
+	}
 	if (redirect.uri) return handleRedirect(ctx, redirect.uri);
 	return isBrowserNavigation(ctx)
 		? logoutSuccessPage(

--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -115,6 +115,8 @@ describe("oauth metadata", async () => {
 			authorization_response_iss_parameter_supported: true,
 			backchannel_logout_supported: true,
 			backchannel_logout_session_supported: true,
+			frontchannel_logout_supported: true,
+			frontchannel_logout_session_supported: true,
 			claims_supported: baseClaims,
 			userinfo_endpoint: `${baseURL}/oauth2/userinfo`,
 			subject_types_supported: ["public"],
@@ -290,6 +292,8 @@ describe("oauth metadata", async () => {
 			authorization_response_iss_parameter_supported: true,
 			backchannel_logout_supported: true,
 			backchannel_logout_session_supported: true,
+			frontchannel_logout_supported: true,
+			frontchannel_logout_session_supported: true,
 		});
 	});
 
@@ -302,6 +306,20 @@ describe("oauth metadata", async () => {
 		const metadata = await auth.api.getOpenIdConfig();
 		expect(metadata.backchannel_logout_supported).toBe(false);
 		expect(metadata.backchannel_logout_session_supported).toBe(false);
+	});
+
+	it("advertises front-channel logout support even when the jwt plugin is disabled", async () => {
+		// Front-channel logout renders iframes carrying plain `iss`/`sid` query
+		// parameters — no signed artifact — so support does not depend on the
+		// jwt plugin.
+		const { auth } = await createTestInstance({
+			oauthProviderConfig: {
+				disableJwtPlugin: true,
+			},
+		});
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata.frontchannel_logout_supported).toBe(true);
+		expect(metadata.frontchannel_logout_session_supported).toBe(true);
 	});
 
 	it("should not provide dynamic client registration endpoint when disabled", async () => {

--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -113,6 +113,8 @@ describe("oauth metadata", async () => {
 			dpop_signing_alg_values_supported: [...DPOP_SIGNING_ALGORITHMS],
 			backchannel_logout_supported: true,
 			backchannel_logout_session_supported: true,
+			frontchannel_logout_supported: true,
+			frontchannel_logout_session_supported: true,
 			claims_supported: baseClaims,
 			claims_parameter_supported: true,
 			userinfo_endpoint: `${baseURL}/oauth2/userinfo`,
@@ -289,6 +291,8 @@ describe("oauth metadata", async () => {
 			authorization_response_iss_parameter_supported: true,
 			backchannel_logout_supported: true,
 			backchannel_logout_session_supported: true,
+			frontchannel_logout_supported: true,
+			frontchannel_logout_session_supported: true,
 		});
 	});
 
@@ -301,6 +305,20 @@ describe("oauth metadata", async () => {
 		const metadata = await auth.api.getOpenIdConfig();
 		expect(metadata.backchannel_logout_supported).toBe(false);
 		expect(metadata.backchannel_logout_session_supported).toBe(false);
+	});
+
+	it("advertises front-channel logout support even when the jwt plugin is disabled", async () => {
+		// Front-channel logout renders iframes carrying plain `iss`/`sid` query
+		// parameters — no signed artifact — so support does not depend on the
+		// jwt plugin.
+		const { auth } = await createTestInstance({
+			oauthProviderConfig: {
+				disableJwtPlugin: true,
+			},
+		});
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata.frontchannel_logout_supported).toBe(true);
+		expect(metadata.frontchannel_logout_session_supported).toBe(true);
 	});
 
 	it("should not provide dynamic client registration endpoint when disabled", async () => {

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -86,6 +86,11 @@ export function authServerMetadata(
 		authorization_response_iss_parameter_supported: true,
 		backchannel_logout_supported: backchannelSupported,
 		backchannel_logout_session_supported: backchannelSupported,
+		// Front-channel logout renders iframes carrying plain `iss`/`sid` query
+		// parameters — no signed artifact — so support is independent of the
+		// JWT plugin.
+		frontchannel_logout_supported: true,
+		frontchannel_logout_session_supported: true,
 	};
 	return metadata;
 }

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -102,6 +102,11 @@ export function authServerMetadata(
 			([...DPOP_SIGNING_ALGORITHMS] as JWSAlgorithms[]),
 		backchannel_logout_supported: backchannelSupported,
 		backchannel_logout_session_supported: backchannelSupported,
+		// Front-channel logout renders iframes carrying plain `iss`/`sid` query
+		// parameters — no signed artifact — so support is independent of the
+		// JWT plugin.
+		frontchannel_logout_supported: true,
+		frontchannel_logout_session_supported: true,
 	};
 	return metadata;
 }

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1330,7 +1330,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							responses: {
 								"200": {
 									description:
-										"Logout successful. May include redirect_uri if post_logout_redirect_uri was provided.",
+										"Logout successful. May include redirect_uri if post_logout_redirect_uri was provided. Browser navigations receive an HTML front-channel logout page when clients with a registered frontchannel_logout_uri hold tokens on the session.",
 									content: {
 										"application/json": {
 											schema: {
@@ -1347,6 +1347,13 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 														description: "Success message",
 													},
 												},
+											},
+										},
+										"text/html": {
+											schema: {
+												type: "string",
+												description:
+													"OIDC Front-Channel Logout page with one hidden iframe per registered RP",
 											},
 										},
 									},
@@ -1378,6 +1385,8 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 						backchannel_logout_uri: SafeUrlSchema.optional(),
 						backchannel_logout_session_required: z.boolean().optional(),
+						frontchannel_logout_uri: SafeUrlSchema.optional(),
+						frontchannel_logout_session_required: z.boolean().optional(),
 						token_endpoint_auth_method: z
 							.enum([
 								"none",
@@ -1533,6 +1542,17 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 														type: "boolean",
 														description:
 															"Whether the RP requires a `sid` claim in every Logout Token",
+													},
+													frontchannel_logout_uri: {
+														type: "string",
+														format: "uri",
+														description:
+															"RP URL rendered in a hidden iframe on the OP's logout page when the end-user's OP session terminates",
+													},
+													frontchannel_logout_session_required: {
+														type: "boolean",
+														description:
+															"Whether the OP appends `iss` and `sid` query parameters to the front-channel logout URI",
 													},
 													token_endpoint_auth_method: {
 														type: "string",

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1452,7 +1452,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							responses: {
 								"200": {
 									description:
-										"Logout completed, or an HTML confirmation page was returned for browser navigation. A redirect is used only for an exact registered post_logout_redirect_uri.",
+										"Logout completed, or an HTML page was returned for browser navigation — a confirmation page, or the OIDC front-channel logout page when clients with a registered frontchannel_logout_uri hold tokens on the session. A redirect is used only for an exact registered post_logout_redirect_uri.",
 									content: {
 										"application/json": {
 											schema: {
@@ -1472,7 +1472,11 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 											},
 										},
 										"text/html": {
-											schema: { type: "string" },
+											schema: {
+												type: "string",
+												description:
+													"Logout confirmation page, or the OIDC Front-Channel Logout page with one hidden iframe per registered RP",
+											},
 										},
 									},
 								},
@@ -1624,6 +1628,17 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 														type: "boolean",
 														description:
 															"Whether the RP requires a `sid` claim in every Logout Token",
+													},
+													frontchannel_logout_uri: {
+														type: "string",
+														format: "uri",
+														description:
+															"RP URL rendered in a hidden iframe on the OP's logout page when the end-user's OP session terminates",
+													},
+													frontchannel_logout_session_required: {
+														type: "boolean",
+														description:
+															"Whether the OP appends `iss` and `sid` query parameters to the front-channel logout URI",
 													},
 													token_endpoint_auth_method: {
 														type: "string",

--- a/packages/oauth-provider/src/oauthClient/index.ts
+++ b/packages/oauth-provider/src/oauthClient/index.ts
@@ -33,6 +33,8 @@ export const adminCreateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 				post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 				backchannel_logout_uri: SafeUrlSchema.optional(),
 				backchannel_logout_session_required: z.boolean().optional(),
+				frontchannel_logout_uri: SafeUrlSchema.optional(),
+				frontchannel_logout_session_required: z.boolean().optional(),
 				token_endpoint_auth_method: z
 					.enum([
 						"none",
@@ -262,6 +264,8 @@ export const createOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 				post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 				backchannel_logout_uri: SafeUrlSchema.optional(),
 				backchannel_logout_session_required: z.boolean().optional(),
+				frontchannel_logout_uri: SafeUrlSchema.optional(),
+				frontchannel_logout_session_required: z.boolean().optional(),
 				token_endpoint_auth_method: z
 					.enum([
 						"none",
@@ -556,6 +560,8 @@ export const adminUpdateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 					post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 					backchannel_logout_uri: SafeUrlSchema.optional(),
 					backchannel_logout_session_required: z.boolean().optional(),
+					frontchannel_logout_uri: SafeUrlSchema.optional(),
+					frontchannel_logout_session_required: z.boolean().optional(),
 					// NOTE: token_endpoint_auth_method is currently immutable since it changes isPublic definition
 					grant_types: z
 						.array(
@@ -612,6 +618,8 @@ export const updateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 					post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 					backchannel_logout_uri: SafeUrlSchema.optional(),
 					backchannel_logout_session_required: z.boolean().optional(),
+					frontchannel_logout_uri: SafeUrlSchema.optional(),
+					frontchannel_logout_session_required: z.boolean().optional(),
 					// NOTE: token_endpoint_auth_method is currently immutable since it changes isPublic definition
 					grant_types: z
 						.array(

--- a/packages/oauth-provider/src/oauthClient/index.ts
+++ b/packages/oauth-provider/src/oauthClient/index.ts
@@ -36,6 +36,8 @@ export const adminCreateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 				post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 				backchannel_logout_uri: SafeUrlSchema.optional(),
 				backchannel_logout_session_required: z.boolean().optional(),
+				frontchannel_logout_uri: SafeUrlSchema.optional(),
+				frontchannel_logout_session_required: z.boolean().optional(),
 				token_endpoint_auth_method: tokenEndpointAuthMethodSchema.optional(),
 				application_type: z.enum(["web", "native"]).optional(),
 				jwks: clientJwksSchema.optional(),
@@ -241,6 +243,8 @@ export const createOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 				post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 				backchannel_logout_uri: SafeUrlSchema.optional(),
 				backchannel_logout_session_required: z.boolean().optional(),
+				frontchannel_logout_uri: SafeUrlSchema.optional(),
+				frontchannel_logout_session_required: z.boolean().optional(),
 				token_endpoint_auth_method: tokenEndpointAuthMethodSchema.optional(),
 				application_type: z.enum(["web", "native"]).optional(),
 				jwks: clientJwksSchema.optional(),
@@ -505,6 +509,8 @@ export const adminUpdateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 					post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 					backchannel_logout_uri: SafeUrlSchema.optional(),
 					backchannel_logout_session_required: z.boolean().optional(),
+					frontchannel_logout_uri: SafeUrlSchema.optional(),
+					frontchannel_logout_session_required: z.boolean().optional(),
 					// token_endpoint_auth_method is immutable because changing the
 					// registered authentication method also changes credential handling.
 					application_type: z.enum(["web", "native"]).optional(),
@@ -559,6 +565,8 @@ export const updateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 					post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 					backchannel_logout_uri: SafeUrlSchema.optional(),
 					backchannel_logout_session_required: z.boolean().optional(),
+					frontchannel_logout_uri: SafeUrlSchema.optional(),
+					frontchannel_logout_session_required: z.boolean().optional(),
 					// token_endpoint_auth_method is immutable because changing the
 					// registered authentication method also changes credential handling.
 					application_type: z.enum(["web", "native"]).optional(),

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -367,6 +367,68 @@ describe("oauth register", async () => {
 			expect(response.error?.status).toBe(400);
 		}
 	});
+
+	it("round-trips frontchannel_logout_uri and frontchannel_logout_session_required", async () => {
+		const frontchannelUri = `${rpBaseUrl}/logout/frontchannel`;
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+			frontchannel_logout_uri: frontchannelUri,
+			frontchannel_logout_session_required: true,
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.frontchannel_logout_uri).toBe(frontchannelUri);
+		expect(response.data?.frontchannel_logout_session_required).toBe(true);
+	});
+
+	it("rejects frontchannel_logout_uri with a fragment", async () => {
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+			frontchannel_logout_uri: `${rpBaseUrl}/logout/frontchannel#section`,
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it("rejects http frontchannel_logout_uri on confidential clients", async () => {
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+			frontchannel_logout_uri: "http://rp.example.com/logout/frontchannel",
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it("allows http frontchannel_logout_uri on public clients", async () => {
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+			token_endpoint_auth_method: "none",
+			type: "native",
+			frontchannel_logout_uri: `${rpBaseUrl}/logout/frontchannel`,
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.frontchannel_logout_uri).toBe(
+			`${rpBaseUrl}/logout/frontchannel`,
+		);
+	});
+
+	it("rejects frontchannel_logout_uri pointing at private, tunneled, or metadata targets", async () => {
+		// The OP directs every end-user's browser at this URI from its own
+		// logout page, so non-public hosts are rejected just like the
+		// back-channel POST target.
+		const targets = [
+			"https://10.0.0.1/logout",
+			"https://169.254.169.254/logout",
+			"https://[::ffff:169.254.169.254]/logout",
+			"https://[64:ff9b::a9fe:a9fe]/logout",
+			"https://100.64.0.1/logout",
+			"https://metadata.google.internal/logout",
+		];
+		for (const frontchannel_logout_uri of targets) {
+			const response = await serverClient.oauth2.register({
+				redirect_uris: [redirectUri],
+				frontchannel_logout_uri,
+			});
+			expect(response.error?.status).toBe(400);
+		}
+	});
 });
 
 describe("oauth register - disableJwtPlugin", async () => {
@@ -400,6 +462,19 @@ describe("oauth register - disableJwtPlugin", async () => {
 			backchannel_logout_uri: `${rpBaseUrl}/logout/backchannel`,
 		});
 		expect(response.error?.status).toBe(400);
+	});
+
+	it("allows frontchannel_logout_uri when jwt plugin is disabled", async () => {
+		// Unlike back-channel logout, front-channel logout involves no signed
+		// Logout Token, so it has no dependency on the jwt plugin.
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [`${rpBaseUrl}/callback`],
+			frontchannel_logout_uri: `${rpBaseUrl}/logout/frontchannel`,
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.frontchannel_logout_uri).toBe(
+			`${rpBaseUrl}/logout/frontchannel`,
+		);
 	});
 });
 

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -21,6 +21,7 @@ import type { OAuthClient } from "./types/oauth";
 describe("oauth register", async () => {
 	const baseUrl = "http://localhost:3000";
 	const rpBaseUrl = "http://localhost:5000";
+	const fcBaseUrl = "https://rp.example.com";
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		baseURL: baseUrl,
 		plugins: [
@@ -697,11 +698,71 @@ describe("oauth register", async () => {
 			expect(response.error?.status).toBe(400);
 		}
 	});
+
+	it("round-trips frontchannel_logout_uri and frontchannel_logout_session_required", async () => {
+		const frontchannelUri = `${fcBaseUrl}/logout/frontchannel`;
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+			frontchannel_logout_uri: frontchannelUri,
+			frontchannel_logout_session_required: true,
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.frontchannel_logout_uri).toBe(frontchannelUri);
+		expect(response.data?.frontchannel_logout_session_required).toBe(true);
+	});
+
+	it("rejects frontchannel_logout_uri with a fragment", async () => {
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+			frontchannel_logout_uri: `${fcBaseUrl}/logout/frontchannel#section`,
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it("rejects http frontchannel_logout_uri", async () => {
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+			frontchannel_logout_uri: "http://rp.example.com/logout/frontchannel",
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it("rejects http frontchannel_logout_uri on public clients too", async () => {
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [redirectUri],
+			token_endpoint_auth_method: "none",
+			application_type: "native",
+			frontchannel_logout_uri: "http://rp.example.com/logout/frontchannel",
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it("rejects frontchannel_logout_uri pointing at private, tunneled, or metadata targets", async () => {
+		// The OP directs every end-user's browser at this URI from its own
+		// logout page, so non-public hosts are rejected just like the
+		// back-channel POST target.
+		const targets = [
+			"https://10.0.0.1/logout",
+			"https://169.254.169.254/logout",
+			"https://[::ffff:169.254.169.254]/logout",
+			"https://[64:ff9b::a9fe:a9fe]/logout",
+			"https://100.64.0.1/logout",
+			"https://metadata.google.internal/logout",
+		];
+		for (const frontchannel_logout_uri of targets) {
+			const response = await serverClient.oauth2.register({
+				redirect_uris: [redirectUri],
+				frontchannel_logout_uri,
+			});
+			expect(response.error?.status).toBe(400);
+		}
+	});
 });
 
 describe("oauth register - disableJwtPlugin", async () => {
 	const baseUrl = "http://localhost:3000";
 	const rpBaseUrl = "http://localhost:5000";
+	const fcBaseUrl = "https://rp.example.com";
 	const { signInWithTestUser, customFetchImpl } = await getTestInstance({
 		baseURL: baseUrl,
 		plugins: [
@@ -726,6 +787,22 @@ describe("oauth register - disableJwtPlugin", async () => {
 			backchannel_logout_uri: `${rpBaseUrl}/logout/backchannel`,
 		});
 		expect(response.error?.status).toBe(400);
+	});
+
+	it("allows frontchannel_logout_uri when jwt plugin is disabled", async () => {
+		// Unlike back-channel logout, front-channel logout involves no signed
+		// Logout Token, so it has no dependency on the jwt plugin.
+		const response = await serverClient.oauth2.register({
+			redirect_uris: [`${rpBaseUrl}/callback`],
+			// http loopback redirects are native-only; web clients need https.
+			application_type: "native",
+			token_endpoint_auth_method: "none",
+			frontchannel_logout_uri: `${fcBaseUrl}/logout/frontchannel`,
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.frontchannel_logout_uri).toBe(
+			`${fcBaseUrl}/logout/frontchannel`,
+		);
 	});
 });
 

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -323,6 +323,62 @@ export async function checkOAuthClient(
 			});
 		}
 	}
+
+	// Front-channel logout never signs anything, so unlike the back-channel
+	// URI this one has no JWT-plugin requirement.
+	if (client.frontchannel_logout_uri !== undefined) {
+		let url: URL;
+		try {
+			url = new URL(client.frontchannel_logout_uri);
+		} catch {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description: "frontchannel_logout_uri must be an absolute URL",
+			});
+		}
+		// Only http/https can be rendered as an iframe `src` from the OP's
+		// logout page; reject anything else up front to avoid storing URIs
+		// that can never be rendered.
+		if (url.protocol !== "https:" && url.protocol !== "http:") {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description: "frontchannel_logout_uri must use http or https",
+			});
+		}
+		// The OP extends this URI with `iss`/`sid` query parameters, so a
+		// fragment has no defined meaning; reject the raw value (mirrors the
+		// back-channel §2.2 treatment, including the bare trailing `#` case
+		// that `url.hash` misses).
+		if (client.frontchannel_logout_uri.includes("#")) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description:
+					"frontchannel_logout_uri must not include a fragment component",
+			});
+		}
+		const loopback = isLoopbackHost(url.hostname);
+		// Spec §2: SHOULD be https. Enforce on confidential clients, with a
+		// loopback carve-out (RFC 8252 §7.3) so local development against
+		// http://127.0.0.1:<port> works.
+		if (!isPublic && url.protocol !== "https:" && !loopback) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description:
+					"frontchannel_logout_uri must use https for confidential clients",
+			});
+		}
+		// The OP directs every end-user's browser at this URI from its own
+		// logout page, so reject non-public hosts to keep the page from
+		// becoming a vector for driving browsers at internal endpoints (same
+		// policy as the back-channel POST target, applied browser-side).
+		if (isPrivateHostname(url.hostname) && !loopback) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description:
+					"frontchannel_logout_uri must not point to a private or reserved address",
+			});
+		}
+	}
 }
 
 export async function createOAuthClientEndpoint(
@@ -459,6 +515,8 @@ export function oauthToSchema(input: OAuthClient): SchemaClient<Scope[]> {
 		post_logout_redirect_uris: postLogoutRedirectUris,
 		backchannel_logout_uri: backchannelLogoutUri,
 		backchannel_logout_session_required: backchannelLogoutSessionRequired,
+		frontchannel_logout_uri: frontchannelLogoutUri,
+		frontchannel_logout_session_required: frontchannelLogoutSessionRequired,
 		token_endpoint_auth_method: tokenEndpointAuthMethod,
 		grant_types: grantTypes,
 		response_types: responseTypes,
@@ -517,6 +575,8 @@ export function oauthToSchema(input: OAuthClient): SchemaClient<Scope[]> {
 		postLogoutRedirectUris,
 		backchannelLogoutUri,
 		backchannelLogoutSessionRequired,
+		frontchannelLogoutUri,
+		frontchannelLogoutSessionRequired,
 		tokenEndpointAuthMethod,
 		grantTypes,
 		responseTypes,
@@ -576,6 +636,8 @@ export function schemaToOAuth(input: SchemaClient<Scope[]>): OAuthClient {
 		postLogoutRedirectUris,
 		backchannelLogoutUri,
 		backchannelLogoutSessionRequired,
+		frontchannelLogoutUri,
+		frontchannelLogoutSessionRequired,
 		tokenEndpointAuthMethod,
 		grantTypes,
 		responseTypes,
@@ -637,6 +699,9 @@ export function schemaToOAuth(input: SchemaClient<Scope[]>): OAuthClient {
 		backchannel_logout_uri: backchannelLogoutUri ?? undefined,
 		backchannel_logout_session_required:
 			backchannelLogoutSessionRequired ?? undefined,
+		frontchannel_logout_uri: frontchannelLogoutUri ?? undefined,
+		frontchannel_logout_session_required:
+			frontchannelLogoutSessionRequired ?? undefined,
 		token_endpoint_auth_method: tokenEndpointAuthMethod ?? undefined,
 		grant_types: grantTypes ?? undefined,
 		response_types: responseTypes ?? undefined,

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -659,6 +659,55 @@ export async function checkOAuthClient(
 			});
 		}
 	}
+
+	// Front-channel logout never signs anything, so unlike the back-channel URI
+	// this one has no JWT-plugin requirement. Every other constraint mirrors the
+	// back-channel treatment above so both logout URIs hold to one policy.
+	if (clientWithDefaults.frontchannel_logout_uri !== undefined) {
+		let url: URL;
+		try {
+			url = new URL(clientWithDefaults.frontchannel_logout_uri);
+		} catch {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description: "frontchannel_logout_uri must be an absolute URL",
+			});
+		}
+		// The OP extends this URI with `iss`/`sid` query parameters, so a
+		// fragment has no defined meaning; check the raw value rather than
+		// `url.hash`, which is empty for a bare trailing `#`.
+		if (clientWithDefaults.frontchannel_logout_uri.includes("#")) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description:
+					"frontchannel_logout_uri must not include a fragment component",
+			});
+		}
+		if (url.protocol !== "https:") {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description: "frontchannel_logout_uri must use https",
+			});
+		}
+		if (url.username || url.password) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description:
+					"frontchannel_logout_uri must not contain credentials",
+			});
+		}
+		// The OP points every end-user's browser at this URI from its own logout
+		// page, so a non-public host would make that page a way to drive browsers
+		// at internal endpoints — the browser-side analogue of the SSRF guard on
+		// the back-channel target.
+		if (isPrivateHostname(url.hostname)) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description:
+					"frontchannel_logout_uri must not point to a private or reserved address",
+			});
+		}
+	}
 }
 
 interface CreateOAuthClientRegistrationBaseInput {
@@ -1271,6 +1320,8 @@ export function oauthToSchema(
 		post_logout_redirect_uris: postLogoutRedirectUris,
 		backchannel_logout_uri: backchannelLogoutUri,
 		backchannel_logout_session_required: backchannelLogoutSessionRequired,
+		frontchannel_logout_uri: frontchannelLogoutUri,
+		frontchannel_logout_session_required: frontchannelLogoutSessionRequired,
 		token_endpoint_auth_method: tokenEndpointAuthMethod,
 		grant_types: grantTypes,
 		response_types: responseTypes,
@@ -1326,6 +1377,8 @@ export function oauthToSchema(
 		postLogoutRedirectUris,
 		backchannelLogoutUri,
 		backchannelLogoutSessionRequired,
+		frontchannelLogoutUri,
+		frontchannelLogoutSessionRequired,
 		tokenEndpointAuthMethod,
 		grantTypes,
 		responseTypes,
@@ -1378,6 +1431,8 @@ export function schemaToOAuth(input: SchemaClient<Scope[]>): OAuthClient {
 		postLogoutRedirectUris,
 		backchannelLogoutUri,
 		backchannelLogoutSessionRequired,
+		frontchannelLogoutUri,
+		frontchannelLogoutSessionRequired,
 		tokenEndpointAuthMethod,
 		grantTypes,
 		responseTypes,
@@ -1440,6 +1495,9 @@ export function schemaToOAuth(input: SchemaClient<Scope[]>): OAuthClient {
 		backchannel_logout_uri: backchannelLogoutUri ?? undefined,
 		backchannel_logout_session_required:
 			backchannelLogoutSessionRequired ?? undefined,
+		frontchannel_logout_uri: frontchannelLogoutUri ?? undefined,
+		frontchannel_logout_session_required:
+			frontchannelLogoutSessionRequired ?? undefined,
 		token_endpoint_auth_method: tokenEndpointAuthMethod ?? undefined,
 		grant_types: grantTypes ?? undefined,
 		response_types: responseTypes ?? undefined,

--- a/packages/oauth-provider/src/schema.ts
+++ b/packages/oauth-provider/src/schema.ts
@@ -108,6 +108,14 @@ export const schema = {
 				type: "boolean",
 				required: false,
 			},
+			frontchannelLogoutUri: {
+				type: "string",
+				required: false,
+			},
+			frontchannelLogoutSessionRequired: {
+				type: "boolean",
+				required: false,
+			},
 			tokenEndpointAuthMethod: {
 				type: "string",
 				required: false,

--- a/packages/oauth-provider/src/schema.ts
+++ b/packages/oauth-provider/src/schema.ts
@@ -117,6 +117,14 @@ export const schema = {
 				type: "boolean",
 				required: false,
 			},
+			frontchannelLogoutUri: {
+				type: "string",
+				required: false,
+			},
+			frontchannelLogoutSessionRequired: {
+				type: "boolean",
+				required: false,
+			},
 			tokenEndpointAuthMethod: {
 				type: "string",
 				required: false,

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1024,6 +1024,23 @@ export interface SchemaClient<
 	 * @default false
 	 */
 	backchannelLogoutSessionRequired?: boolean;
+	/**
+	 * RP URL rendered in a hidden iframe on the OP's logout page when the
+	 * end-user's session ends at `/oauth2/end-session`. Registering it is the
+	 * per-client opt-in for front-channel logout. Must be absolute, without a
+	 * fragment, and HTTPS for confidential clients.
+	 *
+	 * @see https://openid.net/specs/openid-connect-frontchannel-1_0.html#RPLogout
+	 */
+	frontchannelLogoutUri?: string;
+	/**
+	 * When true, the OP appends `iss` and `sid` query parameters to the
+	 * client's `frontchannel_logout_uri` so the RP can validate the request
+	 * and target the right session.
+	 *
+	 * @default false
+	 */
+	frontchannelLogoutSessionRequired?: boolean;
 	tokenEndpointAuthMethod?:
 		| "none"
 		| "client_secret_basic"

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1743,6 +1743,23 @@ export interface SchemaClient<
 	 * @default false
 	 */
 	backchannelLogoutSessionRequired?: boolean;
+	/**
+	 * RP URL rendered in a hidden iframe on the OP's logout page when the
+	 * end-user's session ends at `/oauth2/end-session`. Registering it is the
+	 * per-client opt-in for front-channel logout. Must be absolute, without a
+	 * fragment, and HTTPS for confidential clients.
+	 *
+	 * @see https://openid.net/specs/openid-connect-frontchannel-1_0.html#RPLogout
+	 */
+	frontchannelLogoutUri?: string;
+	/**
+	 * When true, the OP appends `iss` and `sid` query parameters to the
+	 * client's `frontchannel_logout_uri` so the RP can validate the request
+	 * and target the right session.
+	 *
+	 * @default false
+	 */
+	frontchannelLogoutSessionRequired?: boolean;
 	tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
 	grantTypes?: GrantType[];
 	responseTypes?: "code"[];

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -214,6 +214,27 @@ export interface AuthServerMetadata {
 	 * @see https://openid.net/specs/openid-connect-backchannel-1_0.html#OPMetadata
 	 */
 	backchannel_logout_session_supported?: boolean;
+	/**
+	 * Boolean value specifying whether the OP supports HTTP-based (front-channel)
+	 * logout, with true indicating support.
+	 *
+	 * Registered in the "OAuth Authorization Server Metadata" IANA registry
+	 * under OpenID Connect Front-Channel Logout 1.0, so this may appear at both
+	 * `.well-known/oauth-authorization-server` and `.well-known/openid-configuration`.
+	 *
+	 * @default false
+	 * @see https://openid.net/specs/openid-connect-frontchannel-1_0.html#OPLogout
+	 */
+	frontchannel_logout_supported?: boolean;
+	/**
+	 * Boolean value specifying whether the OP can pass `iss` (issuer) and `sid`
+	 * (session ID) query parameters to identify the RP session with the OP when
+	 * the `frontchannel_logout_uri` is used.
+	 *
+	 * @default false
+	 * @see https://openid.net/specs/openid-connect-frontchannel-1_0.html#OPLogout
+	 */
+	frontchannel_logout_session_supported?: boolean;
 }
 
 /**
@@ -337,6 +358,23 @@ export interface OAuthClient {
 	 * @see https://openid.net/specs/openid-connect-backchannel-1_0.html#RPMetadata
 	 */
 	backchannel_logout_session_required?: boolean;
+	/**
+	 * RP URL that the OP renders in a hidden iframe on its logout page so the
+	 * RP can log itself out when the end-user's OP session ends at
+	 * `/oauth2/end-session`.
+	 *
+	 * @see https://openid.net/specs/openid-connect-frontchannel-1_0.html#RPLogout
+	 */
+	frontchannel_logout_uri?: string;
+	/**
+	 * When true, the OP appends `iss` and `sid` query parameters to the
+	 * `frontchannel_logout_uri` so the RP can validate the request and
+	 * determine which session to terminate.
+	 *
+	 * @default false
+	 * @see https://openid.net/specs/openid-connect-frontchannel-1_0.html#RPLogout
+	 */
+	frontchannel_logout_session_required?: boolean;
 	token_endpoint_auth_method?:
 		| "none"
 		| "client_secret_basic"

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -239,6 +239,27 @@ export interface AuthServerMetadata {
 	 * @see https://datatracker.ietf.org/doc/html/rfc9449
 	 */
 	dpop_signing_alg_values_supported?: JWSAlgorithms[];
+	/**
+	 * Boolean value specifying whether the OP supports HTTP-based (front-channel)
+	 * logout, with true indicating support.
+	 *
+	 * Registered in the "OAuth Authorization Server Metadata" IANA registry
+	 * under OpenID Connect Front-Channel Logout 1.0, so this may appear at both
+	 * `.well-known/oauth-authorization-server` and `.well-known/openid-configuration`.
+	 *
+	 * @default false
+	 * @see https://openid.net/specs/openid-connect-frontchannel-1_0.html#OPLogout
+	 */
+	frontchannel_logout_supported?: boolean;
+	/**
+	 * Boolean value specifying whether the OP can pass `iss` (issuer) and `sid`
+	 * (session ID) query parameters to identify the RP session with the OP when
+	 * the `frontchannel_logout_uri` is used.
+	 *
+	 * @default false
+	 * @see https://openid.net/specs/openid-connect-frontchannel-1_0.html#OPLogout
+	 */
+	frontchannel_logout_session_supported?: boolean;
 }
 
 /**
@@ -383,6 +404,23 @@ export interface OAuthClient {
 	 * @see https://openid.net/specs/openid-connect-backchannel-1_0.html#RPMetadata
 	 */
 	backchannel_logout_session_required?: boolean;
+	/**
+	 * RP URL that the OP renders in a hidden iframe on its logout page so the
+	 * RP can log itself out when the end-user's OP session ends at
+	 * `/oauth2/end-session`.
+	 *
+	 * @see https://openid.net/specs/openid-connect-frontchannel-1_0.html#RPLogout
+	 */
+	frontchannel_logout_uri?: string;
+	/**
+	 * When true, the OP appends `iss` and `sid` query parameters to the
+	 * `frontchannel_logout_uri` so the RP can validate the request and
+	 * determine which session to terminate.
+	 *
+	 * @default false
+	 * @see https://openid.net/specs/openid-connect-frontchannel-1_0.html#RPLogout
+	 */
+	frontchannel_logout_session_required?: boolean;
 	token_endpoint_auth_method?: TokenEndpointAuthMethod;
 	grant_types?: GrantType[];
 	response_types?: "code"[];

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -206,6 +206,8 @@ export const clientRegistrationRequestSchema = z.object({
 	post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 	backchannel_logout_uri: SafeUrlSchema.optional(),
 	backchannel_logout_session_required: z.boolean().optional(),
+	frontchannel_logout_uri: SafeUrlSchema.optional(),
+	frontchannel_logout_session_required: z.boolean().optional(),
 	token_endpoint_auth_method: z.string().trim().min(1).optional(),
 	jwks: clientJwksSchema.optional(),
 	jwks_uri: z.string().optional(),


### PR DESCRIPTION
Closes #9922

Implements [OpenID Connect Front-Channel Logout 1.0](https://openid.net/specs/openid-connect-frontchannel-1_0.html) in `@better-auth/oauth-provider` — the browser-based sibling that #9304 explicitly deferred. When the end-user terminates their session with a browser navigation to `/oauth2/end-session`, the OP now responds with a logout page containing one hidden iframe per client that holds tokens on the session and registered a `frontchannel_logout_uri`. The browser fans the logout out by loading each RP's URI so the RP can clear its own session cookies in its own browser context — no server-to-server call involved. Once every iframe settles (or after a 3s safety timeout, so a hung RP cannot stall the user), the page redirects to the validated `post_logout_redirect_uri` when one was provided.

## What the client developer sees

```ts
await auth.api.adminCreateOAuthClient({
  headers,
  body: {
    redirect_uris: [redirectUri],
    enable_end_session: true,
    frontchannel_logout_uri: "https://rp.example.com/logout/frontchannel",
    frontchannel_logout_session_required: true,
  },
});
```

DCR and the client update endpoints accept the same two fields. When `frontchannel_logout_session_required` is `true`, the OP appends `iss` and `sid` query parameters to the iframe URL (§2: if either is included, both MUST be). The OP advertises `frontchannel_logout_supported` and `frontchannel_logout_session_supported` on both discovery endpoints; unlike the back-channel fields these are not gated on the JWT plugin, because front-channel logout signs nothing.

## Behavior preservation

- No front-channel clients on the session → immediate redirect, exactly as before.
- Fetch-style requests (`sec-fetch-mode: cors` or `accept: application/json`) keep the JSON contract — an iframe page is useless to them. Channel selection mirrors `handleRedirect`.
- Back-channel dispatch is untouched: it still fires from `session.delete.before`. Front-channel enumeration runs in the end-session endpoint *before* the session row is deleted, because token rows reference the session with `onDelete: "set null"` and the linkage disappears with the row.

## Rendering and security posture

- Registration validation mirrors `backchannel_logout_uri`: absolute http/https URL, no fragment (including the bare trailing `#` that `url.hash` misses), https on confidential clients with a loopback carve-out (RFC 8252 §7.3), and the same `isPrivateHostname` host policy — applied here because the OP directs every end-user's browser at this URI from its own page.
- Iframe `src` values are HTML-entity escaped; the deferred redirect URL is embedded JSON-encoded with `<` escaped so it cannot break out of the inline script context.
- The page is served with `Cache-Control: no-store` and `Referrer-Policy: no-referrer` — the page URL carries `id_token_hint` and must never leak to RPs via Referer.
- The iframes are plain HTML and fire without JavaScript; a meta-refresh covers the deferred redirect when scripting is disabled.

## Known limitation

Browsers that partition or block third-party cookies (Safari ITP, Chrome's third-party-cookie phase-out) may hide the RP's session cookie inside the iframe — front-channel logout is best-effort by design. The docs say to pair it with back-channel logout when reliable session termination is required.

## Test plan

- `frontchannel-logout.test.ts` (new): iframe-per-client rendering + session termination; `iss`/`sid` appended only for `frontchannel_logout_session_required` clients; validated and unregistered `post_logout_redirect_uri` handling; immediate-redirect preservation when no front-channel client is present; HTML escaping of iframe sources; JSON-contract preservation for fetch-style requests; rendering with `disableJwtPlugin: true`.
- `register.test.ts`: round-trip, fragment / http-on-confidential / private-tunneled-metadata-host rejection, public-client http loopback allowance, and registration allowed with `disableJwtPlugin` (contrast with back-channel).
- `metadata.test.ts`: both discovery documents advertise support; stays `true` with `disableJwtPlugin`.
- Full `@better-auth/oauth-provider` suite passes (437 tests); `pnpm typecheck` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OIDC Front-Channel Logout 1.0 to `@better-auth/oauth-provider`, so browser navigations to `/oauth2/end-session` render a logout page with one hidden iframe per opted-in RP. Previously the endpoint always redirected; now it redirects only when no front-channel targets exist or after the iframes settle.

- Opt-in via client metadata: `frontchannel_logout_uri` and `frontchannel_logout_session_required` (adds `iss`/`sid` query params when true).
- Browser navigations get HTML with hidden iframes and a 3s bounded redirect to a validated `post_logout_redirect_uri`; fetch/JSON requests keep the JSON contract.
- `frontchannel_logout_uri` validation: absolute HTTPS only (no HTTP, including loopback), no fragment, no credentials, and non-public hosts are rejected.
- Discovery advertises `frontchannel_logout_supported` and `frontchannel_logout_session_supported`; support is independent of the JWT plugin.
- Security: iframe sources are escaped; responses use `Cache-Control: no-store` and `Referrer-Policy: no-referrer`.

- Migration
  - Clients must register an HTTPS `frontchannel_logout_uri` without fragments or credentials; HTTP URIs (including loopback) are rejected.
  - RPs that require session matching must set `frontchannel_logout_session_required: true` to receive `iss`/`sid`.

<sup>Written for commit b42b7a1287727cea76bc1aa74bb642cce81761cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

