### PR TITLE
fix(sso): consume SAML AuthnRequest atomically

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1841,5 +1841,43 @@ describe("internal adapter test", async () => {
 			expect(results.find((r) => r !== null)?.value).toBe("fallback-user");
 			expect(store.has("verification:consume:secondary-fallback")).toBe(false);
 		});
+
+		it("warns once when secondary storage cannot consume atomically", async () => {
+			const store = new Map<string, string>();
+			const logs: { level: string; message: string }[] = [];
+			const adapter = await makeAdapter({
+				logger: {
+					log: (level, message) => {
+						logs.push({ level, message });
+					},
+				},
+				verification: { storeInDatabase: false },
+				secondaryStorage: {
+					set(key, value) {
+						store.set(key, value);
+					},
+					get(key) {
+						return store.get(key) ?? null;
+					},
+					delete(key) {
+						store.delete(key);
+					},
+				},
+			});
+
+			for (const id of ["consume:warn-1", "consume:warn-2"]) {
+				await adapter.createVerificationValue({
+					identifier: id,
+					value: "user",
+					expiresAt: new Date(Date.now() + 60_000),
+				});
+				await adapter.consumeVerificationValue(id);
+			}
+
+			const warnings = logs.filter(
+				(l) => l.level === "warn" && l.message.includes("getAndDelete"),
+			);
+			expect(warnings).toHaveLength(1);
+		});
 	});
 });

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -46,6 +46,9 @@ export const createInternalAdapter = (
 	const options = ctx.options;
 	const secondaryStorage = options.secondaryStorage;
 	const verificationConsumeLocks = new Map<string, Promise<void>>();
+	// Warn at most once when a single-use value is consumed through the
+	// non-atomic secondary-storage fallback (see consumeVerificationValue).
+	let warnedNonAtomicConsume = false;
 	const sessionExpiration = options.session?.expiresIn || 60 * 60 * 24 * 7; // 7 days
 	const {
 		createWithHooks,
@@ -1238,12 +1241,13 @@ export const createInternalAdapter = (
 		 *
 		 * The secondary-storage-only path (`storeInDatabase: false`) is atomic
 		 * only when the configured storage implements `getAndDelete`; otherwise
-		 * it falls back to an in-process lock around `get` then `delete`.
+		 * it falls back to an in-process lock around `get` then `delete` and
+		 * warns once, since that fallback cannot coordinate across processes.
 		 *
 		 * FIXME(consume-atomic): make `SecondaryStorage.getAndDelete` required
 		 * in the next breaking release, or require database-backed verification
-		 * storage for security-sensitive consume paths. The compatibility
-		 * fallback cannot coordinate across multiple application processes.
+		 * storage for security-sensitive consume paths, so the non-atomic
+		 * fallback can be removed entirely.
 		 */
 		consumeVerificationValue: async (
 			identifier: string,
@@ -1284,6 +1288,12 @@ export const createInternalAdapter = (
 					if (secondaryStorage.getAndDelete) {
 						return hydrateCachedVerification(
 							await secondaryStorage.getAndDelete(key),
+						);
+					}
+					if (!warnedNonAtomicConsume) {
+						warnedNonAtomicConsume = true;
+						logger.warn(
+							"Secondary storage does not implement `getAndDelete`, so single-use verification values cannot be consumed atomically across processes. Implement `getAndDelete` or use database-backed verification storage to guarantee single use.",
 						);
 					}
 					return withVerificationConsumeLock(key, async () => {

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -253,18 +253,19 @@ export async function processSAMLResponse(
 		const allowIdpInitiated = options?.saml?.allowIdpInitiated !== false;
 
 		if (inResponseTo) {
-			let storedRequest: AuthnRequestRecord | null = null;
-
-			const verification =
-				await ctx.context.internalAdapter.findVerificationValue(
+			// Consume the stored AuthnRequest atomically so two concurrent ACS
+			// submissions cannot both match one outstanding request. The consume
+			// returns null for missing or expired rows, so no separate expiry gate
+			// is needed.
+			const consumed =
+				await ctx.context.internalAdapter.consumeVerificationValue(
 					`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
 				);
-			if (verification) {
+
+			let storedRequest: AuthnRequestRecord | null = null;
+			if (consumed) {
 				try {
-					storedRequest = JSON.parse(verification.value) as AuthnRequestRecord;
-					if (storedRequest && storedRequest.expiresAt < Date.now()) {
-						storedRequest = null;
-					}
+					storedRequest = JSON.parse(consumed.value) as AuthnRequestRecord;
 				} catch {
 					storedRequest = null;
 				}
@@ -289,17 +290,10 @@ export async function processSAMLResponse(
 						actualProvider: providerId,
 					},
 				);
-				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
-				);
 				throw ctx.redirect(
 					`${samlRedirectUrl}?error=invalid_saml_response&error_description=Provider+mismatch`,
 				);
 			}
-
-			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-				`${constants.AUTHN_REQUEST_KEY_PREFIX}${inResponseTo}`,
-			);
 		} else if (!allowIdpInitiated) {
 			ctx.context.logger.error(
 				"SAML IdP-initiated SSO rejected: InResponseTo missing and allowIdpInitiated is false",
@@ -312,6 +306,11 @@ export async function processSAMLResponse(
 	}
 
 	// 13. Replay protection
+	// FIXME(verification-reserve): the tombstone below is written with a
+	// non-atomic read-then-create. Switch to an adapter-level atomic
+	// create-if-absent (reserve) for verification identifiers once available;
+	// `verification.identifier` is intentionally non-unique, so a unique
+	// constraint is not an option here.
 	const samlContent = (parsedResponse as any).samlContent as string | undefined;
 	const assertionId = samlContent ? extractAssertionId(samlContent) : null;
 

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -4489,6 +4489,92 @@ describe("SAML SSO - Assertion Replay Protection", () => {
 		const acsLocation = acsReplayResponse.headers.get("location") || "";
 		expect(acsLocation).toContain("error=replay_detected");
 	});
+
+	it("should issue only one session when the same SP-initiated assertion is submitted concurrently", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [sso()],
+		});
+
+		const { headers } = await signInWithTestUser();
+
+		await auth.api.registerSSOProvider({
+			body: {
+				providerId: "concurrent-replay-provider",
+				issuer: "http://localhost:8081",
+				domain: "http://localhost:8081",
+				samlConfig: {
+					entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+					cert: certificate,
+					callbackUrl: "http://localhost:3000/dashboard",
+					wantAssertionsSigned: false,
+					signatureAlgorithm: "sha256",
+					digestAlgorithm: "sha256",
+					idpMetadata: {
+						metadata: idpMetadata,
+					},
+					spMetadata: {
+						metadata: spMetadata,
+					},
+					identifierFormat:
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+				},
+			},
+			headers,
+		});
+
+		// SP-initiated: signInSSO stores an AuthnRequest keyed by the request ID,
+		// and the mock IdP echoes it back as the response's InResponseTo.
+		const signInRes = await auth.api.signInSSO({
+			body: {
+				providerId: "concurrent-replay-provider",
+				callbackURL: "http://localhost:3000/dashboard",
+			},
+			returnHeaders: true,
+		});
+
+		const relayState = new URL(signInRes.response?.url).searchParams.get(
+			"RelayState",
+		);
+
+		let samlResponse: any;
+		await betterFetch(signInRes.response?.url, {
+			onSuccess: async (context) => {
+				samlResponse = await context.data;
+			},
+		});
+
+		const submit = () =>
+			auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/sp/acs/concurrent-replay-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+							Cookie: signInRes.headers.get("set-cookie") ?? "",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: samlResponse.samlResponse,
+							RelayState: relayState!,
+						}),
+					},
+				),
+			);
+
+		// Both submissions race on the single stored AuthnRequest. Atomic
+		// consumption must let exactly one through; the other finds no request
+		// to match and is rejected.
+		const [first, second] = await Promise.all([submit(), submit()]);
+
+		const locations = [first, second].map(
+			(res) => res.headers.get("location") || "",
+		);
+		const succeeded = locations.filter((loc) => !loc.includes("error"));
+		const failed = locations.filter((loc) => loc.includes("error"));
+
+		expect(succeeded).toHaveLength(1);
+		expect(failed).toHaveLength(1);
+	});
 });
 
 describe("SAML SSO - Single Assertion Validation", () => {

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -4532,12 +4532,13 @@ describe("SAML SSO - Assertion Replay Protection", () => {
 			returnHeaders: true,
 		});
 
-		const relayState = new URL(signInRes.response?.url).searchParams.get(
-			"RelayState",
-		);
+		const signInUrl = signInRes.response?.url;
+		expect(signInUrl).toBeTruthy();
+
+		const relayState = new URL(signInUrl!).searchParams.get("RelayState");
 
 		let samlResponse: any;
-		await betterFetch(signInRes.response?.url, {
+		await betterFetch(signInUrl!, {
 			onSuccess: async (context) => {
 				samlResponse = await context.data;
 			},
@@ -4566,10 +4567,17 @@ describe("SAML SSO - Assertion Replay Protection", () => {
 		// to match and is rejected.
 		const [first, second] = await Promise.all([submit(), submit()]);
 
+		// Both must redirect; a non-redirect failure leaves an empty location
+		// that would otherwise be miscounted as a success below.
+		expect(first.status).toBe(302);
+		expect(second.status).toBe(302);
+
 		const locations = [first, second].map(
 			(res) => res.headers.get("location") || "",
 		);
-		const succeeded = locations.filter((loc) => !loc.includes("error"));
+		const succeeded = locations.filter(
+			(loc) => loc.includes("dashboard") && !loc.includes("error"),
+		);
 		const failed = locations.filter((loc) => loc.includes("error"));
 
 		expect(succeeded).toHaveLength(1);


### PR DESCRIPTION
SP-initiated SAML claims the pending AuthnRequest behind an `InResponseTo` value, then validates the response against it. That claim was a find followed by a separate delete, so two responses for the same request processed at the same time could each read the row before either delete ran, and both passed validation.

Switch to `consumeVerificationValue`, which reads and removes the row in one atomic step: the first caller gets it, a concurrent second gets nothing and is rejected. The redundant expiry check and the standalone delete calls fall away, since consume already drops expired rows.

The IdP-initiated assertion path uses a similar non-atomic write that needs a different primitive (an atomic create-if-absent); it is marked with a FIXME for a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SP‑initiated SAML AuthnRequest consumption atomic to stop duplicate session issuance when two ACS submissions race. Warn once when the storage backend cannot guarantee atomic single-use.

- **Bug Fixes**
  - Use `consumeVerificationValue` to atomically read+delete the stored AuthnRequest; removes separate expiry and delete logic.
  - Emit a one-time warning when secondary storage lacks `getAndDelete`, since the fallback get+delete is not cross-process atomic.
  - Strengthen tests: ensure only one session is issued on concurrent ACS submissions and verify the warning fires once.
  - Leave a FIXME to switch the IdP‑initiated replay tombstone to an atomic create‑if‑absent in a follow‑up.

<sup>Written for commit 76242e1391f17414bedc23b19f269eb567c1f174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

