### PR TITLE
fix(oauth-provider): report `unsupported_token_type` for JWT access-token revocation

### DIFF
--- a/.changeset/oauth-revoke-jwt-unsupported.md
+++ b/.changeset/oauth-revoke-jwt-unsupported.md
@@ -2,6 +2,6 @@
 "@better-auth/oauth-provider": minor
 ---
 
-Revoking a JWT access token at `/oauth2/revoke` now returns `400 unsupported_token_type` instead of a misleading `200`. A JWT access token is self-contained and is never stored, so the server cannot revoke it; the previous success response implied otherwise while the token kept working until expiry.
+Revoking a JWT access token that still verifies for this server now returns `400 unsupported_token_type` at `/oauth2/revoke` instead of a misleading `200`. A JWT is self-contained and is never stored, so the server cannot revoke it; the previous success response implied otherwise while the token kept working until expiry. An already-expired or wrong-audience JWT fails verification and still returns a successful `200` no-op.
 
 To cut off access for a JWT access token, end the session (sign-out, admin revoke, or back-channel logout), which marks `sid`-bound tokens inactive at introspection and userinfo, or rely on a short token lifetime. Opaque and refresh token revocation are unchanged.

--- a/.changeset/oauth-revoke-jwt-unsupported.md
+++ b/.changeset/oauth-revoke-jwt-unsupported.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+Revoking a JWT access token at `/oauth2/revoke` now returns `400 unsupported_token_type` instead of a misleading `200`. A JWT access token is self-contained and is never stored, so the server cannot revoke it; the previous success response implied otherwise while the token kept working until expiry.
+
+To cut off access for a JWT access token, end the session (sign-out, admin revoke, or back-channel logout), which marks `sid`-bound tokens inactive at introspection and userinfo, or rely on a short token lifetime. Opaque and refresh token revocation are unchanged.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -629,13 +629,17 @@ Use the `resources` field in `customAccessTokenClaims` to add claims based on th
 
 [RFC7009](https://datatracker.ietf.org/doc/html/rfc7009)-compliant Revocation.
 
-This endpoint revokes the provided token.
+What the endpoint does depends on the token type:
 
-* opaque `access_token`: immediately removes that `access_token` from the database. `refresh_token` is still valid.
-* JWT `access_token`: verifies that token is safe to remove from client storage.
-* `refresh_token`: removes all `access_tokens` granted using that `refresh_token` and removes the `refresh_token` to prevent further token issuance.
+* opaque `access_token`: deleted from the database immediately. A `refresh_token` from the same grant stays valid.
+* `refresh_token`: deletes every `access_token` it minted and removes the `refresh_token`, so it can no longer issue tokens.
+* JWT `access_token`: cannot be revoked server-side. A JWT is self-contained and is never stored, so there is nothing to delete. The endpoint responds with `400 unsupported_token_type` ([RFC7009 §2.2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.1)) to make clear that no server-side revocation happened.
 
-For an `access_token` type,
+Because a JWT `access_token` cannot be revoked individually, plan for it:
+
+* Keep its lifetime short. Use `accessTokenExpiresIn`, and `m2mAccessTokenExpiresIn` for `client_credentials` tokens.
+* To cut a user off mid-session, end the session (sign-out, admin revoke, or back-channel logout). A JWT `access_token` that carries a session id (`sid`) is reported `active: false` by `/oauth2/introspect` and rejected by `/oauth2/userinfo` once that session ends, even before the token expires.
+* A `client_credentials` JWT `access_token` has no session to end, so a short expiry is the only control available.
 
 ### End Session Endpoint
 

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -633,7 +633,7 @@ What the endpoint does depends on the token type:
 
 * opaque `access_token`: deleted from the database immediately. A `refresh_token` from the same grant stays valid.
 * `refresh_token`: deletes every `access_token` it minted and removes the `refresh_token`, so it can no longer issue tokens.
-* JWT `access_token`: cannot be revoked server-side. A JWT is self-contained and is never stored, so there is nothing to delete. The endpoint responds with `400 unsupported_token_type` ([RFC7009 §2.2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.1)) to make clear that no server-side revocation happened.
+* JWT `access_token`: cannot be revoked server-side. A JWT is self-contained and is never stored, so there is nothing to delete. A token that still verifies for this server responds with `400 unsupported_token_type` ([RFC7009 §2.2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2.1)), making clear that no server-side revocation happened. A JWT that is already expired or carries a different audience is treated as an invalid token and returns a `200` no-op.
 
 Because a JWT `access_token` cannot be revoked individually, plan for it:
 

--- a/packages/oauth-provider/src/revoke.test.ts
+++ b/packages/oauth-provider/src/revoke.test.ts
@@ -170,7 +170,7 @@ describe("oauth revoke", async () => {
 		expect(revocation.error?.status).toBe(401);
 	});
 
-	it("should pass verification with token_type_hint access_token and sent jwt access_token", async () => {
+	it("reports unsupported_token_type for a jwt access_token with token_type_hint access_token", async () => {
 		const tokens = await getTokens(undefined, validAudience);
 		const revocation = await client.oauth2.revoke(
 			{
@@ -186,8 +186,10 @@ describe("oauth revoke", async () => {
 				},
 			},
 		);
-		expect(revocation.data).toBe(null);
-		expect(revocation.error).toBe(null);
+		expect(revocation.error?.status).toBe(400);
+		expect(revocation.error).toMatchObject({
+			error: "unsupported_token_type",
+		});
 	});
 
 	it("should pass verification with token_type_hint access_token and sent opaque access_token", async () => {
@@ -268,7 +270,7 @@ describe("oauth revoke", async () => {
 		expect(revocation.error?.status).toBe(400);
 	});
 
-	it("should pass verification without token_type_hint and sent jwt access_token", async () => {
+	it("reports unsupported_token_type for a jwt access_token without token_type_hint", async () => {
 		const tokens = await getTokens(undefined, validAudience);
 		const revocation = await client.oauth2.revoke(
 			{
@@ -283,8 +285,10 @@ describe("oauth revoke", async () => {
 				},
 			},
 		);
-		expect(revocation.data).toBe(null);
-		expect(revocation.error).toBe(null);
+		expect(revocation.error?.status).toBe(400);
+		expect(revocation.error).toMatchObject({
+			error: "unsupported_token_type",
+		});
 	});
 
 	it("should pass verification without token_type_hint and sent opaque access_token", async () => {

--- a/packages/oauth-provider/src/revoke.ts
+++ b/packages/oauth-provider/src/revoke.ts
@@ -28,7 +28,14 @@ import {
 
 /**
  * Revokes a JWT access token against the configured JWKs.
- * (does nothing if successful since a JWT is not stored on the server)
+ *
+ * A JWT access token is self-contained and never stored, so there is nothing to
+ * delete. Once the token is confirmed to be a valid JWT for this server, the
+ * endpoint reports `unsupported_token_type` (RFC 7009 §2.2.1) instead of a
+ * silent success, so callers can tell that no server-side revocation happened.
+ * An expired or wrong-audience JWT is already inactive and still resolves as a
+ * successful no-op. Session-bound tokens (carrying `sid`) are cut off early by
+ * the session-liveness check in introspection and userinfo.
  */
 async function revokeJwtAccessToken(
 	ctx: GenericEndpointContext,
@@ -73,6 +80,15 @@ async function revokeJwtAccessToken(
 		}
 		throw new Error(error as unknown as string);
 	}
+
+	// Verified: a valid JWT access token for this server. It is self-contained
+	// and not stored, so it cannot be revoked. Report that rather than implying
+	// success (RFC 7009 §2.2.1).
+	throw new APIError("BAD_REQUEST", {
+		error_description:
+			"JWT access tokens are self-contained and cannot be revoked server-side",
+		error: "unsupported_token_type",
+	});
 }
 
 /**
@@ -218,7 +234,12 @@ async function revokeAccessToken(
 		return await revokeJwtAccessToken(ctx, opts, token);
 	} catch (err) {
 		if (err instanceof APIError) {
-			// continue
+			// A confirmed JWT access token cannot be revoked: surface that rather
+			// than falling through to the opaque-token lookup.
+			if (err.body?.error === "unsupported_token_type") {
+				throw err;
+			}
+			// otherwise not a JWT, continue to opaque
 		} else if (err instanceof Error) {
 			throw err;
 		} else {
@@ -305,7 +326,10 @@ export async function revokeEndpoint(
 				return await revokeAccessToken(ctx, opts, client.clientId, token);
 			} catch (error) {
 				if (error instanceof APIError) {
-					if (token_type_hint === "access_token") {
+					if (
+						token_type_hint === "access_token" ||
+						error.body?.error === "unsupported_token_type"
+					) {
 						throw error;
 					} // else continue
 				} else if (error instanceof Error) {
@@ -344,6 +368,11 @@ export async function revokeEndpoint(
 		});
 	} catch (error) {
 		if (error instanceof APIError) {
+			// RFC 7009 §2.2.1: an explicit protocol error (unsupported_token_type)
+			// must surface; an unknown or already-invalid token still succeeds.
+			if (error.body?.error === "unsupported_token_type") {
+				throw error;
+			}
 			if (error.name === "BAD_REQUEST") {
 				return null;
 			}


### PR DESCRIPTION
The revoke endpoint accepted a JWT access token and returned success without revoking anything, so a caller had no way to tell that nothing happened. A JWT access token is self-contained and is never stored, so the server has nothing to delete. RFC 7009 §2.2.1 reserves `unsupported_token_type` for this case, and the endpoint now returns it once a token verifies as a JWT. Expired or wrong-audience tokens stay a successful no-op; opaque and refresh revocation are untouched.

I kept the token stateless rather than minting a `jti` and storing revocation tombstones. Tombstones only help resource servers that introspect on every request, never local JWKS validators, and they bring back the cross-process atomicity concerns we have elsewhere. Reporting the limitation honestly is the smaller, truthful change.
