### PR TITLE
fix: register set-password route

### DIFF
--- a/.changeset/set-password-route.md
+++ b/.changeset/set-password-route.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix `authClient.setPassword` returning 404 by registering the `/set-password` route.

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { createAuthClient } from "../../client";
 import { inferAdditionalFields } from "../../client/plugins";
+import { anonymous } from "../../plugins/anonymous";
+import { anonymousClient } from "../../plugins/anonymous/client";
 import { getTestInstance } from "../../test-utils/test-instance";
 import type { Account, Session } from "../../types";
 
@@ -216,6 +218,60 @@ describe("updateUser", async () => {
 		expect(new Date(newUpdatedAt).getTime()).toBeGreaterThan(
 			new Date(initialUpdatedAt).getTime(),
 		);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9994
+	 */
+	it("should set password for a session without a credential account", async () => {
+		const { client, sessionSetter, db } = await getTestInstance(
+			{
+				plugins: [anonymous()],
+			},
+			{
+				clientOptions: {
+					plugins: [anonymousClient()],
+				},
+				disableTestUser: true,
+			},
+		);
+
+		const headers = new Headers();
+		const anonymousSignIn = await client.signIn.anonymous({
+			fetchOptions: {
+				onSuccess: sessionSetter(headers),
+			},
+		});
+		const userId = anonymousSignIn.data?.user.id;
+
+		expect(anonymousSignIn.error).toBeNull();
+		expect(userId).toBeDefined();
+
+		const res = await client.setPassword({
+			newPassword: "securepassword123",
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(res.error).toBeNull();
+		expect(res.data?.status).toBe(true);
+
+		const credentialAccounts: Account[] = await db.findMany({
+			model: "account",
+			where: [
+				{
+					field: "userId",
+					value: userId!,
+				},
+				{
+					field: "providerId",
+					value: "credential",
+				},
+			],
+		});
+		expect(credentialAccounts).toHaveLength(1);
+		expect(credentialAccounts[0]?.password).toBeTruthy();
 	});
 
 	it("should not update password if current password is wrong", async () => {

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -315,8 +315,10 @@ export const changePassword = createAuthEndpoint(
 );
 
 export const setPassword = createAuthEndpoint(
+	"/set-password",
 	{
 		method: "POST",
+		operationId: "setPassword",
 		body: z.object({
 			/**
 			 * The new password to set
@@ -326,6 +328,31 @@ export const setPassword = createAuthEndpoint(
 			}),
 		}),
 		use: [sensitiveSessionMiddleware],
+		metadata: {
+			openapi: {
+				operationId: "setPassword",
+				description: "Set the password for the user",
+				responses: {
+					"200": {
+						description: "Password successfully set",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										status: {
+											type: "boolean",
+											description: "Indicates if the password was set",
+										},
+									},
+									required: ["status"],
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	},
 	async (ctx) => {
 		const { newPassword } = ctx.body;

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -3739,6 +3739,157 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
         ],
       },
     },
+    "/set-password": {
+      "post": {
+        "description": "Set the password for the user",
+        "operationId": "setPassword",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "newPassword": {
+                    "description": "The new password to set is required",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "newPassword",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "status": {
+                      "description": "Indicates if the password was set",
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "status",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Password successfully set",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Bad Request. Usually due to missing parameters, or invalid parameters.",
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Unauthorized. Due to missing or invalid authentication.",
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Forbidden. You do not have permission to access this resource or to perform this action.",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Not Found. The requested resource was not found.",
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Too Many Requests. You have exceeded the rate limit. Try again later.",
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Internal Server Error. This is a problem with the server that you cannot fix.",
+          },
+        },
+        "security": [
+          {
+            "bearerAuth": [],
+          },
+        ],
+        "tags": [
+          "Default",
+        ],
+      },
+    },
     "/sign-in/email": {
       "post": {
         "description": "Sign in with email and password",


### PR DESCRIPTION
Fixes #9994.

`authClient.setPassword()` was hitting `/set-password`, but the server endpoint did not have that route registered, so it returned 404. This wires the endpoint up, adds a regression test, updates the OpenAPI snapshot, and includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the `/set-password` server route so `authClient.setPassword()` no longer returns 404 and can set a password for sessions without a credential account. Adds OpenAPI metadata and tests to prevent regressions, fixing #9994.

- **Bug Fixes**
  - Register `/set-password` endpoint with `operationId: setPassword`.
  - Add regression test covering anonymous → credential account creation.
  - Update OpenAPI snapshot with request/response schema.
  - Add patch changeset for `better-auth`.

<sup>Written for commit 35c31e5c4ad7f79df1bd78fb5f524caa8b0e7e34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

