### PR TITLE
docs: highlighted emailVerified requirement on manually inserted users

### DIFF
--- a/docs/content/docs/reference/errors/account_not_linked.mdx
+++ b/docs/content/docs/reference/errors/account_not_linked.mdx
@@ -24,6 +24,7 @@ This error occurs during an OAuth flow when a provider account is not linked to 
 ### Verify user identity matching
 
 * Ensure the provider returns a verified email that matches an existing user.
+* Ensure a manually inserted user has their "emailVerified" set to "true".
 
 ### Prompt user action
 

--- a/docs/content/docs/reference/errors/account_not_linked.mdx
+++ b/docs/content/docs/reference/errors/account_not_linked.mdx
@@ -24,7 +24,7 @@ This error occurs during an OAuth flow when a provider account is not linked to 
 ### Verify user identity matching
 
 * Ensure the provider returns a verified email that matches an existing user.
-* Ensure a manually inserted user has their "emailVerified" set to "true".
+* Ensure the matching existing user has `emailVerified: true`, especially if the user row was inserted manually.
 
 ### Prompt user action
 


### PR DESCRIPTION
I added a bullet point to the heading "Verify user identity matching"
saying "Ensure a manually inserted user has their "emailVerified" set to "true"."

Our organization syncs our Active Directory with the User table every day, it was creating users with "emailVerified: false".
In 1.4.6 it was allowing the accounts to link with "emailVerified: false" but in 1.6.16 it requires "emailVerified: true".

It took me a few hours to identify that this flag was causing the linking problem and i thought maybe this would help someone else find the issue faster.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the account_not_linked error docs: during OAuth linking, the matching existing user must have `emailVerified: true`, especially for manually inserted rows. Added this as a bullet under “Verify user identity matching”.

<sup>Written for commit 8579bdac9ee5bc7ef236e20d18793f0c0e98045e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/9999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

