### PR TITLE
chore: add bugs metadata for drizzle adapter

### DIFF
--- a/packages/drizzle-adapter/package.json
+++ b/packages/drizzle-adapter/package.json
@@ -58,5 +58,8 @@
     "drizzle-orm": "^0.45.2",
     "tsdown": "catalog:",
     "typescript": "catalog:"
+  },
+  "bugs": {
+    "url": "https://github.com/better-auth/better-auth/issues"
   }
 }


### PR DESCRIPTION
## Summary
- add npm bugs metadata for the @better-auth/drizzle-adapter package so package tooling can link to the GitHub issue tracker

## Validation
- npm view @better-auth/drizzle-adapter@1.6.16 name version repository homepage bugs license --json
- verified the fork branch package manifest has bugs.url = https://github.com/better-auth/better-auth/issues
- verified the branch is 1 commit ahead and only changes packages/drizzle-adapter/package.json

Charles microbounty: https://github.com/charles-openclaw/charles-microbounties/issues/1192

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add npm `bugs.url` metadata to `@better-auth/drizzle-adapter`, pointing to https://github.com/better-auth/better-auth/issues. This lets npm and other tooling link users directly to the repo’s issue tracker.

<sup>Written for commit b582ee8e4a11f343511a9f51aec423a65e96f543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

