### PR TITLE
fix(mcp): honor discovery metadata overrides

### DIFF
--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -113,12 +113,20 @@ export const getMCPProtectedResourceMetadata = (
 ) => {
 	const baseURL = ctx.context.baseURL;
 	const origin = new URL(baseURL).origin;
+	const metadata = options?.oidcConfig?.metadata as
+		| (Partial<OIDCMetadata> & {
+				authorization_servers?: string[];
+		  })
+		| undefined;
+	const authorizationServers =
+		metadata?.authorization_servers ??
+		(metadata?.issuer ? [metadata.issuer] : [origin]);
 
 	return {
 		resource: options?.resource ?? origin,
-		authorization_servers: [origin],
-		jwks_uri: options?.oidcConfig?.metadata?.jwks_uri ?? `${baseURL}/mcp/jwks`,
-		scopes_supported: options?.oidcConfig?.metadata?.scopes_supported ?? [
+		authorization_servers: authorizationServers,
+		jwks_uri: metadata?.jwks_uri ?? `${baseURL}/mcp/jwks`,
+		scopes_supported: metadata?.scopes_supported ?? [
 			"openid",
 			"profile",
 			"email",
@@ -273,7 +281,7 @@ export const mcp = (options: MCPOptions) => {
 				},
 				async (c) => {
 					try {
-						const metadata = getMCPProviderMetadata(c, options);
+						const metadata = getMCPProviderMetadata(c, options.oidcConfig);
 						return c.json(metadata);
 					} catch (e) {
 						console.log(e);

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -6,7 +6,7 @@ import { getTestInstance } from "../../test-utils/test-instance";
 import { genericOAuth } from "../generic-oauth";
 import { genericOAuthClient } from "../generic-oauth/client";
 import { jwt } from "../jwt";
-import type { Client } from "../oidc-provider/types";
+import type { Client, OIDCMetadata } from "../oidc-provider/types";
 import { mcp, withMcpAuth } from ".";
 
 // Pre-verifies any user the RP creates via OAuth signup so the existing-user
@@ -1211,5 +1211,129 @@ describe("mcp discovery metadata (security)", async () => {
 			resource_signing_alg_values_supported: string[];
 		};
 		expect(body.resource_signing_alg_values_supported).not.toContain("none");
+	});
+
+	it("uses oidcConfig metadata overrides for MCP authorization-server discovery", async () => {
+		const authOrigin = "https://auth.example.com";
+		const { auth } = await getTestInstance({
+			baseURL: "https://app.example.com",
+			plugins: [
+				mcp({
+					loginPage: "/login",
+					oidcConfig: {
+						metadata: {
+							issuer: `${authOrigin}/api/auth`,
+							authorization_endpoint: `${authOrigin}/api/auth/mcp/authorize`,
+							token_endpoint: `${authOrigin}/api/auth/mcp/token`,
+							userinfo_endpoint: `${authOrigin}/api/auth/mcp/userinfo`,
+							jwks_uri: `${authOrigin}/api/auth/mcp/jwks`,
+							registration_endpoint: `${authOrigin}/api/auth/mcp/register`,
+						},
+					},
+				}),
+			],
+		});
+
+		const res = await auth.handler(
+			new Request(
+				`${authOrigin}/api/auth/.well-known/oauth-authorization-server`,
+				{ method: "GET" },
+			),
+		);
+		const body = (await res.json()) as {
+			issuer: string;
+			authorization_endpoint: string;
+			token_endpoint: string;
+			userinfo_endpoint: string;
+			jwks_uri: string;
+			registration_endpoint: string;
+		};
+
+		expect(body.issuer).toBe(`${authOrigin}/api/auth`);
+		expect(body.authorization_endpoint).toBe(
+			`${authOrigin}/api/auth/mcp/authorize`,
+		);
+		expect(body.token_endpoint).toBe(`${authOrigin}/api/auth/mcp/token`);
+		expect(body.userinfo_endpoint).toBe(`${authOrigin}/api/auth/mcp/userinfo`);
+		expect(body.jwks_uri).toBe(`${authOrigin}/api/auth/mcp/jwks`);
+		expect(body.registration_endpoint).toBe(
+			`${authOrigin}/api/auth/mcp/register`,
+		);
+	});
+
+	it("points MCP protected-resource authorization_servers at the configured issuer", async () => {
+		const authOrigin = "https://auth.example.com";
+		const resource = "https://api.example.com/mcp";
+		const { auth } = await getTestInstance({
+			baseURL: "https://app.example.com",
+			plugins: [
+				mcp({
+					loginPage: "/login",
+					resource,
+					oidcConfig: {
+						metadata: {
+							issuer: `${authOrigin}/api/auth`,
+							jwks_uri: `${authOrigin}/api/auth/mcp/jwks`,
+							scopes_supported: ["openid", "mcp:read"],
+						},
+					},
+				}),
+			],
+		});
+
+		const res = await auth.handler(
+			new Request(
+				"https://api.example.com/api/auth/.well-known/oauth-protected-resource",
+				{ method: "GET" },
+			),
+		);
+		const body = (await res.json()) as {
+			resource: string;
+			authorization_servers: string[];
+			jwks_uri: string;
+			scopes_supported: string[];
+		};
+
+		expect(body.resource).toBe(resource);
+		expect(body.authorization_servers).toEqual([`${authOrigin}/api/auth`]);
+		expect(body.jwks_uri).toBe(`${authOrigin}/api/auth/mcp/jwks`);
+		expect(body.scopes_supported).toEqual(["openid", "mcp:read"]);
+	});
+
+	it("allows explicit MCP protected-resource authorization_servers metadata", async () => {
+		const { auth } = await getTestInstance({
+			baseURL: "https://app.example.com",
+			plugins: [
+				mcp({
+					loginPage: "/login",
+					oidcConfig: {
+						metadata: {
+							issuer: "https://auth.example.com/api/auth",
+							authorization_servers: [
+								"https://as-1.example.com",
+								"https://as-2.example.com",
+							],
+						} as Partial<OIDCMetadata> & {
+							authorization_servers: string[];
+						},
+					},
+				}),
+			],
+		});
+
+		const res = await auth.handler(
+			new Request(
+				"https://api.example.com/api/auth/.well-known/oauth-protected-resource",
+				{ method: "GET" },
+			),
+		);
+		const body = (await res.json()) as {
+			authorization_servers: string[];
+		};
+
+		expect(body.authorization_servers).toEqual([
+			"https://as-1.example.com",
+			"https://as-2.example.com",
+		]);
 	});
 });


### PR DESCRIPTION
Fixes #9961.

The MCP authorization-server discovery handler was passing the whole MCP plugin options object into getMCPProviderMetadata. That function expects OIDC options, so oidcConfig.metadata overrides were never applied. In split-origin deployments this can advertise the frontend/baseURL instead of the real authorization server.

This PR does three things.

- Passes options.oidcConfig to getMCPProviderMetadata so issuer and endpoint overrides apply.
- Makes protected-resource authorization_servers derive from explicit metadata, then metadata.issuer, then the current origin as fallback.
- Reuses the same metadata object for jwks_uri and scopes_supported in protected-resource discovery.

I added regression tests for:

- MCP authorization-server discovery using oidcConfig.metadata overrides.
- Protected-resource discovery pointing authorization_servers at the configured issuer.
- Explicit protected-resource authorization_servers metadata when deployments need multiple AS entries.

Validation

- bunx @biomejs/biome check packages/better-auth/src/plugins/mcp/index.ts packages/better-auth/src/plugins/mcp/mcp.test.ts passed.
- git diff --check passed.

I tried the focused Vitest command, but bunx vitest fails before tests run because the temporary Rolldown native binding is rejected by macOS code signing in this environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP discovery to honor OIDC metadata overrides in `better-auth`, ensuring the correct issuer and endpoints are advertised in split-origin deployments. Updates protected-resource discovery to prefer configured authorization servers and reuse OIDC metadata when present.

- **Bug Fixes**
  - Passes `oidcConfig` to `getMCPProviderMetadata` so issuer and endpoint overrides apply.
  - Derives `authorization_servers` from explicit metadata, then `metadata.issuer`, falling back to the current origin.
  - Reuses provided metadata for `jwks_uri` and `scopes_supported` in protected-resource discovery.

<sup>Written for commit c66f81776445ae9aac0bb0172d383e1708c7777f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

