### PR TITLE
fix(sign-in): persist idToken, refreshToken, accessTokenExpiresAt on idToken social sign-in

### DIFF
--- a/.changeset/bumpy-tigers-enjoy.md
+++ b/.changeset/bumpy-tigers-enjoy.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Persist `idToken`, `refreshToken`, and `accessTokenExpiresAt` on id-token social sign-in.

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -310,6 +310,15 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 						providerId: provider.id,
 						accountId: String(userInfo.user.id),
 						accessToken: c.body.idToken.accessToken,
+						idToken: token,
+						refreshToken: c.body.idToken.refreshToken,
+						...(c.body.idToken.expiresAt != null
+							? {
+									accessTokenExpiresAt: new Date(
+										c.body.idToken.expiresAt * 1000,
+									),
+								}
+							: {}),
 					},
 					callbackURL: c.body.callbackURL,
 					disableSignUp:


### PR DESCRIPTION
Fixes #9943 

## Summary

Fixes a bug where tokens provided to `authClient.signIn.social({ idToken })` were not persisted to the associated account. As a result, refresh flows could fail with `REFRESH_TOKEN_NOT_FOUND`.

Specifically, the following values were not being saved:

* `refreshToken`
* `idToken`
* `expiresAt`

## Root Cause

The ID token sign-in path in `sign-in.ts` only forwarded `accessToken` to `handleOAuthUserInfo(...)`.

However, `handleOAuthUserInfo(...)` is responsible for persisting OAuth credentials and expects additional token fields when available:

* `idToken`
* `refreshToken`
* `accessTokenExpiresAt`

Because these values were omitted, they were treated as `undefined` and never persisted to the `Account` record.

## Changes

### Implementation

Updated the ID token sign-in flow to forward:

* `idToken`
* `refreshToken`
* `accessTokenExpiresAt`

`expiresAt` is converted from a Unix timestamp (seconds) to a JavaScript `Date` before being passed to `handleOAuthUserInfo(...)`.

## Files Modified

* `sign-in.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted `idToken`, `refreshToken`, and `accessTokenExpiresAt` during ID-token social sign-in in `better-auth`, fixing failed refresh flows (e.g., REFRESH_TOKEN_NOT_FOUND).
Improves token storage by forwarding all available fields to the OAuth persistence logic.

- **Bug Fixes**
  - Forward `idToken`, `refreshToken`, and `accessTokenExpiresAt` to the OAuth handler in the ID-token social sign-in path.
  - Convert `expiresAt` (seconds) to a JS `Date` for `accessTokenExpiresAt` when present.

<sup>Written for commit ba5e559f03f7f5585837a83080c91846af499a3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

