### PR TITLE
feat(oauth): server-trusted state channel; fix anonymous cookieless linking

### DIFF
--- a/.changeset/anonymous-oauth-server-context.md
+++ b/.changeset/anonymous-oauth-server-context.md
@@ -1,0 +1,11 @@
+---
+"better-auth": minor
+"@better-auth/oauth-provider": patch
+"@better-auth/sso": patch
+---
+
+Anonymous account linking now works after social and generic OAuth sign-in in Expo and other in-app browsers, where the OAuth callback returns without the session cookie. `onLinkAccount` fires and the anonymous user is migrated; before, it was silently skipped.
+
+Plugins can now carry server-trusted data across an OAuth redirect with the new `addOAuthServerContext` API, read back on the callback via `getOAuthState().serverContext`. Unlike `additionalData`, it cannot be set from the request body, so it is the right place for values the server must trust.
+
+For `@better-auth/oauth-provider`, the post-login authorization query now travels through that server-only channel, so it can no longer be injected through `additionalData`.

--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -266,51 +266,46 @@ Example using an after hook:
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
-import { getOAuthState } from "better-auth/api";
+import { createAuthMiddleware, getOAuthState } from "better-auth/api";
 
 export const auth = betterAuth({
   // Other configurations...
   hooks: {
-    after: [
-      {
-        matcher: () => true,
-        handler: async (ctx) => {
-          // Additional data is only available during OAuth callback
-          if (ctx.path === "/callback/:id") {
-            const additionalData = await getOAuthState<{
-              referralCode?: string;
-              source?: string;
-            }>();
+    after: createAuthMiddleware(async (ctx) => {
+      // Additional data is only available during OAuth callback
+      if (ctx.path === "/callback/:id") {
+        const additionalData = await getOAuthState<{
+          referralCode?: string;
+          source?: string;
+        }>();
 
-            if (additionalData) {
-              // IMPORTANT: Validate and sanitize the data before using it
-              // This data comes from the client and should not be trusted
+        if (additionalData) {
+          // IMPORTANT: Validate and sanitize the data before using it
+          // This data comes from the client and should not be trusted
 
-              // Example: Validate and process referral code
-              if (additionalData.referralCode) {
-                const isValidFormat = /^[A-Z0-9]{6}$/.test(additionalData.referralCode);
-                if (isValidFormat) {
-                  // Verify the referral code exists in your database
-                  const referral = await db.referrals.findByCode(additionalData.referralCode);
-                  if (referral) {
-                    // Safe to use the verified referral
-                    await db.referrals.incrementUsage(referral.id);
-                  }
-                }
-              }
-
-              // Track analytics (low-risk usage)
-              if (additionalData.source) {
-                await analytics.track("oauth_signin", {
-                  source: additionalData.source,
-                  userId: ctx.context.session?.user.id,
-                });
+          // Example: Validate and process referral code
+          if (additionalData.referralCode) {
+            const isValidFormat = /^[A-Z0-9]{6}$/.test(additionalData.referralCode);
+            if (isValidFormat) {
+              // Verify the referral code exists in your database
+              const referral = await db.referrals.findByCode(additionalData.referralCode);
+              if (referral) {
+                // Safe to use the verified referral
+                await db.referrals.incrementUsage(referral.id);
               }
             }
           }
-        },
-      },
-    ],
+
+          // Track analytics (low-risk usage)
+          if (additionalData.source) {
+            await analytics.track("oauth_signin", {
+              source: additionalData.source,
+              userId: ctx.context.session?.user.id,
+            });
+          }
+        }
+      }
+    }),
   },
 });
 ```
@@ -349,8 +344,40 @@ Example using a database hook:
   * `link` - the link for the OAuth flow (email and user id)
   * `requestSignUp` - whether to request sign up for the OAuth flow
   * `expiresAt` - the expiration time of the OAuth state
-  * `[key: string]`: any additional data you pass in the OAuth flow
+  * `serverContext` - server-set values that survive the redirect (see [Passing Server-Trusted Data](#passing-server-trusted-data))
+  * `[key: string]` - the `additionalData` you passed in. This originates from the client, so treat it as untrusted.
 </Callout>
+
+#### Passing Server-Trusted Data
+
+`additionalData` is client-supplied, so it must be validated before use on the callback. When a plugin (or your own `before` hook) needs to carry server-derived data across the redirect, use `addOAuthServerContext`. It writes to a server-only slot that the client cannot populate, and the values are readable on the callback under `serverContext`.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import {
+  addOAuthServerContext,
+  createAuthMiddleware,
+  getOAuthState,
+} from "better-auth/api";
+
+export const auth = betterAuth({
+  hooks: {
+    before: createAuthMiddleware(async (ctx) => {
+      // Social and generic OAuth providers both sign in here.
+      if (ctx.path === "/sign-in/social") {
+        // Derived on the server, so it is safe to trust on the callback.
+        await addOAuthServerContext({ tenantId: ctx.context.tenantId });
+      }
+    }),
+    after: createAuthMiddleware(async (ctx) => {
+      if (ctx.path === "/callback/:id") {
+        const tenantId = (await getOAuthState())?.serverContext?.tenantId;
+        // Safe to use without re-validation: the client could not set this.
+      }
+    }),
+  },
+});
+```
 
 ## Handling Providers Without Email
 

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -73,6 +73,8 @@ await authClient.signIn.social({
 
 The `scopes` parameter is additive: appended to the provider's configured scopes, not a replacement. Whatever the user consents to accumulates into the account's `grantedScopes`. Re-authenticating never narrows previously granted scopes.
 
+You can also pass `additionalData` (a `Record<string, any>`) to round-trip client data through the flow; read it back on the callback with `getOAuthState()` and treat it as untrusted. See [Passing Additional Data Through OAuth Flow](/docs/concepts/oauth#passing-additional-data-through-oauth-flow).
+
 ### Link Account
 
 ```ts

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -413,7 +413,7 @@ export { getIp } from "../utils/get-request-ip";
 export { isAPIError } from "../utils/is-api-error";
 export * from "./middlewares";
 export * from "./routes";
-export { getOAuthState } from "./state/oauth";
+export { addOAuthServerContext, getOAuthState } from "./state/oauth";
 export {
 	getShouldSkipSessionRefresh,
 	setShouldSkipSessionRefresh,

--- a/packages/better-auth/src/api/state/oauth.ts
+++ b/packages/better-auth/src/api/state/oauth.ts
@@ -11,15 +11,66 @@ type OAuthState = {
 	};
 	expiresAt: number;
 	requestSignUp?: boolean;
+	/**
+	 * Server-controlled values that ride the OAuth state across the provider
+	 * redirect. Nothing here is reachable from the request body: plugins write it
+	 * with `addOAuthServerContext` and read it back on the callback. Use this for
+	 * data the server must trust (identity, flow continuation), unlike the
+	 * top-level `additionalData` keys below.
+	 */
+	serverContext?: Record<string, unknown>;
+	/**
+	 * Client-supplied `additionalData` is spread onto the top level. Treat every
+	 * key here as untrusted input: it originates from the request body.
+	 */
 	[key: string]: any;
 };
 
-const {
-	get: getOAuthState,
-	/**
-	 * @internal This is unsafe to be used directly. Use setOAuthState instead.
-	 */
-	set: setOAuthState,
-} = defineRequestState<OAuthState | null>(() => null);
+const { get: getRawOAuthState, set: setOAuthState } =
+	defineRequestState<OAuthState | null>(() => null);
 
-export { getOAuthState, setOAuthState };
+/**
+ * Reads the OAuth state for the current request. During a callback it holds the
+ * state parsed from the provider redirect; during sign-in it holds the state
+ * just generated.
+ *
+ * Top-level keys beyond the documented fields are client-supplied
+ * (`additionalData`) and must not be trusted. Server-trusted values live under
+ * {@link OAuthState.serverContext}.
+ */
+const getOAuthState = async <
+	T extends Record<string, unknown> = Record<string, unknown>,
+>(): Promise<(OAuthState & T) | null> => {
+	return (await getRawOAuthState()) as (OAuthState & T) | null;
+};
+
+/**
+ * @internal Read accumulated server context to embed during state generation.
+ */
+const { get: getOAuthServerContext, set: setOAuthServerContext } =
+	defineRequestState<Record<string, unknown> | null>(() => null);
+
+/**
+ * Attaches server-trusted data to the current OAuth flow so it survives the
+ * provider redirect. Call this from a `before` hook on an OAuth sign-in path
+ * (for example `/sign-in/social` or `/sign-in/oauth2`). `generateState` embeds
+ * the accumulated values into the state, and they become readable on the
+ * callback via `getOAuthState().serverContext`.
+ *
+ * Unlike the request body's `additionalData`, values set here cannot be spoofed
+ * by the client. Multiple callers merge: each call adds its own keys. Values are
+ * stored as `unknown`, so narrow their shape when reading them back.
+ */
+const addOAuthServerContext = async (
+	values: Record<string, unknown>,
+): Promise<void> => {
+	const current = await getOAuthServerContext();
+	await setOAuthServerContext({ ...(current ?? {}), ...values });
+};
+
+export {
+	getOAuthState,
+	setOAuthState,
+	addOAuthServerContext,
+	getOAuthServerContext,
+};

--- a/packages/better-auth/src/oauth2/state.ts
+++ b/packages/better-auth/src/oauth2/state.ts
@@ -1,6 +1,6 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
-import { setOAuthState } from "../api/state/oauth";
+import { getOAuthServerContext, setOAuthState } from "../api/state/oauth";
 import { generateRandomString } from "../crypto";
 import type { StateData } from "../state";
 import { generateGenericState, parseGenericState, StateError } from "../state";
@@ -42,6 +42,12 @@ export async function generateState(
 
 	const codeVerifier = options?.codeVerifier ?? generateRandomString(128);
 
+	const pendingServerContext = await getOAuthServerContext();
+	const serverContext =
+		pendingServerContext && Object.keys(pendingServerContext).length
+			? pendingServerContext
+			: undefined;
+
 	const stateData: StateData = {
 		...(options?.additionalData ? options.additionalData : {}),
 		callbackURL,
@@ -49,6 +55,9 @@ export async function generateState(
 		errorURL: c.body?.errorCallbackURL,
 		newUserURL: c.body?.newUserCallbackURL,
 		link: options?.link,
+		// Assigned after the client-controlled `additionalData` spread so a client
+		// cannot smuggle a `serverContext` of its own through the request body.
+		serverContext,
 		expiresAt: Date.now() + 10 * 60 * 1000,
 		requestSignUp: c.body?.requestSignUp,
 		requestedScopes: options?.requestedScopes,

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -1,6 +1,8 @@
 import type { GoogleProfile } from "@better-auth/core/social-providers";
+import { betterFetch } from "@better-fetch/fetch";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
+import { OAuth2Server } from "oauth2-mock-server";
 import {
 	afterAll,
 	afterEach,
@@ -14,8 +16,31 @@ import * as apiModule from "../../api";
 import { signJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../../utils/constants";
+import { genericOAuth } from "../generic-oauth";
 import { anonymous } from ".";
 import { anonymousClient } from "./client";
+
+/**
+ * Drops the session cookie while keeping every other cookie (notably the OAuth
+ * `state` cookie). This reproduces the callback an Expo in-app browser makes:
+ * it carries the state cookie forwarded by the auth proxy but never the
+ * `httpOnly` session cookie, which was set on the originating app request.
+ */
+function stripSessionCookie(
+	headers: Headers,
+	sessionCookiePrefix = "better-auth.session_token",
+): Headers {
+	const result = new Headers(headers);
+	const kept = (headers.get("cookie") ?? "")
+		.split(";")
+		.map((part) => part.trim())
+		.filter((part) => part && !part.startsWith(sessionCookiePrefix));
+	result.delete("cookie");
+	if (kept.length) {
+		result.set("cookie", kept.join("; "));
+	}
+	return result;
+}
 
 let testIdToken: string;
 let handlers: ReturnType<typeof http.post>[];
@@ -66,7 +91,7 @@ afterAll(() => server.close());
 
 describe("anonymous", async () => {
 	const linkAccountFn = vi.fn();
-	const { client, sessionSetter, testUser, cookieSetter } =
+	const { client, sessionSetter, testUser, cookieSetter, auth } =
 		await getTestInstance(
 			{
 				plugins: [
@@ -182,6 +207,79 @@ describe("anonymous", async () => {
 			headers,
 		});
 		expect(linkAccountFn).toHaveBeenCalledWith(expect.any(Object));
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8692
+	 */
+	it("should link the anonymous account on social sign-in when the callback has no session cookie (Expo)", async () => {
+		linkAccountFn.mockClear();
+		const anonHeaders = new Headers();
+		await client.signIn.anonymous({
+			fetchOptions: { onSuccess: sessionSetter(anonHeaders) },
+		});
+		const session = await client.getSession({
+			fetchOptions: { headers: anonHeaders },
+		});
+		expect(session.data?.user.isAnonymous).toBe(true);
+
+		// The before-hook reads the anonymous session from this request's cookie
+		// and stashes the user id in the server-only OAuth state.
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/dashboard",
+			fetchOptions: {
+				onSuccess: cookieSetter(anonHeaders),
+				headers: anonHeaders,
+			},
+		});
+		const state = new URL(signInRes.data?.url || "").searchParams.get("state");
+
+		// The in-app browser returns to the callback with the state cookie but
+		// without the session cookie. Linking must still fire via the OAuth state.
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test" },
+			headers: stripSessionCookie(anonHeaders),
+		});
+
+		expect(linkAccountFn).toHaveBeenCalledWith(expect.any(Object));
+	});
+
+	it("should ignore a client-supplied anonymousUserId on the OAuth callback", async () => {
+		linkAccountFn.mockClear();
+
+		// A real anonymous user whose id an attacker would try to inject.
+		const victimHeaders = new Headers();
+		const victim = await client.signIn.anonymous({
+			fetchOptions: { onSuccess: sessionSetter(victimHeaders) },
+		});
+		const victimId = victim.data?.user.id;
+		expect(victimId).toBeTruthy();
+
+		// The attacker is not anonymous and passes the victim id through the
+		// client-controlled additionalData bag.
+		const attackerHeaders = new Headers();
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/dashboard",
+			additionalData: { anonymousUserId: victimId },
+			fetchOptions: {
+				onSuccess: cookieSetter(attackerHeaders),
+				headers: attackerHeaders,
+			},
+		});
+		const state = new URL(signInRes.data?.url || "").searchParams.get("state");
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test" },
+			headers: attackerHeaders,
+		});
+
+		// The spoofed id is never read from `serverContext`, so no link fires and
+		// the victim survives.
+		expect(linkAccountFn).not.toHaveBeenCalled();
+		const ctx = await auth.$context;
+		const stillThere = await ctx.internalAdapter.findUserById(victimId!);
+		expect(stillThere?.id).toBe(victimId);
 	});
 
 	it("should call onLinkAccount when anonymous user verifies email", async () => {
@@ -576,5 +674,107 @@ describe("anonymous", async () => {
 			expect(deleteUserSessions).toHaveBeenCalledWith("anon-user");
 			expect(deleteUser).toHaveBeenCalledWith("anon-user");
 		});
+	});
+});
+
+/**
+ * Generic OAuth providers register as social providers, so they sign in through
+ * `/sign-in/social` and return on `/callback/:providerId`. The cookie-less Expo
+ * callback must still link the anonymous account on that path.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/8692
+ */
+describe("anonymous linking through generic oauth (Expo)", async () => {
+	const linkAccountFn = vi.fn();
+	const providerId = "test";
+	const server = new OAuth2Server();
+	await server.start();
+	const port = Number(server.issuer.url?.split(":")[2]!);
+
+	afterAll(async () => {
+		await server.stop();
+	});
+
+	const { client, sessionSetter, cookieSetter, customFetchImpl } =
+		await getTestInstance(
+			{
+				plugins: [
+					anonymous({
+						async onLinkAccount(data) {
+							linkAccountFn(data);
+						},
+					}),
+					genericOAuth({
+						config: [
+							{
+								providerId,
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								clientId: "test-client-id",
+								clientSecret: "test-client-secret",
+								pkce: true,
+							},
+						],
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [anonymousClient()],
+				},
+			},
+		);
+
+	beforeAll(async () => {
+		await server.issuer.keys.generate("RS256");
+	});
+
+	server.service.on("beforeUserinfo", (userInfoResponse) => {
+		userInfoResponse.body = {
+			email: "anon-generic-oauth@test.com",
+			name: "Anon Generic OAuth",
+			sub: "anon-generic-oauth",
+			email_verified: true,
+		};
+		userInfoResponse.statusCode = 200;
+	});
+
+	it("links the anonymous account when the callback lacks the session cookie", async () => {
+		linkAccountFn.mockClear();
+		const anonHeaders = new Headers();
+		await client.signIn.anonymous({
+			fetchOptions: { onSuccess: sessionSetter(anonHeaders) },
+		});
+
+		// Generic providers sign in through /sign-in/social; the before-hook
+		// captures the anonymous user id from this request's session cookie.
+		const signInRes = await client.signIn.social({
+			provider: providerId,
+			callbackURL: "http://localhost:3000/dashboard",
+			fetchOptions: {
+				onSuccess: cookieSetter(anonHeaders),
+				headers: anonHeaders,
+			},
+		});
+
+		// Follow the provider redirect to obtain the callback URL (code + state).
+		let callbackLocation: string | null = null;
+		await betterFetch(signInRes.data?.url || "", {
+			method: "GET",
+			redirect: "manual",
+			onError(context) {
+				callbackLocation = context.response.headers.get("location");
+			},
+		});
+		if (!callbackLocation) throw new Error("No redirect location found");
+
+		// Return to the callback without the session cookie (Expo in-app browser).
+		await betterFetch(callbackLocation, {
+			method: "GET",
+			customFetchImpl,
+			headers: stripSessionCookie(anonHeaders),
+			onError() {},
+		});
+
+		expect(linkAccountFn).toHaveBeenCalledWith(expect.any(Object));
 	});
 });

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -1,4 +1,7 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
+import type {
+	BetterAuthPlugin,
+	GenericEndpointContext,
+} from "@better-auth/core";
 import {
 	createAuthEndpoint,
 	createAuthMiddleware,
@@ -7,6 +10,8 @@ import { generateId } from "@better-auth/core/utils/id";
 import * as z from "zod";
 import {
 	APIError,
+	addOAuthServerContext,
+	getOAuthState,
 	getSessionFromCtx,
 	sensitiveSessionMiddleware,
 } from "../../api";
@@ -16,6 +21,7 @@ import {
 	setSessionCookie,
 } from "../../cookies";
 import { mergeSchema, parseUserOutput } from "../../db/schema";
+import type { Session, User } from "../../types";
 import { PACKAGE_VERSION } from "../../version";
 import { ANONYMOUS_ERROR_CODES } from "./error-codes";
 import { schema } from "./schema";
@@ -24,6 +30,53 @@ import type {
 	AnonymousSession,
 	UserWithAnonymous,
 } from "./types";
+
+/**
+ * Resolves the anonymous session being upgraded during an account-link callback.
+ *
+ * The anonymous session is normally read from the request cookie. When the
+ * OAuth callback arrives without that cookie (for example Expo's in-app browser,
+ * which only carries the OAuth state, not the session cookie), the anonymous
+ * user id captured at sign-in is recovered from the server-only OAuth state
+ * instead. Returns `null` when there is no anonymous session to link.
+ */
+async function resolveAnonymousSession(ctx: GenericEndpointContext): Promise<{
+	session: Session & Record<string, any>;
+	user: UserWithAnonymous & Record<string, any>;
+} | null> {
+	const cookieSession = await getSessionFromCtx<{
+		isAnonymous: boolean | null;
+	}>(ctx, { disableRefresh: true });
+	if (cookieSession?.user.isAnonymous) {
+		return {
+			session: cookieSession.session,
+			user: { ...cookieSession.user, isAnonymous: true },
+		};
+	}
+
+	const anonymousUserId = (await getOAuthState())?.serverContext
+		?.anonymousUserId;
+	if (typeof anonymousUserId !== "string") {
+		return null;
+	}
+	const user = (await ctx.context.internalAdapter.findUserById(
+		anonymousUserId,
+	)) as (User & { isAnonymous?: boolean | null }) | null;
+	if (!user?.isAnonymous) {
+		return null;
+	}
+	const [anonymousSession] = await ctx.context.internalAdapter.listSessions(
+		user.id,
+		{ onlyActiveSessions: true },
+	);
+	if (!anonymousSession) {
+		return null;
+	}
+	return {
+		session: anonymousSession,
+		user: { ...user, isAnonymous: true },
+	};
+}
 
 declare module "@better-auth/core" {
 	interface BetterAuthPluginRegistry<AuthOptions, Options> {
@@ -251,6 +304,29 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 			),
 		},
 		hooks: {
+			before: [
+				{
+					matcher(ctx) {
+						// Generic OAuth providers also sign in through `/sign-in/social`,
+						// so this single path covers them too.
+						return ctx.path === "/sign-in/social";
+					},
+					handler: createAuthMiddleware(async (ctx) => {
+						const session = await getSessionFromCtx<{
+							isAnonymous: boolean | null;
+						}>(ctx, { disableRefresh: true });
+						if (!session?.user.isAnonymous) {
+							return;
+						}
+						// Carry the anonymous user id across the provider redirect so the
+						// callback can link the account even when the session cookie is
+						// absent (for example Expo's in-app browser).
+						await addOAuthServerContext({
+							anonymousUserId: session.user.id,
+						});
+					}),
+				},
+			],
 			after: [
 				{
 					matcher(ctx) {
@@ -286,15 +362,12 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 							return;
 						}
 						/**
-						 * Make sure the user had an anonymous session.
+						 * Make sure the user had an anonymous session. Falls back to the
+						 * server-only OAuth state when the callback arrives without the
+						 * anonymous session cookie (for example Expo).
 						 */
-						const session = await getSessionFromCtx<{
-							isAnonymous: boolean | null;
-						}>(ctx, {
-							disableRefresh: true,
-						});
-
-						if (!session || !session.user.isAnonymous) {
+						const session = await resolveAnonymousSession(ctx);
+						if (!session) {
 							return;
 						}
 
@@ -309,21 +382,16 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 							return;
 						}
 
-						const user = {
-							...session.user,
-							// Type hack to ensure `isAnonymous` is correctly inferred as true.
-							// Without this, `isAnonymous` is inferred as `boolean | null` despite
-							// the conditional checks above suggesting otherwise.
-							isAnonymous: session.user.isAnonymous,
-						};
-
 						// At this point the user is linking their previous anonymous account with a
 						// new credential (email / social). Invoke the provided callback so that the
 						// integrator can perform any additional logic such as transferring data
 						// from the anonymous user to the new user.
 						if (options?.onLinkAccount) {
-							await options?.onLinkAccount?.({
-								anonymousUser: { session: session.session, user },
+							await options.onLinkAccount({
+								anonymousUser: {
+									session: session.session,
+									user: session.user,
+								},
 								newUser: newSession,
 								ctx,
 							});

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -968,6 +968,7 @@ describe("signin", async () => {
 				},
 				requestSignUp: true,
 				expiresAt: expiresAt,
+				serverContext: { spoofed: true },
 			},
 			fetchOptions: {
 				onSuccess: cookieSetter(headers),
@@ -1000,6 +1001,9 @@ describe("signin", async () => {
 		});
 		expect(additionalData!.requestSignUp).not.toBe(true);
 		expect(additionalData!.expiresAt).not.toBe(expiresAt);
+		// `serverContext` is reserved for server-set values; a client-supplied one
+		// must never survive the round-trip.
+		expect(additionalData!.serverContext).toBeUndefined();
 	});
 });
 

--- a/packages/better-auth/src/state.ts
+++ b/packages/better-auth/src/state.ts
@@ -33,6 +33,12 @@ const stateDataSchema = z.looseObject({
 	 * (RFC 6749 §5.1).
 	 */
 	requestedScopes: z.array(z.string()).optional(),
+	/**
+	 * Server-controlled values that ride the state across the provider redirect.
+	 * Populated only by `generateState` from `addOAuthServerContext`, never from
+	 * the request body, so it is safe to trust on the callback.
+	 */
+	serverContext: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type StateData = z.infer<typeof stateDataSchema>;

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -4,6 +4,7 @@ import { logger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
 import {
 	APIError,
+	addOAuthServerContext,
 	createAuthEndpoint,
 	createAuthMiddleware,
 	getOAuthState,
@@ -413,11 +414,14 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							postLoginClearedForSession,
 						});
 
-						// If path is social sign-in, add to additional data body
+						// On the social sign-in path the authorize query has to survive the
+						// provider redirect to be resumed after login. Carry it in the
+						// server-only OAuth state so a client cannot inject its own `query`
+						// through the request body.
 						if (ctx.path === "/sign-in/social") {
-							if (ctx.body.additionalData?.query) return;
-							if (!ctx.body.additionalData) ctx.body.additionalData = {};
-							ctx.body.additionalData.query = queryParams.toString();
+							await addOAuthServerContext({
+								query: queryParams.toString(),
+							});
 						}
 					}),
 				},
@@ -442,7 +446,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						// but clearing the login prompt cookie if forced login prompt
 						const _query =
 							(await oAuthState.get())?.query ??
-							((await getOAuthState())?.query as string | undefined);
+							((await getOAuthState())?.serverContext?.query as
+								| string
+								| undefined);
 						if (!_query) return;
 						const query = new URLSearchParams(_query);
 

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -2283,29 +2283,30 @@ describe("SSO OIDC IDP-initiated bounce", async () => {
 	});
 
 	it("should carry ssoProviderId in the bounced state when options.redirectURI is configured", async () => {
-		const { customFetchImpl: sharedRedirectFetch } = await getTestInstance({
-			trustedOrigins: ["http://localhost:8080"],
-			plugins: [
-				sso({
-					redirectURI: "/sso/callback",
-					defaultSSO: [
-						{
-							domain: "idp-initiated-shared.com",
-							providerId: "idp-initiated-shared",
-							oidcConfig: {
-								issuer: "http://localhost:8080",
-								clientId: "idp-initiated-shared-client",
-								clientSecret: "idp-initiated-shared-secret",
-								pkce: true,
-								discoveryEndpoint:
-									"http://localhost:8080/.well-known/openid-configuration",
-								allowIdpInitiated: true,
+		const { customFetchImpl: sharedRedirectFetch, auth: sharedRedirectAuth } =
+			await getTestInstance({
+				trustedOrigins: ["http://localhost:8080"],
+				plugins: [
+					sso({
+						redirectURI: "/sso/callback",
+						defaultSSO: [
+							{
+								domain: "idp-initiated-shared.com",
+								providerId: "idp-initiated-shared",
+								oidcConfig: {
+									issuer: "http://localhost:8080",
+									clientId: "idp-initiated-shared-client",
+									clientSecret: "idp-initiated-shared-secret",
+									pkce: true,
+									discoveryEndpoint:
+										"http://localhost:8080/.well-known/openid-configuration",
+									allowIdpInitiated: true,
+								},
 							},
-						},
-					],
-				}),
-			],
-		});
+						],
+					}),
+				],
+			});
 
 		const res = await sharedRedirectFetch(
 			"http://localhost:3000/api/auth/sso/callback/idp-initiated-shared?code=idp-issued-code",
@@ -2319,7 +2320,21 @@ describe("SSO OIDC IDP-initiated bounce", async () => {
 		expect(url.searchParams.get("redirect_uri")).toBe(
 			"http://localhost:3000/api/auth/sso/callback",
 		);
-		expect(url.searchParams.get("state")).toBeTruthy();
+		const stateNonce = url.searchParams.get("state");
+		expect(stateNonce).toBeTruthy();
+
+		// The shared callback resolves the provider from the server-only
+		// `serverContext` channel, so the bounce must write `ssoProviderId` there
+		// and never into the client-controlled top-level state.
+		const ctx = await sharedRedirectAuth.$context;
+		const verification = await ctx.internalAdapter.findVerificationValue(
+			stateNonce!,
+		);
+		const parsedState = JSON.parse(verification!.value);
+		expect(parsedState.serverContext?.ssoProviderId).toBe(
+			"idp-initiated-shared",
+		);
+		expect(parsedState.ssoProviderId).toBeUndefined();
 	});
 
 	it("should redirect to the error page for providers without the flag", async () => {

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -16,6 +16,7 @@ import {
 } from "better-auth";
 import {
 	APIError,
+	addOAuthServerContext,
 	createAuthEndpoint,
 	getSessionFromCtx,
 	sessionMiddleware,
@@ -1038,12 +1039,14 @@ export const signInSSO = (options?: SSOOptions) => {
 				}
 				const requestedScopes = ctx.body.scopes ||
 					config.scopes || ["openid", "email", "profile", "offline_access"];
-				const state = await generateState(ctx, {
-					additionalData: options?.redirectURI?.trim()
-						? { ssoProviderId: provider.providerId }
-						: false,
-					requestedScopes,
-				});
+				if (options?.redirectURI?.trim()) {
+					// The shared OIDC callback resolves the provider from server-only
+					// state, so it must not be client-spoofable.
+					await addOAuthServerContext({
+						ssoProviderId: provider.providerId,
+					});
+				}
+				const state = await generateState(ctx, { requestedScopes });
 				const redirectURI = getOIDCRedirectURI(
 					ctx.context.baseURL,
 					provider.providerId,
@@ -1098,11 +1101,7 @@ export const signInSSO = (options?: SSOOptions) => {
 					});
 				}
 
-				const { state: relayState } = await generateRelayState(
-					ctx,
-					undefined,
-					false,
-				);
+				const { state: relayState } = await generateRelayState(ctx, undefined);
 
 				const sp = createSP(
 					parsedSamlConfig,
@@ -1644,10 +1643,12 @@ async function bounceIfIdpInitiated(
 		return;
 	}
 
+	if (options?.redirectURI?.trim()) {
+		// The shared OIDC callback resolves the provider from server-only state,
+		// so it must not be client-spoofable.
+		await addOAuthServerContext({ ssoProviderId: provider.providerId });
+	}
 	const state = await generateState(ctx, {
-		additionalData: options?.redirectURI?.trim()
-			? { ssoProviderId: provider.providerId }
-			: false,
 		requestedScopes: config.scopes || [
 			"openid",
 			"email",
@@ -1719,7 +1720,9 @@ export const callbackSSOShared = (options?: SSOOptions) => {
 				throw ctx.redirect(`${errorURL}?error=invalid_state`);
 			}
 
-			const providerId = stateData.ssoProviderId as string | undefined;
+			const providerId = stateData.serverContext?.ssoProviderId as
+				| string
+				| undefined;
 			if (!providerId) {
 				const errorURL = stateData.errorURL || stateData.callbackURL;
 				throw ctx.redirect(

--- a/packages/sso/src/saml-state.ts
+++ b/packages/sso/src/saml-state.ts
@@ -11,7 +11,6 @@ export async function generateRelayState(
 				userId: string;
 		  }
 		| undefined,
-	additionalData: Record<string, any> | false | undefined,
 ) {
 	const callbackURL = c.body.callbackURL;
 	if (!callbackURL) {
@@ -21,8 +20,10 @@ export async function generateRelayState(
 	}
 
 	const codeVerifier = generateRandomString(128);
+	// SAML relay state does not carry `serverContext`: no plugin sets server
+	// context on the SAML sign-in path. If that changes, merge
+	// `getOAuthServerContext()` here as `generateState` does.
 	const stateData: StateData = {
-		...(additionalData ? additionalData : {}),
 		callbackURL,
 		codeVerifier,
 		errorURL: c.body.errorCallbackURL,


### PR DESCRIPTION
On `next`, OAuth plugins move server-derived values across the provider redirect by writing them into `additionalData`, which is spread to the top level of the OAuth state and read back through `getOAuthState()`. That field is client-controlled, so a value read back from it can be injected: a request can set the OAuth provider's post-login `query`. SSO's `ssoProviderId` rides the same untyped bag and is read through an unsafe cast, though it happens to be server-set today. The anonymous plugin needs the same round-trip to link an account after OAuth sign-in, but has no channel for it. So linking silently fails whenever the callback arrives without the session cookie, as on Expo and other in-app browsers.

This adds a dedicated server-only channel. Plugins attach data with `addOAuthServerContext`, which writes to a request-scoped slot. `generateState` embeds that into a new `serverContext` field after the client `additionalData` spread, so the client cannot populate it. The callback reads it from `getOAuthState().serverContext`; client `additionalData` keeps its documented top-level behavior and stays untrusted. The OAuth provider, SSO, and anonymous plugins all move onto the channel, which closes the `query` injection path and drops the SSO cast. The anonymous plugin carries the anonymous user id and recovers the user from state when the callback has no cookie. Generic OAuth is covered too, since those providers sign in through the same `/sign-in/social` path.

Closes #8707 (supersedes the original by @bytaesu)
Fixes #8692
