### PR TITLE
fix(auth): mark plugin-owned session fields as non-input

### DIFF
--- a/.changeset/update-session-authority-fields.md
+++ b/.changeset/update-session-authority-fields.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Passing `activeOrganizationId`, `activeTeamId`, or `impersonatedBy` to `/update-session` now returns a 400. Change these plugin-managed session fields through their dedicated endpoints instead, such as `organization.setActive`.

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -17,6 +17,8 @@ import {
 } from "vitest";
 import { parseCookies, parseSetCookieHeader } from "../../cookies";
 import { signJWT, verifyJWT } from "../../crypto";
+import { admin } from "../../plugins/admin";
+import { organization } from "../../plugins/organization";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { getDate } from "../../utils/date";
 import { freshSessionMiddleware, getSessionFromCtx } from "./session";
@@ -2205,6 +2207,30 @@ describe("updateSession", async () => {
 			// Verify the session cookie is updated by getting the session again
 			const session = await client.getSession();
 			expect((session.data?.session as any).theme).toBe("blue");
+		});
+	});
+});
+
+describe("updateSession plugin authority fields", async () => {
+	// Plugin-owned authority fields must not be writable through the generic
+	// session update route. They are set only by membership/permission-checked
+	// setters (setActiveOrganization, impersonateUser), so /update-session must
+	// reject them even though they live on the session schema.
+	const { client, signInWithTestUser } = await getTestInstance({
+		plugins: [organization({ teams: { enabled: true } }), admin()],
+	});
+
+	it.each([
+		"activeOrganizationId",
+		"activeTeamId",
+		"impersonatedBy",
+	])("should reject forging the %s session field", async (field) => {
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
+			const res = await client.updateSession({
+				[field]: "forged-value",
+			} as any);
+			expect(res.error?.status).toBe(400);
 		});
 	});
 });

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -40,6 +40,11 @@ function getFields(
 		...coreSchema,
 		...(additionalFields ?? {}),
 	};
+	// FIXME: Plugin-contributed fields are input-by-default, so a plugin-owned
+	// authority field is writable through generic input routes (e.g.
+	// /update-session) unless it sets `input: false`. A future breaking change
+	// should make plugin fields non-input by default and require an explicit
+	// opt-in for client-writable ones.
 	for (const plugin of options.plugins || []) {
 		if (plugin.schema && plugin.schema[modelName]) {
 			schema = {

--- a/packages/better-auth/src/plugins/admin/schema.ts
+++ b/packages/better-auth/src/plugins/admin/schema.ts
@@ -31,6 +31,7 @@ export const schema = {
 			impersonatedBy: {
 				type: "string",
 				required: false,
+				input: false,
 			},
 		},
 	},

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -166,11 +166,13 @@ describe("organization", async () => {
 			activeOrganizationId: {
 				type: "string";
 				required: false;
+				input: false;
 			};
 		} & {
 			activeTeamId: {
 				type: "string";
 				required: false;
+				input: false;
 			};
 		};
 

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -1221,6 +1221,7 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 					activeOrganizationId: {
 						type: "string",
 						required: false,
+						input: false,
 						fieldName: opts.schema?.session?.fields?.activeOrganizationId,
 					},
 					...(teamSupport
@@ -1228,6 +1229,7 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 								activeTeamId: {
 									type: "string",
 									required: false,
+									input: false,
 									fieldName: opts.schema?.session?.fields?.activeTeamId,
 								},
 							}
@@ -1239,16 +1241,19 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 							activeTeamId: {
 								type: "string";
 								required: false;
+								input: false;
 							};
 							activeOrganizationId: {
 								type: "string";
 								required: false;
+								input: false;
 							};
 						}
 					: {
 							activeOrganizationId: {
 								type: "string";
 								required: false;
+								input: false;
 							};
 						},
 			},

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -199,6 +199,7 @@ interface SessionDefaultFields {
 	activeOrganizationId: {
 		type: "string";
 		required: false;
+		input: false;
 	};
 }
 
@@ -278,6 +279,7 @@ export type OrganizationSchema<O extends OrganizationOptions> =
 								activeTeamId: {
 									type: "string";
 									required: false;
+									input: false;
 								};
 							}
 						: {});


### PR DESCRIPTION
`/update-session` writes any session field that is not marked `input: false`. The organization plugin's `activeOrganizationId`/`activeTeamId` and the admin plugin's `impersonatedBy` were missing that flag, so they were writable through the generic route instead of only through their dedicated setters, which check membership and permissions.

This marks the three fields `input: false`, matching how the admin plugin already guards its user fields. The dedicated setters are unaffected: they write through the internal adapter, which skips route-level input parsing.

The broader change, making plugin-owned fields non-input by default, is breaking and left for `next`; a `FIXME` marks it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block updates to plugin-owned session fields through `/update-session` to close a security hole. These fields now return 400 and must be set via their permission-checked endpoints.

- **Bug Fixes**
  - Marked `activeOrganizationId`, `activeTeamId`, and `impersonatedBy` as `input: false` in the session schema.
  - Added tests to ensure `/update-session` rejects these fields with 400.
  - Added a FIXME for a future breaking change to make plugin fields non-input by default.

- **Migration**
  - Stop sending `activeOrganizationId`, `activeTeamId`, or `impersonatedBy` to `/update-session`. Use the dedicated setters instead (e.g., `organization.setActive`).

<sup>Written for commit 63155d414d6d2763cb0ff3e015ab8ad9e0f82d1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

