### PR TITLE
feat(device-authorization): allow pre-binding device codes to a user

### DIFF
--- a/.changeset/device-code-user-binding.md
+++ b/.changeset/device-code-user-binding.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The device authorization plugin now accepts an optional `user_id` when issuing a device code via `/device/code`, pre-binding the code to that user. Only the bound user can approve or deny the code, so a publicly visible user code can no longer be claimed by someone else.

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -115,6 +115,12 @@ To initiate device authorization, call `device.code` with the client ID:
        * Space-separated list of requested scopes (optional)
        */
       scope?: string;
+      /**
+       * The user_id to which the device code should be pre-bound. 
+       * This can be used to prevent another authenticated user from
+       * claiming a device code before the intended user verifies it. (optional)
+       */
+      user_id?: string;
   }
   ```
 </APIMethod>
@@ -127,6 +133,7 @@ import { authClient } from "@/lib/auth-client"
 const { data } = await authClient.device.code({
   client_id: "your-client-id",
   scope: "openid profile email",
+  user_id: "your-user-id"
 });
 
 if (data) {

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -116,9 +116,9 @@ To initiate device authorization, call `device.code` with the client ID:
        */
       scope?: string;
       /**
-       * The user_id to which the device code should be pre-bound. 
-       * This can be used to prevent another authenticated user from
-       * claiming a device code before the intended user verifies it. (optional)
+       * The user ID to which the device code should be pre-bound.
+       * When set, only that user can approve or deny the code.
+       * Pass this from trusted server-side code only. (optional)
        */
       user_id?: string;
   }
@@ -133,7 +133,6 @@ import { authClient } from "@/lib/auth-client"
 const { data } = await authClient.device.code({
   client_id: "your-client-id",
   scope: "openid profile email",
-  user_id: "your-user-id"
 });
 
 if (data) {
@@ -142,6 +141,26 @@ if (data) {
   console.log(`Complete verification URL: ${data.verification_uri_complete}`);
 }
 ```
+
+### Pre-binding to a User
+
+If your server already knows which user a device belongs to, pass `user_id` when requesting the device code. The code is then bound to that user from the start. It skips the claiming step, and only the bound user can approve or deny it. Any other signed-in user receives an `access_denied` error.
+
+This is useful when the user code is displayed where others can see it, because no one else can claim the code before the intended user verifies it.
+
+```ts title="server.ts"
+const data = await auth.api.deviceCode({
+  body: {
+    client_id: "your-client-id",
+    scope: "openid profile email",
+    user_id: user.id,
+  },
+});
+```
+
+<Callout type="warn">
+  Pass `user_id` from trusted server-side code. The parameter only restricts who can approve the code, so an untrusted device cannot use it to access another user's account. The protection is only meaningful when your server controls how codes are issued.
+</Callout>
 
 ### Polling for Token
 
@@ -563,6 +582,7 @@ authenticateCLI().catch((err) => {
 4. **HTTPS Only**: Always use HTTPS in production for device authorization
 5. **User Code Format**: User codes use a limited character set (excluding similar-looking characters like 0/O, 1/I) to reduce typing errors
 6. **Authentication Required**: Users must be authenticated when calling `GET /device`. The verification step claims the pending device code for the calling session, and only that session can later approve or deny it
+7. **Pre-binding**: Device codes issued with `user_id` skip the claiming step and can only be approved or denied by that user. Pass `user_id` from trusted server-side code only
 
 ## Options
 

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -890,6 +890,117 @@ describe("device authorization ownership gate", () => {
 		});
 	});
 
+	it("rejects approve from a different user if the code was generated for a different user_id", async () => {
+		const { auth, client, signInWithTestUser, signInWithUser } =
+			await getTestInstance(
+				{
+					plugins: [
+						deviceAuthorization({
+							expiresIn: "5min",
+							interval: "2s",
+						}),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [deviceAuthorizationClient()],
+					},
+				},
+			);
+
+		const { user } = await signInWithTestUser();
+
+		await client.signUp.email({
+			email: ATTACKER_EMAIL,
+			password: ATTACKER_PASSWORD,
+			name: "attacker",
+		});
+		const { headers: attackerHeaders } = await signInWithUser(
+			ATTACKER_EMAIL,
+			ATTACKER_PASSWORD,
+		);
+
+		const { user_code } = await auth.api.deviceCode({
+			body: {
+				client_id: "test-client",
+				user_id: user.id,
+			},
+		});
+
+		await expect(
+			auth.api.deviceApprove({
+				body: { userCode: user_code },
+				headers: attackerHeaders,
+			}),
+		).rejects.toMatchObject({
+			status: "FORBIDDEN",
+			body: { error: "access_denied" },
+		});
+
+		await expect(
+			auth.api.deviceDeny({
+				body: { userCode: user_code },
+				headers: attackerHeaders,
+			}),
+		).rejects.toMatchObject({
+			status: "FORBIDDEN",
+			body: { error: "access_denied" },
+		});
+	});
+
+	it("allows approve when the pre-bound user matches the current user", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				deviceAuthorization({
+					expiresIn: "5min",
+					interval: "2s",
+				}),
+			],
+		});
+
+		const { headers: legitHeaders, user } = await signInWithTestUser();
+
+		const { user_code } = await auth.api.deviceCode({
+			body: {
+				client_id: "test-client",
+				user_id: user.id,
+			},
+		});
+
+		const approve = await auth.api.deviceApprove({
+			body: { userCode: user_code },
+			headers: legitHeaders,
+		});
+		expect(approve).toMatchObject({ success: true });
+	});
+
+	it("allows deny when the pre-bound user matches the current user", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				deviceAuthorization({
+					expiresIn: "5min",
+					interval: "2s",
+				}),
+			],
+		});
+
+		const { headers: legitHeaders, user } = await signInWithTestUser();
+
+		const { user_code } = await auth.api.deviceCode({
+			body: {
+				client_id: "test-client",
+				user_id: user.id,
+			},
+		});
+
+		const deny = await auth.api.deviceDeny({
+			body: { userCode: user_code },
+			headers: legitHeaders,
+		});
+
+		expect(deny).toMatchObject({ success: true });
+	});
+
 	it("does not overwrite a device code claimed after verify reads it", async () => {
 		let adapter: DBAdapter<BetterAuthOptions> | null = null;
 		let concurrentOwnerId: string | undefined;

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -1001,6 +1001,41 @@ describe("device authorization ownership gate", () => {
 		expect(deny).toMatchObject({ success: true });
 	});
 
+	/**
+	 * @see https://datatracker.ietf.org/doc/html/rfc8628#section-3.1
+	 */
+	it("treats an empty user_id as omitted and leaves the code unbound", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				deviceAuthorization({
+					expiresIn: "5min",
+					interval: "2s",
+				}),
+			],
+		});
+
+		const { headers } = await signInWithTestUser();
+
+		const { user_code } = await auth.api.deviceCode({
+			body: {
+				client_id: "test-client",
+				user_id: "",
+			},
+		});
+
+		// The unbound code is claimable by any signed-in user via verify
+		await auth.api.deviceVerify({
+			query: { user_code },
+			headers,
+		});
+
+		const approve = await auth.api.deviceApprove({
+			body: { userCode: user_code },
+			headers,
+		});
+		expect(approve).toMatchObject({ success: true });
+	});
+
 	it("does not overwrite a device code claimed after verify reads it", async () => {
 		let adapter: DBAdapter<BetterAuthOptions> | null = null;
 		let concurrentOwnerId: string | undefined;

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -15,6 +15,12 @@ const deviceCodeBodySchema = z.object({
 	client_id: z.string().meta({
 		description: "The client ID of the application",
 	}),
+	user_id: z
+		.string()
+		.meta({
+			description: "The user ID to which the request should be pre-bound.",
+		})
+		.optional(),
 	scope: z
 		.string()
 		.meta({
@@ -146,7 +152,7 @@ Follow [rfc8628#section-3.2](https://datatracker.ietf.org/doc/html/rfc8628#secti
 				data: {
 					deviceCode,
 					userCode,
-					userId: null,
+					userId: ctx.body.user_id ?? null,
 					expiresAt,
 					status: "pending",
 					pollingInterval: ms(opts.interval),

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -18,7 +18,7 @@ const deviceCodeBodySchema = z.object({
 	user_id: z
 		.string()
 		.meta({
-			description: "The user ID to which the request should be pre-bound.",
+			description: "The user ID to which the device code should be pre-bound.",
 		})
 		.optional(),
 	scope: z
@@ -152,7 +152,7 @@ Follow [rfc8628#section-3.2](https://datatracker.ietf.org/doc/html/rfc8628#secti
 				data: {
 					deviceCode,
 					userCode,
-					userId: ctx.body.user_id ?? null,
+					userId: ctx.body.user_id || null, // An empty user_id is treated as omitted, per RFC 8628 section 3.1
 					expiresAt,
 					status: "pending",
 					pollingInterval: ms(opts.interval),


### PR DESCRIPTION
## Summary

Adds an optional `user_id` parameter to `device.code()`.

When specified, the device code is pre-bound to the given user and can only be approved or denied by that user.

## Use Case

This helps prevent another authenticated user from claiming a device code before the intended user verifies it.

## Changes

- Added optional `user_id` to `/device/code`
- Updated device code claiming logic
- Added tests for valid and invalid users
- Updated documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `user_id` to `device.code()` to pre-bind a device code to a specific user, blocking other signed-in users from approving or denying it. Empty `user_id` values are treated as omitted per RFC 8628.

- **New Features**
  - Add `user_id` to `/device/code` and `device.code()` to bind codes to a user.
  - Approve/Deny now enforce ownership: mismatched users get `access_denied`.
  - Treat empty `user_id` as omitted (RFC 8628); docs updated to recommend server-side use only; tests added.

<sup>Written for commit 4537e389695a22281b706463062dbf7774ba3f88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

