### PR TITLE
fix: harden session authority against stale cookie cache and unverified selectors

### DIFF
--- a/.changeset/api-key-update-session-freshness.md
+++ b/.changeset/api-key-update-session-freshness.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/api-key": patch
+---
+
+Updating an API key now fails when the caller's session has been revoked server-side, instead of succeeding within the cookie-cache window.

--- a/.changeset/delete-user-callback-session-freshness.md
+++ b/.changeset/delete-user-callback-session-freshness.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Completing account deletion through `/delete-user/callback` now fails when the session has been revoked server-side, instead of proceeding within the cookie-cache window. Deployments that keep sessions only in the cookie are unaffected.

--- a/.changeset/get-cookie-cache-expiry.md
+++ b/.changeset/get-cookie-cache-expiry.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+`getCookieCache` now returns `null` for an expired session instead of the stale session data. Middleware that calls it to gate access no longer treats an expired signed cookie as a live session.

--- a/.changeset/mcp-token-expiry.md
+++ b/.changeset/mcp-token-expiry.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Expired MCP access tokens are no longer accepted. A protected MCP resource now rejects a bearer token once it has expired, both on the server and through the remote client. A refresh token is accepted only when the original authorization included the `offline_access` scope.

--- a/.changeset/multi-session-token-binding.md
+++ b/.changeset/multi-session-token-binding.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The multi-session `set-active` and `revoke` endpoints now act only on the session the caller holds a signed cookie for. A request could previously activate or revoke a different session by naming its token in the request body without holding that session's cookie.

--- a/.changeset/oidc-endsession-cross-site.md
+++ b/.changeset/oidc-endsession-cross-site.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The OIDC provider's RP-initiated logout endpoint (`/oauth2/endsession`) no longer logs a user out, or revokes their OAuth tokens, in response to a cross-site GET that carries only a session cookie. Logout authenticated by a valid `id_token_hint` is unaffected.

--- a/packages/api-key/src/routes/update-api-key.ts
+++ b/packages/api-key/src/routes/update-api-key.ts
@@ -275,7 +275,13 @@ export function updateApiKey({
 				rateLimitMax,
 			} = ctx.body;
 
-			const session = await getSessionFromCtx(ctx);
+			// Updating an API key mutates a credential, so resolve the session from
+			// the authoritative store rather than the signed cookie-cache snapshot,
+			// matching create-api-key. A revoked session must not modify a key within
+			// the cookie-cache window.
+			const session = await getSessionFromCtx(ctx, {
+				disableCookieCache: true,
+			});
 			const authRequired = ctx.request || ctx.headers;
 			const user =
 				authRequired && !session

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -19,6 +19,7 @@ import { decryptOAuthToken, setTokenUtil } from "../../oauth2/utils";
 import {
 	freshSessionMiddleware,
 	getSessionFromCtx,
+	isStateful,
 	sessionMiddleware,
 } from "./session";
 
@@ -456,10 +457,8 @@ async function resolveUserId(
 	ctx: GenericEndpointContext,
 	userId?: string,
 ): Promise<string> {
-	const isStateful =
-		!!ctx.context.options.database || !!ctx.context.options.secondaryStorage;
 	const session = await getSessionFromCtx(ctx, {
-		disableCookieCache: isStateful,
+		disableCookieCache: isStateful(ctx),
 	});
 	if (!session && (ctx.request || ctx.headers)) {
 		throw ctx.error("UNAUTHORIZED");

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -518,6 +518,19 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 		},
 	);
 
+/**
+ * Whether the deployment keeps sessions in a durable server-side store
+ * (a database or secondary storage) rather than only in the signed cookie.
+ *
+ * Sensitive operations use this to decide whether the cookie cache is merely an
+ * optimization that must be bypassed for an authoritative read (`true`), or the
+ * only place the session lives and therefore the authority itself (`false`, for
+ * stateless / DB-less deployments). Pass the result as `disableCookieCache` so a
+ * revoked-but-cached session cannot authorize a sensitive action.
+ */
+export const isStateful = (ctx: GenericEndpointContext): boolean =>
+	!!ctx.context.options.database || !!ctx.context.options.secondaryStorage;
+
 export const getSessionFromCtx = async <
 	U extends Record<string, any> = Record<string, any>,
 	S extends Record<string, any> = Record<string, any>,

--- a/packages/better-auth/src/api/routes/update-session.ts
+++ b/packages/better-auth/src/api/routes/update-session.ts
@@ -5,7 +5,7 @@ import * as z from "zod";
 import { deleteSessionCookie, setSessionCookie } from "../../cookies";
 import { parseSessionInput, parseSessionOutput } from "../../db/schema";
 import type { AdditionalSessionFieldsInput } from "../../types";
-import { sessionMiddleware } from "./session";
+import { isStateful, sessionMiddleware } from "./session";
 
 const updateSessionBodySchema = z.record(
 	z.string().meta({
@@ -85,10 +85,7 @@ export const updateSession = <O extends BetterAuthOptions>() =>
 			// revoked or expired server-side; fail closed instead of re-minting from
 			// stale data, which would extend a revoked session. DB-less deployments
 			// keep the session in the cookie and legitimately have no row to update.
-			const isStateful =
-				!!ctx.context.options.database ||
-				!!ctx.context.options.secondaryStorage;
-			if (!updatedSession && isStateful) {
+			if (!updatedSession && isStateful(ctx)) {
 				deleteSessionCookie(ctx);
 				throw APIError.from(
 					"UNAUTHORIZED",

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -737,6 +737,62 @@ describe("delete user", async () => {
 
 		expect(sessionAfterPasswordChange.data).toBeNull();
 	});
+
+	it("rejects /delete-user/callback when the backing session was revoked", async () => {
+		let token = "";
+		const { client, auth, db, sessionSetter } = await getTestInstance(
+			{
+				baseURL: "http://localhost:3000",
+				session: { cookieCache: { enabled: true, maxAge: 60 } },
+				user: {
+					deleteUser: {
+						enabled: true,
+						async sendDeleteAccountVerification(data) {
+							token = data.token;
+						},
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const email = `delete-callback-${Date.now()}@test.com`;
+		const password = "testPassword123";
+		await client.signUp.email({ email, password, name: "Delete Callback" });
+
+		const headers = new Headers();
+		await client.signIn.email({
+			email,
+			password,
+			fetchOptions: { onSuccess: sessionSetter(headers) },
+		});
+
+		// Materialize the cookie cache and capture the backing session token.
+		const sessionRes = await client.getSession({ fetchOptions: { headers } });
+		const sessionToken = sessionRes.data?.session.token;
+		if (!sessionToken) throw new Error("expected an active session");
+
+		// Request deletion while the session is still valid to obtain a token.
+		await client.deleteUser({ password, fetchOptions: { headers } });
+		expect(token.length).toBe(32);
+
+		// Revoke the backing session server-side; the signed session_data cookie
+		// is still present in `headers`.
+		await db.delete({
+			model: "session",
+			where: [{ field: "token", value: sessionToken }],
+		});
+
+		// The GET callback (the email-link path) must not complete deletion from
+		// the stale cookie-cache session now that the backing row is gone.
+		const response = await auth.handler(
+			new Request(
+				`http://localhost:3000/api/auth/delete-user/callback?token=${token}`,
+				{ method: "GET", headers: { cookie: headers.get("cookie") ?? "" } },
+			),
+		);
+		expect(response.status).toBe(404);
+	});
 });
 
 describe("change-email enumeration protection", async () => {

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -10,6 +10,7 @@ import { originCheck } from "../middlewares";
 import { createEmailVerificationToken } from "./email-verification";
 import {
 	getSessionFromCtx,
+	isStateful,
 	sensitiveSessionMiddleware,
 	sessionMiddleware,
 } from "./session";
@@ -619,7 +620,12 @@ export const deleteUserCallback = createAuthEndpoint(
 				code: "NOT_FOUND",
 			});
 		}
-		const session = await getSessionFromCtx(ctx);
+		// Account deletion is sensitive: bypass the cookie cache on stateful
+		// deployments so a revoked-but-cached session cannot complete the deletion
+		// even when paired with a valid delete-account token.
+		const session = await getSessionFromCtx(ctx, {
+			disableCookieCache: isStateful(ctx),
+		});
 		if (!session) {
 			throw APIError.from(
 				"NOT_FOUND",

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1,4 +1,6 @@
 import type { BetterAuthOptions } from "@better-auth/core";
+import { base64Url } from "@better-auth/utils/base64";
+import { createHMAC } from "@better-auth/utils/hmac";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	expireCookie,
@@ -1737,5 +1739,82 @@ describe("expireCookie", () => {
 		expect(setCookieHeader).not.toContain("target=valid");
 		expect(setCookieHeader).not.toContain("target.0=chunk");
 		expect(setCookieHeader).toContain("target=; Path=/; Max-Age=0");
+	});
+});
+
+describe("getCookieCache expiry (compact strategy)", () => {
+	const SECRET = "better-auth.secret";
+
+	// Build a validly-signed compact session_data cookie, mirroring the encoding
+	// in setCookieCache, so the only variable under test is freshness.
+	async function buildCompactCookie(
+		embeddedExpiresAt: Date,
+		outerExpiresAt: number | undefined,
+	) {
+		const sessionData = {
+			session: {
+				id: "s1",
+				token: "session-token",
+				userId: "u1",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				expiresAt: embeddedExpiresAt,
+			},
+			user: {
+				id: "u1",
+				email: "cache@test.com",
+				emailVerified: true,
+				name: "Cache User",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+			updatedAt: Date.now(),
+			version: "1",
+		};
+		const signature = await createHMAC("SHA-256", "base64urlnopad").sign(
+			SECRET,
+			JSON.stringify({ ...sessionData, expiresAt: outerExpiresAt }),
+		);
+		return base64Url.encode(
+			JSON.stringify({
+				session: sessionData,
+				expiresAt: outerExpiresAt,
+				signature,
+			}),
+			{ padding: false },
+		);
+	}
+
+	function requestWith(cookieValue: string) {
+		const headers = new Headers();
+		headers.set("cookie", `better-auth.session_data=${cookieValue}`);
+		return new Request("https://example.com/api/auth/session", { headers });
+	}
+
+	it("returns the session for a fresh snapshot", async () => {
+		const cookie = await buildCompactCookie(
+			new Date(Date.now() + 60 * 60 * 1000),
+			Date.now() + 5 * 60 * 1000,
+		);
+		const cache = await getCookieCache(requestWith(cookie), { secret: SECRET });
+		expect(cache?.user?.email).toBe("cache@test.com");
+	});
+
+	it("returns null when the embedded session has expired", async () => {
+		const cookie = await buildCompactCookie(
+			new Date(Date.now() - 60 * 1000),
+			Date.now() + 5 * 60 * 1000,
+		);
+		const cache = await getCookieCache(requestWith(cookie), { secret: SECRET });
+		expect(cache).toBeNull();
+	});
+
+	it("returns null when the cache window has elapsed", async () => {
+		const cookie = await buildCompactCookie(
+			new Date(Date.now() + 60 * 60 * 1000),
+			Date.now() - 60 * 1000,
+		);
+		const cache = await getCookieCache(requestWith(cookie), { secret: SECRET });
+		expect(cache).toBeNull();
 	});
 });

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -550,6 +550,15 @@ export const getCookieCache = async <
 
 		const strategy = config?.strategy || "compact";
 
+		// A valid signature/encryption only proves integrity, not freshness. Mirror
+		// the in-route session reader and reject a snapshot whose embedded session
+		// has already expired, so a caller using this helper as an auth gate cannot
+		// treat a stale-but-signed cookie as a live session.
+		const isEmbeddedSessionExpired = (payload: S): boolean => {
+			const expiresAt = payload.session?.expiresAt;
+			return !!expiresAt && new Date(expiresAt).getTime() < Date.now();
+		};
+
 		if (strategy === "jwe") {
 			// Use JWE strategy (encrypted)
 			const payload = await symmetricDecodeJWT<S>(
@@ -573,6 +582,9 @@ export const getCookieCache = async <
 						return null;
 					}
 				}
+				if (isEmbeddedSessionExpired(payload)) {
+					return null;
+				}
 				return payload;
 			}
 			return null;
@@ -594,6 +606,9 @@ export const getCookieCache = async <
 					if (cookieVersion !== expectedVersion) {
 						return null;
 					}
+				}
+				if (isEmbeddedSessionExpired(payload)) {
+					return null;
 				}
 				return payload;
 			}
@@ -636,6 +651,19 @@ export const getCookieCache = async <
 				if (cookieVersion !== expectedVersion) {
 					return null;
 				}
+			}
+
+			// The compact strategy carries no `exp` claim, so the outer cache window
+			// and the embedded session lifetime must be checked explicitly (the
+			// jwt/jwe strategies get the outer window from their `exp` claim).
+			if (
+				typeof sessionDataPayload.expiresAt === "number" &&
+				sessionDataPayload.expiresAt < Date.now()
+			) {
+				return null;
+			}
+			if (isEmbeddedSessionExpired(sessionDataPayload.session)) {
+				return null;
 			}
 
 			return sessionDataPayload.session;

--- a/packages/better-auth/src/plugins/mcp/client/index.ts
+++ b/packages/better-auth/src/plugins/mcp/client/index.ts
@@ -162,6 +162,15 @@ export function createMcpAuthClient(
 			if (!data || !data.userId) {
 				return null;
 			}
+			// Defense in depth: the auth server gates expiry, but never authorize a
+			// session whose access token has already expired, in case an older or
+			// misconfigured server returns one.
+			if (
+				data.accessTokenExpiresAt &&
+				new Date(data.accessTokenExpiresAt).getTime() < Date.now()
+			) {
+				return null;
+			}
 
 			return data as McpSession;
 		} catch {

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -449,6 +449,17 @@ export const mcp = (options: MCPOptions) => {
 								error: "invalid_grant",
 							});
 						}
+						// A refresh token is only legitimate when the original grant
+						// included offline_access. Rejecting redemption otherwise makes a
+						// refresh token that was stored without offline_access (and may be
+						// exposed to its access-token holder) unusable for escalation.
+						if (!token.scopes?.split(" ").includes("offline_access")) {
+							throw new APIError("UNAUTHORIZED", {
+								error_description:
+									"refresh token was not issued for the offline_access scope",
+								error: "invalid_grant",
+							});
+						}
 						const refreshClient = await ctx.context.adapter
 							.findOne<Record<string, any>>({
 								model: modelName.oauthClient,
@@ -1029,6 +1040,14 @@ export const mcp = (options: MCPOptions) => {
 							],
 						});
 					if (!accessTokenData) {
+						return c.json(null);
+					}
+					// An access token authorizes a protected resource only while it is
+					// unexpired. Without this gate an expired bearer token keeps
+					// authorizing handlers until its row is deleted (RFC 6750 §3.1
+					// treats an expired token as `invalid_token`).
+					if (accessTokenData.accessTokenExpiresAt < new Date()) {
+						c.headers?.set("WWW-Authenticate", "Bearer");
 						return c.json(null);
 					}
 					return c.json(accessTokenData);

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -1213,3 +1213,119 @@ describe("mcp discovery metadata (security)", async () => {
 		expect(body.resource_signing_alg_values_supported).not.toContain("none");
 	});
 });
+
+describe("mcp session freshness (security)", () => {
+	async function seedToken(
+		db: Awaited<ReturnType<typeof getTestInstance>>["db"],
+		userId: string,
+		overrides: Record<string, unknown>,
+	) {
+		await db.create({
+			model: "oauthApplication",
+			data: {
+				clientId: "freshness-test-client",
+				clientSecret: "freshness-secret",
+				type: "web",
+				name: "Freshness Test Client",
+				redirectUrls: "http://localhost/callback",
+				disabled: false,
+				metadata: null,
+				icon: null,
+				userId: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await db.create({
+			model: "oauthAccessToken",
+			data: {
+				accessToken: "freshness-access-token",
+				refreshToken: "freshness-refresh-token",
+				accessTokenExpiresAt: new Date(Date.now() + 3600 * 1000),
+				refreshTokenExpiresAt: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+				clientId: "freshness-test-client",
+				userId,
+				scopes: "openid profile email offline_access",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				...overrides,
+			},
+		});
+	}
+
+	it("rejects an expired access token and does not invoke the handler", async () => {
+		const { auth, signInWithTestUser, db } = await getTestInstance({
+			baseURL: "http://localhost:3000",
+			plugins: [mcp({ loginPage: "/login" })],
+		});
+		const { user } = await signInWithTestUser();
+		await seedToken(db, user.id, {
+			accessToken: "expired-access-token",
+			accessTokenExpiresAt: new Date(Date.now() - 60 * 1000),
+		});
+
+		let handlerCalled = false;
+		const response = await withMcpAuth(auth, async () => {
+			handlerCalled = true;
+			return new Response("ok");
+		})(
+			new Request("http://localhost:3000/mcp", {
+				headers: { Authorization: "Bearer expired-access-token" },
+			}),
+		);
+
+		expect(response.status).toBe(401);
+		expect(handlerCalled).toBe(false);
+	});
+
+	it("accepts an unexpired access token", async () => {
+		const { auth, signInWithTestUser, db } = await getTestInstance({
+			baseURL: "http://localhost:3000",
+			plugins: [mcp({ loginPage: "/login" })],
+		});
+		const { user } = await signInWithTestUser();
+		await seedToken(db, user.id, { accessToken: "live-access-token" });
+
+		const response = await withMcpAuth(
+			auth,
+			async () => new Response("ok"),
+		)(
+			new Request("http://localhost:3000/mcp", {
+				headers: { Authorization: "Bearer live-access-token" },
+			}),
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	it("rejects a refresh_token grant whose original scopes lack offline_access", async () => {
+		const { customFetchImpl, signInWithTestUser, db } = await getTestInstance({
+			baseURL: "http://localhost:3000",
+			plugins: [mcp({ loginPage: "/login" })],
+		});
+		const { user } = await signInWithTestUser();
+		await seedToken(db, user.id, {
+			refreshToken: "no-offline-refresh-token",
+			scopes: "openid profile email",
+		});
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/mcp/token",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: "no-offline-refresh-token",
+					client_id: "freshness-test-client",
+					client_secret: "freshness-secret",
+				}).toString(),
+			},
+		);
+		const body = await response.json().catch(() => null);
+
+		expect(response.status).toBe(401);
+		expect(body?.error).toBe("invalid_grant");
+		expect(body?.access_token).toBeUndefined();
+	});
+});

--- a/packages/better-auth/src/plugins/multi-session/index.ts
+++ b/packages/better-auth/src/plugins/multi-session/index.ts
@@ -182,8 +182,13 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 							ERROR_CODES.INVALID_SESSION_TOKEN,
 						);
 					}
+					// The signed cookie value is the authoritative token; act on it, not
+					// on the request body. The signature covers the cookie value, not its
+					// name, so a request must not be able to pair a validly-signed cookie
+					// with a different token to activate a session it does not hold a
+					// cookie for.
 					const session =
-						await ctx.context.internalAdapter.findSession(sessionToken);
+						await ctx.context.internalAdapter.findSession(sessionCookie);
 					if (!session || session.session.expiresAt < new Date()) {
 						expireCookie(ctx, {
 							name: multiSessionCookieName,
@@ -262,12 +267,15 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 						);
 					}
 
-					await ctx.context.internalAdapter.deleteSession(sessionToken);
+					// Revoke the session proven by the signed cookie value, not the
+					// request-named token, so possession of one valid multi-session
+					// cookie cannot revoke a different session.
+					await ctx.context.internalAdapter.deleteSession(sessionCookie);
 					expireCookie(ctx, {
 						name: multiSessionCookieName,
 						attributes: ctx.context.authCookies.sessionToken.attributes,
 					});
-					const isActive = ctx.context.session?.session.token === sessionToken;
+					const isActive = ctx.context.session?.session.token === sessionCookie;
 					if (!isActive) return ctx.json({ status: true });
 
 					const cookieHeader = ctx.headers?.get("cookie");

--- a/packages/better-auth/src/plugins/multi-session/multi-session.test.ts
+++ b/packages/better-auth/src/plugins/multi-session/multi-session.test.ts
@@ -295,4 +295,73 @@ describe("multi-session", async () => {
 		});
 		expect(attackerSessionAfter.data).toBeNull();
 	});
+
+	it("binds set-active and revoke to the signed cookie value, not the body token", async () => {
+		// A validly-signed multi-session cookie must only act on the session it was
+		// signed for. The signature covers the cookie value, not its name, so a
+		// request that presents its own valid cookie under another session's cookie
+		// name (naming that other token in the body) must not revoke the other
+		// session.
+		const callerUser = {
+			email: "ms-bind-caller@test.com",
+			password: "password",
+			name: "Caller",
+		};
+		const otherUser = {
+			email: "ms-bind-other@test.com",
+			password: "password",
+			name: "Other",
+		};
+
+		const callerHeaders = new Headers();
+		let callerToken = "";
+		let callerSignedMultiCookie = "";
+		await client.signUp.email(callerUser, {
+			onSuccess: cookieSetter(callerHeaders),
+			onResponse(context) {
+				const cookies = parseSetCookieHeader(
+					context.response.headers.get("set-cookie") || "",
+				);
+				callerToken =
+					cookies.get("better-auth.session_token")?.value.split(".")[0] || "";
+				callerSignedMultiCookie =
+					cookies.get(
+						`better-auth.session_token_multi-${callerToken.toLowerCase()}`,
+					)?.value || "";
+			},
+		});
+
+		const otherHeaders = new Headers();
+		let otherToken = "";
+		await client.signUp.email(otherUser, {
+			onSuccess: cookieSetter(otherHeaders),
+			onResponse(context) {
+				const cookies = parseSetCookieHeader(
+					context.response.headers.get("set-cookie") || "",
+				);
+				otherToken =
+					cookies.get("better-auth.session_token")?.value.split(".")[0] || "";
+			},
+		});
+		expect(callerSignedMultiCookie).not.toBe("");
+		expect(otherToken).not.toBe("");
+
+		// Place the caller's own validly-signed multi-session cookie under the other
+		// session's cookie name and name the other token in the request body.
+		const craftedHeaders = new Headers(callerHeaders);
+		craftedHeaders.set(
+			"cookie",
+			`${callerHeaders.get("cookie")}; better-auth.session_token_multi-${otherToken.toLowerCase()}=${callerSignedMultiCookie}`,
+		);
+
+		await client.multiSession.revoke(
+			{ sessionToken: otherToken },
+			{ headers: craftedHeaders },
+		);
+
+		const otherAfter = await client.getSession({
+			fetchOptions: { headers: otherHeaders },
+		});
+		expect(otherAfter.data?.session.token).toBe(otherToken);
+	});
 });

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -1795,9 +1795,45 @@ export const oidcProvider = (options: OIDCOptions) => {
 
 					const session = await getSessionFromCtx(ctx);
 
+					// Logout deletes the user's session and OAuth tokens, so on an HTTP
+					// request it must be proven intentional: the request is same-site (or
+					// from a trusted origin), or it carries an id_token_hint for the
+					// session being ended. Otherwise a cross-site GET could log the user
+					// out and revoke their tokens, which the global origin check does not
+					// prevent because it skips GET. A request whose site cannot be
+					// established, or a valid id_token_hint for a different user, does not
+					// authorize ending this session.
+					if (ctx.request && (validatedUserId || session)) {
+						const fetchSite = ctx.request.headers.get("Sec-Fetch-Site");
+						const originHeader =
+							ctx.request.headers.get("origin") ||
+							ctx.request.headers.get("referer");
+						const isSameSiteRequest =
+							fetchSite === "same-origin" ||
+							fetchSite === "same-site" ||
+							fetchSite === "none" ||
+							(!!originHeader &&
+								ctx.context.isTrustedOrigin(originHeader, {
+									allowRelativePaths: false,
+								}));
+						const hintMatchesSession =
+							!!validatedUserId && validatedUserId === session?.user.id;
+						if (!isSameSiteRequest && !hintMatchesSession) {
+							throw new APIError("FORBIDDEN", {
+								error: "invalid_request",
+								error_description:
+									"Logout must be same-site or carry an id_token_hint for the current session",
+							});
+						}
+					}
+
 					if (validatedUserId || session) {
 						const userId = validatedUserId || session?.user.id;
 						if (userId) {
+							// FIXME(next): scope deletion to the session/token family
+							// represented by the validated id_token_hint (sid) instead of
+							// every access token for the user. The successor
+							// @better-auth/oauth-provider logout already deletes by sid.
 							await ctx.context.adapter.deleteMany({
 								model: modelName.oauthAccessToken,
 								where: [{ field: "userId", value: userId }],

--- a/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/oidc.test.ts
@@ -980,6 +980,7 @@ describe("oidc", async () => {
 		it("should logout successfully without parameters", async ({ expect }) => {
 			const response = await serverClient.$fetch("/oauth2/endsession", {
 				method: "GET",
+				headers: { "Sec-Fetch-Site": "same-origin" },
 			});
 			expect(response.data).toMatchObject({
 				success: true,
@@ -995,6 +996,7 @@ describe("oidc", async () => {
 				`/oauth2/endsession?client_id=${application.clientId}&post_logout_redirect_uri=${encodeURIComponent(application.redirectUrls[0]!)}&state=test-state`,
 				{
 					method: "GET",
+					headers: { "Sec-Fetch-Site": "same-origin" },
 					onError(context) {
 						redirectLocation = context.response.headers.get("Location") || "";
 					},
@@ -1050,6 +1052,7 @@ describe("oidc", async () => {
 		it("should support POST method", async ({ expect }) => {
 			const response = await serverClient.$fetch("/oauth2/endsession", {
 				method: "POST",
+				headers: { "Sec-Fetch-Site": "same-origin" },
 			});
 			expect(response.data).toMatchObject({
 				success: true,
@@ -2186,5 +2189,80 @@ describe("oidc-provider discovery metadata and PKCE gate (security)", () => {
 			codeChallengeMethod?: string;
 		};
 		expect(storedValue.codeChallengeMethod).toBe("plain");
+	});
+});
+
+describe("oidc end session cross-site protection (security)", async () => {
+	const { auth, signInWithTestUser, db } = await getTestInstance({
+		baseURL: "http://localhost:3000",
+		plugins: [oidcProvider({ loginPage: "/login" })],
+	});
+	const { user, headers } = await signInWithTestUser();
+	const cookie = headers.get("cookie") ?? "";
+
+	async function seedAccessToken() {
+		await db.create({
+			model: "oauthApplication",
+			data: {
+				clientId: "endsession-csrf-client",
+				clientSecret: "endsession-csrf-secret",
+				type: "web",
+				name: "Endsession CSRF Client",
+				redirectUrls: "http://localhost/callback",
+				disabled: false,
+				metadata: null,
+				icon: null,
+				userId: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await db.create({
+			model: "oauthAccessToken",
+			data: {
+				accessToken: "endsession-csrf-access",
+				refreshToken: "endsession-csrf-refresh",
+				accessTokenExpiresAt: new Date(Date.now() + 3600 * 1000),
+				refreshTokenExpiresAt: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+				clientId: "endsession-csrf-client",
+				userId: user.id,
+				scopes: "openid",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+	}
+
+	it("rejects a cross-site GET logout carrying only a session cookie", async () => {
+		await seedAccessToken();
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/api/auth/oauth2/endsession", {
+				method: "GET",
+				headers: { cookie, "Sec-Fetch-Site": "cross-site" },
+			}),
+		);
+		expect(response.status).toBe(403);
+
+		// A blocked logout must leave the session and OAuth tokens intact.
+		const session = await auth.api.getSession({
+			headers: new Headers({ cookie }),
+		});
+		expect(session?.user.id).toBe(user.id);
+		const tokenRow = await db.findOne({
+			model: "oauthAccessToken",
+			where: [{ field: "accessToken", value: "endsession-csrf-access" }],
+		});
+		expect(tokenRow).not.toBeNull();
+	});
+
+	it("allows a same-site cookie-only logout", async () => {
+		const response = await auth.handler(
+			new Request("http://localhost:3000/api/auth/oauth2/endsession", {
+				method: "GET",
+				headers: { cookie, "Sec-Fetch-Site": "same-origin" },
+			}),
+		);
+		expect(response.status).toBe(200);
 	});
 });


### PR DESCRIPTION
Several sensitive flows decided authority from state that is not authoritative: the signed cookie-cache snapshot, which is only a read optimization, or a session token named in the request body. A session revoked server-side, an expired bearer token, or a request naming a session it does not hold could still act, because the authoritative source (the durable store, the token's own expiry, or the signed cookie value) was never consulted.

Each flow now consults that source:

- `/delete-user/callback` and API-key updates resolved the session with the cache enabled, unlike the sensitive endpoints beside them. They force a store read where a durable store exists.
- `getCookieCache` verified only the signature, so a well-signed but expired cookie read as live.
- The MCP resource endpoint never compared the access token's expiry, and the refresh grant never checked the granted scope.
- The multi-session endpoints trusted that a signed cookie existed under the requested name, but the signature binds the cookie value, not the name.
- OIDC logout accepted a state-changing GET, which the global origin check skips, so a cross-site navigation could trigger it.

Removing the refresh token from the MCP resource response would change a public type, so this change gates the token's redemption instead and leaves the response shape unchanged.
