### PR TITLE
fix(kysely-adapter): inline migration-table constants to fix Turbopack build

### DIFF
--- a/.changeset/kysely-migration-subpath.md
+++ b/.changeset/kysely-migration-subpath.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": patch
+"@better-auth/kysely-adapter": patch
 ---
 
-Require Kysely 0.29 for SQLite migration support and import migration primitives from the dedicated Kysely migration subpath.
+Fix build failures under Next.js Turbopack and other strict ESM bundlers, where the SQLite dialects referenced Kysely migration constants that newer Kysely versions no longer expose from their main entry point. The dialects no longer import those constants, so builds succeed on both Kysely 0.28 and 0.29 with no version pinning required.

--- a/.changeset/kysely-migration-subpath.md
+++ b/.changeset/kysely-migration-subpath.md
@@ -1,5 +1,5 @@
 ---
-"@better-auth/kysely-adapter": patch
+"better-auth": patch
 ---
 
-Fix build failures under Next.js Turbopack and other strict ESM bundlers, where the SQLite dialects referenced Kysely migration constants that newer Kysely versions no longer expose from their main entry point. The dialects no longer import those constants, so builds succeed on both Kysely 0.28 and 0.29 with no version pinning required.
+Restore Kysely 0.28 and 0.29 compatibility for SQLite dialect introspection. The dialects now mirror Kysely's stable migration table names locally, avoiding strict ESM build failures in Turbopack without forcing consumers onto Kysely 0.29.

--- a/packages/kysely-adapter/src/bun-sqlite-dialect.ts
+++ b/packages/kysely-adapter/src/bun-sqlite-dialect.ts
@@ -20,7 +20,7 @@ import { CompiledQuery, DefaultQueryCompiler, sql } from "kysely";
 import {
 	DEFAULT_MIGRATION_LOCK_TABLE,
 	DEFAULT_MIGRATION_TABLE,
-} from "kysely/migration";
+} from "./kysely-migration-tables";
 
 class BunSqliteAdapter implements DialectAdapter {
 	get supportsCreateIfNotExists(): boolean {

--- a/packages/kysely-adapter/src/d1-sqlite-dialect.ts
+++ b/packages/kysely-adapter/src/d1-sqlite-dialect.ts
@@ -17,7 +17,7 @@ import { SqliteAdapter, SqliteQueryCompiler } from "kysely";
 import {
 	DEFAULT_MIGRATION_LOCK_TABLE,
 	DEFAULT_MIGRATION_TABLE,
-} from "kysely/migration";
+} from "./kysely-migration-tables";
 
 class D1SqliteAdapter extends SqliteAdapter {}
 

--- a/packages/kysely-adapter/src/kysely-migration-tables.ts
+++ b/packages/kysely-adapter/src/kysely-migration-tables.ts
@@ -1,0 +1,14 @@
+/**
+ * Kysely's internal migration table names, mirrored as local constants.
+ *
+ * Kysely 0.29 moved these from its main entry to the `kysely/migration`
+ * subpath (which 0.28 lacks), and the main entry now exports only type stubs
+ * with no runtime value, which breaks strict ESM bundlers such as Turbopack.
+ * The values are a stable part of Kysely's public migration contract, so
+ * mirroring them lets the SQLite dialects run on both Kysely 0.28 and 0.29
+ * without importing from a moving path.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/9810
+ */
+export const DEFAULT_MIGRATION_TABLE = "kysely_migration";
+export const DEFAULT_MIGRATION_LOCK_TABLE = "kysely_migration_lock";

--- a/packages/kysely-adapter/src/kysely-migration-tables.ts
+++ b/packages/kysely-adapter/src/kysely-migration-tables.ts
@@ -7,6 +7,8 @@
  * The values are a stable part of Kysely's public migration contract, so
  * mirroring them lets the SQLite dialects run on both Kysely 0.28 and 0.29
  * without importing from a moving path.
+ * TODO: Revisit this mirror if Better Auth drops Kysely 0.28 support and can
+ * depend on Kysely's `kysely/migration` export.
  *
  * @see https://github.com/better-auth/better-auth/issues/9810
  */

--- a/packages/kysely-adapter/src/node-sqlite-dialect.ts
+++ b/packages/kysely-adapter/src/node-sqlite-dialect.ts
@@ -20,7 +20,7 @@ import { CompiledQuery, DefaultQueryCompiler, sql } from "kysely";
 import {
 	DEFAULT_MIGRATION_LOCK_TABLE,
 	DEFAULT_MIGRATION_TABLE,
-} from "kysely/migration";
+} from "./kysely-migration-tables";
 
 class NodeSqliteAdapter implements DialectAdapter {
 	get supportsCreateIfNotExists(): boolean {

--- a/packages/kysely-adapter/src/sqlite-introspector.test.ts
+++ b/packages/kysely-adapter/src/sqlite-introspector.test.ts
@@ -1,8 +1,16 @@
 import type { SQLInputValue } from "node:sqlite";
 import { DatabaseSync } from "node:sqlite";
 import { Kysely } from "kysely";
+import {
+	DEFAULT_MIGRATION_LOCK_TABLE as KYSELY_DEFAULT_MIGRATION_LOCK_TABLE,
+	DEFAULT_MIGRATION_TABLE as KYSELY_DEFAULT_MIGRATION_TABLE,
+} from "kysely/migration";
 import { describe, expect, it } from "vitest";
 import { BunSqliteDialect } from "./bun-sqlite-dialect";
+import {
+	DEFAULT_MIGRATION_LOCK_TABLE,
+	DEFAULT_MIGRATION_TABLE,
+} from "./kysely-migration-tables";
 import { NodeSqliteDialect } from "./node-sqlite-dialect";
 
 function createSchema(db: DatabaseSync) {
@@ -62,5 +70,42 @@ describe("sqlite introspector", () => {
 		for (const table of tables) {
 			expect(table.isView).toBe(false);
 		}
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9810
+	 */
+	it("hides Kysely's internal migration tables during introspection", async () => {
+		const sqlite = new DatabaseSync(":memory:");
+		for (const sql of [
+			"CREATE TABLE users (id INTEGER PRIMARY KEY)",
+			`CREATE TABLE ${DEFAULT_MIGRATION_TABLE} (name TEXT)`,
+			`CREATE TABLE ${DEFAULT_MIGRATION_LOCK_TABLE} (id TEXT)`,
+		]) {
+			sqlite.prepare(sql).run();
+		}
+		const db = new Kysely({
+			dialect: new NodeSqliteDialect({ database: sqlite }),
+		});
+
+		const names = (await db.introspection.getTables()).map((t) => t.name);
+		await db.destroy();
+
+		expect(names).toContain("users");
+		expect(names).not.toContain(DEFAULT_MIGRATION_TABLE);
+		expect(names).not.toContain(DEFAULT_MIGRATION_LOCK_TABLE);
+	});
+
+	/**
+	 * Guards against drift: the dialects mirror these constants instead of
+	 * importing them, so they must stay equal to Kysely's own values.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/9810
+	 */
+	it("mirrors Kysely's migration-table constants", () => {
+		expect(DEFAULT_MIGRATION_TABLE).toBe(KYSELY_DEFAULT_MIGRATION_TABLE);
+		expect(DEFAULT_MIGRATION_LOCK_TABLE).toBe(
+			KYSELY_DEFAULT_MIGRATION_LOCK_TABLE,
+		);
 	});
 });

--- a/packages/kysely-adapter/src/sqlite-introspector.test.ts
+++ b/packages/kysely-adapter/src/sqlite-introspector.test.ts
@@ -40,6 +40,38 @@ interface KyselyMigrationTableConstants {
 	DEFAULT_MIGRATION_TABLE: string;
 }
 
+function getErrorCode(error: unknown): string | undefined {
+	if (typeof error !== "object" || error === null || !("code" in error)) {
+		return undefined;
+	}
+
+	const code = error.code;
+	return typeof code === "string" ? code : undefined;
+}
+
+function isMissingKyselyMigrationModule(
+	error: unknown,
+	moduleName: string,
+): boolean {
+	if (!(error instanceof Error)) {
+		return false;
+	}
+
+	const code = getErrorCode(error);
+	if (code === "ERR_PACKAGE_PATH_NOT_EXPORTED") {
+		return true;
+	}
+
+	return (
+		(code === "ERR_MODULE_NOT_FOUND" ||
+			code === "MODULE_NOT_FOUND" ||
+			error.message.includes("Cannot find module") ||
+			error.message.includes("Failed to resolve import") ||
+			error.message.includes("Could not resolve")) &&
+		error.message.includes(moduleName)
+	);
+}
+
 async function loadKyselyMigrationTableConstants(): Promise<KyselyMigrationTableConstants> {
 	const migrationModule = "kysely/migration";
 
@@ -47,7 +79,11 @@ async function loadKyselyMigrationTableConstants(): Promise<KyselyMigrationTable
 		return (await import(
 			migrationModule
 		)) as unknown as KyselyMigrationTableConstants;
-	} catch {
+	} catch (error) {
+		if (!isMissingKyselyMigrationModule(error, migrationModule)) {
+			throw error;
+		}
+
 		return (await import("kysely")) as unknown as KyselyMigrationTableConstants;
 	}
 }

--- a/packages/kysely-adapter/src/sqlite-introspector.test.ts
+++ b/packages/kysely-adapter/src/sqlite-introspector.test.ts
@@ -1,10 +1,6 @@
 import type { SQLInputValue } from "node:sqlite";
 import { DatabaseSync } from "node:sqlite";
 import { Kysely } from "kysely";
-import {
-	DEFAULT_MIGRATION_LOCK_TABLE as KYSELY_DEFAULT_MIGRATION_LOCK_TABLE,
-	DEFAULT_MIGRATION_TABLE as KYSELY_DEFAULT_MIGRATION_TABLE,
-} from "kysely/migration";
 import { describe, expect, it } from "vitest";
 import { BunSqliteDialect } from "./bun-sqlite-dialect";
 import {
@@ -37,6 +33,23 @@ function asBunLikeDatabase(db: DatabaseSync) {
 			db.close();
 		},
 	} as unknown as ConstructorParameters<typeof BunSqliteDialect>[0]["database"];
+}
+
+interface KyselyMigrationTableConstants {
+	DEFAULT_MIGRATION_LOCK_TABLE: string;
+	DEFAULT_MIGRATION_TABLE: string;
+}
+
+async function loadKyselyMigrationTableConstants(): Promise<KyselyMigrationTableConstants> {
+	const migrationModule = "kysely/migration";
+
+	try {
+		return (await import(
+			migrationModule
+		)) as unknown as KyselyMigrationTableConstants;
+	} catch {
+		return (await import("kysely")) as unknown as KyselyMigrationTableConstants;
+	}
 }
 
 describe("sqlite introspector", () => {
@@ -102,7 +115,12 @@ describe("sqlite introspector", () => {
 	 *
 	 * @see https://github.com/better-auth/better-auth/issues/9810
 	 */
-	it("mirrors Kysely's migration-table constants", () => {
+	it("mirrors Kysely's migration-table constants", async () => {
+		const {
+			DEFAULT_MIGRATION_LOCK_TABLE: KYSELY_DEFAULT_MIGRATION_LOCK_TABLE,
+			DEFAULT_MIGRATION_TABLE: KYSELY_DEFAULT_MIGRATION_TABLE,
+		} = await loadKyselyMigrationTableConstants();
+
 		expect(DEFAULT_MIGRATION_TABLE).toBe(KYSELY_DEFAULT_MIGRATION_TABLE);
 		expect(DEFAULT_MIGRATION_LOCK_TABLE).toBe(
 			KYSELY_DEFAULT_MIGRATION_LOCK_TABLE,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ catalogs:
       specifier: 1.3.5
       version: 1.3.5
     kysely:
-      specifier: ^0.29.0
+      specifier: ^0.28.17 || ^0.29.0
       version: 0.29.2
     tsdown:
       specifier: 0.21.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,13 +54,13 @@ catalog:
   '@better-auth/utils': 0.4.1
   '@better-fetch/fetch': 1.1.21
   better-call: 1.3.5
-  kysely: ^0.29.0
+  kysely: ^0.28.17 || ^0.29.0
   tsdown: 0.21.1
   typescript: ^5.9.3
 
 catalogs:
   peer:
-    kysely: ^0.29.0
+    kysely: ^0.28.5 || ^0.29.0
   react19:
     '@types/react': ^19.2.14
     '@types/react-dom': ^19.2.3


### PR DESCRIPTION
better-auth's SQLite dialects imported Kysely's migration-table constants from an entry point that moved between Kysely versions. In 0.29 the main `kysely` entry exports those names only as type stubs with no runtime value, so Next.js Turbopack and other strict ESM bundlers fail the build (#9810). The earlier fix switched the import to `kysely/migration`, but that subpath does not exist on 0.28, so it dropped 0.28 support and shipped as a patch that was really a breaking dependency-floor change.

This takes the simpler route. The two constants are stable, public values (`kysely_migration` and `kysely_migration_lock`), so the dialects mirror them locally instead of importing them. The build no longer references a moving Kysely entry point, so it works across Better Auth's supported Kysely 0.28 range and 0.29 with no peer-range change. That keeps this a genuine patch and unbreaks every affected user, not just those who can upgrade Kysely.

Closes #9913

Same kysely 0.29 migration-constant build failure, reported separately:
Closes #9901
Closes #9909
Closes #9942

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inlined Kysely migration table names in the `@better-auth/kysely-adapter` SQLite dialects to fix strict ESM (Turbopack) builds. Keeps compatibility across Better Auth's supported `kysely` 0.28 range and 0.29 without forcing an upgrade.

- **Bug Fixes**
  - Replaced imports of `DEFAULT_MIGRATION_TABLE` and `DEFAULT_MIGRATION_LOCK_TABLE` with local constants to avoid runtime-less exports in `kysely` 0.29 and the missing `kysely/migration` subpath in 0.28.
  - Added tests that hide migration tables during introspection and mirror-check Kysely's constants, with a robust fallback that rethrows unrelated import failures while supporting both `kysely/migration` and `kysely`.
  - Documented a TODO to remove the mirror when 0.28 is dropped.

- **Dependencies**
  - Restored default and adapter `kysely` support to `^0.28.17 || ^0.29.x`; `@better-auth/core` keeps its wider optional peer range (`^0.28.5 || ^0.29.x`).

<sup>Written for commit dc254b4edb10abd749fd4223b1e28cbf4f6516fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

