### PR TITLE
fix(oauth-provider): make `private_key_jwt` jti single-use atomic across processes

### DIFF
--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -2178,25 +2178,21 @@ export const oauthConsentTableFields = [
 
 Table Name: `oauthClientAssertion`
 
-Records each `private_key_jwt` client assertion `jti` so it can only be used once. The unique `identifier` lets the database reject a replayed or concurrent assertion atomically, which holds even across multiple server processes. Rows are inert once past `expiresAt`; no scheduled job prunes them, so remove expired rows with your own cleanup if the table grows.
+Records each `private_key_jwt` client assertion `jti` so it can only be used once. The row id is a digest of the per-client assertion identifier, so a replayed or concurrent assertion collides on the primary key and the database rejects it atomically, even across multiple server processes. A row keeps blocking its id until deleted; `expiresAt` marks when removal is safe, because the assertion it guards has already expired. No scheduled job prunes these rows, so remove expired rows with your own cleanup if the table grows.
 
 export const oauthClientAssertionTableFields = [
   {
     name: "id",
     type: "string",
-    description: "Database ID of the assertion record",
+    description:
+      "Digest of the per-client assertion identifier (`private_key_jwt:<clientId>:<jti>`)",
     isPrimaryKey: true,
-  },
-  {
-    name: "identifier",
-    type: "string",
-    description: "Per-client assertion key (`private_key_jwt:<clientId>:<jti>`)",
-    isUnique: true,
   },
   {
     name: "expiresAt",
     type: "Date",
-    description: "When the assertion expires and the row becomes inert",
+    description:
+      "When the guarded assertion expires and the row becomes safe to delete",
   },
 ];
 

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -2174,6 +2174,34 @@ export const oauthConsentTableFields = [
 
 <DatabaseTable name="oauthConsent" fields={oauthConsentTableFields} />
 
+### OAuth Client Assertion
+
+Table Name: `oauthClientAssertion`
+
+Records each `private_key_jwt` client assertion `jti` so it can only be used once. The unique `identifier` lets the database reject a replayed or concurrent assertion atomically, which holds even across multiple server processes. Rows are inert once past `expiresAt`; no scheduled job prunes them, so remove expired rows with your own cleanup if the table grows.
+
+export const oauthClientAssertionTableFields = [
+  {
+    name: "id",
+    type: "string",
+    description: "Database ID of the assertion record",
+    isPrimaryKey: true,
+  },
+  {
+    name: "identifier",
+    type: "string",
+    description: "Per-client assertion key (`private_key_jwt:<clientId>:<jti>`)",
+    isUnique: true,
+  },
+  {
+    name: "expiresAt",
+    type: "Date",
+    description: "When the assertion expires and the row becomes inert",
+  },
+];
+
+<DatabaseTable name="oauthClientAssertion" fields={oauthClientAssertionTableFields} />
+
 ## Options
 
 ### Prefix

--- a/packages/oauth-provider/src/schema.ts
+++ b/packages/oauth-provider/src/schema.ts
@@ -349,22 +349,20 @@ export const schema = {
 		},
 	},
 	/**
-	 * Single-use record for `private_key_jwt` client assertion `jti` values.
-	 * The unique `identifier` makes the database the atomic gate: a replayed or
-	 * concurrent assertion fails the insert, so no two token requests can both
-	 * consume the same assertion. A row is inert once past `expiresAt`.
+	 * Single-use record for `private_key_jwt` client assertion `jti` values. The
+	 * row id is a digest of the per-client assertion identifier, so a replayed or
+	 * concurrent assertion collides on the primary key and the insert fails
+	 * atomically on every adapter (SQL primary key, MongoDB `_id`), including
+	 * across multiple server processes.
 	 *
+	 * A row keeps blocking its id until deleted; `expiresAt` marks when removal
+	 * is safe, since the assertion it guards has expired and is rejected earlier.
 	 * TODO: no scheduled job prunes expired rows yet; like the verification
 	 * table, they accumulate until a deployment-level sweep removes them.
 	 */
 	oauthClientAssertion: {
 		modelName: "oauthClientAssertion",
 		fields: {
-			identifier: {
-				type: "string",
-				required: true,
-				unique: true,
-			},
 			expiresAt: {
 				type: "date",
 				required: true,

--- a/packages/oauth-provider/src/schema.ts
+++ b/packages/oauth-provider/src/schema.ts
@@ -348,4 +348,27 @@ export const schema = {
 			},
 		},
 	},
+	/**
+	 * Single-use record for `private_key_jwt` client assertion `jti` values.
+	 * The unique `identifier` makes the database the atomic gate: a replayed or
+	 * concurrent assertion fails the insert, so no two token requests can both
+	 * consume the same assertion. A row is inert once past `expiresAt`.
+	 *
+	 * TODO: no scheduled job prunes expired rows yet; like the verification
+	 * table, they accumulate until a deployment-level sweep removes them.
+	 */
+	oauthClientAssertion: {
+		modelName: "oauthClientAssertion",
+		fields: {
+			identifier: {
+				type: "string",
+				required: true,
+				unique: true,
+			},
+			expiresAt: {
+				type: "date",
+				required: true,
+			},
+		},
+	},
 } satisfies BetterAuthPluginDBSchema;

--- a/packages/oauth-provider/src/utils/client-assertion.ts
+++ b/packages/oauth-provider/src/utils/client-assertion.ts
@@ -30,7 +30,6 @@ function setJwksCache(uri: string, jwks: JSONWebKeySet, fetchedAt: number) {
 	}
 }
 const ALGORITHMS_LIST: string[] = [...PRIVATE_KEY_JWT_SIGNING_ALGORITHMS];
-const pendingAssertionIds = new Set<string>();
 
 /**
  * SSRF gate for user-supplied server-side fetch targets (`jwks_uri`,
@@ -357,51 +356,31 @@ export async function verifyClientAssertion(
 		});
 	}
 
+	// Consume the jti with a single insert: the unique `identifier` makes the
+	// database the atomic gate, so concurrent token requests across workers
+	// cannot both pass a stale lookup. A failed insert that finds an existing
+	// row is a replay; any other error is a real adapter failure and rethrown.
 	const jtiIdentifier = `private_key_jwt:${clientId}:${payload.jti}`;
-	if (pendingAssertionIds.has(jtiIdentifier)) {
-		throw new APIError("BAD_REQUEST", {
-			error_description: "client assertion jti has already been used",
-			error: "invalid_client",
-		});
-	}
-
-	pendingAssertionIds.add(jtiIdentifier);
 	try {
-		const existingJti =
-			await ctx.context.internalAdapter.findVerificationValue(jtiIdentifier);
-		if (existingJti) {
+		await ctx.context.adapter.create({
+			model: "oauthClientAssertion",
+			data: {
+				identifier: jtiIdentifier,
+				expiresAt: new Date(payload.exp * 1000),
+			},
+		});
+	} catch (createErr) {
+		const alreadyUsed = await ctx.context.adapter.findOne({
+			model: "oauthClientAssertion",
+			where: [{ field: "identifier", value: jtiIdentifier }],
+		});
+		if (alreadyUsed) {
 			throw new APIError("BAD_REQUEST", {
 				error_description: "client assertion jti has already been used",
 				error: "invalid_client",
 			});
 		}
-
-		// Store JTI tombstone until the assertion's actual expiry.
-		// If another instance created the tombstone between our find and create
-		// (race in multi-instance deployments), the create may succeed as a
-		// duplicate or throw; either way the assertion is consumed.
-		const jtiExpiry = new Date(payload.exp * 1000);
-		try {
-			await ctx.context.internalAdapter.createVerificationValue({
-				identifier: jtiIdentifier,
-				value: clientId,
-				expiresAt: jtiExpiry,
-			});
-		} catch (createErr) {
-			// If the tombstone already exists (created by another instance in
-			// the race window), treat it as a replay.
-			const doubleCheck =
-				await ctx.context.internalAdapter.findVerificationValue(jtiIdentifier);
-			if (doubleCheck) {
-				throw new APIError("BAD_REQUEST", {
-					error_description: "client assertion jti has already been used",
-					error: "invalid_client",
-				});
-			}
-			throw createErr;
-		}
-	} finally {
-		pendingAssertionIds.delete(jtiIdentifier);
+		throw createErr;
 	}
 
 	return { clientId, client };

--- a/packages/oauth-provider/src/utils/client-assertion.ts
+++ b/packages/oauth-provider/src/utils/client-assertion.ts
@@ -4,6 +4,8 @@ import {
 	PRIVATE_KEY_JWT_SIGNING_ALGORITHMS,
 } from "@better-auth/core/oauth2";
 import { isPublicRoutableHost } from "@better-auth/core/utils/host";
+import { base64Url } from "@better-auth/utils/base64";
+import { createHash } from "@better-auth/utils/hash";
 import { APIError } from "better-call";
 import type { JSONWebKeySet } from "jose";
 import {
@@ -356,24 +358,38 @@ export async function verifyClientAssertion(
 		});
 	}
 
-	// Consume the jti with a single insert: the unique `identifier` makes the
-	// database the atomic gate, so concurrent token requests across workers
-	// cannot both pass a stale lookup. A failed insert that finds an existing
-	// row is a replay; any other error is a real adapter failure and rethrown.
-	const jtiIdentifier = `private_key_jwt:${clientId}:${payload.jti}`;
+	// Consume the jti with a single insert keyed by a digest of the per-client
+	// assertion identifier. The primary key is the atomic gate on every adapter
+	// (SQL primary key, MongoDB `_id`), so concurrent token requests across
+	// workers cannot both pass. A duplicate-key failure means the jti was
+	// already used (replay); any other failure is surfaced unchanged.
+	const jtiDigest = await createHash("SHA-256").digest(
+		new TextEncoder().encode(`private_key_jwt:${clientId}:${payload.jti}`),
+	);
+	const jtiId = base64Url.encode(new Uint8Array(jtiDigest).slice(0, 24), {
+		padding: false,
+	});
 	try {
 		await ctx.context.adapter.create({
 			model: "oauthClientAssertion",
 			data: {
-				identifier: jtiIdentifier,
+				id: jtiId,
 				expiresAt: new Date(payload.exp * 1000),
 			},
+			forceAllowId: true,
 		});
 	} catch (createErr) {
-		const alreadyUsed = await ctx.context.adapter.findOne({
-			model: "oauthClientAssertion",
-			where: [{ field: "identifier", value: jtiIdentifier }],
-		});
+		let alreadyUsed = false;
+		try {
+			alreadyUsed = Boolean(
+				await ctx.context.adapter.findOne({
+					model: "oauthClientAssertion",
+					where: [{ field: "id", value: jtiId }],
+				}),
+			);
+		} catch {
+			// Lookup failed, so a replay cannot be confirmed; surface the insert error.
+		}
 		if (alreadyUsed) {
 			throw new APIError("BAD_REQUEST", {
 				error_description: "client assertion jti has already been used",


### PR DESCRIPTION
The `private_key_jwt` jti single-use guard looked up prior use and wrote the tombstone in two separate steps, backed by an in-process Set that only covers one process. Across multiple processes those steps interleave, so the single-use guarantee does not hold.

Each jti is now recorded under a database unique constraint: the insert is the check, and a duplicate fails atomically. The in-process Set and the pre-read are removed. This follows the refresh-token rotation already in this plugin, which leans on a guarded write rather than read-then-write. A new `oauthClientAssertion` table holds the jti and its expiry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `private_key_jwt` jti single-use atomic across processes and adapters by inserting a primary-key digest per assertion. Adds the `oauthClientAssertion` table and removes the in-memory Set and read-before-write guard.

- **Bug Fixes**
  - Enforce single-use by inserting a primary-key digest of `private_key_jwt:<clientId>:<jti>`; duplicates fail atomically across SQL and Mongo.
  - On insert failure, treat confirmed duplicates as replay; otherwise surface the original error. Mirrors the refresh-token rotation write-first pattern.

- **Migration**
  - Add the `oauthClientAssertion` table (and docs) and run migrations for `packages/oauth-provider`.
  - Set up periodic cleanup for expired rows (`expiresAt`); rows are not auto-pruned.

<sup>Written for commit 2e99e2d68143eca9196623c2df72c6d3e25ecbd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

