### PR TITLE
fix(oauth-provider): return 401 invalid_token for invalid access token on /oauth2/userinfo

### DIFF
--- a/.changeset/oauth-provider-userinfo-401-invalid-token.md
+++ b/.changeset/oauth-provider-userinfo-401-invalid-token.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+The OAuth `/oauth2/userinfo` endpoint now responds with `401` (`invalid_token`, plus a `WWW-Authenticate` header) when the access token is invalid or expired, instead of `400` (`invalid_request`). OAuth clients that auto-refresh tokens typically only do so on a `401`, so the previous `400` left otherwise-valid connections stuck on an expired token until they were manually reconnected.

--- a/packages/oauth-provider/src/userinfo.test.ts
+++ b/packages/oauth-provider/src/userinfo.test.ts
@@ -177,6 +177,24 @@ describe("oauth userinfo", async () => {
 		expect(userinfo.error?.status).toBe(400);
 	});
 
+	/**
+	 * RFC 6750 §3.1: an invalid/expired bearer token must yield 401 invalid_token
+	 * (not 400 invalid_request), so resource clients can trigger token refresh.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/9949
+	 */
+	it("should return 401 invalid_token for an invalid access token", async () => {
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: "Bearer this-is-not-a-valid-access-token",
+				},
+			},
+		);
+		expect(userinfo.error?.status).toBe(401);
+	});
+
 	it("should pass provide all user information - opaque", async () => {
 		const tokens = await getTokens();
 		expect(tokens.data?.access_token).toBeDefined();

--- a/packages/oauth-provider/src/userinfo.ts
+++ b/packages/oauth-provider/src/userinfo.ts
@@ -1,5 +1,5 @@
 import type { GenericEndpointContext } from "@better-auth/core";
-import { APIError } from "better-auth/api";
+import { APIError, isAPIError } from "better-auth/api";
 import type { User } from "better-auth/types";
 import { validateAccessToken } from "./introspect";
 import type { OAuthOptions, Scope } from "./types";
@@ -48,7 +48,32 @@ export async function userInfoEndpoint(
 			error: "invalid_request",
 		});
 	}
-	const jwt = await validateAccessToken(ctx, opts, token);
+	let jwt: Awaited<ReturnType<typeof validateAccessToken>>;
+	try {
+		jwt = await validateAccessToken(ctx, opts, token);
+	} catch (error) {
+		// RFC 6750 §3.1: an invalid or expired bearer token is `invalid_token` and
+		// must be answered with 401 (+ a WWW-Authenticate challenge), not the generic
+		// 400 `invalid_request` that `validateAccessToken` throws when both JWT and
+		// opaque validation fail. Resource clients (e.g. OAuth integrations that rely
+		// on auto-refresh) only renew their token on a 401, so a 400 strands otherwise
+		// valid sessions. The legacy oidc-provider plugin also returned 401 here.
+		if (
+			isAPIError(error) &&
+			(error.body as { error_description?: string } | undefined)
+				?.error_description === "Invalid access token"
+		) {
+			throw new APIError(
+				"UNAUTHORIZED",
+				{ error: "invalid_token", error_description: "Invalid access token" },
+				{
+					"WWW-Authenticate":
+						'Bearer error="invalid_token", error_description="Invalid access token"',
+				},
+			);
+		}
+		throw error;
+	}
 
 	const scopes = (jwt.scope as string | undefined)?.split(" ");
 	if (!scopes?.includes("openid")) {


### PR DESCRIPTION
## What

`/oauth2/userinfo` returns **`400 invalid_request`** for an invalid/expired access token. Per **RFC 6750 §3.1** an invalid bearer token is `invalid_token` and must be answered with **`401`** + a `WWW-Authenticate` challenge. This PR maps that one case to `401 invalid_token` in the userinfo handler.

Closes #9949.

## Why it matters

OAuth clients only run token auto-refresh on a **401** (e.g. Zapier's `autoRefresh`). On a `400` they treat the connection as expired and force a manual reconnect — even though the client still holds a valid refresh token. This is a regression from the legacy `oidc-provider` plugin, whose userinfo returned `401` for the same case.

## Root cause

`validateAccessToken` (`packages/oauth-provider/src/introspect.ts`) tries JWT verification, then opaque verification, and if both fail throws a generic:

```ts
throw new APIError("BAD_REQUEST", {
  error_description: "Invalid access token",
  error: "invalid_request",
});
```

PR #9655 already routes **JWT** verification failures to `401`, but **opaque** access tokens that fail lookup still hit this final `BAD_REQUEST` fallback — so opaque-token deployments (the common case when migrating from `oidc-provider`) still get `400`.

## The change

Scoped to the **userinfo handler** (`userinfo.ts`): wrap the `validateAccessToken` call and, when it reports an invalid token, rethrow as `401 invalid_token` with a `WWW-Authenticate: Bearer` header.

```ts
try {
  jwt = await validateAccessToken(ctx, opts, token);
} catch (error) {
  if (isAPIError(error) && error.body?.error_description === "Invalid access token") {
    throw new APIError("UNAUTHORIZED",
      { error: "invalid_token", error_description: "Invalid access token" },
      { "WWW-Authenticate": 'Bearer error="invalid_token", error_description="Invalid access token"' });
  }
  throw error;
}
```

### Why scope it to userinfo instead of changing `validateAccessToken`?

`validateAccessToken` is shared by `/oauth2/userinfo` and `/oauth2/introspect`. Introspect (RFC 7662) must return `{ active: false }` for an invalid token, not surface a 401 — so changing the shared throw would require also adjusting the introspect path. Keeping the change in the userinfo handler fixes the reported issue without touching introspect/revoke semantics.

> **Separate observation (not addressed here):** the introspect endpoint's catch uses `error.name === "BAD_REQUEST"` (introspect.ts) / `revoke.ts`, but `better-call`'s `APIError` sets `name` to the literal `"APIError"` and stores the status in `error.status` (this package's `mcp.ts` correctly uses `error.status === "UNAUTHORIZED"`). So that `error.name === "BAD_REQUEST"` branch never matches. Happy to file/fix this separately if useful.

## Tests

Added a userinfo test asserting `401` for an invalid access token (`packages/oauth-provider/src/userinfo.test.ts`). The existing `400` test ("without the openid scope") is unaffected — it uses a *valid* token that fails the `openid` scope check, which is a separate path.

## Notes

- Changeset included (`@better-auth/oauth-provider` patch).
- Introspect (RFC 7662) and revoke (RFC 7009) behavior unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`/oauth2/userinfo` now returns 401 `invalid_token` with a `WWW-Authenticate: Bearer` challenge for invalid or expired access tokens. This aligns `@better-auth/oauth-provider` with RFC 6750 and restores client auto-refresh.

- **Bug Fixes**
  - Map "Invalid access token" in `userinfo` to 401 `invalid_token` + `WWW-Authenticate`.
  - Fixes opaque-token path that returned 400 `invalid_request`; JWT path already returned 401.
  - `/oauth2/introspect` and `/oauth2/revoke` unchanged; adds a test for the 401 case.

<sup>Written for commit c4562c16361040c83be1f43842ba9549e2c552fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

