### PR TITLE
feat(passkey): resolve authenticator name from AAGUID at read time

### DIFF
--- a/.changeset/passkey-authenticator-name.md
+++ b/.changeset/passkey-authenticator-name.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/passkey": patch
+---
+
+Resolve a friendly label for a passkey from the authenticator that created it. Passkeys already store the authenticator `aaguid`; the plugin now exports `getAuthenticatorName(aaguid)` and an extensible `commonAuthenticatorNames` map so you can show a provider name (for example "1Password" or "Google Password Manager") when rendering passkeys, with full coverage available through the community AAGUID source. To set a server-side default, `registration.afterVerification` can now return a `name` used when the client supplies none. Passkey names are trimmed on registration and update.

--- a/.cspell/auth-terms.txt
+++ b/.cspell/auth-terms.txt
@@ -5,6 +5,8 @@ unban
 siwe
 scim
 aaguid
+aaguids
+Nord
 unionid
 appleid
 ciam

--- a/docs/content/docs/plugins/passkey.mdx
+++ b/docs/content/docs/plugins/passkey.mdx
@@ -234,6 +234,53 @@ You can list all of the passkeys for the authenticated user by calling `passkey.
   ```
 </APIMethod>
 
+### Naming passkeys by authenticator
+
+When a user registers a passkey without naming it, the stored `name` is left empty. You can show a friendly default in your UI instead, derived from the authenticator that created the credential.
+
+Every passkey row carries an `aaguid`, the identifier of the authenticator *model* (for example Google Password Manager or 1Password). Better Auth stores it at registration and returns it from `listPasskeys`, so you resolve a label at the point you render passkeys. Because resolution happens at read time, an updated provider list applies to passkeys that already exist.
+
+The plugin ships a small, best-effort lookup for the most common authenticators:
+
+```ts title="passkey-list.tsx"
+import { getAuthenticatorName } from "@better-auth/passkey";
+
+const passkeys = await authClient.passkey.listUserPasskeys();
+
+for (const passkey of passkeys.data ?? []) {
+    const label = passkey.name || getAuthenticatorName(passkey.aaguid) || "Passkey";
+}
+```
+
+The built-in list is intentionally small and not authoritative. Many authenticators are missing, and privacy-preserving platforms report an all-zero AAGUID that resolves to nothing (Apple devices do this under the default `attestation: "none"` flow). Extend it with the exported `commonAuthenticatorNames` map, or resolve against the community-maintained source for full coverage:
+
+* [passkeydeveloper/passkey-authenticator-aaguids](https://github.com/passkeydeveloper/passkey-authenticator-aaguids)
+
+```ts title="passkey-list.tsx"
+import { commonAuthenticatorNames } from "@better-auth/passkey";
+
+const names = { ...commonAuthenticatorNames, "your-aaguid": "Your Provider" };
+```
+
+To set a default label on the server at registration time, return a `name` from `registration.afterVerification`. The AAGUID is available on `verification.registrationInfo.aaguid`, and a client-supplied name always takes precedence:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { passkey, getAuthenticatorName } from "@better-auth/passkey";
+
+export const auth = betterAuth({
+    plugins: [
+        passkey({
+            registration: {
+                afterVerification: async ({ verification }) => ({
+                    name: getAuthenticatorName(verification.registrationInfo?.aaguid),
+                }),
+            },
+        }),
+    ],
+});
+```
+
 ### Deleting passkeys
 
 You can delete a passkey by calling `passkey.delete` and providing the passkey ID.

--- a/packages/passkey/src/authenticator-metadata.test.ts
+++ b/packages/passkey/src/authenticator-metadata.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+	commonAuthenticatorNames,
+	getAuthenticatorName,
+} from "./authenticator-metadata";
+
+describe("getAuthenticatorName", () => {
+	it("resolves known AAGUIDs", () => {
+		expect(getAuthenticatorName("ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4")).toBe(
+			"Google Password Manager",
+		);
+		expect(getAuthenticatorName("fbfc3007-154e-4ecc-8c0b-6e020557d7bd")).toBe(
+			"Apple Passwords",
+		);
+		expect(getAuthenticatorName("bada5566-a7aa-401f-bd96-45619a55120d")).toBe(
+			"1Password",
+		);
+		expect(getAuthenticatorName("d548826e-79b4-db40-a3d8-11116f7e8349")).toBe(
+			"Bitwarden",
+		);
+		expect(getAuthenticatorName("53414d53-554e-4700-0000-000000000000")).toBe(
+			"Samsung Pass",
+		);
+	});
+
+	it("resolves every AAGUID of a multi-AAGUID provider", () => {
+		for (const aaguid of [
+			"08987058-cadc-4b81-b6e1-30de50dcbe96",
+			"9ddd1817-af5a-4672-a2b9-3e3dd95000a9",
+			"6028b017-b1d4-4c02-b4b3-afcdafc96bb2",
+		]) {
+			expect(getAuthenticatorName(aaguid)).toBe("Windows Hello");
+		}
+	});
+
+	it("normalizes casing and whitespace", () => {
+		expect(
+			getAuthenticatorName("  DD4EC289-E01D-41C9-BB89-70FA845D4BF2  "),
+		).toBe("iCloud Keychain (Managed)");
+	});
+
+	it("returns undefined for the all-zero AAGUID, even if added to the map", () => {
+		const zero = "00000000-0000-0000-0000-000000000000";
+		expect(getAuthenticatorName(zero)).toBeUndefined();
+		commonAuthenticatorNames[zero] = "Spoofed Provider";
+		try {
+			expect(getAuthenticatorName(zero)).toBeUndefined();
+		} finally {
+			delete commonAuthenticatorNames[zero];
+		}
+	});
+
+	it("returns undefined for unknown, empty, or missing input", () => {
+		expect(
+			getAuthenticatorName("11111111-1111-1111-1111-111111111111"),
+		).toBeUndefined();
+		expect(getAuthenticatorName("")).toBeUndefined();
+		expect(getAuthenticatorName("   ")).toBeUndefined();
+		expect(getAuthenticatorName(undefined)).toBeUndefined();
+		expect(getAuthenticatorName(null)).toBeUndefined();
+	});
+
+	it("does not leak inherited object properties through index lookup", () => {
+		for (const key of ["__proto__", "constructor", "toString", "valueOf"]) {
+			expect(getAuthenticatorName(key)).toBeUndefined();
+		}
+	});
+
+	it("exposes the raw map so consumers can extend it", () => {
+		const extended: Record<string, string> = {
+			...commonAuthenticatorNames,
+			"11111111-1111-1111-1111-111111111111": "My Provider",
+		};
+		expect(extended["11111111-1111-1111-1111-111111111111"]).toBe(
+			"My Provider",
+		);
+		expect(extended["ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4"]).toBe(
+			"Google Password Manager",
+		);
+	});
+});

--- a/packages/passkey/src/authenticator-metadata.ts
+++ b/packages/passkey/src/authenticator-metadata.ts
@@ -1,0 +1,62 @@
+/**
+ * Best-effort map of common authenticator AAGUIDs to a human-readable provider
+ * name, for labeling passkeys in management UIs.
+ *
+ * An AAGUID identifies an authenticator *model* (not a device or a user) and is
+ * present only in the registration response. Better Auth stores it on every
+ * passkey row and returns it from `listPasskeys`, so a display label can be
+ * resolved wherever passkeys are rendered.
+ *
+ * This list is intentionally small and not authoritative. Many authenticators
+ * are missing, and privacy-preserving platforms report an all-zero AAGUID
+ * (`00000000-0000-0000-0000-000000000000`) that matches nothing here. Notably,
+ * Apple devices zero the AAGUID under the default `attestation: "none"` flow, so
+ * the Apple entries below only appear in attested or managed contexts. For full
+ * coverage, resolve against the community-maintained source instead:
+ *
+ * - https://github.com/passkeydeveloper/passkey-authenticator-aaguids
+ *
+ * Names mirror that source verbatim.
+ */
+export const commonAuthenticatorNames: Record<string, string> = {
+	"ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4": "Google Password Manager",
+	"fbfc3007-154e-4ecc-8c0b-6e020557d7bd": "Apple Passwords",
+	"dd4ec289-e01d-41c9-bb89-70fa845d4bf2": "iCloud Keychain (Managed)",
+	"08987058-cadc-4b81-b6e1-30de50dcbe96": "Windows Hello",
+	"9ddd1817-af5a-4672-a2b9-3e3dd95000a9": "Windows Hello",
+	"6028b017-b1d4-4c02-b4b3-afcdafc96bb2": "Windows Hello",
+	"bada5566-a7aa-401f-bd96-45619a55120d": "1Password",
+	"d548826e-79b4-db40-a3d8-11116f7e8349": "Bitwarden",
+	"531126d6-e717-415c-9320-3d9aa6981239": "Dashlane",
+	"b78a0a55-6ef8-d246-a042-ba0f6d55050c": "LastPass",
+	"b84e4048-15dc-4dd0-8640-f4f60813c8af": "NordPass",
+	"50726f74-6f6e-5061-7373-50726f746f6e": "Proton Pass",
+	"0ea242b4-43c4-4a1b-8b17-dd6d0b6baec6": "Keeper",
+	"53414d53-554e-4700-0000-000000000000": "Samsung Pass",
+};
+
+/**
+ * Resolve a best-effort provider name for an authenticator AAGUID.
+ *
+ * Returns `undefined` when the AAGUID is unknown, empty, or the all-zero value
+ * reported by privacy-preserving platforms. Casing and surrounding whitespace
+ * are normalized before lookup.
+ *
+ * @example
+ * ```ts
+ * const label = passkey.name || getAuthenticatorName(passkey.aaguid) || "Passkey";
+ * ```
+ */
+// Reserved by WebAuthn for authenticators that decline to identify their model.
+const ANONYMOUS_AAGUID = "00000000-0000-0000-0000-000000000000";
+
+export const getAuthenticatorName = (
+	aaguid: string | null | undefined,
+): string | undefined => {
+	const normalized = aaguid?.trim().toLowerCase();
+	if (!normalized || normalized === ANONYMOUS_AAGUID) return undefined;
+	// Guard the value type so inherited members (`toString`, `__proto__`, ...)
+	// reached by index lookup never escape as a "name".
+	const name = commonAuthenticatorNames[normalized];
+	return typeof name === "string" ? name : undefined;
+};

--- a/packages/passkey/src/index.ts
+++ b/packages/passkey/src/index.ts
@@ -22,6 +22,10 @@ declare module "@better-auth/core" {
 	}
 }
 
+export {
+	commonAuthenticatorNames,
+	getAuthenticatorName,
+} from "./authenticator-metadata";
 export { PASSKEY_ERROR_CODES } from "./error-codes";
 
 const MAX_AGE_IN_SECONDS = 60 * 5; // 5 minutes

--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -373,6 +373,32 @@ describe("passkey", async () => {
 		expect(updateResult.passkey.name).toBe("newName");
 	});
 
+	it("rejects a whitespace-only passkey name on update", async () => {
+		const { headers, user } = await signInWithTestUser();
+		const context = await auth.$context;
+		const passkey = await context.adapter.create<Omit<Passkey, "id">, Passkey>({
+			model: "passkey",
+			data: {
+				userId: user.id,
+				publicKey: "mockPublicKey",
+				name: "original",
+				counter: 0,
+				deviceType: "singleDevice",
+				credentialID: "update-reject-cred",
+				createdAt: new Date(),
+				backedUp: false,
+				transports: "internal",
+				aaguid: "mockAAGUID",
+			} satisfies Omit<Passkey, "id">,
+		});
+		await expect(
+			auth.api.updatePasskey({
+				headers,
+				body: { id: passkey.id, name: "   " },
+			}),
+		).rejects.toMatchObject({ status: 400 });
+	});
+
 	it("should not delete a passkey that doesn't exist", async () => {
 		const { headers } = await signInWithTestUser();
 		await expect(
@@ -922,6 +948,149 @@ describe("passkey", async () => {
 		} finally {
 			consumeSpy.mockRestore();
 		}
+	});
+});
+
+const buildRegistrationVerification = (
+	aaguid: string,
+	credentialID: string,
+) => ({
+	verified: true,
+	registrationInfo: {
+		aaguid,
+		credentialDeviceType: "singleDevice",
+		credentialBackedUp: false,
+		credential: {
+			id: credentialID,
+			publicKey: new Uint8Array([1, 2, 3]),
+			counter: 0,
+		},
+	},
+});
+
+// A known AAGUID, used to prove the server still does not derive a label from it.
+const googleAaguid = "ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4";
+
+describe("passkey registration naming (default options)", async () => {
+	const { auth, client, cookieSetter, signInWithTestUser } =
+		await getTestInstance({ plugins: [passkey()] });
+
+	const register = async (opts: {
+		aaguid: string;
+		credentialID: string;
+		name?: string;
+	}) => {
+		const { headers } = await signInWithTestUser();
+		headers.set("origin", "http://localhost:3000");
+		serverMocks.verifyRegistrationResponse.mockResolvedValue(
+			buildRegistrationVerification(opts.aaguid, opts.credentialID),
+		);
+		await client.$fetch("/passkey/generate-register-options", {
+			method: "GET",
+			headers,
+			onResponse: cookieSetter(headers),
+		});
+		return auth.api.verifyPasskeyRegistration({
+			headers,
+			body: {
+				response: mockRegistrationResponse,
+				...(opts.name === undefined ? {} : { name: opts.name }),
+			},
+		});
+	};
+
+	afterEach(() => {
+		serverMocks.verifyRegistrationResponse.mockReset();
+	});
+
+	it("stores the trimmed client-provided name", async () => {
+		const record = await register({
+			aaguid: googleAaguid,
+			credentialID: "cred-explicit",
+			name: "  My Work Key  ",
+		});
+		expect(record.name).toBe("My Work Key");
+	});
+
+	it("stores no label for a whitespace-only name", async () => {
+		const record = await register({
+			aaguid: googleAaguid,
+			credentialID: "cred-whitespace",
+			name: "   ",
+		});
+		expect(record.name ?? null).toBeNull();
+	});
+
+	it("does not infer a label from the AAGUID, but persists the raw AAGUID", async () => {
+		const record = await register({
+			aaguid: googleAaguid,
+			credentialID: "cred-no-name",
+		});
+		expect(record.name ?? null).toBeNull();
+		expect(record.aaguid).toBe(googleAaguid);
+	});
+});
+
+describe("passkey registration naming (afterVerification fallback)", async () => {
+	const afterVerification = vi.fn(async () => ({ name: "My Provider" }));
+	const { auth, client, cookieSetter, signInWithTestUser } =
+		await getTestInstance({
+			plugins: [passkey({ registration: { afterVerification } })],
+		});
+
+	const register = async (opts: {
+		aaguid: string;
+		credentialID: string;
+		name?: string;
+	}) => {
+		const { headers } = await signInWithTestUser();
+		headers.set("origin", "http://localhost:3000");
+		serverMocks.verifyRegistrationResponse.mockResolvedValue(
+			buildRegistrationVerification(opts.aaguid, opts.credentialID),
+		);
+		await client.$fetch("/passkey/generate-register-options", {
+			method: "GET",
+			headers,
+			onResponse: cookieSetter(headers),
+		});
+		return auth.api.verifyPasskeyRegistration({
+			headers,
+			body: {
+				response: mockRegistrationResponse,
+				...(opts.name === undefined ? {} : { name: opts.name }),
+			},
+		});
+	};
+
+	afterEach(() => {
+		serverMocks.verifyRegistrationResponse.mockReset();
+	});
+
+	it("uses the returned name when the client provides none", async () => {
+		const record = await register({
+			aaguid: googleAaguid,
+			credentialID: "cred-fallback",
+		});
+		expect(record.name).toBe("My Provider");
+	});
+
+	it("falls back to the returned name when the client sends only whitespace", async () => {
+		const record = await register({
+			aaguid: googleAaguid,
+			credentialID: "cred-whitespace-fallback",
+			name: "   ",
+		});
+		expect(record.name).toBe("My Provider");
+	});
+
+	it("keeps the client-provided name over the returned one, but still runs the hook", async () => {
+		const record = await register({
+			aaguid: googleAaguid,
+			credentialID: "cred-precedence",
+			name: "Explicit Name",
+		});
+		expect(record.name).toBe("Explicit Name");
+		expect(afterVerification).toHaveBeenCalled();
 	});
 });
 

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -500,6 +500,7 @@ const verifyPasskeyRegistrationBodySchema = z.object({
 	response: z.any(),
 	name: z
 		.string()
+		.trim()
 		.meta({
 			description: "Name of the passkey",
 		})
@@ -610,6 +611,7 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) => {
 					displayName: userData.displayName,
 				};
 				let targetUserId = resolvedUser.id;
+				let resolvedName = ctx.body.name || undefined;
 				if (options.registration?.afterVerification) {
 					const result = await options.registration.afterVerification({
 						ctx,
@@ -633,10 +635,13 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) => {
 						}
 						targetUserId = result.userId;
 					}
+					if (!resolvedName) {
+						resolvedName = result?.name?.trim() || undefined;
+					}
 				}
 				const pubKey = base64.encode(credential.publicKey);
 				const newPasskey: Omit<Passkey, "id"> = {
-					name: ctx.body.name,
+					name: resolvedName,
 					userId: targetUserId,
 					credentialID: credential.id,
 					publicKey: pubKey,
@@ -988,7 +993,7 @@ const updatePassKeyBodySchema = z.object({
 	id: z.string().meta({
 		description: `The ID of the passkey which will be updated. Eg: \"passkey-id\"`,
 	}),
-	name: z.string().meta({
+	name: z.string().trim().min(1).meta({
 		description: `The new name which the passkey will be updated to. Eg: \"my-new-passkey-name\"`,
 	}),
 });

--- a/packages/passkey/src/types.ts
+++ b/packages/passkey/src/types.ts
@@ -56,7 +56,13 @@ export interface PasskeyRegistrationOptions {
 		| undefined;
 	/**
 	 * Callback after a successful registration verification.
-	 * Useful for user linking or auditing.
+	 * Useful for user linking, auditing, or labeling the passkey.
+	 *
+	 * Return `userId` to attribute the passkey to a different user. Return `name`
+	 * to set the stored label when the client did not provide one; the AAGUID is
+	 * available via `verification.registrationInfo?.aaguid`. A non-empty
+	 * client-supplied name always takes precedence over the returned `name`;
+	 * whitespace-only input is treated as absent.
 	 */
 	afterVerification?:
 		| ((args: {
@@ -65,7 +71,7 @@ export interface PasskeyRegistrationOptions {
 				user: PasskeyRegistrationUser;
 				clientData: RegistrationResponseJSON;
 				context?: string | null | undefined;
-		  }) => Awaitable<{ userId?: string } | void>)
+		  }) => Awaitable<{ userId?: string; name?: string } | void>)
 		| undefined;
 	/**
 	 * Optional WebAuthn extensions to include in registration options.


### PR DESCRIPTION
Passkeys registered without a name render blank in a user's passkey list. The authenticator's AAGUID is already stored on every passkey row and already returned by `listPasskeys`, so a friendly provider label ("1Password", "Google Password Manager") is a projection over data the client already has.

This supersedes #8725, which resolved that label at registration time and stored it in the `name` column. Baking a best-effort guess into `name` conflates two different things: the label a user chose, and a provider name the server inferred. It also freezes the guess, so existing rows never benefit when the lookup list improves, and `updatePasskey` can overwrite it with no way back. Here `name` stays pure user intent. The provider name is resolved at read time through an exported `getAuthenticatorName` helper and an extensible `commonAuthenticatorNames` map, with full coverage documented for consumers who need it. A server-side default folds into the existing `registration.afterVerification` seam, which can now return a `name`, instead of adding a parallel top-level option.

The built-in list is mirrored verbatim from the community AAGUID source and corrects two errors carried by #8725: one AAGUID was mislabeled Bitwarden when it is ToothPic, and a 1Password entry was included that the source does not list. Passkey names are now trimmed on registration and update.

Closes #8725

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve passkey provider labels from the stored AAGUID at read time to fix blank names in UIs, while keeping the `name` field user-provided only. Adds helpers, an optional server fallback, and stricter name handling.

- **New Features**
  - Export `getAuthenticatorName(aaguid)` and `commonAuthenticatorNames` from `@better-auth/passkey` for labels like "1Password" or "Google Password Manager".
  - Read-time resolution so existing passkeys benefit; the server does not infer or store a label from the AAGUID.
  - `registration.afterVerification` can return a trimmed `name` used when the client provides none or only whitespace; non-empty client names take precedence.
  - Trim passkey names on registration and update; reject whitespace-only on update (400).
  - Ignore the all-zero AAGUID when resolving names. The map is intentionally small, mirrors the community AAGUID source, and can be extended; docs include examples.

<sup>Written for commit 79cc5d787cc6fcba8d983e4682c8fbf70c43ab92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

