### PR TITLE
fix(kysely-adapter): use TOP instead of LIMIT for consumeOne on mssql

### DIFF
--- a/packages/kysely-adapter/src/kysely-adapter.test.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.test.ts
@@ -60,4 +60,47 @@ describe("kysely-adapter", () => {
 		);
 		expect(deleteQuery.returningAll).toHaveBeenCalledTimes(1);
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9903
+	 */
+	it("consumeOne uses TOP instead of LIMIT on mssql", async () => {
+		const selectQuery = {
+			select: vi.fn(() => selectQuery),
+			where: vi.fn(() => selectQuery),
+			limit: vi.fn(() => selectQuery),
+			top: vi.fn(() => selectQuery),
+		};
+		const deleted = {
+			id: "verification-1",
+			identifier: "same-identifier",
+			value: "first",
+		};
+		const deleteQuery = {
+			where: vi.fn(() => deleteQuery),
+			outputAll: vi.fn(() => deleteQuery),
+			executeTakeFirst: vi.fn().mockResolvedValue(deleted),
+		};
+		const db = {
+			selectFrom: vi.fn(() => selectQuery),
+			deleteFrom: vi.fn(() => deleteQuery),
+		} as any;
+		const adapter = kyselyAdapter(db, { type: "mssql" })({});
+
+		const result = await adapter.consumeOne({
+			model: "verification",
+			where: [{ field: "identifier", value: "same-identifier" }],
+		});
+
+		expect(result).toEqual(deleted);
+		// MSSQL has no LIMIT — the row-selection subquery must use TOP.
+		expect(selectQuery.top).toHaveBeenCalledWith(1);
+		expect(selectQuery.limit).not.toHaveBeenCalled();
+		expect(deleteQuery.where).toHaveBeenCalledWith(
+			"verification.id",
+			"in",
+			selectQuery,
+		);
+		expect(deleteQuery.outputAll).toHaveBeenCalledWith("deleted");
+	});
 });

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -805,9 +805,14 @@ export const kyselyAdapter = (
 							: db.transaction().execute(claimFromTransaction);
 					}
 
-					const targetIds = applyWhere(
+					const targetIdsQuery = applyWhere(
 						db.selectFrom(model).select(`${model}.${idField}`),
-					).limit(1);
+					);
+					// MSSQL does not support `LIMIT`; use `TOP` instead (mirrors `findMany`).
+					const targetIds =
+						config?.type === "mssql"
+							? targetIdsQuery.top(1)
+							: targetIdsQuery.limit(1);
 					const query = db
 						.deleteFrom(model)
 						.where(`${model}.${idField}`, "in", targetIds);


### PR DESCRIPTION
## Description

`consumeOne` (used by magic-link token consumption) builds its row-selection subquery with `.limit(1)` unconditionally:

```ts
const targetIds = applyWhere(
  db.selectFrom(model).select(`${model}.${idField}`),
).limit(1);
```

MSSQL does not support `LIMIT`, so on MSSQL this throws and magic-link verification is completely broken (#9903). The sibling `findMany` already handles this by branching to `.top()` for MSSQL — `consumeOne` was simply missing the same branch.

## Fix

Branch on the dialect and use `.top(1)` for MSSQL, `.limit(1)` otherwise, mirroring the existing `findMany` handling:

```ts
const targetIdsQuery = applyWhere(
  db.selectFrom(model).select(`${model}.${idField}`),
);
// MSSQL does not support `LIMIT`; use `TOP` instead (mirrors `findMany`).
const targetIds =
  config?.type === "mssql"
    ? targetIdsQuery.top(1)
    : targetIdsQuery.limit(1);
```

## Tests

Added `consumeOne uses TOP instead of LIMIT on mssql` to the existing `kysely-adapter.test.ts`. It mocks the query builder and asserts `consumeOne` calls `.top(1)` (and never `.limit`) when configured with `{ type: "mssql" }`. I verified the test fails on the previous code and passes with the fix. Existing tests still pass and `pnpm --filter @better-auth/kysely-adapter typecheck` is clean.

Fixes #9903


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes magic-link verification on MSSQL by using TOP instead of LIMIT in `consumeOne`’s subquery in `@better-auth/kysely-adapter` (#9903). Mirrors `findMany` behavior to prevent MSSQL query errors.

- **Bug Fixes**
  - Use `.top(1)` for `mssql`, `.limit(1)` otherwise.
  - Added test to assert `consumeOne` calls `.top(1)` (and not `.limit`) on MSSQL.

<sup>Written for commit 89e00e9423fd23463d978a60aa9272e498eb83af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

