### PR TITLE
fix(security): harden proxy host header validation against ReDoS

### DIFF
--- a/packages/better-auth/src/utils/url.test.ts
+++ b/packages/better-auth/src/utils/url.test.ts
@@ -290,6 +290,49 @@ describe("getBaseURL", () => {
 
 			expect(result).toBe("https://api.v1.staging.example.com/auth");
 		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/8898
+		 */
+		describe("RFC-1035 length bounds (ReDoS hardening)", () => {
+			it("should reject hostnames longer than 255 chars", () => {
+				const tooLong = `${"a".repeat(254)}.com`;
+				const request = new Request("http://localhost:3000/test", {
+					headers: {
+						"x-forwarded-host": tooLong,
+						"x-forwarded-proto": "http",
+					},
+				});
+
+				const result = getBaseURL(undefined, "/auth", request, false, true);
+				expect(result).toBe("http://localhost:3000/auth");
+			});
+
+			it("should reject a label longer than 63 chars (RFC 1035)", () => {
+				const longLabel = `${"a".repeat(64)}.example.com`;
+				const request = new Request("http://localhost:3000/test", {
+					headers: {
+						"x-forwarded-host": longLabel,
+						"x-forwarded-proto": "http",
+					},
+				});
+
+				const result = getBaseURL(undefined, "/auth", request, false, true);
+				expect(result).toBe("http://localhost:3000/auth");
+			});
+
+			it("should reject a hyphen-tailed hostname (must end alphanumeric)", () => {
+				const request = new Request("http://localhost:3000/test", {
+					headers: {
+						"x-forwarded-host": "example-.com",
+						"x-forwarded-proto": "http",
+					},
+				});
+
+				const result = getBaseURL(undefined, "/auth", request, false, true);
+				expect(result).toBe("http://localhost:3000/auth");
+			});
+		});
 	});
 });
 

--- a/packages/better-auth/src/utils/url.ts
+++ b/packages/better-auth/src/utils/url.ts
@@ -88,6 +88,45 @@ function withPath(url: string, path = "/api/auth") {
 	return `${trimmedUrl}${path}`;
 }
 
+// Per RFC 1035: a DNS label is 1–63 chars of alphanumeric + hyphens, may not
+// start or end with a hyphen; total hostname length is at most 253 chars.
+// Single-label match — no quantifier nesting, so safe from ReDoS.
+const HOSTNAME_LABEL_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+
+function isValidHostnameHeader(header: string): boolean {
+	// Reject pathologically long inputs before any per-label work — a long string
+	// ending in `-` was the catastrophic-backtracking trigger on the previous
+	// nested-quantifier regex (see better-auth#8898).
+	if (header.length === 0 || header.length > 255) {
+		return false;
+	}
+
+	// Split off the optional `:port` suffix, then validate hostname labels
+	// individually. Per-label matching has no outer repetition over an
+	// optional inner group, so no ReDoS.
+	const colonIndex = header.lastIndexOf(":");
+	let hostname = header;
+	if (colonIndex !== -1) {
+		const portString = header.slice(colonIndex + 1);
+		if (!/^[0-9]{1,5}$/.test(portString)) {
+			return false;
+		}
+		hostname = header.slice(0, colonIndex);
+	}
+
+	if (hostname.length === 0 || hostname.length > 253) {
+		return false;
+	}
+
+	const labels = hostname.split(".");
+	for (const label of labels) {
+		if (!HOSTNAME_LABEL_REGEX.test(label)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 function validateProxyHeader(header: string, type: "host" | "proto"): boolean {
 	if (!header || header.trim() === "") {
 		return false;
@@ -114,11 +153,6 @@ function validateProxyHeader(header: string, type: "host" | "proto"): boolean {
 			return false;
 		}
 
-		// Basic hostname validation (allows localhost, IPs, and domains with ports)
-		// This is a simple check, not exhaustive RFC validation
-		const hostnameRegex =
-			/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(:[0-9]{1,5})?$/;
-
 		// Also allow IPv4 addresses
 		const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}(:[0-9]{1,5})?$/;
 
@@ -129,7 +163,7 @@ function validateProxyHeader(header: string, type: "host" | "proto"): boolean {
 		const localhostRegex = /^localhost(:[0-9]{1,5})?$/i;
 
 		return (
-			hostnameRegex.test(header) ||
+			isValidHostnameHeader(header) ||
 			ipv4Regex.test(header) ||
 			ipv6Regex.test(header) ||
 			localhostRegex.test(header)


### PR DESCRIPTION
Closes #8898.

## Summary

The `hostnameRegex` in `validateProxyHeader` (`packages/better-auth/src/utils/url.ts`) had nested quantifiers — the inner `([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?` group is itself optional and lives inside the outer `*` repetition of dotted labels:

```ts
/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(:[0-9]{1,5})?$/
```

That shape is the catastrophic-backtracking pattern flagged by safe-regex linters: a crafted `x-forwarded-host` value (e.g. a long string of alphanumeric-hyphen segments that does not end alphanumeric) could pin a CPU per request.

## Fix

Replace the monolithic regex with a label-by-label validator:

- Cap total hostname length at 255 chars and per-label at 63 chars per RFC 1035, **before** any per-label work, so adversarial inputs are rejected without scanning.
- Split off an optional `:port` suffix once on the last `:` and check it with `/^[0-9]{1,5}$/` (no repetition over an optional group).
- Validate each `.`-separated label with a single non-nested anchor pattern: `^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`. The optional group has no outer repetition, so worst case is linear in label length.

Existing `ipv4Regex` / `ipv6Regex` / `localhostRegex` are unchanged — none of them have nested quantifiers, so they're already safe.

## Tests

New `RFC-1035 length bounds (ReDoS hardening)` block in `url.test.ts`:

- Hostname > 255 chars is rejected.
- Single label > 63 chars (RFC 1035 label limit) is rejected.
- Hyphen-tailed label is rejected (must end alphanumeric — the input class that drove the original report).

All 60 existing tests in `url.test.ts` continue to pass; `pnpm typecheck` is clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened proxy Host header validation to remove a ReDoS risk by replacing the nested-quantifier hostname regex with linear-time, label-by-label checks. Adds tests for RFC 1035 bounds and common bad inputs.

- **Bug Fixes**
  - Replaced hostname regex with `isValidHostnameHeader` (splits optional `:port`, validates each label).
  - Enforced RFC 1035 limits: hostname ≤253, label ≤63; early-reject headers >255.
  - Kept IPv4/IPv6/`localhost` validation unchanged.
  - Added tests for >255 hostnames, >63 labels, and hyphen-tailed hostnames; existing tests still pass.

<sup>Written for commit 70cdc9cb9745333285192dfe1548db011c6f4b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

