### PR TITLE
chore: drop `two-factor-newsession-null.md` changeset

### DIFF
--- a/.changeset/two-factor-newsession-null.md
+++ b/.changeset/two-factor-newsession-null.md
@@ -1,5 +1,0 @@
----
-"better-auth": patch
----
-
-Document that `ctx.context.newSession` is `null` while a two-factor challenge is in flight. When a 2FA-enabled user signs in through a credential endpoint, the pending session is discarded and `newSession` is reset to `null` (no authenticated session exists until the second factor is verified). Server-side `after` hooks reading `ctx.context.newSession` must null-check it before accessing `newSession.user`. This clarifies the behavior change introduced in #9639.


### PR DESCRIPTION
Related to #9957