### PR TITLE
fix(session): honor server-side session deletion in update-session and token routes

### DIFF
--- a/.changeset/revalidate-session-against-store.md
+++ b/.changeset/revalidate-session-against-store.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Deleting a session now immediately stops `/update-session` and the account token endpoints (`/get-access-token`, `/refresh-token`, `/account-info`) from accepting it, when cookie cache is enabled alongside a database or secondary storage. Before, these routes kept serving the deleted session from the cached cookie until the cache expired. Deployments that store the session only in the cookie are unaffected.

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -1865,3 +1865,35 @@ describe("account", async () => {
 		expect(refreshedAccountCookie).toBe(true);
 	});
 });
+
+describe("token routes cookie cache revocation", async () => {
+	it("get-access-token fails closed after the session is revoked in a stateful deployment", async () => {
+		const { auth, client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, maxAge: 60 } },
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+		const initial = await client.getSession({
+			fetchOptions: { headers, onSuccess: cookieSetter(headers) },
+		});
+		const sessionToken = initial.data!.session.token;
+		expect(headers.get("cookie")).toContain("session_data");
+
+		// Revoke server-side; the cookie cache is the only thing still vouching.
+		const ctx = await auth.$context;
+		await ctx.internalAdapter.deleteSession(sessionToken);
+
+		// resolveUserId validates against the database before any account lookup,
+		// so the revoked session is rejected outright rather than minting a token.
+		const res = await client.$fetch("/get-access-token", {
+			method: "POST",
+			body: { providerId: "google" },
+			headers,
+		});
+		expect(res.error?.status).toBe(401);
+	});
+});

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -1895,5 +1895,18 @@ describe("token routes cookie cache revocation", async () => {
 			headers,
 		});
 		expect(res.error?.status).toBe(401);
+
+		// A request must not re-enable the cookie cache to revive the revoked
+		// session. `z.coerce.boolean()` reads an empty value as false, so the
+		// forced strict validation has to ignore it.
+		const bypass = await client.$fetch(
+			"/get-access-token?disableCookieCache=",
+			{
+				method: "POST",
+				body: { providerId: "google" },
+				headers,
+			},
+		);
+		expect(bypass.error?.status).toBe(401);
 	});
 });

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -445,12 +445,22 @@ export const unlinkAccount = createAuthEndpoint(
  * `userId` directly. Throws `UNAUTHORIZED` when an HTTP caller is
  * unauthenticated, and `USER_ID_OR_SESSION_REQUIRED` when neither a session
  * nor a `userId` is available.
+ *
+ * When a durable store is authoritative, bypasses the cookie cache: these
+ * routes mint or refresh provider access tokens, so a server-side session
+ * revocation must take effect immediately rather than waiting for the cached
+ * cookie to expire. DB-less deployments keep the session in the cookie itself,
+ * so the cache is left in place for them.
  */
 async function resolveUserId(
 	ctx: GenericEndpointContext,
 	userId?: string,
 ): Promise<string> {
-	const session = await getSessionFromCtx(ctx);
+	const isStateful =
+		!!ctx.context.options.database || !!ctx.context.options.secondaryStorage;
+	const session = await getSessionFromCtx(ctx, {
+		disableCookieCache: isStateful,
+	});
 	if (!session && (ctx.request || ctx.headers)) {
 		throw ctx.error("UNAUTHORIZED");
 	}

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -2311,3 +2311,37 @@ describe("update-session cookie cache revocation", async () => {
 		).toBe("dark");
 	});
 });
+
+describe("forced strict session validation", async () => {
+	it("a request cannot re-enable the cookie cache on a route that forces it off", async () => {
+		const { auth, client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, maxAge: 60 } },
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+		const initial = await client.getSession({
+			fetchOptions: { headers, onSuccess: cookieSetter(headers) },
+		});
+		const sessionToken = initial.data!.session.token;
+
+		const ctx = await auth.$context;
+		await ctx.internalAdapter.deleteSession(sessionToken);
+
+		// `/change-password` forces strict validation through
+		// `sensitiveSessionMiddleware`. An empty `disableCookieCache` query coerces
+		// to false, which must not weaken that forced check back to the cache.
+		const res = await client.$fetch("/change-password?disableCookieCache=", {
+			method: "POST",
+			body: {
+				currentPassword: testUser.password,
+				newPassword: "new-password-1234",
+			},
+			headers,
+		});
+		expect(res.error?.status).toBe(401);
+	});
+});

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -2234,3 +2234,80 @@ describe("updateSession plugin authority fields", async () => {
 		});
 	});
 });
+
+describe("update-session cookie cache revocation", async () => {
+	it("fails closed when the backing session is revoked in a stateful deployment", async () => {
+		const { auth, client, testUser, cookieSetter } = await getTestInstance({
+			session: {
+				cookieCache: { enabled: true, maxAge: 60 },
+				additionalFields: {
+					theme: { type: "string", defaultValue: "light" },
+				},
+			},
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+		const initial = await client.getSession({
+			fetchOptions: { headers, onSuccess: cookieSetter(headers) },
+		});
+		const sessionToken = initial.data!.session.token;
+		expect(headers.get("cookie")).toContain("session_data");
+
+		// Revoke server-side; only the cookie cache still vouches for the session.
+		const ctx = await auth.$context;
+		await ctx.internalAdapter.deleteSession(sessionToken);
+
+		const update = await client.$fetch("/update-session", {
+			method: "POST",
+			body: { theme: "dark" },
+			headers,
+		});
+		expect(update.error?.status).toBe(401);
+
+		// The database is authoritative and says the session is gone.
+		const strict = await client.getSession({
+			query: { disableCookieCache: true },
+			fetchOptions: { headers },
+		});
+		expect(strict.data).toBeNull();
+	});
+
+	it("still refreshes the cookie in a DB-less deployment when no row exists", async () => {
+		const { auth, client, testUser, cookieSetter } = await getTestInstance({
+			database: undefined as any,
+			session: {
+				additionalFields: { theme: { type: "string", defaultValue: "light" } },
+			},
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+		const initial = await client.getSession({
+			fetchOptions: { headers, onSuccess: cookieSetter(headers) },
+		});
+		const sessionToken = initial.data!.session.token;
+
+		// Simulate an instance whose in-memory store never held this session: the
+		// cookie is the source of truth, so the update must still apply.
+		const ctx = await auth.$context;
+		await ctx.internalAdapter.deleteSession(sessionToken);
+
+		const update = await client.$fetch("/update-session", {
+			method: "POST",
+			body: { theme: "dark" },
+			headers,
+			onSuccess: cookieSetter(headers),
+		});
+		expect(update.error).toBeNull();
+		expect(
+			(update.data as { session?: { theme?: string } } | null)?.session?.theme,
+		).toBe("dark");
+	});
+});

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -547,6 +547,14 @@ export const getSessionFromCtx = async <
 		query: {
 			...config,
 			...ctx.query,
+			// `disableCookieCache`/`disableRefresh` only ever make validation
+			// stricter, so OR the caller's intent with the request. A caller that
+			// forces strict validation must not be weakened by a request query
+			// param (e.g. `?disableCookieCache=`), which the plain merge would let
+			// override the forced value back to false.
+			disableCookieCache:
+				config?.disableCookieCache || ctx.query?.disableCookieCache,
+			disableRefresh: config?.disableRefresh || ctx.query?.disableRefresh,
 		},
 	}).catch(() => {
 		return null;

--- a/packages/better-auth/src/api/routes/update-session.ts
+++ b/packages/better-auth/src/api/routes/update-session.ts
@@ -2,7 +2,7 @@ import type { BetterAuthOptions } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import * as z from "zod";
-import { setSessionCookie } from "../../cookies";
+import { deleteSessionCookie, setSessionCookie } from "../../cookies";
 import { parseSessionInput, parseSessionOutput } from "../../db/schema";
 import type { AdditionalSessionFieldsInput } from "../../types";
 import { sessionMiddleware } from "./session";
@@ -80,6 +80,21 @@ export const updateSession = <O extends BetterAuthOptions>() =>
 					updatedAt: new Date(),
 				},
 			);
+
+			// A cookie-cached session with no backing row in a durable store was
+			// revoked or expired server-side; fail closed instead of re-minting from
+			// stale data, which would extend a revoked session. DB-less deployments
+			// keep the session in the cookie and legitimately have no row to update.
+			const isStateful =
+				!!ctx.context.options.database ||
+				!!ctx.context.options.secondaryStorage;
+			if (!updatedSession && isStateful) {
+				deleteSessionCookie(ctx);
+				throw APIError.from(
+					"UNAUTHORIZED",
+					BASE_ERROR_CODES.FAILED_TO_GET_SESSION,
+				);
+			}
 
 			const newSession = updatedSession ?? {
 				...session.session,


### PR DESCRIPTION
With cookie cache enabled, `/update-session` and the account token routes (`/get-access-token`, `/refresh-token`, `/account-info`) resolved the session from the signed cookie, so a session removed from the durable store stayed usable until the cache expired. `/update-session` also re-minted the cache from the stale session on each call, extending it, and the token routes return provider access tokens.

When a database or secondary storage is configured, these routes now resolve against the store: the token routes skip the cookie cache, and `/update-session` fails closed when no backing row exists instead of re-minting. Forcing strict validation everywhere would change the cookie-cache contract and break DB-less ("session in cookie only") setups, so the change is gated on statefulness; cookie-only deployments keep their current behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors server-side session deletion when cookie cache is enabled by validating against the store in stateful setups. Also hardens strict session checks so request query params cannot weaken them.

- **Bug Fixes**
  - Token routes (`/get-access-token`, `/refresh-token`, `/account-info`) bypass the cookie cache in stateful deployments; forced `disableCookieCache`/`disableRefresh` cannot be overridden by request query params.
  - `/update-session` returns 401 and clears the cookie if no backing session exists, preventing re-minting from stale cache in stateful setups.
  - Cookie-only deployments keep current behavior.

<sup>Written for commit fcf5e509718c82a4d1b819f47d8141b42c820826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

