### PR TITLE
fix(oauth-provider): canonicalize signed OAuth query params

### DIFF
--- a/.changeset/fix-oauth-hmac.md
+++ b/.changeset/fix-oauth-hmac.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Fix OAuth provider signed query verification so CDN or proxy query parameter reordering does not break signature validation. Existing signed redirects created before this patch is deployed may fail until their short expiration window elapses.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -803,7 +803,7 @@ During the OAuth flow, users are likely redirected between pages. For example, a
 
 To process each redirect step in the login flow, we verify the signed query provided in the initial `/oauth2/authorize` redirect. All parameters sent to the authorize endpoint (including any custom ones), are signed and verified.
 
-If your sign-in pages include any custom query parameters, you may append them to the end of the signed query (ie after the `sig` field).
+If your sign-in pages include custom page query parameters, they may coexist in the URL, but they should not be added to the signed `oauth_query`. The client plugin forwards only the parameters declared by the signed redirect.
 
 If you utilize the Client Plugin `oauthProviderClient`, then the `oauth_query` parameter is automatically sent to every endpoint that requires it. If you have custom sign-in endpoints, you would need to manually add the window's signed query in the request body `oauth_query`. This should only include the signed query parameters.
 

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -7,13 +7,15 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { validateIssuerUrl } from "./authorize";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
-import type { OAuthClient } from "./types/oauth";
 import {
 	canonicalizeOAuthQueryParams,
 	postLoginClearedParam,
+	setSignedOAuthQueryParameterNames,
 	signedQueryIssuedAtParam,
-	verifyOAuthQueryParams,
-} from "./utils";
+	signedQueryParameterNameParam,
+} from "./signed-query";
+import type { OAuthClient } from "./types/oauth";
+import { verifyOAuthQueryParams } from "./utils";
 
 describe("validateIssuerUrl (RFC 9207)", () => {
 	it("should allow HTTPS URLs unchanged", () => {
@@ -95,6 +97,7 @@ describe("oauth signed query signatures", () => {
 		configure?.(params);
 		params.set("exp", String(Math.floor(Date.now() / 1000) + 600));
 		params.set(signedQueryIssuedAtParam, String(Date.now()));
+		setSignedOAuthQueryParameterNames(params);
 		params.set(
 			"sig",
 			await makeSignature(
@@ -152,11 +155,20 @@ describe("oauth signed query signatures", () => {
 		).toBe(false);
 	});
 
-	it("should preserve params after sig when the client copies signed queries", async () => {
+	it("should preserve custom signed params when the client copies reordered signed queries", async () => {
+		const signedParams = await createSignedParams("test-secret", (params) => {
+			params.set("custom_authorization_context", "tenant-a");
+			params.append("resource", "https://api.example.com");
+		});
+		const reorderedParams = new URLSearchParams();
+		for (const [key, value] of [...signedParams.entries()].reverse()) {
+			reorderedParams.append(key, value);
+		}
+		reorderedParams.append("utm_email", "user@example.com");
+
 		vi.stubGlobal("window", {
 			location: {
-				search:
-					"?client_id=client-a&sig=test-sig&scope=openid&exp=123&resource=https%3A%2F%2Fapi.example.com&utm_email=user%40example.com",
+				search: `?${reorderedParams.toString()}`,
 			},
 		});
 
@@ -173,8 +185,17 @@ describe("oauth signed query signatures", () => {
 		await onRequest?.(ctx as Parameters<NonNullable<typeof onRequest>>[0]);
 
 		const body = JSON.parse(String(ctx.body));
-		expect(body.oauth_query).toBe(
-			"client_id=client-a&sig=test-sig&scope=openid&exp=123&resource=https%3A%2F%2Fapi.example.com",
+		const forwardedParams = new URLSearchParams(body.oauth_query);
+		expect(await verifyOAuthQueryParams(body.oauth_query, "test-secret")).toBe(
+			true,
+		);
+		expect(forwardedParams.get("custom_authorization_context")).toBe(
+			"tenant-a",
+		);
+		expect(forwardedParams.get("resource")).toBe("https://api.example.com");
+		expect(forwardedParams.get("utm_email")).toBeNull();
+		expect(forwardedParams.getAll(signedQueryParameterNameParam)).toContain(
+			"custom_authorization_context",
 		);
 	});
 });

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -1,14 +1,19 @@
 import { createAuthClient } from "better-auth/client";
-import { generateRandomString } from "better-auth/crypto";
+import { generateRandomString, makeSignature } from "better-auth/crypto";
 import { createAuthorizationURL } from "better-auth/oauth2";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { validateIssuerUrl } from "./authorize";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
 import type { OAuthClient } from "./types/oauth";
-import { postLoginClearedParam } from "./utils";
+import {
+	canonicalizeOAuthQueryParams,
+	postLoginClearedParam,
+	signedQueryIssuedAtParam,
+	verifyOAuthQueryParams,
+} from "./utils";
 
 describe("validateIssuerUrl (RFC 9207)", () => {
 	it("should allow HTTPS URLs unchanged", () => {
@@ -69,6 +74,108 @@ describe("validateIssuerUrl (RFC 9207)", () => {
 		expect(
 			validateIssuerUrl("http://auth.example.com:8080/path?query=1#hash"),
 		).toBe("https://auth.example.com:8080/path");
+	});
+});
+
+describe("oauth signed query signatures", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	const createSignedParams = async (
+		secret: string,
+		configure?: (params: URLSearchParams) => void,
+	) => {
+		const params = new URLSearchParams();
+		params.set("client_id", "client-a");
+		params.set("redirect_uri", "https://rp.example.com/callback");
+		params.set("response_type", "code");
+		params.set("scope", "openid profile");
+		params.set("state", "state-a");
+		configure?.(params);
+		params.set("exp", String(Math.floor(Date.now() / 1000) + 600));
+		params.set(signedQueryIssuedAtParam, String(Date.now()));
+		params.set(
+			"sig",
+			await makeSignature(
+				canonicalizeOAuthQueryParams(params).toString(),
+				secret,
+			),
+		);
+		return params;
+	};
+
+	it("should verify signed params when query params are reordered", async () => {
+		const signedParams = await createSignedParams("test-secret");
+		const reordered = new URLSearchParams();
+
+		for (const [key, value] of [...signedParams.entries()].reverse()) {
+			reordered.append(key, value);
+		}
+
+		expect(
+			await verifyOAuthQueryParams(reordered.toString(), "test-secret"),
+		).toBe(true);
+	});
+
+	it("should verify signed params when repeated values are reordered", async () => {
+		const signedParams = await createSignedParams("test-secret", (params) => {
+			params.append("resource", "https://b.example.com");
+			params.append("resource", "https://a.example.com");
+		});
+		const reordered = new URLSearchParams();
+
+		for (const [key, value] of [...signedParams.entries()].reverse()) {
+			reordered.append(key, value);
+		}
+
+		expect(
+			await verifyOAuthQueryParams(reordered.toString(), "test-secret"),
+		).toBe(true);
+	});
+
+	it("should reject tampered signed params", async () => {
+		const signedParams = await createSignedParams("test-secret");
+		signedParams.set("client_id", "client-b");
+
+		expect(
+			await verifyOAuthQueryParams(signedParams.toString(), "test-secret"),
+		).toBe(false);
+	});
+
+	it("should reject duplicate signature params", async () => {
+		const signedParams = await createSignedParams("test-secret");
+		signedParams.append("sig", "extra-sig");
+
+		expect(
+			await verifyOAuthQueryParams(signedParams.toString(), "test-secret"),
+		).toBe(false);
+	});
+
+	it("should preserve params after sig when the client copies signed queries", async () => {
+		vi.stubGlobal("window", {
+			location: {
+				search:
+					"?client_id=client-a&sig=test-sig&scope=openid&exp=123&resource=https%3A%2F%2Fapi.example.com&utm_email=user%40example.com",
+			},
+		});
+
+		const plugin = oauthProviderClient();
+		const onRequest = plugin.fetchPlugins[0]?.hooks?.onRequest;
+		const ctx = {
+			method: "POST",
+			headers: new Headers({
+				"content-type": "application/json",
+			}),
+			body: "{}",
+		};
+
+		await onRequest?.(ctx as Parameters<NonNullable<typeof onRequest>>[0]);
+
+		const body = JSON.parse(String(ctx.body));
+		expect(body.oauth_query).toBe(
+			"client_id=client-a&sig=test-sig&scope=openid&exp=123&resource=https%3A%2F%2Fapi.example.com",
+		);
 	});
 });
 
@@ -147,6 +254,52 @@ describe("oauth authorize - unauthenticated", async () => {
 		expect(loginRedirectUrl).toContain("scope=openid");
 		expect(loginRedirectUrl).toContain(
 			`redirect_uri=${encodeURIComponent(redirectUri)}`,
+		);
+	});
+
+	it("should replace incoming sig when signing the login redirect", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: redirectUri,
+			state: "incoming-sig",
+			scopes: ["openid"],
+			responseType: "code",
+			codeVerifier: generateRandomString(64),
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+		});
+		authUrl.searchParams.append("sig", "attacker-sig");
+
+		let loginRedirectUrl = "";
+		await unauthenticatedClient.$fetch(authUrl.toString(), {
+			onError(context) {
+				loginRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		const loginRedirect = new URL(loginRedirectUrl, authServerBaseUrl);
+		const secret = (auth.options as unknown as { secret: string }).secret;
+		const reordered = new URLSearchParams();
+
+		for (const [key, value] of [
+			...loginRedirect.searchParams.entries(),
+		].reverse()) {
+			reordered.append(key, value);
+		}
+
+		expect(loginRedirect.searchParams.getAll("sig")).toHaveLength(1);
+		expect(loginRedirect.searchParams.get("sig")).not.toBe("attacker-sig");
+		expect(
+			await verifyOAuthQueryParams(loginRedirect.search.slice(1), secret),
+		).toBe(true);
+		expect(await verifyOAuthQueryParams(reordered.toString(), secret)).toBe(
+			true,
 		);
 	});
 

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -12,10 +12,11 @@ import {
 	postLoginClearedParam,
 	setSignedOAuthQueryParameterNames,
 	signedQueryIssuedAtParam,
-	signedQueryParameterNameParam,
 } from "./signed-query";
 import type { OAuthClient } from "./types/oauth";
 import { verifyOAuthQueryParams } from "./utils";
+
+const signedQueryParameterNameParam = "ba_param";
 
 describe("validateIssuerUrl (RFC 9207)", () => {
 	it("should allow HTTPS URLs unchanged", () => {

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -6,6 +6,12 @@ import { generateRandomString, makeSignature } from "better-auth/crypto";
 import type { Verification } from "better-auth/db";
 import { APIError } from "better-call";
 import { oAuthState } from "./oauth";
+import {
+	canonicalizeOAuthQueryParams,
+	postLoginClearedParam,
+	setSignedOAuthQueryParameterNames,
+	signedQueryIssuedAtParam,
+} from "./signed-query";
 import type {
 	OAuthAuthorizationQuery,
 	OAuthConsent,
@@ -16,13 +22,10 @@ import type {
 
 import {
 	clientAllowsGrant,
-	canonicalizeOAuthQueryParams,
 	getClient,
 	getJwtPlugin,
 	isPKCERequired,
 	parsePrompt,
-	postLoginClearedParam,
-	signedQueryIssuedAtParam,
 	storeToken,
 } from "./utils";
 
@@ -662,6 +665,7 @@ async function signParams(
 	if (flags?.postLoginClearedForSession) {
 		params.set(postLoginClearedParam, flags.postLoginClearedForSession);
 	}
+	setSignedOAuthQueryParameterNames(params);
 
 	const signature = await makeSignature(
 		canonicalizeOAuthQueryParams(params).toString(),

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -16,6 +16,7 @@ import type {
 
 import {
 	clientAllowsGrant,
+	canonicalizeOAuthQueryParams,
 	getClient,
 	getJwtPlugin,
 	isPKCERequired,
@@ -655,13 +656,17 @@ async function signParams(
 	);
 	params.set("exp", String(exp));
 	params.set(signedQueryIssuedAtParam, String(issuedAt));
+	params.delete("sig");
 	// Reserved marker: only server-issued consent redirects may sign this.
 	params.delete(postLoginClearedParam);
 	if (flags?.postLoginClearedForSession) {
 		params.set(postLoginClearedParam, flags.postLoginClearedForSession);
 	}
 
-	const signature = await makeSignature(params.toString(), ctx.context.secret);
-	params.append("sig", signature);
+	const signature = await makeSignature(
+		canonicalizeOAuthQueryParams(params).toString(),
+		ctx.context.secret,
+	);
+	params.set("sig", signature);
 	return params.toString();
 }

--- a/packages/oauth-provider/src/client.ts
+++ b/packages/oauth-provider/src/client.ts
@@ -3,13 +3,41 @@ import type { BetterAuthClientPlugin } from "better-auth/types";
 import type { oauthProvider } from "./oauth";
 import { PACKAGE_VERSION } from "./version";
 
+const signedOAuthQueryKeys = new Set([
+	"acr_values",
+	"authorization_details",
+	"ba_iat",
+	"ba_pl",
+	"claims",
+	"client_id",
+	"code_challenge",
+	"code_challenge_method",
+	"display",
+	"exp",
+	"id_token_hint",
+	"login_hint",
+	"max_age",
+	"nonce",
+	"prompt",
+	"redirect_uri",
+	"request_uri",
+	"resource",
+	"response_mode",
+	"response_type",
+	"scope",
+	"sig",
+	"state",
+	"ui_locales",
+]);
+
 function parseSignedQuery(search: string) {
 	const params = new URLSearchParams(search);
 	if (params.has("sig")) {
 		const signedParams = new URLSearchParams();
 		for (const [key, value] of params.entries()) {
-			signedParams.append(key, value);
-			if (key === "sig") break;
+			if (signedOAuthQueryKeys.has(key)) {
+				signedParams.append(key, value);
+			}
 		}
 		return signedParams.toString();
 	}

--- a/packages/oauth-provider/src/client.ts
+++ b/packages/oauth-provider/src/client.ts
@@ -1,47 +1,8 @@
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import type { BetterAuthClientPlugin } from "better-auth/types";
 import type { oauthProvider } from "./oauth";
+import { buildSignedOAuthQuery } from "./signed-query";
 import { PACKAGE_VERSION } from "./version";
-
-const signedOAuthQueryKeys = new Set([
-	"acr_values",
-	"authorization_details",
-	"ba_iat",
-	"ba_pl",
-	"claims",
-	"client_id",
-	"code_challenge",
-	"code_challenge_method",
-	"display",
-	"exp",
-	"id_token_hint",
-	"login_hint",
-	"max_age",
-	"nonce",
-	"prompt",
-	"redirect_uri",
-	"request_uri",
-	"resource",
-	"response_mode",
-	"response_type",
-	"scope",
-	"sig",
-	"state",
-	"ui_locales",
-]);
-
-function parseSignedQuery(search: string) {
-	const params = new URLSearchParams(search);
-	if (params.has("sig")) {
-		const signedParams = new URLSearchParams();
-		for (const [key, value] of params.entries()) {
-			if (signedOAuthQueryKeys.has(key)) {
-				signedParams.append(key, value);
-			}
-		}
-		return signedParams.toString();
-	}
-}
 
 export const oauthProviderClient = () => {
 	return {
@@ -70,7 +31,7 @@ export const oauthProviderClient = () => {
 						) {
 							ctx.body = JSON.stringify({
 								...body,
-								oauth_query: parseSignedQuery(window.location.search),
+								oauth_query: buildSignedOAuthQuery(window.location.search),
 							});
 						}
 					},

--- a/packages/oauth-provider/src/signed-query.test.ts
+++ b/packages/oauth-provider/src/signed-query.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildSignedOAuthQuery,
+	canonicalizeOAuthQueryParams,
+	setSignedOAuthQueryParameterNames,
+	signedQueryParameterNameParam,
+} from "./signed-query";
+
+describe("signed OAuth query", () => {
+	it("builds oauth_query from declared signed params", () => {
+		const signedParams = new URLSearchParams();
+		signedParams.set("client_id", "client-a");
+		signedParams.set("custom_authorization_context", "tenant-a");
+		signedParams.append("resource", "https://api.example.com");
+		signedParams.set("exp", "123");
+		setSignedOAuthQueryParameterNames(signedParams);
+		signedParams.set("sig", "test-sig");
+
+		const reorderedParams = new URLSearchParams();
+		for (const [key, value] of [...signedParams.entries()].reverse()) {
+			reorderedParams.append(key, value);
+		}
+		reorderedParams.append("utm_email", "user@example.com");
+
+		const oauthQuery = buildSignedOAuthQuery(`?${reorderedParams.toString()}`);
+		const oauthParams = new URLSearchParams(oauthQuery);
+
+		expect(oauthParams.get("custom_authorization_context")).toBe("tenant-a");
+		expect(oauthParams.get("resource")).toBe("https://api.example.com");
+		expect(oauthParams.get("utm_email")).toBeNull();
+		expect(oauthParams.getAll(signedQueryParameterNameParam)).toContain(
+			"custom_authorization_context",
+		);
+	});
+
+	it("ignores legacy signed queries without declared signed params", () => {
+		expect(buildSignedOAuthQuery("?client_id=client-a&sig=test-sig")).toBe(
+			undefined,
+		);
+	});
+
+	it("canonicalizes repeated params by key and value", () => {
+		const params = new URLSearchParams();
+		params.append("resource", "https://b.example.com");
+		params.append("client_id", "client-a");
+		params.append("resource", "https://a.example.com");
+
+		expect(canonicalizeOAuthQueryParams(params).toString()).toBe(
+			"client_id=client-a&resource=https%3A%2F%2Fa.example.com&resource=https%3A%2F%2Fb.example.com",
+		);
+	});
+});

--- a/packages/oauth-provider/src/signed-query.test.ts
+++ b/packages/oauth-provider/src/signed-query.test.ts
@@ -3,8 +3,9 @@ import {
 	buildSignedOAuthQuery,
 	canonicalizeOAuthQueryParams,
 	setSignedOAuthQueryParameterNames,
-	signedQueryParameterNameParam,
 } from "./signed-query";
+
+const signedQueryParameterNameParam = "ba_param";
 
 describe("signed OAuth query", () => {
 	it("builds oauth_query from declared signed params", () => {
@@ -23,6 +24,9 @@ describe("signed OAuth query", () => {
 		reorderedParams.append("utm_email", "user@example.com");
 
 		const oauthQuery = buildSignedOAuthQuery(`?${reorderedParams.toString()}`);
+		if (!oauthQuery) {
+			throw new Error("Expected signed OAuth query");
+		}
 		const oauthParams = new URLSearchParams(oauthQuery);
 
 		expect(oauthParams.get("custom_authorization_context")).toBe("tenant-a");

--- a/packages/oauth-provider/src/signed-query.ts
+++ b/packages/oauth-provider/src/signed-query.ts
@@ -1,6 +1,6 @@
 export const signedQueryIssuedAtParam = "ba_iat";
 export const postLoginClearedParam = "ba_pl";
-export const signedQueryParameterNameParam = "ba_param";
+const signedQueryParameterNameParam = "ba_param";
 
 export function canonicalizeOAuthQueryParams(params: URLSearchParams) {
 	const canonicalParams = new URLSearchParams();

--- a/packages/oauth-provider/src/signed-query.ts
+++ b/packages/oauth-provider/src/signed-query.ts
@@ -1,0 +1,71 @@
+export const signedQueryIssuedAtParam = "ba_iat";
+export const postLoginClearedParam = "ba_pl";
+export const signedQueryParameterNameParam = "ba_param";
+
+export function canonicalizeOAuthQueryParams(params: URLSearchParams) {
+	const canonicalParams = new URLSearchParams();
+	const entries = [...params.entries()].sort(
+		([keyA, valueA], [keyB, valueB]) => {
+			if (keyA < keyB) return -1;
+			if (keyA > keyB) return 1;
+			if (valueA < valueB) return -1;
+			if (valueA > valueB) return 1;
+			return 0;
+		},
+	);
+	for (const [key, value] of entries) {
+		canonicalParams.append(key, value);
+	}
+	return canonicalParams;
+}
+
+export function setSignedOAuthQueryParameterNames(params: URLSearchParams) {
+	params.delete(signedQueryParameterNameParam);
+	const signedParameterNames = [
+		...new Set([...params.keys(), signedQueryParameterNameParam]),
+	].sort();
+
+	for (const parameterName of signedParameterNames) {
+		params.append(signedQueryParameterNameParam, parameterName);
+	}
+}
+
+function getSignedOAuthQueryParameterNames(params: URLSearchParams) {
+	const signedParameterNames = params.getAll(signedQueryParameterNameParam);
+	if (!signedParameterNames.length) {
+		return undefined;
+	}
+	return new Set(signedParameterNames);
+}
+
+export function buildSignedOAuthQuery(search: string) {
+	const params = new URLSearchParams(search);
+	if (!params.has("sig")) {
+		return undefined;
+	}
+
+	const signedParameterNames = getSignedOAuthQueryParameterNames(params);
+	if (!signedParameterNames) {
+		return undefined;
+	}
+
+	const signedParams = new URLSearchParams();
+	for (const [key, value] of params.entries()) {
+		if (
+			key === "sig" ||
+			key === signedQueryParameterNameParam ||
+			signedParameterNames.has(key)
+		) {
+			signedParams.append(key, value);
+		}
+	}
+	return signedParams.toString();
+}
+
+export function getSignedQueryIssuedAt(oauthQuery: string): Date | null {
+	const raw = new URLSearchParams(oauthQuery).get(signedQueryIssuedAtParam);
+	if (!raw) return null;
+	const issuedAt = Number(raw);
+	if (!Number.isFinite(issuedAt) || issuedAt <= 0) return null;
+	return new Date(issuedAt);
+}

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -22,7 +22,6 @@ import type {
 } from "../types";
 
 export {
-	canonicalizeOAuthQueryParams,
 	getSignedQueryIssuedAt,
 	postLoginClearedParam,
 	signedQueryIssuedAtParam,

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -11,6 +11,7 @@ import {
 import type { jwt } from "better-auth/plugins";
 import { APIError } from "better-call";
 import type { oauthProvider } from "../oauth";
+import { canonicalizeOAuthQueryParams } from "../signed-query";
 import type {
 	GrantType,
 	OAuthOptions,
@@ -19,6 +20,13 @@ import type {
 	Scope,
 	StoreTokenType,
 } from "../types";
+
+export {
+	canonicalizeOAuthQueryParams,
+	getSignedQueryIssuedAt,
+	postLoginClearedParam,
+	signedQueryIssuedAtParam,
+} from "../signed-query";
 
 class TTLCache<K, V extends { expiresAt?: Date }> {
 	private cache = new Map<K, V>();
@@ -136,23 +144,6 @@ export function resolveSessionAuthTime(value: unknown): Date | undefined {
 }
 
 const cachedTrustedClients = new TTLCache<string, SchemaClient<Scope[]>>();
-
-export function canonicalizeOAuthQueryParams(params: URLSearchParams) {
-	const canonicalParams = new URLSearchParams();
-	const entries = [...params.entries()].sort(
-		([keyA, valueA], [keyB, valueB]) => {
-			if (keyA < keyB) return -1;
-			if (keyA > keyB) return 1;
-			if (valueA < valueB) return -1;
-			if (valueA > valueB) return 1;
-			return 0;
-		},
-	);
-	for (const [key, value] of entries) {
-		canonicalParams.append(key, value);
-	}
-	return canonicalParams;
-}
 
 export async function verifyOAuthQueryParams(
 	oauth_query: string,
@@ -631,17 +622,6 @@ export function searchParamsToQuery(
 		result[key] = values.length === 1 ? values[0]! : values;
 	}
 	return result;
-}
-
-export const signedQueryIssuedAtParam = "ba_iat";
-export const postLoginClearedParam = "ba_pl";
-
-export function getSignedQueryIssuedAt(oauthQuery: string): Date | null {
-	const raw = new URLSearchParams(oauthQuery).get(signedQueryIssuedAtParam);
-	if (!raw) return null;
-	const issuedAt = Number(raw);
-	if (!Number.isFinite(issuedAt) || issuedAt <= 0) return null;
-	return new Date(issuedAt);
 }
 
 export function removePromptFromQuery(query: URLSearchParams, prompt: Prompt) {

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -137,16 +137,38 @@ export function resolveSessionAuthTime(value: unknown): Date | undefined {
 
 const cachedTrustedClients = new TTLCache<string, SchemaClient<Scope[]>>();
 
+export function canonicalizeOAuthQueryParams(params: URLSearchParams) {
+	const canonicalParams = new URLSearchParams();
+	const entries = [...params.entries()].sort(
+		([keyA, valueA], [keyB, valueB]) => {
+			if (keyA < keyB) return -1;
+			if (keyA > keyB) return 1;
+			if (valueA < valueB) return -1;
+			if (valueA > valueB) return 1;
+			return 0;
+		},
+	);
+	for (const [key, value] of entries) {
+		canonicalParams.append(key, value);
+	}
+	return canonicalParams;
+}
+
 export async function verifyOAuthQueryParams(
 	oauth_query: string,
 	secret: string,
 ) {
 	const queryParams = new URLSearchParams(oauth_query);
 	const sig = queryParams.get("sig");
+	const sigs = queryParams.getAll("sig");
 	const exp = Number(queryParams.get("exp"));
 	queryParams.delete("sig");
-	const verifySig = await makeSignature(queryParams.toString(), secret);
+	const verifySig = await makeSignature(
+		canonicalizeOAuthQueryParams(queryParams).toString(),
+		secret,
+	);
 	return (
+		sigs.length === 1 &&
 		!!sig &&
 		constantTimeEqual(sig, verifySig) &&
 		new Date(exp * 1000) >= new Date()


### PR DESCRIPTION
## Summary

Closes #8858.

Signed OAuth redirect params were treated as an ordered string, so a CDN or proxy reorder could make the login or consent resume fail signature verification.

This changes the signed redirect contract to canonicalize by key and value, then declare which parameter names belong to the signed redirect. The client uses that declaration to rebuild `oauth_query` after a redirect, preserving custom signed authorization params while dropping unrelated page params.

Legacy signed redirects without the declaration are not forwarded by the client. That keeps the new contract fail-closed instead of reintroducing broad query forwarding.
