### PR TITLE
feat(auth): add per-provider `requireEmailVerification` for social sign-in

### DIFF
--- a/.changeset/oauth-require-email-verification.md
+++ b/.changeset/oauth-require-email-verification.md
@@ -1,0 +1,8 @@
+---
+"better-auth": minor
+"@better-auth/core": minor
+---
+
+Add `requireEmailVerification` to OAuth provider options, for built-in social providers and the Generic OAuth plugin. When a provider reports an unverified email, the user and account are still created or linked, but no session is issued: the OAuth callback redirects with `?error=email_not_verified`, and ID token and One Tap sign-in return `403` `EMAIL_NOT_VERIFIED`. Verification emails follow the existing `emailVerification.sendOnSignUp` / `sendOnSignIn` settings.
+
+It is opt-in per provider and does not inherit `emailAndPassword.requireEmailVerification`, so existing social logins keep working. The gate checks the local user's verification state, so a user verified through another method keeps access. Only enable it for providers that report a trustworthy `email_verified` signal.

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -166,8 +166,10 @@ Once the user clicks on the link in the email, if the token is valid, the user w
 If you enable require email verification, users must verify their email before they can log in. And every time a user tries to sign in, sendVerificationEmail is called.
 
 <Callout>
-  This only works if you have sendVerificationEmail implemented and if the user
-  is trying to sign in with email and password.
+  For email and password sign-in, this only works if you have
+  sendVerificationEmail implemented. Social sign-in is not gated by this setting;
+  it has its own opt-in [per-provider
+  `requireEmailVerification`](/docs/concepts/oauth#requireemailverification).
 
   When `requireEmailVerification` is enabled, signing up with an existing email returns a success response instead of an error to prevent user enumeration.
 </Callout>

--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -497,6 +497,34 @@ A custom function to verify the ID token.
 
 A boolean value that determines whether to override the user information in the database when signing in. By default, it is set to `false`, meaning that the user information will not be overridden during sign-in. If you want to update the user information every time they sign in, set this to `true`.
 
+### requireEmailVerification
+
+Require this provider's email to be verified before a session is created. Defaults to `false`.
+
+When the provider reports the email as unverified, Better Auth still creates or links the user and account, but it does not issue a session. The OAuth callback redirects with `?error=email_not_verified`, and ID token sign-in returns a `403` with the `EMAIL_NOT_VERIFIED` error code. A verification email is (re)sent according to your `emailVerification` settings: `sendOnSignUp` covers new users and `sendOnSignIn` covers returning users. Configure `emailVerification.sendVerificationEmail` and keep `sendOnSignUp` enabled so blocked users always receive a link to verify.
+
+The gate checks the local user's verification state rather than the provider's claim on each request. A user already verified through another method (such as email and password) keeps access even if the provider later reports the email as unverified.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  socialProviders: {
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      requireEmailVerification: true,
+    },
+  },
+});
+```
+
+This is opt-in per provider and is independent of `emailAndPassword.requireEmailVerification`: enabling email and password verification does not gate social sign-in.
+
+<Callout type="warn">
+  Only enable this for providers that report a trustworthy `email_verified` signal. Several providers always report the email as unverified (or never return one), so enabling it there blocks every sign-in. See [Handling Providers Without Email](/docs/concepts/oauth#handling-providers-without-email).
+</Callout>
+
 ### mapProfileToUser
 
 A custom function to map the user profile returned from the provider to the user object in your database.

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -347,6 +347,7 @@ export const auth = betterAuth({
 * `disableSignUp`: Disable sign up for new users (optional)
 * `disableImplicitSignUp`: Disable implicit sign up for new users (optional)
 * `overrideUserInfoOnSignIn`: Override user info with provider user info on sign in (optional)
+* `requireEmailVerification`: Require this provider's email to be verified before a session is created. Opt-in per provider and independent of `emailAndPassword.requireEmailVerification`. Only enable it for providers that report a trustworthy `email_verified` signal (optional)
 * `prompt`: The prompt to use for the authorization code request (`"select_account"`, `"consent"`, `"login"`, `"none"`, `"select_account consent"`) (optional)
 * `responseMode`: The response mode to use (`"query"`, `"form_post"`) (optional)
 * `getUserInfo`: Custom function to get user info from the provider (optional)

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -13,7 +13,10 @@ import { getAwaitableValue } from "../../context/helpers";
 import { setSessionCookie } from "../../cookies";
 import { generateRandomString } from "../../crypto";
 import { parseUserOutput } from "../../db/schema";
-import { missingEmailLogMessage } from "../../oauth2/errors";
+import {
+	missingEmailLogMessage,
+	OAUTH_CALLBACK_ERROR_CODES,
+} from "../../oauth2/errors";
 import { signInWithOAuthIdentity } from "../../oauth2/sign-in-with-oauth-identity";
 import { generateState } from "../../utils";
 import { formCsrfMiddleware } from "../middlewares/origin-check";
@@ -345,6 +348,12 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 					sourceProfile: userInfo.data,
 				});
 				if (data.error) {
+					if (data.error === OAUTH_CALLBACK_ERROR_CODES.EMAIL_NOT_VERIFIED) {
+						throw APIError.from(
+							"FORBIDDEN",
+							BASE_ERROR_CODES.EMAIL_NOT_VERIFIED,
+						);
+					}
 					throw APIError.from("UNAUTHORIZED", {
 						message: data.error,
 						code: "OAUTH_LINK_ERROR",

--- a/packages/better-auth/src/oauth2/errors.ts
+++ b/packages/better-auth/src/oauth2/errors.ts
@@ -1,8 +1,10 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 
 /**
- * Error codes used in OAuth callback redirects (`?error=<code>`).
- * These are URL-safe strings, not API error objects.
+ * Error codes used in OAuth callback redirects (`?error=<code>`). These are
+ * URL-safe strings, not API error objects. Some also serve as the OAuth seam's
+ * machine-readable `result.error` value, which non-redirect callers (e.g.
+ * id-token sign-in) remap to an API error code.
  */
 export const OAUTH_CALLBACK_ERROR_CODES = {
 	NO_CODE: "no_code",
@@ -17,6 +19,7 @@ export const OAUTH_CALLBACK_ERROR_CODES = {
 	ACCOUNT_ALREADY_LINKED_TO_DIFFERENT_USER:
 		"account_already_linked_to_different_user",
 	EMAIL_NOT_FOUND: "email_not_found",
+	EMAIL_NOT_VERIFIED: "email_not_verified",
 } as const;
 
 const HANDLING_DOCS_URL =

--- a/packages/better-auth/src/oauth2/sign-in-with-oauth-identity.test.ts
+++ b/packages/better-auth/src/oauth2/sign-in-with-oauth-identity.test.ts
@@ -13,6 +13,7 @@ import {
 	it,
 	vi,
 } from "vitest";
+import { parseSetCookieHeader } from "../cookies";
 import { signJWT } from "../crypto";
 import { getTestInstance } from "../test-utils/test-instance";
 import type { User } from "../types";
@@ -1848,5 +1849,246 @@ describe("oauth2 - provider identity is not linkable across users", async () => 
 			"google",
 		);
 		expect(linked?.userId).toBe(userA.userId);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9486
+ */
+describe("oauth2 - per-provider requireEmailVerification gate", async () => {
+	async function setup(config: {
+		requireEmailVerification?: boolean | undefined;
+		emailPasswordRequireEmailVerification?: boolean | undefined;
+		sendOnSignUp?: boolean | undefined;
+		sendOnSignIn?: boolean | undefined;
+		withoutSendVerificationEmail?: boolean | undefined;
+	}) {
+		const sendVerificationEmail = vi.fn(async () => {});
+		const { auth, client, cookieSetter } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+						enabled: true,
+						requireEmailVerification: config.requireEmailVerification,
+					},
+				},
+				emailAndPassword: {
+					enabled: true,
+					requireEmailVerification:
+						config.emailPasswordRequireEmailVerification,
+				},
+				emailVerification: {
+					sendOnSignUp: config.sendOnSignUp,
+					sendOnSignIn: config.sendOnSignIn,
+					sendVerificationEmail: config.withoutSendVerificationEmail
+						? undefined
+						: sendVerificationEmail,
+				},
+			},
+			{ disableTestUser: true },
+		);
+		const ctx = await auth.$context;
+
+		async function signInViaCallback(profile: {
+			email: string;
+			email_verified: boolean;
+			sub: string;
+		}) {
+			server.use(
+				http.post("https://oauth2.googleapis.com/token", async () => {
+					const idToken = await signJWT(
+						{
+							email: profile.email,
+							email_verified: profile.email_verified,
+							name: "OAuth User",
+							sub: profile.sub,
+							iat: 1234567890,
+							exp: 1234567890,
+							aud: "test",
+							iss: "test",
+						},
+						DEFAULT_SECRET,
+					);
+					return HttpResponse.json({
+						access_token: "test_access_token",
+						refresh_token: "test_refresh_token",
+						id_token: idToken,
+					});
+				}),
+			);
+			const headers = new Headers();
+			const signInRes = await client.signIn.social({
+				provider: "google",
+				callbackURL: "/dashboard",
+				newUserCallbackURL: "/welcome",
+				fetchOptions: { onSuccess: cookieSetter(headers) },
+			});
+			const state =
+				new URL(signInRes.data!.url!).searchParams.get("state") || "";
+			let redirectLocation = "";
+			let setCookie = "";
+			await client.$fetch("/callback/google", {
+				query: { state, code: "test_code" },
+				method: "GET",
+				headers,
+				onError(context) {
+					expect(context.response.status).toBe(302);
+					redirectLocation = context.response.headers.get("location") || "";
+					setCookie = context.response.headers.get("set-cookie") || "";
+				},
+			});
+			return { redirectLocation, setCookie };
+		}
+
+		return { ctx, signInViaCallback, sendVerificationEmail };
+	}
+
+	function sessionToken(setCookie: string) {
+		return parseSetCookieHeader(setCookie).get("better-auth.session_token")
+			?.value;
+	}
+
+	it("blocks the session for a new user whose provider email is unverified", async () => {
+		// No sendOnSignUp: the send is driven by requireEmailVerification (the
+		// credential sign-up rule), so a blocked new user still receives a link.
+		const { ctx, signInViaCallback, sendVerificationEmail } = await setup({
+			requireEmailVerification: true,
+		});
+		const email = "gate-new-unverified@example.com";
+
+		const { redirectLocation, setCookie } = await signInViaCallback({
+			email,
+			email_verified: false,
+			sub: "gate_new_unverified",
+		});
+
+		expect(redirectLocation).toContain("error=email_not_verified");
+		expect(sessionToken(setCookie)).toBeUndefined();
+		expect(sendVerificationEmail).toHaveBeenCalledTimes(1);
+
+		// The user and account are still created; only the session is withheld.
+		const user = await ctx.adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: email }],
+		});
+		expect(user?.emailVerified).toBe(false);
+	});
+
+	it("creates a session for a new user whose provider email is verified", async () => {
+		const { signInViaCallback, sendVerificationEmail } = await setup({
+			requireEmailVerification: true,
+			sendOnSignUp: true,
+		});
+
+		const { redirectLocation, setCookie } = await signInViaCallback({
+			email: "gate-new-verified@example.com",
+			email_verified: true,
+			sub: "gate_new_verified",
+		});
+
+		expect(redirectLocation).toContain("/welcome");
+		expect(redirectLocation).not.toContain("error");
+		expect(sessionToken(setCookie)).toBeDefined();
+		expect(sendVerificationEmail).not.toHaveBeenCalled();
+	});
+
+	it("re-sends and blocks a returning unverified user when sendOnSignIn is set", async () => {
+		const { signInViaCallback, sendVerificationEmail } = await setup({
+			requireEmailVerification: true,
+			sendOnSignIn: true,
+		});
+		const profile = {
+			email: "gate-returning@example.com",
+			email_verified: false,
+			sub: "gate_returning",
+		};
+
+		// The first sign-in creates the user and account, then blocks the session.
+		await signInViaCallback(profile);
+		sendVerificationEmail.mockClear();
+
+		// The returning sign-in is blocked again and re-sends the email.
+		const { redirectLocation, setCookie } = await signInViaCallback(profile);
+
+		expect(redirectLocation).toContain("error=email_not_verified");
+		expect(sessionToken(setCookie)).toBeUndefined();
+		expect(sendVerificationEmail).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not gate social sign-in from emailAndPassword.requireEmailVerification", async () => {
+		// Only the credential flag is on; the provider opted out, so social
+		// sign-in must still succeed for an unverified provider email.
+		const { signInViaCallback } = await setup({
+			emailPasswordRequireEmailVerification: true,
+		});
+
+		const { redirectLocation, setCookie } = await signInViaCallback({
+			email: "gate-optin-only@example.com",
+			email_verified: false,
+			sub: "gate_optin_only",
+		});
+
+		expect(redirectLocation).not.toContain("error");
+		expect(sessionToken(setCookie)).toBeDefined();
+	});
+
+	it("lets a returning verified user through the gate without re-sending", async () => {
+		const { signInViaCallback, sendVerificationEmail } = await setup({
+			requireEmailVerification: true,
+			sendOnSignIn: true,
+		});
+		const profile = {
+			email: "gate-returning-verified@example.com",
+			email_verified: true,
+			sub: "gate_returning_verified",
+		};
+
+		// First sign-in creates the user and issues a session (verified).
+		const first = await signInViaCallback(profile);
+		expect(sessionToken(first.setCookie)).toBeDefined();
+
+		// The returning, already-verified user still gets a session and no email.
+		const { redirectLocation, setCookie } = await signInViaCallback(profile);
+		expect(redirectLocation).toContain("/dashboard");
+		expect(redirectLocation).not.toContain("error");
+		expect(sessionToken(setCookie)).toBeDefined();
+		expect(sendVerificationEmail).not.toHaveBeenCalled();
+	});
+
+	it("blocks a returning unverified user without re-sending when sendOnSignIn is unset", async () => {
+		const { signInViaCallback, sendVerificationEmail } = await setup({
+			requireEmailVerification: true,
+		});
+		const profile = {
+			email: "gate-returning-no-resend@example.com",
+			email_verified: false,
+			sub: "gate_returning_no_resend",
+		};
+
+		await signInViaCallback(profile);
+		sendVerificationEmail.mockClear();
+
+		const { redirectLocation, setCookie } = await signInViaCallback(profile);
+		expect(redirectLocation).toContain("error=email_not_verified");
+		expect(sessionToken(setCookie)).toBeUndefined();
+		expect(sendVerificationEmail).not.toHaveBeenCalled();
+	});
+
+	it("blocks an unverified user even when no sendVerificationEmail is configured", async () => {
+		const { signInViaCallback } = await setup({
+			requireEmailVerification: true,
+			withoutSendVerificationEmail: true,
+		});
+
+		const { redirectLocation, setCookie } = await signInViaCallback({
+			email: "gate-no-send@example.com",
+			email_verified: false,
+			sub: "gate_no_send",
+		});
+
+		expect(redirectLocation).toContain("error=email_not_verified");
+		expect(sessionToken(setCookie)).toBeUndefined();
 	});
 });

--- a/packages/better-auth/src/oauth2/sign-in-with-oauth-identity.test.ts
+++ b/packages/better-auth/src/oauth2/sign-in-with-oauth-identity.test.ts
@@ -2025,9 +2025,9 @@ describe("oauth2 - per-provider requireEmailVerification gate", async () => {
 		});
 
 		const { redirectLocation, setCookie } = await signInViaCallback({
-			email: "gate-optin-only@example.com",
+			email: "gate-credential-only@example.com",
 			email_verified: false,
-			sub: "gate_optin_only",
+			sub: "gate_credential_only",
 		});
 
 		expect(redirectLocation).not.toContain("error");

--- a/packages/better-auth/src/oauth2/sign-in-with-oauth-identity.ts
+++ b/packages/better-auth/src/oauth2/sign-in-with-oauth-identity.ts
@@ -8,6 +8,7 @@ import { createEmailVerificationToken } from "../api";
 import type { User } from "../types";
 import { isAPIError } from "../utils/is-api-error";
 import { assertValidUserInfo } from "../utils/validate-user-info";
+import { OAUTH_CALLBACK_ERROR_CODES } from "./errors";
 import { persistOAuthAccount } from "./persist-account";
 import type {
 	ResolvedOAuthUser,
@@ -23,6 +24,12 @@ import { resolveOAuthUser } from "./resolve-account";
  * persist the provider account's tokens and granted scopes through the single
  * write seam, then issue a session and (for a brand-new user) the
  * verification email.
+ *
+ * When the provider opts into `requireEmailVerification` and the local email is
+ * still unverified, no session is issued: the user/account are persisted but the
+ * result carries `EMAIL_NOT_VERIFIED` (the callback redirects with
+ * `?error=email_not_verified`, the id-token path returns `403`), and the
+ * verification email is (re)sent per `sendOnSignUp` / `sendOnSignIn`.
  *
  * Composes {@link resolveOAuthUser} (identity + linking policy) and
  * {@link persistOAuthAccount} (token encryption + grant accumulation), so no
@@ -143,8 +150,41 @@ export async function signInWithOAuthIdentity(
 
 	const { user } = resolved;
 
-	if (isRegister) {
-		await sendSignUpVerificationEmail(c, user, callbackURL);
+	// Read the provider's verification policy from the resolved provider list, not
+	// from `opts`, so the callback, id-token, and oauth-proxy callers all enforce
+	// it without each having to thread the flag.
+	const requireEmailVerification = c.context.socialProviders.find(
+		(p) => p.id === providerId,
+	)?.options?.requireEmailVerification;
+
+	// A brand-new user whose provider email is unverified is sent a verification
+	// email. Mirrors the credential sign-up rule (`sendOnSignUp`, otherwise the
+	// provider's `requireEmailVerification`), so a user the gate is about to block
+	// can still verify and recover.
+	if (
+		isRegister &&
+		!user.emailVerified &&
+		(c.context.options.emailVerification?.sendOnSignUp ??
+			requireEmailVerification)
+	) {
+		await dispatchVerificationEmail(c, user, callbackURL);
+	}
+
+	// Per-provider email-verification gate: when this provider requires a verified
+	// email and the local row is still unverified, the user/account are already
+	// created or linked, but no session is issued. Opt-in per provider and
+	// independent of `emailAndPassword.requireEmailVerification`.
+	if (requireEmailVerification && !user.emailVerified) {
+		// Returning unverified users get a fresh verification email when the app
+		// opted into sign-in sends; brand-new users already received one above.
+		if (!isRegister && c.context.options.emailVerification?.sendOnSignIn) {
+			await dispatchVerificationEmail(c, user, callbackURL);
+		}
+		return {
+			error: OAUTH_CALLBACK_ERROR_CODES.EMAIL_NOT_VERIFIED,
+			data: null,
+			isRegister,
+		};
 	}
 
 	const session = await c.context.internalAdapter.createSession(user.id);
@@ -167,37 +207,33 @@ export async function signInWithOAuthIdentity(
 }
 
 /**
- * Fire the sign-up verification email when the provider did not vouch for the
- * email and the option is enabled. Runs in the background; a failure must not
- * abort the sign-in.
+ * Mint a verification token and dispatch the verification email in the
+ * background. The user and account are already committed by the time this runs,
+ * so a token-mint or send failure must not abort the sign-in. Callers decide
+ * *when* to send (`sendOnSignUp` / `sendOnSignIn`); this owns the token and URL.
  */
-async function sendSignUpVerificationEmail(
+async function dispatchVerificationEmail(
 	c: GenericEndpointContext,
 	user: User,
 	callbackURL: string | undefined,
 ) {
-	if (
-		user.emailVerified ||
-		!c.context.options.emailVerification?.sendOnSignUp ||
-		!c.context.options.emailVerification?.sendVerificationEmail
-	) {
+	const sendVerificationEmail =
+		c.context.options.emailVerification?.sendVerificationEmail;
+	if (!sendVerificationEmail) {
 		return;
 	}
-	// The user and account are already committed by the time this runs, so a
-	// verification-email failure (token mint or send) must not abort the
-	// sign-in. Token creation is awaited inline, so guard the whole block.
 	try {
 		const token = await createEmailVerificationToken(
 			c.context.secret,
 			user.email,
 			undefined,
-			c.context.options.emailVerification.expiresIn,
+			c.context.options.emailVerification?.expiresIn,
 		);
 		const url = `${c.context.baseURL}/verify-email?token=${token}&callbackURL=${encodeURIComponent(
 			callbackURL || "/",
 		)}`;
 		await c.context.runInBackgroundOrAwait(
-			c.context.options.emailVerification.sendVerificationEmail(
+			sendVerificationEmail(
 				{
 					user,
 					url,
@@ -207,6 +243,6 @@ async function sendSignUpVerificationEmail(
 			),
 		);
 	} catch (e) {
-		c.context.logger.error("Failed to send sign-up verification email", e);
+		c.context.logger.error("Failed to send OAuth verification email", e);
 	}
 }

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -835,6 +835,61 @@ describe("oauth2", async () => {
 		);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9486
+	 */
+	it("blocks the session with error=email_not_verified when requireEmailVerification is set", async () => {
+		const { customFetchImpl, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "test-require-verify",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId,
+							clientSecret,
+							pkce: true,
+							requireEmailVerification: true,
+						},
+					],
+				}),
+			],
+		});
+		const authClient = createAuthClient({
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				email: "generic-unverified@test.com",
+				name: "Generic Unverified",
+				sub: "generic-unverified",
+				email_verified: false,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const headers = new Headers();
+		const res = await authClient.signIn.social({
+			provider: "test-require-verify",
+			callbackURL: "http://localhost:3000/dashboard",
+			errorCallbackURL: "http://localhost:3000/error",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+		const { callbackURL, setCookieHeader } = await simulateOAuthFlow(
+			res.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+		expect(callbackURL).toContain("error=email_not_verified");
+		expect(setCookieHeader).not.toContain("better-auth.session_token=");
+	});
+
 	it("should create user when sign ups are disabled and sign up is requested", async () => {
 		server.service.once("beforeUserinfo", (userInfoResponse) => {
 			userInfoResponse.body = {

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -379,6 +379,7 @@ export const genericOAuth = <const ID extends string>(
 					options: {
 						disableSignUp: c.disableSignUp,
 						overrideUserInfoOnSignIn: c.overrideUserInfo,
+						requireEmailVerification: c.requireEmailVerification,
 					},
 				} satisfies UpstreamProvider);
 			}

--- a/packages/better-auth/src/plugins/generic-oauth/types.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/types.ts
@@ -188,6 +188,19 @@ export interface GenericOAuthConfig<ID extends string = string> {
 	 */
 	overrideUserInfo?: boolean | undefined;
 	/**
+	 * Require this provider's email to be verified before a session is created.
+	 *
+	 * When the provider reports the email as unverified, the user and account are
+	 * still created or linked, but no session is issued: the callback redirects
+	 * with `?error=email_not_verified`. The gate checks the local user's
+	 * verification state, so a user already verified through another method keeps
+	 * access. Only enable it for providers that report a trustworthy
+	 * `email_verified` signal.
+	 *
+	 * @default false
+	 */
+	requireEmailVerification?: boolean | undefined;
+	/**
 	 * Accept callbacks from providers that initiate the OAuth flow without
 	 * sending a `state` parameter (e.g. Clever). When enabled, stateless
 	 * callbacks restart the OAuth flow server-side with a fresh `state` and

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -1,10 +1,12 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
+import { BASE_ERROR_CODES } from "@better-auth/core/error";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import * as z from "zod";
 import { APIError } from "../../api";
 import { setSessionCookie } from "../../cookies";
 import { parseUserOutput } from "../../db/schema";
+import { OAUTH_CALLBACK_ERROR_CODES } from "../../oauth2/errors";
 import { signInWithOAuthIdentity } from "../../oauth2/sign-in-with-oauth-identity";
 import { toBoolean } from "../../utils/boolean";
 import { PACKAGE_VERSION } from "../../version";
@@ -143,6 +145,14 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 						sourceProfile: payload as Record<string, unknown>,
 					});
 					if (result.error) {
+						if (
+							result.error === OAUTH_CALLBACK_ERROR_CODES.EMAIL_NOT_VERIFIED
+						) {
+							throw APIError.from(
+								"FORBIDDEN",
+								BASE_ERROR_CODES.EMAIL_NOT_VERIFIED,
+							);
+						}
 						throw new APIError("UNAUTHORIZED", {
 							message: result.error,
 						});

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -162,6 +162,39 @@ describe("one-tap implicit linking gate", async () => {
 	});
 
 	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9486
+	 */
+	it("returns 403 EMAIL_NOT_VERIFIED when the provider requires a verified email", async () => {
+		verifiedPayload.email = "one-tap-unverified@example.com";
+		verifiedPayload.email_verified = false;
+		verifiedPayload.sub = "one_tap_unverified_sub";
+
+		const { client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+					requireEmailVerification: true,
+				},
+			},
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		// 403 distinguishes the mapped EMAIL_NOT_VERIFIED gate from the generic
+		// 401 the unverified-linking path returns.
+		expect(res.error?.status).toBe(403);
+	});
+
+	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9502
 	 */
 	it("links Google One Tap when another provider has the same account ID", async () => {

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -1222,6 +1222,51 @@ describe("Google Provider — multiple client IDs", async () => {
 
 		expect(res.error?.status).toBe(500);
 	});
+
+	it("returns 403 EMAIL_NOT_VERIFIED for an unverified id token when the provider requires verification", async () => {
+		const idToken = await new SignJWT({
+			email: "mobile-unverified@example.com",
+			email_verified: false,
+			name: "Mobile Unverified",
+			sub: "google-sub-unverified",
+		})
+			.setProtectedHeader({ alg: "RS256", kid: googleKid })
+			.setIssuedAt()
+			.setIssuer("https://accounts.google.com")
+			.setAudience(webClientId)
+			.setExpirationTime("1h")
+			.sign(googleKeyPair.privateKey);
+		const { client, auth } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: [webClientId, iosClientId, androidClientId],
+						clientSecret: "test-secret",
+						requireEmailVerification: true,
+					},
+				},
+				emailAndPassword: { enabled: true, requireEmailVerification: false },
+			},
+			{ disableTestUser: true },
+		);
+
+		const res = await client.signIn.social({
+			provider: "google",
+			idToken: { token: idToken },
+		});
+
+		expect(res.error?.status).toBe(403);
+		expect(res.error?.code).toBe("EMAIL_NOT_VERIFIED");
+		expect(res.data).toBeNull();
+
+		// The user is still created; only the session is withheld.
+		const ctx = await auth.$context;
+		const user = await ctx.adapter.findOne<{ emailVerified: boolean }>({
+			model: "user",
+			where: [{ field: "email", value: "mobile-unverified@example.com" }],
+		});
+		expect(user?.emailVerified).toBe(false);
+	});
 });
 
 /**

--- a/packages/core/src/oauth2/oauth-provider.ts
+++ b/packages/core/src/oauth2/oauth-provider.ts
@@ -343,4 +343,27 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 	 * @default false
 	 */
 	overrideUserInfoOnSignIn?: boolean | undefined;
+	/**
+	 * Require this provider's email to be verified before a session is created.
+	 *
+	 * When the provider reports the email as unverified, the user and account are
+	 * still created/linked, but no session is issued: the OAuth callback redirects
+	 * with `?error=email_not_verified` and id-token sign-in returns a `403`
+	 * `EMAIL_NOT_VERIFIED`. A verification email is (re)sent per the
+	 * `emailVerification` settings (`sendOnSignUp` / `sendOnSignIn`).
+	 *
+	 * The gate checks the local user's verification state, not the provider's
+	 * claim on each request: a user already verified through another method (or a
+	 * prior verified sign-in) keeps access even if the provider later reports the
+	 * email as unverified.
+	 *
+	 * This is opt-in per provider and is independent of
+	 * `emailAndPassword.requireEmailVerification`; enabling that does not gate
+	 * social sign-in. Only enable it for providers that report a trustworthy
+	 * `email_verified` signal: several providers always report the email as
+	 * unverified, which would block every sign-in.
+	 *
+	 * @default false
+	 */
+	requireEmailVerification?: boolean | undefined;
 };


### PR DESCRIPTION
Adds an opt-in, per-provider `requireEmailVerification` for social and OAuth sign-in, so a provider's unverified email no longer silently yields a session.

Supersedes #9536, which answered the same request but cannot be continued. That branch was built on `handleOAuthUserInfo`, and `next` has since refactored that layer into `signInWithOAuthIdentity`, so the branch is structurally (not just textually) conflicting. This re-implements the feature on the current seam, with a deliberately different shape.

The flag lives per provider in `ProviderOptions`, not as a global key inside the `socialProviders` map. That keeps the map a clean provider-id map and avoids special-casing a non-provider key in every consumer that iterates it: context resolution, telemetry, SCIM, the CLI. It is strictly opt-in, with no inheritance from `emailAndPassword.requireEmailVerification`. A fallback there would silently start blocking working social logins on existing deployments, and would permanently lock out the providers that never report `email_verified`.

Enforcement lives in the shared sign-in seam rather than being threaded through each route, so the callback, id-token, OAuth proxy, and One Tap paths all honor it by construction. The unverified result is a typed code shared by the producer and both consumers, not a matched string.

Closes #9536
Closes #9486
