### PR TITLE
fix: pg timestamptz generation

### DIFF
--- a/.changeset/stale-spies-attack.md
+++ b/.changeset/stale-spies-attack.md
@@ -1,0 +1,8 @@
+---
+"@better-auth/oauth-provider": patch
+"better-auth": patch
+"@better-auth/passkey": patch
+"auth": patch
+---
+
+Updated the PostgreSQL Drizzle generator to generate date columns using timezone-aware `timestamp` columns (`withTimezone: true`). This resolves timezone parsing discrepancies and silent hour drifts when clients in different default timezones read and write date records.

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.timezone.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.timezone.test.ts
@@ -16,8 +16,15 @@ const helperPath = path.join(
 );
 
 function runHelper(tz: string, mode: string): any {
-	const cmd = `TZ=${tz} TEST_MODE=${mode} node ${tsxCliPath} ${helperPath}`;
-	const output = execSync(cmd, { encoding: "utf8" });
+	const cmd = `node ${tsxCliPath} ${helperPath}`;
+	const output = execSync(cmd, {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			TZ: tz,
+			TEST_MODE: mode,
+		},
+	});
 	return JSON.parse(output.trim());
 }
 

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.timezone.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.timezone.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9920
+ */
+// cspell:ignore Kolkata
+import { execSync } from "node:child_process";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const tsxCliPath = path.resolve(
+	import.meta.dirname,
+	"../../../../packages/cli/node_modules/tsx/dist/cli.mjs",
+);
+const helperPath = path.join(
+	import.meta.dirname,
+	"fixtures/timezone-helper.ts",
+);
+
+function runHelper(tz: string, mode: string): any {
+	const cmd = `TZ=${tz} TEST_MODE=${mode} node ${tsxCliPath} ${helperPath}`;
+	const output = execSync(cmd, { encoding: "utf8" });
+	return JSON.parse(output.trim());
+}
+
+describe("PostgreSQL Timezone Behavior & Schema Type Verification", () => {
+	const originalInstant = 1780920000000; // 2026-06-08T12:00:00.000Z
+
+	it("1. Schema Type Verification: database columns must match expected PostgreSQL types", async () => {
+		// Setup the tables
+		runHelper("UTC", "setup");
+
+		// Query columns info
+		const columns = runHelper("UTC", "verify_types") as Array<{
+			table_name: string;
+			column_name: string;
+			data_type: string;
+		}>;
+
+		console.log("Verified database column types:", columns);
+
+		const naiveCol = columns.find((c) => c.table_name === "naive_ts");
+		const tzCol = columns.find((c) => c.table_name === "tz_ts");
+
+		expect(naiveCol).toBeDefined();
+		expect(naiveCol!.data_type).toBe("timestamp without time zone");
+
+		expect(tzCol).toBeDefined();
+		expect(tzCol!.data_type).toBe("timestamp with time zone");
+	});
+
+	it("2. Before/After Reproduction Validation & Cross-Timezone Roundtrip (Write: America/New_York -> Read: UTC)", async () => {
+		// Setup tables
+		runHelper("UTC", "setup");
+
+		// Write under New York timezone
+		runHelper("America/New_York", "write");
+
+		// Read under UTC timezone
+		const readResult = runHelper("UTC", "read");
+
+		console.log("Roundtrip (NY -> UTC) Results:", readResult);
+
+		// A) Current behavior: timestamp without time zone drifts
+		// America/New_York (UTC-4) writes 12:00:00 UTC as "08:00:00" local wall-clock time.
+		// UTC process reads "08:00:00" and parses it as UTC time, which is 08:00:00 UTC (shifted by -4 hours).
+		expect(readResult.unixTimestamp.naive).not.toBe(originalInstant);
+		expect(readResult.unixTimestamp.naive).toBe(
+			originalInstant - 4 * 60 * 60 * 1000,
+		); // exactly 4 hours early
+
+		// B) Fixed behavior: timestamp with time zone (timestamptz) preserves the same instant
+		expect(readResult.unixTimestamp.tz).toBe(originalInstant);
+	});
+
+	it("3. Cross-Timezone Roundtrip (Write: UTC -> Read: Asia/Kolkata)", async () => {
+		// Setup tables
+		runHelper("UTC", "setup");
+
+		// Write under UTC timezone
+		runHelper("UTC", "write");
+
+		// Read under Kolkata timezone
+		const readResult = runHelper("Asia/Kolkata", "read");
+
+		console.log("Roundtrip (UTC -> Kolkata) Results:", readResult);
+
+		// naive (timestamp without time zone) shifts
+		// UTC writes 12:00:00 UTC as "12:00:00" wall-clock time.
+		// Asia/Kolkata (UTC+5:30) reads "12:00:00" and parses it as Kolkata local time, which is 06:30:00 UTC (shifted by -5.5 hours).
+		expect(readResult.unixTimestamp.naive).not.toBe(originalInstant);
+		expect(readResult.unixTimestamp.naive).toBe(
+			originalInstant - 5.5 * 60 * 60 * 1000,
+		); // exactly 5.5 hours early
+
+		// timestamptz (timestamp with time zone) preserves the instant perfectly
+		expect(readResult.unixTimestamp.tz).toBe(originalInstant);
+	});
+});

--- a/e2e/adapter/test/drizzle-adapter/fixtures/timezone-helper.ts
+++ b/e2e/adapter/test/drizzle-adapter/fixtures/timezone-helper.ts
@@ -1,6 +1,4 @@
-import pg from "pg";
-
-const { Pool } = pg;
+import { Pool } from "pg";
 
 const connectionString = "postgres://user:password@localhost:5432/better_auth";
 
@@ -59,6 +57,8 @@ async function main() {
 				WHERE table_name IN ('naive_ts', 'tz_ts') AND column_name = 'created_at';
 			`);
 			console.log(JSON.stringify(colTypesQuery.rows));
+		} else {
+			throw new Error(`Invalid or missing TEST_MODE: "${mode}"`);
 		}
 	} finally {
 		client.release();

--- a/e2e/adapter/test/drizzle-adapter/fixtures/timezone-helper.ts
+++ b/e2e/adapter/test/drizzle-adapter/fixtures/timezone-helper.ts
@@ -1,0 +1,72 @@
+import pg from "pg";
+
+const { Pool } = pg;
+
+const connectionString = "postgres://user:password@localhost:5432/better_auth";
+
+async function main() {
+	const mode = process.env.TEST_MODE;
+	const pool = new Pool({ connectionString });
+	const client = await pool.connect();
+
+	try {
+		if (mode === "setup") {
+			await client.query("DROP TABLE IF EXISTS naive_ts;");
+			await client.query("DROP TABLE IF EXISTS tz_ts;");
+			await client.query("CREATE TABLE naive_ts (created_at timestamp);");
+			await client.query(
+				"CREATE TABLE tz_ts (created_at timestamp with time zone);",
+			);
+			console.log(JSON.stringify({ success: true }));
+		} else if (mode === "write") {
+			const utcDate = new Date("2026-06-08T12:00:00.000Z");
+			await client.query("DELETE FROM naive_ts;");
+			await client.query("DELETE FROM tz_ts;");
+			await client.query("INSERT INTO naive_ts (created_at) VALUES ($1);", [
+				utcDate,
+			]);
+			await client.query("INSERT INTO tz_ts (created_at) VALUES ($1);", [
+				utcDate,
+			]);
+			console.log(JSON.stringify({ success: true }));
+		} else if (mode === "read") {
+			const naiveRes = await client.query(
+				"SELECT created_at, created_at::text as raw_text FROM naive_ts;",
+			);
+			const tzRes = await client.query(
+				"SELECT created_at, created_at::text as raw_text FROM tz_ts;",
+			);
+
+			const naiveDate = naiveRes.rows[0].created_at;
+			const naiveRawText = naiveRes.rows[0].raw_text;
+			const tzDate = tzRes.rows[0].created_at;
+			const tzRawText = tzRes.rows[0].raw_text;
+
+			console.log(
+				JSON.stringify({
+					rawText: { naive: naiveRawText, tz: tzRawText },
+					unixTimestamp: { naive: naiveDate.getTime(), tz: tzDate.getTime() },
+					isoString: {
+						naive: naiveDate.toISOString(),
+						tz: tzDate.toISOString(),
+					},
+				}),
+			);
+		} else if (mode === "verify_types") {
+			const colTypesQuery = await client.query(`
+				SELECT table_name, column_name, data_type 
+				FROM information_schema.columns 
+				WHERE table_name IN ('naive_ts', 'tz_ts') AND column_name = 'created_at';
+			`);
+			console.log(JSON.stringify(colTypesQuery.rows));
+		}
+	} finally {
+		client.release();
+		await pool.end();
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -127,7 +127,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				},
 				date: {
 					sqlite: `integer('${name}', { mode: 'timestamp_ms' })`,
-					pg: `timestamp('${name}')`,
+					pg: `timestamp('${name}', { mode: 'date', withTimezone: true })`,
 					mysql: `timestamp('${name}', { fsp: 3 })`,
 				},
 				"number[]": {

--- a/packages/cli/test/__snapshots__/auth-schema-drizzle-use-plural.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-drizzle-use-plural.txt
@@ -7,8 +7,10 @@ export const users = pgTable("users", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
   image: text("image"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -18,10 +20,15 @@ export const sessions = pgTable(
   "sessions",
   {
     id: text("id").primaryKey(),
-    expiresAt: timestamp("expires_at").notNull(),
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
     token: text("token").notNull().unique(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
     ipAddress: text("ip_address"),
@@ -45,12 +52,20 @@ export const accounts = pgTable(
     accessToken: text("access_token"),
     refreshToken: text("refresh_token"),
     idToken: text("id_token"),
-    accessTokenExpiresAt: timestamp("access_token_expires_at"),
-    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     scope: text("scope"),
     password: text("password"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
@@ -63,9 +78,14 @@ export const verifications = pgTable(
     id: text("id").primaryKey(),
     identifier: text("identifier").notNull(),
     value: text("value").notNull(),
-    expiresAt: timestamp("expires_at").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/packages/cli/test/__snapshots__/auth-schema-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-number-id.txt
@@ -14,8 +14,10 @@ export const custom_user = pgTable("custom_user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
   image: text("image"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -28,10 +30,15 @@ export const custom_session = pgTable(
   "custom_session",
   {
     id: integer("id").generatedByDefaultAsIdentity().primaryKey(),
-    expiresAt: timestamp("expires_at").notNull(),
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
     token: text("token").notNull().unique(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
     ipAddress: text("ip_address"),
@@ -55,12 +62,20 @@ export const custom_account = pgTable(
     accessToken: text("access_token"),
     refreshToken: text("refresh_token"),
     idToken: text("id_token"),
-    accessTokenExpiresAt: timestamp("access_token_expires_at"),
-    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     scope: text("scope"),
     password: text("password"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
@@ -73,9 +88,14 @@ export const custom_verification = pgTable(
     id: integer("id").generatedByDefaultAsIdentity().primaryKey(),
     identifier: text("identifier").notNull(),
     value: text("value").notNull(),
-    expiresAt: timestamp("expires_at").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/packages/cli/test/__snapshots__/auth-schema-pg-enum.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-pg-enum.txt
@@ -7,8 +7,10 @@ export const user = pgTable("user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
   image: text("image"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -19,10 +21,15 @@ export const session = pgTable(
   "session",
   {
     id: text("id").primaryKey(),
-    expiresAt: timestamp("expires_at").notNull(),
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
     token: text("token").notNull().unique(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
     ipAddress: text("ip_address"),
@@ -46,12 +53,20 @@ export const account = pgTable(
     accessToken: text("access_token"),
     refreshToken: text("refresh_token"),
     idToken: text("id_token"),
-    accessTokenExpiresAt: timestamp("access_token_expires_at"),
-    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     scope: text("scope"),
     password: text("password"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
@@ -64,9 +79,14 @@ export const verification = pgTable(
     id: text("id").primaryKey(),
     identifier: text("identifier").notNull(),
     value: text("value").notNull(),
-    expiresAt: timestamp("expires_at").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/packages/cli/test/__snapshots__/auth-schema-pg-passkey.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-pg-passkey.txt
@@ -14,8 +14,10 @@ export const custom_user = pgTable("custom_user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
   image: text("image"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -25,10 +27,15 @@ export const custom_session = pgTable(
   "custom_session",
   {
     id: text("id").primaryKey(),
-    expiresAt: timestamp("expires_at").notNull(),
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
     token: text("token").notNull().unique(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
     ipAddress: text("ip_address"),
@@ -52,12 +59,20 @@ export const custom_account = pgTable(
     accessToken: text("access_token"),
     refreshToken: text("refresh_token"),
     idToken: text("id_token"),
-    accessTokenExpiresAt: timestamp("access_token_expires_at"),
-    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     scope: text("scope"),
     password: text("password"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
@@ -70,9 +85,14 @@ export const custom_verification = pgTable(
     id: text("id").primaryKey(),
     identifier: text("identifier").notNull(),
     value: text("value").notNull(),
-    expiresAt: timestamp("expires_at").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
@@ -94,7 +114,7 @@ export const passkey = pgTable(
     deviceType: text("device_type").notNull(),
     backedUp: boolean("backed_up").notNull(),
     transports: text("transports"),
-    createdAt: timestamp("created_at"),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true }),
     aaguid: text("aaguid"),
   },
   (table) => [

--- a/packages/cli/test/__snapshots__/auth-schema-pg-uuid.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-pg-uuid.txt
@@ -16,8 +16,10 @@ export const custom_user = pgTable("custom_user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
   image: text("image"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -32,10 +34,15 @@ export const custom_session = pgTable(
     id: uuid("id")
       .default(sql`pg_catalog.gen_random_uuid()`)
       .primaryKey(),
-    expiresAt: timestamp("expires_at").notNull(),
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
     token: text("token").notNull().unique(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
     ipAddress: text("ip_address"),
@@ -61,12 +68,20 @@ export const custom_account = pgTable(
     accessToken: text("access_token"),
     refreshToken: text("refresh_token"),
     idToken: text("id_token"),
-    accessTokenExpiresAt: timestamp("access_token_expires_at"),
-    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     scope: text("scope"),
     password: text("password"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
@@ -81,9 +96,14 @@ export const custom_verification = pgTable(
       .primaryKey(),
     identifier: text("identifier").notNull(),
     value: text("value").notNull(),
-    expiresAt: timestamp("expires_at").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/packages/cli/test/__snapshots__/auth-schema.txt
+++ b/packages/cli/test/__snapshots__/auth-schema.txt
@@ -7,8 +7,10 @@ export const custom_user = pgTable("custom_user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
   image: text("image"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
@@ -21,10 +23,15 @@ export const custom_session = pgTable(
   "custom_session",
   {
     id: text("id").primaryKey(),
-    expiresAt: timestamp("expires_at").notNull(),
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
     token: text("token").notNull().unique(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
     ipAddress: text("ip_address"),
@@ -48,12 +55,20 @@ export const custom_account = pgTable(
     accessToken: text("access_token"),
     refreshToken: text("refresh_token"),
     idToken: text("id_token"),
-    accessTokenExpiresAt: timestamp("access_token_expires_at"),
-    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     scope: text("scope"),
     password: text("password"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
@@ -66,9 +81,14 @@ export const custom_verification = pgTable(
     id: text("id").primaryKey(),
     identifier: text("identifier").notNull(),
     value: text("value").notNull(),
-    expiresAt: timestamp("expires_at").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    expiresAt: timestamp("expires_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    createdAt: timestamp("created_at", { mode: "date", withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date", withTimezone: true })
       .defaultNow()
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -1510,7 +1510,7 @@ describe("--dialect flag support", () => {
 });
 
 describe("PostgreSQL Drizzle timestamptz and migration surface", () => {
-	it("should generate Drizzle schema with withTimezone: true for date fields and not touch other fields", async () => {
+	it("should generate Drizzle schema using withTimezone: true for date fields and not touch other fields", async () => {
 		const schema = await generateDrizzleSchema({
 			file: "test.drizzle",
 			adapter: {

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -1508,3 +1508,79 @@ describe("--dialect flag support", () => {
 		expect(schema.fileName).toBe("test.prisma");
 	});
 });
+
+describe("PostgreSQL Drizzle timestamptz and migration surface", () => {
+	it("should generate Drizzle schema with withTimezone: true for date fields and not touch other fields", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: {
+				id: "drizzle",
+				options: {
+					provider: "pg",
+					schema: {},
+				},
+			} as any,
+			options: {
+				database: {} as any,
+				user: {
+					additionalFields: {
+						lastUsedAt: {
+							type: "date",
+						},
+						accessTokenExpiresAt: {
+							type: "date",
+						},
+						refreshTokenExpiresAt: {
+							type: "date",
+						},
+						otherTextField: {
+							type: "string",
+						},
+						otherBoolField: {
+							type: "boolean",
+						},
+						otherIntField: {
+							type: "number",
+						},
+						otherJsonField: {
+							type: "json",
+						},
+					},
+				},
+			} as BetterAuthOptions,
+		});
+
+		// Assertions for withTimezone: true on all auth-related / date fields
+		expect(schema.code).toMatch(
+			/createdAt:\s*timestamp\("created_at",\s*\{\s*mode:\s*["']date["'],\s*withTimezone:\s*true\s*\}\)/,
+		);
+		expect(schema.code).toMatch(
+			/updatedAt:\s*timestamp\("updated_at",\s*\{\s*mode:\s*["']date["'],\s*withTimezone:\s*true\s*\}\)/,
+		);
+		expect(schema.code).toMatch(
+			/expiresAt:\s*timestamp\("expires_at",\s*\{\s*mode:\s*["']date["'],\s*withTimezone:\s*true,?\s*\}\)/,
+		);
+		expect(schema.code).toMatch(
+			/lastUsedAt:\s*timestamp\("last_used_at",\s*\{\s*mode:\s*["']date["'],\s*withTimezone:\s*true,?\s*\}\)/,
+		);
+		expect(schema.code).toMatch(
+			/accessTokenExpiresAt:\s*timestamp\("access_token_expires_at",\s*\{\s*mode:\s*["']date["'],\s*withTimezone:\s*true,?\s*\}\)/,
+		);
+		expect(schema.code).toMatch(
+			/refreshTokenExpiresAt:\s*timestamp\("refresh_token_expires_at",\s*\{\s*mode:\s*["']date["'],\s*withTimezone:\s*true,?\s*\}\)/,
+		);
+
+		// Assertions that other types are NOT modified
+		expect(schema.code).toContain('otherTextField: text("other_text_field")');
+		expect(schema.code).toContain(
+			'otherBoolField: boolean("other_bool_field")',
+		);
+		expect(schema.code).toContain('otherIntField: integer("other_int_field")');
+		expect(schema.code).toContain('otherJsonField: jsonb("other_json_field")');
+
+		expect(schema.code).not.toMatch(/otherTextField:[^;]*withTimezone/);
+		expect(schema.code).not.toMatch(/otherBoolField:[^;]*withTimezone/);
+		expect(schema.code).not.toMatch(/otherIntField:[^;]*withTimezone/);
+		expect(schema.code).not.toMatch(/otherJsonField:[^;]*withTimezone/);
+	});
+});


### PR DESCRIPTION
## Summary

This PR updates the PostgreSQL Drizzle schema generator to emit timezone-aware timestamps for generated date fields.

Previously, PostgreSQL date columns were generated as:

```ts
timestamp(name)
```

which maps to PostgreSQL `timestamp without time zone`.

This PR changes the mapping to:

```ts
timestamp(name, { mode: "date", withTimezone: true })
```

which maps to PostgreSQL `timestamp with time zone` (`timestamptz`).

### Why?

The generated authentication date fields (`createdAt`, `updatedAt`, `expiresAt`, `lastUsedAt`, `accessTokenExpiresAt`, and `refreshTokenExpiresAt`) represent absolute points in time rather than wall-clock values.

A dedicated integration test was added to reproduce the behavior using multiple runtime timezones (`UTC`, `America/New_York`, and `Asia/Kolkata`). The reproduction demonstrates that timezone-naive timestamps can be interpreted differently across processes running in different timezones, while `timestamptz` preserves the original instant consistently.

### Validation

This change is covered by:

* Generator and snapshot tests verifying PostgreSQL schemas now emit `{ mode: "date", withTimezone: true }`.
* Integration tests validating PostgreSQL column types.
* Cross-timezone roundtrip tests verifying timestamp stability across different runtime timezones.

Closes : #9920 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the PostgreSQL Drizzle schema generator to timezone-aware timestamps for all generated date fields to prevent cross-timezone drift. Adds end-to-end tests that verify column types and confirm consistent instants across timezones.

- **Bug Fixes**
  - Map PG dates from `timestamp(name)` to `timestamp(name, { mode: "date", withTimezone: true })` (uses `timestamptz`).
  - Added cross-timezone roundtrip tests (UTC, America/New_York, Asia/Kolkata) and schema type checks, plus a guard test to ensure non-date fields are unchanged.
  - Updated generator tests and snapshots; added changeset for patch releases to `@better-auth/oauth-provider`, `better-auth`, `@better-auth/passkey`, and `auth`.

- **Migration**
  - Regenerate your Drizzle schema and run a migration.
  - If migrating existing columns manually: `ALTER TABLE ... ALTER COLUMN ... TYPE timestamptz USING ...;`

<sup>Written for commit 910e4aae38e248cde4a5d296c17a6f0dffbd72ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

