### PR TITLE
test(cli): give the integration-style suite a generous timeout

### DIFF
--- a/packages/cli/test/info.test.ts
+++ b/packages/cli/test/info.test.ts
@@ -346,4 +346,4 @@ describe("info command", () => {
 		expect(output.frameworks).toBeNull();
 		expect(output.databases).toBeNull();
 	});
-}, 20000);
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,5 +4,12 @@ export default defineProject({
 	test: {
 		clearMocks: true,
 		restoreMocks: true,
+		// CLI tests are integration-style: they spawn the built CLI as a
+		// subprocess and transpile config files (babel + jiti, importing
+		// better-auth and adapters). That runs in seconds locally but is sensitive
+		// to CI runner load, so the default 5s timeout flakes. Give the whole suite
+		// a generous ceiling instead of scattering per-test overrides.
+		testTimeout: 60_000,
+		hookTimeout: 60_000,
 	},
 });


### PR DESCRIPTION
The CLI tests `get-config` ("resolve resolver type alias") and `info` ("display system information") flake in CI with timeouts. They are integration-style: `info` spawns the built CLI as a subprocess, and `get-config` transpiles a temporary TS config that imports better-auth plus an adapter (babel + jiti). That work finishes in seconds locally but is sensitive to CI runner load, and the default 5s timeout (plus info's 20s) is too tight, so it intermittently overshoots.

This sets a suite-wide `testTimeout`/`hookTimeout` for the CLI package instead of scattering per-test overrides, and removes the one-off 20s on the info describe. The ceiling only affects tests that would otherwise time out; fast tests are unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase timeouts for the CLI test suite to stop CI flakiness on integration-style tests that spawn the built CLI and transpile configs. Set suite-wide `testTimeout` and `hookTimeout` to 60s in `packages/cli/vitest.config.ts` and remove the `info` suite’s 20s per-describe override.

<sup>Written for commit 0accbdb02214356877b7e6e31d2dcac3f26ff364. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

