### PR TITLE
feat(oauth-provider): accept POST on the userinfo endpoint

### DIFF
--- a/.changeset/oauth-provider-userinfo-post.md
+++ b/.changeset/oauth-provider-userinfo-post.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+The UserInfo endpoint (`/oauth2/userinfo`) now accepts `POST` with the access token in the `Authorization` header, in addition to `GET`.

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1112,7 +1112,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 			oauth2UserInfo: createAuthEndpoint(
 				"/oauth2/userinfo",
 				{
-					method: "GET",
+					method: ["GET", "POST"],
 					metadata: {
 						openapi: {
 							description:

--- a/packages/oauth-provider/src/userinfo.test.ts
+++ b/packages/oauth-provider/src/userinfo.test.ts
@@ -198,6 +198,21 @@ describe("oauth userinfo", async () => {
 		});
 	});
 
+	it("should accept POST with the bearer token in the Authorization header", async () => {
+		const tokens = await getTokens();
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${tokens.data?.access_token ?? ""}`,
+				},
+			},
+		);
+		expect(userinfo.data).toMatchObject({ sub: user.id });
+	});
+
 	/**
 	 * Programmatic callers have no `ctx.request`, so userinfo must resolve the
 	 * bearer token from `ctx.headers` for both transports.


### PR DESCRIPTION
The UserInfo endpoint accepted only `GET`. OIDC Core §5.3.1 and the Basic OP profile require accepting `POST` too. The handler already reads the bearer token from the `Authorization` header, so this adds `POST` to the route.

Part of #9178.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
UserInfo in `@better-auth/oauth-provider` now accepts POST, aligning with OIDC Core §5.3.1 and the Basic OP profile. Clients can call `/oauth2/userinfo` via GET or POST with the access token in the `Authorization` header.

- **New Features**
  - Accept POST on `/oauth2/userinfo` in addition to GET.
  - Added test covering POST with `Authorization` header.

<sup>Written for commit 5c01958014e61ada1372ff4e7dc69b06bc78f09a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

