### PR TITLE
fix: jwks caching, oauth id mapping, team invitations, account cookie, and scim deprovision bugs

### DIFF
--- a/.changeset/generic-oauth-map-profile-id-derivation.md
+++ b/.changeset/generic-oauth-map-profile-id-derivation.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Generic OAuth sign-in works again for providers whose userinfo response has no `sub` or `id` field when `mapProfileToUser` derives the account id. An empty `id` field now falls back to `sub`.

--- a/.changeset/introspect-revoke-jwks-instance-cache.md
+++ b/.changeset/introspect-revoke-jwks-instance-cache.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Token introspection and revocation no longer fetch the signing keys from the database on every request. Keys are cached per auth instance with the same five-minute refresh as remote JWKS sources.

--- a/.changeset/jwks-cache-function-sources.md
+++ b/.changeset/jwks-cache-function-sources.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Fixed a memory leak where the JWKS cache could grow on every access token verification.

--- a/.changeset/keep-fresh-account-cookie-on-user-switch.md
+++ b/.changeset/keep-fresh-account-cookie-on-user-switch.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Preserve the fresh account cookie issued while switching users in the same browser instead of expiring it from stale request cookie state.

--- a/.changeset/remove-team-strips-pending-invitations.md
+++ b/.changeset/remove-team-strips-pending-invitations.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Deleting a team no longer breaks its pending invitations. The removed team is dropped from those invitations, which stay valid for their remaining teams or as plain organization-level invitations. Accepting an invitation that still references a missing team fails without consuming the invitation.

--- a/.changeset/scim-org-delete-member-cleanup.md
+++ b/.changeset/scim-org-delete-member-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": patch
+---
+
+Organization-scoped SCIM deletes now remove the user's organization member through the organization adapter so related team memberships and member-removal hooks are applied.

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1,7 +1,19 @@
 import type { BetterAuthOptions } from "@better-auth/core";
+import type { GoogleProfile } from "@better-auth/core/social-providers";
+import { safeJSONParse } from "@better-auth/core/utils/json";
 import { base64Url } from "@better-auth/utils/base64";
 import { createHMAC } from "@better-auth/utils/hmac";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import {
 	expireCookie,
 	getChunkedCookie,
@@ -10,7 +22,9 @@ import {
 	getSessionCookie,
 	parseCookies,
 } from "../cookies";
+import { signJWT, symmetricDecodeJWT } from "../crypto";
 import { getTestInstance } from "../test-utils/test-instance";
+import { DEFAULT_SECRET } from "../utils/constants";
 import {
 	applySetCookies,
 	HOST_COOKIE_PREFIX,
@@ -1739,6 +1753,185 @@ describe("expireCookie", () => {
 		expect(setCookieHeader).not.toContain("target=valid");
 		expect(setCookieHeader).not.toContain("target.0=chunk");
 		expect(setCookieHeader).toContain("target=; Path=/; Max-Age=0");
+	});
+});
+
+describe("account cookie sync on user switch", () => {
+	const server = setupServer();
+	let googleUser = { email: "first@test.com", sub: "first-google-sub" };
+
+	beforeAll(() => {
+		server.listen({ onUnhandledRequest: "bypass" });
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async () => {
+				const data: GoogleProfile = {
+					email: googleUser.email,
+					email_verified: true,
+					name: "Test User",
+					picture: "https://lh3.googleusercontent.com/a-/AOh14GjQ4Z7Vw",
+					exp: 1234567890,
+					sub: googleUser.sub,
+					iat: 1234567890,
+					aud: "test",
+					azp: "test",
+					nbf: 1234567890,
+					iss: "test",
+					locale: "en",
+					jti: "test",
+					given_name: "Test",
+					family_name: "User",
+				};
+				const idToken = await signJWT(data, DEFAULT_SECRET);
+				return HttpResponse.json({
+					access_token: `access-token-${googleUser.sub}`,
+					refresh_token: `refresh-token-${googleUser.sub}`,
+					id_token: idToken,
+				});
+			}),
+		);
+	});
+
+	afterAll(() => server.close());
+
+	const getInstance = () =>
+		getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			account: {
+				storeAccountCookie: true,
+			},
+			session: {
+				cookieCache: {
+					enabled: true,
+				},
+			},
+		});
+
+	it("keeps the fresh account cookie issued for the new user when the request carries another user's stale account cookie", async () => {
+		const { auth, client, cookieSetter } = await getInstance();
+		const ctx = await auth.$context;
+		const accountDataCookieName = ctx.authCookies.accountData.name;
+
+		const headers = new Headers();
+		googleUser = { email: "switch-first@test.com", sub: "switch-first-sub" };
+		const firstSignIn = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+		const firstState =
+			firstSignIn.data && "url" in firstSignIn.data && firstSignIn.data.url
+				? new URL(firstSignIn.data.url).searchParams.get("state") || ""
+				: "";
+		await client.$fetch("/callback/google", {
+			query: { state: firstState, code: "test" },
+			headers,
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				cookieSetter(headers)({ response: context.response });
+			},
+		});
+
+		googleUser = { email: "switch-second@test.com", sub: "switch-second-sub" };
+		const secondSignIn = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			fetchOptions: {
+				headers,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+		const secondState =
+			secondSignIn.data && "url" in secondSignIn.data && secondSignIn.data.url
+				? new URL(secondSignIn.data.url).searchParams.get("state") || ""
+				: "";
+		let secondCallbackSetCookie = "";
+		await client.$fetch("/callback/google", {
+			query: { state: secondState, code: "test" },
+			headers,
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				secondCallbackSetCookie =
+					context.response.headers.get("set-cookie") || "";
+				cookieSetter(headers)({ response: context.response });
+			},
+		});
+
+		const accountSetCookie = parseSetCookieHeader(secondCallbackSetCookie).get(
+			accountDataCookieName,
+		);
+		expect(accountSetCookie?.value).toBeTruthy();
+		expect(accountSetCookie?.["max-age"]).not.toBe(0);
+
+		const session = await auth.api.getSession({ headers });
+		expect(session?.user.email).toBe("switch-second@test.com");
+		const accountData = safeJSONParse<{ userId: string }>(
+			await symmetricDecodeJWT(
+				accountSetCookie?.value || "",
+				ctx.secretConfig,
+				"better-auth-account",
+			),
+		);
+		expect(accountData?.userId).toBe(session?.user.id);
+	});
+
+	it("still expires another user's stale account cookie when the response issues no fresh one", async () => {
+		const { auth, client, cookieSetter } = await getInstance();
+		const ctx = await auth.$context;
+		const accountDataCookieName = ctx.authCookies.accountData.name;
+
+		const headers = new Headers();
+		googleUser = { email: "expire-first@test.com", sub: "expire-first-sub" };
+		const firstSignIn = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+		const firstState =
+			firstSignIn.data && "url" in firstSignIn.data && firstSignIn.data.url
+				? new URL(firstSignIn.data.url).searchParams.get("state") || ""
+				: "";
+		await client.$fetch("/callback/google", {
+			query: { state: firstState, code: "test" },
+			headers,
+			method: "GET",
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				cookieSetter(headers)({ response: context.response });
+			},
+		});
+
+		let signUpSetCookie = "";
+		await client.signUp.email(
+			{
+				email: "expire-second@test.com",
+				password: "password123456",
+				name: "Second User",
+			},
+			{
+				headers,
+				onSuccess(context) {
+					signUpSetCookie = context.response.headers.get("set-cookie") || "";
+				},
+			},
+		);
+
+		const accountSetCookie = parseSetCookieHeader(signUpSetCookie).get(
+			accountDataCookieName,
+		);
+		expect(accountSetCookie?.value).toBeFalsy();
+		expect(accountSetCookie?.["max-age"]).toBe(0);
 	});
 });
 

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -256,8 +256,12 @@ export async function setCookieCache(
 		ctx.setCookie(ctx.context.authCookies.sessionData.name, data, options);
 	}
 
-	// Refresh account cookie to keep it in sync
-	if (ctx.context.options.account?.storeAccountCookie) {
+	// Keep the account cookie in sync, unless this response already set a
+	// fresh one that the stale request copy would downgrade or expire.
+	if (
+		ctx.context.options.account?.storeAccountCookie &&
+		!hasPendingSetCookie(ctx, ctx.context.authCookies.accountData.name)
+	) {
 		const accountData = await getAccountCookie(ctx);
 		if (accountData) {
 			if (accountData.userId === session.user.id) {
@@ -376,6 +380,39 @@ function removeSetCookieEntries(
 			headers.append("set-cookie", entry);
 		}
 	}
+}
+
+/**
+ * Whether the response already has a pending `Set-Cookie` for `cookieName`
+ * or a chunked variant.
+ */
+function hasPendingSetCookie(
+	ctx: GenericEndpointContext,
+	cookieName: string,
+): boolean {
+	const scoped = ctx as CookieScrubView;
+	const targets = new Set<Headers>();
+	if (scoped.responseHeaders) targets.add(scoped.responseHeaders);
+	if (scoped.context?.responseHeaders)
+		targets.add(scoped.context.responseHeaders);
+
+	const exact = `${cookieName}=`;
+	const chunk = `${cookieName}.`;
+
+	for (const headers of targets) {
+		const existing =
+			typeof headers.getSetCookie === "function"
+				? headers.getSetCookie()
+				: splitSetCookieHeader(headers.get("set-cookie") || "");
+		if (
+			existing.some(
+				(entry) => entry.startsWith(exact) || entry.startsWith(chunk),
+			)
+		) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /**

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1356,6 +1356,293 @@ describe("oauth2", async () => {
 		expect(accounts).toHaveLength(0);
 	});
 
+	it("completes sign-in when mapProfileToUser derives the account id from a non-standard userinfo field", async () => {
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				username: "derived-id-user",
+				email: "derived-id@test.com",
+				name: "Derived Id User",
+				picture: "https://test.com/picture.png",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "derived-id-test",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId: clientId,
+							clientSecret: clientSecret,
+							pkce: true,
+							mapProfileToUser: (profile) => {
+								return {
+									id: profile.username,
+									email: profile.email,
+									name: profile.name,
+									emailVerified: profile.email_verified,
+								};
+							},
+						},
+					],
+				}),
+			],
+		});
+		const headers = new Headers();
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const signInRes = await authClient.signIn.oauth2({
+			providerId: "derived-id-test",
+			callbackURL: "http://localhost:3000/dashboard",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+		});
+
+		const { callbackURL, headers: newHeaders } = await simulateOAuthFlow(
+			signInRes.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+
+		expect(callbackURL).toBe("http://localhost:3000/new_user");
+
+		const session = await authClient.getSession({
+			fetchOptions: {
+				headers: newHeaders,
+			},
+		});
+		expect(session.data).not.toBeNull();
+
+		const ctx = await auth.$context;
+		const accounts = await ctx.internalAdapter.findAccounts(
+			session.data?.user.id!,
+		);
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]).toMatchObject({
+			providerId: "derived-id-test",
+			accountId: "derived-id-user",
+		});
+	});
+
+	it("falls back to sub when the userinfo id field is empty", async () => {
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				sub: "abc",
+				id: "",
+				email: "sub-over-empty-id@test.com",
+				name: "Sub Over Empty Id",
+				picture: "https://test.com/picture.png",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "sub-over-empty-id-test",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId: clientId,
+							clientSecret: clientSecret,
+							pkce: true,
+						},
+					],
+				}),
+			],
+		});
+		const headers = new Headers();
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const signInRes = await authClient.signIn.oauth2({
+			providerId: "sub-over-empty-id-test",
+			callbackURL: "http://localhost:3000/dashboard",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+		});
+
+		const { callbackURL, headers: newHeaders } = await simulateOAuthFlow(
+			signInRes.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+
+		expect(callbackURL).toBe("http://localhost:3000/new_user");
+
+		const session = await authClient.getSession({
+			fetchOptions: {
+				headers: newHeaders,
+			},
+		});
+		expect(session.data).not.toBeNull();
+
+		const ctx = await auth.$context;
+		const accounts = await ctx.internalAdapter.findAccounts(
+			session.data?.user.id!,
+		);
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]).toMatchObject({
+			providerId: "sub-over-empty-id-test",
+			accountId: "abc",
+		});
+	});
+
+	it("falls back to sub when the userinfo id field is null", async () => {
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				sub: "null-id-sub",
+				id: null,
+				email: "sub-over-null-id@test.com",
+				name: "Sub Over Null Id",
+				picture: "https://test.com/picture.png",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "sub-over-null-id-test",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId: clientId,
+							clientSecret: clientSecret,
+							pkce: true,
+						},
+					],
+				}),
+			],
+		});
+		const headers = new Headers();
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const signInRes = await authClient.signIn.oauth2({
+			providerId: "sub-over-null-id-test",
+			callbackURL: "http://localhost:3000/dashboard",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+		});
+
+		const { callbackURL, headers: newHeaders } = await simulateOAuthFlow(
+			signInRes.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+
+		expect(callbackURL).toBe("http://localhost:3000/new_user");
+
+		const session = await authClient.getSession({
+			fetchOptions: {
+				headers: newHeaders,
+			},
+		});
+		expect(session.data).not.toBeNull();
+
+		const ctx = await auth.$context;
+		const accounts = await ctx.internalAdapter.findAccounts(
+			session.data?.user.id!,
+		);
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]).toMatchObject({
+			providerId: "sub-over-null-id-test",
+			accountId: "null-id-sub",
+		});
+	});
+
+	it("keeps a non-empty id field as the account id when the userinfo response also has sub", async () => {
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				sub: "subject-1",
+				id: "raw-id-1",
+				email: "id-over-sub@test.com",
+				name: "Id Over Sub",
+				picture: "https://test.com/picture.png",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "id-over-sub-test",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId: clientId,
+							clientSecret: clientSecret,
+							pkce: true,
+						},
+					],
+				}),
+			],
+		});
+		const headers = new Headers();
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		const signInRes = await authClient.signIn.oauth2({
+			providerId: "id-over-sub-test",
+			callbackURL: "http://localhost:3000/dashboard",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+		});
+
+		const { callbackURL, headers: newHeaders } = await simulateOAuthFlow(
+			signInRes.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+
+		expect(callbackURL).toBe("http://localhost:3000/new_user");
+
+		const session = await authClient.getSession({
+			fetchOptions: {
+				headers: newHeaders,
+			},
+		});
+		expect(session.data).not.toBeNull();
+
+		const ctx = await auth.$context;
+		const accounts = await ctx.internalAdapter.findAccounts(
+			session.data?.user.id!,
+		);
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]).toMatchObject({
+			providerId: "id-over-sub-test",
+			accountId: "raw-id-1",
+		});
+	});
+
 	it("should handle custom getUserInfo returning numeric ID", async () => {
 		const numericId = 987654321;
 

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1356,6 +1356,79 @@ describe("oauth2", async () => {
 		expect(accounts).toHaveLength(0);
 	});
 
+	it("falls back to sub when a custom getUserInfo returns an empty id", async () => {
+		const { customFetchImpl, auth, cookieSetter, client } =
+			await getTestInstance(
+				{
+					databaseHooks: {
+						user: {
+							create: {
+								before: async (user) => ({
+									data: { ...user, emailVerified: true },
+								}),
+							},
+						},
+					},
+					plugins: [
+						genericOAuth({
+							config: [
+								{
+									providerId: "empty-id-with-sub-test",
+									authorizationUrl: `http://localhost:${port}/authorize`,
+									tokenUrl: `http://localhost:${port}/token`,
+									clientId: clientId,
+									clientSecret: clientSecret,
+									pkce: true,
+									getUserInfo: async () => ({
+										id: "",
+										sub: "custom-sub-id",
+										email: "custom-sub@test.com",
+										name: "Custom Sub",
+										emailVerified: true,
+									}),
+								},
+							],
+						}),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [genericOAuthClient()],
+					},
+				},
+			);
+
+		const headers = new Headers();
+		const signIn = await client.signIn.oauth2({
+			providerId: "empty-id-with-sub-test",
+			callbackURL: "http://localhost:3000/dashboard",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+			fetchOptions: { onSuccess: cookieSetter(headers) },
+		});
+		const flow = await simulateOAuthFlow(
+			signIn.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+
+		expect(flow.callbackURL).toBe("http://localhost:3000/new_user");
+
+		const session = await client.getSession({
+			fetchOptions: { headers: flow.headers },
+		});
+		expect(session.data).not.toBeNull();
+
+		const ctx = await auth.$context;
+		const accounts = await ctx.internalAdapter.findAccounts(
+			session.data?.user.id!,
+		);
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]).toMatchObject({
+			providerId: "empty-id-with-sub-test",
+			accountId: "custom-sub-id",
+		});
+	});
+
 	it("completes sign-in when mapProfileToUser derives the account id from a non-standard userinfo field", async () => {
 		server.service.once("beforeUserinfo", (userInfoResponse) => {
 			userInfoResponse.body = {
@@ -2119,6 +2192,42 @@ describe("oauth2", async () => {
 		});
 
 		expect(result?.user).toHaveProperty("customField", "async-custom-data");
+	});
+
+	it("falls back to sub when provider wrapper getUserInfo returns an empty id", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "test-wrapper-sub",
+							clientId: clientId,
+							clientSecret: clientSecret,
+							getUserInfo: async () => ({
+								id: "",
+								sub: "wrapped-sub",
+								email: "wrapped-sub@test.com",
+								name: "Wrapped Sub",
+								emailVerified: true,
+							}),
+						},
+					],
+				}),
+			],
+		});
+
+		const context = await auth.$context;
+		const provider = await getAwaitableValue(context.socialProviders, {
+			value: "test-wrapper-sub",
+		});
+
+		const result = await provider!.getUserInfo({
+			accessToken: "test-access-token",
+			idToken: undefined,
+			refreshToken: undefined,
+		});
+
+		expect(result?.user.id).toBe("wrapped-sub");
 	});
 
 	describe("Okta Provider Helper", () => {

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -234,7 +234,9 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 							? userMap.id
 							: isNonEmptyOAuthId(userInfo.id)
 								? userInfo.id
-								: undefined;
+								: isNonEmptyOAuthId(userInfo.sub)
+									? userInfo.sub
+									: undefined;
 						if (rawId === undefined) {
 							return null;
 						}

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -10,6 +10,7 @@ import {
 import { betterFetch } from "@better-fetch/fetch";
 import { PACKAGE_VERSION } from "../../version";
 import { GENERIC_OAUTH_ERROR_CODES } from "./error-codes";
+import type { GenericOAuthUserInfo } from "./routes";
 import {
 	getUserInfo,
 	oAuth2Callback,
@@ -17,6 +18,12 @@ import {
 	signInWithOAuth2,
 } from "./routes";
 import type { GenericOAuthConfig, GenericOAuthOptions } from "./types";
+
+function isNonEmptyOAuthId(
+	id: string | number | null | undefined,
+): id is string | number {
+	return id !== undefined && id !== null && id !== "";
+}
 
 export * from "./providers";
 export type { GenericOAuthConfig, GenericOAuthOptions } from "./types";
@@ -213,23 +220,33 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 						);
 					},
 					async getUserInfo(tokens: OAuth2Tokens) {
-						const userInfo = c.getUserInfo
-							? await c.getUserInfo(tokens)
-							: await getUserInfo(tokens, finalUserInfoUrl);
+						const userInfo = (
+							c.getUserInfo
+								? await c.getUserInfo(tokens)
+								: await getUserInfo(tokens, finalUserInfoUrl)
+						) as GenericOAuthUserInfo | null;
 						if (!userInfo) {
 							return null;
 						}
 
 						const userMap = await c.mapProfileToUser?.(userInfo);
+						const rawId = isNonEmptyOAuthId(userMap?.id)
+							? userMap.id
+							: isNonEmptyOAuthId(userInfo.id)
+								? userInfo.id
+								: undefined;
+						if (rawId === undefined) {
+							return null;
+						}
 
 						return {
 							user: {
-								id: userInfo?.id,
 								email: userInfo?.email,
 								emailVerified: userInfo?.emailVerified,
 								image: userInfo?.image,
 								name: userInfo?.name,
 								...userMap,
+								id: String(rawId),
 							},
 							data: userInfo,
 						};

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -25,6 +25,18 @@ import { isAPIError } from "../../utils/is-api-error";
 import { GENERIC_OAUTH_ERROR_CODES } from "./error-codes";
 import type { GenericOAuthOptions } from "./types";
 
+export type GenericOAuthUserInfo = Omit<OAuth2UserInfo, "id"> & {
+	id?: string | number | null | undefined;
+	sub?: string | number | null | undefined;
+	[key: string]: unknown;
+};
+
+function isNonEmptyOAuthId(
+	id: string | number | null | undefined,
+): id is string | number {
+	return id !== undefined && id !== null && id !== "";
+}
+
 const signInWithOAuth2BodySchema = z.object({
 	providerId: z.string().meta({
 		description: "The provider ID for the OAuth provider",
@@ -426,7 +438,7 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 						providerConfig.getUserInfo
 							? await providerConfig.getUserInfo(tokens)
 							: await getUserInfo(tokens, finalUserInfoUrl)
-					) as OAuth2UserInfo | null;
+					) as GenericOAuthUserInfo | null;
 					if (!userInfo) {
 						redirectOnError(ctx, resolvedErrorURL, "user_info_is_missing");
 					}
@@ -445,11 +457,12 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 						);
 						redirectOnError(ctx, resolvedErrorURL, "email_is_missing");
 					}
-					const rawId =
-						mapUser.id !== undefined && mapUser.id !== null && mapUser.id !== ""
-							? mapUser.id
-							: userInfo.id;
-					const id = rawId !== undefined && rawId !== null ? String(rawId) : "";
+					const rawId = isNonEmptyOAuthId(mapUser.id)
+						? mapUser.id
+						: isNonEmptyOAuthId(userInfo.id)
+							? userInfo.id
+							: undefined;
+					const id = rawId !== undefined ? String(rawId) : "";
 					// A provider must return a stable account id (e.g. `sub`).
 					// Without one, every account would be stored under the same
 					// empty id, letting different users resolve to the same account.
@@ -775,7 +788,7 @@ export const oAuth2LinkAccount = (options: GenericOAuthOptions) =>
 export async function getUserInfo(
 	tokens: OAuth2Tokens,
 	finalUserInfoUrl: string | undefined,
-): Promise<OAuth2UserInfo | null> {
+): Promise<GenericOAuthUserInfo | null> {
 	if (tokens.idToken) {
 		const decoded = decodeJwt(tokens.idToken) as {
 			sub: string;
@@ -814,15 +827,21 @@ export async function getUserInfo(
 		},
 	});
 	const profile = userInfo.data;
-	// Non-empty `id` wins over `sub` to keep stored account ids stable. Empty
-	// is allowed here: `mapProfileToUser` and the callback guard decide later.
-	const subjectId =
-		profile?.id !== undefined && profile.id !== null && profile.id !== ""
-			? profile.id
-			: profile?.sub;
+	if (!profile) {
+		return null;
+	}
+	const { id: profileId, ...profileFields } = profile;
+	// Non-empty `id` wins over `sub` to keep stored account ids stable. OIDC
+	// UserInfo responses must include `sub`; generic OAuth profiles may omit it
+	// and let `mapProfileToUser` derive the account id from another field.
+	const subjectId = isNonEmptyOAuthId(profileId)
+		? profileId
+		: isNonEmptyOAuthId(profile.sub)
+			? profile.sub
+			: undefined;
 	return {
-		...profile,
-		id: subjectId ?? "",
+		...profileFields,
+		...(subjectId !== undefined ? { id: subjectId } : {}),
 		email: profile?.email,
 		emailVerified: profile?.email_verified ?? false,
 		image: profile?.picture,

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -801,9 +801,9 @@ export async function getUserInfo(
 	}
 
 	const userInfo = await betterFetch<{
-		id?: string | number | undefined;
+		id?: string | number | null | undefined;
 		email: string;
-		sub?: string | undefined;
+		sub?: string | null | undefined;
 		name: string;
 		email_verified: boolean;
 		picture: string;
@@ -813,18 +813,19 @@ export async function getUserInfo(
 			Authorization: `Bearer ${tokens.accessToken}`,
 		},
 	});
-	const subjectId = userInfo.data?.sub ?? userInfo.data?.id;
-	// Without a stable subject id, the account would be stored under an empty
-	// id and could be resolved by a different user on the same provider.
-	if (subjectId === undefined || subjectId === null || subjectId === "") {
-		return null;
-	}
+	const profile = userInfo.data;
+	// Non-empty `id` wins over `sub` to keep stored account ids stable. Empty
+	// is allowed here: `mapProfileToUser` and the callback guard decide later.
+	const subjectId =
+		profile?.id !== undefined && profile.id !== null && profile.id !== ""
+			? profile.id
+			: profile?.sub;
 	return {
-		id: subjectId,
-		emailVerified: userInfo.data?.email_verified ?? false,
-		email: userInfo.data?.email,
-		image: userInfo.data?.picture,
-		name: userInfo.data?.name,
-		...userInfo.data,
+		...profile,
+		id: subjectId ?? "",
+		email: profile?.email,
+		emailVerified: profile?.email_verified ?? false,
+		image: profile?.picture,
+		name: profile?.name,
 	};
 }

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -461,7 +461,9 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 						? mapUser.id
 						: isNonEmptyOAuthId(userInfo.id)
 							? userInfo.id
-							: undefined;
+							: isNonEmptyOAuthId(userInfo.sub)
+								? userInfo.sub
+								: undefined;
 					const id = rawId !== undefined ? String(rawId) : "";
 					// A provider must return a stable account id (e.g. `sub`).
 					// Without one, every account would be stored under the same

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.test.ts
@@ -550,6 +550,312 @@ describe("invitation teamId must belong to the invitation's organization", async
 		expect(firstTeamMembers.length).toBe(0);
 	});
 
+	it("uses the accepted invitation team ids if they change after the initial read", async () => {
+		const PASSWORD = "test-password-123";
+		const INVITEE_EMAIL = "accepted-row-invitee@example.com";
+		let db: Awaited<ReturnType<typeof getTestInstance>>["db"];
+		let replacementTeamId = "";
+
+		const instance = await getTestInstance(
+			{
+				databaseHooks: {
+					user: {
+						create: {
+							before: async (user) => ({
+								data: { ...user, emailVerified: true },
+							}),
+						},
+					},
+				},
+				plugins: [
+					organization({
+						teams: { enabled: true },
+						async sendInvitationEmail() {},
+						organizationHooks: {
+							beforeAcceptInvitation: async ({ invitation }) => {
+								await db.update({
+									model: "invitation",
+									where: [{ field: "id", value: invitation.id }],
+									update: { teamId: replacementTeamId },
+								});
+							},
+						},
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [organizationClient({ teams: { enabled: true } })],
+				},
+			},
+		);
+		db = instance.db;
+		const { client, signInWithTestUser, signInWithUser, cookieSetter } =
+			instance;
+
+		const { headers: ownerHeaders } = await signInWithTestUser();
+		const org = await client.organization.create({
+			name: "Org A",
+			slug: "org-a",
+			fetchOptions: {
+				headers: ownerHeaders,
+				onSuccess: cookieSetter(ownerHeaders),
+			},
+		});
+		const staleTeam = await client.organization.createTeam({
+			name: "Stale Team",
+			organizationId: org.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+		const currentTeam = await client.organization.createTeam({
+			name: "Current Team",
+			organizationId: org.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+		replacementTeamId = currentTeam.data!.id;
+
+		const invite = await client.organization.inviteMember({
+			organizationId: org.data!.id,
+			email: INVITEE_EMAIL,
+			role: "member",
+			teamId: staleTeam.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+		const invitationId = String(invite.data!.id);
+
+		await client.signUp.email({
+			email: INVITEE_EMAIL,
+			password: PASSWORD,
+			name: "Invitee",
+		});
+		const { headers: inviteeHeaders, res: inviteeRes } = await signInWithUser(
+			INVITEE_EMAIL,
+			PASSWORD,
+		);
+
+		const accept = await client.organization.acceptInvitation({
+			invitationId,
+			fetchOptions: { headers: inviteeHeaders },
+		});
+
+		expect(accept.error).toBeNull();
+		expect(accept.data?.invitation.teamId).toBe(currentTeam.data!.id);
+
+		const teamMembers = await db.findMany<{ teamId: string }>({
+			model: "teamMember",
+			where: [{ field: "userId", value: inviteeRes.user.id }],
+		});
+		expect(teamMembers.map((m) => m.teamId)).toEqual([currentTeam.data!.id]);
+	});
+
+	it("keeps the invitation pending when a referenced team no longer exists", async () => {
+		const { client, signInWithTestUser, signInWithUser, cookieSetter, db } =
+			await setup();
+
+		const { headers: ownerHeaders } = await signInWithTestUser();
+		const org = await client.organization.create({
+			name: "Org A",
+			slug: "org-a",
+			fetchOptions: {
+				headers: ownerHeaders,
+				onSuccess: cookieSetter(ownerHeaders),
+			},
+		});
+		const invitedTeam = await client.organization.createTeam({
+			name: "Team A",
+			organizationId: org.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+		await client.organization.createTeam({
+			name: "Team B",
+			organizationId: org.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+
+		const invite = await client.organization.inviteMember({
+			organizationId: org.data!.id,
+			email: INVITEE_EMAIL,
+			role: "member",
+			teamId: invitedTeam.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+		const invitationId = String(invite.data!.id);
+
+		await db.delete({
+			model: "team",
+			where: [{ field: "id", value: invitedTeam.data!.id }],
+		});
+
+		await client.signUp.email({
+			email: INVITEE_EMAIL,
+			password: PASSWORD,
+			name: "Invitee",
+		});
+		const { headers: inviteeHeaders } = await signInWithUser(
+			INVITEE_EMAIL,
+			PASSWORD,
+		);
+		const accept = await client.organization.acceptInvitation({
+			invitationId,
+			fetchOptions: { headers: inviteeHeaders },
+		});
+
+		expect(accept.error?.code).toBe("TEAM_NOT_FOUND");
+
+		const invitationAfter = await db.findOne<{ status: string }>({
+			model: "invitation",
+			where: [{ field: "id", value: invitationId }],
+		});
+		expect(invitationAfter?.status).toBe("pending");
+	});
+
+	it("clears the removed team from a pending invitation so it degrades to an organization-level invitation", async () => {
+		const { client, signInWithTestUser, signInWithUser, cookieSetter, db } =
+			await setup();
+
+		const { headers: ownerHeaders } = await signInWithTestUser();
+		const org = await client.organization.create({
+			name: "Org A",
+			slug: "org-a",
+			fetchOptions: {
+				headers: ownerHeaders,
+				onSuccess: cookieSetter(ownerHeaders),
+			},
+		});
+		const invitedTeam = await client.organization.createTeam({
+			name: "Team A",
+			organizationId: org.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+		await client.organization.createTeam({
+			name: "Team B",
+			organizationId: org.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+
+		const invite = await client.organization.inviteMember({
+			organizationId: org.data!.id,
+			email: INVITEE_EMAIL,
+			role: "member",
+			teamId: invitedTeam.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+		const invitationId = String(invite.data!.id);
+
+		const removed = await client.organization.removeTeam({
+			teamId: invitedTeam.data!.id,
+			organizationId: org.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+		expect(removed.error).toBeNull();
+
+		const invitationAfter = await db.findOne<{
+			status: string;
+			teamId: string | null;
+		}>({
+			model: "invitation",
+			where: [{ field: "id", value: invitationId }],
+		});
+		expect(invitationAfter?.status).toBe("pending");
+		expect(invitationAfter?.teamId ?? null).toBeNull();
+
+		await client.signUp.email({
+			email: INVITEE_EMAIL,
+			password: PASSWORD,
+			name: "Invitee",
+		});
+		const { headers: inviteeHeaders, res: inviteeRes } = await signInWithUser(
+			INVITEE_EMAIL,
+			PASSWORD,
+		);
+		const accept = await client.organization.acceptInvitation({
+			invitationId,
+			fetchOptions: { headers: inviteeHeaders },
+		});
+
+		expect(accept.error).toBeNull();
+		expect(accept.data?.member).toBeDefined();
+
+		const teamMembers = await db.findMany({
+			model: "teamMember",
+			where: [{ field: "userId", value: inviteeRes.user.id }],
+		});
+		expect(teamMembers.length).toBe(0);
+	});
+
+	it("keeps the remaining teams on a multi-team invitation when one team is removed", async () => {
+		const { client, signInWithTestUser, signInWithUser, cookieSetter, db } =
+			await setup();
+
+		const { headers: ownerHeaders } = await signInWithTestUser();
+		const org = await client.organization.create({
+			name: "Org A",
+			slug: "org-a",
+			fetchOptions: {
+				headers: ownerHeaders,
+				onSuccess: cookieSetter(ownerHeaders),
+			},
+		});
+		const teamA = await client.organization.createTeam({
+			name: "Team A",
+			organizationId: org.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+		const teamB = await client.organization.createTeam({
+			name: "Team B",
+			organizationId: org.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+
+		const invite = await client.organization.inviteMember({
+			organizationId: org.data!.id,
+			email: INVITEE_EMAIL,
+			role: "member",
+			teamId: [teamA.data!.id, teamB.data!.id],
+			fetchOptions: { headers: ownerHeaders },
+		});
+		const invitationId = String(invite.data!.id);
+
+		const removed = await client.organization.removeTeam({
+			teamId: teamA.data!.id,
+			organizationId: org.data!.id,
+			fetchOptions: { headers: ownerHeaders },
+		});
+		expect(removed.error).toBeNull();
+
+		const invitationAfter = await db.findOne<{
+			status: string;
+			teamId: string | null;
+		}>({
+			model: "invitation",
+			where: [{ field: "id", value: invitationId }],
+		});
+		expect(invitationAfter?.status).toBe("pending");
+		expect(invitationAfter?.teamId).toBe(teamB.data!.id);
+
+		await client.signUp.email({
+			email: INVITEE_EMAIL,
+			password: PASSWORD,
+			name: "Invitee",
+		});
+		const { headers: inviteeHeaders, res: inviteeRes } = await signInWithUser(
+			INVITEE_EMAIL,
+			PASSWORD,
+		);
+		const accept = await client.organization.acceptInvitation({
+			invitationId,
+			fetchOptions: { headers: inviteeHeaders },
+		});
+
+		expect(accept.error).toBeNull();
+
+		const teamMembers = await db.findMany<{ teamId: string }>({
+			model: "teamMember",
+			where: [{ field: "userId", value: inviteeRes.user.id }],
+		});
+		expect(teamMembers.map((m) => m.teamId)).toEqual([teamB.data!.id]);
+	});
+
 	it("does not list another organization's team members from a mismatched teamMember row", async () => {
 		const { client, signInWithTestUser, signInWithUser, cookieSetter, db } =
 			await setup();

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -756,21 +756,21 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				if (
 					ctx.context.orgOptions.teams &&
 					ctx.context.orgOptions.teams.enabled &&
-					"teamId" in invitation &&
-					invitation.teamId
+					"teamId" in acceptedI &&
+					acceptedI.teamId
 				) {
-					const teamIds = (invitation.teamId as string).split(",");
+					const teamIds = (acceptedI.teamId as string).split(",");
 					const onlyOne = teamIds.length === 1;
 
 					for (const teamId of teamIds) {
-						// Confirm the team still belongs to the invitation's
+						// Confirm the team still belongs to the accepted invitation's
 						// organization before adding the member. This keeps team
 						// membership consistent with the invitation's organization,
 						// including for older invitations and for teams that were
 						// moved or removed between invite and accept.
 						const team = await adapter.findTeamById({
 							teamId,
-							organizationId: invitation.organizationId,
+							organizationId: acceptedI.organizationId,
 						});
 						if (!team) {
 							throw APIError.from(
@@ -789,7 +789,7 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 									? await ctx.context.orgOptions.teams.maximumMembersPerTeam({
 											teamId,
 											session: session,
-											organizationId: invitation.organizationId,
+											organizationId: acceptedI.organizationId,
 										})
 									: ctx.context.orgOptions.teams.maximumMembersPerTeam;
 
@@ -828,15 +828,15 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				}
 
 				const createdMember = await adapter.createMember({
-					organizationId: invitation.organizationId,
+					organizationId: acceptedI.organizationId,
 					userId: session.user.id,
-					role: invitation.role,
+					role: acceptedI.role,
 					createdAt: new Date(),
 				});
 
 				await adapter.setActiveOrganization(
 					session.session.token,
-					invitation.organizationId,
+					acceptedI.organizationId,
 					ctx,
 				);
 

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -344,6 +344,35 @@ export const removeTeam = <O extends OrganizationOptions>(options: O) =>
 
 			await adapter.deleteTeam(team.id);
 
+			// Drop the removed team from pending invitations so they stay
+			// acceptable; an emptied list degrades to an org-level invitation.
+			const pendingInvitations = await adapter.findPendingInvitations({
+				organizationId,
+			});
+			for (const invitation of pendingInvitations) {
+				if (!("teamId" in invitation) || !invitation.teamId) {
+					continue;
+				}
+				const teamIds = (invitation.teamId as string).split(",");
+				if (!teamIds.includes(team.id)) {
+					continue;
+				}
+				const remainingTeamIds = teamIds.filter((id) => id !== team.id);
+				await ctx.context.adapter.update({
+					model: "invitation",
+					where: [
+						{
+							field: "id",
+							value: invitation.id,
+						},
+					],
+					update: {
+						teamId:
+							remainingTeamIds.length > 0 ? remainingTeamIds.join(",") : null,
+					},
+				});
+			}
+
 			// Run afterDeleteTeam hook
 			if (options?.organizationHooks?.afterDeleteTeam) {
 				await options?.organizationHooks.afterDeleteTeam({

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -1,4 +1,8 @@
 import { createAuthEndpoint } from "@better-auth/core/api";
+import {
+	getCurrentAdapter,
+	runWithTransaction,
+} from "@better-auth/core/context";
 import { APIError } from "@better-auth/core/error";
 import * as z from "zod";
 import { getSessionFromCtx } from "../../../api";
@@ -342,36 +346,39 @@ export const removeTeam = <O extends OrganizationOptions>(options: O) =>
 				});
 			}
 
-			await adapter.deleteTeam(team.id);
+			await runWithTransaction(ctx.context.adapter, async () => {
+				await adapter.deleteTeam(team.id);
 
-			// Drop the removed team from pending invitations so they stay
-			// acceptable; an emptied list degrades to an org-level invitation.
-			const pendingInvitations = await adapter.findPendingInvitations({
-				organizationId,
-			});
-			for (const invitation of pendingInvitations) {
-				if (!("teamId" in invitation) || !invitation.teamId) {
-					continue;
-				}
-				const teamIds = (invitation.teamId as string).split(",");
-				if (!teamIds.includes(team.id)) {
-					continue;
-				}
-				const remainingTeamIds = teamIds.filter((id) => id !== team.id);
-				await ctx.context.adapter.update({
-					model: "invitation",
-					where: [
-						{
-							field: "id",
-							value: invitation.id,
-						},
-					],
-					update: {
-						teamId:
-							remainingTeamIds.length > 0 ? remainingTeamIds.join(",") : null,
-					},
+				// Drop the removed team from pending invitations so they stay
+				// acceptable; an emptied list degrades to an org-level invitation.
+				const pendingInvitations = await adapter.findPendingInvitations({
+					organizationId,
 				});
-			}
+				const trx = await getCurrentAdapter(ctx.context.adapter);
+				for (const invitation of pendingInvitations) {
+					if (!("teamId" in invitation) || !invitation.teamId) {
+						continue;
+					}
+					const teamIds = (invitation.teamId as string).split(",");
+					if (!teamIds.includes(team.id)) {
+						continue;
+					}
+					const remainingTeamIds = teamIds.filter((id) => id !== team.id);
+					await trx.update({
+						model: "invitation",
+						where: [
+							{
+								field: "id",
+								value: invitation.id,
+							},
+						],
+						update: {
+							teamId:
+								remainingTeamIds.length > 0 ? remainingTeamIds.join(",") : null,
+						},
+					});
+				}
+			});
 
 			// Run afterDeleteTeam hook
 			if (options?.organizationHooks?.afterDeleteTeam) {

--- a/packages/core/src/oauth2/verify.test.ts
+++ b/packages/core/src/oauth2/verify.test.ts
@@ -177,17 +177,18 @@ describe("verifyAccessToken", () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9654
 	 */
-	it("should translate missing kid failures to unauthorized API errors", async () => {
-		const { privateKey } = await createTestJWKS();
+	it("should verify a JWS without kid using the fetched JWKS", async () => {
+		const { publicJWK, privateKey } = await createTestJWKS();
 		const token = await createSignedToken(privateKey, undefined);
+		mockJWKSResponse(publicJWK);
 
-		await expectUnauthorized(
+		await expect(
 			verifyAccessToken(token, {
 				jwksUrl,
 				verifyOptions: { issuer, audience },
 			}),
-		);
-		expect(mockedFetch).not.toHaveBeenCalled();
+		).resolves.toMatchObject({ sub: "user-123" });
+		expect(mockedFetch).toHaveBeenCalledTimes(1);
 	});
 
 	/**
@@ -456,6 +457,38 @@ describe("verifyAccessToken", () => {
 		).resolves.toMatchObject({ sub: "user-123" });
 
 		expect(jwksFetch).toHaveBeenCalledTimes(2);
+		vi.resetModules();
+	});
+
+	it("should refetch a cached jwks source when a no-kid token fails against the cached set", async () => {
+		vi.resetModules();
+		const { verifyJwsAccessToken: verify } = await import("./verify");
+		const oldKey = await createTestJWKS();
+		const newKey = await createTestJWKS();
+		let currentKey = oldKey.publicJWK;
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(jwksResponse(currentKey)),
+		);
+
+		const oldToken = await createSignedToken(oldKey.privateKey, undefined);
+		await expect(
+			verify(oldToken, {
+				jwksFetch: jwksUrl,
+				verifyOptions: { issuer, audience },
+			}),
+		).resolves.toMatchObject({ sub: "user-123" });
+
+		currentKey = newKey.publicJWK;
+		const newToken = await createSignedToken(newKey.privateKey, undefined);
+		await expect(
+			verify(newToken, {
+				jwksFetch: jwksUrl,
+				verifyOptions: { issuer, audience },
+			}),
+		).resolves.toMatchObject({ sub: "user-123" });
+
+		expect(mockedFetch).toHaveBeenCalledTimes(2);
+		mockedFetch.mockReset();
 		vi.resetModules();
 	});
 

--- a/packages/core/src/oauth2/verify.test.ts
+++ b/packages/core/src/oauth2/verify.test.ts
@@ -320,6 +320,172 @@ describe("verifyAccessToken", () => {
 		vi.resetModules();
 	});
 
+	it("should not retain function jwks sources in the cache", async () => {
+		vi.resetModules();
+		const { verifyJwsAccessToken: verify, jwksCache } = await import(
+			"./verify"
+		);
+		const { publicJWK, privateKey, kid } = await createTestJWKS();
+		const token = await createSignedToken(privateKey, kid);
+
+		// A fresh closure per call, like per-request callers do.
+		for (let i = 0; i < 3; i++) {
+			await expect(
+				verify(token, {
+					jwksFetch: async () => ({ keys: [publicJWK] }),
+					verifyOptions: { issuer, audience },
+				}),
+			).resolves.toMatchObject({ sub: "user-123" });
+		}
+
+		expect(jwksCache.size).toBe(0);
+		vi.resetModules();
+	});
+
+	it("should invoke a function jwks source on every verification", async () => {
+		vi.resetModules();
+		const { verifyJwsAccessToken: verify } = await import("./verify");
+		const { publicJWK, privateKey, kid } = await createTestJWKS();
+		const token = await createSignedToken(privateKey, kid);
+		const jwksFetch = vi.fn(async () => ({ keys: [publicJWK] }));
+
+		await expect(
+			verify(token, { jwksFetch, verifyOptions: { issuer, audience } }),
+		).resolves.toMatchObject({ sub: "user-123" });
+		await expect(
+			verify(token, { jwksFetch, verifyOptions: { issuer, audience } }),
+		).resolves.toMatchObject({ sub: "user-123" });
+
+		expect(jwksFetch).toHaveBeenCalledTimes(2);
+		vi.resetModules();
+	});
+
+	it("should fetch a function jwks source once across verifications sharing a jwksCacheKey", async () => {
+		vi.resetModules();
+		const { verifyJwsAccessToken: verify } = await import("./verify");
+		const { publicJWK, privateKey, kid } = await createTestJWKS();
+		const token = await createSignedToken(privateKey, kid);
+		const jwksCacheKey = {};
+		let fetchCount = 0;
+
+		// A fresh closure per call, like per-request callers do.
+		for (let i = 0; i < 3; i++) {
+			await expect(
+				verify(token, {
+					jwksFetch: async () => {
+						fetchCount++;
+						return { keys: [publicJWK] };
+					},
+					jwksCacheKey,
+					verifyOptions: { issuer, audience },
+				}),
+			).resolves.toMatchObject({ sub: "user-123" });
+		}
+
+		expect(fetchCount).toBe(1);
+		vi.resetModules();
+	});
+
+	it("should isolate cached function jwks sources by jwksCacheKey object", async () => {
+		vi.resetModules();
+		const { verifyJwsAccessToken: verify } = await import("./verify");
+		const sourceA = await createTestJWKS();
+		const sourceB = await createTestJWKS();
+		const tokenA = await createSignedToken(sourceA.privateKey, sourceA.kid);
+		const tokenB = await createSignedToken(sourceB.privateKey, sourceB.kid);
+		const cacheKeyA = {};
+		const cacheKeyB = {};
+		const fetchA = vi.fn(async () => ({ keys: [sourceA.publicJWK] }));
+		const fetchB = vi.fn(async () => ({ keys: [sourceB.publicJWK] }));
+
+		await expect(
+			verify(tokenA, {
+				jwksFetch: fetchA,
+				jwksCacheKey: cacheKeyA,
+				verifyOptions: { issuer, audience },
+			}),
+		).resolves.toMatchObject({ sub: "user-123" });
+		await expect(
+			verify(tokenB, {
+				jwksFetch: fetchB,
+				jwksCacheKey: cacheKeyB,
+				verifyOptions: { issuer, audience },
+			}),
+		).resolves.toMatchObject({ sub: "user-123" });
+		// Source B's fetch must not have evicted source A's entry.
+		await expect(
+			verify(tokenA, {
+				jwksFetch: fetchA,
+				jwksCacheKey: cacheKeyA,
+				verifyOptions: { issuer, audience },
+			}),
+		).resolves.toMatchObject({ sub: "user-123" });
+
+		expect(fetchA).toHaveBeenCalledTimes(1);
+		expect(fetchB).toHaveBeenCalledTimes(1);
+		vi.resetModules();
+	});
+
+	it("should refetch a function jwks source when the token kid is missing from the cached set", async () => {
+		vi.resetModules();
+		const { verifyJwsAccessToken: verify } = await import("./verify");
+		const oldKey = await createTestJWKS();
+		const newKey = await createTestJWKS();
+		const jwksCacheKey = {};
+		let currentKeys = [oldKey.publicJWK];
+		const jwksFetch = vi.fn(async () => ({ keys: currentKeys }));
+
+		const oldToken = await createSignedToken(oldKey.privateKey, oldKey.kid);
+		await expect(
+			verify(oldToken, {
+				jwksFetch,
+				jwksCacheKey,
+				verifyOptions: { issuer, audience },
+			}),
+		).resolves.toMatchObject({ sub: "user-123" });
+
+		// A newly rotated-in kid is absent from the cached set and must refetch.
+		currentKeys = [oldKey.publicJWK, newKey.publicJWK];
+		const newToken = await createSignedToken(newKey.privateKey, newKey.kid);
+		await expect(
+			verify(newToken, {
+				jwksFetch,
+				jwksCacheKey,
+				verifyOptions: { issuer, audience },
+			}),
+		).resolves.toMatchObject({ sub: "user-123" });
+
+		expect(jwksFetch).toHaveBeenCalledTimes(2);
+		vi.resetModules();
+	});
+
+	it("should cache a string jwks source across verifications within the TTL", async () => {
+		vi.resetModules();
+		const { verifyJwsAccessToken: verify } = await import("./verify");
+		const { publicJWK, privateKey, kid } = await createTestJWKS();
+		const token = await createSignedToken(privateKey, kid);
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(jwksResponse(publicJWK)),
+		);
+
+		await expect(
+			verify(token, {
+				jwksFetch: jwksUrl,
+				verifyOptions: { issuer, audience },
+			}),
+		).resolves.toMatchObject({ sub: "user-123" });
+		await expect(
+			verify(token, {
+				jwksFetch: jwksUrl,
+				verifyOptions: { issuer, audience },
+			}),
+		).resolves.toMatchObject({ sub: "user-123" });
+
+		expect(mockedFetch).toHaveBeenCalledTimes(1);
+		mockedFetch.mockReset();
+		vi.resetModules();
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9654
 	 */

--- a/packages/core/src/oauth2/verify.test.ts
+++ b/packages/core/src/oauth2/verify.test.ts
@@ -492,6 +492,45 @@ describe("verifyAccessToken", () => {
 		vi.resetModules();
 	});
 
+	it("should not repeatedly refetch a fresh jwks source for invalid no-kid tokens", async () => {
+		vi.resetModules();
+		const { verifyJwsAccessToken: verify } = await import("./verify");
+		const validKey = await createTestJWKS();
+		const invalidKey = await createTestJWKS();
+		mockedFetch.mockImplementation(() =>
+			Promise.resolve(jwksResponse(validKey.publicJWK)),
+		);
+
+		const validToken = await createSignedToken(validKey.privateKey, undefined);
+		await expect(
+			verify(validToken, {
+				jwksFetch: jwksUrl,
+				verifyOptions: { issuer, audience },
+			}),
+		).resolves.toMatchObject({ sub: "user-123" });
+
+		const invalidToken = await createSignedToken(
+			invalidKey.privateKey,
+			undefined,
+		);
+		await expect(
+			verify(invalidToken, {
+				jwksFetch: jwksUrl,
+				verifyOptions: { issuer, audience },
+			}),
+		).rejects.toThrow();
+		await expect(
+			verify(invalidToken, {
+				jwksFetch: jwksUrl,
+				verifyOptions: { issuer, audience },
+			}),
+		).rejects.toThrow();
+
+		expect(mockedFetch).toHaveBeenCalledTimes(2);
+		mockedFetch.mockReset();
+		vi.resetModules();
+	});
+
 	it("should cache a string jwks source across verifications within the TTL", async () => {
 		vi.resetModules();
 		const { verifyJwsAccessToken: verify } = await import("./verify");

--- a/packages/core/src/oauth2/verify.ts
+++ b/packages/core/src/oauth2/verify.ts
@@ -29,6 +29,7 @@ function isJoseInfrastructureError(error: joseErrors.JOSEError) {
 interface JwksCacheEntry {
 	jwks: JSONWebKeySet;
 	fetchedAt: number;
+	noKidRefetchedAt?: number | undefined;
 }
 
 type JwksFetchOptions = {
@@ -46,6 +47,7 @@ type ResolvedJwks = {
 	jwks: JSONWebKeySet;
 	fromCache: boolean;
 	kid: string | undefined;
+	noKidRefetchedAt?: number | undefined;
 };
 
 /**
@@ -65,6 +67,7 @@ const functionJwksCache = new WeakMap<object, JwksCacheEntry>();
  * @internal
  */
 const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+const JWKS_NO_KID_REFETCH_COOLDOWN_MS = 30 * 1000;
 
 /**
  * Returns the cached key set when it is within the TTL. When the token carries
@@ -87,11 +90,15 @@ function shouldRefetchCachedJwksWithoutKid(
 	error: unknown,
 	resolved: ResolvedJwks,
 ) {
-	return (
+	const isRetryableNoKidFailure =
 		resolved.fromCache &&
 		!resolved.kid &&
 		(error instanceof joseErrors.JWKSNoMatchingKey ||
-			error instanceof joseErrors.JWSSignatureVerificationFailed)
+			error instanceof joseErrors.JWSSignatureVerificationFailed);
+	if (!isRetryableNoKidFailure) return false;
+	if (!resolved.noKidRefetchedAt) return true;
+	return (
+		Date.now() - resolved.noKidRefetchedAt >= JWKS_NO_KID_REFETCH_COOLDOWN_MS
 	);
 }
 
@@ -223,29 +230,53 @@ async function getJwksForVerification(
 			if (!jwks) throw new Error("No jwks found");
 			return { jwks, fromCache: false, kid };
 		}
+		const cached = functionJwksCache.get(cacheKey);
 		const cachedJwks = opts.forceRefresh
 			? undefined
-			: getFreshJwksWithKid(functionJwksCache.get(cacheKey), kid);
-		if (cachedJwks) return { jwks: cachedJwks, fromCache: true, kid };
+			: getFreshJwksWithKid(cached, kid);
+		if (cachedJwks) {
+			return {
+				jwks: cachedJwks,
+				fromCache: true,
+				kid,
+				noKidRefetchedAt: cached?.noKidRefetchedAt,
+			};
+		}
 		const jwks = await opts.jwksFetch();
 		if (!jwks) throw new Error("No jwks found");
-		functionJwksCache.set(cacheKey, { jwks, fetchedAt: Date.now() });
+		const fetchedAt = Date.now();
+		functionJwksCache.set(cacheKey, {
+			jwks,
+			fetchedAt,
+			...(opts.forceRefresh && !kid ? { noKidRefetchedAt: fetchedAt } : {}),
+		});
 		return { jwks, fromCache: false, kid };
 	}
 
 	// The cache is scoped to `cacheKey`, so a token is only ever matched
 	// against the key set published by its own source.
 	const cacheKey = opts.jwksFetch;
+	const cached = jwksCache.get(cacheKey);
 	const cachedJwks = opts.forceRefresh
 		? undefined
-		: getFreshJwksWithKid(jwksCache.get(cacheKey), kid);
+		: getFreshJwksWithKid(cached, kid);
 	if (!cachedJwks) {
 		const jwks = await fetchJwks(opts.jwksFetch);
-		jwksCache.set(cacheKey, { jwks, fetchedAt: Date.now() });
+		const fetchedAt = Date.now();
+		jwksCache.set(cacheKey, {
+			jwks,
+			fetchedAt,
+			...(opts.forceRefresh && !kid ? { noKidRefetchedAt: fetchedAt } : {}),
+		});
 		return { jwks, fromCache: false, kid };
 	}
 
-	return { jwks: cachedJwks, fromCache: true, kid };
+	return {
+		jwks: cachedJwks,
+		fromCache: true,
+		kid,
+		noKidRefetchedAt: cached?.noKidRefetchedAt,
+	};
 }
 
 /**

--- a/packages/core/src/oauth2/verify.ts
+++ b/packages/core/src/oauth2/verify.ts
@@ -4,6 +4,7 @@ import type {
 	JSONWebKeySet,
 	JWTPayload,
 	JWTVerifyOptions,
+	JWTVerifyResult,
 	ProtectedHeaderParameters,
 } from "jose";
 import {
@@ -30,6 +31,23 @@ interface JwksCacheEntry {
 	fetchedAt: number;
 }
 
+type JwksFetchOptions = {
+	/** Jwks url or promise of a Jwks */
+	jwksFetch: string | (() => Promise<JSONWebKeySet | undefined>);
+	/**
+	 * Stable object to cache the result of a function `jwksFetch` under,
+	 * with the same TTL and kid-miss refetch rules as string sources.
+	 * Without it, a function source is fetched on every verification.
+	 */
+	jwksCacheKey?: object;
+};
+
+type ResolvedJwks = {
+	jwks: JSONWebKeySet;
+	fromCache: boolean;
+	kid: string | undefined;
+};
+
 /**
  * @internal
  */
@@ -49,18 +67,53 @@ const functionJwksCache = new WeakMap<object, JwksCacheEntry>();
 const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
 
 /**
- * Returns the cached key set when it is within the TTL and contains `kid`.
- * Anything else (no entry, expired, or a kid absent from the set, e.g. a
- * newly rotated-in key) requires a refetch.
+ * Returns the cached key set when it is within the TTL. When the token carries
+ * `kid`, the cached set must contain that key id; without `kid`, key selection
+ * is deferred to JOSE because RFC 7515 makes the header parameter optional.
  */
 function getFreshJwksWithKid(
 	cached: JwksCacheEntry | undefined,
-	kid: string,
+	kid: string | undefined,
 ): JSONWebKeySet | undefined {
 	if (!cached) return undefined;
 	if (Date.now() - cached.fetchedAt >= JWKS_CACHE_TTL_MS) return undefined;
-	if (!cached.jwks.keys.some((jwk) => jwk.kid === kid)) return undefined;
+	if (kid && !cached.jwks.keys.some((jwk) => jwk.kid === kid)) {
+		return undefined;
+	}
 	return cached.jwks;
+}
+
+function shouldRefetchCachedJwksWithoutKid(
+	error: unknown,
+	resolved: ResolvedJwks,
+) {
+	return (
+		resolved.fromCache &&
+		!resolved.kid &&
+		(error instanceof joseErrors.JWKSNoMatchingKey ||
+			error instanceof joseErrors.JWSSignatureVerificationFailed)
+	);
+}
+
+async function fetchJwks(
+	jwksFetch: JwksFetchOptions["jwksFetch"],
+): Promise<JSONWebKeySet> {
+	const jwks =
+		typeof jwksFetch === "string"
+			? await betterFetch<JSONWebKeySet>(jwksFetch, {
+					headers: {
+						Accept: "application/json",
+					},
+				}).then(async (res) => {
+					if (res.error)
+						throw new Error(
+							`Jwks failed: ${res.error.message ?? res.error.statusText}`,
+						);
+					return res.data;
+				})
+			: await jwksFetch();
+	if (!jwks) throw new Error("No jwks found");
+	return jwks;
 }
 
 export interface VerifyAccessTokenRemote {
@@ -99,27 +152,36 @@ export interface VerifyAccessTokenRemote {
  */
 export async function verifyJwsAccessToken(
 	token: string,
-	opts: {
-		/** Jwks url or promise of a Jwks */
-		jwksFetch: string | (() => Promise<JSONWebKeySet | undefined>);
-		/**
-		 * Stable object to cache the result of a function `jwksFetch` under,
-		 * with the same TTL and kid-miss refetch rules as string sources.
-		 * Without it, a function source is fetched on every verification.
-		 */
-		jwksCacheKey?: object;
+	opts: JwksFetchOptions & {
 		/** Verify options */
 		verifyOptions: JWTVerifyOptions &
 			Required<Pick<JWTVerifyOptions, "audience" | "issuer">>;
 	},
 ) {
 	try {
-		const jwks = await getJwks(token, opts);
-		const jwt = await jwtVerify<JWTPayload>(
-			token,
-			createLocalJWKSet(jwks),
-			opts.verifyOptions,
-		);
+		const resolved = await getJwksForVerification(token, opts);
+		let jwt: JWTVerifyResult<JWTPayload>;
+		try {
+			jwt = await jwtVerify<JWTPayload>(
+				token,
+				createLocalJWKSet(resolved.jwks),
+				opts.verifyOptions,
+			);
+		} catch (error) {
+			if (shouldRefetchCachedJwksWithoutKid(error, resolved)) {
+				const refreshed = await getJwksForVerification(token, {
+					...opts,
+					forceRefresh: true,
+				});
+				jwt = await jwtVerify<JWTPayload>(
+					token,
+					createLocalJWKSet(refreshed.jwks),
+					opts.verifyOptions,
+				);
+			} else {
+				throw error;
+			}
+		}
 		// Return the JWT payload in introspection format
 		// https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
 		if (jwt.payload.azp) {
@@ -132,18 +194,13 @@ export async function verifyJwsAccessToken(
 	}
 }
 
-export async function getJwks(
+export async function getJwks(token: string, opts: JwksFetchOptions) {
+	return (await getJwksForVerification(token, opts)).jwks;
+}
+
+async function getJwksForVerification(
 	token: string,
-	opts: {
-		/** Jwks url or promise of a Jwks */
-		jwksFetch: string | (() => Promise<JSONWebKeySet | undefined>);
-		/**
-		 * Stable object to cache the result of a function `jwksFetch` under,
-		 * with the same TTL and kid-miss refetch rules as string sources.
-		 * Without it, a function source is fetched on every verification.
-		 */
-		jwksCacheKey?: object;
-	},
+	opts: JwksFetchOptions & { forceRefresh?: boolean },
 ) {
 	// Attempt to decode the token and find a matching kid in jwks
 	let jwtHeaders: ProtectedHeaderParameters | undefined;
@@ -154,9 +211,6 @@ export async function getJwks(
 		throw new Error(error as unknown as string);
 	}
 
-	if (!jwtHeaders.kid) {
-		throw new APIError("UNAUTHORIZED", { message: "invalid access token" });
-	}
 	const kid = jwtHeaders.kid;
 
 	// Function sources have no usable identity of their own (callers pass
@@ -167,41 +221,31 @@ export async function getJwks(
 		if (!cacheKey) {
 			const jwks = await opts.jwksFetch();
 			if (!jwks) throw new Error("No jwks found");
-			return jwks;
+			return { jwks, fromCache: false, kid };
 		}
-		const cachedJwks = getFreshJwksWithKid(
-			functionJwksCache.get(cacheKey),
-			kid,
-		);
-		if (cachedJwks) return cachedJwks;
+		const cachedJwks = opts.forceRefresh
+			? undefined
+			: getFreshJwksWithKid(functionJwksCache.get(cacheKey), kid);
+		if (cachedJwks) return { jwks: cachedJwks, fromCache: true, kid };
 		const jwks = await opts.jwksFetch();
 		if (!jwks) throw new Error("No jwks found");
 		functionJwksCache.set(cacheKey, { jwks, fetchedAt: Date.now() });
-		return jwks;
+		return { jwks, fromCache: false, kid };
 	}
 
 	// The cache is scoped to `cacheKey`, so a token is only ever matched
 	// against the key set published by its own source.
 	const cacheKey = opts.jwksFetch;
-	const cachedJwks = getFreshJwksWithKid(jwksCache.get(cacheKey), kid);
+	const cachedJwks = opts.forceRefresh
+		? undefined
+		: getFreshJwksWithKid(jwksCache.get(cacheKey), kid);
 	if (!cachedJwks) {
-		const jwks = await betterFetch<JSONWebKeySet>(opts.jwksFetch, {
-			headers: {
-				Accept: "application/json",
-			},
-		}).then(async (res) => {
-			if (res.error)
-				throw new Error(
-					`Jwks failed: ${res.error.message ?? res.error.statusText}`,
-				);
-			return res.data;
-		});
-		if (!jwks) throw new Error("No jwks found");
+		const jwks = await fetchJwks(opts.jwksFetch);
 		jwksCache.set(cacheKey, { jwks, fetchedAt: Date.now() });
-		return jwks;
+		return { jwks, fromCache: false, kid };
 	}
 
-	return cachedJwks;
+	return { jwks: cachedJwks, fromCache: true, kid };
 }
 
 /**

--- a/packages/core/src/oauth2/verify.ts
+++ b/packages/core/src/oauth2/verify.ts
@@ -30,10 +30,16 @@ interface JwksCacheEntry {
 	fetchedAt: number;
 }
 
-const jwksCache = new Map<
-	string | (() => Promise<JSONWebKeySet | undefined>),
-	JwksCacheEntry
->();
+/**
+ * @internal
+ */
+export const jwksCache = new Map<string, JwksCacheEntry>();
+
+/**
+ * Cache for function jwks sources, keyed by a caller-provided stable object.
+ * Entries are released with their key, so per-request keys cannot accumulate.
+ */
+const functionJwksCache = new WeakMap<object, JwksCacheEntry>();
 
 /**
  * How long a cached JWKS is trusted before it is refetched
@@ -41,6 +47,21 @@ const jwksCache = new Map<
  * @internal
  */
 const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Returns the cached key set when it is within the TTL and contains `kid`.
+ * Anything else (no entry, expired, or a kid absent from the set, e.g. a
+ * newly rotated-in key) requires a refetch.
+ */
+function getFreshJwksWithKid(
+	cached: JwksCacheEntry | undefined,
+	kid: string,
+): JSONWebKeySet | undefined {
+	if (!cached) return undefined;
+	if (Date.now() - cached.fetchedAt >= JWKS_CACHE_TTL_MS) return undefined;
+	if (!cached.jwks.keys.some((jwk) => jwk.kid === kid)) return undefined;
+	return cached.jwks;
+}
 
 export interface VerifyAccessTokenRemote {
 	/** Full url of the introspect endpoint. Should end with `/oauth2/introspect` */
@@ -81,6 +102,12 @@ export async function verifyJwsAccessToken(
 	opts: {
 		/** Jwks url or promise of a Jwks */
 		jwksFetch: string | (() => Promise<JSONWebKeySet | undefined>);
+		/**
+		 * Stable object to cache the result of a function `jwksFetch` under,
+		 * with the same TTL and kid-miss refetch rules as string sources.
+		 * Without it, a function source is fetched on every verification.
+		 */
+		jwksCacheKey?: object;
 		/** Verify options */
 		verifyOptions: JWTVerifyOptions &
 			Required<Pick<JWTVerifyOptions, "audience" | "issuer">>;
@@ -110,6 +137,12 @@ export async function getJwks(
 	opts: {
 		/** Jwks url or promise of a Jwks */
 		jwksFetch: string | (() => Promise<JSONWebKeySet | undefined>);
+		/**
+		 * Stable object to cache the result of a function `jwksFetch` under,
+		 * with the same TTL and kid-miss refetch rules as string sources.
+		 * Without it, a function source is fetched on every verification.
+		 */
+		jwksCacheKey?: object;
 	},
 ) {
 	// Attempt to decode the token and find a matching kid in jwks
@@ -126,38 +159,49 @@ export async function getJwks(
 	}
 	const kid = jwtHeaders.kid;
 
-	const cacheKey = opts.jwksFetch;
-	const cached = jwksCache.get(cacheKey);
-	const isFresh = cached
-		? Date.now() - cached.fetchedAt < JWKS_CACHE_TTL_MS
-		: false;
-	const hasKid = cached?.jwks.keys.some((jwk) => jwk.kid === kid) ?? false;
+	// Function sources have no usable identity of their own (callers pass
+	// fresh closures per request), so they are cached only under a stable
+	// caller-provided key object.
+	if (typeof opts.jwksFetch !== "string") {
+		const cacheKey = opts.jwksCacheKey;
+		if (!cacheKey) {
+			const jwks = await opts.jwksFetch();
+			if (!jwks) throw new Error("No jwks found");
+			return jwks;
+		}
+		const cachedJwks = getFreshJwksWithKid(
+			functionJwksCache.get(cacheKey),
+			kid,
+		);
+		if (cachedJwks) return cachedJwks;
+		const jwks = await opts.jwksFetch();
+		if (!jwks) throw new Error("No jwks found");
+		functionJwksCache.set(cacheKey, { jwks, fetchedAt: Date.now() });
+		return jwks;
+	}
 
-	// Refetch when this source has no cached set, the cached set has expired, or
-	// it does not contain the token's kid (e.g. a newly rotated-in key). The
-	// cache is scoped to `cacheKey`, so a token is only ever matched against the
-	// key set published by its own source.
-	if (!cached || !isFresh || !hasKid) {
-		const jwks =
-			typeof opts.jwksFetch === "string"
-				? await betterFetch<JSONWebKeySet>(opts.jwksFetch, {
-						headers: {
-							Accept: "application/json",
-						},
-					}).then(async (res) => {
-						if (res.error)
-							throw new Error(
-								`Jwks failed: ${res.error.message ?? res.error.statusText}`,
-							);
-						return res.data;
-					})
-				: await opts.jwksFetch();
+	// The cache is scoped to `cacheKey`, so a token is only ever matched
+	// against the key set published by its own source.
+	const cacheKey = opts.jwksFetch;
+	const cachedJwks = getFreshJwksWithKid(jwksCache.get(cacheKey), kid);
+	if (!cachedJwks) {
+		const jwks = await betterFetch<JSONWebKeySet>(opts.jwksFetch, {
+			headers: {
+				Accept: "application/json",
+			},
+		}).then(async (res) => {
+			if (res.error)
+				throw new Error(
+					`Jwks failed: ${res.error.message ?? res.error.statusText}`,
+				);
+			return res.data;
+		});
 		if (!jwks) throw new Error("No jwks found");
 		jwksCache.set(cacheKey, { jwks, fetchedAt: Date.now() });
 		return jwks;
 	}
 
-	return cached.jwks;
+	return cachedJwks;
 }
 
 /**

--- a/packages/oauth-provider/src/introspect.test.ts
+++ b/packages/oauth-provider/src/introspect.test.ts
@@ -6,7 +6,7 @@ import {
 } from "better-auth/oauth2";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
 import type { OAuthOptions, Scope } from "./types";
@@ -326,6 +326,43 @@ describe("oauth introspect", async () => {
 			iat: expect.any(Number),
 			sid: expect.any(String),
 		});
+	});
+
+	it("should read the signing keys once across repeated jwt introspections", async () => {
+		const tokens = await getTokens(undefined, {
+			resource: validAudience,
+		});
+		const ctx = await auth.$context;
+		const findMany = vi.spyOn(ctx.adapter, "findMany");
+		// Shift only Date past the JWKS cache TTL so any entry cached by earlier
+		// introspections is stale and exactly one fresh read is expected.
+		vi.useFakeTimers({ toFake: ["Date"], now: Date.now() + 6 * 60 * 1000 });
+		try {
+			for (let i = 0; i < 2; i++) {
+				const introspection = await client.oauth2.introspect(
+					{
+						client_id: oauthClient?.client_id,
+						client_secret: oauthClient?.client_secret,
+						token: tokens.data?.access_token!,
+						token_type_hint: "access_token",
+					},
+					{
+						headers: {
+							accept: "application/json",
+							"content-type": "application/x-www-form-urlencoded",
+						},
+					},
+				);
+				expect(introspection.data).toMatchObject({ active: true });
+			}
+			const jwksReads = findMany.mock.calls.filter(
+				([args]) => args.model === "jwks",
+			);
+			expect(jwksReads).toHaveLength(1);
+		} finally {
+			vi.useRealTimers();
+			findMany.mockRestore();
+		}
 	});
 
 	it("should pass without token_type_hint and sent opaque access_token", async () => {

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -59,6 +59,9 @@ async function validateJwtAccessToken(
 						// @ts-expect-error response is a JSONWebKeySet but within the response field
 						return jwksRes?.response as JSONWebKeySet | undefined;
 					},
+			// The plugin instance is stable across requests, so the key set
+			// fetched by the per-request closure above is cached under it.
+			jwksCacheKey: jwtPlugin,
 			verifyOptions: {
 				audience: opts.validAudiences ?? ctx.context.baseURL,
 				issuer: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,

--- a/packages/oauth-provider/src/revoke.ts
+++ b/packages/oauth-provider/src/revoke.ts
@@ -49,6 +49,9 @@ async function revokeJwtAccessToken(
 						// @ts-expect-error response is a JSONWebKeySet but within the response field
 						return jwksRes?.response as JSONWebKeySet | undefined;
 					},
+			// The plugin instance is stable across requests, so the key set
+			// fetched by the per-request closure above is cached under it.
+			jwksCacheKey: jwtPlugin,
 			verifyOptions: {
 				audience: opts.validAudiences ?? ctx.context.baseURL,
 				issuer: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -13,6 +13,7 @@ import {
 } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
 import type { Member } from "better-auth/plugins";
+import { getOrgAdapter } from "better-auth/plugins";
 import * as z from "zod";
 import { getAccountId, getUserFullName, getUserPrimaryEmail } from "./mappings";
 import type { AuthMiddleware } from "./middlewares";
@@ -1147,21 +1148,46 @@ export const deleteSCIMUser = (authMiddleware: AuthMiddleware) =>
 			// Deprovision instead: drop their membership in this organization and
 			// the SCIM account link for this provider, leaving the user intact.
 			if (organizationId) {
-				await ctx.context.adapter.transaction(async () => {
-					await ctx.context.adapter.deleteMany({
-						model: "member",
-						where: [
-							{ field: "organizationId", value: organizationId },
-							{ field: "userId", value: userId },
-						],
+				const orgOptions = ctx.context.getPlugin("organization")?.options;
+				const orgAdapter = getOrgAdapter(ctx.context, orgOptions);
+				const member = await findOrganizationMember(
+					ctx,
+					userId,
+					organizationId,
+				);
+				const organization = member
+					? await orgAdapter.findOrganizationById(organizationId)
+					: null;
+
+				if (member && organization) {
+					await orgOptions?.organizationHooks?.beforeRemoveMember?.({
+						member,
+						user,
+						organization,
 					});
-					if (account) {
-						await ctx.context.adapter.delete({
-							model: "account",
-							where: [{ field: "id", value: account.id }],
-						});
-					}
-				});
+				}
+
+				if (member) {
+					await orgAdapter.deleteMember({
+						memberId: member.id,
+						organizationId,
+						userId,
+					});
+				}
+				if (account) {
+					await ctx.context.adapter.delete({
+						model: "account",
+						where: [{ field: "id", value: account.id }],
+					});
+				}
+
+				if (member && organization) {
+					await orgOptions?.organizationHooks?.afterRemoveMember?.({
+						member,
+						user,
+						organization,
+					});
+				}
 
 				ctx.setStatus(204);
 				return;

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -1148,7 +1148,14 @@ export const deleteSCIMUser = (authMiddleware: AuthMiddleware) =>
 			// Deprovision instead: drop their membership in this organization and
 			// the SCIM account link for this provider, leaving the user intact.
 			if (organizationId) {
-				const orgOptions = ctx.context.getPlugin("organization")?.options;
+				const organizationPlugin = ctx.context.getPlugin("organization");
+				if (!organizationPlugin) {
+					throw new SCIMAPIError("BAD_REQUEST", {
+						detail:
+							"Organization-scoped SCIM deprovisioning requires the organization plugin",
+					});
+				}
+				const orgOptions = organizationPlugin.options;
 				const orgAdapter = getOrgAdapter(ctx.context, orgOptions);
 				const member = await findOrganizationMember(
 					ctx,
@@ -1167,19 +1174,39 @@ export const deleteSCIMUser = (authMiddleware: AuthMiddleware) =>
 					});
 				}
 
-				if (member) {
-					await orgAdapter.deleteMember({
-						memberId: member.id,
-						organizationId,
-						userId,
-					});
-				}
-				if (account) {
-					await ctx.context.adapter.delete({
-						model: "account",
-						where: [{ field: "id", value: account.id }],
-					});
-				}
+				await ctx.context.adapter.transaction(async (trx) => {
+					if (member) {
+						await trx.delete({
+							model: "member",
+							where: [{ field: "id", value: member.id }],
+						});
+						if (orgOptions?.teams?.enabled) {
+							const teams = await trx.findMany<{ id: string }>({
+								model: "team",
+								where: [{ field: "organizationId", value: organizationId }],
+							});
+							if (teams.length > 0) {
+								await trx.deleteMany({
+									model: "teamMember",
+									where: [
+										{ field: "userId", value: userId },
+										{
+											field: "teamId",
+											value: teams.map((team) => team.id),
+											operator: "in",
+										},
+									],
+								});
+							}
+						}
+					}
+					if (account) {
+						await trx.delete({
+							model: "account",
+							where: [{ field: "id", value: account.id }],
+						});
+					}
+				});
 
 				if (member && organization) {
 					await orgOptions?.organizationHooks?.afterRemoveMember?.({

--- a/packages/scim/src/scim-users.test.ts
+++ b/packages/scim/src/scim-users.test.ts
@@ -814,6 +814,121 @@ describe("SCIM", () => {
 				expect.objectContaining({ message: "User not found" }),
 			);
 		});
+
+		it("removes team memberships when an org-scoped SCIM delete removes the member", async () => {
+			const adminUser = {
+				email: "scim-team-admin@test.com",
+				password: "password",
+				name: "SCIM Team Admin",
+			};
+
+			const data = {
+				user: [],
+				session: [],
+				verification: [],
+				account: [],
+				ssoProvider: [],
+				scimProvider: [],
+				organization: [],
+				member: [],
+				invitation: [],
+				team: [],
+				teamMember: [],
+			};
+			const memory = memoryAdapter(data);
+
+			const auth = betterAuth({
+				database: memory,
+				baseURL: "http://localhost:3000",
+				emailAndPassword: { enabled: true },
+				plugins: [sso(), scim(), organization({ teams: { enabled: true } })],
+			});
+
+			const authClient = createAuthClient({
+				baseURL: "http://localhost:3000",
+				plugins: [bearer(), scimClient()],
+				fetchOptions: {
+					customFetchImpl: async (url, init) =>
+						auth.handler(new Request(url, init)),
+				},
+			});
+
+			await authClient.signUp.email(adminUser);
+			const adminHeaders = new Headers();
+			await authClient.signIn.email(adminUser, {
+				throw: true,
+				onSuccess: setCookieToHeader(adminHeaders),
+			});
+
+			const org = await auth.api.createOrganization({
+				body: { slug: "the-team-org", name: "the team org" },
+				headers: adminHeaders,
+			});
+
+			const { scimToken } = await auth.api.generateSCIMToken({
+				body: {
+					providerId: "provider-team-cleanup",
+					organizationId: org!.id,
+				},
+				headers: adminHeaders,
+			});
+
+			const created = await auth.api.createSCIMUser({
+				body: {
+					userName: "scim-team-user",
+					emails: [{ value: "scim-team-user@email.com" }],
+				},
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+
+			const team = await auth.api.createTeam({
+				body: { name: "the-team", organizationId: org!.id },
+				headers: adminHeaders,
+			});
+
+			await auth.api.addTeamMember({
+				body: {
+					teamId: team.id,
+					userId: created.id,
+					organizationId: org!.id,
+				},
+				headers: adminHeaders,
+			});
+
+			const ctx = await auth.$context;
+
+			const teamMemberBefore = await ctx.adapter.findOne({
+				model: "teamMember",
+				where: [
+					{ field: "teamId", value: team.id },
+					{ field: "userId", value: created.id },
+				],
+			});
+			expect(teamMemberBefore).not.toBeNull();
+
+			await auth.api.deleteSCIMUser({
+				params: { userId: created.id },
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+
+			const memberAfter = await ctx.adapter.findOne({
+				model: "member",
+				where: [
+					{ field: "organizationId", value: org!.id },
+					{ field: "userId", value: created.id },
+				],
+			});
+			expect(memberAfter).toBeNull();
+
+			const teamMemberAfter = await ctx.adapter.findOne({
+				model: "teamMember",
+				where: [
+					{ field: "teamId", value: team.id },
+					{ field: "userId", value: created.id },
+				],
+			});
+			expect(teamMemberAfter).toBeNull();
+		});
 	});
 
 	describe("Default SCIM provider", () => {


### PR DESCRIPTION
Several auth edge cases could leave cached credentials, provider identity, or organization membership state out of sync with the authoritative row.

This patch keeps each fix at the boundary that owns that state:

- JWKS verification scopes caches by source, treats JWS `kid` as optional, and rate-limits no-`kid` forced refetches so key rotation still gets a retry without turning repeated invalid tokens into JWKS fetches. Function-based JWKS sources can still opt into a stable cache key without retaining per-request closures.
- Generic OAuth keeps non-empty provider ids stable, falls back to OIDC UserInfo `sub` when `id` is empty or null in both callback and provider-wrapper paths, and leaves missing ids absent so `mapProfileToUser` can derive the account id before the callback guard requires a non-empty value.
- Invitation acceptance validates and writes from the claimed invitation row after the pending-to-accepted transition. Team deletion removes deleted team ids from pending invitations inside the same transaction as the team delete.
- Account-cookie refresh skips stale request-cookie sync when the response already contains a fresh account cookie.
- Organization-scoped SCIM deletes keep member hooks around a single transaction that removes the organization membership, team memberships, and SCIM account link.