### PR TITLE
fix(admin): enforce set-role and ban permissions on createUser and updateUser

### DIFF
--- a/.changeset/admin-field-permissions.md
+++ b/.changeset/admin-field-permissions.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The admin plugin's `createUser` and `updateUser` now require `user:set-role` to assign a role and `user:ban` to set ban state (`banned`, `banReason`, `banExpires`) through the `data` payload, matching `setRole` and `banUser`. Admins without those permissions now receive a 403 from these endpoints when they include those fields. Server-side `auth.api` calls and admins that hold the permissions are unaffected.

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -1934,6 +1934,201 @@ describe("access control", async () => {
 	});
 });
 
+describe("create-user role escalation", async () => {
+	const ac = createAccessControl({
+		user: ["create", "set-role"],
+	});
+	const roles = {
+		admin: ac.newRole({ user: ["create", "set-role"] }),
+		support: ac.newRole({ user: ["create"] }),
+		user: ac.newRole({ user: [] }),
+	};
+
+	const { client, auth, signInWithUser } = await getTestInstance(
+		{ plugins: [admin({ ac, roles })] },
+		{ clientOptions: { plugins: [adminClient({ ac, roles })] } },
+	);
+
+	// Seed the actors server-side. A server call has no session, so it bypasses
+	// the role guard, which is also the property that keeps backend provisioning
+	// able to assign roles.
+	await auth.api.createUser({
+		body: {
+			email: "root@test.com",
+			password: "password",
+			name: "Root Admin",
+			role: "admin",
+		},
+	});
+	await auth.api.createUser({
+		body: {
+			email: "support@test.com",
+			password: "password",
+			name: "Support",
+			role: "support",
+		},
+	});
+
+	it("blocks a user:create-only admin from assigning a role", async () => {
+		const { headers } = await signInWithUser("support@test.com", "password");
+		const res = await client.admin.createUser(
+			{
+				email: "escalated@test.com",
+				password: "password",
+				name: "Escalated",
+				role: "admin",
+			},
+			{ headers },
+		);
+		expect(res.error?.status).toBe(403);
+		expect(res.error?.code).toBe(
+			ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CHANGE_USERS_ROLE.code,
+		);
+	});
+
+	it("blocks the same admin from smuggling a role through data", async () => {
+		const { headers } = await signInWithUser("support@test.com", "password");
+		const res = await client.admin.createUser(
+			{
+				email: "smuggled@test.com",
+				password: "password",
+				name: "Smuggled",
+				data: { role: "admin" },
+			},
+			{ headers },
+		);
+		expect(res.error?.status).toBe(403);
+	});
+
+	it("ignores data.role for an authorized admin; role only comes from the role param", async () => {
+		const { headers } = await signInWithUser("root@test.com", "password");
+		const res = await client.admin.createUser(
+			{
+				email: "data-role@test.com",
+				password: "password",
+				name: "Data Role",
+				data: { role: "admin" },
+			},
+			{ headers },
+		);
+		expect(res.error).toBeNull();
+		expect(res.data?.user.role).toBe("user");
+	});
+
+	it("still lets a user:set-role admin assign roles via the role param", async () => {
+		const { headers } = await signInWithUser("root@test.com", "password");
+		const res = await client.admin.createUser(
+			{
+				email: "new-admin@test.com",
+				password: "password",
+				name: "New Admin",
+				role: "admin",
+			},
+			{ headers },
+		);
+		expect(res.error).toBeNull();
+		expect(res.data?.user.role).toBe("admin");
+	});
+});
+
+describe("admin ban-field authority", async () => {
+	const ac = createAccessControl({
+		user: ["create", "ban", "update"],
+	});
+	const roles = {
+		admin: ac.newRole({ user: ["create", "ban", "update"] }),
+		creator: ac.newRole({ user: ["create"] }),
+		updater: ac.newRole({ user: ["update"] }),
+		user: ac.newRole({ user: [] }),
+	};
+
+	const { client, auth, signInWithUser } = await getTestInstance(
+		{ plugins: [admin({ ac, roles })] },
+		{ clientOptions: { plugins: [adminClient({ ac, roles })] } },
+	);
+
+	// Seed actors and a target via trusted server calls (no session, no guard).
+	await auth.api.createUser({
+		body: {
+			email: "ban-admin@test.com",
+			password: "password",
+			name: "Ban Admin",
+			role: "admin",
+		},
+	});
+	await auth.api.createUser({
+		body: {
+			email: "creator@test.com",
+			password: "password",
+			name: "Creator",
+			role: "creator",
+		},
+	});
+	await auth.api.createUser({
+		body: {
+			email: "updater@test.com",
+			password: "password",
+			name: "Updater",
+			role: "updater",
+		},
+	});
+	const target = await auth.api.createUser({
+		body: {
+			email: "ban-target@test.com",
+			password: "password",
+			name: "Ban Target",
+			role: "user",
+		},
+	});
+
+	it("blocks creating a banned user without user:ban", async () => {
+		const { headers } = await signInWithUser("creator@test.com", "password");
+		const res = await client.admin.createUser(
+			{
+				email: "prebanned@test.com",
+				password: "password",
+				name: "Prebanned",
+				data: { banned: true },
+			},
+			{ headers },
+		);
+		expect(res.error?.status).toBe(403);
+		expect(res.error?.code).toBe(
+			ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_BAN_USERS.code,
+		);
+	});
+
+	it("blocks setting ban state via update-user without user:ban", async () => {
+		const { headers } = await signInWithUser("updater@test.com", "password");
+		const res = await client.admin.updateUser(
+			{
+				userId: target?.user.id ?? "",
+				data: { banned: true },
+			},
+			{ headers },
+		);
+		expect(res.error?.status).toBe(403);
+		expect(res.error?.code).toBe(
+			ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_BAN_USERS.code,
+		);
+	});
+
+	it("lets a user:ban admin create a banned user via data", async () => {
+		const { headers } = await signInWithUser("ban-admin@test.com", "password");
+		const res = await client.admin.createUser(
+			{
+				email: "banned-ok@test.com",
+				password: "password",
+				name: "Banned OK",
+				data: { banned: true },
+			},
+			{ headers },
+		);
+		expect(res.error).toBeNull();
+		expect(res.data?.user.banned).toBe(true);
+	});
+});
+
 describe("edge cases: userId validation", async () => {
 	const { signInWithTestUser, customFetchImpl, auth } = await getTestInstance(
 		{

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -2029,6 +2029,40 @@ describe("create-user role escalation", async () => {
 		expect(res.error).toBeNull();
 		expect(res.data?.user.role).toBe("admin");
 	});
+
+	it("keeps email and name authoritative over values in data", async () => {
+		const { headers } = await signInWithUser("root@test.com", "password");
+		const res = await client.admin.createUser(
+			{
+				email: "real@test.com",
+				password: "password",
+				name: "Real Name",
+				data: { email: "spoofed@test.com", name: "Spoofed" },
+			},
+			{ headers },
+		);
+		expect(res.error).toBeNull();
+		expect(res.data?.user.email).toBe("real@test.com");
+		expect(res.data?.user.name).toBe("Real Name");
+	});
+
+	it("rejects role names that are not own properties of the configured roles", async () => {
+		const { headers } = await signInWithUser("root@test.com", "password");
+		const res = await client.admin.createUser(
+			{
+				email: "proto@test.com",
+				password: "password",
+				name: "Proto",
+				// @ts-expect-error intentionally passing a role that is not configured
+				role: "toString",
+			},
+			{ headers },
+		);
+		expect(res.error?.status).toBe(400);
+		expect(res.error?.code).toBe(
+			ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_SET_NON_EXISTENT_VALUE.code,
+		);
+	});
 });
 
 describe("admin ban-field authority", async () => {

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -352,6 +352,68 @@ export const createUser = <O extends AdminOptions>(opts: O) =>
 						ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CREATE_USERS,
 					);
 				}
+
+				// Assigning a role at creation requires `user:set-role` and a known
+				// role, matching `setRole` and `adminUpdateUser`. Without this guard a
+				// delegated `user:create` admin could mint an `admin` account.
+				const requestedRole = ctx.body.role ?? ctx.body.data?.role;
+				if (requestedRole !== undefined) {
+					const canSetRole = hasPermission({
+						userId: session.user.id,
+						role: session.user.role,
+						options: opts,
+						permissions: {
+							user: ["set-role"],
+						},
+					});
+					if (!canSetRole) {
+						throw APIError.from(
+							"FORBIDDEN",
+							ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CHANGE_USERS_ROLE,
+						);
+					}
+					const requestedRoles = Array.isArray(requestedRole)
+						? requestedRole
+						: [requestedRole];
+					for (const role of requestedRoles) {
+						if (typeof role !== "string") {
+							throw APIError.from(
+								"BAD_REQUEST",
+								ADMIN_ERROR_CODES.INVALID_ROLE_TYPE,
+							);
+						}
+						if (opts.roles && !opts.roles[role as keyof typeof opts.roles]) {
+							throw APIError.from(
+								"BAD_REQUEST",
+								ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_SET_NON_EXISTENT_VALUE,
+							);
+						}
+					}
+				}
+
+				// Setting ban state (`banned`, `banReason`, `banExpires`) requires
+				// `user:ban`, the same permission `banUser` enforces.
+				const setsBanState =
+					ctx.body.data != null &&
+					["banned", "banReason", "banExpires"].some((field) =>
+						Object.prototype.hasOwnProperty.call(ctx.body.data, field),
+					);
+				if (setsBanState) {
+					const canBanUser = hasPermission({
+						userId: session.user.id,
+						role: session.user.role,
+						options: opts,
+						permissions: {
+							user: ["ban"],
+						},
+					});
+					if (!canBanUser) {
+						throw APIError.from(
+							"FORBIDDEN",
+							ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_BAN_USERS,
+						);
+					}
+				}
 			}
 
 			const email = ctx.body.email.toLowerCase();
@@ -368,14 +430,20 @@ export const createUser = <O extends AdminOptions>(opts: O) =>
 					ADMIN_ERROR_CODES.USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL,
 				);
 			}
+			// FIXME: `data` is spread raw, bypassing the `input:false` enforcement
+			// that endpoint input-parsing applies elsewhere. Role and ban fields are
+			// permission-guarded above, but other `input:false` fields (e.g. core
+			// `emailVerified`) can still be set here. Enforcing `input:false`
+			// uniformly across createUser and adminUpdateUser is a breaking change
+			// deferred to the next branch.
 			const user = await ctx.context.internalAdapter.createUser<UserWithRole>({
 				email: email,
 				name: ctx.body.name,
+				...ctx.body.data,
 				role:
 					(ctx.body.role && parseRoles(ctx.body.role)) ??
 					opts?.defaultRole ??
 					"user",
-				...ctx.body.data,
 			});
 
 			if (!user) {
@@ -514,6 +582,28 @@ export const adminUpdateUser = (opts: AdminOptions) =>
 				(ctx.body.data as Record<string, any>).role = parseRoles(
 					inputRoles as string[],
 				);
+			}
+
+			// Ban state (`banned`, `banReason`, `banExpires`) is owned by the ban
+			// endpoints; writing it here requires `user:ban`, same as `banUser`.
+			const setsBanState = ["banned", "banReason", "banExpires"].some((field) =>
+				Object.prototype.hasOwnProperty.call(ctx.body.data, field),
+			);
+			if (setsBanState) {
+				const canBanUser = hasPermission({
+					userId: ctx.context.session.user.id,
+					role: ctx.context.session.user.role,
+					options: opts,
+					permissions: {
+						user: ["ban"],
+					},
+				});
+				if (!canBanUser) {
+					throw APIError.from(
+						"FORBIDDEN",
+						ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_BAN_USERS,
+					);
+				}
 			}
 
 			const isUserExist = await ctx.context.internalAdapter.findUserById(

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -145,7 +145,7 @@ export const setRole = <O extends AdminOptions>(opts: O) =>
 					? ctx.body.role
 					: [ctx.body.role];
 				for (const role of inputRoles) {
-					if (!roles[role as keyof typeof roles]) {
+					if (!Object.prototype.hasOwnProperty.call(roles, role)) {
 						throw APIError.from(
 							"BAD_REQUEST",
 							ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_SET_NON_EXISTENT_VALUE,
@@ -382,7 +382,10 @@ export const createUser = <O extends AdminOptions>(opts: O) =>
 								ADMIN_ERROR_CODES.INVALID_ROLE_TYPE,
 							);
 						}
-						if (opts.roles && !opts.roles[role as keyof typeof opts.roles]) {
+						if (
+							opts.roles &&
+							!Object.prototype.hasOwnProperty.call(opts.roles, role)
+						) {
 							throw APIError.from(
 								"BAD_REQUEST",
 								ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_SET_NON_EXISTENT_VALUE,
@@ -437,9 +440,9 @@ export const createUser = <O extends AdminOptions>(opts: O) =>
 			// uniformly across createUser and adminUpdateUser is a breaking change
 			// deferred to the next branch.
 			const user = await ctx.context.internalAdapter.createUser<UserWithRole>({
+				...ctx.body.data,
 				email: email,
 				name: ctx.body.name,
-				...ctx.body.data,
 				role:
 					(ctx.body.role && parseRoles(ctx.body.role)) ??
 					opts?.defaultRole ??
@@ -572,7 +575,10 @@ export const adminUpdateUser = (opts: AdminOptions) =>
 							ADMIN_ERROR_CODES.INVALID_ROLE_TYPE,
 						);
 					}
-					if (opts.roles && !opts.roles[role as keyof typeof opts.roles]) {
+					if (
+						opts.roles &&
+						!Object.prototype.hasOwnProperty.call(opts.roles, role)
+					) {
 						throw APIError.from(
 							"BAD_REQUEST",
 							ADMIN_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_SET_NON_EXISTENT_VALUE,


### PR DESCRIPTION
`createUser` and `updateUser` write their `data` payload straight to the user record, so `role` and ban state (`banned`, `banReason`, `banExpires`) were not covered by the permission checks that `setRole` and `banUser` apply to those same fields.

This aligns both paths with the dedicated endpoints: assigning a role requires `user:set-role` plus a configured role (the role check mirrors the one already in `adminUpdateUser`); writing ban state requires `user:ban`. `createUser` now resolves `role` after spreading `data`, so the request's `role` field is authoritative.

Scoped to these two authority fields. Enforcing `input:false` on `data` wholesale would reject legitimate server-set custom fields and is breaking, so it's deferred to `next` (FIXME left at the spread site). Server-side `auth.api` calls keep their no-session bypass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `user:set-role` and `user:ban` on `createUser`/`updateUser` in `better-auth`, and hardens role validation. `email`, `name`, and `role` now override any matching fields in `data` to prevent spoofing.

- **Bug Fixes**
  - Require `user:set-role` to assign roles; validate with an own-property check and reject inherited/unknown names.
  - Require `user:ban` to set `banned`, `banReason`, or `banExpires`.
  - In `createUser`, explicit `email`, `name`, and `role` win over `data`; `data.role` is ignored.
  - Apply the hardened role check to `setRole` and `adminUpdateUser`; server-side `auth.api` calls still bypass session guards for provisioning.

<sup>Written for commit 140e54d99cd812893c809bb88b220517815b68f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

