### PR TITLE
feat(oauth-provider)!: enforce max_age

### DIFF
--- a/.changeset/oauth-provider-max-age.md
+++ b/.changeset/oauth-provider-max-age.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+`max_age` is now enforced. When a client requests `max_age` and the user authenticated longer ago than that window, the provider sends them back to log in, and the resulting ID token's `auth_time` reflects the fresh login. Previously `max_age` was accepted but ignored, so flows that relied on it being a no-op will now prompt the user to log in again.

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -308,6 +308,19 @@ describe("oauth authorize - max_age (OIDC Core 1.0 §3.1.2.1)", async () => {
 		expect(location).toContain("error=invalid_request");
 		expect(location).not.toContain("/login");
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/9936
+	 */
+	it("returns invalid_request for empty max_age values", async () => {
+		for (const maxAge of ["", "   "]) {
+			const location = await redirectFor(maxAge);
+
+			expect(location).toContain(redirectUri);
+			expect(location).toContain("error=invalid_request");
+			expect(location).not.toContain("/login");
+		}
+	});
 });
 
 describe("oauth authorize - request_uri resolution", async () => {
@@ -318,6 +331,7 @@ describe("oauth authorize - request_uri resolution", async () => {
 	const requestUri = "urn:better-auth:par:test";
 	const requestUriWithPostLoginMarker = "urn:better-auth:par:post-login";
 	const requestUriWithInvalidMaxAge = "urn:better-auth:par:invalid-max-age";
+	const requestUriWithReorderedPrompt = "urn:better-auth:par:reordered-prompt";
 
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		baseURL: authServerBaseUrl,
@@ -350,6 +364,13 @@ describe("oauth authorize - request_uri resolution", async () => {
 						return {
 							...resolvedParams,
 							max_age: "-1",
+						};
+					}
+
+					if (receivedRequestUri === requestUriWithReorderedPrompt) {
+						return {
+							...resolvedParams,
+							prompt: "consent login",
 						};
 					}
 
@@ -486,6 +507,30 @@ describe("oauth authorize - request_uri resolution", async () => {
 		expect(callbackRedirectUrl).toContain(redirectUri);
 		expect(callbackRedirectUrl).toContain("error=invalid_request");
 		expect(callbackRedirectUrl).not.toContain("/login");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/9936
+	 */
+	it("should accept valid PAR prompt values in any order", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("request_uri", requestUriWithReorderedPrompt);
+
+		let loginRedirectUrl = "";
+		await unauthenticatedClient.$fetch(authUrl.toString(), {
+			onError(context) {
+				loginRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		const loginRedirect = new URL(loginRedirectUrl, authServerBaseUrl);
+		expect(loginRedirect.pathname).toBe("/login");
+		expect(loginRedirect.searchParams.get("prompt")).toBe("consent login");
 	});
 });
 

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -187,6 +187,87 @@ describe("oauth authorize - unauthenticated", async () => {
 	});
 });
 
+describe("oauth authorize - max_age (OIDC Core 1.0 §3.1.2.1)", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const authenticatedClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: { customFetchImpl, headers },
+	});
+
+	let oauthClient: OAuthClient | null;
+	const redirectUri = `${rpBaseUrl}/api/auth/callback/test`;
+	beforeAll(async () => {
+		oauthClient = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: { redirect_uris: [redirectUri], skip_consent: true },
+		});
+	});
+
+	function authorizeUrl(maxAge: string, prompt?: string) {
+		if (!oauthClient?.client_id) throw new Error("beforeAll not run properly");
+		const url = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		url.searchParams.set("client_id", oauthClient.client_id);
+		url.searchParams.set("redirect_uri", redirectUri);
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("scope", "openid");
+		url.searchParams.set("state", "123");
+		url.searchParams.set("code_challenge", generateRandomString(43));
+		url.searchParams.set("code_challenge_method", "S256");
+		url.searchParams.set("max_age", maxAge);
+		if (prompt) url.searchParams.set("prompt", prompt);
+		return url.toString();
+	}
+
+	async function redirectFor(maxAge: string, prompt?: string) {
+		let location = "";
+		await authenticatedClient.$fetch(authorizeUrl(maxAge, prompt), {
+			onError(context) {
+				location = context.response.headers.get("Location") || "";
+			},
+		});
+		return location;
+	}
+
+	it("forces re-authentication when the session is older than max_age", async () => {
+		// Let the session land in an earlier second than the request, so any
+		// elapsed time exceeds max_age=0 and re-authentication is required.
+		await new Promise((resolve) => setTimeout(resolve, 1100));
+		const location = await redirectFor("0");
+		expect(location).toContain("/login");
+	});
+
+	it("does not re-authenticate when the session is within max_age", async () => {
+		const location = await redirectFor("10000");
+		expect(location).toContain(redirectUri);
+		expect(location).toContain("code=");
+		expect(location).not.toContain("/login");
+	});
+
+	it("returns login_required for prompt=none when the session is older than max_age", async () => {
+		await new Promise((resolve) => setTimeout(resolve, 1100));
+		const location = await redirectFor("0", "none");
+		expect(location).toContain("error=login_required");
+		expect(location).not.toContain("/login");
+	});
+});
+
 describe("oauth authorize - request_uri resolution", async () => {
 	const authServerBaseUrl = "http://localhost:3000";
 	const rpBaseUrl = "http://localhost:5000";

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -212,18 +212,24 @@ describe("oauth authorize - max_age (OIDC Core 1.0 §3.1.2.1)", async () => {
 	});
 
 	let oauthClient: OAuthClient | null;
+	let oauthClientNeedsConsent: OAuthClient | null;
 	const redirectUri = `${rpBaseUrl}/api/auth/callback/test`;
 	beforeAll(async () => {
 		oauthClient = await auth.api.adminCreateOAuthClient({
 			headers,
 			body: { redirect_uris: [redirectUri], skip_consent: true },
 		});
+		oauthClientNeedsConsent = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: { redirect_uris: [redirectUri], skip_consent: false },
+		});
 	});
 
-	function authorizeUrl(maxAge: string, prompt?: string) {
-		if (!oauthClient?.client_id) throw new Error("beforeAll not run properly");
+	function authorizeUrl(maxAge: string, prompt?: string, clientId?: string) {
+		const resolvedClientId = clientId ?? oauthClient?.client_id;
+		if (!resolvedClientId) throw new Error("beforeAll not run properly");
 		const url = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
-		url.searchParams.set("client_id", oauthClient.client_id);
+		url.searchParams.set("client_id", resolvedClientId);
 		url.searchParams.set("redirect_uri", redirectUri);
 		url.searchParams.set("response_type", "code");
 		url.searchParams.set("scope", "openid");
@@ -235,9 +241,13 @@ describe("oauth authorize - max_age (OIDC Core 1.0 §3.1.2.1)", async () => {
 		return url.toString();
 	}
 
-	async function redirectFor(maxAge: string, prompt?: string) {
+	async function redirectFor(
+		maxAge: string,
+		prompt?: string,
+		clientId?: string,
+	) {
 		let location = "";
-		await authenticatedClient.$fetch(authorizeUrl(maxAge, prompt), {
+		await authenticatedClient.$fetch(authorizeUrl(maxAge, prompt, clientId), {
 			onError(context) {
 				location = context.response.headers.get("Location") || "";
 			},
@@ -245,10 +255,10 @@ describe("oauth authorize - max_age (OIDC Core 1.0 §3.1.2.1)", async () => {
 		return location;
 	}
 
-	it("forces re-authentication when the session is older than max_age", async () => {
-		// Let the session land in an earlier second than the request, so any
-		// elapsed time exceeds max_age=0 and re-authentication is required.
-		await new Promise((resolve) => setTimeout(resolve, 1100));
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/9936
+	 */
+	it("treats max_age=0 as an explicit re-authentication request", async () => {
 		const location = await redirectFor("0");
 		expect(location).toContain("/login");
 	});
@@ -260,10 +270,42 @@ describe("oauth authorize - max_age (OIDC Core 1.0 §3.1.2.1)", async () => {
 		expect(location).not.toContain("/login");
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/9936
+	 */
+	it("removes satisfied max_age before redirecting to consent", async () => {
+		if (!oauthClientNeedsConsent?.client_id) {
+			throw new Error("beforeAll not run properly");
+		}
+
+		const location = await redirectFor(
+			"10000",
+			undefined,
+			oauthClientNeedsConsent.client_id,
+		);
+		const consentUrl = new URL(location, authServerBaseUrl);
+
+		expect(consentUrl.pathname).toBe("/consent");
+		expect(consentUrl.searchParams.get("max_age")).toBeNull();
+		expect(consentUrl.searchParams.get("client_id")).toBe(
+			oauthClientNeedsConsent.client_id,
+		);
+	});
+
 	it("returns login_required for prompt=none when the session is older than max_age", async () => {
-		await new Promise((resolve) => setTimeout(resolve, 1100));
 		const location = await redirectFor("0", "none");
 		expect(location).toContain("error=login_required");
+		expect(location).not.toContain("/login");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/9936
+	 */
+	it("returns invalid_request for invalid max_age values", async () => {
+		const location = await redirectFor("-1");
+
+		expect(location).toContain(redirectUri);
+		expect(location).toContain("error=invalid_request");
 		expect(location).not.toContain("/login");
 	});
 });
@@ -275,6 +317,7 @@ describe("oauth authorize - request_uri resolution", async () => {
 	const redirectUri = `${rpBaseUrl}/api/auth/callback/${providerId}`;
 	const requestUri = "urn:better-auth:par:test";
 	const requestUriWithPostLoginMarker = "urn:better-auth:par:post-login";
+	const requestUriWithInvalidMaxAge = "urn:better-auth:par:invalid-max-age";
 
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		baseURL: authServerBaseUrl,
@@ -300,6 +343,13 @@ describe("oauth authorize - request_uri resolution", async () => {
 						return {
 							...resolvedParams,
 							[postLoginClearedParam]: "attacker-session",
+						};
+					}
+
+					if (receivedRequestUri === requestUriWithInvalidMaxAge) {
+						return {
+							...resolvedParams,
+							max_age: "-1",
 						};
 					}
 
@@ -412,6 +462,30 @@ describe("oauth authorize - request_uri resolution", async () => {
 		expect(loginRedirectUrl).not.toContain("admin");
 		// prompt=none was not in the PAR payload — must not appear
 		expect(loginRedirectUrl).not.toContain("prompt=none");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/9936
+	 */
+	it("should validate resolved PAR parameters through the authorization query schema", async () => {
+		if (!oauthClient?.client_id) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", oauthClient.client_id);
+		authUrl.searchParams.set("request_uri", requestUriWithInvalidMaxAge);
+
+		let callbackRedirectUrl = "";
+		await unauthenticatedClient.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(callbackRedirectUrl).toContain(redirectUri);
+		expect(callbackRedirectUrl).toContain("error=invalid_request");
+		expect(callbackRedirectUrl).not.toContain("/login");
 	});
 });
 

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -14,6 +14,7 @@ import type {
 	Scope,
 	VerificationValue,
 } from "./types";
+import { authorizationQuerySchema } from "./types/zod";
 
 import {
 	checkResource,
@@ -33,11 +34,24 @@ import {
  * last authenticated. The caller supplies `nowSeconds`, keeping this pure.
  */
 function isWithinMaxAge(
-	authTimeSeconds: number,
-	maxAge: number,
-	nowSeconds: number,
+	sessionCreatedAt: Date,
+	maxAgeSeconds: number,
+	now: Date,
 ): boolean {
-	return nowSeconds - authTimeSeconds <= maxAge;
+	if (maxAgeSeconds === 0) return false;
+	return now.getTime() - sessionCreatedAt.getTime() <= maxAgeSeconds * 1000;
+}
+
+export type OAuthRedirectResult = {
+	redirect: true;
+	url: string;
+};
+
+function removeMaxAgeFromAuthorizationQuery(
+	query: OAuthAuthorizationQuery,
+): OAuthAuthorizationQuery {
+	const { max_age: _maxAge, ...queryWithoutMaxAge } = query;
+	return queryWithoutMaxAge;
 }
 
 /**
@@ -89,7 +103,10 @@ function deriveResponseMode(
 	return "query";
 }
 
-export const handleRedirect = (ctx: GenericEndpointContext, uri: string) => {
+export const handleRedirect = (
+	ctx: GenericEndpointContext,
+	uri: string,
+): OAuthRedirectResult => {
 	const fromFetch = isBrowserFetchRequest(ctx.request?.headers);
 	const acceptJson = ctx.headers?.get("accept")?.includes("application/json");
 	if (fromFetch || acceptJson) {
@@ -258,7 +275,7 @@ async function resolveTrustedRedirectUri(
  */
 export function authorizeRedirectOnError(
 	opts: OAuthOptions<Scope[]>,
-): OAuthRedirectOnError<GenericEndpointContext> {
+): OAuthRedirectOnError<GenericEndpointContext, OAuthRedirectResult> {
 	return async ({ error, error_description, ctx }) => {
 		const raw = (ctx.query ?? {}) as Record<string, unknown>;
 		const clientId =
@@ -295,7 +312,7 @@ export async function authorizeEndpoint(
 		isAuthorize?: boolean;
 		postLogin?: boolean;
 	},
-) {
+): Promise<OAuthRedirectResult> {
 	// Grant type must include authorization_code to use this endpoint
 	if (opts.grantTypes && !opts.grantTypes.includes("authorization_code")) {
 		throw new APIError("NOT_FOUND");
@@ -307,6 +324,7 @@ export async function authorizeEndpoint(
 			error: "invalid_request",
 		});
 	}
+	const request = ctx.request;
 
 	// Resolve request_uri (PAR) before processing
 	let query: OAuthAuthorizationQuery = ctx.query;
@@ -340,6 +358,16 @@ export async function authorizeEndpoint(
 			query.client_id = urlClientId;
 		}
 	}
+	ctx.query = query;
+	const parsedQuery = authorizationQuerySchema.safeParse(query);
+	if (!parsedQuery.success) {
+		return authorizeRedirectOnError(opts)({
+			error: "invalid_request",
+			error_description: "invalid authorization request",
+			ctx,
+		});
+	}
+	query = parsedQuery.data as OAuthAuthorizationQuery;
 	ctx.query = query;
 	await oAuthState.set({
 		query: serializeAuthorizationQuery(query).toString(),
@@ -516,20 +544,17 @@ export async function authorizeEndpoint(
 	// login page performs (minting a fresh session whose createdAt becomes the
 	// new auth_time). Reuse the prompt=login redirect rather than deleting the
 	// session, so other relying parties are not back-channel logged out.
-	// Authorization params arrive as strings on resumed and request_uri flows,
-	// so coerce defensively and ignore a malformed max_age rather than risk a
-	// re-auth loop on a NaN or negative value.
-	const maxAge = query.max_age != null ? Number(query.max_age) : undefined;
-	const staleForMaxAge =
+	const maxAgeSeconds = query.max_age;
+	const hasSatisfiedMaxAge =
 		session != null &&
-		maxAge !== undefined &&
-		Number.isInteger(maxAge) &&
-		maxAge >= 0 &&
-		!isWithinMaxAge(
-			Math.floor(new Date(session.session.createdAt).getTime() / 1000),
-			maxAge,
-			Math.floor(Date.now() / 1000),
+		maxAgeSeconds !== undefined &&
+		isWithinMaxAge(
+			new Date(session.session.createdAt),
+			maxAgeSeconds,
+			new Date(),
 		);
+	const staleForMaxAge =
+		session != null && maxAgeSeconds !== undefined && !hasSatisfiedMaxAge;
 	if (
 		!session ||
 		staleForMaxAge ||
@@ -551,6 +576,10 @@ export async function authorizeEndpoint(
 			promptSet?.has("create") ? "create" : "login",
 		);
 	}
+	if (hasSatisfiedMaxAge) {
+		query = removeMaxAgeFromAuthorizationQuery(query);
+		ctx.query = query;
+	}
 
 	// Force account selection (eg. multi-session)
 	if (settings?.isAuthorize && promptSet?.has("select_account")) {
@@ -563,7 +592,7 @@ export async function authorizeEndpoint(
 		opts.selectAccount
 	) {
 		const selectedAccountRedirect = await opts.selectAccount.shouldRedirect({
-			headers: ctx.request.headers,
+			headers: request.headers,
 			user: session.user,
 			session: session.session,
 			scopes: requestedScopes,
@@ -585,7 +614,7 @@ export async function authorizeEndpoint(
 	// Redirect to complete registration steps
 	if (opts.signup?.shouldRedirect) {
 		const signupRedirect = await opts.signup.shouldRedirect({
-			headers: ctx.request.headers,
+			headers: request.headers,
 			user: session.user,
 			session: session.session,
 			scopes: requestedScopes,
@@ -608,7 +637,7 @@ export async function authorizeEndpoint(
 
 	if (!settings?.postLogin && opts.postLogin) {
 		const postLoginRedirect = await opts.postLogin.shouldRedirect({
-			headers: ctx.request.headers,
+			headers: request.headers,
 			user: session.user,
 			session: session.session,
 			scopes: requestedScopes,

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -31,7 +31,7 @@ import {
 /**
  * Whether a past authentication is still fresh enough for an OIDC `max_age`
  * request: true when no more than `maxAge` seconds have elapsed since the user
- * last authenticated. The caller supplies `nowSeconds`, keeping this pure.
+ * last authenticated. The caller supplies `now`, keeping this pure.
  */
 function isWithinMaxAge(
 	sessionCreatedAt: Date,

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -28,6 +28,19 @@ import {
 } from "./utils";
 
 /**
+ * Whether a past authentication is still fresh enough for an OIDC `max_age`
+ * request: true when no more than `maxAge` seconds have elapsed since the user
+ * last authenticated. The caller supplies `nowSeconds`, keeping this pure.
+ */
+function isWithinMaxAge(
+	authTimeSeconds: number,
+	maxAge: number,
+	nowSeconds: number,
+): boolean {
+	return nowSeconds - authTimeSeconds <= maxAge;
+}
+
+/**
  * Formats an error url. Per OIDC Core 1.0 §5 / RFC 6749 §4.2.2.1, errors on
  * implicit and hybrid flows are delivered in the URL fragment, not the query.
  * Callers on the code flow (default) omit `mode` and get query delivery.
@@ -499,7 +512,30 @@ export async function authorizeEndpoint(
 
 	// Check for session
 	const session = await getSessionFromCtx(ctx);
-	if (!session || promptSet?.has("login") || promptSet?.has("create")) {
+	// A stale session under `max_age` requires re-authentication, which the host
+	// login page performs (minting a fresh session whose createdAt becomes the
+	// new auth_time). Reuse the prompt=login redirect rather than deleting the
+	// session, so other relying parties are not back-channel logged out.
+	// Authorization params arrive as strings on resumed and request_uri flows,
+	// so coerce defensively and ignore a malformed max_age rather than risk a
+	// re-auth loop on a NaN or negative value.
+	const maxAge = query.max_age != null ? Number(query.max_age) : undefined;
+	const staleForMaxAge =
+		session != null &&
+		maxAge !== undefined &&
+		Number.isInteger(maxAge) &&
+		maxAge >= 0 &&
+		!isWithinMaxAge(
+			Math.floor(new Date(session.session.createdAt).getTime() / 1000),
+			maxAge,
+			Math.floor(Date.now() / 1000),
+		);
+	if (
+		!session ||
+		staleForMaxAge ||
+		promptSet?.has("login") ||
+		promptSet?.has("create")
+	) {
 		if (promptNone) {
 			return redirectWithPromptNoneError(
 				ctx,

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -4,8 +4,9 @@ import { authorizeEndpoint, formatErrorURL, getIssuer } from "./authorize";
 import { oAuthState } from "./oauth";
 import type { OAuthConsent, OAuthOptions, Scope } from "./types";
 import {
-	normalizeTimestampValue,
+	isSessionFreshForSignedQuery,
 	parsePrompt,
+	removeMaxAgeFromQuery,
 	removePromptFromQuery,
 	searchParamsToQuery,
 } from "./utils";
@@ -65,7 +66,7 @@ export async function consentEndpoint(
 	const hasLoginPrompt = promptSet.has("login");
 	const hasSatisfiedLoginPrompt =
 		hasLoginPrompt &&
-		sessionSatisfiesLoginPrompt(
+		isSessionFreshForSignedQuery(
 			session?.session.createdAt,
 			oauthRequest?.signedQueryIssuedAt,
 		);
@@ -149,6 +150,7 @@ export async function consentEndpoint(
 	let authorizationQuery = removePromptFromQuery(query, "consent");
 	if (hasSatisfiedLoginPrompt) {
 		authorizationQuery = removePromptFromQuery(authorizationQuery, "login");
+		authorizationQuery = removeMaxAgeFromQuery(authorizationQuery);
 	}
 	ctx.query = searchParamsToQuery(authorizationQuery);
 	const postLoginClearedForThisSession =
@@ -161,16 +163,4 @@ export async function consentEndpoint(
 		redirect: true,
 		url,
 	};
-}
-
-// Relies on session.createdAt being immutable for the session's lifetime; a
-// refresh path that rewrites it would silently accept a pre-request session.
-function sessionSatisfiesLoginPrompt(
-	sessionCreatedAt: Date | string | undefined,
-	signedQueryIssuedAt: Date | undefined,
-) {
-	if (!signedQueryIssuedAt) return false;
-	const normalized = normalizeTimestampValue(sessionCreatedAt);
-	if (!normalized) return false;
-	return normalized.getTime() >= signedQueryIssuedAt.getTime();
 }

--- a/packages/oauth-provider/src/oauth-endpoint.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.ts
@@ -74,9 +74,9 @@ export interface OAuthEndpointRedirectContext<Ctx = unknown> {
 	ctx: Ctx;
 }
 
-export type OAuthRedirectOnError<Ctx = any> = (
+export type OAuthRedirectOnError<Ctx = unknown, Result = unknown> = (
 	result: OAuthEndpointRedirectContext<Ctx>,
-) => unknown;
+) => Result | Promise<Result>;
 
 type ValidationErrorHookArgs = {
 	message: string;
@@ -85,14 +85,16 @@ type ValidationErrorHookArgs = {
 
 type ValidationErrorHook = (args: ValidationErrorHookArgs) => unknown;
 
-export interface OAuthEndpointExtras {
+export interface OAuthEndpointExtras<
+	Ctx = EndpointContext<string, EndpointOptions, AuthContext>,
+> {
 	/**
 	 * Invoked when validation fails. Presence switches delivery from a JSON
 	 * `APIError` envelope to this callback, which receives the request
 	 * context so it can compute an RP redirect URL from already-parsed query
 	 * params.
 	 */
-	redirectOnError?: OAuthRedirectOnError;
+	redirectOnError?: OAuthRedirectOnError<Ctx>;
 	/**
 	 * Forwarded to `better-call` and awaited before the RFC envelope is
 	 * synthesized, so callers can observe or transform issues.
@@ -134,7 +136,8 @@ export function createOAuthEndpoint<
 	R,
 >(
 	path: Path,
-	options: Options & OAuthEndpointExtras,
+	options: Options &
+		OAuthEndpointExtras<EndpointContext<Path, Options, AuthContext>>,
 	handler: (ctx: EndpointContext<Path, Options, AuthContext>) => Promise<R>,
 ): StrictEndpoint<Path, Options, R> {
 	const {

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -563,6 +563,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							.pipe(z.enum(["S256"]))
 							.optional(),
 						nonce: z.string().optional(),
+						max_age: z.coerce.number().int().nonnegative().optional(),
 						resource: z
 							.union([ResourceUriSchema, z.array(ResourceUriSchema).min(1)])
 							.optional(),
@@ -653,6 +654,14 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 									required: false,
 									schema: { type: "string" },
 									description: "OpenID Connect nonce",
+								},
+								{
+									name: "max_age",
+									in: "query",
+									required: false,
+									schema: { type: "integer", minimum: 0 },
+									description:
+										"Maximum authentication age in seconds; forces re-authentication when exceeded",
 								},
 								{
 									name: "resource",

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -36,13 +36,19 @@ import { revokeEndpoint } from "./revoke";
 import { schema } from "./schema";
 import { tokenEndpoint } from "./token";
 import type { OAuthOptions, Scope } from "./types";
-import { ResourceUriSchema, SafeUrlSchema } from "./types/zod";
+import {
+	authorizationQuerySchema,
+	ResourceUriSchema,
+	SafeUrlSchema,
+} from "./types/zod";
 import { userInfoEndpoint } from "./userinfo";
 import {
 	getJwtPlugin,
 	getSignedQueryIssuedAt,
+	isSessionFreshForSignedQuery,
 	mergeDiscoveryMetadata,
 	postLoginClearedParam,
+	removeMaxAgeFromQuery,
 	removePromptFromQuery,
 	searchParamsToQuery,
 	signedQueryIssuedAtParam,
@@ -65,6 +71,20 @@ export const oAuthState = defineRequestState<{
 	postLoginClearedForSession?: string;
 } | null>(() => null);
 export const getOAuthProviderState = oAuthState.get;
+const signedQueryIssuedAtMsKey = "signedQueryIssuedAtMs";
+
+function getServerContextSignedQueryIssuedAt(value: unknown) {
+	const issuedAtMs =
+		typeof value === "number"
+			? value
+			: typeof value === "string"
+				? Number(value)
+				: undefined;
+	if (!issuedAtMs || !Number.isFinite(issuedAtMs) || issuedAtMs <= 0) {
+		return undefined;
+	}
+	return new Date(issuedAtMs);
+}
 
 /**
  * oAuth 2.1 provider plugin for Better Auth.
@@ -421,6 +441,11 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						if (ctx.path === "/sign-in/social") {
 							await addOAuthServerContext({
 								query: queryParams.toString(),
+								...(signedQueryIssuedAt
+									? {
+											[signedQueryIssuedAtMsKey]: signedQueryIssuedAt.getTime(),
+										}
+									: {}),
 							});
 						}
 					}),
@@ -444,11 +469,12 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						if (!sessionToken) return;
 						// Continue with authorization request by using the initial prompt
 						// but clearing the login prompt cookie if forced login prompt
+						const oauthRequest = await oAuthState.get();
+						const oauthState = await getOAuthState();
+						const serverContext = oauthState?.serverContext;
 						const _query =
-							(await oAuthState.get())?.query ??
-							((await getOAuthState())?.serverContext?.query as
-								| string
-								| undefined);
+							oauthRequest?.query ??
+							(serverContext?.query as string | undefined);
 						if (!_query) return;
 						const query = new URLSearchParams(_query);
 
@@ -470,9 +496,21 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						if (!isNavigationRequest) {
 							ctx.headers?.set("accept", "application/json");
 						}
-						ctx.query = searchParamsToQuery(
-							removePromptFromQuery(query, "login"),
-						);
+						const signedQueryIssuedAt =
+							oauthRequest?.signedQueryIssuedAt ??
+							getServerContextSignedQueryIssuedAt(
+								serverContext?.[signedQueryIssuedAtMsKey],
+							);
+						let authorizationQuery = removePromptFromQuery(query, "login");
+						if (
+							isSessionFreshForSignedQuery(
+								session.session.createdAt,
+								signedQueryIssuedAt,
+							)
+						) {
+							authorizationQuery = removeMaxAgeFromQuery(authorizationQuery);
+						}
+						ctx.query = searchParamsToQuery(authorizationQuery);
 						return await authorizeEndpoint(ctx, opts);
 					}),
 				},
@@ -547,41 +585,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				"/oauth2/authorize",
 				{
 					method: "GET",
-					query: z.object({
-						response_type: z
-							.string()
-							.pipe(z.enum(["code"]))
-							.optional(),
-						client_id: z.string(),
-						redirect_uri: SafeUrlSchema.optional(),
-						scope: z.string().optional(),
-						state: z.string().optional(),
-						request_uri: z.string().optional(),
-						code_challenge: z.string().optional(),
-						code_challenge_method: z
-							.string()
-							.pipe(z.enum(["S256"]))
-							.optional(),
-						nonce: z.string().optional(),
-						max_age: z.coerce.number().int().nonnegative().optional(),
-						resource: z
-							.union([ResourceUriSchema, z.array(ResourceUriSchema).min(1)])
-							.optional(),
-						prompt: z
-							.string()
-							.pipe(
-								z.enum([
-									"none",
-									"consent",
-									"login",
-									"create",
-									"select_account",
-									"login consent",
-									"select_account consent",
-								]),
-							)
-							.optional(),
-					}),
+					query: authorizationQuerySchema,
 					redirectOnError: authorizeRedirectOnError(opts),
 					errorCodesByField: {
 						response_type: { invalid: "unsupported_response_type" },

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -3115,4 +3115,37 @@ describe("verificationValueSchema", () => {
 			);
 		}
 	});
+
+	it("should coerce valid max_age values in stored authorization queries", () => {
+		const result = verificationValueSchema.safeParse({
+			type: "authorization_code",
+			query: {
+				client_id: "test",
+				redirect_uri: "https://example.com",
+				max_age: "30",
+			},
+			userId: "u1",
+			sessionId: "s1",
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.query.max_age).toBe(30);
+		}
+	});
+
+	it("should reject invalid max_age values in stored authorization queries", () => {
+		const result = verificationValueSchema.safeParse({
+			type: "authorization_code",
+			query: {
+				client_id: "test",
+				redirect_uri: "https://example.com",
+				max_age: -1,
+			},
+			userId: "u1",
+			sessionId: "s1",
+		});
+
+		expect(result.success).toBe(false);
+	});
 });

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -3148,4 +3148,51 @@ describe("verificationValueSchema", () => {
 
 		expect(result.success).toBe(false);
 	});
+
+	it("should reject empty max_age values in stored authorization queries", () => {
+		for (const maxAge of ["", "   "]) {
+			const result = verificationValueSchema.safeParse({
+				type: "authorization_code",
+				query: {
+					client_id: "test",
+					redirect_uri: "https://example.com",
+					max_age: maxAge,
+				},
+				userId: "u1",
+				sessionId: "s1",
+			});
+
+			expect(result.success).toBe(false);
+		}
+	});
+
+	it("should accept valid prompt values in any order", () => {
+		const result = verificationValueSchema.safeParse({
+			type: "authorization_code",
+			query: {
+				client_id: "test",
+				redirect_uri: "https://example.com",
+				prompt: "consent login",
+			},
+			userId: "u1",
+			sessionId: "s1",
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("should reject prompt=none combined with other prompt values", () => {
+		const result = verificationValueSchema.safeParse({
+			type: "authorization_code",
+			query: {
+				client_id: "test",
+				redirect_uri: "https://example.com",
+				prompt: "none login",
+			},
+			userId: "u1",
+			sessionId: "s1",
+		});
+
+		expect(result.success).toBe(false);
+	});
 });

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -1,53 +1,11 @@
+import { SafeUrlSchema } from "@better-auth/core/utils/redirect-uri";
 import * as z from "zod";
-
-/**
- * Runtime schema for OAuthAuthorizationQuery.
- * Uses passthrough to tolerate fields added by future extensions (PAR, FPA, etc.)
- */
-const oauthAuthorizationQuerySchema = z
-	.object({
-		response_type: z.literal("code").optional(),
-		request_uri: z.string().optional(),
-		redirect_uri: z.string(),
-		scope: z.string().optional(),
-		state: z.string().optional(),
-		client_id: z.string(),
-		prompt: z.string().optional(),
-		display: z.string().optional(),
-		ui_locales: z.string().optional(),
-		max_age: z.coerce.number().optional(),
-		acr_values: z.string().optional(),
-		login_hint: z.string().optional(),
-		id_token_hint: z.string().optional(),
-		code_challenge: z.string().optional(),
-		code_challenge_method: z.literal("S256").optional(),
-		nonce: z.string().optional(),
-		resource: z.union([z.string(), z.array(z.string())]).optional(),
-	})
-	.passthrough();
-
-/**
- * Runtime schema for the authorization code verification value.
- * Validates structure on deserialization from the JSON blob stored in the DB.
- * Uses passthrough so future fields (e.g. from authorization challenge) don't break parsing.
- */
-export const verificationValueSchema = z
-	.object({
-		type: z.literal("authorization_code"),
-		query: oauthAuthorizationQuerySchema,
-		sessionId: z.string(),
-		userId: z.string(),
-		referenceId: z.string().optional(),
-		authTime: z.number().optional(),
-		resource: z.array(z.string()).optional(),
-	})
-	.passthrough();
 
 /**
  * Re-exported from `@better-auth/core` so every OAuth provider plugin shares one
  * redirect-URI scheme policy. See `@better-auth/core/utils/redirect-uri`.
  */
-export { SafeUrlSchema } from "@better-auth/core/utils/redirect-uri";
+export { SafeUrlSchema };
 
 const DANGEROUS_SCHEMES = ["javascript:", "data:", "vbscript:"];
 
@@ -81,3 +39,72 @@ export const ResourceUriSchema = z.string().superRefine((val, ctx) => {
 		});
 	}
 });
+
+const authorizationPromptSchema = z
+	.string()
+	.pipe(
+		z.enum([
+			"none",
+			"consent",
+			"login",
+			"create",
+			"select_account",
+			"login consent",
+			"select_account consent",
+		]),
+	);
+
+/**
+ * Runtime schema for OAuthAuthorizationQuery.
+ * Uses passthrough to tolerate fields added by future extensions (PAR, FPA, etc.)
+ */
+export const authorizationQuerySchema = z
+	.object({
+		response_type: z
+			.string()
+			.pipe(z.enum(["code"]))
+			.optional(),
+		request_uri: z.string().optional(),
+		redirect_uri: SafeUrlSchema.optional(),
+		scope: z.string().optional(),
+		state: z.string().optional(),
+		client_id: z.string(),
+		prompt: authorizationPromptSchema.optional(),
+		display: z.string().optional(),
+		ui_locales: z.string().optional(),
+		max_age: z.coerce.number().int().nonnegative().optional(),
+		acr_values: z.string().optional(),
+		login_hint: z.string().optional(),
+		id_token_hint: z.string().optional(),
+		code_challenge: z.string().optional(),
+		code_challenge_method: z
+			.string()
+			.pipe(z.enum(["S256"]))
+			.optional(),
+		nonce: z.string().optional(),
+		resource: z
+			.union([ResourceUriSchema, z.array(ResourceUriSchema).min(1)])
+			.optional(),
+	})
+	.passthrough();
+
+const storedAuthorizationQuerySchema = authorizationQuerySchema.extend({
+	redirect_uri: SafeUrlSchema,
+});
+
+/**
+ * Runtime schema for the authorization code verification value.
+ * Validates structure on deserialization from the JSON blob stored in the DB.
+ * Uses passthrough so future fields (e.g. from authorization challenge) don't break parsing.
+ */
+export const verificationValueSchema = z
+	.object({
+		type: z.literal("authorization_code"),
+		query: storedAuthorizationQuerySchema,
+		sessionId: z.string(),
+		userId: z.string(),
+		referenceId: z.string().optional(),
+		authTime: z.number().optional(),
+		resource: z.array(z.string()).optional(),
+	})
+	.passthrough();

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -40,19 +40,59 @@ export const ResourceUriSchema = z.string().superRefine((val, ctx) => {
 	}
 });
 
-const authorizationPromptSchema = z
-	.string()
-	.pipe(
-		z.enum([
-			"none",
-			"consent",
-			"login",
-			"create",
-			"select_account",
-			"login consent",
-			"select_account consent",
-		]),
-	);
+const authorizationPromptTokenSchema = z.enum([
+	"none",
+	"consent",
+	"login",
+	"create",
+	"select_account",
+]);
+
+const authorizationPromptSchema = z.string().superRefine((value, ctx) => {
+	const promptTokens = value
+		.split(" ")
+		.map((token) => token.trim())
+		.filter(Boolean);
+	const promptSet = new Set<string>();
+	if (!promptTokens.length) {
+		ctx.addIssue({
+			code: "custom",
+			message: "prompt must include at least one value",
+		});
+		return;
+	}
+	for (const token of promptTokens) {
+		const result = authorizationPromptTokenSchema.safeParse(token);
+		if (!result.success) {
+			ctx.addIssue({
+				code: "custom",
+				message: `unsupported prompt value: ${token}`,
+			});
+			continue;
+		}
+		promptSet.add(result.data);
+	}
+	if (promptSet.has("none") && promptSet.size > 1) {
+		ctx.addIssue({
+			code: "custom",
+			message: "prompt=none cannot be combined with other prompt values",
+		});
+	}
+});
+
+const maxAgeSchema = z
+	.union([z.number(), z.string().trim().min(1)])
+	.transform((value, ctx) => {
+		const maxAge = typeof value === "number" ? value : Number(value);
+		if (!Number.isInteger(maxAge) || maxAge < 0) {
+			ctx.addIssue({
+				code: "custom",
+				message: "max_age must be a non-negative integer",
+			});
+			return z.NEVER;
+		}
+		return maxAge;
+	});
 
 /**
  * Runtime schema for OAuthAuthorizationQuery.
@@ -72,7 +112,7 @@ export const authorizationQuerySchema = z
 		prompt: authorizationPromptSchema.optional(),
 		display: z.string().optional(),
 		ui_locales: z.string().optional(),
-		max_age: z.coerce.number().int().nonnegative().optional(),
+		max_age: maxAgeSchema.optional(),
 		acr_values: z.string().optional(),
 		login_hint: z.string().optional(),
 		id_token_hint: z.string().optional(),

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -812,6 +812,16 @@ export function getSignedQueryIssuedAt(oauthQuery: string): Date | null {
 	return new Date(issuedAt);
 }
 
+export function isSessionFreshForSignedQuery(
+	sessionCreatedAt: Date | string | undefined,
+	signedQueryIssuedAt: Date | undefined,
+) {
+	if (!signedQueryIssuedAt) return false;
+	const normalized = normalizeTimestampValue(sessionCreatedAt);
+	if (!normalized) return false;
+	return normalized.getTime() >= signedQueryIssuedAt.getTime();
+}
+
 export function removePromptFromQuery(query: URLSearchParams, prompt: Prompt) {
 	const nextQuery = new URLSearchParams(query);
 	const prompts = nextQuery.get("prompt")?.split(" ");
@@ -822,6 +832,12 @@ export function removePromptFromQuery(query: URLSearchParams, prompt: Prompt) {
 			? nextQuery.set("prompt", prompts.join(" "))
 			: nextQuery.delete("prompt");
 	}
+	return nextQuery;
+}
+
+export function removeMaxAgeFromQuery(query: URLSearchParams) {
+	const nextQuery = new URLSearchParams(query);
+	nextQuery.delete("max_age");
 	return nextQuery;
 }
 

--- a/packages/oauth-provider/src/utils/query-serialization.test.ts
+++ b/packages/oauth-provider/src/utils/query-serialization.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
 	getSignedQueryIssuedAt,
+	isSessionFreshForSignedQuery,
+	removeMaxAgeFromQuery,
 	removePromptFromQuery,
 	searchParamsToQuery,
 	signedQueryIssuedAtParam,
@@ -110,6 +112,27 @@ describe("removePromptFromQuery", () => {
 	});
 });
 
+describe("removeMaxAgeFromQuery", () => {
+	it("removes max_age and preserves other params", () => {
+		const params = new URLSearchParams(
+			"client_id=abc&max_age=0&prompt=login&scope=openid",
+		);
+		const result = searchParamsToQuery(removeMaxAgeFromQuery(params));
+
+		expect(result.max_age).toBeUndefined();
+		expect(result.client_id).toBe("abc");
+		expect(result.prompt).toBe("login");
+		expect(result.scope).toBe("openid");
+	});
+
+	it("does not mutate the original query", () => {
+		const params = new URLSearchParams("client_id=abc&max_age=0");
+		removeMaxAgeFromQuery(params);
+
+		expect(params.get("max_age")).toBe("0");
+	});
+});
+
 describe("getSignedQueryIssuedAt", () => {
 	it("reads the signed query issue time when present", () => {
 		const issuedAt = 1777026004123;
@@ -139,5 +162,36 @@ describe("getSignedQueryIssuedAt", () => {
 		});
 
 		expect(getSignedQueryIssuedAt(params.toString())).toBeNull();
+	});
+});
+
+describe("isSessionFreshForSignedQuery", () => {
+	it("accepts a session created at or after the signed query issue time", () => {
+		const issuedAt = new Date("2026-06-08T12:00:00.000Z");
+
+		expect(isSessionFreshForSignedQuery(issuedAt, issuedAt)).toBe(true);
+		expect(
+			isSessionFreshForSignedQuery(
+				new Date("2026-06-08T12:00:00.001Z"),
+				issuedAt,
+			),
+		).toBe(true);
+	});
+
+	it("rejects a session that predates the signed query issue time", () => {
+		expect(
+			isSessionFreshForSignedQuery(
+				new Date("2026-06-08T11:59:59.999Z"),
+				new Date("2026-06-08T12:00:00.000Z"),
+			),
+		).toBe(false);
+	});
+
+	it("rejects missing or invalid timestamps", () => {
+		const issuedAt = new Date("2026-06-08T12:00:00.000Z");
+
+		expect(isSessionFreshForSignedQuery(undefined, issuedAt)).toBe(false);
+		expect(isSessionFreshForSignedQuery("not-a-date", issuedAt)).toBe(false);
+		expect(isSessionFreshForSignedQuery(issuedAt, undefined)).toBe(false);
 	});
 });


### PR DESCRIPTION
`max_age` was parsed off the authorization request and then dropped, so a client capping authentication age never got re-authentication (OIDC Core §3.1.2.1). This enforces it at the authorize endpoint.

The enforcement reuses the existing `prompt=login` redirect rather than deleting the session: deleting it would fire the session-end hook that drives OIDC back-channel logout, signing the user out of every other relying party on each re-auth. The host login page re-authenticates and mints a fresh session, whose creation time the handler already records as `auth_time`.

Part of #9178.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces OIDC `max_age` in `@better-auth/oauth-provider` so clients can cap authentication age; when exceeded we redirect with `prompt=login` instead of deleting the session, or return `login_required` for `prompt=none`. Also validates `prompt` values and combinations. Aligns with #9178.

- **New Features**
  - Validate and normalize `max_age` across authorize, PAR, and stored queries; invalid values now return `invalid_request`.
  - Enforce `max_age` by redirecting with `prompt=login` when the session is older; strip satisfied `max_age` before consent and post-login to avoid extra prompts.
  - Validate `prompt`: accept valid tokens in any order, forbid `prompt=none` with other values, and re-validate PAR-resolved params; invalid prompts return `invalid_request`.

- **Migration**
  - Behavior change: clients sending `max_age` may see extra login prompts or `login_required` on silent flows; invalid `max_age` or invalid `prompt` combos now fail with `invalid_request`.
  - No code changes required for RPs; ensure UX handles re-auth redirects or `login_required`.

<sup>Written for commit 0e94249d3306e22681338d308ffe43e9fd920b60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

