### PR TITLE
feat(oauth-provider)!: align OIDC authentication context

### DIFF
--- a/.changeset/oauth-provider-acr-unspecified.md
+++ b/.changeset/oauth-provider-acr-unspecified.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+ID tokens and the `acr_values_supported` discovery value now report `"0"` (the RFC 6711 "unspecified" value) instead of `urn:mace:incommon:iap:bronze`. Relying parties that hardcoded the bronze value must update to `"0"`.

--- a/.changeset/oauth-provider-acr-unspecified.md
+++ b/.changeset/oauth-provider-acr-unspecified.md
@@ -2,4 +2,4 @@
 "@better-auth/oauth-provider": minor
 ---
 
-ID tokens and the `acr_values_supported` discovery value now report `"0"` (the RFC 6711 "unspecified" value) instead of `urn:mace:incommon:iap:bronze`. Relying parties that hardcoded the bronze value must update to `"0"`.
+ID tokens and the `acr_values_supported` discovery value now report `"0"` (the OpenID Connect level 0 value for no assurance) instead of `urn:mace:incommon:iap:bronze`. Relying parties that hardcoded the bronze value must update to `"0"`.

--- a/docs/content/docs/plugins/jwt.mdx
+++ b/docs/content/docs/plugins/jwt.mdx
@@ -416,14 +416,13 @@ export const jwksTableFields = [
 
 ### Algorithm of the Key Pair
 
-The algorithm used for the generation of the key pair. The default is **EdDSA** with the **Ed25519** curve. Below are the available options:
+The algorithm used for the generation of the key pair. The default is **RS256**. Below are the available options:
 
 ```ts title="auth.ts"
 jwt({
   jwks: {
     keyPairConfig: {
-      alg: "EdDSA",
-      crv: "Ed25519"
+      alg: "RS256"
     }
   }
 })

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1121,13 +1121,15 @@ oauthProvider({
 
 ### Claims
 
-Internally, we support the following claims are supported: \["sub", "iss", "aud", "exp", "iat", "sid", "scope", "azp"].
+Internally, we support the following claims are supported: \["sub", "iss", "aud", "exp", "iat", "sid", "scope", "azp", "auth\_time", "acr", "amr", "at\_hash", "nonce"].
 
 Id token and user info claims should be namespaced when possible to avoid potential future conflicts.
 
 Claims added inside `customIdTokenClaims` and `customUserInfoClaims` should be added to the `advertisedMetadata.claims_supported` so clients can validate that claim received. In the following example, it would be the base claims plus `locale` and `https://example.com/org`.
 
-Pro tip: these functions can may also throw errors such as a user is no longer a member of the organization or no longer has the requested permissions.
+`customIdTokenClaims` cannot override protocol-owned ID token claims such as `iss`, `sub`, `aud`, `exp`, `iat`, `nonce`, `auth_time`, `acr`, `amr`, `at_hash`, `sid`, or `scope`. Use `authenticationContext` to provide `auth_time`, `acr`, and `amr`.
+
+Pro tip: these functions may also throw errors such as a user is no longer a member of the organization or no longer has the requested permissions.
 
 ```ts title="auth.ts"
 oauthProvider({
@@ -1150,6 +1152,27 @@ oauthProvider({
     return {
       locale: "en-GB",
     };
+  },
+})
+```
+
+#### Authentication Context
+
+By default, ID tokens include `acr: "0"`, the OpenID Connect level 0 value for no assurance. Use `authenticationContext` when your login flow has established a stronger authentication context, such as MFA.
+
+Only advertise ACR values that your provider can actually issue. The resolved `acr` must be listed in `acrValuesSupported`.
+
+```ts title="auth.ts"
+oauthProvider({
+  authenticationContext: {
+    acrValuesSupported: ["0", "urn:example:loa:mfa"],
+    resolve: ({ defaultContext }) => {
+      return {
+        ...defaultContext,
+        acr: "urn:example:loa:mfa",
+        amr: ["pwd", "otp"],
+      };
+    },
   },
 })
 ```
@@ -2027,6 +2050,20 @@ export const oauthRefreshTokenTableFields = [
     type: "Date",
     description:
       "Original authentication time. Preserved across token rotation so refreshed ID tokens include a correct auth_time claim per OIDC Core 1.0 Section 12.2.",
+    isOptional: true,
+  },
+  {
+    name: "acr",
+    type: "string",
+    description:
+      "Authentication Context Class Reference satisfied at authorization time.",
+    isOptional: true,
+  },
+  {
+    name: "amr",
+    type: "string[]",
+    description:
+      "Authentication Methods References used at authorization time.",
     isOptional: true,
   },
   {

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -13,12 +13,17 @@ import { getJwksAdapter } from "./adapter";
 import { schema } from "./schema";
 import { getJwtToken, signJWT } from "./sign";
 import type { JwtOptions } from "./types";
-import { createJwk } from "./utils";
+import { createJwk, DEFAULT_JWT_ALGORITHM } from "./utils";
 import { verifyJWT as verifyJWTHelper } from "./verify";
 
 export { resolveSigningKey, signJWT } from "./sign";
 export type * from "./types";
-export { createJwk, generateExportedKeyPair, toExpJWT } from "./utils";
+export {
+	createJwk,
+	DEFAULT_JWT_ALGORITHM,
+	generateExportedKeyPair,
+	toExpJWT,
+} from "./utils";
 export { verifyJWT } from "./verify";
 
 declare module "@better-auth/core" {
@@ -168,8 +173,19 @@ export const jwt = <O extends JwtOptions>(options?: O) => {
 					const adapter = getJwksAdapter(ctx.context.adapter, options);
 
 					let keySets = await adapter.getAllKeys(ctx);
+					const requestedAlg =
+						options?.jwks?.keyPairConfig?.alg ?? DEFAULT_JWT_ALGORITHM;
+					const now = Date.now();
 
-					if (!keySets || keySets?.length === 0) {
+					const hasActiveRequestedAlgKey = keySets?.some((key) => {
+						const keyAlg = key.alg ?? requestedAlg;
+						return (
+							keyAlg === requestedAlg &&
+							(!key.expiresAt || key.expiresAt.getTime() > now)
+						);
+					});
+
+					if (!keySets || keySets?.length === 0 || !hasActiveRequestedAlgKey) {
 						await createJwk(ctx, options);
 						keySets = await adapter.getAllKeys(ctx);
 					}
@@ -180,7 +196,6 @@ export const jwt = <O extends JwtOptions>(options?: O) => {
 						);
 					}
 
-					const now = Date.now();
 					const DEFAULT_GRACE_PERIOD = 60 * 60 * 24 * 30;
 					const gracePeriod =
 						(options?.jwks?.gracePeriod ?? DEFAULT_GRACE_PERIOD) * 1000;
@@ -201,7 +216,7 @@ export const jwt = <O extends JwtOptions>(options?: O) => {
 					return ctx.json({
 						keys: keys.map((keySet) => {
 							return {
-								alg: keySet.alg ?? options?.jwks?.keyPairConfig?.alg ?? "EdDSA",
+								alg: keySet.alg ?? requestedAlg,
 								crv: keySet.crv ?? defaultCrv,
 								...JSON.parse(keySet.publicKey),
 								kid: keySet.id,
@@ -285,7 +300,7 @@ export const jwt = <O extends JwtOptions>(options?: O) => {
 								payload: {
 									sub: string;
 									aud: string;
-									[key: string]: any;
+									[key: string]: unknown;
 								} | null;
 							},
 						},

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -1,5 +1,5 @@
-import type { JSONWebKeySet } from "jose";
-import { createLocalJWKSet, jwtVerify } from "jose";
+import type { JSONWebKeySet, JWTPayload } from "jose";
+import { createLocalJWKSet, decodeProtectedHeader, jwtVerify } from "jose";
 import { describe, expect, it } from "vitest";
 import { createAuthClient } from "../../client";
 import { getTestInstance } from "../../test-utils/test-instance";
@@ -66,7 +66,7 @@ describe("jwt", async () => {
 		const jwks = await client.jwks();
 
 		expect(jwks.data?.keys).length.above(0);
-		expect(jwks.data?.keys[0]!.alg).toBe("EdDSA");
+		expect(jwks.data?.keys[0]!.alg).toBe("RS256");
 	});
 
 	it("Signed tokens can be validated with the JWKS", async () => {
@@ -487,17 +487,21 @@ describe("jwt - remote url", async () => {
 	});
 
 	it("should work with different algorithms when remoteUrl is set", async () => {
-		const algorithms = ["ES256", "ES512", "RS256", "PS256", "EdDSA"];
+		const keyPairConfigs: JWKOptions[] = [
+			{ alg: "ES256" },
+			{ alg: "ES512" },
+			{ alg: "RS256" },
+			{ alg: "PS256" },
+			{ alg: "EdDSA" },
+		];
 
-		for (const alg of algorithms) {
+		for (const keyPairConfig of keyPairConfigs) {
 			const { auth } = await getTestInstance({
 				plugins: [
 					jwt({
 						jwks: {
 							remoteUrl: "https://example.com/.well-known/jwks.json",
-							keyPairConfig: {
-								alg: alg as any,
-							},
+							keyPairConfig,
 						},
 					}),
 				],
@@ -543,7 +547,7 @@ describe("jwt - remote url", async () => {
 	});
 
 	it("should work with custom sign function and remoteUrl", async () => {
-		const mockSignFunction = (payload: any) => {
+		const mockSignFunction = (payload: JWTPayload) => {
 			// Mock JWT with test signature
 			const header = Buffer.from(
 				JSON.stringify({ alg: "ES256", typ: "JWT" }),
@@ -746,6 +750,71 @@ describe("jwt - custom adapter", async () => {
 		expect(token?.token).toBeDefined();
 		expect(storage.length).toBe(1);
 	});
+
+	it("creates a default-algorithm key when the latest stored key uses a previous algorithm", async () => {
+		const previousKeyPair = await generateExportedKeyPair({
+			jwks: {
+				keyPairConfig: {
+					alg: "EdDSA",
+					crv: "Ed25519",
+				},
+				disablePrivateKeyEncryption: true,
+			},
+		});
+		const storage: Jwk[] = [
+			{
+				id: crypto.randomUUID(),
+				alg: "EdDSA",
+				crv: "Ed25519",
+				publicKey: JSON.stringify(previousKeyPair.publicWebKey),
+				privateKey: JSON.stringify(previousKeyPair.privateWebKey),
+				createdAt: new Date(Date.now() - 1000),
+			},
+		];
+		const { auth, customFetchImpl } = await getTestInstance({
+			plugins: [
+				jwt({
+					jwks: {
+						disablePrivateKeyEncryption: true,
+					},
+					adapter: {
+						getJwks: async () => {
+							return storage;
+						},
+						createJwk: async (data) => {
+							const key = {
+								...data,
+								id: crypto.randomUUID(),
+								createdAt: new Date(),
+							};
+							storage.push(key);
+							return key;
+						},
+					},
+				}),
+			],
+		});
+		const client = createAuthClient({
+			plugins: [jwtClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+
+		const jwks = await client.jwks();
+		expect(jwks.data?.keys.some((key) => key.alg === "RS256")).toBe(true);
+
+		const token = await auth.api.signJWT({
+			body: {
+				payload: {
+					sub: "123",
+				},
+			},
+		});
+		expect(token?.token).toBeDefined();
+		expect(decodeProtectedHeader(token.token!).alg).toBe("RS256");
+	});
 });
 
 describe("jwt - custom jwksPath", async () => {
@@ -827,9 +896,9 @@ describe("toExpJWT", () => {
 
 	describe("with invalid string input", () => {
 		it("should throw TypeError for invalid format", () => {
-			expect(() => toExpJWT("invalid" as any, iat)).toThrow(TypeError);
-			expect(() => toExpJWT("" as any, iat)).toThrow(TypeError);
-			expect(() => toExpJWT("abc123" as any, iat)).toThrow(TypeError);
+			expect(() => toExpJWT("invalid", iat)).toThrow(TypeError);
+			expect(() => toExpJWT("", iat)).toThrow(TypeError);
+			expect(() => toExpJWT("abc123", iat)).toThrow(TypeError);
 		});
 	});
 });

--- a/packages/better-auth/src/plugins/jwt/rotation.test.ts
+++ b/packages/better-auth/src/plugins/jwt/rotation.test.ts
@@ -56,7 +56,7 @@ describe("jwt rotation", async () => {
 	it("should return keys within grace period", async () => {
 		vi.useFakeTimers();
 		const storage: Jwk[] = [];
-		const rotationInterval = 1; // 1 second
+		const rotationInterval = 10; // 10 seconds
 		const gracePeriod = 1; // 1 second
 
 		const { auth } = await getTestInstance({
@@ -85,7 +85,7 @@ describe("jwt rotation", async () => {
 		await auth.api.signJWT({ body: { payload: { sub: "user1" } } });
 
 		// Advance time past rotation interval but within grace period
-		vi.advanceTimersByTime(1100);
+		vi.advanceTimersByTime(10_100);
 
 		// Trigger rotation by signing
 		await auth.api.signJWT({ body: { payload: { sub: "user1" } } });

--- a/packages/better-auth/src/plugins/jwt/sign.ts
+++ b/packages/better-auth/src/plugins/jwt/sign.ts
@@ -5,7 +5,7 @@ import { importJWK, SignJWT } from "jose";
 import { symmetricDecrypt } from "../../crypto";
 import { getJwksAdapter } from "./adapter";
 import type { JwtOptions, ResolvedSigningKey } from "./types";
-import { createJwk, toExpJWT } from "./utils";
+import { createJwk, DEFAULT_JWT_ALGORITHM, toExpJWT } from "./utils";
 
 type JWTPayloadWithOptional = {
 	/**
@@ -79,8 +79,14 @@ export async function resolveSigningKey(
 		return null;
 	}
 	const adapter = getJwksAdapter(ctx.context.adapter, options);
+	const requestedAlg =
+		options?.jwks?.keyPairConfig?.alg ?? DEFAULT_JWT_ALGORITHM;
 	let key = await adapter.getLatestKey(ctx);
-	if (!key || (key.expiresAt && key.expiresAt < new Date())) {
+	if (
+		!key ||
+		(key.expiresAt && key.expiresAt < new Date()) ||
+		(key.alg != null && key.alg !== requestedAlg)
+	) {
 		key = await createJwk(ctx, options);
 	}
 	const privateKeyEncryptionEnabled =
@@ -95,7 +101,7 @@ export async function resolveSigningKey(
 				);
 			})
 		: key.privateKey;
-	const alg = key.alg ?? options?.jwks?.keyPairConfig?.alg ?? "EdDSA";
+	const alg = key.alg ?? requestedAlg;
 	const privateKey = await importJWK(JSON.parse(privateWebKey), alg);
 	return { alg, kid: key.id, privateKey };
 }

--- a/packages/better-auth/src/plugins/jwt/types.ts
+++ b/packages/better-auth/src/plugins/jwt/types.ts
@@ -19,7 +19,7 @@ export interface JwtOptions {
 				 *
 				 * @see https://github.com/panva/jose/blob/main/src/runtime/node/generate.ts
 				 *
-				 * @default { alg: 'EdDSA', crv: 'Ed25519' }
+				 * @default { alg: 'RS256' }
 				 */
 				keyPairConfig?: JWKOptions | undefined;
 				/**
@@ -91,17 +91,17 @@ export interface JwtOptions {
 				 * A function that is called to define the payload of the JWT
 				 */
 				definePayload?: (session: {
-					user: User & Record<string, any>;
-					session: Session & Record<string, any>;
-				}) => Awaitable<Record<string, any>> | undefined;
+					user: User & Record<string, unknown>;
+					session: Session & Record<string, unknown>;
+				}) => Awaitable<Record<string, unknown>> | undefined;
 				/**
 				 * A function that is called to get the subject of the JWT
 				 *
 				 * @default session.user.id
 				 */
 				getSubject?: (session: {
-					user: User & Record<string, any>;
-					session: Session & Record<string, any>;
+					user: User & Record<string, unknown>;
+					session: Session & Record<string, unknown>;
 				}) => Awaitable<string> | undefined;
 				/**
 				 * A custom function to remote sign the jwt payload.

--- a/packages/better-auth/src/plugins/jwt/utils.ts
+++ b/packages/better-auth/src/plugins/jwt/utils.ts
@@ -6,6 +6,8 @@ import { sec } from "../../utils/time";
 import { getJwksAdapter } from "./adapter";
 import type { Jwk, JwtOptions } from "./types";
 
+export const DEFAULT_JWT_ALGORITHM = "RS256";
+
 /**
  * Converts an expirationTime to ISO seconds expiration time (the format of JWT exp)
  *
@@ -32,8 +34,7 @@ export async function generateExportedKeyPair(
 	options?: JwtOptions | undefined,
 ) {
 	const { alg, ...cfg } = options?.jwks?.keyPairConfig ?? {
-		alg: "EdDSA",
-		crv: "Ed25519",
+		alg: DEFAULT_JWT_ALGORITHM,
 	};
 	const { publicKey, privateKey } = await generateKeyPair(alg, {
 		...cfg,

--- a/packages/better-auth/src/plugins/jwt/verify.ts
+++ b/packages/better-auth/src/plugins/jwt/verify.ts
@@ -5,6 +5,7 @@ import type { JWTPayload } from "jose";
 import { importJWK, jwtVerify } from "jose";
 import { getJwksAdapter } from "./adapter";
 import type { JwtOptions } from "./types";
+import { DEFAULT_JWT_ALGORITHM } from "./utils";
 
 /**
  * Verify a JWT token using the JWKS public keys
@@ -46,7 +47,8 @@ export async function verifyJWT<T extends JWTPayload = JWTPayload>(
 		}
 
 		const publicKey = JSON.parse(key.publicKey);
-		const alg = key.alg ?? options?.jwks?.keyPairConfig?.alg ?? "EdDSA";
+		const alg =
+			key.alg ?? options?.jwks?.keyPairConfig?.alg ?? DEFAULT_JWT_ALGORITHM;
 		const cryptoKey = await importJWK(publicKey, alg);
 
 		const baseURLOrigin =

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -1491,7 +1491,7 @@ describe("oidc-jwt", async () => {
 	});
 
 	test.for([
-		{ useJwt: true, description: "with jwt plugin", expected: "EdDSA" },
+		{ useJwt: true, description: "with jwt plugin", expected: "RS256" },
 		{ useJwt: false, description: "without jwt plugin", expected: "HS256" },
 	])("testing oidc-provider $description to return token signed with $expected", async ({
 		useJwt,

--- a/packages/oauth-provider/src/authentication-context.ts
+++ b/packages/oauth-provider/src/authentication-context.ts
@@ -15,8 +15,8 @@ import { parseClientMetadata, resolveSessionAuthTime } from "./utils";
  * @see https://openid.net/specs/openid-connect-core-1_0.html#IDToken
  */
 export const LEVEL_0_ACR = "0";
-export const DEFAULT_ACR_VALUES_SUPPORTED = [LEVEL_0_ACR] as const;
-export const DEFAULT_ID_TOKEN_SIGNING_ALGORITHM = DEFAULT_JWT_ALGORITHM;
+const DEFAULT_ACR_VALUES_SUPPORTED = [LEVEL_0_ACR] as const;
+const DEFAULT_ID_TOKEN_SIGNING_ALGORITHM = DEFAULT_JWT_ALGORITHM;
 
 const RESERVED_ID_TOKEN_CLAIMS = new Set([
 	"iss",

--- a/packages/oauth-provider/src/authentication-context.ts
+++ b/packages/oauth-provider/src/authentication-context.ts
@@ -1,13 +1,166 @@
-/**
- * Authentication-context values carried into issued ID tokens.
- */
+import type { JWSAlgorithms, JwtOptions } from "better-auth/plugins";
+import { DEFAULT_JWT_ALGORITHM } from "better-auth/plugins";
+import type { Session, User } from "better-auth/types";
+import type {
+	OAuthAuthenticationContext,
+	OAuthOptions,
+	SchemaClient,
+	Scope,
+} from "./types";
+import { parseClientMetadata, resolveSessionAuthTime } from "./utils";
 
 /**
- * Authentication Context Class Reference reported when the provider does not
- * attest a specific assurance level. `"0"` is the RFC 6711 "unspecified" value:
- * an honest default rather than a claim to an assurance tier the provider never
- * evaluated.
+ * OpenID Connect level 0: no assurance that the same person is present.
  *
- * @see https://www.rfc-editor.org/rfc/rfc6711#section-4
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#IDToken
  */
-export const UNSPECIFIED_ACR = "0";
+export const LEVEL_0_ACR = "0";
+export const DEFAULT_ACR_VALUES_SUPPORTED = [LEVEL_0_ACR] as const;
+export const DEFAULT_ID_TOKEN_SIGNING_ALGORITHM = DEFAULT_JWT_ALGORITHM;
+
+const RESERVED_ID_TOKEN_CLAIMS = new Set([
+	"iss",
+	"sub",
+	"aud",
+	"exp",
+	"nbf",
+	"iat",
+	"jti",
+	"nonce",
+	"auth_time",
+	"acr",
+	"amr",
+	"azp",
+	"at_hash",
+	"c_hash",
+	"sid",
+	"scope",
+]);
+
+type NormalizedOAuthAuthenticationContext = OAuthAuthenticationContext & {
+	acr: string;
+};
+
+function uniqueValues<T extends string>(values: T[]): T[] {
+	return Array.from(new Set(values));
+}
+
+function normalizeString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function normalizeStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const values = value.filter(
+		(item): item is string => typeof item === "string" && item.length > 0,
+	);
+	return values.length ? uniqueValues(values) : undefined;
+}
+
+export function sanitizeCustomIdTokenClaims(
+	claims: unknown,
+): Record<string, unknown> {
+	const sanitized: Record<string, unknown> = {};
+	if (!claims || typeof claims !== "object" || Array.isArray(claims)) {
+		return sanitized;
+	}
+	for (const [name, value] of Object.entries(claims)) {
+		if (!RESERVED_ID_TOKEN_CLAIMS.has(name)) {
+			sanitized[name] = value;
+		}
+	}
+	return sanitized;
+}
+
+export function getAcrValuesSupported(
+	opts: OAuthOptions<Scope[]>,
+): readonly string[] {
+	const configured = opts.authenticationContext?.acrValuesSupported?.filter(
+		(value) => value.length > 0,
+	);
+	return configured?.length
+		? uniqueValues(configured)
+		: DEFAULT_ACR_VALUES_SUPPORTED;
+}
+
+export function isAuthenticationFresh(
+	authTime: Date | undefined,
+	maxAgeSeconds: number | undefined,
+	now: Date = new Date(),
+): boolean {
+	if (maxAgeSeconds === undefined) return true;
+	if (!authTime) return false;
+	if (maxAgeSeconds === 0) return false;
+	return now.getTime() - authTime.getTime() <= maxAgeSeconds * 1000;
+}
+
+export function getStoredAuthenticationContext(
+	authenticationContext: OAuthAuthenticationContext,
+) {
+	return {
+		authTime: authenticationContext.authTime?.getTime(),
+		acr: authenticationContext.acr,
+		amr: authenticationContext.amr,
+	};
+}
+
+export function normalizeAuthenticationContext(
+	authenticationContext: OAuthAuthenticationContext | undefined,
+): NormalizedOAuthAuthenticationContext {
+	return {
+		authTime: authenticationContext?.authTime,
+		acr: normalizeString(authenticationContext?.acr) ?? LEVEL_0_ACR,
+		amr: normalizeStringArray(authenticationContext?.amr),
+	};
+}
+
+export async function resolveAuthenticationContext(input: {
+	opts: OAuthOptions<Scope[]>;
+	user: User & Record<string, unknown>;
+	session: Session & Record<string, unknown>;
+	client: SchemaClient<Scope[]>;
+	scopes: string[];
+	headers: Headers;
+	requestedAcrValues?: string[];
+}): Promise<OAuthAuthenticationContext> {
+	const defaultContext = normalizeAuthenticationContext({
+		authTime: resolveSessionAuthTime(input.session),
+		acr: LEVEL_0_ACR,
+	});
+	const resolved = await input.opts.authenticationContext?.resolve?.({
+		user: input.user,
+		session: input.session,
+		client: input.client,
+		scopes: input.scopes,
+		headers: input.headers,
+		metadata: parseClientMetadata(input.client.metadata),
+		requestedAcrValues: input.requestedAcrValues,
+		defaultContext,
+	});
+	const authenticationContext = normalizeAuthenticationContext({
+		...defaultContext,
+		...resolved,
+	});
+
+	const acrValuesSupported = getAcrValuesSupported(input.opts);
+	if (!acrValuesSupported.includes(authenticationContext.acr)) {
+		throw new Error(
+			`authenticationContext.resolve returned unsupported acr "${authenticationContext.acr}"`,
+		);
+	}
+
+	return authenticationContext;
+}
+
+export function getIdTokenSigningAlgValuesSupported(input: {
+	disableJwtPlugin?: boolean;
+	jwtPluginOptions?: JwtOptions;
+}): JWSAlgorithms[] | ["HS256"] {
+	if (input.disableJwtPlugin) {
+		return ["HS256"];
+	}
+	return [
+		input.jwtPluginOptions?.jwks?.keyPairConfig?.alg ??
+			DEFAULT_ID_TOKEN_SIGNING_ALGORITHM,
+	];
+}

--- a/packages/oauth-provider/src/authentication-context.ts
+++ b/packages/oauth-provider/src/authentication-context.ts
@@ -1,0 +1,13 @@
+/**
+ * Authentication-context values carried into issued ID tokens.
+ */
+
+/**
+ * Authentication Context Class Reference reported when the provider does not
+ * attest a specific assurance level. `"0"` is the RFC 6711 "unspecified" value:
+ * an honest default rather than a claim to an assurance tier the provider never
+ * evaluated.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc6711#section-4
+ */
+export const UNSPECIFIED_ACR = "0";

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -5,15 +5,22 @@ import { getSessionFromCtx } from "better-auth/api";
 import { generateRandomString, makeSignature } from "better-auth/crypto";
 import type { Verification } from "better-auth/db";
 import { APIError } from "better-call";
+import {
+	getStoredAuthenticationContext,
+	isAuthenticationFresh,
+	resolveAuthenticationContext,
+} from "./authentication-context";
 import { oAuthState } from "./oauth";
 import type { OAuthErrorCode, OAuthRedirectOnError } from "./oauth-endpoint";
 import type {
+	OAuthAuthenticationContext,
 	OAuthAuthorizationQuery,
 	OAuthConsent,
 	OAuthOptions,
 	Scope,
 	VerificationValue,
 } from "./types";
+import { authorizationQuerySchema } from "./types/zod";
 
 import {
 	checkResource,
@@ -76,7 +83,22 @@ function deriveResponseMode(
 	return "query";
 }
 
-export const handleRedirect = (ctx: GenericEndpointContext, uri: string) => {
+function removeMaxAgeFromAuthorizationQuery(
+	query: OAuthAuthorizationQuery,
+): OAuthAuthorizationQuery {
+	const { max_age: _maxAge, ...queryWithoutMaxAge } = query;
+	return queryWithoutMaxAge;
+}
+
+export type OAuthRedirectResult = {
+	redirect: true;
+	url: string;
+};
+
+export const handleRedirect = (
+	ctx: GenericEndpointContext,
+	uri: string,
+): OAuthRedirectResult => {
 	const fromFetch = isBrowserFetchRequest(ctx.request?.headers);
 	const acceptJson = ctx.headers?.get("accept")?.includes("application/json");
 	if (fromFetch || acceptJson) {
@@ -245,7 +267,7 @@ async function resolveTrustedRedirectUri(
  */
 export function authorizeRedirectOnError(
 	opts: OAuthOptions<Scope[]>,
-): OAuthRedirectOnError<GenericEndpointContext> {
+): OAuthRedirectOnError<GenericEndpointContext, OAuthRedirectResult> {
 	return async ({ error, error_description, ctx }) => {
 		const raw = (ctx.query ?? {}) as Record<string, unknown>;
 		const clientId =
@@ -282,7 +304,7 @@ export async function authorizeEndpoint(
 		isAuthorize?: boolean;
 		postLogin?: boolean;
 	},
-) {
+): Promise<OAuthRedirectResult> {
 	// Grant type must include authorization_code to use this endpoint
 	if (opts.grantTypes && !opts.grantTypes.includes("authorization_code")) {
 		throw new APIError("NOT_FOUND");
@@ -294,6 +316,7 @@ export async function authorizeEndpoint(
 			error: "invalid_request",
 		});
 	}
+	const request = ctx.request;
 
 	// Resolve request_uri (PAR) before processing
 	let query: OAuthAuthorizationQuery = ctx.query;
@@ -327,6 +350,16 @@ export async function authorizeEndpoint(
 			query.client_id = urlClientId;
 		}
 	}
+	ctx.query = query;
+	const parsedQuery = authorizationQuerySchema.safeParse(query);
+	if (!parsedQuery.success) {
+		return authorizeRedirectOnError(opts)({
+			error: "invalid_request",
+			error_description: "invalid authorization request",
+			ctx,
+		});
+	}
+	query = parsedQuery.data as OAuthAuthorizationQuery;
 	ctx.query = query;
 	await oAuthState.set({
 		query: serializeAuthorizationQuery(query).toString(),
@@ -499,7 +532,23 @@ export async function authorizeEndpoint(
 
 	// Check for session
 	const session = await getSessionFromCtx(ctx);
-	if (!session || promptSet?.has("login") || promptSet?.has("create")) {
+	const maxAgeSeconds = query.max_age;
+	const hasSatisfiedMaxAge =
+		session != null &&
+		maxAgeSeconds !== undefined &&
+		isAuthenticationFresh(
+			new Date(session.session.createdAt),
+			maxAgeSeconds,
+			new Date(),
+		);
+	const staleForMaxAge =
+		session != null && maxAgeSeconds !== undefined && !hasSatisfiedMaxAge;
+	if (
+		!session ||
+		staleForMaxAge ||
+		promptSet?.has("login") ||
+		promptSet?.has("create")
+	) {
 		if (promptNone) {
 			return redirectWithPromptNoneError(
 				ctx,
@@ -514,6 +563,10 @@ export async function authorizeEndpoint(
 			opts,
 			promptSet?.has("create") ? "create" : "login",
 		);
+	}
+	if (hasSatisfiedMaxAge) {
+		query = removeMaxAgeFromAuthorizationQuery(query);
+		ctx.query = query;
 	}
 
 	// Force account selection (eg. multi-session)
@@ -603,18 +656,30 @@ export async function authorizeEndpoint(
 		session: session.session,
 		scopes: requestedScopes,
 	});
-
-	// Can skip consent (unless forced by prompt above)
-	if (client.skipConsent) {
+	const createAuthorizationCode = async () => {
+		const authenticationContext = await resolveAuthenticationContext({
+			opts,
+			user: session.user,
+			session: session.session,
+			client,
+			scopes: requestedScopes,
+			headers: request.headers,
+			requestedAcrValues: query.acr_values?.split(" ").filter(Boolean),
+		});
 		return redirectWithAuthorizationCode(ctx, opts, {
 			query,
 			clientId: client.clientId,
 			userId: session.user.id,
 			sessionId: session.session.id,
-			authTime: new Date(session.session.createdAt).getTime(),
+			authenticationContext,
 			referenceId,
 			resource: requestedResources,
 		});
+	};
+
+	// Can skip consent (unless forced by prompt above)
+	if (client.skipConsent) {
+		return createAuthorizationCode();
 	}
 	const consent = await ctx.context.adapter.findOne<OAuthConsent<Scope[]>>({
 		model: "oauthConsent",
@@ -677,15 +742,7 @@ export async function authorizeEndpoint(
 		});
 	}
 
-	return redirectWithAuthorizationCode(ctx, opts, {
-		query,
-		clientId: client.clientId,
-		userId: session.user.id,
-		sessionId: session.session.id,
-		authTime: new Date(session.session.createdAt).getTime(),
-		referenceId,
-		resource: requestedResources,
-	});
+	return createAuthorizationCode();
 }
 
 function serializeAuthorizationQuery(query: OAuthAuthorizationQuery) {
@@ -711,7 +768,7 @@ async function redirectWithAuthorizationCode(
 		clientId: string;
 		userId: string;
 		sessionId: string;
-		authTime: number;
+		authenticationContext: OAuthAuthenticationContext;
 		referenceId?: string;
 		resource?: string[];
 	},
@@ -719,6 +776,9 @@ async function redirectWithAuthorizationCode(
 	const code = generateRandomString(32, "a-z", "A-Z", "0-9");
 	const iat = Math.floor(Date.now() / 1000);
 	const exp = iat + (opts.codeExpiresIn ?? 600);
+	const storedAuthenticationContext = getStoredAuthenticationContext(
+		verificationValue.authenticationContext,
+	);
 
 	const data: Omit<Verification, "id" | "createdAt"> = {
 		identifier: await storeToken(opts.storeTokens, code, "authorization_code"),
@@ -730,7 +790,9 @@ async function redirectWithAuthorizationCode(
 			userId: verificationValue.userId,
 			sessionId: verificationValue?.sessionId,
 			referenceId: verificationValue.referenceId,
-			authTime: verificationValue.authTime,
+			authTime: storedAuthenticationContext.authTime,
+			acr: storedAuthenticationContext.acr,
+			amr: storedAuthenticationContext.amr,
 			resource: verificationValue.resource,
 		} satisfies VerificationValue),
 	};

--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -26,6 +26,11 @@ describe("oauth metadata", async () => {
 		"sid",
 		"scope",
 		"azp",
+		"auth_time",
+		"acr",
+		"amr",
+		"at_hash",
+		"nonce",
 		"email",
 		"email_verified",
 		"name",
@@ -118,7 +123,7 @@ describe("oauth metadata", async () => {
 			claims_supported: baseClaims,
 			userinfo_endpoint: `${baseURL}/oauth2/userinfo`,
 			subject_types_supported: ["public"],
-			id_token_signing_alg_values_supported: ["EdDSA"],
+			id_token_signing_alg_values_supported: ["RS256"],
 			end_session_endpoint: `${baseURL}/oauth2/end-session`,
 			acr_values_supported: ["0"],
 			prompt_values_supported: [
@@ -385,6 +390,23 @@ describe("oauth metadata", async () => {
 		const metadata = await auth.api.getOpenIdConfig();
 		expect(metadata).toMatchObject({
 			claims_supported: [...baseClaims, ...customClaims],
+		});
+		const oauthMetadata = await auth.api.getOAuthServerConfig();
+		expect(oauthMetadata).toMatchObject(metadata ?? {});
+	});
+
+	it("should advertise configured authentication context values", async () => {
+		const acrValuesSupported = ["0", "urn:example:loa:mfa"];
+		const { auth } = await createTestInstance({
+			oauthProviderConfig: {
+				authenticationContext: {
+					acrValuesSupported,
+				},
+			},
+		});
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata).toMatchObject({
+			acr_values_supported: acrValuesSupported,
 		});
 		const oauthMetadata = await auth.api.getOAuthServerConfig();
 		expect(oauthMetadata).toMatchObject(metadata ?? {});

--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -120,7 +120,7 @@ describe("oauth metadata", async () => {
 			subject_types_supported: ["public"],
 			id_token_signing_alg_values_supported: ["EdDSA"],
 			end_session_endpoint: `${baseURL}/oauth2/end-session`,
-			acr_values_supported: ["urn:mace:incommon:iap:bronze"],
+			acr_values_supported: ["0"],
 			prompt_values_supported: [
 				"login",
 				"consent",
@@ -410,6 +410,16 @@ describe("oauth metadata", async () => {
 		});
 		const oauthMetadata = await auth.api.getOAuthServerConfig();
 		expect(oauthMetadata).toMatchObject(metadata ?? {});
+	});
+
+	it("advertises the configured RS256 signing algorithm (Config OP)", async () => {
+		const { auth } = await createTestInstance({
+			jwtConfig: { jwks: { keyPairConfig: { alg: "RS256" } } },
+		});
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata).toMatchObject({
+			id_token_signing_alg_values_supported: ["RS256"],
+		});
 	});
 
 	it("should support disableJwtPlugin", async () => {

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -1,7 +1,10 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { PRIVATE_KEY_JWT_SIGNING_ALGORITHMS } from "@better-auth/core/oauth2";
 import type { JWSAlgorithms, JwtOptions } from "better-auth/plugins";
-import { UNSPECIFIED_ACR } from "./authentication-context";
+import {
+	getAcrValuesSupported,
+	getIdTokenSigningAlgValuesSupported,
+} from "./authentication-context";
 import { validateIssuerUrl } from "./authorize";
 import type { OAuthOptions, Scope } from "./types";
 import type {
@@ -125,14 +128,12 @@ export function oidcServerMetadata(
 		subject_types_supported: opts.pairwiseSecret
 			? ["public", "pairwise"]
 			: ["public"],
-		id_token_signing_alg_values_supported: jwtPluginOptions?.jwks?.keyPairConfig
-			?.alg
-			? [jwtPluginOptions?.jwks?.keyPairConfig?.alg]
-			: opts.disableJwtPlugin
-				? ["HS256"]
-				: ["EdDSA"],
+		id_token_signing_alg_values_supported: getIdTokenSigningAlgValuesSupported({
+			disableJwtPlugin: opts.disableJwtPlugin,
+			jwtPluginOptions,
+		}),
 		end_session_endpoint: `${baseURL}/oauth2/end-session`,
-		acr_values_supported: [UNSPECIFIED_ACR],
+		acr_values_supported: [...getAcrValuesSupported(opts)],
 		prompt_values_supported: [
 			"login",
 			"consent",
@@ -150,6 +151,11 @@ export function oidcServerMetadata(
 // Cache for 15s with a short stale window; metadata rarely changes.
 const METADATA_CACHE_CONTROL =
 	"public, max-age=15, stale-while-revalidate=15, stale-if-error=86400";
+
+type ExportedMetadataRequest = {
+	request: Request;
+	asResponse: false;
+};
 
 export function metadataResponse(
 	body: unknown,
@@ -174,7 +180,7 @@ export function metadataResponse(
 export const oauthProviderAuthServerMetadata = <
 	Auth extends {
 		api: {
-			getOAuthServerConfig: (...args: any) => any;
+			getOAuthServerConfig: (input: ExportedMetadataRequest) => unknown;
 		};
 	},
 >(
@@ -201,7 +207,7 @@ export const oauthProviderAuthServerMetadata = <
 export const oauthProviderOpenIdConfigMetadata = <
 	Auth extends {
 		api: {
-			getOpenIdConfig: (...args: any) => any;
+			getOpenIdConfig: (input: ExportedMetadataRequest) => unknown;
 		};
 	},
 >(

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -1,6 +1,7 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { PRIVATE_KEY_JWT_SIGNING_ALGORITHMS } from "@better-auth/core/oauth2";
 import type { JWSAlgorithms, JwtOptions } from "better-auth/plugins";
+import { UNSPECIFIED_ACR } from "./authentication-context";
 import { validateIssuerUrl } from "./authorize";
 import type { OAuthOptions, Scope } from "./types";
 import type {
@@ -131,7 +132,7 @@ export function oidcServerMetadata(
 				? ["HS256"]
 				: ["EdDSA"],
 		end_session_endpoint: `${baseURL}/oauth2/end-session`,
-		acr_values_supported: ["urn:mace:incommon:iap:bronze"],
+		acr_values_supported: [UNSPECIFIED_ACR],
 		prompt_values_supported: [
 			"login",
 			"consent",

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -7,6 +7,7 @@ import {
 } from "./authentication-context";
 import { validateIssuerUrl } from "./authorize";
 import type { OAuthOptions, Scope } from "./types";
+import { supportedPromptValues } from "./types";
 import type {
 	AuthServerMetadata,
 	GrantType,
@@ -134,13 +135,7 @@ export function oidcServerMetadata(
 		}),
 		end_session_endpoint: `${baseURL}/oauth2/end-session`,
 		acr_values_supported: [...getAcrValuesSupported(opts)],
-		prompt_values_supported: [
-			"login",
-			"consent",
-			"create",
-			"select_account",
-			"none",
-		],
+		prompt_values_supported: [...supportedPromptValues],
 	};
 	return {
 		...metadata,

--- a/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
@@ -78,13 +78,13 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 
 	async function captureRedirect(path: string) {
 		let status = 0;
-		let location: string | null = null;
+		let location: string | undefined;
 		await client.$fetch(path, {
 			method: "GET",
 			redirect: "manual",
 			onResponse: async (context) => {
 				status = context.response.status;
-				location = context.response.headers.get("location");
+				location = context.response.headers.get("location") ?? undefined;
 			},
 		});
 		return { status, location };

--- a/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
@@ -161,6 +161,46 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 	});
 
 	describe("oauth2Authorize (redirect delivery)", () => {
+		it("unsupported prompt value → invalid_request", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const state = "opaque-state-prompt";
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				response_type: "code",
+				prompt: "not_a_prompt",
+				state,
+			}).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			expect(location).toBeTruthy();
+			const errorUrl = new URL(location!);
+			expect(location!.startsWith(redirectUri)).toBe(true);
+			expect(errorUrl.searchParams.get("error")).toBe("invalid_request");
+			expect(errorUrl.searchParams.get("error_description")).toMatch(/prompt/);
+			expect(errorUrl.searchParams.get("state")).toBe(state);
+		});
+
+		it("prompt=none combined with another prompt → invalid_request", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				response_type: "code",
+				prompt: "none login",
+				state: "opaque-state-prompt-none",
+			}).toString();
+			const { location } = await captureRedirect(`/oauth2/authorize?${qs}`);
+			expect(location).toBeTruthy();
+			const errorUrl = new URL(location!);
+			expect(location!.startsWith(redirectUri)).toBe(true);
+			expect(errorUrl.searchParams.get("error")).toBe("invalid_request");
+			expect(errorUrl.searchParams.get("error_description")).toMatch(/none/);
+		});
+
 		it("unsupported response_type=token → error in fragment (OIDC §5)", async () => {
 			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
 			const state = "opaque-state-abc";

--- a/packages/oauth-provider/src/oauth-endpoint.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.ts
@@ -74,9 +74,9 @@ export interface OAuthEndpointRedirectContext<Ctx = unknown> {
 	ctx: Ctx;
 }
 
-export type OAuthRedirectOnError<Ctx = any> = (
+export type OAuthRedirectOnError<Ctx = never, Result = unknown> = (
 	result: OAuthEndpointRedirectContext<Ctx>,
-) => unknown;
+) => Result | Promise<Result>;
 
 type ValidationErrorHookArgs = {
 	message: string;
@@ -113,6 +113,13 @@ export interface OAuthEndpointExtras {
 	defaultError?: OAuthErrorCode;
 }
 
+type OAuthEndpointExtraKey = keyof OAuthEndpointExtras;
+
+type OAuthEndpointOptions<Options extends EndpointOptions> =
+	Omit<Options, OAuthEndpointExtraKey> extends EndpointOptions
+		? Omit<Options, OAuthEndpointExtraKey>
+		: never;
+
 /**
  * Wraps `createAuthEndpoint` so zod schemas stay the single source of truth
  * for body/query shape while validation failures serialize as the RFC 6749
@@ -130,13 +137,15 @@ export interface OAuthEndpointExtras {
  */
 export function createOAuthEndpoint<
 	Path extends string,
-	Options extends EndpointOptions,
+	Options extends EndpointOptions & OAuthEndpointExtras,
 	R,
 >(
 	path: Path,
-	options: Options & OAuthEndpointExtras,
-	handler: (ctx: EndpointContext<Path, Options, AuthContext>) => Promise<R>,
-): StrictEndpoint<Path, Options, R> {
+	options: Options,
+	handler: (
+		ctx: EndpointContext<Path, OAuthEndpointOptions<Options>, AuthContext>,
+	) => Promise<R>,
+): StrictEndpoint<Path, OAuthEndpointOptions<Options>, R> {
 	const {
 		redirectOnError,
 		onValidationError: userHook,
@@ -158,7 +167,7 @@ export function createOAuthEndpoint<
 					),
 				});
 			},
-		} as unknown as Options;
+		} as unknown as OAuthEndpointOptions<Options>;
 		return createAuthEndpoint(path, forwarded, handler);
 	}
 
@@ -175,7 +184,7 @@ export function createOAuthEndpoint<
 	};
 
 	async function validateSlot(
-		ctx: EndpointContext<Path, Options, AuthContext>,
+		ctx: EndpointContext<Path, OAuthEndpointOptions<Options>, AuthContext>,
 		slot: "body" | "query",
 		schema: z.ZodTypeAny | undefined,
 	): Promise<{ ok: true } | { ok: false; response: unknown }> {
@@ -191,22 +200,27 @@ export function createOAuthEndpoint<
 				issues: result.error.issues,
 			});
 		}
+		const response = await (
+			redirect as OAuthRedirectOnError<
+				EndpointContext<Path, OAuthEndpointOptions<Options>, AuthContext>
+			>
+		)({
+			...mapIssuesToOAuthError(
+				result.error.issues,
+				errorCodesByField,
+				defaultError,
+			),
+			ctx,
+		});
 		return {
 			ok: false,
-			response: redirect({
-				...mapIssuesToOAuthError(
-					result.error.issues,
-					errorCodesByField,
-					defaultError,
-				),
-				ctx,
-			}),
+			response,
 		};
 	}
 
 	return createAuthEndpoint(
 		path,
-		forwarded as unknown as Options,
+		forwarded as unknown as OAuthEndpointOptions<Options>,
 		async (ctx) => {
 			const body = await validateSlot(ctx, "body", bodySchema);
 			if (!body.ok) return body.response;
@@ -214,7 +228,7 @@ export function createOAuthEndpoint<
 			if (!query.ok) return query.response;
 			return handler(ctx);
 		},
-	) as StrictEndpoint<Path, Options, R>;
+	) as StrictEndpoint<Path, OAuthEndpointOptions<Options>, R>;
 }
 
 export function mapIssuesToOAuthError(

--- a/packages/oauth-provider/src/oauth-endpoint.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.ts
@@ -85,7 +85,7 @@ type ValidationErrorHookArgs = {
 
 type ValidationErrorHook = (args: ValidationErrorHookArgs) => unknown;
 
-export interface OAuthEndpointExtras {
+interface OAuthEndpointExtras {
 	/**
 	 * Invoked when validation fails. Presence switches delivery from a JSON
 	 * `APIError` envelope to this callback, which receives the request
@@ -113,7 +113,11 @@ export interface OAuthEndpointExtras {
 	defaultError?: OAuthErrorCode;
 }
 
-type OAuthEndpointExtraKey = keyof OAuthEndpointExtras;
+type OAuthEndpointExtraKey =
+	| "redirectOnError"
+	| "onValidationError"
+	| "errorCodesByField"
+	| "defaultError";
 
 type OAuthEndpointOptions<Options extends EndpointOptions> =
 	Omit<Options, OAuthEndpointExtraKey> extends EndpointOptions

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -42,6 +42,14 @@ function isRedirectResult(
 	);
 }
 
+function requireRedirectUrl(result: { url?: string }): string {
+	expect(result.url).toBeDefined();
+	if (!result.url) {
+		throw new Error("Expected OAuth redirect URL");
+	}
+	return result.url;
+}
+
 describe("oauth - init", () => {
 	const createSecondaryStorage = () => ({
 		set(key: string, value: string, ttl?: number) {},
@@ -379,7 +387,7 @@ describe("oauth", async () => {
 		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
 
 		let loginRedirectUri = "";
-		await authClient.$fetch(data.url, {
+		await authClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(ctx) {
 				loginRedirectUri = ctx.response.headers.get("Location") || "";
@@ -455,7 +463,7 @@ describe("oauth", async () => {
 		);
 
 		let loginRedirectUri = "";
-		await authClient.$fetch(data.url, {
+		await authClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(ctx) {
 				loginRedirectUri = ctx.response.headers.get("Location") || "";
@@ -498,6 +506,71 @@ describe("oauth", async () => {
 		expect(signInResponse.url).not.toContain(`${authServerBaseUrl}/login`);
 	});
 
+	it("should clear max_age after login so max_age=0 does not loop", async ({
+		onTestFinished,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { customFetchImpl: customFetchImplRP } = await createTestInstance();
+		const client = createAuthClient({
+			baseURL: rpBaseUrl,
+			fetchOptions: {
+				customFetchImpl: customFetchImplRP,
+			},
+		});
+		const headers = new Headers();
+		const data = await client.signIn.social(
+			{
+				provider: providerId,
+				callbackURL: "/success",
+			},
+			{
+				throw: true,
+				onSuccess: cookieSetter(headers),
+			},
+		);
+		const authorizeUrl = new URL(requireRedirectUrl(data));
+		authorizeUrl.searchParams.set("max_age", "0");
+
+		let loginRedirectUri = "";
+		await authClient.$fetch(authorizeUrl.toString(), {
+			method: "GET",
+			onError(ctx) {
+				loginRedirectUri = ctx.response.headers.get("Location") || "";
+			},
+		});
+		expect(loginRedirectUri).toContain("/login");
+		expect(loginRedirectUri).toContain("max_age=0");
+
+		vi.stubGlobal("window", {
+			location: {
+				href: "",
+				search: new URL(loginRedirectUri, authServerBaseUrl).search,
+			},
+		});
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const signInResponse = await authClient.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				throw: true,
+			},
+		);
+		expect(signInResponse.redirect).toBe(true);
+		expect(signInResponse.url).toContain(
+			`${rpBaseUrl}/api/auth/callback/${providerId}`,
+		);
+		expect(signInResponse.url).not.toContain(`${authServerBaseUrl}/login`);
+		expect(signInResponse.url).not.toContain("max_age=0");
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/7041
 	 */
@@ -529,7 +602,7 @@ describe("oauth", async () => {
 		);
 
 		let loginRedirectUri = "";
-		await authClient.$fetch(data.url, {
+		await authClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(ctx) {
 				loginRedirectUri = ctx.response.headers.get("Location") || "";
@@ -602,7 +675,7 @@ describe("oauth", async () => {
 		);
 
 		let loginRedirectUri = "";
-		await authClient.$fetch(data.url, {
+		await authClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(ctx) {
 				loginRedirectUri = ctx.response.headers.get("Location") || "";
@@ -673,7 +746,7 @@ describe("oauth", async () => {
 		);
 
 		let loginRedirectUri = "";
-		await authClient.$fetch(data.url, {
+		await authClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(ctx) {
 				loginRedirectUri = ctx.response.headers.get("Location") || "";
@@ -761,7 +834,7 @@ describe("oauth", async () => {
 		);
 
 		let loginRedirectUri = "";
-		await authClient.$fetch(data.url, {
+		await authClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(ctx) {
 				loginRedirectUri = ctx.response.headers.get("Location") || "";
@@ -851,7 +924,7 @@ describe("oauth", async () => {
 		);
 
 		let loginRedirectUri = "";
-		await authClient.$fetch(data.url, {
+		await authClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(ctx) {
 				loginRedirectUri = ctx.response.headers.get("Location") || "";
@@ -932,7 +1005,7 @@ describe("oauth", async () => {
 		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
 
 		let loginRedirectUri = "";
-		await authClient.$fetch(data.url, {
+		await authClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(ctx) {
@@ -1227,7 +1300,7 @@ describe("oauth - prompt", async () => {
 
 		// Check for redirection to /login
 		let loginRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(context) {
 				loginRedirectUri = context.response.headers.get("Location") || "";
@@ -1272,7 +1345,7 @@ describe("oauth - prompt", async () => {
 
 		// Check for redirection to /signup
 		let signupRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(context) {
 				signupRedirectUri = context.response.headers.get("Location") || "";
@@ -1319,7 +1392,7 @@ describe("oauth - prompt", async () => {
 
 		// Check for redirection to /setup
 		let setupRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(context) {
@@ -1396,7 +1469,7 @@ describe("oauth - prompt", async () => {
 		);
 
 		let setupRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(context) {
@@ -1469,7 +1542,7 @@ describe("oauth - prompt", async () => {
 
 		// Check for redirection to /consent
 		let consentRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(context) {
@@ -1560,7 +1633,7 @@ describe("oauth - prompt", async () => {
 
 		// No redirect and user should get code
 		let callbackRedirectUrl = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(context) {
@@ -1627,7 +1700,7 @@ describe("oauth - prompt", async () => {
 
 		// Check for redirection to /consent
 		let consentRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(context) {
@@ -1673,7 +1746,7 @@ describe("oauth - prompt", async () => {
 		expect(data.url).toContain(`prompt=consent`);
 
 		let consentRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(context) {
@@ -1775,7 +1848,7 @@ describe("oauth - prompt", async () => {
 
 		// Check for redirection to /select-account
 		let selectAccountRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(ctx) {
@@ -1847,7 +1920,7 @@ describe("oauth - prompt", async () => {
 			expect(data.url).toContain(`prompt=none`);
 
 			let callbackRedirectUri = "";
-			await serverClient.$fetch(data.url, {
+			await serverClient.$fetch(requireRedirectUrl(data), {
 				method: "GET",
 				headers,
 				onError(context) {
@@ -1898,7 +1971,7 @@ describe("oauth - prompt", async () => {
 			expect(data.url).toContain(`prompt=none`);
 
 			let callbackRedirectUri = "";
-			await serverClient.$fetch(data.url, {
+			await serverClient.$fetch(requireRedirectUrl(data), {
 				method: "GET",
 				headers,
 				onError(context) {
@@ -1957,7 +2030,7 @@ describe("oauth - prompt", async () => {
 
 		// Check for redirection to /login
 		let loginRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(context) {
@@ -2068,7 +2141,7 @@ describe("oauth - prompt", async () => {
 		}
 
 		let loginRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers: rpHeaders,
 			onError(context) {
@@ -2141,7 +2214,7 @@ describe("oauth - prompt", async () => {
 
 		// Check for redirection to /select-account
 		let selectAccountRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(ctx) {
@@ -2222,7 +2295,7 @@ describe("oauth - prompt", async () => {
 
 		// Check for redirection to /select-organization
 		let selectOrgRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(context) {
@@ -2300,7 +2373,7 @@ describe("oauth - prompt", async () => {
 
 		// Check for redirection to /select-account
 		let selectAccountRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers,
 			onError(context) {
@@ -2412,7 +2485,7 @@ describe("oauth - prompt", async () => {
 		}
 
 		let selectOrgRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers: freshHeaders,
 			onError(context) {
@@ -2505,7 +2578,7 @@ describe("oauth - prompt", async () => {
 		}
 
 		let selectOrgRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			headers: freshHeaders,
 			onError(context) {
@@ -2870,7 +2943,7 @@ describe("oauth - config", () => {
 		expect(data.url).toContain(`client_id=${oauthClient?.client_id}`);
 
 		let redirectUriResponse = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(context) {
 				redirectUriResponse = context.response.headers.get("Location") || "";
@@ -2970,7 +3043,7 @@ describe("oauth - config", () => {
 		expect(data.url).toContain(`client_id=${oauthClient?.client_id}`);
 
 		let redirectUriResponse = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(context) {
 				redirectUriResponse = context.response.headers.get("Location") || "";
@@ -3090,7 +3163,7 @@ describe("oauth - config", () => {
 		expect(data.url).toContain(`client_id=${oauthClient?.client_id}`);
 
 		let redirectUriResponse = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(requireRedirectUrl(data), {
 			method: "GET",
 			onError(context) {
 				redirectUriResponse = context.response.headers.get("Location") || "";
@@ -3188,7 +3261,7 @@ describe("oauth - config", () => {
 			const jwks = await authorizationServer.api.getJwks();
 			const jwkSet = createLocalJWKSet(jwks);
 			const checkSignature = await jwtVerify(tokens.data?.idToken!, jwkSet, {
-				algorithms: ["EdDSA"],
+				algorithms: ["RS256"],
 			});
 			expect(checkSignature).toBeDefined();
 		}

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -118,6 +118,11 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		"sid",
 		"scope",
 		"azp",
+		"auth_time",
+		"acr",
+		"amr",
+		"at_hash",
+		"nonce",
 		...(scopes.has("email") ? ["email", "email_verified"] : []),
 		...(scopes.has("profile")
 			? ["name", "picture", "family_name", "given_name"]
@@ -470,6 +475,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						if (!isNavigationRequest) {
 							ctx.headers?.set("accept", "application/json");
 						}
+						query.delete("max_age");
 						ctx.query = searchParamsToQuery(
 							removePromptFromQuery(query, "login"),
 						);
@@ -557,6 +563,12 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						scope: z.string().optional(),
 						state: z.string().optional(),
 						request_uri: z.string().optional(),
+						display: z.string().optional(),
+						ui_locales: z.string().optional(),
+						max_age: z.coerce.number().int().nonnegative().optional(),
+						acr_values: z.string().optional(),
+						login_hint: z.string().optional(),
+						id_token_hint: z.string().optional(),
 						code_challenge: z.string().optional(),
 						code_challenge_method: z
 							.string()
@@ -566,20 +578,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						resource: z
 							.union([ResourceUriSchema, z.array(ResourceUriSchema).min(1)])
 							.optional(),
-						prompt: z
-							.string()
-							.pipe(
-								z.enum([
-									"none",
-									"consent",
-									"login",
-									"create",
-									"select_account",
-									"login consent",
-									"select_account consent",
-								]),
-							)
-							.optional(),
+						prompt: z.string().optional(),
 					}),
 					redirectOnError: authorizeRedirectOnError(opts),
 					errorCodesByField: {

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -36,7 +36,11 @@ import { revokeEndpoint } from "./revoke";
 import { schema } from "./schema";
 import { tokenEndpoint } from "./token";
 import type { OAuthOptions, Scope } from "./types";
-import { ResourceUriSchema, SafeUrlSchema } from "./types/zod";
+import {
+	authorizationQuerySchema,
+	ResourceUriSchema,
+	SafeUrlSchema,
+} from "./types/zod";
 import { userInfoEndpoint } from "./userinfo";
 import {
 	getJwtPlugin,
@@ -553,33 +557,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				"/oauth2/authorize",
 				{
 					method: "GET",
-					query: z.object({
-						response_type: z
-							.string()
-							.pipe(z.enum(["code"]))
-							.optional(),
-						client_id: z.string(),
-						redirect_uri: SafeUrlSchema.optional(),
-						scope: z.string().optional(),
-						state: z.string().optional(),
-						request_uri: z.string().optional(),
-						display: z.string().optional(),
-						ui_locales: z.string().optional(),
-						max_age: z.coerce.number().int().nonnegative().optional(),
-						acr_values: z.string().optional(),
-						login_hint: z.string().optional(),
-						id_token_hint: z.string().optional(),
-						code_challenge: z.string().optional(),
-						code_challenge_method: z
-							.string()
-							.pipe(z.enum(["S256"]))
-							.optional(),
-						nonce: z.string().optional(),
-						resource: z
-							.union([ResourceUriSchema, z.array(ResourceUriSchema).min(1)])
-							.optional(),
-						prompt: z.string().optional(),
-					}),
+					query: authorizationQuerySchema,
 					redirectOnError: authorizeRedirectOnError(opts),
 					errorCodesByField: {
 						response_type: { invalid: "unsupported_response_type" },

--- a/packages/oauth-provider/src/private-key-jwt-e2e.test.ts
+++ b/packages/oauth-provider/src/private-key-jwt-e2e.test.ts
@@ -56,7 +56,10 @@ describe("private_key_jwt e2e", async () => {
 				const nodeHandler = toNodeHandler(auth.handler);
 				return async (req, res) => {
 					if (req.url === "/.well-known/openid-configuration") {
-						const config = await auth.api.getOpenIdConfig();
+						const api = auth.api as typeof auth.api & {
+							getOpenIdConfig: () => Promise<unknown>;
+						};
+						const config = await api.getOpenIdConfig();
 						res.setHeader("Content-Type", "application/json");
 						res.end(JSON.stringify(config));
 						return;

--- a/packages/oauth-provider/src/private-key-jwt.test.ts
+++ b/packages/oauth-provider/src/private-key-jwt.test.ts
@@ -360,20 +360,23 @@ describe("private_key_jwt authentication", async () => {
 		const code1 = await getAuthCode(assertionClient.client_id, cv1);
 		const assertion1 = await signAssertion({ jti });
 
-		const result1 = await client.$fetch("/oauth2/token", {
-			method: "POST",
-			body: new URLSearchParams({
-				grant_type: "authorization_code",
-				code: code1,
-				redirect_uri: redirectUri,
-				client_id: assertionClient.client_id,
-				client_assertion_type:
-					"urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-				client_assertion: assertion1,
-				code_verifier: cv1,
-			}),
-			headers: { "content-type": "application/x-www-form-urlencoded" },
-		});
+		const result1 = await client.$fetch<{ access_token?: string }>(
+			"/oauth2/token",
+			{
+				method: "POST",
+				body: new URLSearchParams({
+					grant_type: "authorization_code",
+					code: code1,
+					redirect_uri: redirectUri,
+					client_id: assertionClient.client_id,
+					client_assertion_type:
+						"urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+					client_assertion: assertion1,
+					code_verifier: cv1,
+				}),
+				headers: { "content-type": "application/x-www-form-urlencoded" },
+			},
+		);
 		expect(result1.data?.access_token).toBeDefined();
 
 		// Second request with same jti should fail

--- a/packages/oauth-provider/src/schema.ts
+++ b/packages/oauth-provider/src/schema.ts
@@ -216,6 +216,14 @@ export const schema = {
 				type: "date",
 				required: false,
 			},
+			acr: {
+				type: "string",
+				required: false,
+			},
+			amr: {
+				type: "string[]",
+				required: false,
+			},
 			// Immutable
 			scopes: {
 				type: "string[]",

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -2564,7 +2564,7 @@ describe("scope preservation through authorization code flow", async () => {
 	});
 });
 
-describe("at_hash in id tokens", async () => {
+describe("id token claims", async () => {
 	const authServerBaseUrl = "http://localhost:3000";
 	const rpBaseUrl = "http://localhost:5000";
 	const validAudience = "https://myapi.example.com";
@@ -2685,6 +2685,12 @@ describe("at_hash in id tokens", async () => {
 		expect(decoded.at_hash).toBeDefined();
 		expect(typeof decoded.at_hash).toBe("string");
 		expect((decoded.at_hash as string).length).toBeGreaterThan(0);
+	});
+
+	it("issues acr '0' (RFC 6711 unspecified) by default", async ({ expect }) => {
+		const tokens = await getTokens(["openid"]);
+		const decoded = decodeJwt(tokens.id_token!);
+		expect(decoded.acr).toBe("0");
 	});
 
 	/**

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -2157,6 +2157,7 @@ describe("id token claim override security", async () => {
 				customIdTokenClaims: () => ({
 					acr: "silver",
 					auth_time: 0,
+					amr: ["pwd"],
 					sub: "evil",
 					iss: "https://evil.com",
 					aud: "evil-client",
@@ -2259,12 +2260,13 @@ describe("id token claim override security", async () => {
 		return decodeJwt(tokens.data!.id_token!);
 	}
 
-	it("customIdTokenClaims can override acr and auth_time", async ({
+	it("customIdTokenClaims cannot override authentication context claims", async ({
 		expect,
 	}) => {
 		const claims = await getIdTokenClaims();
-		expect(claims.acr).toBe("silver");
-		expect(claims.auth_time).toBe(0);
+		expect(claims.acr).toBe("0");
+		expect(claims.auth_time).not.toBe(0);
+		expect(claims.amr).toBeUndefined();
 	});
 
 	it("customIdTokenClaims cannot override pinned security claims", async ({
@@ -2278,6 +2280,151 @@ describe("id token claim override security", async () => {
 		expect(claims.iat).not.toBe(0);
 		expect(claims.exp).not.toBe(0);
 		expect(claims.sid).not.toBe("evil-sid");
+	});
+});
+
+describe("id token authentication context", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const resolvedAcr = "urn:example:loa:mfa";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt({
+				jwt: {
+					issuer: authServerBaseUrl,
+				},
+			}),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+				authenticationContext: {
+					acrValuesSupported: ["0", resolvedAcr],
+					resolve: () => ({
+						acr: resolvedAcr,
+						amr: ["pwd", "otp"],
+					}),
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient(), jwtClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/callback/${providerId}`;
+
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		oauthClient = response;
+	});
+
+	async function getTokens() {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(32);
+		const { url } = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			state: "authentication-context",
+			scopes: ["openid", "offline_access"],
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(url.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const callbackUrl = new URL(callbackRedirectUrl);
+		const code = callbackUrl.searchParams.get("code");
+		expect(code).toBeTruthy();
+
+		const { body, headers: tokenHeaders } = await authorizationCodeRequest({
+			code: code!,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		const tokens = await client.$fetch<{
+			id_token?: string;
+			refresh_token?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+		expect(tokens.data?.id_token).toBeDefined();
+		expect(tokens.data?.refresh_token).toBeDefined();
+		return tokens.data!;
+	}
+
+	it("emits resolved acr/amr and preserves them on refresh", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const tokens = await getTokens();
+		const idToken = decodeJwt(tokens.id_token!);
+		expect(idToken.acr).toBe(resolvedAcr);
+		expect(idToken.amr).toEqual(["pwd", "otp"]);
+
+		const { body, headers: tokenHeaders } = await refreshAccessTokenRequest({
+			refreshToken: tokens.refresh_token!,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+		const refreshedTokens = await client.$fetch<{
+			id_token?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+		expect(refreshedTokens.data?.id_token).toBeDefined();
+		const refreshedIdToken = decodeJwt(refreshedTokens.data!.id_token!);
+		expect(refreshedIdToken.acr).toBe(resolvedAcr);
+		expect(refreshedIdToken.amr).toEqual(["pwd", "otp"]);
 	});
 });
 
@@ -2687,17 +2834,17 @@ describe("id token claims", async () => {
 		expect((decoded.at_hash as string).length).toBeGreaterThan(0);
 	});
 
-	it("issues acr '0' (RFC 6711 unspecified) by default", async ({ expect }) => {
+	it("issues acr '0' (OIDC Core level 0) by default", async ({ expect }) => {
 		const tokens = await getTokens(["openid"]);
 		const decoded = decodeJwt(tokens.id_token!);
 		expect(decoded.acr).toBe("0");
 	});
 
 	/**
-	 * EdDSA (Ed25519) uses SHA-512 per RFC 8032.
-	 * at_hash = base64url(left-half(SHA-512(access_token)))
+	 * RS256 uses SHA-256 per OIDC Core hash algorithm selection.
+	 * at_hash = base64url(left-half(SHA-256(access_token)))
 	 */
-	it("at_hash should match manual computation for EdDSA", async ({
+	it("at_hash should match manual computation for RS256", async ({
 		expect,
 	}) => {
 		const tokens = await getTokens(["openid"]);
@@ -2705,7 +2852,7 @@ describe("id token claims", async () => {
 
 		const digest = new Uint8Array(
 			await crypto.subtle.digest(
-				"SHA-512",
+				"SHA-256",
 				new TextEncoder().encode(tokens.access_token!),
 			),
 		);
@@ -3051,6 +3198,9 @@ describe("verificationValueSchema", () => {
 			},
 			userId: "user-1",
 			sessionId: "session-1",
+			authTime: 1710000000000,
+			acr: "0",
+			amr: ["pwd"],
 		};
 
 		const result = verificationValueSchema.safeParse(value);
@@ -3120,5 +3270,38 @@ describe("verificationValueSchema", () => {
 				"should-pass-through",
 			);
 		}
+	});
+
+	it("should coerce valid max_age values in stored authorization queries", () => {
+		const result = verificationValueSchema.safeParse({
+			type: "authorization_code",
+			query: {
+				client_id: "test",
+				redirect_uri: "https://example.com",
+				max_age: "30",
+			},
+			userId: "u1",
+			sessionId: "s1",
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.query.max_age).toBe(30);
+		}
+	});
+
+	it("should reject invalid max_age values in stored authorization queries", () => {
+		const result = verificationValueSchema.safeParse({
+			type: "authorization_code",
+			query: {
+				client_id: "test",
+				redirect_uri: "https://example.com",
+				max_age: -1,
+			},
+			userId: "u1",
+			sessionId: "s1",
+		});
+
+		expect(result.success).toBe(false);
 	});
 });

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -6,6 +6,7 @@ import { resolveSigningKey, signJWT, toExpJWT } from "better-auth/plugins";
 import type { Session, User } from "better-auth/types";
 import type { JWTPayload } from "jose";
 import { base64url, decodeProtectedHeader, SignJWT } from "jose";
+import { UNSPECIFIED_ACR } from "./authentication-context";
 import type {
 	OAuthOptions,
 	OAuthRefreshToken,
@@ -155,10 +156,7 @@ async function createIdToken(
 	const resolvedSub = await resolveSubjectIdentifier(user.id, client, opts);
 	const authTimeSec =
 		authTime != null ? Math.floor(authTime.getTime() / 1000) : undefined;
-	// TODO: this should be validated against the login process
-	// - bronze : password only
-	// - silver : mfa
-	const acr = "urn:mace:incommon:iap:bronze";
+	const acr = UNSPECIFIED_ACR;
 
 	const customClaims = opts.customIdTokenClaims
 		? await opts.customIdTokenClaims({

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -6,8 +6,13 @@ import { resolveSigningKey, signJWT, toExpJWT } from "better-auth/plugins";
 import type { Session, User } from "better-auth/types";
 import type { JWTPayload } from "jose";
 import { base64url, decodeProtectedHeader, SignJWT } from "jose";
-import { UNSPECIFIED_ACR } from "./authentication-context";
+import {
+	LEVEL_0_ACR,
+	normalizeAuthenticationContext,
+	sanitizeCustomIdTokenClaims,
+} from "./authentication-context";
 import type {
+	OAuthAuthenticationContext,
 	OAuthOptions,
 	OAuthRefreshToken,
 	SchemaClient,
@@ -147,23 +152,31 @@ async function createIdToken(
 	scopes: string[],
 	nonce?: string,
 	sessionId?: string,
-	authTime?: Date,
+	authenticationContext?: OAuthAuthenticationContext,
 	accessToken?: string,
 ) {
 	const iat = Math.floor(Date.now() / 1000);
 	const exp = iat + (opts.idTokenExpiresIn ?? 36000);
 	const userClaims = userNormalClaims(user, scopes);
 	const resolvedSub = await resolveSubjectIdentifier(user.id, client, opts);
+	const resolvedAuthenticationContext = normalizeAuthenticationContext(
+		authenticationContext,
+	);
 	const authTimeSec =
-		authTime != null ? Math.floor(authTime.getTime() / 1000) : undefined;
-	const acr = UNSPECIFIED_ACR;
+		resolvedAuthenticationContext.authTime != null
+			? Math.floor(resolvedAuthenticationContext.authTime.getTime() / 1000)
+			: undefined;
+	const acr = resolvedAuthenticationContext.acr ?? LEVEL_0_ACR;
+	const amr = resolvedAuthenticationContext.amr;
 
 	const customClaims = opts.customIdTokenClaims
-		? await opts.customIdTokenClaims({
-				user,
-				scopes,
-				metadata: parseClientMetadata(client.metadata),
-			})
+		? sanitizeCustomIdTokenClaims(
+				await opts.customIdTokenClaims({
+					user,
+					scopes,
+					metadata: parseClientMetadata(client.metadata),
+				}),
+			)
 		: {};
 
 	const jwtPluginOptions = opts.disableJwtPlugin
@@ -189,9 +202,10 @@ async function createIdToken(
 	);
 	const payload: JWTPayload = {
 		...userClaims,
+		...customClaims,
 		auth_time: authTimeSec,
 		acr,
-		...customClaims,
+		amr,
 		at_hash: atHash,
 		iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
 		sub: resolvedSub,
@@ -378,7 +392,7 @@ async function createRefreshToken(
 	scopes: string[],
 	payload: JWTPayload,
 	originalRefresh?: OAuthRefreshToken<Scope[]> & { id: string },
-	authTime?: Date,
+	authenticationContext?: OAuthAuthenticationContext,
 	resources?: string[],
 ) {
 	const iat = payload.iat ?? Math.floor(Date.now() / 1000);
@@ -398,7 +412,9 @@ async function createRefreshToken(
 		sessionId,
 		userId: user.id,
 		referenceId,
-		authTime,
+		authTime: authenticationContext?.authTime,
+		acr: authenticationContext?.acr,
+		amr: authenticationContext?.amr,
 		scopes,
 		resources,
 		createdAt: new Date(iat * 1000),
@@ -475,7 +491,7 @@ interface CreateUserTokensParams {
 	sessionId?: string;
 	nonce?: string;
 	refreshToken?: OAuthRefreshToken<Scope[]> & { id: string };
-	authTime?: Date;
+	authenticationContext?: OAuthAuthenticationContext;
 	verificationValue?: VerificationValue;
 	resources?: string[];
 	/** Full original authorized resources for the grant, used to seed the refresh token
@@ -497,7 +513,7 @@ async function createUserTokens(
 		sessionId,
 		nonce,
 		refreshToken: existingRefreshToken,
-		authTime,
+		authenticationContext,
 		verificationValue,
 	} = params;
 
@@ -573,7 +589,7 @@ async function createUserTokens(
 						sid: sessionId,
 					},
 					existingRefreshToken,
-					authTime,
+					authenticationContext,
 					refreshResources,
 				)
 			: undefined;
@@ -627,7 +643,7 @@ async function createUserTokens(
 							sid: sessionId,
 						},
 						existingRefreshToken,
-						authTime,
+						authenticationContext,
 						refreshResources,
 					)
 				: undefined,
@@ -643,7 +659,7 @@ async function createUserTokens(
 				scopes,
 				nonce,
 				sessionId,
-				authTime,
+				authenticationContext,
 				accessToken,
 			)
 		: undefined;
@@ -944,6 +960,11 @@ async function handleAuthorizationCodeGrant(
 		verificationValue.authTime != null
 			? normalizeTimestampValue(verificationValue.authTime)
 			: resolveSessionAuthTime(session);
+	const authenticationContext = normalizeAuthenticationContext({
+		authTime,
+		acr: verificationValue.acr,
+		amr: verificationValue.amr,
+	});
 
 	return createUserTokens(ctx, opts, {
 		client,
@@ -953,7 +974,7 @@ async function handleAuthorizationCodeGrant(
 		referenceId: verificationValue.referenceId,
 		sessionId: session.id,
 		nonce: verificationValue.query?.nonce,
-		authTime,
+		authenticationContext,
 		verificationValue,
 		resources: effectiveResources,
 		originalResources: authorizedResources,
@@ -1186,6 +1207,11 @@ async function handleRefreshTokenGrant(
 		refreshToken.authTime != null
 			? normalizeTimestampValue(refreshToken.authTime)
 			: undefined;
+	const authenticationContext = normalizeAuthenticationContext({
+		authTime,
+		acr: refreshToken.acr,
+		amr: refreshToken.amr,
+	});
 
 	// Generate new tokens
 	return createUserTokens(ctx, opts, {
@@ -1197,6 +1223,6 @@ async function handleRefreshTokenGrant(
 		sessionId: refreshToken.sessionId,
 		refreshToken,
 		resources: resources ?? refreshToken.resources,
-		authTime,
+		authenticationContext,
 	});
 }

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -27,11 +27,20 @@ type InternallySupportedScopes =
 	| "email"
 	| "offline_access";
 export type Scope = LiteralString | InternallySupportedScopes;
-export type Prompt = "none" | "consent" | "login" | "create" | "select_account";
+export const supportedPromptValues = [
+	"login",
+	"consent",
+	"create",
+	"select_account",
+	"none",
+] as const;
+export type Prompt = (typeof supportedPromptValues)[number];
+type InteractivePrompt = Exclude<Prompt, "none">;
 export type AuthorizePrompt =
 	| Prompt
-	| "login consent"
-	| "select_account consent";
+	| `${InteractivePrompt} ${InteractivePrompt}`
+	| `${InteractivePrompt} ${InteractivePrompt} ${InteractivePrompt}`
+	| `${InteractivePrompt} ${InteractivePrompt} ${InteractivePrompt} ${InteractivePrompt}`;
 
 /**
  * Describes how to resolve a `client_id` from an external source (a URL-based

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -80,6 +80,55 @@ export interface ClientDiscovery<
 	discoveryMetadata?: Record<string, unknown>;
 }
 
+export interface OAuthAuthenticationContext {
+	/**
+	 * Time when the end user last actively authenticated.
+	 *
+	 * Emitted as the `auth_time` ID token claim when available.
+	 */
+	authTime?: Date;
+	/**
+	 * Authentication Context Class Reference satisfied by the current session.
+	 *
+	 * Defaults to `"0"`, the OpenID Connect level 0 value for no assurance.
+	 */
+	acr?: string;
+	/**
+	 * Authentication Methods References used for the current session.
+	 *
+	 * Values should use registered AMR identifiers when possible.
+	 */
+	amr?: string[];
+}
+
+export interface OAuthAuthenticationContextOptions<
+	Scopes extends readonly Scope[] = InternallySupportedScopes[],
+> {
+	/**
+	 * ACR values this provider can honestly issue.
+	 *
+	 * Defaults to `["0"]`, OpenID Connect level 0.
+	 */
+	acrValuesSupported?: string[];
+	/**
+	 * Resolve the authentication context for an authorization grant.
+	 *
+	 * Return only values that were established by the authentication flow.
+	 * Do not use this hook for arbitrary custom ID token claims.
+	 */
+	resolve?: (info: {
+		user: User & Record<string, unknown>;
+		session: Session & Record<string, unknown>;
+		client: SchemaClient<Scopes>;
+		scopes: string[];
+		headers: Headers;
+		metadata?: Record<string, unknown>;
+		requestedAcrValues?: string[];
+		defaultContext: Required<Pick<OAuthAuthenticationContext, "acr">> &
+			OAuthAuthenticationContext;
+	}) => Awaitable<OAuthAuthenticationContext | undefined>;
+}
+
 export interface OAuthOptions<
 	Scopes extends readonly Scope[] = InternallySupportedScopes[],
 > {
@@ -527,7 +576,7 @@ export interface OAuthOptions<
 		scopes: Scopes;
 		/** The access token payload used in the /userinfo request */
 		jwt: JWTPayload;
-	}) => Awaitable<Record<string, any>>;
+	}) => Awaitable<Record<string, unknown>>;
 	/**
 	 * Custom claims attached to OIDC id tokens.
 	 *
@@ -544,8 +593,15 @@ export interface OAuthOptions<
 		/** Scopes granted for this token */
 		scopes: Scopes;
 		/** oAuthClient metadata */
-		metadata?: Record<string, any>;
-	}) => Awaitable<Record<string, any>>;
+		metadata?: Record<string, unknown>;
+	}) => Awaitable<Record<string, unknown>>;
+	/**
+	 * Authentication context emitted in OIDC ID tokens.
+	 *
+	 * This owns `auth_time`, `acr`, and `amr`. `customIdTokenClaims`
+	 * cannot override these protocol claims.
+	 */
+	authenticationContext?: OAuthAuthenticationContextOptions<Scopes>;
 	/**
 	 * Custom claims attached to access tokens.
 	 *
@@ -569,8 +625,8 @@ export interface OAuthOptions<
 		/** The resources requested. */
 		resources?: string[];
 		/** oAuthClient metadata */
-		metadata?: Record<string, any>;
-	}) => Awaitable<Record<string, any>>;
+		metadata?: Record<string, unknown>;
+	}) => Awaitable<Record<string, unknown>>;
 	/**
 	 * Custom fields to include in the token response body.
 	 *
@@ -594,7 +650,7 @@ export interface OAuthOptions<
 		/** Scopes granted for this token */
 		scopes: Scopes;
 		/** oAuthClient metadata */
-		metadata?: Record<string, any>;
+		metadata?: Record<string, unknown>;
 		/**
 		 * The authorization code verification value.
 		 * Only present for `authorization_code` grant. Contains the original
@@ -618,7 +674,7 @@ export interface OAuthOptions<
 		 * Advertised claims_supported located at /.well-known/openid-configuration
 		 *
 		 * Internally supported claims:
-		 * ["sub", "iss", "aud", "exp", "iat", "sid", "scope", "azp"]
+		 * ["sub", "iss", "aud", "exp", "iat", "sid", "scope", "azp", "auth_time", "acr", "amr", "at_hash", "nonce"]
 		 */
 		claims_supported?: string[];
 	};
@@ -934,6 +990,8 @@ export interface VerificationValue {
 	resource?: string[];
 	referenceId?: string;
 	authTime?: number;
+	acr?: string;
+	amr?: string[];
 }
 
 /**
@@ -1164,6 +1222,14 @@ export interface OAuthRefreshToken<
 	 * Persisted so refreshed ID tokens can include a correct `auth_time` claim.
 	 */
 	authTime?: Date;
+	/**
+	 * Authentication Context Class Reference satisfied at authorization time.
+	 */
+	acr?: string;
+	/**
+	 * Authentication Methods References used at authorization time.
+	 */
+	amr?: string[];
 	/**
 	 * Scopes granted for this refresh token.
 	 *

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -233,17 +233,13 @@ export interface OIDCMetadata extends AuthServerMetadata {
 	 */
 	userinfo_endpoint: string;
 	/**
-	 * acr_values supported.
+	 * Supported Authentication Context Class Reference values.
 	 *
-	 * - `urn:mace:incommon:iap:silver`: Silver level of assurance
-	 * - `urn:mace:incommon:iap:bronze`: Bronze level of assurance
+	 * The provider does not yet attest a specific assurance level, so it reports
+	 * the RFC 6711 "unspecified" value `"0"`.
 	 *
-	 * Determination of acr_value is considered bronze by default.
-	 * Silver level determination coming soon.
-	 *
-	 * @default
-	 * ["urn:mace:incommon:iap:bronze"]
-	 * @see https://incommon.org/federation/attributes.html
+	 * @default ["0"]
+	 * @see https://www.rfc-editor.org/rfc/rfc6711#section-4
 	 */
 	acr_values_supported: string[];
 	/**

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -235,11 +235,11 @@ export interface OIDCMetadata extends AuthServerMetadata {
 	/**
 	 * Supported Authentication Context Class Reference values.
 	 *
-	 * The provider does not yet attest a specific assurance level, so it reports
-	 * the RFC 6711 "unspecified" value `"0"`.
+	 * The default value `"0"` is the OpenID Connect level 0 value for no
+	 * assurance.
 	 *
 	 * @default ["0"]
-	 * @see https://www.rfc-editor.org/rfc/rfc6711#section-4
+	 * @see https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 	 */
 	acr_values_supported: string[];
 	/**
@@ -259,7 +259,7 @@ export interface OIDCMetadata extends AuthServerMetadata {
 	 * to sharing key vulnerabilities!
 	 *
 	 * @default
-	 * ["EdDSA"]
+	 * ["RS256"]
 	 */
 	id_token_signing_alg_values_supported: JWSAlgorithms[];
 	/**

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -1,47 +1,5 @@
+import { SafeUrlSchema } from "@better-auth/core/utils/redirect-uri";
 import * as z from "zod";
-
-/**
- * Runtime schema for OAuthAuthorizationQuery.
- * Uses passthrough to tolerate fields added by future extensions (PAR, FPA, etc.)
- */
-const oauthAuthorizationQuerySchema = z
-	.object({
-		response_type: z.literal("code").optional(),
-		request_uri: z.string().optional(),
-		redirect_uri: z.string(),
-		scope: z.string().optional(),
-		state: z.string().optional(),
-		client_id: z.string(),
-		prompt: z.string().optional(),
-		display: z.string().optional(),
-		ui_locales: z.string().optional(),
-		max_age: z.coerce.number().optional(),
-		acr_values: z.string().optional(),
-		login_hint: z.string().optional(),
-		id_token_hint: z.string().optional(),
-		code_challenge: z.string().optional(),
-		code_challenge_method: z.literal("S256").optional(),
-		nonce: z.string().optional(),
-		resource: z.union([z.string(), z.array(z.string())]).optional(),
-	})
-	.passthrough();
-
-/**
- * Runtime schema for the authorization code verification value.
- * Validates structure on deserialization from the JSON blob stored in the DB.
- * Uses passthrough so future fields (e.g. from authorization challenge) don't break parsing.
- */
-export const verificationValueSchema = z
-	.object({
-		type: z.literal("authorization_code"),
-		query: oauthAuthorizationQuerySchema,
-		sessionId: z.string(),
-		userId: z.string(),
-		referenceId: z.string().optional(),
-		authTime: z.number().optional(),
-		resource: z.array(z.string()).optional(),
-	})
-	.passthrough();
 
 /**
  * Re-exported from `@better-auth/core` so every OAuth provider plugin shares one
@@ -81,3 +39,60 @@ export const ResourceUriSchema = z.string().superRefine((val, ctx) => {
 		});
 	}
 });
+
+/**
+ * Runtime schema for OAuthAuthorizationQuery.
+ * Uses passthrough to tolerate fields added by future extensions (PAR, FPA, etc.)
+ */
+export const authorizationQuerySchema = z
+	.object({
+		response_type: z
+			.string()
+			.pipe(z.enum(["code"]))
+			.optional(),
+		request_uri: z.string().optional(),
+		redirect_uri: SafeUrlSchema.optional(),
+		scope: z.string().optional(),
+		state: z.string().optional(),
+		client_id: z.string(),
+		prompt: z.string().optional(),
+		display: z.string().optional(),
+		ui_locales: z.string().optional(),
+		max_age: z.coerce.number().int().nonnegative().optional(),
+		acr_values: z.string().optional(),
+		login_hint: z.string().optional(),
+		id_token_hint: z.string().optional(),
+		code_challenge: z.string().optional(),
+		code_challenge_method: z
+			.string()
+			.pipe(z.enum(["S256"]))
+			.optional(),
+		nonce: z.string().optional(),
+		resource: z
+			.union([ResourceUriSchema, z.array(ResourceUriSchema).min(1)])
+			.optional(),
+	})
+	.passthrough();
+
+const storedAuthorizationQuerySchema = authorizationQuerySchema.extend({
+	redirect_uri: SafeUrlSchema,
+});
+
+/**
+ * Runtime schema for the authorization code verification value.
+ * Validates structure on deserialization from the JSON blob stored in the DB.
+ * Uses passthrough so future fields (e.g. from authorization challenge) don't break parsing.
+ */
+export const verificationValueSchema = z
+	.object({
+		type: z.literal("authorization_code"),
+		query: storedAuthorizationQuerySchema,
+		sessionId: z.string(),
+		userId: z.string(),
+		referenceId: z.string().optional(),
+		authTime: z.number().optional(),
+		acr: z.string().optional(),
+		amr: z.array(z.string()).optional(),
+		resource: z.array(z.string()).optional(),
+	})
+	.passthrough();

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -1,5 +1,6 @@
 import { SafeUrlSchema } from "@better-auth/core/utils/redirect-uri";
 import * as z from "zod";
+import { supportedPromptValues } from ".";
 
 /**
  * Re-exported from `@better-auth/core` so every OAuth provider plugin shares one
@@ -8,6 +9,34 @@ import * as z from "zod";
 export { SafeUrlSchema } from "@better-auth/core/utils/redirect-uri";
 
 const DANGEROUS_SCHEMES = ["javascript:", "data:", "vbscript:"];
+const supportedPromptValueSet = new Set<string>(supportedPromptValues);
+
+const authorizationPromptSchema = z.string().superRefine((value, ctx) => {
+	const prompts = value.split(" ");
+	if (prompts.length === 0 || prompts.some((prompt) => prompt.length === 0)) {
+		ctx.addIssue({
+			code: "custom",
+			message: "prompt must be a space-delimited list of supported values",
+		});
+		return;
+	}
+	const unsupportedPrompt = prompts.find(
+		(prompt) => !supportedPromptValueSet.has(prompt),
+	);
+	if (unsupportedPrompt) {
+		ctx.addIssue({
+			code: "custom",
+			message: "prompt contains an unsupported value",
+		});
+		return;
+	}
+	if (prompts.includes("none") && prompts.length > 1) {
+		ctx.addIssue({
+			code: "custom",
+			message: "prompt value none cannot be combined with other prompt values",
+		});
+	}
+});
 
 /**
  * Validates an RFC 8707 resource indicator. The value must be an absolute URI
@@ -55,7 +84,7 @@ export const authorizationQuerySchema = z
 		scope: z.string().optional(),
 		state: z.string().optional(),
 		client_id: z.string(),
-		prompt: z.string().optional(),
+		prompt: authorizationPromptSchema.optional(),
 		display: z.string().optional(),
 		ui_locales: z.string().optional(),
 		max_age: z.coerce.number().int().nonnegative().optional(),

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -602,9 +602,14 @@ export async function validateClientCredentials(
  */
 export function parseClientMetadata(
 	metadata: string | object | undefined,
-): object | undefined {
+): Record<string, unknown> | undefined {
 	if (!metadata) return undefined;
-	return typeof metadata === "string" ? JSON.parse(metadata) : metadata;
+	const parsed =
+		typeof metadata === "string" ? (JSON.parse(metadata) as unknown) : metadata;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return undefined;
+	}
+	return parsed as Record<string, unknown>;
 }
 
 export type ExtractedCredentials =

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -20,6 +20,7 @@ import type {
 	Scope,
 	StoreTokenType,
 } from "../types";
+import { supportedPromptValues } from "../types";
 
 class TTLCache<K, V extends { expiresAt?: Date }> {
 	private cache = new Map<K, V>();
@@ -727,17 +728,11 @@ export async function extractClientCredentials(
  * @param prompt
  */
 export function parsePrompt(prompt: string) {
-	const prompts = prompt.split(" ").map((p) => p.trim());
+	const prompts = prompt.trim().split(/\s+/);
 	const set = new Set<Prompt>();
 	for (const p of prompts) {
-		if (
-			p === "login" ||
-			p === "consent" ||
-			p === "create" ||
-			p === "select_account" ||
-			p === "none"
-		) {
-			set.add(p);
+		if (supportedPromptValues.includes(p as Prompt)) {
+			set.add(p as Prompt);
 		}
 	}
 	return new Set(set);


### PR DESCRIPTION
Removing the inaccurate InCommon bronze `acr` claim (#9178) was correct, but reporting `"0"` on its own left the OIDC authentication-context contract half-built. The provider could not assert a real assurance level, `auth_time`/`acr`/`amr` drifted every time a refresh token rotated the ID token, `max_age` was accepted but never enforced, and discovery advertised signing algorithms and `acr` values the provider did not actually use. This PR finishes that contract.

## Why each change

- **`acr: "0"` is OpenID Connect level 0, not an assurance level.** The old `urn:mace:incommon:iap:bronze` asserted an InCommon/RFC 6711 level the provider never evaluated.
- **`authenticationContext` is the sanctioned way to assert `acr`/`amr`.** It resolves from the user, session, client, scopes, request headers, and requested `acr_values`, and refuses to emit an `acr` outside the configured supported set.
- **Authentication context is persisted, not recomputed.** `auth_time`, `acr`, and `amr` are stored on the authorization code and refresh token, so a rotated ID token keeps the original login's values (OIDC Core 1.0 §12.2).
- **`max_age` is enforced before the code is issued.** `max_age=0` forces re-authentication; the query is cleared on the way back so login does not loop.
- **`customIdTokenClaims` can no longer overwrite protocol claims.** Without this guard a custom claim could forge `auth_time`, `acr`, `nonce`, or `at_hash`.
- **Discovery reflects reality.** `acr_values_supported` and `id_token_signing_alg_values_supported` are derived from the live provider and JWT configuration.

## JWT signing default → RS256

The JWT/JWKS default moves from EdDSA to RS256, the algorithm OIDC Core requires every implementation to support, so relying parties verify ID tokens without extra configuration. The signing-key resolver now also mints a key matching the configured `alg` when the stored key does not match, fixing a latent case where changing `keyPairConfig.alg` left tokens signed under the old algorithm.

**Breaking:** four user-visible breaks ship here (the `acr` value, `max_age` enforcement, the `customIdTokenClaims` lockdown, the RS256 default). Migration is in the changeset.
