### PR TITLE
feat(docs): theme toggle respect system theme

### DIFF
--- a/docs/components/theme-toggle.tsx
+++ b/docs/components/theme-toggle.tsx
@@ -4,13 +4,23 @@ import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 
 export function ThemeToggle() {
-	const { setTheme, resolvedTheme } = useTheme();
+	const { resolvedTheme, setTheme, systemTheme, theme } = useTheme();
+
+	// this toggles "system <> opposite theme" instead of "dark <> light"
+	const isExplicitTheme = theme === "light" || theme === "dark";
+	const isSameAsSystem = theme === systemTheme;
+	const nextTheme =
+		isExplicitTheme && !isSameAsSystem
+			? "system"
+			: resolvedTheme === "dark"
+				? "light"
+				: "dark";
 
 	return (
 		<Button
 			variant="link"
 			size="icon"
-			onClick={() => setTheme(resolvedTheme === "light" ? "dark" : "light")}
+			onClick={() => setTheme(nextTheme)}
 			suppressHydrationWarning
 		>
 			{/* Sun icon - visible in light mode */}


### PR DESCRIPTION
## Summary

- update docs theme toggle behavior
- add a small shared hook for theme toggle logic

## Behavior

Before:
clicking the toggle always switched directly between dark <> light
so once clicked, it stopped following the system theme, it stays fixed

After:
toggle now switches "system <> fixed opposite theme"
so when switching back to theme equal to system it will keep following system

## Testing

- Verified locally

## Breaking changes

None

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the docs theme toggle to respect the system theme. The toggle now switches between System and the opposite explicit theme, so switching back to System follows your device again.

- **New Features**
  - Updated `ThemeToggle` to compute `nextTheme` using `theme`, `resolvedTheme`, and `systemTheme` from `next-themes`, toggling "system <> opposite theme" instead of "light <> dark".

<sup>Written for commit 04b3395cb31fd5f8f65bf069529ffb3611dbf4ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

