### PR TITLE
fix(auth)!: harden validateUserInfo source contract

### DIFF
--- a/.changeset/social-auth-validation.md
+++ b/.changeset/social-auth-validation.md
@@ -1,12 +1,12 @@
 ---
-"@better-auth/core": minor
-"better-auth": minor
+"@better-auth/core": major
+"better-auth": major
 "@better-auth/sso": patch
 "@better-auth/scim": patch
 ---
 
 Add a `user.validateUserInfo` provisioning gate that lets applications reject an identity before a user is created or a new account is linked. It runs once at the creation step for every method that provisions a user (OAuth, SSO/SAML, email/password, magic link, email OTP, anonymous, SIWE, phone number, admin-created users, and SCIM), including stateless setups with no persistent database.
 
-It also re-runs when an existing OAuth or SSO user signs in again (`source.action` is `"sign-in"`), where it receives the fresh provider email and profile so a domain or org policy can reject a user whose provider identity moved out of bounds. Non-OAuth returning sign-ins are not re-validated.
+It also re-runs when an existing OAuth or SSO user signs in again (`source.action` is `"sign-in"`), where it receives the fresh provider email and profile so a domain or org policy can reject a user whose provider identity moved out of bounds. Non-provider returning sign-ins are not re-validated.
 
-The callback receives the mapped `user` plus a `source` describing the `action` (`create-user`, `link-account`, or `sign-in`), the `method`, and, for OAuth, the provider id and raw profile. Return `{ error, errorDescription }` to reject: browser flows redirect to the error URL and programmatic flows return a `403`.
+The callback receives the mapped `user` plus a `source` describing the `action` (`create-user`, `link-account`, or `sign-in`), the `method`, and provider metadata: `source.oauth` for OAuth providers and `source.sso` for OIDC/SAML SSO providers. Return `{ error, errorDescription }` to reject: browser flows redirect to the error URL and programmatic flows return a `403`.

--- a/.changeset/social-auth-validation.md
+++ b/.changeset/social-auth-validation.md
@@ -1,6 +1,6 @@
 ---
-"@better-auth/core": major
-"better-auth": major
+"@better-auth/core": minor
+"better-auth": minor
 "@better-auth/sso": patch
 "@better-auth/scim": patch
 ---

--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -301,11 +301,11 @@ await authClient.deleteUser({
 
 ### Callbacks
 
-**validateUserInfo**: A gate that decides which identities Better Auth admits. It fires just before a user is created (`create-user`) or a new provider account is linked (`link-account`), for every authentication method (OAuth, email/password, magic link, email OTP, anonymous, SIWE, phone number, and admin-created users), including stateless setups with no persistent database, so policy lives in one place instead of per provider.
+**validateUserInfo**: A gate that decides which identities Better Auth admits. It fires just before a user is created (`create-user`) or a new provider account is linked (`link-account`), for every authentication method (OAuth, OIDC SSO, SAML SSO, email/password, magic link, email OTP, anonymous, SIWE, phone number, admin-created users, and SCIM), including stateless setups with no persistent database, so policy lives in one place instead of per provider.
 
-It also fires when an existing **OAuth** user signs in again (`sign-in`), and there it receives the *fresh* provider email and profile rather than the stored row. That lets a domain or org policy reject a user whose provider identity moved out of bounds (for example, an email that left the allowed domain). Non-OAuth returning sign-ins are not re-validated, because their stored row has not changed since `create-user` gated it; use the admin plugin's ban controls or a `databaseHooks.session.create.before` hook to block those.
+It also fires when an existing **OAuth or SSO** user signs in again (`sign-in`), and there it receives the *fresh* provider email and profile rather than the stored row. That lets a domain or org policy reject a user whose provider identity moved out of bounds (for example, an email that left the allowed domain). Non-provider returning sign-ins are not re-validated, because their stored row has not changed since `create-user` gated it; use the admin plugin's ban controls or a `databaseHooks.session.create.before` hook to block those.
 
-`source.action` is `"create-user"`, `"link-account"`, or `"sign-in"`, and `source.method` is the authentication method. For OAuth methods, `source.oauth` carries the provider id and the raw provider profile.
+`source.action` is `"create-user"`, `"link-account"`, or `"sign-in"`, and `source.method` is the authentication method. For OAuth, `source.oauth` carries the provider id and raw provider profile. For OIDC and SAML SSO, `source.sso` carries the SSO provider id and raw provider claims or assertion attributes.
 
 Return nothing to allow provisioning. Return an object with `error` to reject it: browser/redirect flows send the rejection to the configured error URL, while programmatic flows return a `403` API error. Avoid putting sensitive details in `errorDescription` because it is returned to the client.
 

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -331,7 +331,10 @@ export const callbackOAuth = createAuthEndpoint(
 					(provider.disableImplicitSignUp && !requestSignUp) ||
 					provider.options?.disableSignUp,
 				overrideUserInfo: provider.options?.overrideUserInfoOnSignIn,
-				sourceProfile: providerResult.data,
+				source: {
+					method: "oauth",
+					oauth: { providerId: provider.id, profile: providerResult.data },
+				},
 				grantAuthority: provider.grantAuthority,
 			});
 		} catch (e) {

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -345,7 +345,10 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 					disableSignUp:
 						(provider.disableImplicitSignUp && !c.body.requestSignUp) ||
 						provider.disableSignUp,
-					sourceProfile: userInfo.data,
+					source: {
+						method: "oauth",
+						oauth: { providerId: provider.id, profile: userInfo.data },
+					},
 				});
 				if (data.error) {
 					if (data.error === OAUTH_CALLBACK_ERROR_CODES.EMAIL_NOT_VERIFIED) {

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 import type { GenericEndpointContext } from "@better-auth/core";
+import { runWithEndpointContext } from "@better-auth/core/context";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { betterAuth } from "../auth/full";
@@ -179,6 +180,112 @@ describe("internal adapter test", async () => {
 		expect(pluginHookUserCreateBefore).toHaveBeenCalledOnce();
 		expect(hookUserCreateAfter).toHaveBeenCalledOnce();
 		expect(hookUserCreateBefore).toHaveBeenCalledOnce();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/9864
+	 */
+	it("rejects createUser outside an endpoint context when validateUserInfo is configured", async () => {
+		const { auth } = await getTestInstance(
+			{
+				user: {
+					validateUserInfo() {
+						return;
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+		const context = await auth.$context;
+
+		await expect(
+			context.internalAdapter.createUser(
+				{
+					email: "missing-context@example.com",
+					name: "Missing Context",
+					emailVerified: false,
+				},
+				{ method: "test" },
+			),
+		).rejects.toMatchObject({
+			body: { code: "validation_context_missing" },
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/9864
+	 */
+	it("requires a provisioning source when validateUserInfo is configured", async () => {
+		const { auth } = await getTestInstance(
+			{
+				user: {
+					validateUserInfo() {
+						return;
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+		const context = await auth.$context;
+		const missingSource = undefined as unknown as Parameters<
+			typeof context.internalAdapter.createUser
+		>[1];
+
+		await runWithEndpointContext(
+			{ context } as unknown as GenericEndpointContext,
+			async () => {
+				await expect(
+					context.internalAdapter.createUser(
+						{
+							email: "missing-source@example.com",
+							name: "Missing Source",
+							emailVerified: false,
+						},
+						missingSource,
+					),
+				).rejects.toMatchObject({
+					body: { code: "validation_source_missing" },
+				});
+			},
+		);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/9864
+	 */
+	it("forces create-user as the createUser validation action", async () => {
+		let capturedAction: string | undefined;
+		const { auth } = await getTestInstance(
+			{
+				user: {
+					validateUserInfo({ source }) {
+						capturedAction = source.action;
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+		const context = await auth.$context;
+		const spoofedSource = {
+			method: "test",
+			action: "sign-in",
+		} as unknown as Parameters<typeof context.internalAdapter.createUser>[1];
+
+		await runWithEndpointContext(
+			{ context } as unknown as GenericEndpointContext,
+			async () => {
+				await context.internalAdapter.createUser(
+					{
+						email: "canonical-action@example.com",
+						name: "Canonical Action",
+						emailVerified: false,
+					},
+					spoofedSource,
+				);
+			},
+		);
+
+		expect(capturedAction).toBe("create-user");
 	});
 	it("should find session with custom userId", async () => {
 		const { client, signInWithTestUser } = await getTestInstance({

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -4,6 +4,7 @@ import type {
 	GenericEndpointContext,
 	InternalAdapter,
 	UserProvisioningSource,
+	ValidateUserInfoSource,
 } from "@better-auth/core";
 import {
 	getCurrentAdapter,
@@ -12,12 +13,16 @@ import {
 } from "@better-auth/core/context";
 import type { DBAdapter, Where } from "@better-auth/core/db/adapter";
 import type { InternalLogger } from "@better-auth/core/env";
+import { APIError } from "@better-auth/core/error";
 import { generateId } from "@better-auth/core/utils/id";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import type { Account, Session, User, Verification } from "../types";
 import { getDate } from "../utils/date";
 import { getIp } from "../utils/get-request-ip";
-import { assertValidUserInfo } from "../utils/validate-user-info";
+import {
+	assertValidUserInfo,
+	assertValidUserInfoSource,
+} from "../utils/validate-user-info";
 import {
 	getSessionDefaultFields,
 	parseSessionOutput,
@@ -129,14 +134,29 @@ export const createInternalAdapter = (
 			};
 
 			if (options.user?.validateUserInfo) {
-				// Skipped outside a request context (no request to hand the hook).
-				const endpointContext = await getCurrentAuthContext().catch(() => null);
-				if (endpointContext) {
-					await assertValidUserInfo(endpointContext as GenericEndpointContext, {
-						user: data,
-						source: { action: "create-user", ...source },
+				const validationSource: ValidateUserInfoSource = {
+					...source,
+					action: "create-user",
+				};
+				assertValidUserInfoSource(validationSource);
+				let endpointContext: GenericEndpointContext;
+				try {
+					endpointContext =
+						(await getCurrentAuthContext()) as GenericEndpointContext;
+				} catch (error) {
+					logger.error(
+						"Unable to run validateUserInfo: missing endpoint context",
+						error,
+					);
+					throw new APIError("FORBIDDEN", {
+						code: "validation_context_missing",
+						message: "User validation requires an endpoint context",
 					});
 				}
+				await assertValidUserInfo(endpointContext, {
+					user: data,
+					source: validationSource,
+				});
 			}
 
 			const createdUser = await createWithHooks(data, "user", undefined);

--- a/packages/better-auth/src/oauth2/resolve-account.ts
+++ b/packages/better-auth/src/oauth2/resolve-account.ts
@@ -1,4 +1,7 @@
-import type { GenericEndpointContext } from "@better-auth/core";
+import type {
+	GenericEndpointContext,
+	UserProvisioningSource,
+} from "@better-auth/core";
 import { isDevelopment, logger } from "@better-auth/core/env";
 import type { Account, User } from "../types";
 import { isAPIError } from "../utils/is-api-error";
@@ -29,10 +32,10 @@ export interface ResolveOAuthUserParams {
 	providerId: string;
 	linkPolicy: OAuthLinkPolicy;
 	/**
-	 * The raw, unmapped provider profile. Forwarded to the `validateUserInfo`
+	 * Authentication source metadata forwarded to the `validateUserInfo`
 	 * provisioning gate when a new user is created here.
 	 */
-	profile?: Record<string, unknown> | undefined;
+	source: UserProvisioningSource;
 }
 
 /**
@@ -72,7 +75,7 @@ export async function resolveOAuthUser(
 	c: GenericEndpointContext,
 	params: ResolveOAuthUserParams,
 ): Promise<ResolvedOAuthUser | ResolveOAuthUserError> {
-	const { userInfo, providerId, linkPolicy, profile } = params;
+	const { userInfo, providerId, linkPolicy, source } = params;
 
 	let dbUser: Awaited<
 		ReturnType<typeof c.context.internalAdapter.findOAuthUser>
@@ -102,7 +105,7 @@ export async function resolveOAuthUser(
 					...restUserInfo,
 					email: userInfo.email.toLowerCase(),
 				},
-				{ method: "oauth", oauth: { providerId, profile } },
+				source,
 			);
 			return {
 				user: createdUser,

--- a/packages/better-auth/src/oauth2/sign-in-with-oauth-identity.ts
+++ b/packages/better-auth/src/oauth2/sign-in-with-oauth-identity.ts
@@ -1,4 +1,7 @@
-import type { GenericEndpointContext } from "@better-auth/core";
+import type {
+	GenericEndpointContext,
+	UserProvisioningSource,
+} from "@better-auth/core";
 import { runWithTransaction } from "@better-auth/core/context";
 import type {
 	OAuth2Tokens,
@@ -50,10 +53,10 @@ export async function signInWithOAuthIdentity(
 		overrideUserInfo?: boolean | undefined;
 		isTrustedProvider?: boolean | undefined;
 		/**
-		 * The raw, unmapped provider profile. Forwarded to the
-		 * `validateUserInfo` provisioning gate when this sign-in creates a user.
+		 * Authentication source metadata forwarded to the `validateUserInfo`
+		 * provisioning gate for create, link, and returning sign-in actions.
 		 */
-		sourceProfile?: Record<string, unknown> | undefined;
+		source: UserProvisioningSource;
 		/**
 		 * The provider's declared {@link GrantAuthority}; `"full-grant"` lets a
 		 * non-empty echo replace the stored grant (the only narrowing path).
@@ -72,7 +75,7 @@ export async function signInWithOAuthIdentity(
 		disableSignUp,
 		overrideUserInfo,
 		isTrustedProvider,
-		sourceProfile,
+		source,
 		grantAuthority,
 	} = opts;
 
@@ -87,7 +90,7 @@ export async function signInWithOAuthIdentity(
 			const r = await resolveOAuthUser(c, {
 				userInfo,
 				providerId,
-				profile: sourceProfile,
+				source,
 				linkPolicy: { isTrustedProvider, disableSignUp, overrideUserInfo },
 			});
 			// Resolution failed (sign-up disabled, linking gate rejected, or the
@@ -105,12 +108,16 @@ export async function signInWithOAuthIdentity(
 			// createUser. Runs before the account write so a rejection rolls back the
 			// link and token refresh.
 			if (!r.isRegister) {
+				const { id: _providerAccountId, ...providerUserInfo } = userInfo;
 				await assertValidUserInfo(c, {
-					user: { ...r.user, email: userInfo.email.toLowerCase() },
+					user: {
+						...providerUserInfo,
+						id: r.user.id,
+						email: userInfo.email.toLowerCase(),
+					},
 					source: {
+						...source,
 						action: r.linkedAccount === null ? "link-account" : "sign-in",
-						method: "oauth",
-						oauth: { providerId, profile: sourceProfile },
 					},
 				});
 			}

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -283,7 +283,13 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							grantAuthority: provider?.grantAuthority,
 							callbackURL: payload.callbackURL,
 							disableSignUp: payload.disableSignUp,
-							sourceProfile: payload.profile,
+							source: {
+								method: "oauth",
+								oauth: {
+									providerId: payload.account.providerId,
+									profile: payload.profile,
+								},
+							},
 						});
 					} catch (e) {
 						if (isAPIError(e) && e.body?.code) {

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -142,7 +142,13 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 						accountId: sub,
 						tokens: { idToken, scopes: ["openid", "profile", "email"] },
 						disableSignUp: options?.disableSignup,
-						sourceProfile: payload as Record<string, unknown>,
+						source: {
+							method: "oauth",
+							oauth: {
+								providerId: "google",
+								profile: payload as Record<string, unknown>,
+							},
+						},
 					});
 					if (result.error) {
 						if (

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -2786,17 +2786,21 @@ describe("validateUserInfo callback", async () => {
 		expect(actions).toEqual(["create-user", "sign-in"]);
 	});
 
-	// The OAuth-specific security case: a returning user whose provider email
-	// moved to a now-disallowed domain must be rejected, and the hook must see
-	// the FRESH provider email, not the stored row.
-	it("re-validates a returning OAuth user against the fresh provider email", async () => {
-		const tokenFor = (email: string) =>
+	// The OAuth-specific security case: a returning user whose provider identity
+	// moved out of policy must be rejected, and the hook must see the fresh
+	// mapped provider user, not the stored row.
+	it("re-validates a returning OAuth user against the fresh provider identity", async () => {
+		const tokenFor = (identity: {
+			email: string;
+			name: string;
+			emailVerified: boolean;
+		}) =>
 			http.post("https://oauth2.googleapis.com/token", async () => {
 				const idToken = await signJWT(
 					{
-						email,
-						email_verified: true,
-						name: "Mover",
+						email: identity.email,
+						email_verified: identity.emailVerified,
+						name: identity.name,
 						picture: "https://test.com/picture.png",
 						sub: "mover-sub",
 						iat: 1234567890,
@@ -2811,6 +2815,9 @@ describe("validateUserInfo callback", async () => {
 			});
 
 		let emailSeenOnSignIn: string | undefined;
+		let emailVerifiedSeenOnSignIn: boolean | undefined;
+		let nameSeenOnSignIn: string | undefined;
+		let idSeenOnSignIn: string | undefined;
 		const { client, cookieSetter } = await getTestInstance(
 			{
 				user: {
@@ -2819,6 +2826,9 @@ describe("validateUserInfo callback", async () => {
 							return;
 						}
 						emailSeenOnSignIn = user.email as string;
+						emailVerifiedSeenOnSignIn = user.emailVerified as boolean;
+						nameSeenOnSignIn = user.name as string;
+						idSeenOnSignIn = user.id as string;
 						if (user.email?.endsWith("@blocked.com")) {
 							return {
 								error: "domain_revoked",
@@ -2860,19 +2870,36 @@ describe("validateUserInfo callback", async () => {
 		};
 
 		// First sign-in on an allowed domain provisions the user.
-		mswServer.use(tokenFor("mover@allowed.com"));
+		mswServer.use(
+			tokenFor({
+				email: "mover@allowed.com",
+				name: "Allowed Mover",
+				emailVerified: true,
+			}),
+		);
 		const first = await signIn();
 		const session = await client.getSession({
 			fetchOptions: { headers: first.headers },
 		});
 		expect(session.data?.user.email).toBe("mover@allowed.com");
+		expect(session.data?.user.name).toBe("Allowed Mover");
 
-		// The provider now asserts a disallowed email for the same account.
-		mswServer.use(tokenFor("mover@blocked.com"));
+		// The provider now asserts a disallowed identity for the same account.
+		mswServer.use(
+			tokenFor({
+				email: "mover@blocked.com",
+				name: "Blocked Mover",
+				emailVerified: false,
+			}),
+		);
 		const second = await signIn();
 
-		// The hook saw the fresh provider email, not the stored allowed one.
+		// The hook saw the fresh provider identity, not the stored allowed one,
+		// while keeping the Better Auth user id instead of the provider account id.
 		expect(emailSeenOnSignIn).toBe("mover@blocked.com");
+		expect(nameSeenOnSignIn).toBe("Blocked Mover");
+		expect(emailVerifiedSeenOnSignIn).toBe(false);
+		expect(idSeenOnSignIn).toBe(session.data?.user.id);
 		expect(second.redirectLocation).toContain("error=domain_revoked");
 	});
 

--- a/packages/better-auth/src/types/index.ts
+++ b/packages/better-auth/src/types/index.ts
@@ -11,6 +11,7 @@ export type {
 	ValidateUserInfoOAuthInfo,
 	ValidateUserInfoResult,
 	ValidateUserInfoSource,
+	ValidateUserInfoSSOInfo,
 } from "@better-auth/core";
 export type * from "@better-auth/core/social-providers";
 export * from "../client/types";

--- a/packages/better-auth/src/utils/validate-user-info.ts
+++ b/packages/better-auth/src/utils/validate-user-info.ts
@@ -5,6 +5,32 @@ import type {
 import { APIError } from "@better-auth/core/error";
 import type { User } from "../types";
 
+export function assertValidUserInfoSource(
+	source: ValidateUserInfoSource,
+): void {
+	if (!source?.method) {
+		throw new APIError("FORBIDDEN", {
+			code: "validation_source_missing",
+			message: "User validation source is required",
+		});
+	}
+	if (source.method === "oauth" && !source.oauth?.providerId) {
+		throw new APIError("FORBIDDEN", {
+			code: "validation_source_missing",
+			message: "OAuth user validation source requires oauth.providerId",
+		});
+	}
+	if (
+		(source.method === "sso-oidc" || source.method === "sso-saml") &&
+		!source.sso?.providerId
+	) {
+		throw new APIError("FORBIDDEN", {
+			code: "validation_source_missing",
+			message: "SSO user validation source requires sso.providerId",
+		});
+	}
+}
+
 /**
  * Invoke the application's `user.validateUserInfo` gate and throw a `403`
  * {@link APIError} if it rejects.
@@ -23,6 +49,7 @@ export async function assertValidUserInfo(
 	if (!validate) {
 		return;
 	}
+	assertValidUserInfoSource(data.source);
 
 	let result: Awaited<ReturnType<typeof validate>>;
 	try {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -30,6 +30,7 @@ export type {
 	ValidateUserInfoOAuthInfo,
 	ValidateUserInfoResult,
 	ValidateUserInfoSource,
+	ValidateUserInfoSSOInfo,
 } from "./init-options";
 export type {
 	BetterAuthPlugin,

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -54,13 +54,13 @@ export type GenerateIdFn = (options: {
  * - `create-user`: a brand-new user record is about to be created.
  * - `link-account`: a new provider account is about to be linked to an
  *   already-existing user.
- * - `sign-in`: an existing OAuth user is signing in again. This is the one case
- *   where the provider can assert *changed* data, so the hook receives the
- *   fresh provider email and profile (not the stored row), letting a domain or
- *   org policy reject a user whose provider identity moved out of bounds.
+ * - `sign-in`: an existing OAuth or SSO user is signing in again. This is the
+ *   one case where the provider can assert *changed* data, so the hook receives
+ *   the fresh provider email and profile (not the stored row), letting a domain
+ *   or org policy reject a user whose provider identity moved out of bounds.
  *
- * Non-OAuth returning sign-ins are not re-validated: they carry only the stored
- * row, which has not changed since `create-user` gated it. Use the admin
+ * Non-provider returning sign-ins are not re-validated: they carry only the
+ * stored row, which has not changed since `create-user` gated it. Use the admin
  * plugin's ban controls or a `databaseHooks.session.create.before` hook to
  * block those.
  */
@@ -73,6 +73,8 @@ export type ValidateUserInfoAction = "create-user" | "link-account" | "sign-in";
  */
 export type ValidateUserInfoMethod =
 	| "oauth"
+	| "sso-oidc"
+	| "sso-saml"
 	| "email-password"
 	| "magic-link"
 	| "email-otp"
@@ -82,7 +84,7 @@ export type ValidateUserInfoMethod =
 	| "admin"
 	| (string & {});
 
-/** OAuth-specific provisioning context; present only when `method` is OAuth-based. */
+/** OAuth-specific provisioning context; present only when `method` is `"oauth"`. */
 export type ValidateUserInfoOAuthInfo = {
 	/** The social or generic OAuth provider id (e.g. `"google"`). */
 	providerId: string;
@@ -90,23 +92,37 @@ export type ValidateUserInfoOAuthInfo = {
 	profile?: Record<string, unknown> | undefined;
 };
 
+/** SSO-specific provisioning context; present for OIDC and SAML SSO methods. */
+export type ValidateUserInfoSSOInfo = {
+	/** The configured SSO provider id. */
+	providerId: string;
+	/** The raw OIDC claims or SAML assertion attributes, unmapped. */
+	profile?: Record<string, unknown> | undefined;
+};
+
 /** Provisioning origin passed to `createUser`; the creation seam adds `action: "create-user"` to build {@link ValidateUserInfoSource}. */
 export type UserProvisioningSource = {
 	method: ValidateUserInfoMethod;
-	/** Provider id and raw profile; present iff `method` is OAuth-based. */
+	/** Provider id and raw profile; present iff `method` is `"oauth"`. */
 	oauth?: ValidateUserInfoOAuthInfo | undefined;
+	/** Provider id and raw profile; present iff `method` is `"sso-oidc"` or `"sso-saml"`. */
+	sso?: ValidateUserInfoSSOInfo | undefined;
 };
 
 /**
  * The context passed to `validateUserInfo`: the lifecycle
  * {@link ValidateUserInfoAction}, the {@link ValidateUserInfoMethod}, and (for
- * OAuth-based methods) the {@link ValidateUserInfoOAuthInfo}.
+ * OAuth/SSO provider methods) protocol-specific provider metadata.
  *
  * ```ts
  * // Scope to one OAuth provider:
  * if (source.oauth?.providerId !== "google") return;
  * // Branch on the method:
  * if (source.method === "anonymous") return { error: "no_anonymous" };
+ * // Inspect SSO claims:
+ * if (source.method === "sso-saml" && source.sso?.profile?.department !== "eng") {
+ *   return { error: "invalid_department" };
+ * }
  * ```
  */
 export type ValidateUserInfoSource = UserProvisioningSource & {
@@ -861,7 +877,7 @@ export type BetterAuthOptions = {
 				 * provider email and profile, so a domain policy can reject a user
 				 * whose provider identity moved out of bounds.
 				 *
-				 * Non-OAuth returning sign-ins are not re-validated; use the admin
+				 * Non-provider returning sign-ins are not re-validated; use the admin
 				 * plugin's ban controls or a `databaseHooks.session.create.before`
 				 * hook for those.
 				 *

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -797,9 +797,17 @@ describe("provisioning", async (ctx) => {
  */
 describe("provisionUser should only be called for new users", async () => {
 	const provisionUserFn = vi.fn();
+	const validateUserInfoFn = vi.fn();
 	const { auth, signInWithTestUser, customFetchImpl, cookieSetter } =
 		await getTestInstance({
 			trustedOrigins: ["http://localhost:8080"],
+			user: {
+				validateUserInfo({ source }) {
+					if (source.method === "sso-oidc") {
+						validateUserInfoFn(source);
+					}
+				},
+			},
 			plugins: [
 				sso({
 					provisionUser: provisionUserFn,
@@ -897,6 +905,7 @@ describe("provisionUser should only be called for new users", async () => {
 		});
 
 		provisionUserFn.mockClear();
+		validateUserInfoFn.mockClear();
 
 		// First sign-in: new user -> provisionUser should be called
 		const signInHeaders1 = new Headers();
@@ -910,6 +919,16 @@ describe("provisionUser should only be called for new users", async () => {
 		});
 		await simulateOAuthFlow(res1.url, signInHeaders1);
 		expect(provisionUserFn).toHaveBeenCalledTimes(1);
+		expect(validateUserInfoFn).toHaveBeenCalledTimes(1);
+		expect(validateUserInfoFn.mock.calls[0]?.[0]).toMatchObject({
+			action: "create-user",
+			method: "sso-oidc",
+			sso: {
+				providerId: "provision-test",
+				profile: { sub: "provision-test-sub" },
+			},
+		});
+		expect(validateUserInfoFn.mock.calls[0]?.[0].oauth).toBeUndefined();
 
 		provisionUserFn.mockClear();
 
@@ -925,6 +944,16 @@ describe("provisionUser should only be called for new users", async () => {
 		});
 		await simulateOAuthFlow(res2.url, signInHeaders2);
 		expect(provisionUserFn).toHaveBeenCalledTimes(0);
+		expect(validateUserInfoFn).toHaveBeenCalledTimes(2);
+		expect(validateUserInfoFn.mock.calls[1]?.[0]).toMatchObject({
+			action: "sign-in",
+			method: "sso-oidc",
+			sso: {
+				providerId: "provision-test",
+				profile: { sub: "provision-test-sub" },
+			},
+		});
+		expect(validateUserInfoFn.mock.calls[1]?.[0].oauth).toBeUndefined();
 	});
 });
 

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -404,9 +404,10 @@ export async function processSAMLResponse(
 			tokens: {},
 			callbackURL: postAuthRedirect,
 			disableSignUp: options?.disableImplicitSignUp,
-			// The raw, unmapped SAML assertion attributes, forwarded to the
-			// validateUserInfo gate as `source.oauth.profile`.
-			sourceProfile: attributes,
+			source: {
+				method: "sso-saml",
+				sso: { providerId, profile: attributes },
+			},
 			isTrustedProvider,
 		});
 	} catch (e) {

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1363,7 +1363,7 @@ async function handleOIDCCallback(
 	} | null = null;
 	const mapping = config.mapping || {};
 	// The raw, unmapped provider claims, forwarded to the validateUserInfo gate
-	// as `source.oauth.profile` so a policy can inspect provider-specific fields.
+	// as `source.sso.profile` so a policy can inspect provider-specific fields.
 	let rawProfile: Record<string, unknown> | undefined;
 
 	if (config.userInfoEndpoint) {
@@ -1490,7 +1490,10 @@ async function handleOIDCCallback(
 			callbackURL,
 			disableSignUp: options?.disableImplicitSignUp && !requestSignUp,
 			overrideUserInfo: config.overrideUserInfo,
-			sourceProfile: rawProfile,
+			source: {
+				method: "sso-oidc",
+				sso: { providerId: provider.providerId, profile: rawProfile },
+			},
 			isTrustedProvider,
 		});
 	} catch (e) {

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -5794,7 +5794,15 @@ describe("SAML Single Logout (SLO)", () => {
  */
 describe("SAML provisionUser should only be called for new users", async () => {
 	const provisionUserFn = vi.fn();
+	const validateUserInfoFn = vi.fn();
 	const { auth, signInWithTestUser } = await getTestInstance({
+		user: {
+			validateUserInfo({ source }) {
+				if (source.method === "sso-saml") {
+					validateUserInfoFn(source);
+				}
+			},
+		},
 		plugins: [
 			sso({
 				provisionUser: provisionUserFn,
@@ -5830,6 +5838,7 @@ describe("SAML provisionUser should only be called for new users", async () => {
 		});
 
 		provisionUserFn.mockClear();
+		validateUserInfoFn.mockClear();
 
 		// First sign-in: new user -> provisionUser should be called
 		const response1 = await auth.api.signInSSO({
@@ -5864,6 +5873,16 @@ describe("SAML provisionUser should only be called for new users", async () => {
 		});
 
 		expect(provisionUserFn).toHaveBeenCalledTimes(1);
+		expect(validateUserInfoFn).toHaveBeenCalledTimes(1);
+		expect(validateUserInfoFn.mock.calls[0]?.[0]).toMatchObject({
+			action: "create-user",
+			method: "sso-saml",
+			sso: {
+				providerId: "saml-provision-test",
+			},
+		});
+		expect(validateUserInfoFn.mock.calls[0]?.[0].sso?.profile).toBeDefined();
+		expect(validateUserInfoFn.mock.calls[0]?.[0].oauth).toBeUndefined();
 
 		provisionUserFn.mockClear();
 
@@ -5900,6 +5919,16 @@ describe("SAML provisionUser should only be called for new users", async () => {
 		});
 
 		expect(provisionUserFn).toHaveBeenCalledTimes(0);
+		expect(validateUserInfoFn).toHaveBeenCalledTimes(2);
+		expect(validateUserInfoFn.mock.calls[1]?.[0]).toMatchObject({
+			action: "sign-in",
+			method: "sso-saml",
+			sso: {
+				providerId: "saml-provision-test",
+			},
+		});
+		expect(validateUserInfoFn.mock.calls[1]?.[0].sso?.profile).toBeDefined();
+		expect(validateUserInfoFn.mock.calls[1]?.[0].oauth).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
Follow-up to #9864.

## What changed

- Fails closed when `internalAdapter.createUser` runs with `user.validateUserInfo` configured but no endpoint context or provisioning source is available.
- Canonicalizes create-user validation source metadata so callers cannot spoof `source.action` at the create seam.
- Threads a full `UserProvisioningSource` through the shared OAuth identity resolver instead of passing only a raw profile.
- Validates returning OAuth/SSO users against the fresh mapped provider identity, while preserving the local Better Auth user id.
- Splits SSO protocol metadata out of `source.oauth` into `source.sso`, with `source.method` values of `sso-oidc` and `sso-saml`.
- Documents the new source contract and marks the core/better-auth changeset as major.

## Why

The original implementation made `validateUserInfo` look like a durable provisioning gate, but a direct `createUser` call outside request context silently bypassed it. The shared OAuth resolver also hardcoded OAuth metadata for SSO callers and revalidated returning provider sign-ins with stale stored user data. Those patterns would make future integrations copy a leaky contract.

## Validation

- `pnpm --config.verify-deps-before-run=false vitest packages/better-auth/src/db/internal-adapter.test.ts -t "validateUserInfo|createUser"`
- `pnpm --config.verify-deps-before-run=false vitest packages/better-auth/src/social.test.ts -t "validateUserInfo callback"`
- `pnpm --config.verify-deps-before-run=false vitest packages/sso/src/oidc.test.ts -t "provisionUser should only be called"`
- `pnpm --config.verify-deps-before-run=false vitest packages/sso/src/saml.test.ts -t "SAML provisionUser should only be called"`
- `pnpm --config.verify-deps-before-run=false typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the `user.validateUserInfo` contract by requiring an endpoint context and a canonical source, re-validates returning OAuth/SSO sign-ins against fresh provider identity, and moves SSO metadata to `source.sso` with `method` set to `sso-oidc` or `sso-saml`. Upgrades `@better-auth/core` and `better-auth` to a new major.

- **Bug Fixes**
  - `createUser` fails closed when `validateUserInfo` is enabled but there’s no endpoint context or provisioning source.
  - Rejects invalid validation sources (e.g. missing `providerId` for OAuth/SSO) with `validation_source_missing`.
  - Canonicalizes the validation action to `create-user` to prevent spoofing.
  - OAuth/SSO sign-ins re-validate against fresh provider identity while preserving the local Better Auth user id.

- **Migration**
  - Ensure all direct `createUser` calls run within an endpoint context and pass a proper `UserProvisioningSource`.
  - Update SSO checks from `source.oauth` to `source.sso`, and handle `source.method` values `sso-oidc`/`sso-saml`.
  - Expect re-validation on returning OAuth/SSO sign-ins; adjust policies/tests if they relied on stored rows.
  - Upgrade to the new major versions of `@better-auth/core` and `better-auth`.

<sup>Written for commit b2fe58a06cc0d26fa6f761b854b2d9f552a16a3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

