### PR TITLE
fix(api): validate Origin/Referer on cookieless email sign-in and sign-up

### DIFF
--- a/.changeset/origin-validation-cookieless-first-login.md
+++ b/.changeset/origin-validation-cookieless-first-login.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Email sign-in and sign-up now validate the `Origin` or `Referer` header against `trustedOrigins` even when the request carries no cookies. Requests that send no origin header at all (such as curl or server-to-server clients) are unaffected. A non-browser client that sends an untrusted `Origin`/`Referer` without cookies now receives a 403 and must add that origin to `trustedOrigins`.

--- a/.changeset/origin-validation-cookieless-first-login.md
+++ b/.changeset/origin-validation-cookieless-first-login.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Email sign-in and sign-up now validate the `Origin` or `Referer` header against `trustedOrigins` even when the request carries no cookies. Requests that send no origin header at all (such as curl or server-to-server clients) are unaffected. A non-browser client that sends an untrusted `Origin`/`Referer` without cookies now receives a 403 and must add that origin to `trustedOrigins`.
+Email sign-in and sign-up now validate the `Origin` or `Referer` header against `trustedOrigins` even when the request carries no cookies. Requests that send no `Origin`/`Referer` header and no Fetch Metadata (such as curl or server-to-server clients) are unaffected. A non-browser client that sends an untrusted `Origin`/`Referer` without cookies now receives a 403 and must add that origin to `trustedOrigins`.

--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -13,6 +13,7 @@ base64urlnopad
 remoteip
 noreferrer
 noopener
+Referer
 pcre
 llms
 svgjs

--- a/docs/content/docs/reference/security.mdx
+++ b/docs/content/docs/reference/security.mdx
@@ -51,14 +51,14 @@ Better Auth includes multiple safeguards to prevent Cross-Site Request Forgery (
 
    * If the browser indicates a **cross-site navigation** (for example: `Sec-Fetch-Site: cross-site` and `Sec-Fetch-Mode: navigate`), Better Auth **blocks** the request as a potential login CSRF attack.
 
-   * If the request is **same-origin** or **same-site**, Better Auth still validates the `Origin`/`Referer` against your `trustedOrigins` configuration, using the existing origin validation logic.
+   * Otherwise, if the request carries an `Origin` or `Referer` header, Better Auth validates it against your `trustedOrigins` configuration and rejects untrusted origins. This applies whether or not the client sends Fetch Metadata headers.
 
-   * If the client does **not** send Fetch Metadata headers (older browsers, some mobile WebViews, non-browser clients), Better Auth falls back to its **previous behavior** and only performs origin validation when cookies are present, preserving backward compatibility.
+   * Only when the request carries **no** `Origin` or `Referer` header at all (some non-browser clients) does Better Auth fall back to permissive behavior, so server-to-server and native clients are not rejected.
 
    This mechanism allows modern browsers to receive stronger protection against first-login CSRF attacks **without requiring CSRF tokens or client-side JavaScript**, and works seamlessly with progressive enhancement patterns.
 
    <Callout type="info">
-     Non-browser HTTP clients (mobile apps, server-to-server) should set the `Origin` or `Referer` header appropriately when making requests that include cookies. This ensures proper CSRF validation regardless of Fetch Metadata support.
+     Non-browser HTTP clients (mobile apps, server-to-server) that send an `Origin` or `Referer` header must use a value listed in `trustedOrigins`, since Better Auth validates it whenever it is present. Clients that send no origin header at all are not affected.
    </Callout>
 
 5. **No Mutations on GET Requests (with additional safeguards)**

--- a/docs/content/docs/reference/security.mdx
+++ b/docs/content/docs/reference/security.mdx
@@ -53,12 +53,12 @@ Better Auth includes multiple safeguards to prevent Cross-Site Request Forgery (
 
    * Otherwise, if the request carries an `Origin` or `Referer` header, Better Auth validates it against your `trustedOrigins` configuration and rejects untrusted origins. This applies whether or not the client sends Fetch Metadata headers.
 
-   * Only when the request carries **no** `Origin` or `Referer` header at all (some non-browser clients) does Better Auth fall back to permissive behavior, so server-to-server and native clients are not rejected.
+   * Only when the request carries **neither** Fetch Metadata headers **nor** an `Origin`/`Referer` header (typical of non-browser clients) does Better Auth fall back to permissive behavior, so server-to-server and native clients are not rejected.
 
    This mechanism allows modern browsers to receive stronger protection against first-login CSRF attacks **without requiring CSRF tokens or client-side JavaScript**, and works seamlessly with progressive enhancement patterns.
 
    <Callout type="info">
-     Non-browser HTTP clients (mobile apps, server-to-server) that send an `Origin` or `Referer` header must use a value listed in `trustedOrigins`, since Better Auth validates it whenever it is present. Clients that send no origin header at all are not affected.
+     Non-browser HTTP clients (mobile apps, server-to-server) that send an `Origin` or `Referer` header must use a value listed in `trustedOrigins`, since Better Auth validates it whenever it is present. Clients that send no origin header and no Fetch Metadata (typical of non-browser tooling) are not affected.
    </Callout>
 
 5. **No Mutations on GET Requests (with additional safeguards)**

--- a/packages/better-auth/src/api/middlewares/origin-check.test.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.test.ts
@@ -386,6 +386,27 @@ describe("Fetch Metadata CSRF Protection", async () => {
 		expect(response.status).toBe(403);
 	});
 
+	it("should reject an untrusted Referer on first-login when Fetch Metadata is missing", async (ctx) => {
+		const crossRefererRequest = new Request(
+			"http://localhost:3000/api/auth/sign-in/email",
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					referer: "https://evil.com",
+				},
+				body: JSON.stringify({
+					email: testUser.email,
+					password: testUser.password,
+				}),
+			},
+		);
+
+		const response = await auth.handler(crossRefererRequest);
+
+		expect(response.status).toBe(403);
+	});
+
 	it("should allow a first-login request that sends no cookies, Fetch Metadata, or origin", async (ctx) => {
 		const nonBrowserRequest = new Request(
 			"http://localhost:3000/api/auth/sign-in/email",

--- a/packages/better-auth/src/api/middlewares/origin-check.test.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.test.ts
@@ -75,7 +75,7 @@ describe("Origin Check", async () => {
 		expect(res.error?.status).toBe(403);
 	});
 
-	it("should allow untrusted origin if they don't contain cookies", async (ctx) => {
+	it("should reject untrusted origin even without cookies", async (ctx) => {
 		const client = createAuthClient({
 			baseURL: "http://localhost:3000",
 			fetchOptions: {
@@ -89,7 +89,7 @@ describe("Origin Check", async () => {
 			email: testUser.email,
 			password: testUser.password,
 		});
-		expect(res.data?.user).toBeDefined();
+		expect(res.error?.status).toBe(403);
 	});
 
 	it("should reject untrusted redirectTo", async (ctx) => {
@@ -361,6 +361,47 @@ describe("Fetch Metadata CSRF Protection", async () => {
 		);
 
 		const response = await auth.handler(requestWithoutMetadata);
+
+		expect(response.status).not.toBe(403);
+	});
+
+	it("should reject an untrusted origin on first-login when Fetch Metadata is missing", async (ctx) => {
+		const crossOriginRequest = new Request(
+			"http://localhost:3000/api/auth/sign-in/email",
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					origin: "https://evil.com",
+				},
+				body: JSON.stringify({
+					email: testUser.email,
+					password: testUser.password,
+				}),
+			},
+		);
+
+		const response = await auth.handler(crossOriginRequest);
+
+		expect(response.status).toBe(403);
+	});
+
+	it("should allow a first-login request that sends no cookies, Fetch Metadata, or origin", async (ctx) => {
+		const nonBrowserRequest = new Request(
+			"http://localhost:3000/api/auth/sign-in/email",
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					email: testUser.email,
+					password: testUser.password,
+				}),
+			},
+		);
+
+		const response = await auth.handler(nonBrowserRequest);
 
 		expect(response.status).not.toBe(403);
 	});

--- a/packages/better-auth/src/api/middlewares/origin-check.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.ts
@@ -326,6 +326,14 @@ async function validateFormCsrf(ctx: GenericEndpointContext): Promise<void> {
 		return await validateOrigin(ctx, true);
 	}
 
-	// No cookies, no Fetch Metadata → fallback to old behavior (no validation)
+	// No Fetch Metadata. A present Origin/Referer is still trustworthy evidence of
+	// cross-site intent, so validate it even without cookies. Only requests that carry
+	// no origin header at all (non-browser clients like curl or server-to-server) keep
+	// the permissive fallback.
+	const originHeader = headers.get("origin") || headers.get("referer");
+	if (originHeader) {
+		return await validateOrigin(ctx, true);
+	}
+
 	return;
 }


### PR DESCRIPTION
Origin validation on the email sign-in and sign-up routes was gated on cookie presence: it ran only when the request already carried cookies. A first-login request with no cookies but a present `Origin` or `Referer` header therefore skipped the check.

This makes the check run whenever an `Origin`/`Referer` is present, independent of cookies. The permissive path stays only for requests that send no origin header at all, so non-browser callers (server-to-server, native clients) are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `Origin`/`Referer` validation on cookieless first-login for email sign-in and sign-up to close a CSRF gap. Requests that send `Origin` or `Referer` are validated even without cookies; only calls with no `Origin`/`Referer` and no Fetch Metadata remain permissive.

- **Bug Fixes**
  - In `better-auth`, validate a present `Origin`/`Referer` against `trustedOrigins` even without cookies; keep permissive path only when both `Origin`/`Referer` and Fetch Metadata are missing.
  - Added tests for cookieless, no-metadata paths covering both `Origin` and `Referer`; updated docs to clarify the fallback behavior.

<sup>Written for commit bb5795c0936471d3e800aa6a01cca21bf9043667. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

