### PR TITLE
feat(auth)!: harden atomic state transitions

### DIFF
--- a/.changeset/accept-invitation-team-capacity.md
+++ b/.changeset/accept-invitation-team-capacity.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Accepting a team invitation now checks the team's member limit before adding the member, inside a transaction. Previously the member was created first and the count compared afterward, so a team one slot below its limit wrongly rejected the member that should have fit and left an orphaned membership row; concurrent accepts could also exceed the limit.

--- a/.changeset/accept-invitation-team-capacity.md
+++ b/.changeset/accept-invitation-team-capacity.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": patch
+"better-auth": minor
 ---
 
-Accepting a team invitation now checks the team's member limit before adding the member and releases the invitation claim back to pending if the membership work fails. Previously the member was created first and the count compared afterward, so a team one slot below its limit wrongly rejected the member that should have fit and left an orphaned membership row. Full cross-adapter concurrent capacity enforcement still requires a durable per-team capacity lock/counter.
+Team capacity now uses a durable `team.memberCount` counter and an internal unique `teamMember.membershipKey` so `maximumMembersPerTeam` is enforced atomically across invitation acceptance, direct team-member adds, and add-member-with-team calls. Previously the team limit relied on count-then-create checks that could admit multiple concurrent members into one remaining slot.

--- a/.changeset/accept-invitation-team-capacity.md
+++ b/.changeset/accept-invitation-team-capacity.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Accepting a team invitation now checks the team's member limit before adding the member, inside a transaction. Previously the member was created first and the count compared afterward, so a team one slot below its limit wrongly rejected the member that should have fit and left an orphaned membership row; concurrent accepts could also exceed the limit.
+Accepting a team invitation now checks the team's member limit before adding the member and releases the invitation claim back to pending if the membership work fails. Previously the member was created first and the count compared afterward, so a team one slot below its limit wrongly rejected the member that should have fit and left an orphaned membership row. Full cross-adapter concurrent capacity enforcement still requires a durable per-team capacity lock/counter.

--- a/.changeset/adapters-native-increment-one.md
+++ b/.changeset/adapters-native-increment-one.md
@@ -1,0 +1,9 @@
+---
+"@better-auth/memory-adapter": patch
+"@better-auth/kysely-adapter": patch
+"@better-auth/drizzle-adapter": patch
+"@better-auth/prisma-adapter": patch
+"@better-auth/mongo-adapter": patch
+---
+
+The memory, Kysely, Drizzle, Prisma, and MongoDB adapters now implement `incrementOne` natively (a single atomic statement: an arithmetic `UPDATE ... RETURNING`, Prisma's atomic increment, or Mongo's `findOneAndUpdate` with `$inc`). Guarded counter updates no longer depend on the transaction-based fallback, so they stay atomic even on the default configuration where adapter transactions are not enabled.

--- a/.changeset/api-key-atomic-quota.md
+++ b/.changeset/api-key-atomic-quota.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/api-key": patch
+---
+
+API key usage quotas and per-key rate limits are now enforced with atomic guarded updates against the database row. Concurrent verifications of the same key can no longer drive `remaining` below zero or push `requestCount` past the configured maximum. Secondary-storage-only deployments (without `fallbackToDatabase`) keep a best-effort read-modify-write for these counters, since there is no database row to guard.

--- a/.changeset/delete-account-token-single-use.md
+++ b/.changeset/delete-account-token-single-use.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The delete-account confirmation token is now consumed before the account is deleted, so concurrent callbacks carrying the same token can no longer run the deletion more than once.

--- a/.changeset/device-code-single-use.md
+++ b/.changeset/device-code-single-use.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Approved device codes are now claimed atomically during token polling, so concurrent polls can no longer redeem the same device code more than once.

--- a/.changeset/electron-code-single-use.md
+++ b/.changeset/electron-code-single-use.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/electron": patch
+---
+
+Electron authorization codes are now consumed atomically, so concurrent token exchanges of the same code can no longer both mint a session.

--- a/.changeset/email-otp-attempts-atomic.md
+++ b/.changeset/email-otp-attempts-atomic.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": patch
+"better-auth": minor
 ---
 
 Email OTP verification now consumes the code atomically and tracks failed attempts without a race, so concurrent submissions can no longer replay a single-use code or slip past the attempt limit.

--- a/.changeset/email-otp-attempts-atomic.md
+++ b/.changeset/email-otp-attempts-atomic.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Email OTP verification now consumes the code atomically and tracks failed attempts without a race, so concurrent submissions can no longer replay a single-use code or slip past the attempt limit.

--- a/.changeset/hibp-password-paths.md
+++ b/.changeset/hibp-password-paths.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The Have I Been Pwned plugin now checks submitted passwords against the breach database on more password-setting endpoints by default, including the email-OTP and phone-number reset-password routes and the admin create-user and set-user-password routes. A breached password can no longer be set through those routes when the plugin is enabled with its default paths.

--- a/.changeset/increment-one-primitive.md
+++ b/.changeset/increment-one-primitive.md
@@ -1,5 +1,5 @@
 ---
-"@better-auth/core": patch
+"@better-auth/core": minor
 ---
 
-Add the `incrementOne` adapter primitive and the optional `SecondaryStorage.increment` method. `incrementOne` atomically applies signed numeric deltas to a single row under a where-clause guard (for example, decrementing a remaining-uses counter only while it is still positive) and returns the updated row, or null when the guard matched no row. Adapters that do not implement it natively get a transaction-based compare-and-swap fallback. `SecondaryStorage.increment` atomically increments a counter and sets its time-to-live only when the key is first created.
+Add the required `incrementOne` adapter primitive and required `SecondaryStorage.increment` method. `incrementOne` atomically applies signed numeric deltas to a single row under a where-clause guard (for example, decrementing a remaining-uses counter only while it is still positive) and returns the updated row, or null when the guard matched no row. Custom adapters must implement this primitive natively; Better Auth no longer provides a transaction-based fallback for guarded increments. `SecondaryStorage.increment` atomically increments a counter and sets its time-to-live only when the key is first created.

--- a/.changeset/increment-one-primitive.md
+++ b/.changeset/increment-one-primitive.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Add the `incrementOne` adapter primitive and the optional `SecondaryStorage.increment` method. `incrementOne` atomically applies signed numeric deltas to a single row under a where-clause guard (for example, decrementing a remaining-uses counter only while it is still positive) and returns the updated row, or null when the guard matched no row. Adapters that do not implement it natively get a transaction-based compare-and-swap fallback. `SecondaryStorage.increment` atomically increments a counter and sets its time-to-live only when the key is first created.

--- a/.changeset/memory-adapter-transaction-isolation.md
+++ b/.changeset/memory-adapter-transaction-isolation.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/memory-adapter": patch
+---
+
+Memory adapter transactions are now isolated. A transaction that throws no longer restores the whole database, so it can no longer erase rows written by other operations running at the same time. A singular `update` or `delete` called with an empty filter is now a no-op instead of changing every row, and `updateMany` returns the number of affected rows.

--- a/.changeset/one-time-token-single-use.md
+++ b/.changeset/one-time-token-single-use.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+One-time tokens are now consumed atomically, so two concurrent redemptions of the same token can no longer both return a session.

--- a/.changeset/passkey-ceremony-binding.md
+++ b/.changeset/passkey-ceremony-binding.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/passkey": patch
+---
+
+Passkey challenges are now bound to the ceremony that created them, so a registration can no longer consume an authentication challenge (or the reverse). Registration is also rejected when the resolved target user id is empty.

--- a/.changeset/password-reset-token-single-use.md
+++ b/.changeset/password-reset-token-single-use.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Password reset tokens are now consumed atomically before the password changes, so two concurrent reset requests carrying the same token can no longer both succeed.

--- a/.changeset/phone-otp-attempts-atomic.md
+++ b/.changeset/phone-otp-attempts-atomic.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Phone number OTP verification now consumes the code atomically and tracks failed attempts without a race, so concurrent submissions can no longer replay a single-use code or slip past the attempt limit.

--- a/.changeset/phone-otp-attempts-atomic.md
+++ b/.changeset/phone-otp-attempts-atomic.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": patch
+"better-auth": minor
 ---
 
 Phone number OTP verification now consumes the code atomically and tracks failed attempts without a race, so concurrent submissions can no longer replay a single-use code or slip past the attempt limit.

--- a/.changeset/rate-limit-atomic-consume.md
+++ b/.changeset/rate-limit-atomic-consume.md
@@ -1,0 +1,6 @@
+---
+"@better-auth/core": patch
+"better-auth": patch
+---
+
+Rate limiting is now enforced in a single atomic step on the request instead of checking the count on the request and incrementing it on the response. Concurrent requests can no longer all pass the same stale count and bypass the limit. The in-memory store is now bounded (expired entries are swept and the map is capped), and the database backend prunes expired rows in the background. A new optional `consume` method on the rate-limit storage contract performs the atomic check-and-increment (backed by `incrementOne` for the database and by `SecondaryStorage.increment` for secondary storage); a storage without it falls back to the previous best-effort behavior with a one-time warning.

--- a/.changeset/rate-limit-atomic-consume.md
+++ b/.changeset/rate-limit-atomic-consume.md
@@ -1,6 +1,6 @@
 ---
-"@better-auth/core": patch
-"better-auth": patch
+"@better-auth/core": minor
+"better-auth": minor
 ---
 
-Rate limiting is now enforced in a single atomic step on the request instead of checking the count on the request and incrementing it on the response. Concurrent requests can no longer all pass the same stale count and bypass the limit. The in-memory store is now bounded (expired entries are swept and the map is capped), and the database backend prunes expired rows in the background. A new optional `consume` method on the rate-limit storage contract performs the atomic check-and-increment (backed by `incrementOne` for the database and by `SecondaryStorage.increment` for secondary storage); a storage without it falls back to the previous best-effort behavior with a one-time warning.
+Rate limiting is now enforced in a single atomic step on the request instead of checking the count on the request and incrementing it on the response. Concurrent requests can no longer all pass the same stale count and bypass the limit. The in-memory store is now bounded (expired entries are swept and the map is capped), and the database backend prunes expired rows in the background. `BetterAuthRateLimitStorage` now requires a `consume` method that performs the atomic check-and-increment directly; separate `get`/`set` rate-limit storage is no longer accepted.

--- a/.changeset/redis-increment.md
+++ b/.changeset/redis-increment.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/redis-storage": patch
+---
+
+Redis secondary storage now implements `increment`, an atomic counter for rate limiting that sets the key's time-to-live only when the key is first created, so a window can no longer be extended by sustained traffic.

--- a/.changeset/reserve-verification-value.md
+++ b/.changeset/reserve-verification-value.md
@@ -1,6 +1,6 @@
 ---
-"@better-auth/core": patch
-"better-auth": patch
+"@better-auth/core": minor
+"better-auth": minor
 ---
 
-Add `internalAdapter.reserveVerificationValue`, a first-writer-wins create keyed by a deterministic primary key. It atomically records a single-use marker (such as a replay tombstone) so that exactly one concurrent caller succeeds and every other observes that the marker is already taken. The database path is atomic through the primary key; secondary-storage-only verification is best-effort.
+Add `internalAdapter.reserveVerificationValue`, a first-writer-wins create keyed by a deterministic primary key. It atomically records a single-use marker (such as a replay tombstone) so that exactly one concurrent caller succeeds and every other observes that the marker is already taken. Reservation requires database-backed verification storage; secondary-storage-only verification fails closed because it has no primary key boundary for the marker.

--- a/.changeset/reserve-verification-value.md
+++ b/.changeset/reserve-verification-value.md
@@ -1,0 +1,6 @@
+---
+"@better-auth/core": patch
+"better-auth": patch
+---
+
+Add `internalAdapter.reserveVerificationValue`, a first-writer-wins create keyed by a deterministic primary key. It atomically records a single-use marker (such as a replay tombstone) so that exactly one concurrent caller succeeds and every other observes that the marker is already taken. The database path is atomic through the primary key; secondary-storage-only verification is best-effort.

--- a/.changeset/saml-replay-reserve.md
+++ b/.changeset/saml-replay-reserve.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+SAML assertion replay protection is now atomic. The used-assertion tombstone was written with a non-atomic find-then-create, so two concurrent submissions of the same assertion could both pass the check and proceed. It now reserves the assertion id in a single atomic step, so a replayed assertion is rejected even under concurrent requests.

--- a/.changeset/siwe-nonce-single-use.md
+++ b/.changeset/siwe-nonce-single-use.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The Sign-In with Ethereum nonce is now consumed atomically before signature verification, so the same nonce can no longer replay a sign-in under concurrent requests.

--- a/.changeset/two-factor-challenge-single-use.md
+++ b/.changeset/two-factor-challenge-single-use.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Two-factor sign-in challenges are now single-use and expiry-checked. An expired challenge can no longer complete login when paired with a valid TOTP, OTP, or backup code, and two concurrent verifications of the same challenge can no longer each create a session.

--- a/.changeset/twofactor-otp-attempts-atomic.md
+++ b/.changeset/twofactor-otp-attempts-atomic.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": patch
+"better-auth": minor
 ---
 
 Two-factor OTP verification now consumes the code atomically and tracks failed attempts without a race, so concurrent submissions can no longer replay a single-use code or slip past the attempt limit.

--- a/.changeset/twofactor-otp-attempts-atomic.md
+++ b/.changeset/twofactor-otp-attempts-atomic.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Two-factor OTP verification now consumes the code atomically and tracks failed attempts without a race, so concurrent submissions can no longer replay a single-use code or slip past the attempt limit.

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -133,6 +133,8 @@ To use secondary storage, implement the `SecondaryStorage` interface:
 ```typescript
 interface SecondaryStorage {
   get: (key: string) => Promise<unknown>;
+  getAndDelete: (key: string) => Promise<unknown>;
+  increment: (key: string, ttl: number) => Promise<number>;
   set: (key: string, value: string, ttl?: number) => Promise<void>;
   delete: (key: string) => Promise<void>;
 }
@@ -195,11 +197,29 @@ import { betterAuth } from "better-auth";
 const redis = createClient();
 await redis.connect();
 
+const incrementScript = `
+local value = redis.call("INCR", KEYS[1])
+if value == 1 then
+  redis.call("EXPIRE", KEYS[1], ARGV[1])
+end
+return value
+`;
+
 export const auth = betterAuth({
 	// ... other options
 	secondaryStorage: {
 		get: async (key) => {
 			return await redis.get(key);
+		},
+		getAndDelete: async (key) => {
+			return await redis.getDel(key);
+		},
+		increment: async (key, ttl) => {
+			const value = await redis.eval(incrementScript, {
+				keys: [key],
+				arguments: [String(ttl)],
+			});
+			return Number(value);
 		},
 		set: async (key, value, ttl) => {
 			if (ttl) await redis.set(key, value, { EX: ttl });

--- a/docs/content/docs/concepts/rate-limit.mdx
+++ b/docs/content/docs/concepts/rate-limit.mdx
@@ -226,16 +226,20 @@ export const auth = betterAuth({
     //...other options
     rateLimit: {
         customStorage: {
-            get: async (key) => {
-                // get rate limit data
-            },
-            set: async (key, value) => {
-                // set rate limit data
+            consume: async (key, rule) => {
+                // atomically record one request for `key`
+                // rule.window is in seconds, rule.max is the request limit
+                return {
+                    allowed: true,
+                    retryAfter: null,
+                };
             },
         },
     },
 })
 ```
+
+`customStorage.consume` must check and increment in one operation. Better Auth no longer accepts separate `get` and `set` methods for rate limiting because that shape can allow concurrent requests to pass the same stale counter.
 
 ## Handling Rate Limit Errors
 

--- a/docs/content/docs/guides/create-a-db-adapter.mdx
+++ b/docs/content/docs/guides/create-a-db-adapter.mdx
@@ -251,9 +251,9 @@ deleteMany: async ({ model, where }) => {
 };
 ```
 
-### `consumeOne` method (optional)
+### `consumeOne` method
 
-The `consumeOne` method atomically deletes a single matching record and returns it, so that two concurrent requests cannot both consume the same row. It powers single-use credentials such as one-time verification challenges. Implementing it is optional: when omitted, the adapter factory falls back to wrapping `findMany` + `deleteMany` in a `transaction`, using the deleted-row count as the race gate.
+The `consumeOne` method atomically deletes a single matching record and returns it, so that two concurrent requests cannot both consume the same row. It powers single-use credentials such as one-time verification challenges.
 
 parameters:
 
@@ -270,8 +270,39 @@ consumeOne: async ({ model, where }) => {
 };
 ```
 
-<Callout type="info">
-  Although the factory provides a fallback, implementing `consumeOne` natively is recommended: the fallback is race-safe only under a real `transaction` with an accurate delete count. Stores without multi-document transactions therefore need a native atomic delete-and-return (`DELETE ... RETURNING`, `findOneAndDelete`, or a revision-conditional delete).
+<Callout type="warn">
+  `consumeOne` is required. Better Auth does not provide a `findMany` plus `deleteMany` fallback because that shape cannot guarantee single-use semantics across adapters without a native atomic delete-and-return operation.
+</Callout>
+
+### `incrementOne` method
+
+The `incrementOne` method atomically updates one matching record by applying numeric deltas and optional set values, then returns the updated row. It powers guarded counters such as rate limits, quotas, and one-winner state transitions.
+
+parameters:
+
+* `model`: The model/table name to update.
+* `where`: The `where` clause that must still match for the increment to apply.
+* `increment`: Numeric deltas to apply, such as `{ count: 1 }` or `{ remaining: -1 }`.
+* `set`: Optional fields to set in the same atomic operation.
+
+**Returns** `Promise<T | null>`: the updated record, or `null` if no row matched. Implementations must update at most one matching row.
+
+```ts title="Example"
+incrementOne: async ({ model, where, increment, set }) => {
+  const [row] = await db
+    .update(model)
+    .set({
+      ...set,
+      count: sql`${model.count} + ${increment.count ?? 0}`,
+    })
+    .where(where)
+    .returning();
+  return row ?? null;
+};
+```
+
+<Callout type="warn">
+  `incrementOne` is required. Better Auth uses it as a compare-and-swap primitive: the `where` clause is part of the guard, so concurrent requests cannot all update a stale snapshot.
 </Callout>
 
 ### `findOne` method
@@ -486,7 +517,7 @@ Whether the adapter supports transactions. If `false`, operations run sequential
 
 ### `debugLogs`
 
-Used to enable debug logs for the adapter. You can pass in a boolean, or an object with the following keys: `create`, `update`, `updateMany`, `findOne`, `findMany`, `delete`, `deleteMany`, `count`.
+Used to enable debug logs for the adapter. You can pass in a boolean, or an object with the following keys: `create`, `update`, `updateMany`, `findOne`, `findMany`, `delete`, `deleteMany`, `consumeOne`, `incrementOne`, `count`.
 If any of the keys are `true`, the debug logs will be enabled for that method.
 
 ```ts title="Example"

--- a/docs/content/docs/plugins/api-key/reference.mdx
+++ b/docs/content/docs/plugins/api-key/reference.mdx
@@ -193,11 +193,11 @@ export const auth = betterAuth({
 });
 ```
 
-`customStorage` <span className="opacity-70">`{ get: (key: string) => Promise<unknown> | unknown; set: (key: string, value: string, ttl?: number) => Promise<void | null | unknown> | void; delete: (key: string) => Promise<void | null | string> | void; }`</span>
+`customStorage` <span className="opacity-70">`SecondaryStorage`</span>
 
-Custom storage methods for API keys. If provided, these methods will be used instead of `ctx.context.secondaryStorage`. Custom methods take precedence over global secondary storage.
+Custom secondary storage for API keys. If provided, it is used instead of `ctx.context.secondaryStorage`. Custom storage takes precedence over global secondary storage.
 
-Useful when you want to use a different storage backend specifically for API keys, or when you need custom logic for storage operations.
+Useful when you want to use a different storage backend specifically for API keys, or when you need custom logic for storage operations. It must implement the full secondary-storage contract, including `getAndDelete` and `increment`.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
@@ -209,6 +209,8 @@ export const auth = betterAuth({
       storage: "secondary-storage",
       customStorage: {
         get: async (key) => await customStorage.get(key),
+        getAndDelete: async (key) => await customStorage.getAndDelete(key),
+        increment: async (key, ttl) => await customStorage.increment(key, ttl),
         set: async (key, value, ttl) => await customStorage.set(key, value, ttl),
         delete: async (key) => await customStorage.delete(key), 
       },

--- a/docs/content/docs/plugins/magic-link.mdx
+++ b/docs/content/docs/plugins/magic-link.mdx
@@ -153,5 +153,5 @@ The `storeToken` function can be one of the following:
 The storage backend itself is controlled by the global [`verification`](/docs/reference/options#verification) config. If you configure `secondaryStorage`, magic link verification records can be stored there instead of the database.
 
 <Callout type="warn">
-  When `secondaryStorage` backs verification (`verification.storeInDatabase: false`), the atomic single-use guarantee from [GHSA-hc7v-rggr-4hvx](https://github.com/better-auth/better-auth/security/advisories/GHSA-hc7v-rggr-4hvx) requires your secondary storage to expose `getAndDelete` (Redis `GETDEL`, KV `getAndDelete`). If the implementation only exposes `get` and `delete`, the consume falls back to an in-process JavaScript lock that does not coordinate across multiple application instances. Multi-instance deployments using secondary-storage verification MUST configure a backend that implements `getAndDelete`.
+  When `secondaryStorage` backs verification (`verification.storeInDatabase: false`), the atomic single-use guarantee from [GHSA-hc7v-rggr-4hvx](https://github.com/better-auth/better-auth/security/advisories/GHSA-hc7v-rggr-4hvx) requires your secondary storage to expose `getAndDelete` (Redis `GETDEL`, KV `getAndDelete`). Better Auth no longer falls back to separate `get` and `delete` operations for verification consumes.
 </Callout>

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -1998,6 +1998,8 @@ The teams feature supports several configuration options:
   }
   ```
 
+  `maximumMembersPerTeam` is enforced when accepting team invitations, when adding an existing organization member to a team, and when adding a new organization member with a `teamId`.
+
 * `allowRemovingAllTeams`: Control whether the last team can be removed
   ```ts
   teams: {
@@ -2037,6 +2039,11 @@ export const teamsFeatureTeamTableFields = [
 		name: "name",
 		type: "string",
 		description: "The name of the team",
+	},
+	{
+		name: "memberCount",
+		type: "number",
+		description: "Durable member count used to enforce team capacity",
 	},
 	{
 		name: "organizationId",
@@ -2082,6 +2089,12 @@ export const teamsFeatureTeamMemberTableFields = [
 		description: "The ID of the user",
 		isForeignKey: true,
 		references: { model: "user", field: "id" },
+	},
+	{
+		name: "membershipKey",
+		type: "string",
+		description: "Internal unique key for the team and user membership pair",
+		isOptional: true,
 	},
 	{
 		name: "createdAt",
@@ -2329,6 +2342,11 @@ export const optionalTeamTableFields = [
 		description: "The name of the team",
 	},
 	{
+		name: "memberCount",
+		type: "number",
+		description: "Durable member count used to enforce team capacity",
+	},
+	{
 		name: "organizationId",
 		type: "string",
 		description: "The ID of the organization",
@@ -2372,6 +2390,12 @@ export const teamsFeatureTeamTableFields0 = [
 		description: "The ID of the user",
 		isForeignKey: true,
 		references: { model: "user", field: "id" },
+	},
+	{
+		name: "membershipKey",
+		type: "string",
+		description: "Internal unique key for the team and user membership pair",
+		isOptional: true,
 	},
 	{
 		name: "createdAt",

--- a/docs/content/docs/reference/instrumentation.mdx
+++ b/docs/content/docs/reference/instrumentation.mdx
@@ -68,7 +68,7 @@ Middlewares are also supported:
 | ------------------------ | ----------------------------- | ---------------------------------------------- |
 | `db {operation} {model}` | Span for a database operation | All adapter operations (create, findOne, etc.) |
 
-* **Operations:** `create`, `findOne`, `findMany`, `update`, `updateMany`, `delete`, `deleteMany`, `count`
+* **Operations:** `create`, `findOne`, `findMany`, `update`, `updateMany`, `delete`, `deleteMany`, `consumeOne`, `incrementOne`, `count`
 * **Models:** Core models include `user`, `account`, `session`, `verification`, plus plugin-defined models (e.g. `organization`, `rateLimit`).
 * **Attributes:**
   * `db.operation.name` - The database operation name (e.g. `create`)

--- a/e2e/adapter/test/memory-adapter/adapter.memory.test.ts
+++ b/e2e/adapter/test/memory-adapter/adapter.memory.test.ts
@@ -28,6 +28,9 @@ const { execute } = await testAdapter({
 	},
 	tests: [
 		normalTestSuite(),
+		// The conformance wrapper re-resolves the adapter on every operation, so it
+		// cannot observe an in-memory transaction's isolation: rollback and commit
+		// semantics for this adapter are covered directly in memory-adapter.test.ts.
 		transactionsTestSuite({ disableTests: { ALL: true } }),
 		authFlowTestSuite(),
 		numberIdTestSuite(),

--- a/packages/api-key/src/adapter.ts
+++ b/packages/api-key/src/adapter.ts
@@ -235,6 +235,41 @@ async function getApiKeyByIdFromStorage(
 }
 
 /**
+ * Serializes reference-list mutations per `refKey` within a single process.
+ * Each new mutation chains onto the previous one for the same key, so the
+ * read/modify/write below never interleaves with another mutation of the same
+ * list. This closes the lost-update race in secondary-storage-only mode, where
+ * the serialized list is the source of truth for listing.
+ *
+ * Limitation: the lock is in-process only. Across multiple server instances
+ * sharing one secondary storage, concurrent writers can still lose updates.
+ * Secondary storage with `fallbackToDatabase` avoids this by treating the list
+ * as an invalidate-only cache with the database as the source of truth.
+ * FIXME(api-key-reflist-durable): on `next`, drop the source-of-truth reference
+ * list entirely and make the database authoritative for listing, removing this
+ * in-process lock.
+ */
+const refListLocks = new Map<string, Promise<unknown>>();
+
+function withRefListLock<T>(
+	refKey: string,
+	task: () => Promise<T>,
+): Promise<T> {
+	const previous = refListLocks.get(refKey) ?? Promise.resolve();
+	const run = previous.then(task, task);
+	// The map holds the `.finally()` chain, so the cleanup must compare against
+	// that same promise (not `run`) or the entry is never removed and the map
+	// grows without bound.
+	const tracked = run.finally(() => {
+		if (refListLocks.get(refKey) === tracked) {
+			refListLocks.delete(refKey);
+		}
+	});
+	refListLocks.set(refKey, tracked);
+	return run;
+}
+
+/**
  * Read-modify-write the ref list:
  * used only when the list is the source of truth.
  */
@@ -243,23 +278,25 @@ async function modifyRefList(
 	refKey: string,
 	modify: (ids: string[]) => string[],
 ): Promise<void> {
-	const refListData = await storage.get(refKey);
-	let keyIds: string[] = [];
-	if (refListData && typeof refListData === "string") {
-		try {
-			keyIds = JSON.parse(refListData);
-		} catch {
-			keyIds = [];
+	await withRefListLock(refKey, async () => {
+		const refListData = await storage.get(refKey);
+		let keyIds: string[] = [];
+		if (refListData && typeof refListData === "string") {
+			try {
+				keyIds = JSON.parse(refListData);
+			} catch {
+				keyIds = [];
+			}
+		} else if (Array.isArray(refListData)) {
+			keyIds = refListData;
 		}
-	} else if (Array.isArray(refListData)) {
-		keyIds = refListData;
-	}
-	const next = modify(keyIds);
-	if (next.length === 0) {
-		await storage.delete(refKey);
-	} else {
-		await storage.set(refKey, JSON.stringify(next));
-	}
+		const next = modify(keyIds);
+		if (next.length === 0) {
+			await storage.delete(refKey);
+		} else {
+			await storage.set(refKey, JSON.stringify(next));
+		}
+	});
 }
 
 async function setApiKeyInStorage(

--- a/packages/api-key/src/adapter.ts
+++ b/packages/api-key/src/adapter.ts
@@ -266,7 +266,7 @@ function withRefListLock<T>(
 		}
 	});
 	refListLocks.set(refKey, tracked);
-	return run;
+	return tracked;
 }
 
 /**

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -2564,6 +2564,18 @@ describe("api-key", async () => {
 			get(key) {
 				return store.get(key) || null;
 			},
+			getAndDelete(key) {
+				const value = store.get(key) || null;
+				store.delete(key);
+				expirationMap.delete(key);
+				return value;
+			},
+			increment(key, ttl) {
+				const count = Number(store.get(key) ?? 0) + 1;
+				store.set(key, String(count));
+				if (ttl !== undefined) expirationMap.set(key, ttl);
+				return count;
+			},
 			delete(key) {
 				store.delete(key);
 				expirationMap.delete(key);
@@ -2949,6 +2961,18 @@ describe("api-key", async () => {
 			},
 			get(key) {
 				return store.get(key) || null;
+			},
+			getAndDelete(key) {
+				const value = store.get(key) || null;
+				store.delete(key);
+				expirationMap.delete(key);
+				return value;
+			},
+			increment(key, ttl) {
+				const count = Number(store.get(key) ?? 0) + 1;
+				store.set(key, String(count));
+				if (ttl !== undefined) expirationMap.set(key, ttl);
+				return count;
 			},
 			delete(key) {
 				store.delete(key);
@@ -4990,6 +5014,16 @@ describe("verify should not write back stale state", async () => {
 			get(key) {
 				return store.get(key) || null;
 			},
+			getAndDelete(key) {
+				const value = store.get(key) || null;
+				store.delete(key);
+				return value;
+			},
+			increment(key) {
+				const count = Number(store.get(key) ?? 0) + 1;
+				store.set(key, String(count));
+				return count;
+			},
 			delete(key) {
 				store.delete(key);
 			},
@@ -5054,6 +5088,192 @@ describe("verify should not write back stale state", async () => {
 				k.startsWith("api-key:"),
 			);
 			expect(apiKeyEntries).toEqual([]);
+		});
+	});
+});
+
+describe("concurrent verification enforces atomic counters", async () => {
+	describe("database storage", async () => {
+		// A gate that releases all waiters only once `size` of them have arrived,
+		// forcing every concurrent verification to read the same pre-update row
+		// before any write runs. Without this, the synchronous SQLite driver lets
+		// each verification finish before the next begins and no race is observed.
+		function createArrivalGate(size: number) {
+			let arrived = 0;
+			let release!: () => void;
+			const ready = new Promise<void>((resolve) => {
+				release = resolve;
+			});
+			return async () => {
+				arrived++;
+				if (arrived >= size) release();
+				await ready;
+			};
+		}
+
+		const concurrency = 8;
+		let gate: (() => Promise<void>) | null = null;
+		const customAPIKeyValidator = async () => {
+			if (gate) await gate();
+			return true;
+		};
+
+		const { auth, signInWithTestUser } = await getTestInstance(
+			{
+				plugins: [apiKey({ customAPIKeyValidator })],
+			},
+			{
+				clientOptions: {
+					plugins: [apiKeyClient()],
+				},
+			},
+		);
+
+		afterEach(() => {
+			gate = null;
+		});
+
+		it("does not let concurrent verifications drop remaining below zero", async () => {
+			const { headers, user } = await signInWithTestUser();
+			const created = await auth.api.createApiKey({
+				body: { remaining: 1, userId: user.id },
+			});
+
+			gate = createArrivalGate(concurrency);
+			const results = await Promise.all(
+				Array.from({ length: concurrency }, () =>
+					auth.api.verifyApiKey({ body: { key: created.key } }),
+				),
+			);
+
+			const accepted = results.filter((r) => r.valid);
+			expect(accepted.length).toBe(1);
+			for (const r of results) {
+				if (!r.valid) {
+					expect(r.error?.code).toBe("USAGE_EXCEEDED");
+				}
+			}
+
+			const stored = await auth.api.getApiKey({
+				query: { id: created.id },
+				headers,
+			});
+			expect(stored.remaining).toBe(0);
+		});
+
+		it("does not let concurrent verifications exceed the per-key rate limit", async () => {
+			const { headers, user } = await signInWithTestUser();
+			const created = await auth.api.createApiKey({
+				body: {
+					rateLimitEnabled: true,
+					rateLimitMax: 2,
+					rateLimitTimeWindow: 60_000,
+					userId: user.id,
+				},
+			});
+
+			// Prime the window with one accepted request so the concurrent burst
+			// races the in-window increment path, not the first-request branch.
+			// With max 2 and one already used, exactly one of the burst may pass.
+			await auth.api.verifyApiKey({ body: { key: created.key } });
+
+			gate = createArrivalGate(concurrency);
+			const results = await Promise.all(
+				Array.from({ length: concurrency }, () =>
+					auth.api.verifyApiKey({ body: { key: created.key } }),
+				),
+			);
+
+			const accepted = results.filter((r) => r.valid);
+			expect(accepted.length).toBe(1);
+			for (const r of results) {
+				if (!r.valid) {
+					expect(r.error?.code).toBe("RATE_LIMITED");
+				}
+			}
+
+			const stored = await auth.api.getApiKey({
+				query: { id: created.id },
+				headers,
+			});
+			expect(stored.requestCount).toBe(2);
+		});
+	});
+
+	describe("secondary storage reference list", async () => {
+		const store = new Map<string, string>();
+		// A read of the gated key yields for a tick before returning. Two
+		// concurrent writers without a lock therefore both read the same pre-write
+		// reference list and the lost update is exercised deterministically; a
+		// correctly serialized writer reads the gated key one at a time and keeps
+		// both entries.
+		let gatedKey: string | null = null;
+
+		const secondaryStorage: SecondaryStorage = {
+			set(key, value) {
+				store.set(key, value as string);
+			},
+			async get(key) {
+				if (key === gatedKey) {
+					await new Promise((resolve) => setTimeout(resolve, 5));
+				}
+				return store.get(key) || null;
+			},
+			getAndDelete(key) {
+				const value = store.get(key) || null;
+				store.delete(key);
+				return value;
+			},
+			increment(key) {
+				const count = Number(store.get(key) ?? 0) + 1;
+				store.set(key, String(count));
+				return count;
+			},
+			delete(key) {
+				store.delete(key);
+			},
+		};
+
+		const { auth, signInWithTestUser } = await getTestInstance(
+			{
+				secondaryStorage,
+				plugins: [apiKey({ storage: "secondary-storage" })],
+			},
+			{
+				clientOptions: {
+					plugins: [apiKeyClient()],
+				},
+			},
+		);
+
+		beforeEach(() => {
+			store.clear();
+			gatedKey = null;
+		});
+
+		it("does not hide an active key when two creates run concurrently", async () => {
+			const { headers, user } = await signInWithTestUser();
+
+			gatedKey = `api-key:by-ref:${user.id}`;
+
+			const [keyA, keyB] = await Promise.all([
+				auth.api.createApiKey({ body: {}, headers }),
+				auth.api.createApiKey({ body: {}, headers }),
+			]);
+
+			gatedKey = null;
+
+			const listed = await auth.api.listApiKeys({ headers });
+			const listedIds = listed.apiKeys.map((k) => k.id);
+			expect(listedIds).toContain(keyA.id);
+			expect(listedIds).toContain(keyB.id);
+
+			for (const created of [keyA, keyB]) {
+				const verified = await auth.api.verifyApiKey({
+					body: { key: created.key },
+				});
+				expect(verified.valid).toBe(true);
+			}
 		});
 	});
 });

--- a/packages/api-key/src/rate-limit.ts
+++ b/packages/api-key/src/rate-limit.ts
@@ -2,96 +2,96 @@ import { API_KEY_ERROR_CODES as ERROR_CODES } from ".";
 import type { PredefinedApiKeyOptions } from "./routes";
 import type { ApiKey } from "./types";
 
-interface RateLimitResult {
-	success: boolean;
-	message: string | null;
-	tryAgainIn: number | null;
-	update: Partial<ApiKey> | null;
-}
+/**
+ * The atomic action the verify route must apply for the current request, derived
+ * from a single read of the API key. The route translates each variant into a
+ * guarded storage operation so concurrent verifications cannot exceed the limit.
+ */
+export type RateLimitDecision =
+	| {
+			/** Rate limiting does not apply; only stamp `lastRequest`. */
+			type: "skip";
+			lastRequest: Date | null;
+	  }
+	| {
+			/** First request in a fresh window: set `requestCount` to 1. */
+			type: "start";
+			now: Date;
+	  }
+	| {
+			/** Window elapsed: reset `requestCount` to 1, guarded on the window. */
+			type: "reset";
+			now: Date;
+			/** `lastRequest` must still predate this instant for the reset to apply. */
+			windowStart: Date;
+	  }
+	| {
+			/** Within the window and under the max: increment `requestCount` by 1. */
+			type: "increment";
+			now: Date;
+			max: number;
+			windowStart: Date;
+	  }
+	| {
+			/** Within the window and at the max: reject. */
+			type: "deny";
+			message: string;
+			tryAgainIn: number;
+	  };
 
 /**
- * Determines if a request is allowed based on rate limiting parameters.
- *
- * @returns An object indicating whether the request is allowed and, if not,
- *          a message and updated ApiKey data.
+ * Decides how the current request affects the per-key rate-limit counter, based
+ * on the read-in-memory ApiKey. The verify route applies the result atomically;
+ * this function performs no writes.
  */
-export function isRateLimited(
-	/**
-	 * The ApiKey object containing rate limiting information
-	 */
+export function evaluateRateLimit(
 	apiKey: ApiKey,
 	opts: PredefinedApiKeyOptions,
-): RateLimitResult {
+): RateLimitDecision {
 	const now = new Date();
 	const lastRequest = apiKey.lastRequest;
 	const rateLimitTimeWindow = apiKey.rateLimitTimeWindow;
 	const rateLimitMax = apiKey.rateLimitMax;
-	let requestCount = apiKey.requestCount;
 
-	if (opts.rateLimit.enabled === false)
-		return {
-			success: true,
-			message: null,
-			update: { lastRequest: now },
-			tryAgainIn: null,
-		};
+	if (opts.rateLimit.enabled === false) {
+		return { type: "skip", lastRequest: now };
+	}
 
-	if (apiKey.rateLimitEnabled === false)
-		return {
-			success: true,
-			message: null,
-			update: { lastRequest: now },
-			tryAgainIn: null,
-		};
+	if (apiKey.rateLimitEnabled === false) {
+		return { type: "skip", lastRequest: now };
+	}
 
 	if (rateLimitTimeWindow === null || rateLimitMax === null) {
-		// Rate limiting is disabled.
-		return {
-			success: true,
-			message: null,
-			update: null,
-			tryAgainIn: null,
-		};
+		// Rate limiting is disabled for this key.
+		return { type: "skip", lastRequest: null };
 	}
 
 	if (lastRequest === null) {
-		// No previous requests, so allow the first one.
-		return {
-			success: true,
-			message: null,
-			update: { lastRequest: now, requestCount: 1 },
-			tryAgainIn: null,
-		};
+		return { type: "start", now };
 	}
 
 	const timeSinceLastRequest = now.getTime() - new Date(lastRequest).getTime();
 
 	if (timeSinceLastRequest > rateLimitTimeWindow) {
-		// Time window has passed, reset the request count.
 		return {
-			success: true,
-			message: null,
-			update: { lastRequest: now, requestCount: 1 },
-			tryAgainIn: null,
+			type: "reset",
+			now,
+			windowStart: new Date(now.getTime() - rateLimitTimeWindow),
 		};
 	}
 
-	if (requestCount >= rateLimitMax) {
-		// Rate limit exceeded.
+	if (apiKey.requestCount >= rateLimitMax) {
 		return {
-			success: false,
+			type: "deny",
 			message: ERROR_CODES.RATE_LIMIT_EXCEEDED.message,
-			update: null,
 			tryAgainIn: Math.ceil(rateLimitTimeWindow - timeSinceLastRequest),
 		};
 	}
 
-	// Request is allowed.
-	requestCount++;
 	return {
-		success: true,
-		message: null,
-		tryAgainIn: null,
-		update: { lastRequest: now, requestCount: requestCount },
+		type: "increment",
+		now,
+		max: rateLimitMax,
+		windowStart: new Date(now.getTime() - rateLimitTimeWindow),
 	};
 }

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -12,7 +12,7 @@ import {
 	migrateDoubleStringifiedMetadata,
 	setApiKey,
 } from "../adapter";
-import { isRateLimited } from "../rate-limit";
+import { evaluateRateLimit } from "../rate-limit";
 import type { apiKeySchema } from "../schema";
 import type { ApiKey } from "../types";
 import { isAPIError } from "../utils";
@@ -130,9 +130,7 @@ export async function validateApiKey({
 		}
 	}
 
-	let remaining = apiKey.remaining;
-	let lastRefillAt = apiKey.lastRefillAt;
-
+	// A non-refillable key that is already exhausted is removed and rejected.
 	if (apiKey.remaining === 0 && apiKey.refillAmount === null) {
 		const deleteExhaustedKey = async () => {
 			if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
@@ -162,86 +160,275 @@ export async function validateApiKey({
 		}
 
 		throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
-	} else if (remaining !== null) {
-		const now = Date.now();
-		const refillInterval = apiKey.refillInterval;
-		const refillAmount = apiKey.refillAmount;
-		const lastTime = new Date(lastRefillAt ?? apiKey.createdAt).getTime();
+	}
 
-		if (refillInterval && refillAmount) {
-			// if they provide refill info, then we should refill once the interval is reached.
+	const usesDatabase =
+		opts.storage === "database" ||
+		(opts.storage === "secondary-storage" && opts.fallbackToDatabase);
 
-			const timeSinceLastRequest = now - lastTime;
-			if (timeSinceLastRequest > refillInterval) {
-				remaining = refillAmount;
-				lastRefillAt = new Date();
+	const newApiKey = usesDatabase
+		? await claimUsageInDatabase({ ctx, apiKey, opts, hashedKey })
+		: await claimUsageInSecondaryStorage({ ctx, apiKey, opts, hashedKey });
+
+	return { apiKey: newApiKey, opts };
+}
+
+/**
+ * Atomically consume quota and a rate-limit slot against the database row, the
+ * source of truth for `database` and `secondary-storage` + `fallbackToDatabase`
+ * modes. Each guarded `incrementOne` only mutates the row while the guard still
+ * holds, so concurrent verifications cannot drive `remaining` below zero or push
+ * `requestCount` past the configured max. The cache (when present) is refreshed
+ * from the resulting row.
+ */
+async function claimUsageInDatabase({
+	ctx,
+	apiKey,
+	opts,
+	hashedKey,
+}: {
+	ctx: GenericEndpointContext;
+	apiKey: ApiKey;
+	opts: PredefinedApiKeyOptions;
+	hashedKey: string;
+}): Promise<ApiKey> {
+	let row: ApiKey = apiKey;
+
+	if (apiKey.remaining !== null) {
+		row = await consumeRemaining(ctx, apiKey);
+	}
+
+	row = await consumeRateLimit(ctx, row, opts);
+
+	// A final `updatedAt` stamp returns the fully consolidated row, reflecting
+	// every guarded counter write applied above.
+	const finalRow = await ctx.context.adapter.update<ApiKey>({
+		model: API_KEY_TABLE_NAME,
+		where: [{ field: "id", value: row.id }],
+		update: { updatedAt: new Date() },
+	});
+
+	// A null result means the row was deleted concurrently (for example the key
+	// was revoked). Do not fall back to the in-memory row and re-cache a key
+	// whose authoritative record is gone.
+	if (!finalRow) {
+		throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
+	}
+
+	if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
+		await setApiKey(ctx, finalRow, opts);
+	}
+
+	return finalRow;
+}
+
+/**
+ * Guarded quota consumption. When a refill is due, exactly one verification wins
+ * the refill (compare-and-swap on the observed `lastRefillAt`); any concurrent
+ * verification falls through to the plain guarded decrement against the refilled
+ * value. The decrement only applies while `remaining > 0`, so it can never go
+ * negative. Returns the updated row; throws when the quota is exhausted.
+ */
+async function consumeRemaining(
+	ctx: GenericEndpointContext,
+	apiKey: ApiKey,
+): Promise<ApiKey> {
+	const now = new Date();
+	const { refillInterval, refillAmount } = apiKey;
+
+	if (refillInterval && refillAmount) {
+		const lastTime = new Date(
+			apiKey.lastRefillAt ?? apiKey.createdAt,
+		).getTime();
+		if (now.getTime() - lastTime > refillInterval) {
+			const refilled = await ctx.context.adapter.incrementOne<ApiKey>({
+				model: API_KEY_TABLE_NAME,
+				where: [
+					{ field: "id", value: apiKey.id },
+					{ field: "lastRefillAt", value: apiKey.lastRefillAt },
+				],
+				increment: {},
+				set: { remaining: refillAmount - 1, lastRefillAt: now },
+			});
+			if (refilled) {
+				return refilled;
 			}
-		}
-
-		if (remaining === 0) {
-			// if there are no more remaining requests, than the key is invalid
-			throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
-		} else {
-			remaining--;
+			// Lost the refill CAS: another verification already refilled. Fall
+			// through and decrement against the refreshed value.
 		}
 	}
 
-	const { message, success, update, tryAgainIn } = isRateLimited(apiKey, opts);
+	const decremented = await ctx.context.adapter.incrementOne<ApiKey>({
+		model: API_KEY_TABLE_NAME,
+		where: [
+			{ field: "id", value: apiKey.id },
+			{ field: "remaining", operator: "gt", value: 0 },
+		],
+		increment: { remaining: -1 },
+	});
 
-	if (success === false) {
+	if (!decremented) {
+		throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
+	}
+
+	return decremented;
+}
+
+/**
+ * Guarded rate-limit consumption. The common in-window path increments
+ * `requestCount` only while it is below the max (compare-and-swap), so a burst
+ * of concurrent verifications can never exceed the limit. Window resets and the
+ * first request in a window are guarded conditional sets; a request that loses
+ * every guard within an active window is rejected. Returns the updated row, or
+ * the unchanged row when rate limiting does not apply.
+ */
+async function consumeRateLimit(
+	ctx: GenericEndpointContext,
+	apiKey: ApiKey,
+	opts: PredefinedApiKeyOptions,
+): Promise<ApiKey> {
+	const decision = evaluateRateLimit(apiKey, opts);
+
+	if (decision.type === "deny") {
 		throw new APIError("TOO_MANY_REQUESTS", {
-			message: message ?? undefined,
+			message: decision.message,
 			code: "RATE_LIMITED" as const,
-			details: {
-				tryAgainIn,
-			},
+			details: { tryAgainIn: decision.tryAgainIn },
 		});
 	}
 
+	if (decision.type === "skip") {
+		if (decision.lastRequest === null) {
+			return apiKey;
+		}
+		const updated = await ctx.context.adapter.update<ApiKey>({
+			model: API_KEY_TABLE_NAME,
+			where: [{ field: "id", value: apiKey.id }],
+			update: { lastRequest: decision.lastRequest },
+		});
+		return updated ?? apiKey;
+	}
+
+	if (decision.type === "increment") {
+		const incremented = await ctx.context.adapter.incrementOne<ApiKey>({
+			model: API_KEY_TABLE_NAME,
+			where: [
+				{ field: "id", value: apiKey.id },
+				{
+					field: "lastRequest",
+					operator: "gt",
+					value: decision.windowStart,
+				},
+				{
+					field: "requestCount",
+					operator: "lt",
+					value: decision.max,
+				},
+			],
+			increment: { requestCount: 1 },
+			set: { lastRequest: decision.now },
+		});
+		if (incremented) {
+			return incremented;
+		}
+		// The window rolled or the max was reached between the read and the
+		// write. Re-evaluate against the freshest row to apply the right guard.
+		const fresh = await ctx.context.adapter.findOne<ApiKey>({
+			model: API_KEY_TABLE_NAME,
+			where: [{ field: "id", value: apiKey.id }],
+		});
+		if (!fresh) {
+			throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
+		}
+		return consumeRateLimit(ctx, fresh, opts);
+	}
+
+	// "start" and "reset": set the count to 1 for a fresh window, guarded so a
+	// concurrent increment in the same window cannot be silently overwritten.
+	const windowGuard =
+		decision.type === "reset"
+			? {
+					field: "lastRequest",
+					operator: "lte" as const,
+					value: decision.windowStart,
+				}
+			: { field: "lastRequest", operator: "eq" as const, value: null };
+
+	const started = await ctx.context.adapter.incrementOne<ApiKey>({
+		model: API_KEY_TABLE_NAME,
+		where: [{ field: "id", value: apiKey.id }, windowGuard],
+		increment: {},
+		set: { requestCount: 1, lastRequest: decision.now },
+	});
+	if (started) {
+		return started;
+	}
+	// Another verification already opened the window. Re-evaluate so this
+	// request consumes an increment slot instead of resetting the count.
+	const fresh = await ctx.context.adapter.findOne<ApiKey>({
+		model: API_KEY_TABLE_NAME,
+		where: [{ field: "id", value: apiKey.id }],
+	});
+	if (!fresh) {
+		throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
+	}
+	return consumeRateLimit(ctx, fresh, opts);
+}
+
+/**
+ * Secondary-storage-only mode has no database row to guard, so quota and
+ * rate-limit consumption stays a read-modify-write merge over the serialized
+ * key. This is the residual non-atomic path; strict enforcement requires the
+ * database (use `fallbackToDatabase`) or an atomic secondary-storage primitive.
+ * FIXME(api-key-secondary-atomic): back this with SecondaryStorage.increment on
+ * `next` so secondary-storage-only mode enforces quota and rate limits atomically.
+ */
+async function claimUsageInSecondaryStorage({
+	ctx,
+	apiKey,
+	opts,
+	hashedKey,
+}: {
+	ctx: GenericEndpointContext;
+	apiKey: ApiKey;
+	opts: PredefinedApiKeyOptions;
+	hashedKey: string;
+}): Promise<ApiKey> {
+	let remaining = apiKey.remaining;
+	let lastRefillAt = apiKey.lastRefillAt;
+
+	if (remaining !== null) {
+		const now = Date.now();
+		const { refillInterval, refillAmount } = apiKey;
+		const lastTime = new Date(lastRefillAt ?? apiKey.createdAt).getTime();
+		if (refillInterval && refillAmount && now - lastTime > refillInterval) {
+			remaining = refillAmount;
+			lastRefillAt = new Date();
+		}
+		if (remaining === 0) {
+			throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
+		}
+		remaining--;
+	}
+
+	const rateLimitUpdate = applyRateLimitToSnapshot(apiKey, opts);
+
 	const mutations: Partial<ApiKey> = {
-		...update,
+		...rateLimitUpdate,
 		remaining,
 		lastRefillAt,
 		updatedAt: new Date(),
 	};
 
-	const updated: ApiKey = {
-		...apiKey,
-		...mutations,
-	};
-
 	const performUpdate = async (): Promise<ApiKey | null> => {
-		if (opts.storage === "database") {
-			return ctx.context.adapter.update<ApiKey>({
-				model: API_KEY_TABLE_NAME,
-				where: [{ field: "id", value: apiKey.id }],
-				update: mutations,
-			});
-		} else if (
-			opts.storage === "secondary-storage" &&
-			opts.fallbackToDatabase
-		) {
-			const dbUpdated = await ctx.context.adapter.update<ApiKey>({
-				model: API_KEY_TABLE_NAME,
-				where: [{ field: "id", value: apiKey.id }],
-				update: mutations,
-			});
-			if (dbUpdated) {
-				await setApiKey(ctx, dbUpdated, opts);
-			}
-			return dbUpdated;
-		} else {
-			const fresh = await getApiKey(ctx, hashedKey, opts);
-			if (!fresh) {
-				return null;
-			}
-			const merged: ApiKey = { ...fresh, ...mutations };
-			await setApiKey(ctx, merged, opts);
-			return merged;
+		const fresh = await getApiKey(ctx, hashedKey, opts);
+		if (!fresh) {
+			return null;
 		}
+		const merged: ApiKey = { ...fresh, ...mutations };
+		await setApiKey(ctx, merged, opts);
+		return merged;
 	};
-
-	let newApiKey: ApiKey | null = null;
 
 	if (opts.deferUpdates) {
 		ctx.context.runInBackground(
@@ -249,18 +436,48 @@ export async function validateApiKey({
 				ctx.context.logger.error("Failed to update API key:", error);
 			}),
 		);
-		newApiKey = updated;
-	} else {
-		newApiKey = await performUpdate();
-		if (!newApiKey) {
-			throw APIError.from(
-				"INTERNAL_SERVER_ERROR",
-				ERROR_CODES.FAILED_TO_UPDATE_API_KEY,
-			);
-		}
+		return { ...apiKey, ...mutations };
 	}
 
-	return { apiKey: newApiKey, opts };
+	const updated = await performUpdate();
+	if (!updated) {
+		throw APIError.from(
+			"INTERNAL_SERVER_ERROR",
+			ERROR_CODES.FAILED_TO_UPDATE_API_KEY,
+		);
+	}
+	return updated;
+}
+
+/**
+ * Translate a rate-limit decision into a counter snapshot for the
+ * secondary-storage merge write. Denials throw before any write.
+ */
+function applyRateLimitToSnapshot(
+	apiKey: ApiKey,
+	opts: PredefinedApiKeyOptions,
+): Partial<ApiKey> {
+	const decision = evaluateRateLimit(apiKey, opts);
+	switch (decision.type) {
+		case "deny":
+			throw new APIError("TOO_MANY_REQUESTS", {
+				message: decision.message,
+				code: "RATE_LIMITED" as const,
+				details: { tryAgainIn: decision.tryAgainIn },
+			});
+		case "skip":
+			return decision.lastRequest === null
+				? {}
+				: { lastRequest: decision.lastRequest };
+		case "start":
+		case "reset":
+			return { lastRequest: decision.now, requestCount: 1 };
+		case "increment":
+			return {
+				lastRequest: decision.now,
+				requestCount: apiKey.requestCount + 1,
+			};
+	}
 }
 
 const verifyApiKeyBodySchema = z.object({

--- a/packages/api-key/src/types.ts
+++ b/packages/api-key/src/types.ts
@@ -4,6 +4,7 @@ import type {
 	HookEndpointContext,
 	LiteralString,
 } from "@better-auth/core";
+import type { SecondaryStorage } from "@better-auth/core/db";
 import type { Statements } from "better-auth/plugins/access";
 import type { InferOptionSchema } from "better-auth/types";
 import type { apiKeySchema } from "./schema";
@@ -242,26 +243,7 @@ export interface ApiKeyConfigurationOptions {
 	 * Useful when you want to use a different storage backend specifically for API keys,
 	 * or when you need custom logic for storage operations.
 	 */
-	customStorage?:
-		| {
-				/**
-				 * Get a value from storage
-				 */
-				get: (key: string) => Awaitable<unknown>;
-				/**
-				 * Set a value in storage
-				 */
-				set: (
-					key: string,
-					value: string,
-					ttl?: number | undefined,
-				) => Awaitable<void | null | unknown>;
-				/**
-				 * Delete a value from storage
-				 */
-				delete: (key: string) => Awaitable<void | null | string>;
-		  }
-		| undefined;
+	customStorage?: SecondaryStorage | undefined;
 	/**
 	 * Defer non-critical updates (rate limiting counters, timestamps, remaining count)
 	 * to run after the response is sent using the global `advanced.backgroundTasks` handler.

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -19,7 +19,7 @@ import { createRouter } from "better-call";
 import type { OverrideMerge, UnionToIntersection } from "../types";
 import { isAPIError } from "../utils/is-api-error";
 import { originCheckMiddleware } from "./middlewares";
-import { onRequestRateLimit, onResponseRateLimit } from "./rate-limiter";
+import { onRequestRateLimit } from "./rate-limiter";
 import {
 	accountInfo,
 	callbackOAuth,
@@ -328,7 +328,6 @@ export const router = <Option extends BetterAuthOptions>(
 			return currentRequest;
 		},
 		async onResponse(res, req) {
-			await onResponseRateLimit(req, ctx);
 			for (const plugin of ctx.options.plugins || []) {
 				if (plugin.onResponse) {
 					const response = await withSpan(

--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -68,7 +68,7 @@ function decideConsume(
 		};
 	}
 	const timeSinceLastRequest = now - data.lastRequest;
-	if (timeSinceLastRequest > windowInMs) {
+	if (timeSinceLastRequest >= windowInMs) {
 		return {
 			next: { ...data, count: 1, lastRequest: now },
 			update: true,
@@ -118,6 +118,8 @@ function createDatabaseStorageWrapper(
 ): BetterAuthRateLimitStorage {
 	const model = "rateLimit";
 	const db = ctx.adapter;
+	let longestObservedWindow = Math.max(...getConfiguredRateLimitWindows(ctx));
+	const shouldPruneRows = !hasDynamicRateLimitWindows(ctx);
 	const readRow = async (key: string) => {
 		const res = await db.findMany<RateLimit>({
 			model,
@@ -134,6 +136,9 @@ function createDatabaseStorageWrapper(
 		key: string,
 		rule: { window: number; max: number },
 	): Promise<{ allowed: boolean; retryAfter: number | null }> => {
+		if (rule.window > longestObservedWindow) {
+			longestObservedWindow = rule.window;
+		}
 		const windowInMs = rule.window * 1000;
 		const data = await readRow(key);
 		const now = Date.now();
@@ -166,7 +171,7 @@ function createDatabaseStorageWrapper(
 
 		// Window elapsed: reset to a single request, guarded on the window so a
 		// concurrent increment in a new window cannot be clobbered.
-		if (timeSinceLastRequest > windowInMs) {
+		if (timeSinceLastRequest >= windowInMs) {
 			const reset = await db.incrementOne<RateLimit>({
 				model,
 				where: [
@@ -211,7 +216,7 @@ function createDatabaseStorageWrapper(
 		if (!fresh) {
 			return consume(key, rule);
 		}
-		if (now - fresh.lastRequest > windowInMs) {
+		if (now - fresh.lastRequest >= windowInMs) {
 			return consume(key, rule);
 		}
 		return {
@@ -223,11 +228,10 @@ function createDatabaseStorageWrapper(
 	// Best-effort sweep of clearly-expired rows to bound table growth. A failure
 	// here never blocks the request.
 	const deleteExpiredRows = (now: number) => {
-		const longestWindow = Math.max(
-			ctx.rateLimit.window,
-			...getDefaultSpecialRules().map((r) => r.window),
-		);
-		const cutoff = now - longestWindow * 1000;
+		if (!shouldPruneRows) {
+			return;
+		}
+		const cutoff = now - longestObservedWindow * 1000;
 		ctx.runInBackground(
 			db
 				.deleteMany({
@@ -242,6 +246,35 @@ function createDatabaseStorageWrapper(
 	return {
 		consume,
 	};
+}
+
+function hasDynamicRateLimitWindows(ctx: AuthContext) {
+	return Object.values(ctx.rateLimit.customRules ?? {}).some(
+		(rule) => typeof rule === "function",
+	);
+}
+
+function getConfiguredRateLimitWindows(ctx: AuthContext) {
+	const windows = [
+		ctx.rateLimit.window,
+		...getDefaultSpecialRules().map((rule) => rule.window),
+	];
+	for (const plugin of ctx.options.plugins || []) {
+		if (plugin.rateLimit) {
+			windows.push(...plugin.rateLimit.map((rule) => rule.window));
+		}
+	}
+	if (ctx.rateLimit.customRules) {
+		for (const customRule of Object.values(ctx.rateLimit.customRules)) {
+			if (customRule && typeof customRule !== "function") {
+				windows.push(customRule.window);
+			}
+		}
+	}
+	const validWindows = windows.filter(
+		(window) => Number.isFinite(window) && window > 0,
+	);
+	return validWindows.length > 0 ? validWindows : [ctx.rateLimit.window];
 }
 
 function getRateLimitStorage(

--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -119,7 +119,6 @@ function createDatabaseStorageWrapper(
 	const model = "rateLimit";
 	const db = ctx.adapter;
 	let longestObservedWindow = Math.max(...getConfiguredRateLimitWindows(ctx));
-	const shouldPruneRows = !hasDynamicRateLimitWindows(ctx);
 	const readRow = async (key: string) => {
 		const res = await db.findMany<RateLimit>({
 			model,
@@ -228,9 +227,6 @@ function createDatabaseStorageWrapper(
 	// Best-effort sweep of clearly-expired rows to bound table growth. A failure
 	// here never blocks the request.
 	const deleteExpiredRows = (now: number) => {
-		if (!shouldPruneRows) {
-			return;
-		}
 		const cutoff = now - longestObservedWindow * 1000;
 		ctx.runInBackground(
 			db
@@ -246,12 +242,6 @@ function createDatabaseStorageWrapper(
 	return {
 		consume,
 	};
-}
-
-function hasDynamicRateLimitWindows(ctx: AuthContext) {
-	return Object.values(ctx.rateLimit.customRules ?? {}).some(
-		(rule) => typeof rule === "function",
-	);
 }
 
 function getConfiguredRateLimitWindows(ctx: AuthContext) {

--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -2,8 +2,8 @@ import type {
 	AuthContext,
 	BetterAuthRateLimitStorage,
 } from "@better-auth/core";
+import { BetterAuthError } from "@better-auth/core/error";
 import { createRateLimitKey } from "@better-auth/core/utils/ip";
-import { safeJSONParse } from "@better-auth/core/utils/json";
 import { normalizePathname } from "@better-auth/core/utils/url";
 import type { RateLimit } from "../../types";
 import { getIp } from "../../utils/get-request-ip";
@@ -16,15 +16,80 @@ interface MemoryRateLimitEntry {
 
 const memory = new Map<string, MemoryRateLimitEntry>();
 
-function shouldRateLimit(
-	max: number,
-	window: number,
-	rateLimitData: RateLimit,
-) {
+// Cap the in-process store so a flood of distinct keys (e.g. spoofed IPs)
+// cannot grow it without bound. Sweeping expired entries on each access keeps
+// the live set small; the cap is the hard ceiling once everything is fresh.
+const MEMORY_STORE_MAX_ENTRIES = 100_000;
+
+function pruneMemoryStore() {
 	const now = Date.now();
-	const windowInMs = window * 1000;
-	const timeSinceLastRequest = now - rateLimitData.lastRequest;
-	return timeSinceLastRequest < windowInMs && rateLimitData.count >= max;
+	for (const [key, entry] of memory) {
+		if (now >= entry.expiresAt) {
+			memory.delete(key);
+		}
+	}
+	if (memory.size <= MEMORY_STORE_MAX_ENTRIES) {
+		return;
+	}
+	// Map preserves insertion order, so the oldest keys come first.
+	const overflow = memory.size - MEMORY_STORE_MAX_ENTRIES;
+	let removed = 0;
+	for (const key of memory.keys()) {
+		memory.delete(key);
+		if (++removed >= overflow) {
+			break;
+		}
+	}
+}
+
+/**
+ * Decide an atomic rate-limit step against an in-memory `RateLimit` snapshot
+ * for the rolling `window` (seconds) and `max`. Shared by the memory backend
+ * (read-decide-write is atomic under single-threaded JS) and as the fallback
+ * for storages lacking an atomic primitive.
+ */
+function decideConsume(
+	data: RateLimit | null | undefined,
+	rule: { window: number; max: number },
+	now: number,
+): {
+	next: RateLimit;
+	update: boolean;
+	allowed: boolean;
+	retryAfter: number | null;
+} {
+	const windowInMs = rule.window * 1000;
+	if (!data) {
+		return {
+			next: { key: "", count: 1, lastRequest: now },
+			update: false,
+			allowed: true,
+			retryAfter: null,
+		};
+	}
+	const timeSinceLastRequest = now - data.lastRequest;
+	if (timeSinceLastRequest > windowInMs) {
+		return {
+			next: { ...data, count: 1, lastRequest: now },
+			update: true,
+			allowed: true,
+			retryAfter: null,
+		};
+	}
+	if (data.count >= rule.max) {
+		return {
+			next: data,
+			update: true,
+			allowed: false,
+			retryAfter: getRetryAfter(data.lastRequest, rule.window),
+		};
+	}
+	return {
+		next: { ...data, count: data.count + 1, lastRequest: now },
+		update: true,
+		allowed: true,
+		retryAfter: null,
+	};
 }
 
 function rateLimitResponse(retryAfter: number) {
@@ -53,49 +118,129 @@ function createDatabaseStorageWrapper(
 ): BetterAuthRateLimitStorage {
 	const model = "rateLimit";
 	const db = ctx.adapter;
-	return {
-		get: async (key: string) => {
-			const res = await db.findMany<RateLimit>({
-				model,
-				where: [{ field: "key", value: key }],
-			});
-			const data = res[0];
+	const readRow = async (key: string) => {
+		const res = await db.findMany<RateLimit>({
+			model,
+			where: [{ field: "key", value: key }],
+		});
+		const data = res[0];
+		if (typeof data?.lastRequest === "bigint") {
+			data.lastRequest = Number(data.lastRequest);
+		}
+		return data;
+	};
 
-			if (typeof data?.lastRequest === "bigint") {
-				data.lastRequest = Number(data.lastRequest);
-			}
+	const consume = async (
+		key: string,
+		rule: { window: number; max: number },
+	): Promise<{ allowed: boolean; retryAfter: number | null }> => {
+		const windowInMs = rule.window * 1000;
+		const data = await readRow(key);
+		const now = Date.now();
 
-			return data;
-		},
-		set: async (
-			key: string,
-			value: RateLimit,
-			_update?: boolean | undefined,
-		) => {
+		// Fresh key: open the window only by creating the row. An update here
+		// would reset the count for a key a concurrent request already opened,
+		// letting every racer pass; creating instead means one request opens the
+		// window and the rest fall through to re-read and be counted.
+		if (!data) {
 			try {
-				if (_update) {
-					await db.updateMany({
-						model,
-						where: [{ field: "key", value: key }],
-						update: {
-							count: value.count,
-							lastRequest: value.lastRequest,
-						},
-					});
-				} else {
-					await db.create({
-						model,
-						data: {
-							key,
-							count: value.count,
-							lastRequest: value.lastRequest,
-						},
-					});
+				await db.create({
+					model,
+					data: { key, count: 1, lastRequest: now },
+				});
+				return { allowed: true, retryAfter: null };
+			} catch (error) {
+				// The create either lost a race against a concurrent opener (the row
+				// now exists) or failed for a real reason. Re-read once: re-decide
+				// only when the row is now present, otherwise surface the original
+				// error rather than retrying a genuine failure indefinitely.
+				const existing = await readRow(key);
+				if (!existing) {
+					throw error;
 				}
-			} catch (e) {
-				ctx.logger.error("Error setting rate limit", e);
+				return consume(key, rule);
 			}
-		},
+		}
+
+		const timeSinceLastRequest = now - data.lastRequest;
+
+		// Window elapsed: reset to a single request, guarded on the window so a
+		// concurrent increment in a new window cannot be clobbered.
+		if (timeSinceLastRequest > windowInMs) {
+			const reset = await db.incrementOne<RateLimit>({
+				model,
+				where: [
+					{ field: "key", value: key },
+					{
+						field: "lastRequest",
+						operator: "lte",
+						value: data.lastRequest,
+					},
+				],
+				increment: {},
+				set: { count: 1, lastRequest: now },
+			});
+			if (reset) {
+				deleteExpiredRows(now);
+				return { allowed: true, retryAfter: null };
+			}
+			return consume(key, rule);
+		}
+
+		// Within the window and under the max: increment guarded on both the
+		// window and the max, so a burst of concurrent requests can never exceed
+		// the limit.
+		const windowStart = now - windowInMs;
+		const incremented = await db.incrementOne<RateLimit>({
+			model,
+			where: [
+				{ field: "key", value: key },
+				{ field: "lastRequest", operator: "gt", value: windowStart },
+				{ field: "count", operator: "lt", value: rule.max },
+			],
+			increment: { count: 1 },
+			set: { lastRequest: now },
+		});
+		if (incremented) {
+			return { allowed: true, retryAfter: null };
+		}
+
+		// Guard missed: the window rolled or the max was reached between the read
+		// and the write. Re-read and re-decide.
+		const fresh = await readRow(key);
+		if (!fresh) {
+			return consume(key, rule);
+		}
+		if (now - fresh.lastRequest > windowInMs) {
+			return consume(key, rule);
+		}
+		return {
+			allowed: false,
+			retryAfter: getRetryAfter(fresh.lastRequest, rule.window),
+		};
+	};
+
+	// Best-effort sweep of clearly-expired rows to bound table growth. A failure
+	// here never blocks the request.
+	const deleteExpiredRows = (now: number) => {
+		const longestWindow = Math.max(
+			ctx.rateLimit.window,
+			...getDefaultSpecialRules().map((r) => r.window),
+		);
+		const cutoff = now - longestWindow * 1000;
+		ctx.runInBackground(
+			db
+				.deleteMany({
+					model,
+					where: [{ field: "lastRequest", operator: "lt", value: cutoff }],
+				})
+				.then(() => undefined)
+				.catch((e) => ctx.logger.error("Error pruning rate limit rows", e)),
+		);
+	};
+
+	return {
+		consume,
 	};
 }
 
@@ -110,47 +255,49 @@ function getRateLimitStorage(
 	}
 	const storage = ctx.rateLimit.storage;
 	if (storage === "secondary-storage") {
+		const ttlFor = (window: number) =>
+			window ?? ctx.options.rateLimit?.window ?? 10;
+		const increment = ctx.options.secondaryStorage?.increment;
+		if (!increment) {
+			throw new BetterAuthError(
+				"Secondary-storage rate limiting requires SecondaryStorage.increment.",
+			);
+		}
 		return {
-			get: async (key: string) => {
-				const data = await ctx.options.secondaryStorage?.get(key);
-				return data ? safeJSONParse<RateLimit>(data) : null;
-			},
-			set: async (
-				key: string,
-				value: RateLimit,
-				_update?: boolean | undefined,
-			) => {
-				const ttl =
-					rateLimitSettings?.window ?? ctx.options.rateLimit?.window ?? 10;
-				await ctx.options.secondaryStorage?.set?.(
-					key,
-					JSON.stringify(value),
-					ttl,
-				);
+			consume: async (key, rule) => {
+				// `increment` creates the counter with `ttl = window` on first use
+				// and never extends it, so the counter expires a fixed window after
+				// it opened. The post-increment value is the request count within
+				// that window.
+				const count = await increment(key, ttlFor(rule.window));
+				if (count <= rule.max) {
+					return { allowed: true, retryAfter: null };
+				}
+				return { allowed: false, retryAfter: rule.window };
 			},
 		};
 	} else if (storage === "memory") {
+		const ttlFor = (window: number) =>
+			window ?? ctx.options.rateLimit?.window ?? 10;
 		return {
-			async get(key: string) {
+			// Single-threaded JS makes this read-decide-write atomic: no other
+			// request runs between the `memory.get` and the `memory.set` below.
+			async consume(key, rule) {
+				pruneMemoryStore();
+				const now = Date.now();
 				const entry = memory.get(key);
-				if (!entry) {
-					return null;
+				const current = entry && now < entry.expiresAt ? entry.data : undefined;
+				const decision = decideConsume(current, rule, now);
+				if (decision.allowed) {
+					memory.set(key, {
+						data: { ...decision.next, key },
+						expiresAt: now + ttlFor(rule.window) * 1000,
+					});
 				}
-				// Check if entry has expired
-				if (Date.now() >= entry.expiresAt) {
-					memory.delete(key);
-					return null;
-				}
-				return entry.data;
-			},
-			async set(key: string, value: RateLimit, _update?: boolean | undefined) {
-				const ttl =
-					rateLimitSettings?.window ?? ctx.options.rateLimit?.window ?? 10;
-				const expiresAt = Date.now() + ttl * 1000;
-				memory.set(key, {
-					data: value,
-					expiresAt,
-				});
+				return {
+					allowed: decision.allowed,
+					retryAfter: decision.retryAfter,
+				};
 			},
 		};
 	}
@@ -228,6 +375,12 @@ async function resolveRateLimitConfig(req: Request, ctx: AuthContext) {
 	return { key, currentWindow, currentMax };
 }
 
+/**
+ * Decides the rate limit for the request in a single atomic step. The whole
+ * check-and-increment happens here in the request phase; there is no separate
+ * response-phase write-back, so concurrent requests cannot all pass a stale
+ * read before any increment lands.
+ */
 export async function onRequestRateLimit(req: Request, ctx: AuthContext) {
 	if (!ctx.rateLimit.enabled) {
 		return;
@@ -241,61 +394,11 @@ export async function onRequestRateLimit(req: Request, ctx: AuthContext) {
 	const storage = getRateLimitStorage(ctx, {
 		window: currentWindow,
 	});
-	const data = await storage.get(key);
+	const rule = { window: currentWindow, max: currentMax };
 
-	if (data && shouldRateLimit(currentMax, currentWindow, data)) {
-		const retryAfter = getRetryAfter(data.lastRequest, currentWindow);
-		return rateLimitResponse(retryAfter);
-	}
-}
-
-export async function onResponseRateLimit(req: Request, ctx: AuthContext) {
-	if (!ctx.rateLimit.enabled) {
-		return;
-	}
-	const config = await resolveRateLimitConfig(req, ctx);
-	if (!config) {
-		return;
-	}
-	const { key, currentWindow } = config;
-
-	const storage = getRateLimitStorage(ctx, {
-		window: currentWindow,
-	});
-	const data = await storage.get(key);
-	const now = Date.now();
-
-	if (!data) {
-		await storage.set(key, {
-			key,
-			count: 1,
-			lastRequest: now,
-		});
-	} else {
-		const timeSinceLastRequest = now - data.lastRequest;
-
-		if (timeSinceLastRequest > currentWindow * 1000) {
-			// Reset the count if the window has passed since the last request
-			await storage.set(
-				key,
-				{
-					...data,
-					count: 1,
-					lastRequest: now,
-				},
-				true,
-			);
-		} else {
-			await storage.set(
-				key,
-				{
-					...data,
-					count: data.count + 1,
-					lastRequest: now,
-				},
-				true,
-			);
-		}
+	const { allowed, retryAfter } = await storage.consume(key, rule);
+	if (!allowed) {
+		return rateLimitResponse(retryAfter ?? currentWindow);
 	}
 }
 

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -311,11 +311,10 @@ describe("custom rate limiting storage", async () => {
 			lastRequest = rateLimitData.lastRequest;
 			if (i >= 3) {
 				expect(response.error?.status).toBe(429);
-				expect(rateLimitData.count).toBe(3);
 			} else {
 				expect(response.error).toBeNull();
-				expect(rateLimitData.count).toBe(i + 1);
 			}
+			expect(rateLimitData.count).toBe(i + 1);
 			const rateLimitExp = expirationMap.get("127.0.0.1|/sign-in/email");
 			expect(rateLimitExp).toBe(10);
 		}

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -285,6 +285,79 @@ describe("database rate-limit pruning", async () => {
 	});
 });
 
+describe("database rate-limit pruning with dynamic rules", async () => {
+	const backgroundTasks: Promise<unknown>[] = [];
+	const { client, db, testUser } = await getTestInstance({
+		rateLimit: {
+			enabled: true,
+			storage: "database",
+			customRules: {
+				"/sign-in/email": () => ({ window: 120, max: 10 }),
+			},
+		},
+		advanced: {
+			backgroundTasks: {
+				handler(promise) {
+					backgroundTasks.push(promise);
+				},
+			},
+		},
+	});
+
+	beforeEach(() => {
+		backgroundTasks.length = 0;
+	});
+
+	it("prunes stale rows using the longest observed dynamic window", async () => {
+		const now = Date.now();
+		const activeDynamicKey = createRateLimitKey("127.0.0.1", "/dynamic-active");
+		const staleDynamicKey = createRateLimitKey("127.0.0.1", "/dynamic-stale");
+		const signInKey = createRateLimitKey("127.0.0.1", "/sign-in/email");
+		await db.create({
+			model: "rateLimit",
+			data: {
+				key: activeDynamicKey,
+				count: 1,
+				lastRequest: now - 90_000,
+			},
+		});
+		await db.create({
+			model: "rateLimit",
+			data: {
+				key: staleDynamicKey,
+				count: 1,
+				lastRequest: now - 130_000,
+			},
+		});
+		await db.create({
+			model: "rateLimit",
+			data: {
+				key: signInKey,
+				count: 1,
+				lastRequest: now - 130_000,
+			},
+		});
+
+		await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+		});
+		await Promise.all(backgroundTasks);
+
+		const activeDynamicRow = await db.findOne<RateLimit>({
+			model: "rateLimit",
+			where: [{ field: "key", value: activeDynamicKey }],
+		});
+		expect(activeDynamicRow).not.toBeNull();
+
+		const staleDynamicRow = await db.findOne<RateLimit>({
+			model: "rateLimit",
+			where: [{ field: "key", value: staleDynamicKey }],
+		});
+		expect(staleDynamicRow).toBeNull();
+	});
+});
+
 describe("custom rate limiting storage", async () => {
 	const store = new Map<string, string>();
 	const expirationMap = new Map<string, number>();

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -1,7 +1,46 @@
+import type { SecondaryStorage } from "@better-auth/core/db";
 import { normalizeIP } from "@better-auth/core/utils/ip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import type { RateLimit } from "../../types";
+
+function createRateLimitSecondaryStorage(
+	store: Map<string, string>,
+	expirationMap?: Map<string, number>,
+): SecondaryStorage {
+	return {
+		set(key, value, ttl) {
+			store.set(key, value);
+			if (ttl !== undefined) expirationMap?.set(key, ttl);
+		},
+		get(key) {
+			return store.get(key) || null;
+		},
+		getAndDelete(key) {
+			const value = store.get(key) || null;
+			store.delete(key);
+			expirationMap?.delete(key);
+			return value;
+		},
+		increment(key, ttl) {
+			const existing = store.get(key);
+			const current = existing ? (JSON.parse(existing) as RateLimit) : null;
+			const count = (current?.count ?? 0) + 1;
+			const next: RateLimit = {
+				key,
+				count,
+				lastRequest: Date.now(),
+			};
+			store.set(key, JSON.stringify(next));
+			if (!current && ttl !== undefined) expirationMap?.set(key, ttl);
+			return count;
+		},
+		delete(key) {
+			store.delete(key);
+			expirationMap?.delete(key);
+		},
+	};
+}
 
 describe("rate-limiter", async () => {
 	const { client, testUser } = await getTestInstance({
@@ -101,6 +140,71 @@ describe("rate-limiter", async () => {
 	});
 });
 
+describe("atomic concurrent enforcement", () => {
+	for (const storage of ["memory", "database"] as const) {
+		describe(`${storage} storage`, async () => {
+			const { client, testUser } = await getTestInstance({
+				rateLimit: {
+					enabled: true,
+					storage,
+					customRules: {
+						"/sign-in/email": { window: 10, max: 1 },
+					},
+				},
+			});
+
+			// The memory backend keeps a process-global store shared across test
+			// instances. Fake timers let each case advance the clock far past any
+			// prior 10s window so it starts from a clean window for this key. Each
+			// case advances by a distinct offset so frozen fake clocks across cases
+			// never collide on the same instant.
+			afterEach(() => {
+				vi.useRealTimers();
+			});
+
+			it("lets exactly one of two simultaneous requests through", async () => {
+				vi.useFakeTimers();
+				vi.advanceTimersByTime(120000);
+				const [a, b] = await Promise.all([
+					client.signIn.email({
+						email: testUser.email,
+						password: testUser.password,
+					}),
+					client.signIn.email({
+						email: testUser.email,
+						password: testUser.password,
+					}),
+				]);
+				const statuses = [a.error?.status, b.error?.status].sort();
+				expect(statuses).toEqual([429, undefined]);
+			});
+
+			it("resets the count once the window elapses", async () => {
+				vi.useFakeTimers();
+				vi.advanceTimersByTime(240000);
+				// Exhaust the max=1 budget, confirm the next request is blocked.
+				const first = await client.signIn.email({
+					email: testUser.email,
+					password: testUser.password,
+				});
+				expect(first.error?.status).not.toBe(429);
+				const blocked = await client.signIn.email({
+					email: testUser.email,
+					password: testUser.password,
+				});
+				expect(blocked.error?.status).toBe(429);
+
+				vi.advanceTimersByTime(11000);
+				const allowed = await client.signIn.email({
+					email: testUser.email,
+					password: testUser.password,
+				});
+				expect(allowed.error?.status).not.toBe(429);
+			});
+		});
+	}
+});
+
 describe("custom rate limiting storage", async () => {
 	const store = new Map<string, string>();
 	const expirationMap = new Map<string, number>();
@@ -108,19 +212,7 @@ describe("custom rate limiting storage", async () => {
 		rateLimit: {
 			enabled: true,
 		},
-		secondaryStorage: {
-			set(key, value, ttl) {
-				store.set(key, value);
-				if (ttl) expirationMap.set(key, ttl);
-			},
-			get(key) {
-				return store.get(key) || null;
-			},
-			delete(key) {
-				store.delete(key);
-				expirationMap.delete(key);
-			},
-		},
+		secondaryStorage: createRateLimitSecondaryStorage(store, expirationMap),
 	});
 
 	it("should use custom storage", async () => {
@@ -241,17 +333,7 @@ describe("should work in development/test environment", () => {
 				window: 10,
 				max: 3,
 			},
-			secondaryStorage: {
-				set(key, value) {
-					store.set(key, value);
-				},
-				get(key) {
-					return store.get(key) || null;
-				},
-				delete(key) {
-					store.delete(key);
-				},
-			},
+			secondaryStorage: createRateLimitSecondaryStorage(store),
 		});
 
 		for (let i = 0; i < 4; i++) {
@@ -285,17 +367,7 @@ describe("should work in development/test environment", () => {
 				window: 10,
 				max: 3,
 			},
-			secondaryStorage: {
-				set(key, value) {
-					store.set(key, value);
-				},
-				get(key) {
-					return store.get(key) || null;
-				},
-				delete(key) {
-					store.delete(key);
-				},
-			},
+			secondaryStorage: createRateLimitSecondaryStorage(store),
 		});
 
 		for (let i = 0; i < 4; i++) {

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -1,5 +1,5 @@
 import type { SecondaryStorage } from "@better-auth/core/db";
-import { normalizeIP } from "@better-auth/core/utils/ip";
+import { createRateLimitKey, normalizeIP } from "@better-auth/core/utils/ip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import type { RateLimit } from "../../types";
@@ -201,8 +201,88 @@ describe("atomic concurrent enforcement", () => {
 				});
 				expect(allowed.error?.status).not.toBe(429);
 			});
+
+			it("resets the count at the exact window boundary", async () => {
+				vi.useFakeTimers();
+				vi.advanceTimersByTime(360000);
+				const first = await client.signIn.email({
+					email: testUser.email,
+					password: testUser.password,
+				});
+				expect(first.error?.status).not.toBe(429);
+				const blocked = await client.signIn.email({
+					email: testUser.email,
+					password: testUser.password,
+				});
+				expect(blocked.error?.status).toBe(429);
+
+				vi.advanceTimersByTime(10000);
+				const allowed = await client.signIn.email({
+					email: testUser.email,
+					password: testUser.password,
+				});
+				expect(allowed.error?.status).not.toBe(429);
+			});
 		});
 	}
+});
+
+describe("database rate-limit pruning", async () => {
+	const backgroundTasks: Promise<unknown>[] = [];
+	const { client, db, testUser } = await getTestInstance({
+		rateLimit: {
+			enabled: true,
+			storage: "database",
+			customRules: {
+				"/get-session": { window: 120, max: 10 },
+			},
+		},
+		advanced: {
+			backgroundTasks: {
+				handler(promise) {
+					backgroundTasks.push(promise);
+				},
+			},
+		},
+	});
+
+	beforeEach(() => {
+		backgroundTasks.length = 0;
+	});
+
+	it("keeps active rows from longer configured windows", async () => {
+		const now = Date.now();
+		const longWindowKey = createRateLimitKey("127.0.0.1", "/get-session");
+		const signInKey = createRateLimitKey("127.0.0.1", "/sign-in/email");
+		await db.create({
+			model: "rateLimit",
+			data: {
+				key: longWindowKey,
+				count: 1,
+				lastRequest: now - 90_000,
+			},
+		});
+		await db.create({
+			model: "rateLimit",
+			data: {
+				key: signInKey,
+				count: 1,
+				lastRequest: now - 11_000,
+			},
+		});
+
+		await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+		});
+		await Promise.all(backgroundTasks);
+
+		const activeLongWindowRow = await db.findOne<RateLimit>({
+			model: "rateLimit",
+			where: [{ field: "key", value: longWindowKey }],
+		});
+		expect(activeLongWindowRow).not.toBeNull();
+	});
 });
 
 describe("custom rate limiting storage", async () => {

--- a/packages/better-auth/src/api/routes/email-verification.test.ts
+++ b/packages/better-auth/src/api/routes/email-verification.test.ts
@@ -480,6 +480,16 @@ describe("Email Verification Secondary Storage", async () => {
 				get(key) {
 					return store.get(key) || null;
 				},
+				getAndDelete(key) {
+					const value = store.get(key) || null;
+					store.delete(key);
+					return value;
+				},
+				increment(key) {
+					const count = Number(store.get(key) ?? 0) + 1;
+					store.set(key, String(count));
+					return count;
+				},
 				delete(key) {
 					store.delete(key);
 				},

--- a/packages/better-auth/src/api/routes/password.test.ts
+++ b/packages/better-auth/src/api/routes/password.test.ts
@@ -206,6 +206,61 @@ describe("forgot password", async () => {
 		expect(res.error?.status).toBe(400);
 	});
 
+	// A single reset token is single-use: two requests racing the same valid
+	// token must yield exactly one password change. Otherwise a leaked token
+	// could still be replayed during the window between validating and deleting
+	// the verification row, letting an attacker overwrite the chosen password.
+	it("should reject a concurrent reset using the same token", async () => {
+		const email = "race-reset@email.com";
+		await client.signUp.email({
+			name: "Race Reset User",
+			email,
+			password: "originalPassword123",
+		});
+
+		await client.requestPasswordReset({
+			email,
+			redirectTo: "http://localhost:3000",
+		});
+		const raceToken = token;
+
+		const attackerPassword = "attacker-password-123";
+		const legitimatePassword = "legitimate-password-123";
+		const [first, second] = await Promise.all([
+			client.resetPassword(
+				{ newPassword: legitimatePassword },
+				{ query: { token: raceToken } },
+			),
+			client.resetPassword(
+				{ newPassword: attackerPassword },
+				{ query: { token: raceToken } },
+			),
+		]);
+
+		const results = [first, second];
+		const succeeded = results.filter((res) => res.data?.status === true);
+		const rejected = results.filter((res) => res.error?.status === 400);
+		expect(succeeded).toHaveLength(1);
+		expect(rejected).toHaveLength(1);
+
+		const winningPassword =
+			first.data?.status === true ? legitimatePassword : attackerPassword;
+		const losingPassword =
+			first.data?.status === true ? attackerPassword : legitimatePassword;
+
+		const winSignIn = await client.signIn.email({
+			email,
+			password: winningPassword,
+		});
+		expect(winSignIn.data?.user).toBeDefined();
+
+		const loseSignIn = await client.signIn.email({
+			email,
+			password: losingPassword,
+		});
+		expect(loseSignIn.error?.status).toBe(401);
+	});
+
 	it("should expire", async () => {
 		const { client, signInWithTestUser, testUser } = await getTestInstance({
 			emailAndPassword: {

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -290,9 +290,12 @@ export const resetPassword = createAuthEndpoint(
 
 		const id = `reset-password:${token}`;
 
+		// Consume the single-use reset token before any password change so two
+		// concurrent requests with the same token cannot both proceed: the first
+		// caller wins, every racer (and any expired token) gets null.
 		const verification =
-			await ctx.context.internalAdapter.findVerificationValue(id);
-		if (!verification || verification.expiresAt < new Date()) {
+			await ctx.context.internalAdapter.consumeVerificationValue(id);
+		if (!verification) {
 			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_TOKEN);
 		}
 		const userId = verification.value;
@@ -309,7 +312,6 @@ export const resetPassword = createAuthEndpoint(
 		} else {
 			await ctx.context.internalAdapter.updatePassword(userId, hashedPassword);
 		}
-		await ctx.context.internalAdapter.deleteVerificationByIdentifier(id);
 
 		if (ctx.context.options.emailAndPassword?.onPasswordReset) {
 			const user = await ctx.context.internalAdapter.findUserById(userId);

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -503,6 +503,16 @@ describe("session storage", async () => {
 			get(key) {
 				return store.get(key) || null;
 			},
+			getAndDelete(key) {
+				const value = store.get(key) || null;
+				store.delete(key);
+				return value;
+			},
+			increment(key) {
+				const count = Number(store.get(key) ?? 0) + 1;
+				store.set(key, String(count));
+				return count;
+			},
 			delete(key) {
 				store.delete(key);
 			},

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -332,6 +332,16 @@ describe("updateUser", async () => {
 					get(key) {
 						return store.get(key) || null;
 					},
+					getAndDelete(key) {
+						const value = store.get(key) || null;
+						store.delete(key);
+						return value;
+					},
+					increment(key) {
+						const count = Number(store.get(key) ?? 0) + 1;
+						store.set(key, String(count));
+						return count;
+					},
 					delete(key) {
 						store.delete(key);
 					},
@@ -378,6 +388,16 @@ describe("updateUser", async () => {
 				},
 				get(key) {
 					return store.get(key) || null;
+				},
+				getAndDelete(key) {
+					const value = store.get(key) || null;
+					store.delete(key);
+					return value;
+				},
+				increment(key) {
+					const count = Number(store.get(key) ?? 0) + 1;
+					store.set(key, String(count));
+					return count;
 				},
 				delete(key) {
 					store.delete(key);
@@ -553,6 +573,16 @@ describe("delete user", async () => {
 				get(key) {
 					return store.get(key) || null;
 				},
+				getAndDelete(key) {
+					const value = store.get(key) || null;
+					store.delete(key);
+					return value;
+				},
+				increment(key) {
+					const count = Number(store.get(key) ?? 0) + 1;
+					store.set(key, String(count));
+					return count;
+				},
 				delete(key) {
 					store.delete(key);
 				},
@@ -617,6 +647,62 @@ describe("delete user", async () => {
 			});
 			const nullSession = await client.getSession();
 			expect(nullSession.data).toBeNull();
+		});
+	});
+
+	// The delete-account token is single-use: two concurrent callbacks with
+	// the same token must delete the account exactly once. Whichever request
+	// consumes the verification row first wins; the loser sees an invalid
+	// token. The destructive beforeDelete/afterDelete hooks must each fire
+	// once, and no verification row may survive the deletion.
+	it("should delete only once when the same token is used concurrently", async () => {
+		let token = "";
+		const beforeDelete = vi.fn(async () => {
+			// Widen the race so both requests pass the token lookup before
+			// either one finishes the destructive work.
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		});
+		const afterDelete = vi.fn(async () => {});
+		const { client, signInWithTestUser, testUser, db } = await getTestInstance({
+			user: {
+				deleteUser: {
+					enabled: true,
+					async sendDeleteAccountVerification(data, _) {
+						token = data.token;
+					},
+					beforeDelete,
+					afterDelete,
+				},
+			},
+		});
+		const { runWithUser } = await signInWithTestUser();
+		await runWithUser(async () => {
+			const requestRes = await client.deleteUser({
+				password: testUser.password,
+			});
+			expect(requestRes.data).toMatchObject({ success: true });
+			expect(token.length).toBe(32);
+
+			const [first, second] = await Promise.all([
+				client.deleteUser({ token }),
+				client.deleteUser({ token }),
+			]);
+
+			const successes = [first, second].filter(
+				(res) => res.data && (res.data as { success?: boolean }).success,
+			);
+			const failures = [first, second].filter((res) => res.error);
+			expect(successes.length).toBe(1);
+			expect(failures.length).toBe(1);
+
+			expect(beforeDelete).toHaveBeenCalledTimes(1);
+			expect(afterDelete).toHaveBeenCalledTimes(1);
+
+			const remaining = await db.findMany({
+				model: "verification",
+				where: [{ field: "identifier", value: `delete-account-${token}` }],
+			});
+			expect(remaining.length).toBe(0);
 		});
 	});
 

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -626,13 +626,14 @@ export const deleteUserCallback = createAuthEndpoint(
 				BASE_ERROR_CODES.FAILED_TO_GET_USER_INFO,
 			);
 		}
-		const token = await ctx.context.internalAdapter.findVerificationValue(
+		// Consume the single-use delete token atomically before any
+		// destructive work so concurrent callbacks with the same token can
+		// only delete the account once: the first caller wins, later racers
+		// get null. A wrong-owner token is still burned by this consume.
+		const token = await ctx.context.internalAdapter.consumeVerificationValue(
 			`delete-account-${ctx.query.token}`,
 		);
-		if (!token || token.expiresAt < new Date()) {
-			throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.INVALID_TOKEN);
-		}
-		if (token.value !== session.user.id) {
+		if (!token || token.value !== session.user.id) {
 			throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.INVALID_TOKEN);
 		}
 		const beforeDelete = ctx.context.options.user.deleteUser?.beforeDelete;
@@ -642,9 +643,6 @@ export const deleteUserCallback = createAuthEndpoint(
 		await ctx.context.internalAdapter.deleteUser(session.user.id);
 		await ctx.context.internalAdapter.deleteUserSessions(session.user.id);
 		await ctx.context.internalAdapter.deleteAccounts(session.user.id);
-		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-			`delete-account-${ctx.query.token}`,
-		);
 
 		deleteSessionCookie(ctx);
 

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -362,6 +362,8 @@ describe("base context creation", () => {
 				} as any,
 				secondaryStorage: {
 					get: vi.fn(),
+					getAndDelete: vi.fn(),
+					increment: vi.fn(),
 					set: vi.fn(),
 					delete: vi.fn(),
 				},
@@ -437,6 +439,8 @@ describe("base context creation", () => {
 			const res = await initBase({
 				secondaryStorage: {
 					get: vi.fn(),
+					getAndDelete: vi.fn(),
+					increment: vi.fn(),
 					set: vi.fn(),
 					delete: vi.fn(),
 				},
@@ -861,6 +865,8 @@ describe("base context creation", () => {
 			const res = await initBase({
 				secondaryStorage: {
 					get: vi.fn(),
+					getAndDelete: vi.fn(),
+					increment: vi.fn(),
 					set: vi.fn(),
 					delete: vi.fn(),
 				},
@@ -880,6 +886,8 @@ describe("base context creation", () => {
 			const res = await initBase({
 				secondaryStorage: {
 					get: vi.fn(),
+					getAndDelete: vi.fn(),
+					increment: vi.fn(),
 					set: vi.fn(),
 					delete: vi.fn(),
 				},
@@ -1839,6 +1847,8 @@ describe("base context creation", () => {
 		it("should handle secondaryStorage configuration", async () => {
 			const mockStorage = {
 				get: vi.fn(),
+				getAndDelete: vi.fn(),
+				increment: vi.fn(),
 				set: vi.fn(),
 				delete: vi.fn(),
 			};

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1,6 +1,7 @@
 import { DatabaseSync } from "node:sqlite";
 import type { GenericEndpointContext } from "@better-auth/core";
 import { runWithEndpointContext } from "@better-auth/core/context";
+import type { SecondaryStorage } from "@better-auth/core/db";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { betterAuth } from "../auth/full";
@@ -14,9 +15,41 @@ import type {
 } from "../types";
 import { getMigrations } from "./get-migration";
 
+function createStringSecondaryStorage(
+	store: Map<string, string>,
+	ttlStore?: Map<string, number>,
+): SecondaryStorage {
+	return {
+		set(key, value, ttl) {
+			store.set(key, value);
+			if (ttl !== undefined) ttlStore?.set(key, ttl);
+		},
+		get(key) {
+			return store.get(key) || null;
+		},
+		getAndDelete(key) {
+			const value = store.get(key) || null;
+			store.delete(key);
+			ttlStore?.delete(key);
+			return value;
+		},
+		increment(key, ttl) {
+			const current = Number(store.get(key) ?? 0);
+			const count = Number.isFinite(current) ? current + 1 : 1;
+			store.set(key, String(count));
+			if (current === 0 && ttl !== undefined) ttlStore?.set(key, ttl);
+			return count;
+		},
+		delete(key) {
+			store.delete(key);
+			ttlStore?.delete(key);
+		},
+	};
+}
+
 describe("internal adapter test", async () => {
-	const map = new Map();
-	const expirationMap = new Map();
+	const map = new Map<string, string>();
+	const expirationMap = new Map<string, number>();
 	let id = 1;
 	const hookUserCreateBefore = vi.fn();
 	const hookUserCreateAfter = vi.fn();
@@ -37,19 +70,7 @@ describe("internal adapter test", async () => {
 		verification: {
 			storeInDatabase: true,
 		},
-		secondaryStorage: {
-			set(key, value, ttl) {
-				map.set(key, value);
-				expirationMap.set(key, ttl);
-			},
-			get(key) {
-				return map.get(key);
-			},
-			delete(key) {
-				map.delete(key);
-				expirationMap.delete(key);
-			},
-		},
+		secondaryStorage: createStringSecondaryStorage(map, expirationMap),
 		advanced: {
 			database: {
 				generateId() {
@@ -579,6 +600,17 @@ describe("internal adapter test", async () => {
 					const item = mockStorage.get(key);
 					return item?.value || null;
 				},
+				getAndDelete(key: string) {
+					const item = mockStorage.get(key);
+					mockStorage.delete(key);
+					return item?.value || null;
+				},
+				increment(key: string, ttl: number) {
+					const item = mockStorage.get(key);
+					const count = Number(item?.value ?? 0) + 1;
+					mockStorage.set(key, { value: String(count), ttl });
+					return count;
+				},
 				delete(key: string) {
 					mockStorage.delete(key);
 				},
@@ -725,8 +757,10 @@ describe("internal adapter test", async () => {
 		expect(typeof session.id).toBe("string");
 		expect(session.id.length).toBeGreaterThan(0);
 
+		const storedSessionsRaw = map.get(`active-sessions-${user.id}`);
+		expect(storedSessionsRaw).toBeDefined();
 		const storedSessions: { token: string; expiresAt: number }[] = JSON.parse(
-			map.get(`active-sessions-${user.id}`),
+			storedSessionsRaw!,
 		);
 		const token = session.token;
 		// Check stored sessions
@@ -737,12 +771,13 @@ describe("internal adapter test", async () => {
 			prev.expiresAt >= curr.expiresAt ? prev : curr,
 		);
 		const actualExp = expirationMap.get(`active-sessions-${user.id}`);
+		expect(actualExp).toBeDefined();
 		const expectedExp = Math.floor(
 			(lastExpiration.expiresAt - Date.now()) / 1000,
 		);
 		// max 1s clock drift between check and set
-		expect(actualExp - expectedExp).toBeLessThanOrEqual(1);
-		expect(actualExp - expectedExp).toBeGreaterThanOrEqual(0);
+		expect(actualExp! - expectedExp).toBeLessThanOrEqual(1);
+		expect(actualExp! - expectedExp).toBeGreaterThanOrEqual(0);
 
 		const storedSession = safeJSONParse<{
 			session: Session;
@@ -754,12 +789,13 @@ describe("internal adapter test", async () => {
 			activeOrganizationId: "1",
 		});
 		const actualTokenExp = expirationMap.get(token);
+		expect(actualTokenExp).toBeDefined();
 		const expectedTokenExp = Math.floor(
 			(expiresAt.getTime() - Date.now()) / 1000,
 		);
 		// max 1s clock drift between check and set
-		expect(actualTokenExp - expectedTokenExp).toBeLessThanOrEqual(1);
-		expect(actualTokenExp - expectedTokenExp).toBeGreaterThanOrEqual(0);
+		expect(actualTokenExp! - expectedTokenExp).toBeLessThanOrEqual(1);
+		expect(actualTokenExp! - expectedTokenExp).toBeGreaterThanOrEqual(0);
 	});
 
 	it("should delete on secondary storage", async () => {
@@ -780,27 +816,32 @@ describe("internal adapter test", async () => {
 			);
 			if (i > 0) {
 				const actualExp = expirationMap.get(`active-sessions-${userId}`);
+				expect(actualExp).toBeDefined();
 				const expectedExp = Math.floor(
 					(expiresAt.getTime() - Date.now()) / 1000,
 				);
-				expect(actualExp - expectedExp).toBeLessThanOrEqual(1); // max 1s clock drift between check and set
-				expect(actualExp - expectedExp).toBeGreaterThanOrEqual(0); // max 1s clock drift between check and set
+				expect(actualExp! - expectedExp).toBeLessThanOrEqual(1); // max 1s clock drift between check and set
+				expect(actualExp! - expectedExp).toBeGreaterThanOrEqual(0); // max 1s clock drift between check and set
 			} else {
 				expect(expirationMap.get(`active-sessions-${userId}`)).toBeUndefined();
 			}
 		}
+		const storedSessionsRaw = map.get(`active-sessions-${userId}`);
+		expect(storedSessionsRaw).toBeDefined();
 		const storedSessions: { token: string; expiresAt: number }[] = JSON.parse(
-			map.get(`active-sessions-${userId}`),
+			storedSessionsRaw!,
 		);
 		expect(storedSessions.length).toBe(4);
-		const token = storedSessions.at(-1)?.token;
+		const token = storedSessions.at(-1)!.token;
 		const tokenStored = map.get(token);
 		expect(tokenStored).toBeDefined();
 
 		// Delete session should clean expiresAt and token
 		await internalAdapter.deleteSession(token!);
+		const afterDeletedRaw = map.get(`active-sessions-${userId}`);
+		expect(afterDeletedRaw).toBeDefined();
 		const afterDeleted: { token: string; expiresAt: number }[] = JSON.parse(
-			map.get(`active-sessions-${userId}`),
+			afterDeletedRaw!,
 		);
 		expect(afterDeleted.length).toBe(3);
 		const removedToken = map.get(token);
@@ -810,11 +851,12 @@ describe("internal adapter test", async () => {
 			prev.expiresAt >= curr.expiresAt ? prev : curr,
 		);
 		const actualExp = expirationMap.get(`active-sessions-${userId}`);
+		expect(actualExp).toBeDefined();
 		const expectedExp = Math.floor(
 			(lastExpiration.expiresAt - Date.now()) / 1000,
 		);
-		expect(actualExp - expectedExp).toBeLessThanOrEqual(1); // max 1s clock drift between check and set
-		expect(actualExp - expectedExp).toBeGreaterThanOrEqual(0); // max 1s clock drift between check and set
+		expect(actualExp! - expectedExp).toBeLessThanOrEqual(1); // max 1s clock drift between check and set
+		expect(actualExp! - expectedExp).toBeGreaterThanOrEqual(0); // max 1s clock drift between check and set
 	});
 
 	it("should delete a single account", async () => {
@@ -882,17 +924,7 @@ describe("internal adapter test", async () => {
 
 		const testOpts = {
 			database: new DatabaseSync(":memory:"),
-			secondaryStorage: {
-				set(key: string, value: string, ttl?: number) {
-					testMap.set(key, value);
-				},
-				get(key: string) {
-					return testMap.get(key) || null;
-				},
-				delete(key: string) {
-					testMap.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(testMap),
 		} satisfies BetterAuthOptions;
 
 		(await getMigrations(testOpts)).runMigrations();
@@ -933,17 +965,7 @@ describe("internal adapter test", async () => {
 
 		const testOpts = {
 			database: new DatabaseSync(":memory:"),
-			secondaryStorage: {
-				set(key: string, value: string, ttl?: number) {
-					testMap.set(key, value);
-				},
-				get(key: string) {
-					return testMap.get(key) || null;
-				},
-				delete(key: string) {
-					testMap.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(testMap),
 		} satisfies BetterAuthOptions;
 
 		(await getMigrations(testOpts)).runMigrations();
@@ -980,17 +1002,7 @@ describe("internal adapter test", async () => {
 
 		const testOpts = {
 			database: new DatabaseSync(":memory:"),
-			secondaryStorage: {
-				set(key: string, value: string, ttl?: number) {
-					testMap.set(key, value);
-				},
-				get(key: string) {
-					return testMap.get(key) || null;
-				},
-				delete(key: string) {
-					testMap.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(testMap),
 		} satisfies BetterAuthOptions;
 
 		(await getMigrations(testOpts)).runMigrations();
@@ -1026,17 +1038,7 @@ describe("internal adapter test", async () => {
 		const testMap = new Map<string, string>();
 		const testOpts = {
 			database: new DatabaseSync(":memory:"),
-			secondaryStorage: {
-				set(key: string, value: string, ttl?: number) {
-					testMap.set(key, value);
-				},
-				get(key: string) {
-					return testMap.get(key) || null;
-				},
-				delete(key: string) {
-					testMap.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(testMap),
 		} satisfies BetterAuthOptions;
 
 		(await getMigrations(testOpts)).runMigrations();
@@ -1070,17 +1072,7 @@ describe("internal adapter test", async () => {
 
 		const testOpts = {
 			database: new DatabaseSync(":memory:"),
-			secondaryStorage: {
-				set(key: string, value: string, ttl?: number) {
-					testMap.set(key, value);
-				},
-				get(key: string) {
-					return testMap.get(key) || null;
-				},
-				delete(key: string) {
-					testMap.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(testMap),
 		} satisfies BetterAuthOptions;
 
 		(await getMigrations(testOpts)).runMigrations();
@@ -1122,21 +1114,10 @@ describe("internal adapter test", async () => {
 
 		const testOpts = {
 			database: new DatabaseSync(":memory:"),
-			secondaryStorage: {
-				set(key: string, value: string, ttl?: number) {
-					testMap.set(key, value);
-					if (ttl !== undefined) {
-						testExpirationMap.set(key, ttl);
-					}
-				},
-				get(key: string) {
-					return testMap.get(key) || null;
-				},
-				delete(key: string) {
-					testMap.delete(key);
-					testExpirationMap.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(
+				testMap,
+				testExpirationMap,
+			),
 		} satisfies BetterAuthOptions;
 
 		// Run migrations for the new database
@@ -1230,21 +1211,10 @@ describe("internal adapter test", async () => {
 
 		const testOpts = {
 			database: new DatabaseSync(":memory:"),
-			secondaryStorage: {
-				set(key: string, value: string, ttl?: number) {
-					testMap.set(key, value);
-					if (ttl !== undefined) {
-						testExpirationMap.set(key, ttl);
-					}
-				},
-				get(key: string) {
-					return testMap.get(key) || null;
-				},
-				delete(key: string) {
-					testMap.delete(key);
-					testExpirationMap.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(
+				testMap,
+				testExpirationMap,
+			),
 		} satisfies BetterAuthOptions;
 
 		(await getMigrations(testOpts)).runMigrations();
@@ -1296,19 +1266,7 @@ describe("internal adapter test", async () => {
 			return {
 				dataMap,
 				ttlMap,
-				storage: {
-					set(key: string, value: string, ttl?: number) {
-						dataMap.set(key, value);
-						if (ttl) ttlMap.set(key, ttl);
-					},
-					get(key: string) {
-						return dataMap.get(key) || null;
-					},
-					delete(key: string) {
-						dataMap.delete(key);
-						ttlMap.delete(key);
-					},
-				},
+				storage: createStringSecondaryStorage(dataMap, ttlMap),
 			};
 		}
 
@@ -1498,7 +1456,7 @@ describe("internal adapter test", async () => {
 		 * where date fields are still ISO 8601 strings, not Date instances.
 		 */
 		function createPreParsedStorage() {
-			const dataMap = new Map<string, any>();
+			const dataMap = new Map<string, unknown>();
 			const ttlMap = new Map<string, number>();
 			return {
 				dataMap,
@@ -1511,6 +1469,19 @@ describe("internal adapter test", async () => {
 					},
 					get(key: string) {
 						return dataMap.get(key) ?? null;
+					},
+					getAndDelete(key: string) {
+						const value = dataMap.get(key) ?? null;
+						dataMap.delete(key);
+						ttlMap.delete(key);
+						return value;
+					},
+					increment(key: string, ttl: number) {
+						const current = Number(dataMap.get(key) ?? 0);
+						const count = Number.isFinite(current) ? current + 1 : 1;
+						dataMap.set(key, count);
+						if (current === 0) ttlMap.set(key, ttl);
+						return count;
 					},
 					delete(key: string) {
 						dataMap.delete(key);
@@ -1812,6 +1783,11 @@ describe("internal adapter test", async () => {
 						return store.get(key) ?? null;
 					},
 					getAndDelete,
+					increment(key) {
+						const count = Number(store.get(key) ?? 0) + 1;
+						store.set(key, String(count));
+						return count;
+					},
 					delete(key) {
 						store.delete(key);
 					},
@@ -1840,17 +1816,7 @@ describe("internal adapter test", async () => {
 			const store = new Map<string, string>();
 			const adapter = await makeAdapter({
 				verification: { storeInDatabase: false },
-				secondaryStorage: {
-					set(key, value) {
-						store.set(key, value);
-					},
-					get(key) {
-						return store.get(key) ?? null;
-					},
-					delete(key) {
-						store.delete(key);
-					},
-				},
+				secondaryStorage: createStringSecondaryStorage(store),
 			});
 
 			// Bypass `createVerificationValue`'s TTL gate by writing directly
@@ -1881,17 +1847,7 @@ describe("internal adapter test", async () => {
 			const store = new Map<string, string>();
 			const adapter = await makeAdapter({
 				verification: { storeInDatabase: false },
-				secondaryStorage: {
-					set(key, value) {
-						store.set(key, value);
-					},
-					get(key) {
-						return store.get(key) ?? null;
-					},
-					delete(key) {
-						store.delete(key);
-					},
-				},
+				secondaryStorage: createStringSecondaryStorage(store),
 			});
 			await adapter.createVerificationValue({
 				identifier: "consume:secondary-hydrate",
@@ -1912,17 +1868,7 @@ describe("internal adapter test", async () => {
 			const store = new Map<string, string>();
 			const adapter = await makeAdapter({
 				verification: { storeInDatabase: false },
-				secondaryStorage: {
-					set(key, value) {
-						store.set(key, value);
-					},
-					get(key) {
-						return store.get(key) ?? null;
-					},
-					delete(key) {
-						store.delete(key);
-					},
-				},
+				secondaryStorage: createStringSecondaryStorage(store),
 			});
 
 			store.set(
@@ -1942,77 +1888,103 @@ describe("internal adapter test", async () => {
 			);
 			expect(result).toBeNull();
 		});
+	});
 
-		it("serializes the secondary storage compatibility fallback within one process", async () => {
-			const store = new Map<string, string>();
-			const adapter = await makeAdapter({
-				verification: { storeInDatabase: false },
-				secondaryStorage: {
-					set(key, value) {
-						store.set(key, value);
-					},
-					async get(key) {
-						await new Promise((resolve) => setTimeout(resolve, 5));
-						return store.get(key) ?? null;
-					},
-					delete(key) {
-						store.delete(key);
-					},
-				},
+	describe("reserveVerificationValue", () => {
+		async function makeAdapter(overrides?: Partial<BetterAuthOptions>) {
+			const opts = {
+				database: new DatabaseSync(":memory:"),
+				...overrides,
+			} satisfies BetterAuthOptions;
+			(await getMigrations(opts)).runMigrations();
+			const ctx = await init(opts);
+			return ctx.internalAdapter;
+		}
+
+		it("returns true the first time and the row is findable", async () => {
+			const adapter = await makeAdapter();
+
+			const reserved = await adapter.reserveVerificationValue({
+				identifier: "reserve:fresh",
+				value: "jti-1",
+				expiresAt: new Date(Date.now() + 60_000),
 			});
-			await adapter.createVerificationValue({
-				identifier: "consume:secondary-fallback",
-				value: "fallback-user",
+			expect(reserved).toBe(true);
+
+			const found = await adapter.findVerificationValue("reserve:fresh");
+			expect(found).not.toBeNull();
+			expect(found!.value).toBe("jti-1");
+		});
+
+		it("returns false the second time for the same identifier", async () => {
+			const adapter = await makeAdapter();
+
+			const first = await adapter.reserveVerificationValue({
+				identifier: "reserve:once",
+				value: "jti-2",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+			expect(first).toBe(true);
+
+			const second = await adapter.reserveVerificationValue({
+				identifier: "reserve:once",
+				value: "jti-2-replay",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+			expect(second).toBe(false);
+		});
+
+		it("yields exactly one winner under concurrent reserve", async () => {
+			const adapter = await makeAdapter();
+
+			const results = await Promise.all([
+				adapter.reserveVerificationValue({
+					identifier: "reserve:race",
+					value: "jti-3",
+					expiresAt: new Date(Date.now() + 60_000),
+				}),
+				adapter.reserveVerificationValue({
+					identifier: "reserve:race",
+					value: "jti-3",
+					expiresAt: new Date(Date.now() + 60_000),
+				}),
+			]);
+
+			expect(results.filter((r) => r === true)).toHaveLength(1);
+			expect(results.filter((r) => r === false)).toHaveLength(1);
+		});
+
+		it("reserves independently across different identifiers", async () => {
+			const adapter = await makeAdapter();
+
+			const first = await adapter.reserveVerificationValue({
+				identifier: "reserve:independent-a",
+				value: "jti-a",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+			const second = await adapter.reserveVerificationValue({
+				identifier: "reserve:independent-b",
+				value: "jti-b",
 				expiresAt: new Date(Date.now() + 60_000),
 			});
 
-			const results = await Promise.all([
-				adapter.consumeVerificationValue("consume:secondary-fallback"),
-				adapter.consumeVerificationValue("consume:secondary-fallback"),
-				adapter.consumeVerificationValue("consume:secondary-fallback"),
-			]);
-
-			expect(results.filter((r) => r !== null)).toHaveLength(1);
-			expect(results.find((r) => r !== null)?.value).toBe("fallback-user");
-			expect(store.has("verification:consume:secondary-fallback")).toBe(false);
+			expect(first).toBe(true);
+			expect(second).toBe(true);
 		});
 
-		it("warns once when secondary storage cannot consume atomically", async () => {
-			const store = new Map<string, string>();
-			const logs: { level: string; message: string }[] = [];
+		it("fails closed when verification reservation is secondary-storage-only", async () => {
 			const adapter = await makeAdapter({
-				logger: {
-					log: (level, message) => {
-						logs.push({ level, message });
-					},
-				},
 				verification: { storeInDatabase: false },
-				secondaryStorage: {
-					set(key, value) {
-						store.set(key, value);
-					},
-					get(key) {
-						return store.get(key) ?? null;
-					},
-					delete(key) {
-						store.delete(key);
-					},
-				},
+				secondaryStorage: createStringSecondaryStorage(new Map()),
 			});
 
-			for (const id of ["consume:warn-1", "consume:warn-2"]) {
-				await adapter.createVerificationValue({
-					identifier: id,
-					value: "user",
+			await expect(
+				adapter.reserveVerificationValue({
+					identifier: "reserve:secondary-only",
+					value: "jti-secondary",
 					expiresAt: new Date(Date.now() + 60_000),
-				});
-				await adapter.consumeVerificationValue(id);
-			}
-
-			const warnings = logs.filter(
-				(l) => l.level === "warn" && l.message.includes("getAndDelete"),
-			);
-			expect(warnings).toHaveLength(1);
+				}),
+			).rejects.toThrow(/requires database-backed verification storage/);
 		});
 	});
 });

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1408,9 +1408,10 @@ export const createInternalAdapter = (
 		 * from a deterministic primary key (`SHA-256` of `reserve:<identifier>`).
 		 * The database path is atomic: the primary key turns the INSERT into the
 		 * first-writer-wins gate, and a duplicate is detected portably by
-		 * re-reading the row rather than matching adapter-specific errors. The
-		 * secondary-storage-only path has no primary key to enforce uniqueness, so
-		 * it is best-effort under concurrency.
+		 * re-reading the row rather than matching adapter-specific errors.
+		 * Secondary-storage-only verification cannot enforce the deterministic
+		 * primary-key gate, so this operation fails closed unless verification is
+		 * backed by the database.
 		 *
 		 * The atomic guarantee requires the configured adapter to reject a
 		 * duplicate primary key on insert, which every real database enforces. The

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -13,9 +13,11 @@ import {
 } from "@better-auth/core/context";
 import type { DBAdapter, Where } from "@better-auth/core/db/adapter";
 import type { InternalLogger } from "@better-auth/core/env";
-import { APIError } from "@better-auth/core/error";
+import { APIError, BetterAuthError } from "@better-auth/core/error";
 import { generateId } from "@better-auth/core/utils/id";
 import { safeJSONParse } from "@better-auth/core/utils/json";
+import { base64Url } from "@better-auth/utils/base64";
+import { createHash } from "@better-auth/utils/hash";
 import type { Account, Session, User, Verification } from "../types";
 import { getDate } from "../utils/date";
 import { getIp } from "../utils/get-request-ip";
@@ -54,9 +56,6 @@ export const createInternalAdapter = (
 	const options = ctx.options;
 	const secondaryStorage = options.secondaryStorage;
 	const verificationConsumeLocks = new Map<string, Promise<void>>();
-	// Warn at most once when a single-use value is consumed through the
-	// non-atomic secondary-storage fallback (see consumeVerificationValue).
-	let warnedNonAtomicConsume = false;
 	const sessionExpiration = options.session?.expiresIn || 60 * 60 * 24 * 7; // 7 days
 	const {
 		createWithHooks,
@@ -1275,15 +1274,9 @@ export const createInternalAdapter = (
 		 * is still deleted (so it cannot be replayed later) but `null` is
 		 * returned. Callers do not need their own `expiresAt` gate.
 		 *
-		 * The secondary-storage-only path (`storeInDatabase: false`) is atomic
-		 * only when the configured storage implements `getAndDelete`; otherwise
-		 * it falls back to an in-process lock around `get` then `delete` and
-		 * warns once, since that fallback cannot coordinate across processes.
-		 *
-		 * FIXME(consume-atomic): make `SecondaryStorage.getAndDelete` required
-		 * in the next breaking release, or require database-backed verification
-		 * storage for security-sensitive consume paths, so the non-atomic
-		 * fallback can be removed entirely.
+		 * The secondary-storage-only path (`storeInDatabase: false`) consumes
+		 * through `getAndDelete`, which is required on `SecondaryStorage` so
+		 * single-use values are not read and deleted as separate operations.
 		 */
 		consumeVerificationValue: async (
 			identifier: string,
@@ -1321,24 +1314,9 @@ export const createInternalAdapter = (
 
 			if (secondaryStorage && !options.verification?.storeInDatabase) {
 				const consumeCacheKey = async (key: string) => {
-					if (secondaryStorage.getAndDelete) {
-						return hydrateCachedVerification(
-							await secondaryStorage.getAndDelete(key),
-						);
-					}
-					if (!warnedNonAtomicConsume) {
-						warnedNonAtomicConsume = true;
-						logger.warn(
-							"Secondary storage does not implement `getAndDelete`, so single-use verification values cannot be consumed atomically across processes. Implement `getAndDelete` or use database-backed verification storage to guarantee single use.",
-						);
-					}
-					return withVerificationConsumeLock(key, async () => {
-						const raw = await secondaryStorage.get(key);
-						const parsed = hydrateCachedVerification(raw);
-						if (!parsed) return null;
-						await secondaryStorage.delete(key);
-						return parsed;
-					});
+					return hydrateCachedVerification(
+						await secondaryStorage.getAndDelete(key),
+					);
 				};
 
 				for (const stored of identifiersToTry) {
@@ -1414,6 +1392,101 @@ export const createInternalAdapter = (
 			// invalid, so callers can rely on a non-null return meaning "valid".
 			if (!consumed || consumed.expiresAt < new Date()) return null;
 			return consumed;
+		},
+		/**
+		 * First-writer-wins create keyed by a deterministic primary key derived
+		 * from `identifier`. Returns `true` when this caller created the row and
+		 * `false` when a row for the same identifier already existed.
+		 *
+		 * The dual of `consumeVerificationValue`: where consume races to delete a
+		 * marker exactly once, reserve races to create a marker exactly once. Use
+		 * it for replay tombstones (a SAML assertion id, a JWT `jti`) where the
+		 * first caller wins and every later caller must observe that the marker is
+		 * already taken.
+		 *
+		 * The `verification.identifier` column is non-unique, so uniqueness comes
+		 * from a deterministic primary key (`SHA-256` of `reserve:<identifier>`).
+		 * The database path is atomic: the primary key turns the INSERT into the
+		 * first-writer-wins gate, and a duplicate is detected portably by
+		 * re-reading the row rather than matching adapter-specific errors. The
+		 * secondary-storage-only path has no primary key to enforce uniqueness, so
+		 * it is best-effort under concurrency.
+		 *
+		 * The atomic guarantee requires the configured adapter to reject a
+		 * duplicate primary key on insert, which every real database enforces. The
+		 * in-memory adapter does not enforce primary-key uniqueness, so reservation
+		 * is best-effort there (it is intended for development and tests).
+		 */
+		reserveVerificationValue: async (data: {
+			identifier: string;
+			value: string;
+			expiresAt: Date;
+		}): Promise<boolean> => {
+			const reservationId = base64Url.encode(
+				new Uint8Array(
+					await createHash("SHA-256").digest(
+						new TextEncoder().encode("reserve:" + data.identifier),
+					),
+				),
+				{ padding: false },
+			);
+			const storageOption = getStorageOption(
+				data.identifier,
+				options.verification?.storeIdentifier,
+			);
+			const storedIdentifier = await processIdentifier(
+				data.identifier,
+				storageOption,
+			);
+
+			if (secondaryStorage && !options.verification?.storeInDatabase) {
+				throw new BetterAuthError(
+					"reserveVerificationValue requires database-backed verification storage. Set verification.storeInDatabase to true for flows that reserve verification values.",
+				);
+			}
+
+			try {
+				await adapter.create({
+					model: "verification",
+					data: {
+						id: reservationId,
+						identifier: storedIdentifier,
+						value: data.value,
+						expiresAt: data.expiresAt,
+						createdAt: new Date(),
+						updatedAt: new Date(),
+					},
+					forceAllowId: true,
+				});
+			} catch (error) {
+				// A create error is ambiguous across adapters: confirm it was a
+				// duplicate (the row exists) rather than a real failure before
+				// reporting "lost".
+				const existing = await adapter.findOne<Verification>({
+					model: "verification",
+					where: [{ field: "id", value: reservationId }],
+				});
+				if (existing) return false;
+				throw error;
+			}
+
+			if (secondaryStorage) {
+				const ttl = getTTLSeconds(data.expiresAt);
+				if (ttl > 0) {
+					await secondaryStorage.set(
+						`verification:${storedIdentifier}`,
+						JSON.stringify({
+							id: reservationId,
+							identifier: storedIdentifier,
+							value: data.value,
+							expiresAt: data.expiresAt,
+						}),
+						ttl,
+					);
+				}
+			}
+
+			return true;
 		},
 		updateVerificationByIdentifier: async (
 			identifier: string,

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -1,3 +1,4 @@
+import type { SecondaryStorage } from "@better-auth/core/db";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { beforeEach, describe, expect, it } from "vitest";
 import { admin } from "../plugins/admin/admin";
@@ -6,21 +7,63 @@ import { anonymous } from "../plugins/anonymous";
 import { anonymousClient } from "../plugins/anonymous/client";
 import { getTestInstance } from "../test-utils/test-instance";
 
+function createStringSecondaryStorage(
+	store: Map<string, string>,
+): SecondaryStorage {
+	return {
+		set(key, value) {
+			store.set(key, value);
+		},
+		get(key) {
+			return store.get(key) || null;
+		},
+		getAndDelete(key) {
+			const value = store.get(key) || null;
+			store.delete(key);
+			return value;
+		},
+		increment(key) {
+			const count = Number(store.get(key) ?? 0) + 1;
+			store.set(key, String(count));
+			return count;
+		},
+		delete(key) {
+			store.delete(key);
+		},
+	};
+}
+
+function createParsedSecondaryStorage(
+	store: Map<string, unknown>,
+): SecondaryStorage {
+	return {
+		set(key, value) {
+			store.set(key, safeJSONParse<unknown>(value));
+		},
+		get(key) {
+			return store.get(key) ?? null;
+		},
+		getAndDelete(key) {
+			const value = store.get(key) ?? null;
+			store.delete(key);
+			return value;
+		},
+		increment(key) {
+			const count = Number(store.get(key) ?? 0) + 1;
+			store.set(key, count);
+			return count;
+		},
+		delete(key) {
+			store.delete(key);
+		},
+	};
+}
+
 describe("secondary storage - get returns JSON string", async () => {
 	const store = new Map<string, string>();
 
 	const { client, signInWithTestUser } = await getTestInstance({
-		secondaryStorage: {
-			set(key, value, ttl) {
-				store.set(key, value);
-			},
-			get(key) {
-				return store.get(key) || null;
-			},
-			delete(key) {
-				store.delete(key);
-			},
-		},
+		secondaryStorage: createStringSecondaryStorage(store),
 		rateLimit: {
 			enabled: false,
 		},
@@ -74,20 +117,10 @@ describe("secondary storage - get returns JSON string", async () => {
 });
 
 describe("secondary storage - get returns already-parsed object", async () => {
-	const store = new Map<string, any>();
+	const store = new Map<string, unknown>();
 
 	const { client, signInWithTestUser } = await getTestInstance({
-		secondaryStorage: {
-			set(key, value, ttl) {
-				store.set(key, safeJSONParse(value));
-			},
-			get(key) {
-				return store.get(key);
-			},
-			delete(key) {
-				store.delete(key);
-			},
-		},
+		secondaryStorage: createParsedSecondaryStorage(store),
 		rateLimit: {
 			enabled: false,
 		},
@@ -106,6 +139,9 @@ describe("secondary storage - get returns already-parsed object", async () => {
 		const userId = s1.data!.session.userId;
 		const activeList = store.get(`active-sessions-${userId}`);
 		expect(Array.isArray(activeList)).toBe(true);
+		if (!Array.isArray(activeList)) {
+			throw new Error("Expected active sessions to be stored as an array");
+		}
 		expect(activeList.length).toBe(1);
 
 		const list = await client.listSessions({ fetchOptions: { headers } });
@@ -130,17 +166,7 @@ describe("secondary storage - storeSessionInDatabase", () => {
 		const store = new Map<string, string>();
 
 		const { client, signInWithTestUser } = await getTestInstance({
-			secondaryStorage: {
-				set(key, value, ttl) {
-					store.set(key, value);
-				},
-				get(key) {
-					return store.get(key) || null;
-				},
-				delete(key) {
-					store.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(store),
 			session: {
 				storeSessionInDatabase: true,
 				preserveSessionInDatabase: false,
@@ -182,17 +208,7 @@ describe("secondary storage - storeSessionInDatabase", () => {
 		const store = new Map<string, string>();
 
 		const { client, signInWithTestUser } = await getTestInstance({
-			secondaryStorage: {
-				set(key, value, ttl) {
-					store.set(key, value);
-				},
-				get(key) {
-					return store.get(key) || null;
-				},
-				delete(key) {
-					store.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(store),
 			session: {
 				storeSessionInDatabase: true,
 				preserveSessionInDatabase: true,
@@ -236,17 +252,7 @@ describe("secondary storage - storeSessionInDatabase", () => {
 			const deletedSessionIds: string[] = [];
 
 			const { auth, client, db, signInWithTestUser } = await getTestInstance({
-				secondaryStorage: {
-					set(key, value) {
-						store.set(key, value);
-					},
-					get(key) {
-						return store.get(key) || null;
-					},
-					delete(key) {
-						store.delete(key);
-					},
-				},
+				secondaryStorage: createStringSecondaryStorage(store),
 				session: {
 					storeSessionInDatabase: true,
 					preserveSessionInDatabase: true,
@@ -305,17 +311,7 @@ describe("secondary storage - admin removeUser cleans up sessions", async () => 
 
 	const { client, signInWithUser, customFetchImpl } = await getTestInstance({
 		plugins: [admin()],
-		secondaryStorage: {
-			set(key, value, ttl) {
-				store.set(key, value);
-			},
-			get(key) {
-				return store.get(key) || null;
-			},
-			delete(key) {
-				store.delete(key);
-			},
-		},
+		secondaryStorage: createStringSecondaryStorage(store),
 		databaseHooks: {
 			user: {
 				create: {
@@ -396,17 +392,7 @@ describe("secondary storage - /delete-anonymous-user cleans up sessions", async 
 	const { client, auth, sessionSetter } = await getTestInstance(
 		{
 			plugins: [anonymous()],
-			secondaryStorage: {
-				set(key, value, ttl) {
-					store.set(key, value);
-				},
-				get(key) {
-					return store.get(key) || null;
-				},
-				delete(key) {
-					store.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(store),
 			rateLimit: {
 				enabled: false,
 			},

--- a/packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts
+++ b/packages/better-auth/src/plugins/additional-fields/additional-fields.test.ts
@@ -298,6 +298,16 @@ describe("additionalFields", async () => {
 				get(key) {
 					return store.get(key) || null;
 				},
+				getAndDelete(key) {
+					const value = store.get(key) || null;
+					store.delete(key);
+					return value;
+				},
+				increment(key) {
+					const count = Number(store.get(key) ?? 0) + 1;
+					store.set(key, String(count));
+					return count;
+				},
 				delete(key) {
 					store.delete(key);
 				},

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -569,6 +569,110 @@ describe("device authorization flow", async () => {
 			});
 		});
 	});
+
+	describe("concurrent token redemption", () => {
+		// Invariant: an approved device code is single-use. Two polls racing to
+		// redeem the same approved code must yield exactly one token; the loser
+		// is rejected and the row must not survive for a third redemption.
+		it("should redeem an approved device code at most once under concurrent polling", async () => {
+			const { headers } = await signInWithTestUser();
+
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: { client_id: "test-client" },
+			});
+
+			await auth.api.deviceVerify({
+				query: { user_code },
+				headers,
+			});
+
+			await auth.api.deviceApprove({
+				body: { userCode: user_code },
+				headers,
+			});
+
+			const poll = () =>
+				auth.api
+					.deviceToken({
+						body: {
+							grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+							device_code,
+							client_id: "test-client",
+						},
+					})
+					.then(
+						(value) => ({ ok: true as const, value }),
+						(error) => ({ ok: false as const, error }),
+					);
+
+			const results = await Promise.all([poll(), poll()]);
+
+			const successes = results.filter(
+				(result) => result.ok && "access_token" in result.value,
+			);
+			expect(successes).toHaveLength(1);
+
+			const rowAfter = await db.findOne<DeviceCode>({
+				model: "deviceCode",
+				where: [{ field: "deviceCode", value: device_code }],
+			});
+			expect(rowAfter).toBeNull();
+
+			await expect(
+				auth.api.deviceToken({
+					body: {
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						device_code,
+						client_id: "test-client",
+					},
+				}),
+			).rejects.toMatchObject({
+				body: { error: "invalid_grant" },
+			});
+		});
+
+		it("should burn an expired approved device code instead of issuing a token", async () => {
+			const { headers } = await signInWithTestUser();
+
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: { client_id: "test-client" },
+			});
+
+			await auth.api.deviceVerify({
+				query: { user_code },
+				headers,
+			});
+
+			await auth.api.deviceApprove({
+				body: { userCode: user_code },
+				headers,
+			});
+
+			await db.update({
+				model: "deviceCode",
+				where: [{ field: "deviceCode", value: device_code }],
+				update: { expiresAt: new Date(Date.now() - 1000) },
+			});
+
+			await expect(
+				auth.api.deviceToken({
+					body: {
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						device_code,
+						client_id: "test-client",
+					},
+				}),
+			).rejects.toMatchObject({
+				body: { error: "expired_token" },
+			});
+
+			const rowAfter = await db.findOne<DeviceCode>({
+				model: "deviceCode",
+				where: [{ field: "deviceCode", value: device_code }],
+			});
+			expect(rowAfter).toBeNull();
+		});
+	});
 });
 
 describe("device authorization ownership gate", () => {

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -407,7 +407,8 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 				}>({
 					model: "deviceCode",
 					where: [
-						{ field: "deviceCode", value: device_code },
+						{ field: "id", value: deviceCodeRecord.id },
+						{ field: "clientId", value: client_id },
 						{ field: "status", value: "approved" },
 					],
 				});

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -396,8 +396,32 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 			}
 
 			if (deviceCodeRecord.status === "approved" && deviceCodeRecord.userId) {
+				// Atomically claim the approved code as the single race gate:
+				// concurrent polls contend on this delete-and-return, and only the
+				// caller that removes the row may issue a session. Losers receive
+				// null and are rejected, so the code is redeemed at most once.
+				const claimedDeviceCode = await ctx.context.adapter.consumeOne<{
+					id: string;
+					userId?: string | undefined;
+					scope?: string | undefined;
+				}>({
+					model: "deviceCode",
+					where: [
+						{ field: "deviceCode", value: device_code },
+						{ field: "status", value: "approved" },
+					],
+				});
+
+				if (!claimedDeviceCode?.userId) {
+					throw new APIError("BAD_REQUEST", {
+						error: "invalid_grant",
+						error_description:
+							DEVICE_AUTHORIZATION_ERROR_CODES.INVALID_DEVICE_CODE.message,
+					});
+				}
+
 				const user = await ctx.context.internalAdapter.findUserById(
-					deviceCodeRecord.userId,
+					claimedDeviceCode.userId,
 				);
 
 				if (!user) {
@@ -442,17 +466,6 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 					);
 				}
 
-				// Delete the device code after successful authorization
-				await ctx.context.adapter.delete({
-					model: "deviceCode",
-					where: [
-						{
-							field: "id",
-							value: deviceCodeRecord.id,
-						},
-					],
-				});
-
 				// Return OAuth 2.0 compliant token response
 				return ctx.json(
 					{
@@ -461,7 +474,7 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 						expires_in: Math.floor(
 							(new Date(session.expiresAt).getTime() - Date.now()) / 1000,
 						),
-						scope: deviceCodeRecord.scope || "",
+						scope: claimedDeviceCode.scope || "",
 					},
 					{
 						headers: {

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -2023,6 +2023,101 @@ describe("race condition protection", async () => {
 		});
 		expect(res2.error?.code).toBe("INVALID_OTP");
 	});
+
+	it("should allow exactly one success when the same OTP is verified concurrently", async () => {
+		const email = "race-concurrent-signin@domain.com";
+		await client.emailOtp.sendVerificationOtp({ email, type: "sign-in" });
+
+		const results = await Promise.all([
+			client.signIn.emailOtp({ email, otp }),
+			client.signIn.emailOtp({ email, otp }),
+		]);
+
+		const successes = results.filter((r) => r.data?.token);
+		const failures = results.filter((r) => r.error);
+		expect(successes).toHaveLength(1);
+		expect(failures).toHaveLength(1);
+		expect(failures[0]!.error?.code).toBe("INVALID_OTP");
+
+		const verificationValue =
+			await authCtx.internalAdapter.findVerificationValue(
+				`sign-in-otp-${email}`,
+			);
+		expect(verificationValue).toBeNull();
+	});
+
+	it("should allow exactly one success when the same email-verification OTP is verified concurrently", async () => {
+		const email = "race-concurrent-verify@domain.com";
+		await client.emailOtp.sendVerificationOtp({ email, type: "sign-in" });
+		await client.signIn.emailOtp({ email, otp });
+
+		await client.emailOtp.sendVerificationOtp({
+			email,
+			type: "email-verification",
+		});
+
+		const results = await Promise.all([
+			client.emailOtp.verifyEmail({ email, otp }),
+			client.emailOtp.verifyEmail({ email, otp }),
+		]);
+
+		const successes = results.filter((r) => r.data?.status === true);
+		const failures = results.filter((r) => r.error);
+		expect(successes).toHaveLength(1);
+		expect(failures).toHaveLength(1);
+		expect(failures[0]!.error?.code).toBe("INVALID_OTP");
+	});
+
+	it("should increment attempts on a wrong code without burning a valid OTP, and reject replay of a consumed code", async () => {
+		const email = "race-wrong-code@domain.com";
+		await client.emailOtp.sendVerificationOtp({ email, type: "sign-in" });
+		const validOtp = otp;
+
+		const wrong = await client.signIn.emailOtp({
+			email,
+			otp: "000000" === validOtp ? "111111" : "000000",
+		});
+		expect(wrong.error?.code).toBe("INVALID_OTP");
+
+		const afterWrong = await authCtx.internalAdapter.findVerificationValue(
+			`sign-in-otp-${email}`,
+		);
+		expect(afterWrong).not.toBeNull();
+		const [, attempts] = splitAtLastColon(afterWrong!.value);
+		expect(parseInt(attempts)).toBe(1);
+
+		const success = await client.signIn.emailOtp({ email, otp: validOtp });
+		expect(success.data?.token).toBeDefined();
+
+		const replay = await client.signIn.emailOtp({ email, otp: validOtp });
+		expect(replay.error?.code).toBe("INVALID_OTP");
+	});
+
+	it("should lock out after the attempt budget is exhausted and not recreate the OTP", async () => {
+		const email = "race-lockout@domain.com";
+		await client.emailOtp.sendVerificationOtp({ email, type: "sign-in" });
+		const validOtp = otp;
+		const wrongOtp = "000000" === validOtp ? "111111" : "000000";
+
+		// The default budget is 3 wrong tries; the next one is locked out.
+		await client.signIn.emailOtp({ email, otp: wrongOtp });
+		await client.signIn.emailOtp({ email, otp: wrongOtp });
+		await client.signIn.emailOtp({ email, otp: wrongOtp });
+		const lockedOut = await client.signIn.emailOtp({ email, otp: wrongOtp });
+		expect(lockedOut.error?.code).toBe("TOO_MANY_ATTEMPTS");
+
+		const verificationValue =
+			await authCtx.internalAdapter.findVerificationValue(
+				`sign-in-otp-${email}`,
+			);
+		expect(verificationValue).toBeNull();
+
+		const afterLockout = await client.signIn.emailOtp({
+			email,
+			otp: validOtp,
+		});
+		expect(afterLockout.error?.code).toBe("INVALID_OTP");
+	});
 });
 
 describe("email-otp-resendStrategy", async () => {

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -1082,52 +1082,11 @@ export const requestEmailChangeEmailOTP = (opts: RequiredEmailOTPOptions) =>
 					});
 				}
 
-				const currentEmailVerificationValue =
-					await ctx.context.internalAdapter.findVerificationValue(
-						toOTPIdentifier("email-verification", email),
-					);
-				if (!currentEmailVerificationValue) {
-					throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
-				}
-				const currentEmailIdentifier = toOTPIdentifier(
-					"email-verification",
-					email,
-				);
-				if (currentEmailVerificationValue.expiresAt < new Date()) {
-					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						currentEmailIdentifier,
-					);
-					throw APIError.from("BAD_REQUEST", ERROR_CODES.OTP_EXPIRED);
-				}
-
-				const [otpValue, attempts] = splitAtLastColon(
-					currentEmailVerificationValue.value,
-				);
-				const allowedAttempts = opts?.allowedAttempts || 3;
-				if (attempts && parseInt(attempts) >= allowedAttempts) {
-					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						currentEmailIdentifier,
-					);
-					throw APIError.from("FORBIDDEN", ERROR_CODES.TOO_MANY_ATTEMPTS);
-				}
-
-				const verified = await verifyStoredOTP(
+				await atomicVerifyOTP(
 					ctx,
 					opts,
-					otpValue,
+					toOTPIdentifier("email-verification", email),
 					ctx.body.otp,
-				);
-				if (!verified) {
-					await ctx.context.internalAdapter.updateVerificationByIdentifier(
-						currentEmailIdentifier,
-						{
-							value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
-						},
-					);
-					throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
-				}
-				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					currentEmailIdentifier,
 				);
 			} else {
 				if (ctx.body.otp) {
@@ -1254,45 +1213,11 @@ export const changeEmailEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				});
 			}
 
-			const verificationValue =
-				await ctx.context.internalAdapter.findVerificationValue(
-					toOTPIdentifier("change-email", `${email}-${newEmail}`),
-				);
-			if (!verificationValue) {
-				throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
-			}
-			const changeEmailIdentifier = toOTPIdentifier(
-				"change-email",
-				`${email}-${newEmail}`,
-			);
-			if (verificationValue.expiresAt < new Date()) {
-				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					changeEmailIdentifier,
-				);
-				throw APIError.from("BAD_REQUEST", ERROR_CODES.OTP_EXPIRED);
-			}
-
-			const [otpValue, attempts] = splitAtLastColon(verificationValue.value);
-			const allowedAttempts = opts?.allowedAttempts || 3;
-			if (attempts && parseInt(attempts) >= allowedAttempts) {
-				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					changeEmailIdentifier,
-				);
-				throw APIError.from("FORBIDDEN", ERROR_CODES.TOO_MANY_ATTEMPTS);
-			}
-
-			const verified = await verifyStoredOTP(ctx, opts, otpValue, ctx.body.otp);
-			if (!verified) {
-				await ctx.context.internalAdapter.updateVerificationByIdentifier(
-					changeEmailIdentifier,
-					{
-						value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
-					},
-				);
-				throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
-			}
-			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-				changeEmailIdentifier,
+			await atomicVerifyOTP(
+				ctx,
+				opts,
+				toOTPIdentifier("change-email", `${email}-${newEmail}`),
+				ctx.body.otp,
 			);
 
 			const currentUser =
@@ -1353,9 +1278,15 @@ const defaultOTPGenerator = (options: EmailOTPOptions) =>
 	generateRandomString(options.otpLength ?? 6, "0-9");
 
 /**
- * Atomically verifies OTP with race condition protection.
- * Deletes token before verification to prevent concurrent reuse.
- * Re-creates token with incremented attempts on failure.
+ * Verifies a single-use OTP with race-condition protection.
+ *
+ * The atomic consume is the single gate: only the first concurrent caller
+ * receives the record, every later racer receives `null` and is rejected, so
+ * a correct OTP can only ever be accepted once. When the submitted code is
+ * wrong the record is recreated with the same value and expiry and an
+ * incremented attempt count so the next try can still find it; the budget is
+ * enforced before verification, and a record whose attempts are exhausted is
+ * left consumed (no recreate), locking the identifier out.
  */
 async function atomicVerifyOTP(
 	ctx: GenericEndpointContext,
@@ -1363,41 +1294,45 @@ async function atomicVerifyOTP(
 	identifier: string,
 	providedOTP: string,
 ): Promise<void> {
-	const verificationValue =
+	// Surface the OTP_EXPIRED error shape before consuming. The consume itself
+	// drops expired rows and returns null, which would otherwise be
+	// indistinguishable from a missing record; this read only reports expiry
+	// and never decides the success path, so it does not weaken the race gate.
+	const existing =
 		await ctx.context.internalAdapter.findVerificationValue(identifier);
-
-	if (!verificationValue) {
-		throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
-	}
-
-	if (verificationValue.expiresAt < new Date()) {
+	if (existing && existing.expiresAt < new Date()) {
 		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 			identifier,
 		);
 		throw APIError.from("BAD_REQUEST", ERROR_CODES.OTP_EXPIRED);
 	}
 
-	const [otpValue, attempts] = splitAtLastColon(verificationValue.value);
-	const allowedAttempts = opts?.allowedAttempts || 3;
+	const consumed =
+		await ctx.context.internalAdapter.consumeVerificationValue(identifier);
 
-	if (attempts && parseInt(attempts) >= allowedAttempts) {
-		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-			identifier,
-		);
-		throw APIError.from("FORBIDDEN", ERROR_CODES.TOO_MANY_ATTEMPTS);
+	// A null result means the record was missing, already consumed by a racing
+	// request, or expired: there is nothing valid left to verify against.
+	if (!consumed) {
+		throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
 	}
 
-	// Atomically delete token before verification to prevent race condition
-	await ctx.context.internalAdapter.deleteVerificationByIdentifier(identifier);
+	const [otpValue, attempts] = splitAtLastColon(consumed.value);
+	const allowedAttempts = opts?.allowedAttempts || 3;
+	const usedAttempts = parseInt(attempts || "0");
+
+	// Budget exhausted: the record stays consumed, so no further attempt can
+	// replay it.
+	if (usedAttempts >= allowedAttempts) {
+		throw APIError.from("FORBIDDEN", ERROR_CODES.TOO_MANY_ATTEMPTS);
+	}
 
 	const verified = await verifyStoredOTP(ctx, opts, otpValue, providedOTP);
 
 	if (!verified) {
-		// Re-create with incremented attempts
 		await ctx.context.internalAdapter.createVerificationValue({
-			value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
+			value: `${otpValue}:${usedAttempts + 1}`,
 			identifier,
-			expiresAt: verificationValue.expiresAt,
+			expiresAt: consumed.expiresAt,
 		});
 		throw APIError.from("BAD_REQUEST", ERROR_CODES.INVALID_OTP);
 	}

--- a/packages/better-auth/src/plugins/haveibeenpwned/haveibeenpwned.test.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/haveibeenpwned.test.ts
@@ -1,6 +1,33 @@
-import { describe, expect, it } from "vitest";
+import { createHash } from "@better-auth/utils/hash";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
+import { admin } from "../admin/admin";
+import { adminClient } from "../admin/client";
+import { emailOTP } from "../email-otp";
+import { emailOTPClient } from "../email-otp/client";
+import { phoneNumber } from "../phone-number";
+import { phoneNumberClient } from "../phone-number/client";
 import { haveIBeenPwned } from "./index";
+
+/**
+ * Stubs the Have I Been Pwned range API so the given password is reported as
+ * breached. The plugin sends only the first five hash characters; the response
+ * must carry the remaining suffix for the comparison to match.
+ */
+async function mockBreached(password: string) {
+	const sha1Hash = (
+		await createHash("SHA-1", "hex").digest(password)
+	).toUpperCase();
+	const suffix = sha1Hash.substring(5);
+	const realFetch = globalThis.fetch;
+	vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+		const url = input instanceof Request ? input.url : input.toString();
+		if (url.startsWith("https://api.pwnedpasswords.com/range/")) {
+			return new Response(`${suffix}:42\n`, { status: 200 });
+		}
+		return realFetch(input, init);
+	});
+}
 
 describe("have-i-been-pwned", async () => {
 	const { client, auth } = await getTestInstance(
@@ -86,6 +113,188 @@ describe("have-i-been-pwned", async () => {
 
 			expect(result.error).toBeNull();
 			expect(result.data?.user).toBeDefined();
+		});
+	});
+
+	describe("reset password with email OTP", async () => {
+		let otp = "";
+		const { client } = await getTestInstance(
+			{
+				plugins: [
+					haveIBeenPwned(),
+					emailOTP({
+						async sendVerificationOTP({ otp: _otp }) {
+							otp = _otp;
+						},
+					}),
+				],
+			},
+			{
+				disableTestUser: true,
+				clientOptions: {
+					plugins: [emailOTPClient()],
+				},
+			},
+		);
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		it("should reject a compromised password on /email-otp/reset-password", async () => {
+			const email = `email-otp-${Date.now()}@example.com`;
+			await client.signUp.email({
+				email,
+				password: `Str0ng!P@ssw0rd-${Date.now()}`,
+				name: "Test User",
+			});
+			await client.emailOtp.requestPasswordReset({ email });
+
+			const breached = "breached-via-email-otp";
+			await mockBreached(breached);
+			const result = await client.emailOtp.resetPassword({
+				email,
+				otp,
+				password: breached,
+			});
+
+			expect(result.error?.status).toBe(400);
+			expect(result.error?.code).toBe("PASSWORD_COMPROMISED");
+		});
+	});
+
+	describe("reset password with phone number OTP", async () => {
+		let resetOtp = "";
+		let signUpOtp = "";
+		const { client } = await getTestInstance(
+			{
+				plugins: [
+					haveIBeenPwned(),
+					phoneNumber({
+						async sendOTP({ code }) {
+							signUpOtp = code;
+						},
+						sendPasswordResetOTP({ code }) {
+							resetOtp = code;
+						},
+						signUpOnVerification: {
+							getTempEmail(phone) {
+								return `temp-${phone}@example.com`;
+							},
+						},
+					}),
+				],
+			},
+			{
+				disableTestUser: true,
+				clientOptions: {
+					plugins: [phoneNumberClient()],
+				},
+			},
+		);
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		it("should reject a compromised password on /phone-number/reset-password", async () => {
+			const phone = `+1555${Date.now().toString().slice(-7)}`;
+			await client.phoneNumber.sendOtp({ phoneNumber: phone });
+			await client.phoneNumber.verify({ phoneNumber: phone, code: signUpOtp });
+			await client.phoneNumber.requestPasswordReset({ phoneNumber: phone });
+
+			const breached = "breached-via-phone-otp";
+			await mockBreached(breached);
+			const result = await client.phoneNumber.resetPassword({
+				phoneNumber: phone,
+				otp: resetOtp,
+				newPassword: breached,
+			});
+
+			expect(result.error?.status).toBe(400);
+			expect(result.error?.code).toBe("PASSWORD_COMPROMISED");
+		});
+	});
+
+	describe("admin password endpoints", async () => {
+		const { client, signInWithUser } = await getTestInstance(
+			{
+				plugins: [haveIBeenPwned(), admin()],
+				databaseHooks: {
+					user: {
+						create: {
+							before: async (user) => ({
+								data: {
+									...user,
+									...(user.name === "Admin" ? { role: "admin" } : {}),
+								},
+							}),
+						},
+					},
+				},
+			},
+			{
+				disableTestUser: true,
+				clientOptions: {
+					plugins: [adminClient()],
+				},
+			},
+		);
+		const adminEmail = `admin-${Date.now()}@example.com`;
+		const adminPassword = `Str0ng!P@ssw0rd-${Date.now()}`;
+		await client.signUp.email({
+			email: adminEmail,
+			password: adminPassword,
+			name: "Admin",
+		});
+		const { headers: adminHeaders } = await signInWithUser(
+			adminEmail,
+			adminPassword,
+		);
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		it("should reject a compromised password on /admin/create-user", async () => {
+			const breached = "breached-via-admin-create";
+			await mockBreached(breached);
+			const result = await client.admin.createUser(
+				{
+					name: "Created User",
+					email: `admin-create-${Date.now()}@example.com`,
+					password: breached,
+				},
+				{ headers: adminHeaders },
+			);
+
+			expect(result.error?.status).toBe(400);
+			expect(result.error?.code).toBe("PASSWORD_COMPROMISED");
+		});
+
+		it("should reject a compromised password on /admin/set-user-password", async () => {
+			const createRes = await client.admin.createUser(
+				{
+					name: "Target User",
+					email: `admin-set-${Date.now()}@example.com`,
+					password: `Str0ng!P@ssw0rd-${Date.now()}`,
+				},
+				{ headers: adminHeaders },
+			);
+			const userId = createRes.data?.user.id || "";
+
+			const breached = "breached-via-admin-set";
+			await mockBreached(breached);
+			const result = await client.admin.setUserPassword(
+				{
+					userId,
+					newPassword: breached,
+				},
+				{ headers: adminHeaders },
+			);
+
+			expect(result.error?.status).toBe(400);
+			expect(result.error?.code).toBe("PASSWORD_COMPROMISED");
 		});
 	});
 });

--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -74,7 +74,7 @@ export interface HaveIBeenPwnedOptions {
 	/**
 	 * Paths to check for password
 	 *
-	 * @default ["/sign-up/email", "/change-password", "/reset-password"]
+	 * @default ["/sign-up/email", "/change-password", "/reset-password", "/email-otp/reset-password", "/phone-number/reset-password", "/admin/create-user", "/admin/set-user-password"]
 	 */
 	paths?: string[];
 	/**
@@ -90,6 +90,10 @@ export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions | undefined) => {
 		"/sign-up/email",
 		"/change-password",
 		"/reset-password",
+		"/email-otp/reset-password",
+		"/phone-number/reset-password",
+		"/admin/create-user",
+		"/admin/set-user-password",
 	];
 
 	return {

--- a/packages/better-auth/src/plugins/one-time-token/index.ts
+++ b/packages/better-auth/src/plugins/one-time-token/index.ts
@@ -176,21 +176,16 @@ export const oneTimeToken = (options?: OneTimeTokenOptions | undefined) => {
 				async (c) => {
 					const { token } = c.body;
 					const storedToken = await storeToken(c, token);
+					// Atomically burn the single-use record before issuing a session,
+					// so two concurrent redemptions of the same token resolve to one
+					// success. A null return means missing or expired (already burned).
 					const verificationValue =
-						await c.context.internalAdapter.findVerificationValue(
+						await c.context.internalAdapter.consumeVerificationValue(
 							`one-time-token:${storedToken}`,
 						);
 					if (!verificationValue) {
 						throw c.error("BAD_REQUEST", {
 							message: "Invalid token",
-						});
-					}
-					await c.context.internalAdapter.deleteVerificationByIdentifier(
-						`one-time-token:${storedToken}`,
-					);
-					if (verificationValue.expiresAt < new Date()) {
-						throw c.error("BAD_REQUEST", {
-							message: "Token expired",
 						});
 					}
 					const session = await c.context.internalAdapter.findSession(

--- a/packages/better-auth/src/plugins/one-time-token/one-time-token.test.ts
+++ b/packages/better-auth/src/plugins/one-time-token/one-time-token.test.ts
@@ -61,6 +61,30 @@ describe("One-time token", async () => {
 		vi.useRealTimers();
 	});
 
+	// A one-time token is single-use: racing two redemptions of the same
+	// valid token must burn the record exactly once, so only one caller
+	// gets a session and the other is rejected.
+	it("should only redeem a token once under concurrent verification", async () => {
+		const { headers } = await signInWithTestUser();
+		const response = await auth.api.generateOneTimeToken({
+			headers,
+		});
+		expect(response.token).toBeDefined();
+
+		const results = await Promise.allSettled([
+			auth.api.verifyOneTimeToken({ body: { token: response.token } }),
+			auth.api.verifyOneTimeToken({ body: { token: response.token } }),
+		]);
+
+		const fulfilled = results.filter((r) => r.status === "fulfilled");
+		const rejected = results.filter((r) => r.status === "rejected");
+		expect(fulfilled).toHaveLength(1);
+		expect(rejected).toHaveLength(1);
+		expect(isAPIError((rejected[0] as PromiseRejectedResult).reason)).toBe(
+			true,
+		);
+	});
+
 	it("should work with client", async () => {
 		const { headers } = await signInWithTestUser();
 		const response = await client.oneTimeToken.generate({

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -3,9 +3,14 @@ import {
 	getCurrentAdapter,
 	runWithTransaction,
 } from "@better-auth/core/context";
-import type { WhereOperator } from "@better-auth/core/db/adapter";
+import type {
+	DBTransactionAdapter,
+	WhereOperator,
+} from "@better-auth/core/db/adapter";
 import { BetterAuthError } from "@better-auth/core/error";
 import { filterOutputFields } from "@better-auth/core/utils/db";
+import { base64Url } from "@better-auth/utils/base64";
+import { createHash } from "@better-auth/utils/hash";
 import { parseJSON } from "../../client/parser";
 import type { InferAdditionalFieldsFromPluginOptions } from "../../db";
 import type { Session, User } from "../../types";
@@ -24,6 +29,151 @@ import type {
 	TeamMember,
 } from "./schema";
 import type { OrganizationOptions } from "./types";
+
+type StoredTeamMember = TeamMember & {
+	membershipKey?: string;
+};
+
+async function computeTeamMembershipKey(data: {
+	teamId: string;
+	userId: string;
+}) {
+	const digest = await createHash("SHA-256").digest(
+		new TextEncoder().encode(JSON.stringify([data.teamId, data.userId])),
+	);
+	return base64Url.encode(new Uint8Array(digest), { padding: false });
+}
+
+async function findTeamMemberByKeyOrPair(
+	adapter: DBTransactionAdapter,
+	data: {
+		teamId: string;
+		userId: string;
+		membershipKey: string;
+	},
+) {
+	const memberByKey = await adapter.findOne<StoredTeamMember>({
+		model: "teamMember",
+		where: [{ field: "membershipKey", value: data.membershipKey }],
+	});
+	if (memberByKey) return memberByKey;
+
+	return adapter.findOne<StoredTeamMember>({
+		model: "teamMember",
+		where: [
+			{ field: "teamId", value: data.teamId },
+			{ field: "userId", value: data.userId },
+		],
+	});
+}
+
+async function syncTeamMemberCount(
+	adapter: DBTransactionAdapter,
+	teamId: string,
+) {
+	const memberCount = await adapter.count({
+		model: "teamMember",
+		where: [{ field: "teamId", value: teamId }],
+	});
+	await adapter.incrementOne<Team>({
+		model: "team",
+		where: [
+			{ field: "id", value: teamId },
+			{ field: "memberCount", operator: "lt", value: memberCount },
+		],
+		increment: {},
+		set: { memberCount },
+	});
+}
+
+async function reserveTeamSeat(
+	adapter: DBTransactionAdapter,
+	data: {
+		teamId: string;
+		maximumMembersPerTeam: number;
+	},
+) {
+	const team = await adapter.incrementOne<Team>({
+		model: "team",
+		where: [
+			{ field: "id", value: data.teamId },
+			{
+				field: "memberCount",
+				operator: "lt",
+				value: data.maximumMembersPerTeam,
+			},
+		],
+		increment: { memberCount: 1 },
+	});
+	return Boolean(team);
+}
+
+async function incrementTeamMemberCount(
+	adapter: DBTransactionAdapter,
+	teamId: string,
+) {
+	await adapter.incrementOne<Team>({
+		model: "team",
+		where: [{ field: "id", value: teamId }],
+		increment: { memberCount: 1 },
+	});
+}
+
+async function releaseTeamSeats(
+	adapter: DBTransactionAdapter,
+	teamId: string,
+	count: number,
+) {
+	if (count <= 0) return;
+	await adapter.incrementOne<Team>({
+		model: "team",
+		where: [
+			{ field: "id", value: teamId },
+			{ field: "memberCount", operator: "gte", value: count },
+		],
+		increment: { memberCount: -count },
+	});
+}
+
+async function createTeamMemberWithKey(
+	adapter: DBTransactionAdapter,
+	data: {
+		teamId: string;
+		userId: string;
+		membershipKey: string;
+	},
+) {
+	try {
+		const member = await adapter.create<
+			Omit<TeamMember, "id"> & { membershipKey: string },
+			StoredTeamMember
+		>({
+			model: "teamMember",
+			data: {
+				teamId: data.teamId,
+				userId: data.userId,
+				membershipKey: data.membershipKey,
+				createdAt: new Date(),
+			},
+		});
+		return { status: "created" as const, member };
+	} catch (error) {
+		const existing = await findTeamMemberByKeyOrPair(adapter, data);
+		if (existing) {
+			return { status: "existing" as const, member: existing };
+		}
+		throw error;
+	}
+}
+
+function stripTeamMembershipKey(member: StoredTeamMember): TeamMember {
+	const { membershipKey: _membershipKey, ...output } = member;
+	return output;
+}
+
+function stripTeamMembershipKeys(members: StoredTeamMember[]): TeamMember[] {
+	return members.map(stripTeamMembershipKey);
+}
 
 export const getOrgAdapter = <O extends OrganizationOptions>(
 	context: AuthContext,
@@ -360,18 +510,15 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 						model: "team",
 						where: [{ field: "organizationId", value: organizationId }],
 					});
-					if (teams.length > 0) {
-						await adapter.deleteMany({
+					for (const team of teams) {
+						const deleted = await adapter.deleteMany({
 							model: "teamMember",
 							where: [
 								{ field: "userId", value: userId },
-								{
-									field: "teamId",
-									value: teams.map((team) => team.id),
-									operator: "in",
-								},
+								{ field: "teamId", value: team.id },
 							],
 						});
+						await releaseTeamSeats(adapter, team.id, deleted);
 					}
 				}
 				return member;
@@ -625,12 +772,19 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 		createTeam: async (data: TeamInput) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
-			const team = await adapter.create<TeamInput, InferTeam<O, false>>({
+			const team = await adapter.create<
+				TeamInput & { memberCount: number },
+				InferTeam<O, false> & { memberCount?: number }
+			>({
 				model: "team",
-				data,
+				data: { ...data, memberCount: 0 },
 				forceAllowId: true,
 			});
-			return team;
+			const { memberCount: _memberCount, ...output } = team;
+			return filterOutputFields(
+				output,
+				teamAdditionalFields,
+			) as unknown as InferTeam<O>;
 		},
 		findTeamById: async <IncludeMembers extends boolean>({
 			teamId,
@@ -647,7 +801,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		> => {
 			const adapter = await getCurrentAdapter(baseAdapter);
 			const result = await adapter.findOne<
-				InferTeam<O> & { teamMember: TeamMember[] }
+				InferTeam<O> & { teamMember: StoredTeamMember[] }
 			>({
 				model: "team",
 				where: [
@@ -672,11 +826,23 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			if (!result) {
 				return null;
 			}
-			const { teamMember, ...team } = result;
+			const {
+				teamMember,
+				memberCount: _memberCount,
+				...team
+			} = result as InferTeam<O> & {
+				teamMember?: StoredTeamMember[];
+				memberCount?: number;
+			};
 
 			return {
-				...team,
-				...(includeTeamMembers ? { members: teamMember } : {}),
+				...(filterOutputFields(
+					team,
+					teamAdditionalFields,
+				) as unknown as InferTeam<O>),
+				...(includeTeamMembers
+					? { members: stripTeamMembershipKeys(teamMember ?? []) }
+					: {}),
 			} as any;
 		},
 		updateTeam: async (
@@ -690,7 +856,10 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			const adapter = await getCurrentAdapter(baseAdapter);
 			if ("id" in data) data.id = undefined;
 			const team = await adapter.update<
-				InferTeam<O, false> & InferAdditionalFieldsFromPluginOptions<"team", O>
+				InferTeam<O, false> &
+					InferAdditionalFieldsFromPluginOptions<"team", O> & {
+						memberCount?: number;
+					}
 			>({
 				model: "team",
 				where: [
@@ -703,7 +872,12 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					...data,
 				},
 			});
-			return team;
+			if (!team) return team;
+			const { memberCount: _memberCount, ...output } = team;
+			return filterOutputFields(
+				output,
+				teamAdditionalFields,
+			) as unknown as InferTeam<O>;
 		},
 
 		deleteTeam: async (teamId: string) => {
@@ -741,7 +915,16 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					},
 				],
 			});
-			return teams;
+			return teams.map((team) => {
+				const { memberCount: _memberCount, ...output } = team as InferTeam<
+					O,
+					false
+				> & { memberCount?: number };
+				return filterOutputFields(
+					output,
+					teamAdditionalFields,
+				) as unknown as InferTeam<O>;
+			});
 		},
 
 		createTeamInvitation: async ({
@@ -797,7 +980,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 
 		listTeamMembers: async (data: { teamId: string }) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
-			const members = await adapter.findMany<TeamMember>({
+			const members = await adapter.findMany<StoredTeamMember>({
 				model: "teamMember",
 				where: [
 					{
@@ -807,7 +990,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				],
 			});
 
-			return members;
+			return stripTeamMembershipKeys(members);
 		},
 		countTeamMembers: async (data: { teamId: string }) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
@@ -840,12 +1023,20 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				},
 			});
 
-			return results.map((result) => result.team);
+			return results.map((result) => {
+				const { memberCount: _memberCount, ...team } = result.team as Team & {
+					memberCount?: number;
+				};
+				return filterOutputFields(
+					team,
+					teamAdditionalFields,
+				) as unknown as InferTeam<O>;
+			});
 		},
 
 		findTeamMember: async (data: { teamId: string; userId: string }) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
-			const member = await adapter.findOne<TeamMember>({
+			const member = await adapter.findOne<StoredTeamMember>({
 				model: "teamMember",
 				where: [
 					{
@@ -859,49 +1050,38 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				],
 			});
 
-			return member;
+			return member ? stripTeamMembershipKey(member) : null;
 		},
 
 		findOrCreateTeamMember: async (data: {
 			teamId: string;
 			userId: string;
 		}) => {
-			const adapter = await getCurrentAdapter(baseAdapter);
-			const member = await adapter.findOne<TeamMember>({
-				model: "teamMember",
-				where: [
-					{
-						field: "teamId",
-						value: data.teamId,
-					},
-					{
-						field: "userId",
-						value: data.userId,
-					},
-				],
-			});
+			return runWithTransaction(baseAdapter, async () => {
+				const adapter = await getCurrentAdapter(baseAdapter);
+				const membershipKey = await computeTeamMembershipKey(data);
+				const existing = await findTeamMemberByKeyOrPair(adapter, {
+					...data,
+					membershipKey,
+				});
+				if (existing) return stripTeamMembershipKey(existing);
 
-			if (member) return member;
-
-			return await adapter.create<Omit<TeamMember, "id">, TeamMember>({
-				model: "teamMember",
-				data: {
-					teamId: data.teamId,
-					userId: data.userId,
-					createdAt: new Date(),
-				},
+				await syncTeamMemberCount(adapter, data.teamId);
+				const result = await createTeamMemberWithKey(adapter, {
+					...data,
+					membershipKey,
+				});
+				if (result.status === "created") {
+					await incrementTeamMemberCount(adapter, data.teamId);
+				}
+				return stripTeamMembershipKey(result.member);
 			});
 		},
 		/**
-		 * Adds a user to a team only when the team is below its member limit,
-		 * reading the count and creating the membership in one transaction where
-		 * the adapter supports one. Returns the existing membership unchanged
-		 * (no capacity charge) when the user already belongs to the team.
-		 *
-		 * FIXME(organization-team-capacity-atomic): this count/create sequence is
-		 * not a portable aggregate-capacity lock on adapters without isolated
-		 * transactions. A full fix needs a durable per-team counter/lock boundary
-		 * and composite teamMember uniqueness.
+		 * Adds a user to a team by reserving capacity on the team row before
+		 * creating the membership row. The durable team counter is the aggregate
+		 * capacity boundary; the membership key is the single-column uniqueness
+		 * boundary for a user within a team.
 		 */
 		addTeamMemberWithLimit: async (data: {
 			teamId: string;
@@ -912,41 +1092,48 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		> => {
 			return runWithTransaction(baseAdapter, async () => {
 				const adapter = await getCurrentAdapter(baseAdapter);
-				const existing = await adapter.findOne<TeamMember>({
-					model: "teamMember",
-					where: [
-						{ field: "teamId", value: data.teamId },
-						{ field: "userId", value: data.userId },
-					],
+				const membershipKey = await computeTeamMembershipKey(data);
+				const existing = await findTeamMemberByKeyOrPair(adapter, {
+					teamId: data.teamId,
+					userId: data.userId,
+					membershipKey,
 				});
 				if (existing) {
-					return { status: "added", member: existing };
+					return { status: "added", member: stripTeamMembershipKey(existing) };
 				}
-				const count = await adapter.count({
-					model: "teamMember",
-					where: [{ field: "teamId", value: data.teamId }],
+				await syncTeamMemberCount(adapter, data.teamId);
+				const reserved = await reserveTeamSeat(adapter, {
+					teamId: data.teamId,
+					maximumMembersPerTeam: data.maximumMembersPerTeam,
 				});
-				if (count >= data.maximumMembersPerTeam) {
+				if (!reserved) {
 					return { status: "limitReached" };
 				}
-				const member = await adapter.create<Omit<TeamMember, "id">, TeamMember>(
-					{
-						model: "teamMember",
-						data: {
-							teamId: data.teamId,
-							userId: data.userId,
-							createdAt: new Date(),
-						},
-					},
-				);
-				return { status: "added", member };
+				let result: Awaited<ReturnType<typeof createTeamMemberWithKey>>;
+				try {
+					result = await createTeamMemberWithKey(adapter, {
+						teamId: data.teamId,
+						userId: data.userId,
+						membershipKey,
+					});
+				} catch (error) {
+					await releaseTeamSeats(adapter, data.teamId, 1);
+					throw error;
+				}
+				if (result.status === "existing") {
+					await releaseTeamSeats(adapter, data.teamId, 1);
+				}
+				return {
+					status: "added",
+					member: stripTeamMembershipKey(result.member),
+				};
 			});
 		},
 		removeTeamMember: async (data: { teamId: string; userId: string }) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
 			// use `deleteMany` instead of `delete` since Prisma requires 1 unique field for normal `delete` operations
 			// FKs do not count thus breaking the operation. As a solution, we'll use `deleteMany` instead.
-			await adapter.deleteMany({
+			const deleted = await adapter.deleteMany({
 				model: "teamMember",
 				where: [
 					{
@@ -959,6 +1146,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					},
 				],
 			});
+			await releaseTeamSeats(adapter, data.teamId, deleted);
 		},
 		findInvitationsByTeamId: async (teamId: string) => {
 			const adapter = await getCurrentAdapter(baseAdapter);

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -892,6 +892,52 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				},
 			});
 		},
+		/**
+		 * Adds a user to a team only when the team is below its member limit,
+		 * reading the count and creating the membership in one transaction so
+		 * concurrent accepts cannot both pass the check. Returns the existing
+		 * membership unchanged (no capacity charge) when the user already
+		 * belongs to the team.
+		 */
+		addTeamMemberWithLimit: async (data: {
+			teamId: string;
+			userId: string;
+			maximumMembersPerTeam: number;
+		}): Promise<
+			{ status: "added"; member: TeamMember } | { status: "limitReached" }
+		> => {
+			return runWithTransaction(baseAdapter, async () => {
+				const adapter = await getCurrentAdapter(baseAdapter);
+				const existing = await adapter.findOne<TeamMember>({
+					model: "teamMember",
+					where: [
+						{ field: "teamId", value: data.teamId },
+						{ field: "userId", value: data.userId },
+					],
+				});
+				if (existing) {
+					return { status: "added", member: existing };
+				}
+				const count = await adapter.count({
+					model: "teamMember",
+					where: [{ field: "teamId", value: data.teamId }],
+				});
+				if (count >= data.maximumMembersPerTeam) {
+					return { status: "limitReached" };
+				}
+				const member = await adapter.create<Omit<TeamMember, "id">, TeamMember>(
+					{
+						model: "teamMember",
+						data: {
+							teamId: data.teamId,
+							userId: data.userId,
+							createdAt: new Date(),
+						},
+					},
+				);
+				return { status: "added", member };
+			});
+		},
 		removeTeamMember: async (data: { teamId: string; userId: string }) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
 			// use `deleteMany` instead of `delete` since Prisma requires 1 unique field for normal `delete` operations
@@ -1053,17 +1099,22 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 		updateInvitation: async (data: {
 			invitationId: string;
-			status: "accepted" | "canceled" | "rejected";
+			status: "pending" | "accepted" | "canceled" | "rejected";
+			/**
+			 * Only transition when the invitation is currently in this status. The
+			 * guarded update is atomic, so a concurrent caller racing the same
+			 * transition gets `null` instead of both proceeding.
+			 */
+			fromStatus?: "pending";
 		}) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
+			const where = [{ field: "id", value: data.invitationId }];
+			if (data.fromStatus) {
+				where.push({ field: "status", value: data.fromStatus });
+			}
 			const invitation = await adapter.update<InferInvitation<O, false>>({
 				model: "invitation",
-				where: [
-					{
-						field: "id",
-						value: data.invitationId,
-					},
-				],
+				where,
 				update: {
 					status: data.status,
 				},

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -894,10 +894,14 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 		/**
 		 * Adds a user to a team only when the team is below its member limit,
-		 * reading the count and creating the membership in one transaction so
-		 * concurrent accepts cannot both pass the check. Returns the existing
-		 * membership unchanged (no capacity charge) when the user already
-		 * belongs to the team.
+		 * reading the count and creating the membership in one transaction where
+		 * the adapter supports one. Returns the existing membership unchanged
+		 * (no capacity charge) when the user already belongs to the team.
+		 *
+		 * FIXME(organization-team-capacity-atomic): this count/create sequence is
+		 * not a portable aggregate-capacity lock on adapters without isolated
+		 * transactions. A full fix needs a durable per-team counter/lock boundary
+		 * and composite teamMember uniqueness.
 		 */
 		addTeamMemberWithLimit: async (data: {
 			teamId: string;
@@ -1105,7 +1109,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			 * guarded update is atomic, so a concurrent caller racing the same
 			 * transition gets `null` instead of both proceeding.
 			 */
-			fromStatus?: "pending";
+			fromStatus?: "pending" | "accepted" | "canceled" | "rejected";
 		}) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
 			const where = [{ field: "id", value: data.invitationId }];

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -945,6 +945,14 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 							required: true,
 							fieldName: opts.schema?.team?.fields?.name,
 						},
+						memberCount: {
+							type: "number",
+							required: true,
+							defaultValue: 0,
+							input: false,
+							returned: false,
+							fieldName: opts.schema?.team?.fields?.memberCount,
+						},
 						organizationId: {
 							type: "string",
 							required: true,
@@ -991,6 +999,14 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 							},
 							fieldName: opts.schema?.teamMember?.fields?.userId,
 							index: true,
+						},
+						membershipKey: {
+							type: "string",
+							required: false,
+							unique: true,
+							input: false,
+							returned: false,
+							fieldName: opts.schema?.teamMember?.fields?.membershipKey,
 						},
 						createdAt: {
 							type: "date",

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -847,6 +847,7 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				await adapter.updateInvitation({
 					invitationId: ctx.body.invitationId,
 					status: "pending",
+					fromStatus: "accepted",
 				});
 				throw error;
 			});

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -1,5 +1,6 @@
 import type { GenerateIdFn, LiteralString } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
+import { runWithTransaction } from "@better-auth/core/context";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import * as z from "zod";
 import { getSessionFromCtx } from "../../../api/routes";
@@ -732,99 +733,124 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				});
 			}
 
+			// Claim the invitation atomically so only one concurrent accept wins the
+			// pending -> accepted transition; the guarded update is a single statement
+			// and atomic on every adapter. The membership work then runs in a
+			// transaction so it is all-or-nothing where the adapter supports it, and if
+			// it fails the claim is released back to pending so the invitee can retry
+			// instead of being stranded as accepted with no membership.
 			const acceptedI = await adapter.updateInvitation({
 				invitationId: ctx.body.invitationId,
 				status: "accepted",
+				fromStatus: "pending",
 			});
 			if (!acceptedI) {
+				// Another request already accepted this invitation.
 				throw APIError.from(
 					"BAD_REQUEST",
-					ORGANIZATION_ERROR_CODES.FAILED_TO_RETRIEVE_INVITATION,
+					ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
 				);
 			}
-			if (
-				ctx.context.orgOptions.teams &&
-				ctx.context.orgOptions.teams.enabled &&
-				"teamId" in acceptedI &&
-				acceptedI.teamId
-			) {
-				const teamIds = (acceptedI.teamId as string).split(",");
-				const onlyOne = teamIds.length === 1;
 
-				for (const teamId of teamIds) {
-					// Confirm the team still belongs to the invitation's
-					// organization before adding the member. This keeps team
-					// membership consistent with the invitation's organization,
-					// including for older invitations and for teams that were
-					// moved or removed between invite and accept.
-					const team = await adapter.findTeamById({
-						teamId,
-						organizationId: invitation.organizationId,
-					});
-					if (!team) {
-						throw APIError.from(
-							"BAD_REQUEST",
-							ORGANIZATION_ERROR_CODES.TEAM_NOT_FOUND,
-						);
-					}
+			const member = await runWithTransaction(ctx.context.adapter, async () => {
+				if (
+					ctx.context.orgOptions.teams &&
+					ctx.context.orgOptions.teams.enabled &&
+					"teamId" in invitation &&
+					invitation.teamId
+				) {
+					const teamIds = (invitation.teamId as string).split(",");
+					const onlyOne = teamIds.length === 1;
 
-					await adapter.findOrCreateTeamMember({
-						teamId: teamId,
-						userId: session.user.id,
-					});
-
-					if (
-						typeof ctx.context.orgOptions.teams.maximumMembersPerTeam !==
-						"undefined"
-					) {
-						const members = await adapter.countTeamMembers({ teamId });
-
-						const maximumMembersPerTeam =
-							typeof ctx.context.orgOptions.teams.maximumMembersPerTeam ===
-							"function"
-								? await ctx.context.orgOptions.teams.maximumMembersPerTeam({
-										teamId,
-										session: session,
-										organizationId: invitation.organizationId,
-									})
-								: ctx.context.orgOptions.teams.maximumMembersPerTeam;
-
-						if (members >= maximumMembersPerTeam) {
+					for (const teamId of teamIds) {
+						// Confirm the team still belongs to the invitation's
+						// organization before adding the member. This keeps team
+						// membership consistent with the invitation's organization,
+						// including for older invitations and for teams that were
+						// moved or removed between invite and accept.
+						const team = await adapter.findTeamById({
+							teamId,
+							organizationId: invitation.organizationId,
+						});
+						if (!team) {
 							throw APIError.from(
-								"FORBIDDEN",
-								ORGANIZATION_ERROR_CODES.TEAM_MEMBER_LIMIT_REACHED,
+								"BAD_REQUEST",
+								ORGANIZATION_ERROR_CODES.TEAM_NOT_FOUND,
 							);
 						}
+
+						if (
+							typeof ctx.context.orgOptions.teams.maximumMembersPerTeam !==
+							"undefined"
+						) {
+							const maximumMembersPerTeam =
+								typeof ctx.context.orgOptions.teams.maximumMembersPerTeam ===
+								"function"
+									? await ctx.context.orgOptions.teams.maximumMembersPerTeam({
+											teamId,
+											session: session,
+											organizationId: invitation.organizationId,
+										})
+									: ctx.context.orgOptions.teams.maximumMembersPerTeam;
+
+							const result = await adapter.addTeamMemberWithLimit({
+								teamId,
+								userId: session.user.id,
+								maximumMembersPerTeam,
+							});
+							if (result.status === "limitReached") {
+								throw APIError.from(
+									"FORBIDDEN",
+									ORGANIZATION_ERROR_CODES.TEAM_MEMBER_LIMIT_REACHED,
+								);
+							}
+						} else {
+							await adapter.findOrCreateTeamMember({
+								teamId: teamId,
+								userId: session.user.id,
+							});
+						}
+					}
+
+					if (onlyOne) {
+						const teamId = teamIds[0]!;
+						const updatedSession = await adapter.setActiveTeam(
+							session.session.token,
+							teamId,
+							ctx,
+						);
+
+						await setSessionCookie(ctx, {
+							session: updatedSession,
+							user: session.user,
+						});
 					}
 				}
 
-				if (onlyOne) {
-					const teamId = teamIds[0]!;
-					const updatedSession = await adapter.setActiveTeam(
-						session.session.token,
-						teamId,
-						ctx,
-					);
+				const createdMember = await adapter.createMember({
+					organizationId: invitation.organizationId,
+					userId: session.user.id,
+					role: invitation.role,
+					createdAt: new Date(),
+				});
 
-					await setSessionCookie(ctx, {
-						session: updatedSession,
-						user: session.user,
-					});
-				}
-			}
+				await adapter.setActiveOrganization(
+					session.session.token,
+					invitation.organizationId,
+					ctx,
+				);
 
-			const member = await adapter.createMember({
-				organizationId: invitation.organizationId,
-				userId: session.user.id,
-				role: invitation.role,
-				createdAt: new Date(),
+				return createdMember;
+			}).catch(async (error) => {
+				// The membership work failed; release the claim so the invitation is
+				// pending again and the invitee can retry.
+				await adapter.updateInvitation({
+					invitationId: ctx.body.invitationId,
+					status: "pending",
+				});
+				throw error;
 			});
 
-			await adapter.setActiveOrganization(
-				session.session.token,
-				invitation.organizationId,
-				ctx,
-			);
 			if (options?.organizationHooks?.afterAcceptInvitation) {
 				await options?.organizationHooks.afterAcceptInvitation({
 					invitation: acceptedI as unknown as Invitation,

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -196,10 +196,54 @@ export const addMember = <O extends OrganizationOptions>(option: O) => {
 			const createdMember = await adapter.createMember(memberData);
 
 			if (teamId) {
-				await adapter.findOrCreateTeamMember({
-					userId: user.id,
-					teamId,
-				});
+				try {
+					if (
+						typeof ctx.context.orgOptions.teams?.maximumMembersPerTeam !==
+						"undefined"
+					) {
+						const configuredMaximumMembersPerTeam =
+							ctx.context.orgOptions.teams.maximumMembersPerTeam;
+						let maximumMembersPerTeam: number;
+						if (typeof configuredMaximumMembersPerTeam === "function") {
+							if (!session) {
+								throw APIError.fromStatus("UNAUTHORIZED");
+							}
+							maximumMembersPerTeam = await configuredMaximumMembersPerTeam({
+								teamId,
+								session: {
+									user: session.user,
+									session: session.session,
+								},
+								organizationId: orgId,
+							});
+						} else {
+							maximumMembersPerTeam = configuredMaximumMembersPerTeam;
+						}
+						const result = await adapter.addTeamMemberWithLimit({
+							userId: user.id,
+							teamId,
+							maximumMembersPerTeam,
+						});
+						if (result.status === "limitReached") {
+							throw APIError.from(
+								"FORBIDDEN",
+								ORGANIZATION_ERROR_CODES.TEAM_MEMBER_LIMIT_REACHED,
+							);
+						}
+					} else {
+						await adapter.findOrCreateTeamMember({
+							userId: user.id,
+							teamId,
+						});
+					}
+				} catch (error) {
+					await adapter.deleteMember({
+						memberId: createdMember.id,
+						organizationId: orgId,
+						userId: user.id,
+					});
+					throw error;
+				}
 			}
 
 			// Run afterAddMember hook

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -10,6 +10,7 @@ import { getOrgAdapter } from "../adapter";
 import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
 import { hasPermission } from "../has-permission";
+import type { TeamMember } from "../schema";
 import { teamSchema } from "../schema";
 import type { OrganizationOptions } from "../types";
 
@@ -383,7 +384,11 @@ export const updateTeam = <O extends OrganizationOptions>(options: O) => {
 				}),
 				data: z
 					.object({
-						...teamSchema.shape,
+						...teamSchema.omit({
+							id: true,
+							createdAt: true,
+							updatedAt: true,
+						}).shape,
 						...additionalFieldsSchema.shape,
 					})
 					.partial(),
@@ -1234,10 +1239,38 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 				}
 			}
 
-			const teamMember = await adapter.findOrCreateTeamMember({
-				teamId: ctx.body.teamId,
-				userId: ctx.body.userId,
-			});
+			let teamMember: TeamMember;
+			if (
+				typeof ctx.context.orgOptions.teams?.maximumMembersPerTeam !==
+				"undefined"
+			) {
+				const maximumMembersPerTeam =
+					typeof ctx.context.orgOptions.teams.maximumMembersPerTeam ===
+					"function"
+						? await ctx.context.orgOptions.teams.maximumMembersPerTeam({
+								teamId: ctx.body.teamId,
+								session,
+								organizationId,
+							})
+						: ctx.context.orgOptions.teams.maximumMembersPerTeam;
+				const result = await adapter.addTeamMemberWithLimit({
+					teamId: ctx.body.teamId,
+					userId: ctx.body.userId,
+					maximumMembersPerTeam,
+				});
+				if (result.status === "limitReached") {
+					throw APIError.from(
+						"FORBIDDEN",
+						ORGANIZATION_ERROR_CODES.TEAM_MEMBER_LIMIT_REACHED,
+					);
+				}
+				teamMember = result.member;
+			} else {
+				teamMember = await adapter.findOrCreateTeamMember({
+					teamId: ctx.body.teamId,
+					userId: ctx.body.userId,
+				});
+			}
 
 			// Run afterAddTeamMember hook
 			if (options?.organizationHooks?.afterAddTeamMember) {

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -56,6 +56,13 @@ interface TeamDefaultFields {
 		type: "string";
 		required: true;
 	};
+	memberCount: {
+		type: "number";
+		required: true;
+		defaultValue: 0;
+		input: false;
+		returned: false;
+	};
 	organizationId: {
 		type: "string";
 		required: true;
@@ -90,6 +97,13 @@ interface TeamMemberDefaultFields {
 			model: "user";
 			field: "id";
 		};
+	};
+	membershipKey: {
+		type: "string";
+		required: false;
+		unique: true;
+		input: false;
+		returned: false;
 	};
 	createdAt: {
 		type: "date";

--- a/packages/better-auth/src/plugins/organization/team.test.ts
+++ b/packages/better-auth/src/plugins/organization/team.test.ts
@@ -503,7 +503,11 @@ describe("team", async () => {
 				headers: newHeaders,
 			},
 		);
-		expect(acceptInvitationResponse.data).toBeDefined();
+		expect(acceptInvitationResponse.error).toBeNull();
+		expect(acceptInvitationResponse.data?.member?.userId).toBe(
+			signUpRes.data?.user.id,
+		);
+		expect(acceptInvitationResponse.data?.invitation?.status).toBe("accepted");
 
 		const res2 = await client.organization.inviteMember(
 			{
@@ -1841,5 +1845,182 @@ describe("invitation team ids are scoped to the invited organization", async () 
 		expect(otherOrgTeamMembers.some((m) => m.userId === inviteeUserId)).toBe(
 			false,
 		);
+	});
+});
+
+describe("accept-invitation validates team capacity before adding the member", async () => {
+	const { auth, client, signInWithTestUser, cookieSetter } =
+		await getTestInstance({
+			plugins: [
+				organization({
+					async sendInvitationEmail() {},
+					teams: {
+						enabled: true,
+						maximumMembersPerTeam: 2,
+					},
+				}),
+			],
+			logger: { level: "error" },
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (user) => ({
+							data: { ...user, emailVerified: true },
+						}),
+					},
+				},
+			},
+		});
+
+	const ctx = await auth.$context;
+	const owner = await signInWithTestUser();
+	const org = await auth.api.createOrganization({
+		headers: owner.headers,
+		body: { name: "Capacity Org", slug: "capacity-org" },
+	});
+	if (!org) throw new Error("failed to create organization");
+
+	let seedCounter = 0;
+	const seedTeamMember = async (teamId: string) => {
+		const seedUser = await auth.api.signUpEmail({
+			body: {
+				name: `Seed ${seedCounter}`,
+				email: `seed-${seedCounter++}@email.com`,
+				password: "password12345",
+			},
+		});
+		await ctx.adapter.create({
+			model: "teamMember",
+			data: {
+				teamId,
+				userId: seedUser.user.id,
+				createdAt: new Date(),
+			},
+		});
+	};
+
+	const inviteAndSignUp = async (teamId: string, email: string) => {
+		const invitation = await auth.api.createInvitation({
+			headers: owner.headers,
+			body: { email, role: "member", organizationId: org.id, teamId },
+		});
+		const inviteeHeaders = new Headers();
+		const signUp = await client.signUp.email(
+			{ email, password: "password12345", name: email },
+			{ onSuccess: cookieSetter(inviteeHeaders) },
+		);
+		return {
+			invitationId: invitation.id!,
+			inviteeHeaders,
+			userId: signUp.data!.user.id,
+		};
+	};
+
+	it("accepts the final member when the team is one below capacity", async () => {
+		const team = await auth.api.createTeam({
+			headers: owner.headers,
+			body: { name: "Almost Full Team", organizationId: org.id },
+		});
+		// One existing member; the limit is two, so the accept must fit.
+		await seedTeamMember(team.id);
+
+		const { invitationId, inviteeHeaders, userId } = await inviteAndSignUp(
+			team.id,
+			"capacity-fits@email.com",
+		);
+
+		const accept = await auth.api.acceptInvitation({
+			headers: inviteeHeaders,
+			body: { invitationId },
+		});
+
+		expect(accept?.member?.userId).toBe(userId);
+		expect(accept?.invitation?.status).toBe("accepted");
+
+		const members = await ctx.adapter.findMany<{ userId: string }>({
+			model: "teamMember",
+			where: [{ field: "teamId", value: team.id }],
+		});
+		expect(members).toHaveLength(2);
+		expect(members.some((m) => m.userId === userId)).toBe(true);
+	});
+
+	it("rejects with TEAM_MEMBER_LIMIT_REACHED and creates no membership row when the team fills between invite and accept", async () => {
+		const team = await auth.api.createTeam({
+			headers: owner.headers,
+			body: { name: "Filling Team", organizationId: org.id },
+		});
+		// Invite while the team is below the limit, then fill it so the accept
+		// would overflow: the capacity check must run at accept time.
+		await seedTeamMember(team.id);
+		const { invitationId, inviteeHeaders, userId } = await inviteAndSignUp(
+			team.id,
+			"capacity-overflows@email.com",
+		);
+		await seedTeamMember(team.id);
+
+		await expect(
+			auth.api.acceptInvitation({
+				headers: inviteeHeaders,
+				body: { invitationId },
+			}),
+		).rejects.toMatchObject({
+			status: "FORBIDDEN",
+			body: { code: "TEAM_MEMBER_LIMIT_REACHED" },
+		});
+
+		const members = await ctx.adapter.findMany<{ userId: string }>({
+			model: "teamMember",
+			where: [{ field: "teamId", value: team.id }],
+		});
+		expect(members).toHaveLength(2);
+		expect(members.some((m) => m.userId === userId)).toBe(false);
+
+		// The invitation must stay pending so the invitee can retry; a capacity
+		// failure cannot leave them marked accepted with no membership.
+		const invitationAfter = await ctx.adapter.findOne<{ status: string }>({
+			model: "invitation",
+			where: [{ field: "id", value: invitationId }],
+		});
+		expect(invitationAfter?.status).toBe("pending");
+
+		const orgMembers = await ctx.adapter.findMany<{ userId: string }>({
+			model: "member",
+			where: [{ field: "organizationId", value: org.id }],
+		});
+		expect(orgMembers.some((m) => m.userId === userId)).toBe(false);
+	});
+
+	it("accepts only once when the same invitation is accepted concurrently", async () => {
+		const team = await auth.api.createTeam({
+			headers: owner.headers,
+			body: { name: "Concurrent Team", organizationId: org.id },
+		});
+		const { invitationId, inviteeHeaders, userId } = await inviteAndSignUp(
+			team.id,
+			"concurrent-accept@email.com",
+		);
+
+		const results = await Promise.allSettled([
+			auth.api.acceptInvitation({
+				headers: inviteeHeaders,
+				body: { invitationId },
+			}),
+			auth.api.acceptInvitation({
+				headers: inviteeHeaders,
+				body: { invitationId },
+			}),
+		]);
+
+		// One request wins the claim; the other observes the invitation is no
+		// longer pending and is rejected, never running the side effects twice.
+		expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+		expect(results.filter((r) => r.status === "rejected")).toHaveLength(1);
+
+		const orgMembers = await ctx.adapter.findMany<{ userId: string }>({
+			model: "member",
+			where: [{ field: "organizationId", value: org.id }],
+		});
+		expect(orgMembers.filter((m) => m.userId === userId)).toHaveLength(1);
 	});
 });

--- a/packages/better-auth/src/plugins/organization/team.test.ts
+++ b/packages/better-auth/src/plugins/organization/team.test.ts
@@ -2023,4 +2023,50 @@ describe("accept-invitation validates team capacity before adding the member", a
 		});
 		expect(orgMembers.filter((m) => m.userId === userId)).toHaveLength(1);
 	});
+
+	it("does not reopen an invitation when a stale rollback loses its status guard", async () => {
+		const team = await auth.api.createTeam({
+			headers: owner.headers,
+			body: { name: "Rollback Guard Team", organizationId: org.id },
+		});
+		const { invitationId } = await inviteAndSignUp(
+			team.id,
+			"rollback-guard@email.com",
+		);
+
+		const accepted = await ctx.adapter.update<{ status: string }>({
+			model: "invitation",
+			where: [
+				{ field: "id", value: invitationId },
+				{ field: "status", value: "pending" },
+			],
+			update: { status: "accepted" },
+		});
+		expect(accepted?.status).toBe("accepted");
+		const rejected = await ctx.adapter.update<{ status: string }>({
+			model: "invitation",
+			where: [
+				{ field: "id", value: invitationId },
+				{ field: "status", value: "accepted" },
+			],
+			update: { status: "rejected" },
+		});
+		expect(rejected?.status).toBe("rejected");
+
+		const staleRollback = await ctx.adapter.update<{ status: string }>({
+			model: "invitation",
+			where: [
+				{ field: "id", value: invitationId },
+				{ field: "status", value: "accepted" },
+			],
+			update: { status: "pending" },
+		});
+		expect(staleRollback).toBeNull();
+
+		const invitationAfter = await ctx.adapter.findOne<{ status: string }>({
+			model: "invitation",
+			where: [{ field: "id", value: invitationId }],
+		});
+		expect(invitationAfter?.status).toBe("rejected");
+	});
 });

--- a/packages/better-auth/src/plugins/organization/team.test.ts
+++ b/packages/better-auth/src/plugins/organization/team.test.ts
@@ -1943,6 +1943,117 @@ describe("accept-invitation validates team capacity before adding the member", a
 		});
 		expect(members).toHaveLength(2);
 		expect(members.some((m) => m.userId === userId)).toBe(true);
+
+		const teamAfter = await ctx.adapter.findOne<{ memberCount: number }>({
+			model: "team",
+			where: [{ field: "id", value: team.id }],
+		});
+		expect(teamAfter?.memberCount).toBe(2);
+	});
+
+	it("enforces the team limit when adding an existing organization member directly", async () => {
+		const team = await auth.api.createTeam({
+			headers: owner.headers,
+			body: { name: "Direct Add Capacity Team", organizationId: org.id },
+		});
+		await seedTeamMember(team.id);
+		const firstUser = await auth.api.signUpEmail({
+			body: {
+				name: "Direct Add One",
+				email: "direct-add-one@email.com",
+				password: "password12345",
+			},
+		});
+		const secondUser = await auth.api.signUpEmail({
+			body: {
+				name: "Direct Add Two",
+				email: "direct-add-two@email.com",
+				password: "password12345",
+			},
+		});
+		for (const user of [firstUser.user, secondUser.user]) {
+			await ctx.adapter.create({
+				model: "member",
+				data: {
+					organizationId: org.id,
+					userId: user.id,
+					role: "member",
+					createdAt: new Date(),
+				},
+			});
+		}
+
+		const added = await auth.api.addTeamMember({
+			headers: owner.headers,
+			body: {
+				teamId: team.id,
+				userId: firstUser.user.id,
+				organizationId: org.id,
+			},
+		});
+		expect(added.userId).toBe(firstUser.user.id);
+
+		await expect(
+			auth.api.addTeamMember({
+				headers: owner.headers,
+				body: {
+					teamId: team.id,
+					userId: secondUser.user.id,
+					organizationId: org.id,
+				},
+			}),
+		).rejects.toMatchObject({
+			status: "FORBIDDEN",
+			body: { code: "TEAM_MEMBER_LIMIT_REACHED" },
+		});
+
+		const members = await ctx.adapter.findMany<{ userId: string }>({
+			model: "teamMember",
+			where: [{ field: "teamId", value: team.id }],
+		});
+		expect(members).toHaveLength(2);
+		expect(members.some((m) => m.userId === firstUser.user.id)).toBe(true);
+		expect(members.some((m) => m.userId === secondUser.user.id)).toBe(false);
+	});
+
+	it("rolls back addMember when the requested team is already full", async () => {
+		const team = await auth.api.createTeam({
+			headers: owner.headers,
+			body: { name: "Add Member Full Team", organizationId: org.id },
+		});
+		await seedTeamMember(team.id);
+		await seedTeamMember(team.id);
+		const newUser = await auth.api.signUpEmail({
+			body: {
+				name: "Full Team Add Member",
+				email: "full-team-add-member@email.com",
+				password: "password12345",
+			},
+		});
+
+		await expect(
+			auth.api.addMember({
+				headers: owner.headers,
+				body: {
+					userId: newUser.user.id,
+					role: "member",
+					organizationId: org.id,
+					teamId: team.id,
+				},
+			}),
+		).rejects.toMatchObject({
+			status: "FORBIDDEN",
+			body: { code: "TEAM_MEMBER_LIMIT_REACHED" },
+		});
+
+		const orgMember = await ctx.adapter.findOne<{ id: string }>({
+			model: "member",
+			where: [
+				{ field: "organizationId", value: org.id },
+				{ field: "userId", value: newUser.user.id },
+			],
+		});
+		expect(orgMember).toBeNull();
 	});
 
 	it("rejects with TEAM_MEMBER_LIMIT_REACHED and creates no membership row when the team fills between invite and accept", async () => {
@@ -1989,6 +2100,53 @@ describe("accept-invitation validates team capacity before adding the member", a
 			where: [{ field: "organizationId", value: org.id }],
 		});
 		expect(orgMembers.some((m) => m.userId === userId)).toBe(false);
+	});
+
+	it("accepts only one of two concurrent invitations competing for the final team slot", async () => {
+		const team = await auth.api.createTeam({
+			headers: owner.headers,
+			body: { name: "Final Slot Team", organizationId: org.id },
+		});
+		await seedTeamMember(team.id);
+		const firstInvite = await inviteAndSignUp(
+			team.id,
+			"final-slot-one@email.com",
+		);
+		const secondInvite = await inviteAndSignUp(
+			team.id,
+			"final-slot-two@email.com",
+		);
+
+		const results = await Promise.allSettled([
+			auth.api.acceptInvitation({
+				headers: firstInvite.inviteeHeaders,
+				body: { invitationId: firstInvite.invitationId },
+			}),
+			auth.api.acceptInvitation({
+				headers: secondInvite.inviteeHeaders,
+				body: { invitationId: secondInvite.invitationId },
+			}),
+		]);
+
+		expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+		expect(results.filter((r) => r.status === "rejected")).toHaveLength(1);
+
+		const members = await ctx.adapter.findMany<{ userId: string }>({
+			model: "teamMember",
+			where: [{ field: "teamId", value: team.id }],
+		});
+		expect(members).toHaveLength(2);
+		const acceptedInviteeCount = members.filter(
+			(m) =>
+				m.userId === firstInvite.userId || m.userId === secondInvite.userId,
+		).length;
+		expect(acceptedInviteeCount).toBe(1);
+
+		const teamAfter = await ctx.adapter.findOne<{ memberCount: number }>({
+			model: "team",
+			where: [{ field: "id", value: team.id }],
+		});
+		expect(teamAfter?.memberCount).toBe(2);
 	});
 
 	it("accepts only once when the same invitation is accepted concurrently", async () => {

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -328,7 +328,7 @@ export interface OrganizationOptions {
 				team?: {
 					modelName?: string;
 					fields?: {
-						[key in keyof Omit<Team, "id">]?: string;
+						[key in keyof Omit<Team, "id"> | "memberCount"]?: string;
 					};
 					additionalFields?: {
 						[key in string]: DBFieldAttribute;
@@ -337,7 +337,7 @@ export interface OrganizationOptions {
 				teamMember?: {
 					modelName?: string;
 					fields?: {
-						[key in keyof Omit<TeamMember, "id">]?: string;
+						[key in keyof Omit<TeamMember, "id"> | "membershipKey"]?: string;
 					};
 				};
 				organizationRole?: {

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -599,6 +599,120 @@ describe("verify phone-number", async () => {
 	});
 });
 
+describe("verify phone-number race condition protection", async () => {
+	let otp = "";
+
+	const { client, auth } = await getTestInstance(
+		{
+			plugins: [
+				phoneNumber({
+					async sendOTP({ code }) {
+						otp = code;
+					},
+					signUpOnVerification: {
+						getTempEmail(phoneNumber) {
+							return `temp-${phoneNumber}`;
+						},
+					},
+					allowedAttempts: 3,
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [phoneNumberClient()],
+			},
+		},
+	);
+	const authCtx = await auth.$context;
+
+	it("should allow exactly one success when the same code is verified concurrently", async () => {
+		const phoneNumber = "+251900000001";
+		await client.phoneNumber.sendOtp({ phoneNumber });
+
+		// Force both verifications to read the live OTP row before either
+		// consumes it. Without an atomic consume gate, both would read a valid
+		// code and both would mint a session; the gate must let only one win.
+		const originalFind = authCtx.internalAdapter.findVerificationValue;
+		let entered = 0;
+		let releaseBarrier!: () => void;
+		const barrier = new Promise<void>((resolve) => {
+			releaseBarrier = resolve;
+		});
+		authCtx.internalAdapter.findVerificationValue = (async (
+			identifier: string,
+			...rest: unknown[]
+		) => {
+			const result = await (
+				originalFind as (...args: unknown[]) => Promise<unknown>
+			)(identifier, ...rest);
+			if (identifier === phoneNumber) {
+				entered++;
+				if (entered >= 2) releaseBarrier();
+				await barrier;
+			}
+			return result;
+		}) as typeof authCtx.internalAdapter.findVerificationValue;
+
+		try {
+			const results = await Promise.all([
+				client.phoneNumber.verify({ phoneNumber, code: otp }),
+				client.phoneNumber.verify({ phoneNumber, code: otp }),
+			]);
+
+			const successes = results.filter((r) => r.data?.status === true);
+			const failures = results.filter((r) => r.error);
+			expect(successes).toHaveLength(1);
+			expect(failures).toHaveLength(1);
+			// The loser must be cleanly rejected by the OTP gate, not fail by
+			// accident downstream after both consumed the same code.
+			expect(failures[0]!.error?.status).toBe(400);
+			expect(failures[0]!.error?.message).toBe("Invalid OTP");
+		} finally {
+			authCtx.internalAdapter.findVerificationValue = originalFind;
+		}
+
+		const verificationValue =
+			await authCtx.internalAdapter.findVerificationValue(phoneNumber);
+		expect(verificationValue).toBeNull();
+	});
+
+	it("should increment the stored attempt counter by exactly one per wrong code", async () => {
+		const phoneNumber = "+251900000002";
+		await client.phoneNumber.sendOtp({ phoneNumber });
+		const correctCode = otp;
+
+		for (let expectedAttempts = 1; expectedAttempts <= 2; expectedAttempts++) {
+			const res = await client.phoneNumber.verify({
+				phoneNumber,
+				code: "000000",
+			});
+			expect(res.error?.status).toBe(400);
+			expect(res.error?.message).toBe("Invalid OTP");
+
+			const stored =
+				await authCtx.internalAdapter.findVerificationValue(phoneNumber);
+			expect(stored).not.toBeNull();
+			const [storedValue, attempts] = stored!.value.split(":");
+			// The original code survives each wrong attempt so the user can
+			// still redeem it, and the counter advances by exactly one.
+			expect(storedValue).toBe(correctCode);
+			expect(attempts).toBe(String(expectedAttempts));
+		}
+
+		const res = await client.phoneNumber.verify({
+			phoneNumber,
+			code: correctCode,
+		});
+		expect(res.error).toBe(null);
+		expect(res.data?.status).toBe(true);
+
+		const consumed =
+			await authCtx.internalAdapter.findVerificationValue(phoneNumber);
+		expect(consumed).toBeNull();
+	});
+});
+
 describe("reset password flow attempts", async () => {
 	let otp = "";
 	let resetOtp = "";

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -891,9 +891,11 @@ async function verifyPhoneNumberOTP(
 		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.OTP_EXPIRED);
 	}
 
-	const allowedAttempts = opts?.allowedAttempts || 3;
-	const [, peekedAttempts] = existing.value.split(":");
-	if (peekedAttempts && parseInt(peekedAttempts) >= allowedAttempts) {
+	const allowedAttempts = opts?.allowedAttempts ?? 3;
+	const peekedAttempts = parseVerificationAttempts(
+		existing.value.split(":")[1],
+	);
+	if (peekedAttempts >= allowedAttempts) {
 		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 			identifier,
 		);
@@ -909,8 +911,9 @@ async function verifyPhoneNumberOTP(
 		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.INVALID_OTP);
 	}
 
-	const [otpValue, attempts] = consumed.value.split(":");
-	if (attempts && parseInt(attempts) >= allowedAttempts) {
+	const [otpValue, rawAttempts] = consumed.value.split(":");
+	const attempts = parseVerificationAttempts(rawAttempts);
+	if (attempts >= allowedAttempts) {
 		throw APIError.from(
 			"FORBIDDEN",
 			PHONE_NUMBER_ERROR_CODES.TOO_MANY_ATTEMPTS,
@@ -918,12 +921,17 @@ async function verifyPhoneNumberOTP(
 	}
 	if (otpValue !== providedCode) {
 		await ctx.context.internalAdapter.createVerificationValue({
-			value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
+			value: `${otpValue}:${attempts + 1}`,
 			identifier,
 			expiresAt: consumed.expiresAt,
 		});
 		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.INVALID_OTP);
 	}
+}
+
+function parseVerificationAttempts(value: string | undefined) {
+	const attempts = Number(value ?? 0);
+	return Number.isSafeInteger(attempts) && attempts > 0 ? attempts : 0;
 }
 
 function generateOTP(size: number) {

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -339,43 +339,7 @@ async function verifyAndConsumePhoneNumberOTP(
 		return;
 	}
 
-	const otp =
-		await ctx.context.internalAdapter.findVerificationValue(phoneNumber);
-	if (!otp || otp.expiresAt < new Date()) {
-		if (otp && otp.expiresAt < new Date()) {
-			throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.OTP_EXPIRED);
-		}
-		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.OTP_NOT_FOUND);
-	}
-
-	const [otpValue, attemptsValue] = otp.value.split(":");
-	const attempts = parseVerificationAttempts(attemptsValue);
-	const allowedAttempts = opts.allowedAttempts ?? 3;
-	if (attempts >= allowedAttempts) {
-		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-			phoneNumber,
-		);
-		throw APIError.from(
-			"FORBIDDEN",
-			PHONE_NUMBER_ERROR_CODES.TOO_MANY_ATTEMPTS,
-		);
-	}
-	if (otpValue !== code) {
-		await ctx.context.internalAdapter.updateVerificationByIdentifier(
-			phoneNumber,
-			{
-				value: `${otpValue}:${attempts + 1}`,
-			},
-		);
-		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.INVALID_OTP);
-	}
-
-	await ctx.context.internalAdapter.deleteVerificationByIdentifier(phoneNumber);
-}
-
-function parseVerificationAttempts(value: string | undefined) {
-	const attempts = Number(value ?? 0);
-	return Number.isSafeInteger(attempts) && attempts > 0 ? attempts : 0;
+	await verifyPhoneNumberOTP(ctx, opts, phoneNumber, code);
 }
 
 /**
@@ -831,46 +795,8 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			},
 		},
 		async (ctx) => {
-			const verification =
-				await ctx.context.internalAdapter.findVerificationValue(
-					`${ctx.body.phoneNumber}-request-password-reset`,
-				);
-			if (!verification) {
-				throw APIError.from(
-					"BAD_REQUEST",
-					PHONE_NUMBER_ERROR_CODES.OTP_NOT_FOUND,
-				);
-			}
-			if (verification.expiresAt < new Date()) {
-				throw APIError.from(
-					"BAD_REQUEST",
-					PHONE_NUMBER_ERROR_CODES.OTP_EXPIRED,
-				);
-			}
-			const [otpValue, attempts] = verification.value.split(":");
-			const allowedAttempts = opts?.allowedAttempts || 3;
 			const phoneResetIdentifier = `${ctx.body.phoneNumber}-request-password-reset`;
-			if (attempts && parseInt(attempts) >= allowedAttempts) {
-				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					phoneResetIdentifier,
-				);
-				throw APIError.from(
-					"FORBIDDEN",
-					PHONE_NUMBER_ERROR_CODES.TOO_MANY_ATTEMPTS,
-				);
-			}
-			if (ctx.body.otp !== otpValue) {
-				await ctx.context.internalAdapter.updateVerificationByIdentifier(
-					phoneResetIdentifier,
-					{
-						value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
-					},
-				);
-				throw APIError.from(
-					"BAD_REQUEST",
-					PHONE_NUMBER_ERROR_CODES.INVALID_OTP,
-				);
-			}
+			await verifyPhoneNumberOTP(ctx, opts, phoneResetIdentifier, ctx.body.otp);
 			const userRes = await ctx.context.adapter.findOne<
 				UserWithPhoneNumber & { account: Account[] | undefined }
 			>({
@@ -919,9 +845,6 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 					hashedPassword,
 				);
 			}
-			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-				phoneResetIdentifier,
-			);
 
 			if (ctx.context.options.emailAndPassword?.onPasswordReset) {
 				await ctx.context.options.emailAndPassword.onPasswordReset(
@@ -939,6 +862,69 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			});
 		},
 	);
+
+/**
+ * Atomically verifies a phone-number OTP against a stored verification value.
+ *
+ * Consuming the row is the race gate: the first concurrent caller wins the
+ * row, every racer behind it gets `null` and is rejected, so the same code can
+ * never satisfy two simultaneous verifications. On a wrong code that is still
+ * within the attempt budget, the row is recreated with the same value and
+ * expiry and an incremented attempt counter. Once the budget is exhausted the
+ * row is not recreated.
+ */
+async function verifyPhoneNumberOTP(
+	ctx: GenericEndpointContext,
+	opts: RequiredPhoneNumberOptions,
+	identifier: string,
+	providedCode: string,
+): Promise<void> {
+	const existing =
+		await ctx.context.internalAdapter.findVerificationValue(identifier);
+	if (!existing) {
+		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.OTP_NOT_FOUND);
+	}
+	if (existing.expiresAt < new Date()) {
+		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+			identifier,
+		);
+		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.OTP_EXPIRED);
+	}
+
+	const allowedAttempts = opts?.allowedAttempts || 3;
+	const [, peekedAttempts] = existing.value.split(":");
+	if (peekedAttempts && parseInt(peekedAttempts) >= allowedAttempts) {
+		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+			identifier,
+		);
+		throw APIError.from(
+			"FORBIDDEN",
+			PHONE_NUMBER_ERROR_CODES.TOO_MANY_ATTEMPTS,
+		);
+	}
+
+	const consumed =
+		await ctx.context.internalAdapter.consumeVerificationValue(identifier);
+	if (!consumed) {
+		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.INVALID_OTP);
+	}
+
+	const [otpValue, attempts] = consumed.value.split(":");
+	if (attempts && parseInt(attempts) >= allowedAttempts) {
+		throw APIError.from(
+			"FORBIDDEN",
+			PHONE_NUMBER_ERROR_CODES.TOO_MANY_ATTEMPTS,
+		);
+	}
+	if (otpValue !== providedCode) {
+		await ctx.context.internalAdapter.createVerificationValue({
+			value: `${otpValue}:${parseInt(attempts || "0") + 1}`,
+			identifier,
+			expiresAt: consumed.expiresAt,
+		});
+		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.INVALID_OTP);
+	}
+}
 
 function generateOTP(size: number) {
 	return generateRandomString(size, "0-9");

--- a/packages/better-auth/src/plugins/siwe/index.ts
+++ b/packages/better-auth/src/plugins/siwe/index.ts
@@ -132,14 +132,17 @@ export const siwe = (options: SIWEPluginOptions) => {
 					}
 
 					try {
-						// Find stored nonce with wallet address and chain ID context
+						// Atomically consume the single-use nonce before any signature
+						// work or state mutation. The first concurrent request wins; every
+						// racer gets null, so the same nonce can never replay a login.
+						// Consuming here (not after verification) also burns the record on
+						// a failed attempt and applies the built-in expiry gate.
 						const verification =
-							await ctx.context.internalAdapter.findVerificationValue(
+							await ctx.context.internalAdapter.consumeVerificationValue(
 								`siwe:${walletAddress}:${chainId}`,
 							);
 
-						// Ensure nonce is valid and not expired
-						if (!verification || new Date() > verification.expiresAt) {
+						if (!verification) {
 							throw APIError.fromStatus("UNAUTHORIZED", {
 								message: "Unauthorized: Invalid or expired nonce",
 								status: 401,
@@ -230,11 +233,6 @@ export const siwe = (options: SIWEPluginOptions) => {
 								status: 401,
 							});
 						}
-
-						// Clean up used nonce
-						await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-							`siwe:${walletAddress}:${chainId}`,
-						);
 
 						// Look for existing user by their wallet addresses
 						let user: User | null = null;

--- a/packages/better-auth/src/plugins/siwe/siwe.test.ts
+++ b/packages/better-auth/src/plugins/siwe/siwe.test.ts
@@ -477,6 +477,109 @@ describe("siwe", async () => {
 		expect(data?.success).toBe(true);
 	});
 
+	// The nonce is single-use. Two requests presenting the same valid nonce at
+	// the same time must collapse to exactly one authenticated session: the
+	// first request to consume the row wins, the racer sees the row already
+	// gone. Without an atomic consume, both reads observe the row before either
+	// delete lands and both mint a session, replaying a single-use login.
+	it("should mint exactly one session when the same nonce is verified concurrently", async () => {
+		const { client, auth } = await getTestInstance(
+			{
+				plugins: [
+					siwe({
+						domain,
+						async getNonce() {
+							return NONCE;
+						},
+						async verifyMessage({ signature }) {
+							// Stall inside signature verification to widen the window
+							// between the two requests. With a non-atomic nonce read both
+							// requests would already have passed the nonce check and would
+							// both mint a session; the atomic consume rejects the racer
+							// before it ever reaches this point.
+							await new Promise((resolve) => setTimeout(resolve, 50));
+							return signature === "valid_signature";
+						},
+					}),
+				],
+			},
+			{ clientOptions: { plugins: [siweClient()] } },
+		);
+
+		await client.siwe.nonce({ walletAddress, chainId });
+
+		const ctx = await auth.$context;
+		const sessionsBefore = await ctx.adapter.findMany({ model: "session" });
+
+		const verifyOnce = () =>
+			client.siwe.verify({
+				message: siweMessage(),
+				signature: "valid_signature",
+				walletAddress,
+				chainId,
+			});
+
+		const [first, second] = await Promise.all([verifyOnce(), verifyOnce()]);
+
+		const successes = [first, second].filter((r) => r.data?.success === true);
+		const failures = [first, second].filter((r) => r.error != null);
+		expect(successes.length).toBe(1);
+		expect(failures.length).toBe(1);
+		expect(failures[0]?.error?.status).toBe(401);
+
+		// Exactly one wallet record and one new session for the SIWE login.
+		const wallets = await ctx.adapter.findMany({
+			model: "walletAddress",
+			where: [{ field: "address", operator: "eq", value: walletAddress }],
+		});
+		expect(wallets.length).toBe(1);
+		const sessionsAfter = await ctx.adapter.findMany({ model: "session" });
+		expect(sessionsAfter.length).toBe(sessionsBefore.length + 1);
+	});
+
+	// An expired nonce must be rejected even before any signature work, and the
+	// expired row must still be burned so it can never be replayed later.
+	it("should reject an expired nonce and consume the row", async () => {
+		const { client, auth } = await getTestInstance(
+			{
+				plugins: [
+					siwe({
+						domain,
+						async getNonce() {
+							return NONCE;
+						},
+						async verifyMessage({ signature }) {
+							return signature === "valid_signature";
+						},
+					}),
+				],
+			},
+			{ clientOptions: { plugins: [siweClient()] } },
+		);
+
+		const ctx = await auth.$context;
+		const identifier = `siwe:${walletAddress}:${chainId}`;
+		await ctx.internalAdapter.createVerificationValue({
+			identifier,
+			value: NONCE,
+			expiresAt: new Date(Date.now() - 1000),
+		});
+
+		const { error } = await client.siwe.verify({
+			message: siweMessage(),
+			signature: "valid_signature",
+			walletAddress,
+			chainId,
+		});
+		expect(error?.status).toBe(401);
+		expect(error?.code).toBe("UNAUTHORIZED_INVALID_OR_EXPIRED_NONCE");
+
+		// The expired row is gone, so a retry cannot replay it.
+		const remaining =
+			await ctx.internalAdapter.findVerificationValue(identifier);
+		expect(remaining).toBeNull();
+	});
+
 	it("should not allow nonce reuse", async () => {
 		const { client } = await getTestInstance(
 			{

--- a/packages/better-auth/src/plugins/two-factor/otp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/otp/index.ts
@@ -306,27 +306,27 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 		},
 		async (ctx) => {
 			const { session, key, valid, invalid } = await verifyTwoFactor(ctx);
-			const toCheckOtp =
-				await ctx.context.internalAdapter.findVerificationValue(
+			// Consume the OTP row atomically as the race gate. The first concurrent
+			// submission wins the row; every other racer receives null and is
+			// rejected, so a burst of guesses cannot all read the same attempt
+			// counter before any write lands. Expiry is gated inside the consume,
+			// so a stale row returns null without minting a session.
+			const consumed =
+				await ctx.context.internalAdapter.consumeVerificationValue(
 					`2fa-otp-${key}`,
 				);
-			const [otp, counter] = toCheckOtp?.value?.split(":") ?? [];
-			if (!toCheckOtp || toCheckOtp.expiresAt < new Date()) {
-				if (toCheckOtp) {
-					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						`2fa-otp-${key}`,
-					);
-				}
+			if (!consumed) {
 				throw APIError.from(
 					"BAD_REQUEST",
 					TWO_FACTOR_ERROR_CODES.OTP_HAS_EXPIRED,
 				);
 			}
+			const [otp, counter] = consumed.value?.split(":") ?? [];
 			const allowedAttempts = options?.allowedAttempts || 5;
-			if (parseInt(counter!) >= allowedAttempts) {
-				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					`2fa-otp-${key}`,
-				);
+			const attempts = parseInt(counter!, 10) || 0;
+			if (attempts >= allowedAttempts) {
+				// The budget is spent. The row stays consumed, so the next
+				// submission is rejected as expired/already-consumed.
 				throw APIError.from(
 					"BAD_REQUEST",
 					TWO_FACTOR_ERROR_CODES.TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE,
@@ -342,6 +342,7 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 				new TextEncoder().encode(inputValue),
 			);
 			if (isCodeValid) {
+				// Leave the row consumed: a valid OTP is single-use.
 				if (!session.user.twoFactorEnabled) {
 					if (!session.session) {
 						throw APIError.from(
@@ -373,15 +374,17 @@ export const otp2fa = (options?: OTPOptions | undefined) => {
 					});
 				}
 				return valid(ctx);
-			} else {
-				await ctx.context.internalAdapter.updateVerificationByIdentifier(
-					`2fa-otp-${key}`,
-					{
-						value: `${otp}:${(parseInt(counter!, 10) || 0) + 1}`,
-					},
-				);
-				return invalid("INVALID_CODE");
 			}
+			// Wrong code within budget: re-arm the row with the incremented counter
+			// and the original expiry. The recreated counter is the durable record
+			// of the attempt, so the next submission either keeps guessing or hits
+			// the lock-out guard above. The original expiry caps the whole burst.
+			await ctx.context.internalAdapter.createVerificationValue({
+				value: `${otp}:${attempts + 1}`,
+				identifier: `2fa-otp-${key}`,
+				expiresAt: consumed.expiresAt,
+			});
+			return invalid("INVALID_CODE");
 		},
 	);
 

--- a/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
@@ -1,14 +1,16 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
+import type { SecondaryStorage } from "@better-auth/core/db";
 import { createOTP } from "@better-auth/utils/otp";
 import { describe, expect, it } from "vitest";
 import { symmetricDecrypt } from "../../crypto";
+import { convertSetCookieToCookie } from "../../test-utils/headers";
 import { getTestInstance } from "../../test-utils/test-instance";
-import type { User } from "../../types";
+import type { Session, User, Verification } from "../../types";
 import { DEFAULT_SECRET } from "../../utils/constants";
 import { phoneNumber } from "../phone-number";
 import { username } from "../username";
-import { twoFactor } from ".";
+import { TWO_FACTOR_ERROR_CODES, twoFactor } from ".";
 import type { TwoFactorTable, UserWithTwoFactor } from "./types";
 
 /**
@@ -399,5 +401,333 @@ describe("two-factor security: chunked session_data is fully scrubbed on 2FA-req
 
 		const session = await auth.api.getSession({ headers: replay });
 		expect(session).toBeNull();
+	});
+});
+
+/**
+ * The signed `two_factor` challenge is a single-use, time-bounded credential:
+ * exactly one verification may complete it, and only within its expiry window.
+ *
+ * Two failures violated that contract. The challenge row was loaded with a
+ * plain existence check that never inspected `expiresAt`, so a replayed cookie
+ * pointing at an expired-but-not-yet-cleaned row could still mint a session
+ * once a valid TOTP was supplied. And the row was deleted only after the
+ * session was created, so two concurrent verifications of the same cookie
+ * could both pass the stale read and each mint a separate session. Consuming
+ * the row atomically before session creation closes both: expiry is rejected
+ * because the consume returns null for expired rows, and the race is rejected
+ * because only the first caller wins the delete-and-return.
+ */
+describe("two-factor security: 2FA challenge is single-use and expiry-bounded", async () => {
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [twoFactor()],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const dbUser = await db.findOne<User>({
+		model: "user",
+		where: [{ field: "email", value: testUser.email }],
+	});
+	const userId = dbUser?.id as string;
+
+	const enrollment = await auth.api.enableTwoFactor({
+		body: { password: testUser.password },
+		headers,
+	});
+	if (enrollment.method !== "totp") {
+		throw new Error("expected totp enrollment");
+	}
+	const row = await db.findOne<TwoFactorTable>({
+		model: "twoFactor",
+		where: [{ field: "userId", value: userId }],
+	});
+	const secret = await symmetricDecrypt({
+		key: DEFAULT_SECRET,
+		data: row!.secret,
+	});
+	const enrollCode = await createOTP(secret).totp();
+	await auth.api.verifyTOTP({ body: { code: enrollCode }, headers });
+	const verified = await db.findOne<UserWithTwoFactor>({
+		model: "user",
+		where: [{ field: "id", value: userId }],
+	});
+	if (!verified?.twoFactorEnabled) {
+		throw new Error("failed to enable 2FA for test user");
+	}
+
+	async function startChallenge(): Promise<Headers> {
+		const res = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			asResponse: true,
+		});
+		expect(res.status).toBe(200);
+		return convertSetCookieToCookie(res.headers);
+	}
+
+	function countSessions(): Promise<Session[]> {
+		return db.findMany<Session>({
+			model: "session",
+			where: [{ field: "userId", value: userId }],
+		});
+	}
+
+	it("rejects an expired two-factor sign-in challenge even with a valid TOTP", async () => {
+		const challengeHeaders = await startChallenge();
+		const challengeRow = await db.findOne<Verification>({
+			model: "verification",
+			where: [{ field: "value", value: userId }],
+		});
+		expect(challengeRow).not.toBeNull();
+
+		// Force the challenge past its expiry while leaving the row present, so
+		// the only thing standing between a stale cookie and a session is the
+		// server-side expiry gate.
+		await db.update({
+			model: "verification",
+			where: [{ field: "id", value: challengeRow!.id }],
+			update: { expiresAt: new Date(Date.now() - 60 * 1000) },
+		});
+
+		const sessionsBefore = await countSessions();
+		const freshCode = await createOTP(secret).totp();
+		const res = await auth.api.verifyTOTP({
+			body: { code: freshCode },
+			headers: challengeHeaders,
+			asResponse: true,
+		});
+
+		expect(res.status).toBe(401);
+		const json = (await res.json()) as { message: string };
+		expect(json.message).toBe(
+			TWO_FACTOR_ERROR_CODES.INVALID_TWO_FACTOR_COOKIE.message,
+		);
+
+		const setCookies = res.headers.getSetCookie();
+		const tokenEntries = setCookies.filter((entry) =>
+			entry.startsWith("better-auth.session_token="),
+		);
+		for (const entry of tokenEntries) {
+			const firstSegment = entry.split(";")[0] ?? "";
+			const eq = firstSegment.indexOf("=");
+			expect(eq > 0 ? firstSegment.slice(eq + 1) : "").toBe("");
+		}
+
+		const sessionsAfter = await countSessions();
+		expect(sessionsAfter.length).toBe(sessionsBefore.length);
+	});
+
+	it("two concurrent verifications of the same challenge yield exactly one session", async () => {
+		const challengeHeaders = await startChallenge();
+		const sessionsBefore = await countSessions();
+		const code = await createOTP(secret).totp();
+
+		const [first, second] = await Promise.all([
+			auth.api.verifyTOTP({
+				body: { code },
+				headers: challengeHeaders,
+				asResponse: true,
+			}),
+			auth.api.verifyTOTP({
+				body: { code },
+				headers: challengeHeaders,
+				asResponse: true,
+			}),
+		]);
+
+		const statuses = [first.status, second.status].sort();
+		expect(statuses).toEqual([200, 401]);
+
+		const sessionsAfter = await countSessions();
+		expect(sessionsAfter.length).toBe(sessionsBefore.length + 1);
+	});
+});
+
+/**
+ * The two-factor OTP attempt counter must survive a burst of concurrent
+ * submissions. The counter used to be tracked with a read-counter then
+ * write-counter pair, so concurrent wrong guesses could all read the same
+ * value before any write landed and exhaust far more than `allowedAttempts`
+ * guesses against a single code. Consuming the OTP row atomically before the
+ * code comparison makes the row itself the race gate: every wrong guess burns
+ * the row and re-arms it with the next counter, so only one submission can act
+ * on each counter value and the budget cannot be raced past. The same gate
+ * guarantees a single correct code mints at most one session.
+ */
+describe("two-factor security: OTP attempts are atomic under concurrency", async () => {
+	const allowedAttempts = 3;
+	let currentOTP = "";
+
+	// A secondary storage whose normal reads of the OTP row are deliberately
+	// slow while `getAndDelete` is immediate. Without an atomic consume gate,
+	// every concurrent verification could finish a slow read of the same
+	// counter before any write lands. The fix consumes the row through the
+	// required storage primitive, so each attempt observes a distinct counter.
+	const store = new Map<string, { value: string; expiresAt: number }>();
+	const isOtpRow = (key: string) => key.includes("2fa-otp");
+	const secondaryStorage: SecondaryStorage = {
+		async get(key: string) {
+			if (isOtpRow(key)) {
+				await new Promise((resolve) => setTimeout(resolve, 25));
+			}
+			const entry = store.get(key);
+			if (!entry) return null;
+			if (entry.expiresAt < Date.now()) {
+				store.delete(key);
+				return null;
+			}
+			return entry.value;
+		},
+		async getAndDelete(key: string) {
+			const entry = store.get(key);
+			store.delete(key);
+			if (!entry || entry.expiresAt < Date.now()) {
+				return null;
+			}
+			return entry.value;
+		},
+		async increment(key: string, ttl: number) {
+			const entry = store.get(key);
+			const count = Number(entry?.value ?? 0) + 1;
+			store.set(key, {
+				value: String(count),
+				expiresAt: Date.now() + ttl * 1000,
+			});
+			return count;
+		},
+		async set(key: string, value: string, ttl?: number) {
+			store.set(key, {
+				value,
+				expiresAt: Date.now() + (ttl ?? 60) * 1000,
+			});
+		},
+		async delete(key: string) {
+			store.delete(key);
+		},
+	};
+
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		secondaryStorage,
+		plugins: [
+			twoFactor({
+				otpOptions: {
+					allowedAttempts,
+					sendOTP({ otp }) {
+						currentOTP = otp;
+					},
+				},
+			}),
+		],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const dbUser = await db.findOne<User>({
+		model: "user",
+		where: [{ field: "email", value: testUser.email }],
+	});
+	const userId = dbUser?.id as string;
+
+	const enrollment = await auth.api.enableTwoFactor({
+		body: { password: testUser.password },
+		headers,
+	});
+	if (enrollment.method !== "totp") {
+		throw new Error("expected totp enrollment");
+	}
+	const row = await db.findOne<TwoFactorTable>({
+		model: "twoFactor",
+		where: [{ field: "userId", value: userId }],
+	});
+	const secret = await symmetricDecrypt({
+		key: DEFAULT_SECRET,
+		data: row!.secret,
+	});
+	const enrollCode = await createOTP(secret).totp();
+	await auth.api.verifyTOTP({ body: { code: enrollCode }, headers });
+	const verified = await db.findOne<UserWithTwoFactor>({
+		model: "user",
+		where: [{ field: "id", value: userId }],
+	});
+	if (!verified?.twoFactorEnabled) {
+		throw new Error("failed to enable 2FA for test user");
+	}
+
+	async function startChallengeWithOtp(): Promise<Headers> {
+		const signIn = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			asResponse: true,
+		});
+		expect(signIn.status).toBe(200);
+		const challengeHeaders = convertSetCookieToCookie(signIn.headers);
+		await auth.api.sendTwoFactorOTP({ headers: challengeHeaders });
+		return challengeHeaders;
+	}
+
+	function verifyOtp(
+		challengeHeaders: Headers,
+		code: string,
+	): Promise<Response> {
+		return auth.api.verifyTwoFactorOTP({
+			body: { code },
+			headers: challengeHeaders,
+			asResponse: true,
+		});
+	}
+
+	it("counts wrong guesses up to the limit then locks out", async () => {
+		const challengeHeaders = await startChallengeWithOtp();
+
+		for (let i = 0; i < allowedAttempts; i++) {
+			const res = await verifyOtp(challengeHeaders, "000000");
+			expect(res.status).toBe(401);
+			const json = (await res.json()) as { message: string };
+			expect(json.message).toBe(TWO_FACTOR_ERROR_CODES.INVALID_CODE.message);
+		}
+
+		// The budget is spent: even the correct code is locked out.
+		const locked = await verifyOtp(challengeHeaders, currentOTP);
+		expect(locked.status).toBe(400);
+		const lockedJson = (await locked.json()) as { message: string };
+		expect(lockedJson.message).toBe(
+			TWO_FACTOR_ERROR_CODES.TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE.message,
+		);
+	});
+
+	it("a concurrent burst of wrong guesses cannot exceed the attempt budget", async () => {
+		const challengeHeaders = await startChallengeWithOtp();
+		const burst = allowedAttempts * 4;
+
+		const results = await Promise.all(
+			Array.from({ length: burst }, () =>
+				verifyOtp(challengeHeaders, "111111"),
+			),
+		);
+		const bodies = await Promise.all(
+			results.map((res) => res.json() as Promise<{ message?: string }>),
+		);
+
+		const invalidCount = bodies.filter(
+			(body) => body.message === TWO_FACTOR_ERROR_CODES.INVALID_CODE.message,
+		).length;
+
+		// Each wrong guess consumes exactly one counter slot, so no matter how
+		// many race in at once the number of accepted guesses is capped by the
+		// budget. The remaining racers lose the consume and are rejected.
+		expect(invalidCount).toBeLessThanOrEqual(allowedAttempts);
+	});
+
+	it("concurrent correct codes mint at most one session", async () => {
+		const challengeHeaders = await startChallengeWithOtp();
+
+		const results = await Promise.all([
+			verifyOtp(challengeHeaders, currentOTP),
+			verifyOtp(challengeHeaders, currentOTP),
+			verifyOtp(challengeHeaders, currentOTP),
+		]);
+		// Only the racer that wins the OTP consume may complete; the others lose
+		// the consume and never reach session creation, so at most one 200.
+		const successCount = results.filter((res) => res.status === 200).length;
+		expect(successCount).toBeLessThanOrEqual(1);
 	});
 });

--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -58,8 +58,24 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 		);
 		return {
 			valid: async (ctx: GenericEndpointContext) => {
+				// The 2FA challenge is single-use and time-bounded. Burn it
+				// atomically before issuing a session so a stale (expired) replay
+				// or two concurrent verifications of the same cookie cannot each
+				// mint a session: the consume returns null for an expired or
+				// already-consumed row, and only the first racer wins it.
+				const consumed =
+					await ctx.context.internalAdapter.consumeVerificationValue(
+						signedTwoFactorCookie,
+					);
+				if (!consumed || consumed.value !== user.id) {
+					expireCookie(ctx, twoFactorCookie);
+					throw APIError.from(
+						"UNAUTHORIZED",
+						TWO_FACTOR_ERROR_CODES.INVALID_TWO_FACTOR_COOKIE,
+					);
+				}
 				const session = await ctx.context.internalAdapter.createSession(
-					verificationToken.value,
+					consumed.value,
 					!!dontRememberMe,
 				);
 				if (!session) {
@@ -68,10 +84,6 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 						code: "FAILED_TO_CREATE_SESSION",
 					});
 				}
-				// Delete the verification token from the database after successful verification
-				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					signedTwoFactorCookie,
-				);
 				await setSessionCookie(ctx, {
 					session,
 					user,

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -64,6 +64,9 @@ function createMockAdapter(adapterId: string, dialect?: string): DBAdapter {
 		consumeOne: async () => {
 			throw new Error("Mock adapter methods should not be called");
 		},
+		incrementOne: async () => {
+			throw new Error("Mock adapter methods should not be called");
+		},
 		transaction: async (callback) => {
 			throw new Error("Mock adapter methods should not be called");
 		},

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -1096,6 +1096,9 @@ describe("--adapter flag support (mock adapter)", () => {
 			consumeOne: async () => {
 				throw new Error("Mock adapter methods should not be called");
 			},
+			incrementOne: async () => {
+				throw new Error("Mock adapter methods should not be called");
+			},
 			transaction: async (callback) => {
 				throw new Error("Mock adapter methods should not be called");
 			},
@@ -1336,6 +1339,9 @@ describe("--dialect flag support", () => {
 				throw new Error("Mock adapter methods should not be called");
 			},
 			consumeOne: async () => {
+				throw new Error("Mock adapter methods should not be called");
+			},
+			incrementOne: async () => {
 				throw new Error("Mock adapter methods should not be called");
 			},
 			transaction: async (callback) => {

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -1,18 +1,21 @@
 import { describe, expect, it } from "vitest";
 import type { BetterAuthOptions } from "../../types";
 import { createAdapterFactory } from "./factory";
-import type { CleanedWhere, CustomAdapter } from "./index";
+import type { CustomAdapter, Where } from "./index";
 
-function createCustomAdapter(overrides: Partial<CustomAdapter>): CustomAdapter {
+function createCustomAdapter(
+	overrides: Partial<CustomAdapter> = {},
+): CustomAdapter {
 	return {
-		create: async <T extends Record<string, any>>({ data }: { data: T }) =>
-			data,
-		update: async <T>() => null as T | null,
+		create: async ({ data }) => data,
+		update: async () => null,
 		updateMany: async () => 0,
-		findOne: async <T>() => null as T | null,
-		findMany: async <T>() => [] as T[],
+		findOne: async () => null,
+		findMany: async () => [],
 		delete: async () => {},
 		deleteMany: async () => 0,
+		consumeOne: async () => null,
+		incrementOne: async () => null,
 		count: async () => 0,
 		...overrides,
 	};
@@ -51,63 +54,44 @@ function createTestAdapter({
 			fields: {
 				identifier: "identifier_text",
 			},
+			additionalFields: {
+				attempts: {
+					type: "number",
+					required: false,
+					fieldName: "attempt_count",
+				},
+			},
 			...options.verification,
 		},
 	});
 }
 
-describe("createAdapterFactory consumeOne fallback", () => {
-	it("uses transaction adapter methods without double-transforming input or output", async () => {
-		const findMany: CustomAdapter["findMany"] = async <T>(
-			params: Parameters<CustomAdapter["findMany"]>[0],
-		) => {
-			const { model, where, limit } = params;
-			expect(model).toBe("verificationRecords");
-			expect(limit).toBe(1);
-			expect(where).toEqual([
-				{
-					field: "identifier_text",
-					value: "token:findMany",
-					operator: "eq",
-					connector: "AND",
-					mode: "sensitive",
-				},
-			]);
-			return [
-				{
-					id: "verification-id",
-					identifier_text: "stored-token",
-				},
-			] as T[];
-		};
-		const deleteMany: CustomAdapter["deleteMany"] = async ({
-			model,
-			where,
-		}) => {
-			expect(model).toBe("verificationRecords");
-			expect(where).toEqual([
-				{
-					field: "identifier_text",
-					value: "token:deleteMany",
-					operator: "eq",
-					connector: "AND",
-					mode: "sensitive",
-				},
-				{
-					field: "id",
-					value: "verification-id",
-					operator: "eq",
-					connector: "AND",
-					mode: "sensitive",
-				},
-			] satisfies CleanedWhere[]);
-			return 1;
-		};
-
+describe("createAdapterFactory atomic primitives", () => {
+	it("delegates consumeOne to the native adapter with transformed where and output", async () => {
 		const adapter = createTestAdapter({
 			adapter: createCustomAdapter({
-				findMany,
-				deleteMany,
+				consumeOne: async <T>({
+					model,
+					where,
+				}: {
+					model: string;
+					where: Required<Where>[];
+				}) => {
+					expect(model).toBe("verificationRecords");
+					expect(where).toEqual([
+						{
+							field: "identifier_text",
+							value: "token:consumeOne",
+							operator: "eq",
+							connector: "AND",
+							mode: "sensitive",
+						},
+					]);
+					return {
+						id: "verification-id",
+						identifier_text: "stored-token",
+					} as T;
+				},
 			}),
 		});
 
@@ -118,70 +102,75 @@ describe("createAdapterFactory consumeOne fallback", () => {
 			},
 		);
 
-		expect(result?.id).toBe("verification-id");
-		expect(result?.identifier).toBe("stored-token:output");
+		expect(result).toEqual({
+			id: "verification-id",
+			identifier: "stored-token:output",
+		});
 	});
 
-	it("returns null when the delete loses the consume race", async () => {
+	it("delegates incrementOne to the native adapter with mapped increment fields", async () => {
 		const adapter = createTestAdapter({
 			adapter: createCustomAdapter({
-				findMany: async <T>() =>
-					[
+				incrementOne: async <T>({
+					model,
+					where,
+					increment,
+					set,
+				}: {
+					model: string;
+					where: Required<Where>[];
+					increment: Record<string, number>;
+					set?: Record<string, unknown> | undefined;
+				}) => {
+					expect(model).toBe("verificationRecords");
+					expect(where).toEqual([
 						{
-							id: "verification-id",
-							identifier_text: "stored-token",
+							field: "identifier_text",
+							value: "token:incrementOne",
+							operator: "eq",
+							connector: "AND",
+							mode: "sensitive",
 						},
-					] as T[],
-				deleteMany: async () => 0,
+					]);
+					expect(increment).toEqual({ attempt_count: 1 });
+					expect(set).toEqual({
+						value: "next",
+						updatedAt: expect.any(Date),
+					});
+					return {
+						id: "verification-id",
+						identifier_text: "stored-token",
+						attempt_count: 2,
+						value: "next",
+					} as T;
+				},
 			}),
 		});
 
-		const result = await adapter.consumeOne({
+		const result = await adapter.incrementOne<{
+			id: string;
+			identifier: string;
+			attempts: number;
+			value: string;
+		}>({
 			model: "verification",
 			where: [{ field: "identifier", value: "token" }],
+			increment: { attempts: 1 },
+			set: { value: "next" },
 		});
 
-		expect(result).toBeNull();
+		expect(result).toEqual({
+			id: "verification-id",
+			identifier: "stored-token:output",
+			attempts: 2,
+			value: "next",
+		});
 	});
 
-	it("fails closed when deleteMany returns a non-finite count", async () => {
-		// A misbehaving adapter that returns NaN gives no proof the row was
-		// deleted, so a single-use consume must not report success.
+	it("throws a clear error when consumeOne is missing at runtime", async () => {
 		const adapter = createTestAdapter({
 			adapter: createCustomAdapter({
-				findMany: async <T>() =>
-					[
-						{
-							id: "verification-id",
-							identifier_text: "stored-token",
-						},
-					] as T[],
-				deleteMany: async () => Number.NaN,
-			}),
-		});
-
-		const result = await adapter.consumeOne({
-			model: "verification",
-			where: [{ field: "identifier", value: "token" }],
-		});
-
-		expect(result).toBeNull();
-	});
-
-	it("throws when deleteMany returns a non-numeric value", async () => {
-		const adapter = createTestAdapter({
-			adapter: createCustomAdapter({
-				findMany: async <T>() =>
-					[
-						{
-							id: "verification-id",
-							identifier_text: "stored-token",
-						},
-					] as T[],
-				// A misbehaving adapter (e.g. a document store returning the raw
-				// delete response) breaks the count-based race gate. The fallback
-				// must surface this instead of reporting a spurious miss.
-				deleteMany: async () => ({ deleted: true }) as unknown as number,
+				consumeOne: undefined as unknown as CustomAdapter["consumeOne"],
 			}),
 		});
 
@@ -190,6 +179,38 @@ describe("createAdapterFactory consumeOne fallback", () => {
 				model: "verification",
 				where: [{ field: "identifier", value: "token" }],
 			}),
-		).rejects.toThrowError(/non-numeric value from deleteMany/);
+		).rejects.toThrow(/must implement consumeOne/);
+	});
+
+	it("throws a clear error when incrementOne is missing at runtime", async () => {
+		const adapter = createTestAdapter({
+			adapter: createCustomAdapter({
+				incrementOne: undefined as unknown as CustomAdapter["incrementOne"],
+			}),
+		});
+
+		await expect(
+			adapter.incrementOne({
+				model: "verification",
+				where: [{ field: "identifier", value: "token" }],
+				increment: { attempts: 1 },
+			}),
+		).rejects.toThrow(/must implement incrementOne/);
+	});
+
+	it("throws a clear error when updateMany does not return a finite count", async () => {
+		const adapter = createTestAdapter({
+			adapter: createCustomAdapter({
+				updateMany: async () => Number.NaN,
+			}),
+		});
+
+		await expect(
+			adapter.updateMany({
+				model: "verification",
+				where: [{ field: "identifier", value: "token" }],
+				update: { value: "next" },
+			}),
+		).rejects.toThrow(/updateMany must return a finite number/);
 	});
 });

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -138,6 +138,11 @@ export const createAdapterFactory =
 							!config.debugLogs.consumeOne
 						) {
 							return;
+						} else if (
+							method === "incrementOne" &&
+							!config.debugLogs.incrementOne
+						) {
+							return;
 						} else if (method === "count" && !config.debugLogs.count) {
 							return;
 						}
@@ -491,6 +496,7 @@ export const createAdapterFactory =
 				| "delete"
 				| "deleteMany"
 				| "consumeOne"
+				| "incrementOne"
 				| "count";
 		}): W extends undefined ? undefined : CleanedWhere[] => {
 			if (!where) return undefined as any;
@@ -1057,6 +1063,14 @@ export const createAdapterFactory =
 							update: data,
 						}),
 				);
+				if (
+					typeof updatedCount !== "number" ||
+					!Number.isFinite(updatedCount)
+				) {
+					throw new BetterAuthError(
+						`Adapter "${config.adapterId}" updateMany must return a finite number affected row count.`,
+					);
+				}
 				debugLog(
 					{ method: "updateMany" },
 					`${formatTransactionId(thisTransactionId)} ${formatStep(3, 4)}`,
@@ -1341,75 +1355,19 @@ export const createAdapterFactory =
 					{ model, where },
 				);
 
-				let res: T | null;
-				let resultNeedsOutputTransform = true;
-				if (adapterInstance.consumeOne) {
-					res = await withSpan(
-						`db consumeOne ${model}`,
-						{
-							[ATTR_DB_OPERATION_NAME]: "consumeOne",
-							[ATTR_DB_COLLECTION_NAME]: model,
-						},
-						() => adapterInstance.consumeOne!<T>({ model, where }),
+				if (typeof adapterInstance.consumeOne !== "function") {
+					throw new BetterAuthError(
+						`Adapter "${config.adapterId}" must implement consumeOne for atomic single-use credential consumption.`,
 					);
-				} else {
-					// TODO(consume-one-required): adapters without native `consumeOne`
-					// fall back to `transaction(findMany + deleteMany)`. Race-safe on
-					// engines with real transaction isolation; race window narrows
-					// (does not close) on adapters that fall through to sequential
-					// execution. Remove this branch when consumeOne becomes required.
-					// FIXME(consume-one-nested-transaction): custom adapters without a
-					// native consumeOne have no portable signal for "already inside a
-					// transaction". First-party adapters mark transaction-scoped
-					// adapters as as-is; make that capability explicit in the next
-					// breaking adapter contract.
-					res = await withSpan(
-						`db consumeOne ${model}`,
-						{
-							[ATTR_DB_OPERATION_NAME]: "consumeOne",
-							[ATTR_DB_COLLECTION_NAME]: model,
-						},
-						() =>
-							adapter.transaction(async (trx) => {
-								const rows = await trx.findMany<Record<string, any>>({
-									model: unsafeModel,
-									where: unsafeWhere,
-									limit: 1,
-								});
-								const target = rows[0];
-								if (!target) return null;
-								const deleted = await trx.deleteMany({
-									model: unsafeModel,
-									where: [
-										...unsafeWhere,
-										{
-											field: "id",
-											value: target.id,
-											operator: "eq",
-											connector: "AND",
-											mode: "sensitive",
-										},
-									],
-								});
-								// `deleteMany` is typed `Promise<number>`. A non-number breaks
-								// the contract, so fail loud. A finite-number check then closes
-								// the NaN/Infinity hole: `NaN > 0` is false and `Infinity > 0`
-								// is true, so a bare `deleted > 0` would misclassify both. Only
-								// a finite positive count proves we won the delete race; any
-								// other value fails closed (returns null) so a single-use row
-								// is never reported consumed without proof.
-								if (typeof deleted !== "number") {
-									throw new BetterAuthError(
-										`Adapter "${config.adapterId}" returned a non-numeric value from deleteMany during the consumeOne fallback. Return the number of deleted rows, or implement a native consumeOne for atomic single-use consumption.`,
-									);
-								}
-								return Number.isFinite(deleted) && deleted > 0
-									? (target as T)
-									: null;
-							}),
-					);
-					resultNeedsOutputTransform = false;
 				}
+				const res = await withSpan(
+					`db consumeOne ${model}`,
+					{
+						[ATTR_DB_OPERATION_NAME]: "consumeOne",
+						[ATTR_DB_COLLECTION_NAME]: model,
+					},
+					() => adapterInstance.consumeOne<T>({ model, where }),
+				);
 
 				debugLog(
 					{ method: "consumeOne" },
@@ -1418,11 +1376,7 @@ export const createAdapterFactory =
 					{ model, data: res },
 				);
 				let transformed: any = res;
-				if (
-					!config.disableTransformOutput &&
-					resultNeedsOutputTransform &&
-					res
-				) {
+				if (!config.disableTransformOutput && res) {
 					transformed = await transformOutput(
 						res as Record<string, any>,
 						unsafeModel,
@@ -1434,6 +1388,89 @@ export const createAdapterFactory =
 					{ method: "consumeOne" },
 					`${formatTransactionId(thisTransactionId)} ${formatStep(3, 3)}`,
 					`${formatMethod("consumeOne")} ${formatAction("Parsed Result")}:`,
+					{ model, data: transformed },
+				);
+				return transformed as T | null;
+			},
+			incrementOne: async <T>({
+				model: unsafeModel,
+				where: unsafeWhere,
+				increment: unsafeIncrement,
+				set: unsafeSet,
+			}: {
+				model: string;
+				where: Where[];
+				increment: Record<string, number>;
+				set?: Record<string, unknown> | undefined;
+			}): Promise<T | null> => {
+				transactionId++;
+				const thisTransactionId = transactionId;
+				const model = getModelName(unsafeModel);
+				const where = transformWhereClause({
+					model: unsafeModel,
+					where: unsafeWhere,
+					action: "incrementOne",
+				});
+				unsafeModel = getDefaultModelName(unsafeModel);
+				debugLog(
+					{ method: "incrementOne" },
+					`${formatTransactionId(thisTransactionId)} ${formatStep(1, 3)}`,
+					`${formatMethod("incrementOne")} ${formatAction("IncrementOne")}:`,
+					{ model, where, increment: unsafeIncrement, set: unsafeSet },
+				);
+
+				if (typeof adapterInstance.incrementOne !== "function") {
+					throw new BetterAuthError(
+						`Adapter "${config.adapterId}" must implement incrementOne for atomic guarded counter updates.`,
+					);
+				}
+				const mappedKeys = config.mapKeysTransformInput ?? {};
+				const increment: Record<string, number> = {};
+				for (const [field, delta] of Object.entries(unsafeIncrement)) {
+					increment[
+						mappedKeys[field] || getFieldName({ model: unsafeModel, field })
+					] = delta;
+				}
+				let set: Record<string, unknown> | undefined;
+				if (unsafeSet && !config.disableTransformInput) {
+					set = await transformInput(unsafeSet, unsafeModel, "update");
+				} else {
+					set = unsafeSet;
+				}
+				const res = await withSpan(
+					`db incrementOne ${model}`,
+					{
+						[ATTR_DB_OPERATION_NAME]: "incrementOne",
+						[ATTR_DB_COLLECTION_NAME]: model,
+					},
+					() =>
+						adapterInstance.incrementOne<T>({
+							model,
+							where,
+							increment,
+							set,
+						}),
+				);
+
+				debugLog(
+					{ method: "incrementOne" },
+					`${formatTransactionId(thisTransactionId)} ${formatStep(2, 3)}`,
+					`${formatMethod("incrementOne")} ${formatAction("DB Result")}:`,
+					{ model, data: res },
+				);
+				let transformed: any = res;
+				if (!config.disableTransformOutput && res) {
+					transformed = await transformOutput(
+						res as Record<string, any>,
+						unsafeModel,
+						undefined,
+						undefined,
+					);
+				}
+				debugLog(
+					{ method: "incrementOne" },
+					`${formatTransactionId(thisTransactionId)} ${formatStep(3, 3)}`,
+					`${formatMethod("incrementOne")} ${formatAction("Parsed Result")}:`,
 					{ model, data: transformed },
 				);
 				return transformed as T | null;

--- a/packages/core/src/db/adapter/index.ts
+++ b/packages/core/src/db/adapter/index.ts
@@ -16,6 +16,7 @@ export type DBAdapterDebugLogOption =
 			delete?: boolean | undefined;
 			deleteMany?: boolean | undefined;
 			consumeOne?: boolean | undefined;
+			incrementOne?: boolean | undefined;
 			count?: boolean | undefined;
 	  }
 	| {
@@ -213,6 +214,7 @@ export interface DBAdapterFactoryConfig<
 					| "delete"
 					| "deleteMany"
 					| "consumeOne"
+					| "incrementOne"
 					| "count";
 				/**
 				 * The model name.
@@ -458,12 +460,40 @@ export type DBAdapter<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	 * race-safe primitive for consuming single-use credentials
 	 * (verification tokens, authorization codes, one-time tokens).
 	 *
-	 * Always defined on the factory-wrapped adapter. When the underlying
-	 * `CustomAdapter` does not implement `consumeOne`, the factory provides
-	 * a fallback that wraps `findMany + deleteMany` in `transaction(...)`
-	 * and returns the row only when the delete reports an affected row.
+	 * Always defined on the factory-wrapped adapter. The underlying
+	 * `CustomAdapter` must implement this natively; there is no portable
+	 * fallback that can guarantee cross-process single-use semantics.
 	 */
 	consumeOne: <T>(data: { model: string; where: Where[] }) => Promise<T | null>;
+	/**
+	 * Atomically apply signed numeric deltas to a single row matching the where
+	 * clause. For each entry in `increment`, the operation applies
+	 * `field = field + delta` in one atomic step; a negative delta decrements.
+	 *
+	 * The `where` clause is both the selector AND the guard: comparison
+	 * operators are honored, so passing `{ field: "remaining", operator: "gt",
+	 * value: 0 }` only mutates the row while `remaining` is still above zero.
+	 * When the guard matches no row, the operation makes no change and returns
+	 * `null`.
+	 *
+	 * The optional `set` map assigns absolute values to fields in the same
+	 * atomic operation, alongside the increments.
+	 *
+	 * Returns the updated row, or `null` when the guard matched no row. Under
+	 * concurrent invocation against the same row, this is the race-safe
+	 * primitive for guarded counter updates (e.g. decrementing a remaining-uses
+	 * counter only while it is still positive).
+	 *
+	 * Always defined on the factory-wrapped adapter. The underlying
+	 * `CustomAdapter` must implement this natively; there is no portable
+	 * fallback that can guarantee guarded counter semantics across runtimes.
+	 */
+	incrementOne: <T>(data: {
+		model: string;
+		where: Where[];
+		increment: Record<string, number>;
+		set?: Record<string, unknown> | undefined;
+	}) => Promise<T | null>;
 	/**
 	 * Execute multiple operations in a transaction.
 	 * If the adapter doesn't support transactions, operations will be executed sequentially.
@@ -551,17 +581,32 @@ export interface CustomAdapter {
 		where: CleanedWhere[];
 	}) => Promise<number>;
 	/**
-	 * Optional native atomic single-row consume. When omitted, the adapter
-	 * factory falls back to `transaction(findMany + deleteMany)`.
+	 * Native atomic single-row consume.
 	 * Implementing this method natively (e.g. `DELETE ... RETURNING *`,
 	 * `findOneAndDelete`, `OUTPUT deleted.*`) gives one round trip and the
 	 * strongest race-safety guarantee. Implementations must delete at most
-	 * one matching row. TODO(consume-one-required): tighten to required in the
-	 * next minor on `next`.
+	 * one matching row.
 	 */
-	consumeOne?: <T>(data: {
+	consumeOne: <T>(data: {
 		model: string;
 		where: CleanedWhere[];
+	}) => Promise<T | null>;
+	/**
+	 * Native atomic guarded counter mutation. Applies
+	 * `field = field + delta` for each entry in `increment` (negative deltas
+	 * decrement), with `where` acting as both selector and guard and `set`
+	 * assigning absolute values in the same operation. Returns the updated row,
+	 * or `null` when the guard matched no row.
+	 *
+	 * Implementing this natively (e.g. `UPDATE ... SET n = n + $delta WHERE ...
+	 * RETURNING *`) gives one round trip and the strongest race-safety
+	 * guarantee.
+	 */
+	incrementOne: <T>(data: {
+		model: string;
+		where: CleanedWhere[];
+		increment: Record<string, number>;
+		set?: Record<string, unknown> | undefined;
 	}) => Promise<T | null>;
 	count: ({
 		model,

--- a/packages/core/src/db/adapter/types.ts
+++ b/packages/core/src/db/adapter/types.ts
@@ -123,6 +123,7 @@ export type AdapterFactoryCustomizeAdapterCreator = (config: {
 			| "delete"
 			| "deleteMany"
 			| "consumeOne"
+			| "incrementOne"
 			| "count";
 	}) => W extends undefined ? undefined : CleanedWhere[];
 }) => CustomAdapter;

--- a/packages/core/src/db/test/get-tables.test.ts
+++ b/packages/core/src/db/test/get-tables.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { getAuthTables } from "../get-tables";
+import type { SecondaryStorage } from "../type";
+
+const secondaryStorageStub: SecondaryStorage = {
+	get: async () => null,
+	getAndDelete: async () => null,
+	increment: async () => 1,
+	set: async () => {},
+	delete: async () => {},
+};
 
 describe("getAuthTables", () => {
 	it("should use correct field name for refreshTokenExpiresAt", () => {
@@ -83,11 +92,7 @@ describe("getAuthTables", () => {
 
 	it("should exclude verification table when secondaryStorage is configured", () => {
 		const tables = getAuthTables({
-			secondaryStorage: {
-				get: async () => null,
-				set: async () => {},
-				delete: async () => {},
-			},
+			secondaryStorage: secondaryStorageStub,
 		});
 
 		expect(tables.verification).toBeUndefined();
@@ -95,11 +100,7 @@ describe("getAuthTables", () => {
 
 	it("should include verification table when storeInDatabase is true", () => {
 		const tables = getAuthTables({
-			secondaryStorage: {
-				get: async () => null,
-				set: async () => {},
-				delete: async () => {},
-			},
+			secondaryStorage: secondaryStorageStub,
 			verification: {
 				storeInDatabase: true,
 			},

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -313,16 +313,21 @@ export interface SecondaryStorage {
 	get: (key: string) => Awaitable<unknown>;
 	/**
 	 * Atomically get a value and delete it from storage.
-	 *
-	 * This is optional for backwards compatibility with existing secondary
-	 * storage implementations. Single-use credential consumers use it when
-	 * present to avoid a read-then-delete race.
-	 *
-	 * TODO(secondary-storage-atomic-consume): make this required in the next
-	 * breaking release, or require database-backed verification storage for
-	 * security-sensitive consume paths.
 	 */
-	getAndDelete?: (key: string) => Awaitable<unknown>;
+	getAndDelete: (key: string) => Awaitable<unknown>;
+	/**
+	 * Atomically increment the counter at `key` by one, returning the
+	 * post-increment value.
+	 *
+	 * When the key is absent, it is created with a value of `1` and the given
+	 * `ttl` (in SECONDS). The TTL is applied only on creation; later increments
+	 * never extend it, so the counter expires a fixed window after it was first
+	 * created.
+	 *
+	 * Required so secondary-storage-backed rate limiting can enforce the limit
+	 * in one distributed-safe operation.
+	 */
+	increment: (key: string, ttl: number) => Awaitable<number>;
 	set: (
 		/**
 		 * Key to store

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -237,6 +237,23 @@ export interface InternalAdapter<
 	 */
 	consumeVerificationValue(identifier: string): Promise<Verification | null>;
 
+	/**
+	 * First-writer-wins create keyed by a deterministic primary key derived from
+	 * `identifier`. Returns `true` when this caller created the row and `false`
+	 * when a row for the same identifier already existed.
+	 *
+	 * The dual of `consumeVerificationValue`: reserve races to create a marker
+	 * exactly once, where consume races to delete one exactly once. Use it for
+	 * replay tombstones (a SAML assertion id, a JWT `jti`) where the first caller
+	 * wins. The database path is atomic via the primary key; the
+	 * secondary-storage-only path is best-effort under concurrency.
+	 */
+	reserveVerificationValue(data: {
+		identifier: string;
+		value: string;
+		expiresAt: Date;
+	}): Promise<boolean>;
+
 	updateVerificationByIdentifier(
 		identifier: string,
 		data: Partial<Verification>,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -245,8 +245,9 @@ export interface InternalAdapter<
 	 * The dual of `consumeVerificationValue`: reserve races to create a marker
 	 * exactly once, where consume races to delete one exactly once. Use it for
 	 * replay tombstones (a SAML assertion id, a JWT `jti`) where the first caller
-	 * wins. The database path is atomic via the primary key; the
-	 * secondary-storage-only path is best-effort under concurrency.
+	 * wins. The database path is atomic via the primary key. Secondary-storage-only
+	 * verification is not supported for reservation and runtime implementations
+	 * should fail closed unless verification is backed by the database.
 	 */
 	reserveVerificationValue(data: {
 		identifier: string;

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -14,7 +14,6 @@ import type {
 	Account,
 	DBFieldAttribute,
 	ModelNames,
-	RateLimit,
 	SecondaryStorage,
 	Session,
 	User,
@@ -187,12 +186,27 @@ export type DynamicBaseURLConfig = {
 export type BaseURLConfig = string | DynamicBaseURLConfig;
 
 export interface BetterAuthRateLimitStorage {
-	get: (key: string) => Promise<RateLimit | null | undefined>;
-	set: (
+	/**
+	 * Atomically records one request against `key` within the rolling `window`
+	 * (in seconds) and reports whether it is allowed.
+	 *
+	 * When `allowed` is true the count was incremented within the active window,
+	 * or the window had elapsed and was reset to start at 1. When `allowed` is
+	 * false the limit was already reached and `retryAfter` is the number of
+	 * seconds until the window frees up.
+	 *
+	 * Performing the check and the increment in a single step closes the
+	 * concurrent-bypass gap of the separate `get`/`set` path: N simultaneous
+	 * requests can no longer all pass a stale read before any increment lands.
+	 *
+	 * Custom storages must implement this operation directly. Better Auth no
+	 * longer accepts separate `get`/`set` rate-limit storage because that shape
+	 * cannot enforce a distributed limit under concurrent requests.
+	 */
+	consume: (
 		key: string,
-		value: RateLimit,
-		update?: boolean | undefined,
-	) => Promise<void>;
+		rule: { window: number; max: number },
+	) => Promise<{ allowed: boolean; retryAfter: number | null }>;
 }
 
 export type BetterAuthRateLimitRule = {

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -1,3 +1,4 @@
+import { is, SQL } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 import { drizzleAdapter } from "./drizzle-adapter";
 
@@ -202,6 +203,227 @@ describe("drizzle-adapter", () => {
 					data: { name: "Test", email: "test@example.com" },
 				}),
 			).rejects.toThrow(/Schema not found/);
+		});
+	});
+
+	describe("updateMany affected-row count", () => {
+		const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
+		const userTable = {
+			id: { name: "id" },
+			name: { name: "name" },
+			email: { name: "email" },
+			emailVerified: { name: "emailVerified" },
+			image: { name: "image" },
+			createdAt: { name: "createdAt" },
+			updatedAt: { name: "updatedAt" },
+		};
+
+		/**
+		 * Builds a mock db whose `update().set().where()` chain resolves to the
+		 * raw driver result a given dialect produces for an UPDATE.
+		 */
+		function createUpdateDb(driverResult: unknown) {
+			return {
+				_: { fullSchema: { user: userTable } },
+				update: vi.fn().mockReturnValue({
+					set: vi.fn().mockReturnValue({
+						where: vi.fn().mockResolvedValue(driverResult),
+					}),
+				}),
+			} as any;
+		}
+
+		// updateMany must satisfy the DBAdapter contract: it returns the number
+		// of affected rows, not the raw (dialect-specific) driver result.
+		it.each([
+			{ provider: "sqlite" as const, result: { changes: 2 }, expected: 2 },
+			{ provider: "sqlite" as const, result: { changes: 0 }, expected: 0 },
+			{ provider: "pg" as const, result: { rowCount: 2 }, expected: 2 },
+			{ provider: "pg" as const, result: { rowCount: 0 }, expected: 0 },
+			{
+				provider: "mysql" as const,
+				result: { rowsAffected: 2 },
+				expected: 2,
+			},
+			{
+				provider: "mysql" as const,
+				result: [{ affectedRows: 2 }],
+				expected: 2,
+			},
+		])("returns the affected-row count for $provider ($expected)", async ({
+			provider,
+			result,
+			expected,
+		}) => {
+			const db = createUpdateDb(result);
+			const adapter = drizzleAdapter(db, { provider })({
+				secret: defaultSecret,
+			});
+
+			const count = await adapter.updateMany({
+				model: "user",
+				where: [{ field: "emailVerified", value: false }],
+				update: { emailVerified: true },
+			});
+
+			expect(count).toBe(expected);
+		});
+	});
+
+	describe("incrementOne", () => {
+		const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
+		// `attempts` is a plain numeric column the increment targets; the rest
+		// mirror the default user table so the factory's schema validation passes.
+		const userTable = {
+			id: { name: "id" },
+			name: { name: "name" },
+			email: { name: "email" },
+			emailVerified: { name: "emailVerified" },
+			image: { name: "image" },
+			attempts: { name: "attempts" },
+			createdAt: { name: "createdAt" },
+			updatedAt: { name: "updatedAt" },
+		};
+
+		/**
+		 * Builds a mock db that mirrors the adapter's single-row update: a
+		 * `select().from().where().limit()` subquery picks one id, then
+		 * `update().set().where().returning()` mutates by that id. Captures the
+		 * `set` payload, the update's `where` args, and the select guard so a test
+		 * can assert the `field = field + delta` expression and that the update is
+		 * pinned to one selected id rather than the raw guard clause.
+		 */
+		function createIncrementDb(returned: unknown[]) {
+			const calls: {
+				set?: Record<string, unknown>;
+				whereArgs?: unknown[];
+				selectGuard?: unknown[];
+			} = {};
+			const returning = vi.fn().mockResolvedValue(returned);
+			const updateWhere = vi.fn((...args: unknown[]) => {
+				calls.whereArgs = args;
+				return { returning };
+			});
+			const set = vi.fn((payload: Record<string, unknown>) => {
+				calls.set = payload;
+				return { where: updateWhere };
+			});
+			const targetIds = { __subquery: true };
+			const selectLimit = vi.fn().mockReturnValue(targetIds);
+			const selectWhere = vi.fn((...args: unknown[]) => {
+				calls.selectGuard = args;
+				return { limit: selectLimit };
+			});
+			const selectFrom = vi.fn().mockReturnValue({ where: selectWhere });
+			const db = {
+				_: { fullSchema: { user: userTable } },
+				select: vi.fn().mockReturnValue({ from: selectFrom }),
+				update: vi.fn().mockReturnValue({ set }),
+			} as any;
+			return { db, calls, targetIds };
+		}
+
+		function createAdapter(db: any) {
+			return drizzleAdapter(db, { provider: "sqlite" })({
+				secret: defaultSecret,
+				user: {
+					additionalFields: {
+						attempts: { type: "number", required: false },
+					},
+				},
+			});
+		}
+
+		it("compiles each increment to a `column + delta` expression", async () => {
+			const { db, calls } = createIncrementDb([{ id: "user-1", attempts: 4 }]);
+			const adapter = createAdapter(db);
+
+			const result = await adapter.incrementOne<{
+				id: string;
+				attempts: number;
+			}>({
+				model: "user",
+				where: [{ field: "id", value: "user-1" }],
+				increment: { attempts: 3 },
+			});
+
+			expect(result).toEqual({ id: "user-1", attempts: 4 });
+			const expr = calls.set?.attempts;
+			expect(is(expr, SQL)).toBe(true);
+			const chunks = (expr as SQL).queryChunks;
+			// The compiled expression embeds the target column, a " + " separator,
+			// and the raw delta operand, proving the update is `attempts + 3`.
+			expect(chunks).toContainEqual(userTable.attempts);
+			expect(chunks).toContainEqual({ value: [" + "] });
+			expect(chunks).toContain(3);
+			// The guard runs on the SELECT that picks one id (one predicate here);
+			// the UPDATE is pinned to that single id, not the raw guard clause.
+			expect(calls.selectGuard).toHaveLength(1);
+			expect(calls.whereArgs).toHaveLength(1);
+		});
+
+		it("applies absolute `set` assignments alongside increments", async () => {
+			const { db, calls } = createIncrementDb([
+				{ id: "user-1", attempts: 1, name: "Renamed" },
+			]);
+			const adapter = createAdapter(db);
+
+			await adapter.incrementOne({
+				model: "user",
+				where: [{ field: "id", value: "user-1" }],
+				increment: { attempts: 1 },
+				set: { name: "Renamed" },
+			});
+
+			expect(is(calls.set?.attempts, SQL)).toBe(true);
+			// Absolute assignments are written verbatim, not wrapped in arithmetic.
+			expect(calls.set?.name).toBe("Renamed");
+		});
+
+		it("mutates at most one row when the guard matches many", async () => {
+			// A guard that holds for many rows (`attempts > 0`) must still touch a
+			// single row. The adapter selects one id under `.limit(1)` and pins the
+			// UPDATE to that id, so a non-unique guard cannot fan out.
+			const { db, calls, targetIds } = createIncrementDb([
+				{ id: "user-1", attempts: 5 },
+			]);
+			const adapter = createAdapter(db);
+
+			const result = await adapter.incrementOne({
+				model: "user",
+				where: [{ field: "attempts", value: 0, operator: "gt" }],
+				increment: { attempts: 1 },
+			});
+
+			expect(result).toEqual({ id: "user-1", attempts: 5 });
+
+			// The non-unique guard is applied to the SELECT, which is capped to one
+			// row; the UPDATE never receives the raw guard.
+			expect(db.select).toHaveBeenCalledTimes(1);
+			expect(calls.selectGuard).toHaveLength(1);
+
+			// The UPDATE is guarded by a single `id IN (<one-row subquery>)`
+			// predicate, not the original multi-row clause.
+			expect(calls.whereArgs).toHaveLength(1);
+			const updateGuard = calls.whereArgs?.[0];
+			expect(is(updateGuard, SQL)).toBe(true);
+			// The pinned predicate embeds the single-id subquery, proving the update
+			// targets only the one selected row.
+			expect((updateGuard as SQL).queryChunks).toContain(targetIds);
+		});
+
+		it("returns null when the guard matches no row", async () => {
+			const { db } = createIncrementDb([]);
+			const adapter = createAdapter(db);
+
+			const result = await adapter.incrementOne({
+				model: "user",
+				// A `gt` guard that no row satisfies must yield null, never a row.
+				where: [{ field: "attempts", value: 100, operator: "gt" }],
+				increment: { attempts: -1 },
+			});
+
+			expect(result).toBeNull();
 		});
 	});
 });

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -1,4 +1,4 @@
-import { is, SQL } from "drizzle-orm";
+import { is, Param, SQL } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 import { drizzleAdapter } from "./drizzle-adapter";
 
@@ -268,6 +268,30 @@ describe("drizzle-adapter", () => {
 
 			expect(count).toBe(expected);
 		});
+
+		it.each([
+			{ provider: "sqlite" as const, result: { changes: Number.NaN } },
+			{ provider: "pg" as const, result: { rowCount: "2" } },
+			{ provider: "mysql" as const, result: [{ affectedRows: Infinity }] },
+		])("throws for invalid affected-row counts from $provider", async ({
+			provider,
+			result,
+		}) => {
+			const db = createUpdateDb(result);
+			const adapter = drizzleAdapter(db, { provider })({
+				secret: defaultSecret,
+			});
+
+			await expect(
+				adapter.updateMany({
+					model: "user",
+					where: [{ field: "emailVerified", value: false }],
+					update: { emailVerified: true },
+				}),
+			).rejects.toThrow(
+				"Drizzle adapter updateMany returned an invalid affected row count",
+			);
+		});
 	});
 
 	describe("incrementOne", () => {
@@ -352,10 +376,13 @@ describe("drizzle-adapter", () => {
 			expect(is(expr, SQL)).toBe(true);
 			const chunks = (expr as SQL).queryChunks;
 			// The compiled expression embeds the target column, a " + " separator,
-			// and the raw delta operand, proving the update is `attempts + 3`.
+			// and a parameterized delta operand, proving the update is
+			// `attempts + 3` without relying on raw primitive SQL chunks.
 			expect(chunks).toContainEqual(userTable.attempts);
 			expect(chunks).toContainEqual({ value: [" + "] });
-			expect(chunks).toContain(3);
+			expect(
+				chunks.some((chunk) => is(chunk, Param) && chunk.value === 3),
+			).toBe(true);
 			// The guard runs on the SELECT that picks one id (one predicate here);
 			// the UPDATE is pinned to that single id, not the raw guard clause.
 			expect(calls.selectGuard).toHaveLength(1);

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -57,12 +57,14 @@ function getAffectedRowCount(
 	} else if (hasDriverRowCount(result)) {
 		count = readDriverRowCount(result);
 	}
-	if (typeof count !== "number") {
+	if (typeof count !== "number" || !Number.isFinite(count)) {
 		logger.error(
-			`[Drizzle Adapter] The result of the ${operation} operation is not a number. This is likely a bug in the adapter. Please report this issue to the Better Auth team.`,
+			`[Drizzle Adapter] The result of the ${operation} operation is not a finite number. This is likely a bug in the adapter. Please report this issue to the Better Auth team.`,
 			{ result, ...context },
 		);
-		return 0;
+		throw new BetterAuthError(
+			`Drizzle adapter ${operation} returned an invalid affected row count`,
+		);
 	}
 	return count;
 }
@@ -1022,7 +1024,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								`The field "${field}" does not exist in the schema for the model "${model}". Please update your schema.`,
 							);
 						}
-						assignments[columnName] = sql`${column} + ${delta}`;
+						assignments[columnName] = sql`${column} + ${sql.param(delta)}`;
 					}
 					if (set) {
 						for (const [field, value] of Object.entries(set)) {

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -41,6 +41,51 @@ export interface DB {
 	[key: string]: any;
 }
 
+function getAffectedRowCount(
+	result: unknown,
+	operation: "updateMany" | "deleteMany",
+	context: { model: string; where: Where[] },
+): number {
+	let count: unknown = 0;
+	if (result && typeof result === "object" && "rowCount" in result) {
+		count = (result as { rowCount: unknown }).rowCount;
+	} else if (Array.isArray(result)) {
+		count =
+			result.length > 0 && hasDriverRowCount(result[0])
+				? readDriverRowCount(result[0])
+				: result.length;
+	} else if (hasDriverRowCount(result)) {
+		count = readDriverRowCount(result);
+	}
+	if (typeof count !== "number") {
+		logger.error(
+			`[Drizzle Adapter] The result of the ${operation} operation is not a number. This is likely a bug in the adapter. Please report this issue to the Better Auth team.`,
+			{ result, ...context },
+		);
+		return 0;
+	}
+	return count;
+}
+
+function hasDriverRowCount(result: unknown): boolean {
+	return (
+		!!result &&
+		typeof result === "object" &&
+		("affectedRows" in result ||
+			"rowsAffected" in result ||
+			"changes" in result)
+	);
+}
+
+function readDriverRowCount(result: unknown): unknown {
+	const r = result as {
+		affectedRows?: unknown;
+		rowsAffected?: unknown;
+		changes?: unknown;
+	};
+	return r.affectedRows ?? r.rowsAffected ?? r.changes;
+}
+
 export interface DrizzleAdapterConfig {
 	/**
 	 * The schema object that defines the tables and fields
@@ -888,7 +933,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						.update(schemaModel)
 						.set(values)
 						.where(...clause);
-					return await builder;
+					const res = await builder;
+					return getAffectedRowCount(res, "updateMany", { model, where });
 				},
 				async delete({ model, where }) {
 					const schemaModel = getSchema(model);
@@ -901,21 +947,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					const clause = convertWhereClause(where, model);
 					const builder = db.delete(schemaModel).where(...clause);
 					const res = await builder;
-					let count = 0;
-					if (res && "rowCount" in res) count = res.rowCount;
-					else if (Array.isArray(res)) count = res.length;
-					else if (
-						res &&
-						("affectedRows" in res || "rowsAffected" in res || "changes" in res)
-					)
-						count = res.affectedRows ?? res.rowsAffected ?? res.changes;
-					if (typeof count !== "number") {
-						logger.error(
-							"[Drizzle Adapter] The result of the deleteMany operation is not a number. This is likely a bug in the adapter. Please report this issue to the Better Auth team.",
-							{ res, model, where },
-						);
-					}
-					return count;
+					return getAffectedRowCount(res, "deleteMany", { model, where });
 				},
 				async consumeOne({ model, where }) {
 					const schemaModel = getSchema(model);
@@ -970,6 +1002,91 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						.where(inArray(idColumn, targetIds))
 						.returning();
 					return (deleted[0] as any) ?? null;
+				},
+				async incrementOne({ model, where, increment, set }) {
+					const schemaModel = getSchema(model);
+					const clause = convertWhereClause(where, model);
+					const idField = getFieldName({ model, field: "id" });
+					const idColumn = schemaModel[idField];
+
+					// Build `field = field + delta` for each increment plus the absolute
+					// `set` assignments. The where clause selects and guards the row, but
+					// the mutation is pinned to a single id so a non-unique guard cannot
+					// touch more than one row (single-row contract, like consumeOne).
+					const assignments: Record<string, unknown> = {};
+					for (const [field, delta] of Object.entries(increment)) {
+						const columnName = getFieldName({ model, field });
+						const column = schemaModel[columnName];
+						if (!column) {
+							throw new BetterAuthError(
+								`The field "${field}" does not exist in the schema for the model "${model}". Please update your schema.`,
+							);
+						}
+						assignments[columnName] = sql`${column} + ${delta}`;
+					}
+					if (set) {
+						for (const [field, value] of Object.entries(set)) {
+							const columnName = getFieldName({ model, field });
+							if (!schemaModel[columnName]) {
+								throw new BetterAuthError(
+									`The field "${field}" does not exist in the schema for the model "${model}". Please update your schema.`,
+								);
+							}
+							assignments[columnName] = value;
+						}
+					}
+
+					if (config.provider === "mysql") {
+						// MySQL has no UPDATE ... RETURNING. Hold the guarded row under
+						// SELECT ... FOR UPDATE inside a transaction so concurrent updates
+						// serialize, then read the mutated row back by id.
+						const mutateInTransaction = async (tx: DB) => {
+							const rows = await tx
+								.select()
+								.from(schemaModel)
+								.where(...clause)
+								.for("update")
+								.limit(1);
+							const target = rows[0];
+							if (!target) return null;
+							const targetId = target[idField] ?? (target as any).id;
+							if (targetId === undefined || targetId === null || !idColumn) {
+								return null;
+							}
+							await tx
+								.update(schemaModel)
+								.set(assignments)
+								.where(eq(idColumn, targetId))
+								.execute();
+							const updated = await tx
+								.select()
+								.from(schemaModel)
+								.where(eq(idColumn, targetId))
+								.limit(1)
+								.execute();
+							return (updated[0] as any) ?? null;
+						};
+						return inTransaction
+							? mutateInTransaction(db)
+							: db.transaction(mutateInTransaction);
+					}
+
+					if (!idColumn) {
+						return null;
+					}
+					// Pin the update to one selected id so a non-unique guard mutates at
+					// most one row, mirroring consumeOne's single-row selection.
+					const targetIds = db
+						.select({ id: idColumn })
+						.from(schemaModel)
+						.where(...clause)
+						.limit(1);
+					const updated = await db
+						.update(schemaModel)
+						.set(assignments)
+						.where(inArray(idColumn, targetIds))
+						.returning();
+					return (updated[0] as any) ?? null;
 				},
 				options: config,
 			};

--- a/packages/electron/src/routes.ts
+++ b/packages/electron/src/routes.ts
@@ -60,10 +60,14 @@ export const electronToken = (_opts: ElectronOptions) =>
 			},
 		},
 		async (ctx) => {
-			const token = await ctx.context.internalAdapter.findVerificationValue(
+			// Consume the single-use authorization code up front so concurrent
+			// exchanges of the same code cannot both mint a session: the first
+			// caller receives the row, every racer gets null. consume also gates
+			// expiry, so no separate expiresAt check is needed.
+			const token = await ctx.context.internalAdapter.consumeVerificationValue(
 				`electron:${ctx.body.token}`,
 			);
-			if (!token || token.expiresAt < new Date()) {
+			if (!token) {
 				throw APIError.from("NOT_FOUND", ELECTRON_ERROR_CODES.INVALID_TOKEN);
 			}
 
@@ -94,10 +98,6 @@ export const electronToken = (_opts: ElectronOptions) =>
 					ELECTRON_ERROR_CODES.INVALID_CODE_VERIFIER,
 				);
 			}
-			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-				`electron:${ctx.body.token}`,
-			);
-
 			const user = await ctx.context.internalAdapter.findUserById(
 				tokenRecord.userId,
 			);

--- a/packages/electron/test/electron.test.ts
+++ b/packages/electron/test/electron.test.ts
@@ -225,6 +225,60 @@ describe("Electron", () => {
 		expect(mockElectron.safeStorage.encryptString).toHaveBeenCalled();
 	});
 
+	// The Electron authorization code is single-use. Two concurrent exchanges of
+	// the same valid token/state/code_verifier must yield exactly one session;
+	// the losing racer must be rejected because the code is consumed atomically.
+	it("should mint only one session for concurrent exchanges of the same code", async ({
+		setProcessType,
+	}) => {
+		setProcessType("browser");
+
+		const { user } = await auth.api.signUpEmail({
+			body: {
+				email: "concurrent-exchange@test.com",
+				password: "password",
+				name: "Concurrent Exchange",
+			},
+		});
+
+		const codeVerifier = base64Url.encode(randomBytes(32));
+		const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+		const identifier = generateRandomString(16, "A-Z", "a-z", "0-9");
+		await (await auth.$context).adapter.create({
+			model: "verification",
+			data: {
+				identifier: `electron:${identifier}`,
+				value: JSON.stringify({
+					userId: user.id,
+					codeChallenge,
+					codeChallengeMethod: "s256",
+					state: "abc",
+				}),
+				expiresAt: new Date(Date.now() + 300 * 1000),
+			},
+		});
+
+		const exchange = () =>
+			client.$fetch<any>("/electron/token", {
+				method: "POST",
+				body: {
+					token: identifier,
+					code_verifier: codeVerifier,
+					state: "abc",
+				},
+			});
+
+		const results = await Promise.all([exchange(), exchange()]);
+
+		const succeeded = results.filter((r) => r.data?.token);
+		const failed = results.filter((r) => r.error);
+
+		expect(succeeded).toHaveLength(1);
+		expect(failed).toHaveLength(1);
+		expect(failed[0]?.error?.status).toBe(404);
+	});
+
 	it("should emit authenticated event on success", async ({
 		setProcessType,
 	}) => {
@@ -658,7 +712,6 @@ describe("Electron", () => {
 		});
 
 		const ctx = await auth.$context;
-		const spy = vi.spyOn(ctx.internalAdapter, "deleteVerificationByIdentifier");
 
 		const { data } = await client.$fetch<any>("/electron/token", {
 			method: "POST",
@@ -671,7 +724,11 @@ describe("Electron", () => {
 
 		expect(data?.token).toBeDefined();
 		expect(data?.user.id).toBe(user.id);
-		expect(spy).toHaveBeenCalled();
+
+		const remaining = await ctx.internalAdapter.findVerificationValue(
+			`electron:${identifier}`,
+		);
+		expect(remaining).toBeNull();
 	});
 
 	describe("transferUser", () => {

--- a/packages/kysely-adapter/src/increment-one.test.ts
+++ b/packages/kysely-adapter/src/increment-one.test.ts
@@ -1,0 +1,229 @@
+import { DatabaseSync } from "node:sqlite";
+import type { BetterAuthOptions } from "@better-auth/core";
+import { Kysely } from "kysely";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { kyselyAdapter } from "./kysely-adapter";
+import { NodeSqliteDialect } from "./node-sqlite-dialect";
+
+interface CountersTable {
+	id: string;
+	name: string;
+	remaining: number;
+	used: number;
+	status: string;
+}
+
+interface TestDatabase {
+	counters: CountersTable;
+}
+
+// Register `counters` as a known model through a plugin schema so the factory
+// recognizes the table, maps field names, and delegates to the native
+// incrementOne against the real SQLite database.
+const options: BetterAuthOptions = {
+	plugins: [
+		{
+			id: "counters-test",
+			schema: {
+				counters: {
+					fields: {
+						name: { type: "string" },
+						remaining: { type: "number" },
+						used: { type: "number" },
+						status: { type: "string" },
+					},
+				},
+			},
+		},
+	],
+};
+
+let sqlite: DatabaseSync;
+let db: Kysely<TestDatabase>;
+let executedSql: string[];
+
+function buildAdapter() {
+	return kyselyAdapter(db as unknown as Kysely<any>, { type: "sqlite" })(
+		options,
+	);
+}
+
+beforeEach(() => {
+	sqlite = new DatabaseSync(":memory:");
+	sqlite
+		.prepare(
+			"CREATE TABLE counters (id TEXT PRIMARY KEY, name TEXT, remaining INTEGER, used INTEGER, status TEXT)",
+		)
+		.run();
+	executedSql = [];
+	db = new Kysely<TestDatabase>({
+		dialect: new NodeSqliteDialect({ database: sqlite }),
+		log(event) {
+			if (event.level === "query") {
+				executedSql.push(event.query.sql);
+			}
+		},
+	});
+});
+
+afterEach(async () => {
+	await db.destroy();
+});
+
+describe("kysely incrementOne native", () => {
+	it("applies deltas atomically and returns the updated row", async () => {
+		await db
+			.insertInto("counters")
+			.values({
+				id: "a",
+				name: "alpha",
+				remaining: 3,
+				used: 0,
+				status: "open",
+			})
+			.execute();
+		const adapter = buildAdapter();
+
+		const result = await adapter.incrementOne<CountersTable>({
+			model: "counters",
+			where: [{ field: "name", value: "alpha" }],
+			increment: { remaining: -1, used: 1 },
+		});
+
+		expect(result?.remaining).toBe(2);
+		expect(result?.used).toBe(1);
+
+		// The native path issues a single self-referential UPDATE
+		// (`set field = field + delta`) with RETURNING, not the fallback's
+		// SELECT-then-UPDATE pair.
+		const updates = executedSql.filter((sql) => sql.startsWith("update"));
+		expect(updates).toHaveLength(1);
+		expect(updates[0]).toMatch(/"remaining"\s*=\s*"remaining"\s*\+/i);
+		expect(updates[0]).toMatch(/returning/i);
+		expect(executedSql.some((sql) => sql.startsWith("select"))).toBe(false);
+
+		const row = await db
+			.selectFrom("counters")
+			.selectAll()
+			.where("name", "=", "alpha")
+			.executeTakeFirst();
+		expect(row?.remaining).toBe(2);
+		expect(row?.used).toBe(1);
+	});
+
+	it("applies absolute `set` assignments alongside increments", async () => {
+		await db
+			.insertInto("counters")
+			.values({
+				id: "b",
+				name: "beta",
+				remaining: 5,
+				used: 2,
+				status: "open",
+			})
+			.execute();
+		const adapter = buildAdapter();
+
+		const result = await adapter.incrementOne<CountersTable>({
+			model: "counters",
+			where: [{ field: "name", value: "beta" }],
+			increment: { remaining: -1 },
+			set: { status: "closed" },
+		});
+
+		expect(result?.remaining).toBe(4);
+		expect(result?.status).toBe("closed");
+	});
+
+	it("mutates exactly one row when the guard matches multiple", async () => {
+		await db
+			.insertInto("counters")
+			.values([
+				{
+					id: "d1",
+					name: "shared",
+					remaining: 5,
+					used: 0,
+					status: "open",
+				},
+				{
+					id: "d2",
+					name: "shared",
+					remaining: 5,
+					used: 0,
+					status: "open",
+				},
+				{
+					id: "d3",
+					name: "shared",
+					remaining: 5,
+					used: 0,
+					status: "open",
+				},
+			])
+			.execute();
+		const adapter = buildAdapter();
+
+		// The guard (`remaining > 0`) matches all three rows, but the single-row
+		// contract requires that at most one row is mutated and returned.
+		const result = await adapter.incrementOne<CountersTable>({
+			model: "counters",
+			where: [
+				{ field: "name", value: "shared" },
+				{ field: "remaining", value: 0, operator: "gt" },
+			],
+			increment: { remaining: -1, used: 1 },
+		});
+
+		expect(result?.remaining).toBe(4);
+		expect(result?.used).toBe(1);
+
+		const rows = await db
+			.selectFrom("counters")
+			.selectAll()
+			.where("name", "=", "shared")
+			.orderBy("id")
+			.execute();
+		const mutated = rows.filter((r) => r.remaining === 4 && r.used === 1);
+		const untouched = rows.filter((r) => r.remaining === 5 && r.used === 0);
+		expect(mutated).toHaveLength(1);
+		expect(untouched).toHaveLength(2);
+		// The returned row is the one that was actually mutated.
+		expect(mutated[0]?.id).toBe(result?.id);
+	});
+
+	it("returns null when the guard matches no row and leaves data untouched", async () => {
+		await db
+			.insertInto("counters")
+			.values({
+				id: "c",
+				name: "gamma",
+				remaining: 0,
+				used: 4,
+				status: "open",
+			})
+			.execute();
+		const adapter = buildAdapter();
+
+		// The guard requires `remaining > 0`; with remaining already at 0 the
+		// update must match nothing rather than driving the counter negative.
+		const result = await adapter.incrementOne<CountersTable>({
+			model: "counters",
+			where: [
+				{ field: "name", value: "gamma" },
+				{ field: "remaining", value: 0, operator: "gt" },
+			],
+			increment: { remaining: -1 },
+		});
+
+		expect(result).toBeNull();
+
+		const row = await db
+			.selectFrom("counters")
+			.selectAll()
+			.where("name", "=", "gamma")
+			.executeTakeFirst();
+		expect(row?.remaining).toBe(0);
+		expect(row?.used).toBe(4);
+	});
+});

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -813,6 +813,90 @@ export const kyselyAdapter = (
 						.where(`${model}.${idField}`, "in", targetIds);
 					return deleteWithReturning(query);
 				},
+				async incrementOne({ model, where, increment, set }) {
+					const { and, or } = convertWhereClause(model, where);
+					const applyWhere = (query: any) => {
+						if (and) {
+							query = query.where((eb: any) =>
+								eb.and(and.map((expr) => expr(eb))),
+							);
+						}
+						if (or) {
+							query = query.where((eb: any) =>
+								eb.or(or.map((expr) => expr(eb))),
+							);
+						}
+						return query;
+					};
+					// Each increment field becomes a self-referential assignment
+					// (`field = field + delta`) so the database, not the
+					// application, performs the arithmetic atomically. Absolute
+					// `set` assignments are applied in the same statement.
+					const assignments: Record<string, any> = { ...(set ?? {}) };
+					for (const [field, delta] of Object.entries(increment)) {
+						assignments[field] = sql`${sql.ref(field)} + ${delta}`;
+					}
+					const idField = getFieldName({ model, field: "id" });
+
+					if (config?.type === "mysql") {
+						// MySQL does not support `UPDATE ... RETURNING`. Hold the
+						// target row under `SELECT ... FOR UPDATE`, apply the guarded
+						// update inside the same transaction, then read the row back.
+						// Concurrent claimants block on the lock; a racer that
+						// invalidated the guard observes zero updated rows.
+						const incrementInTransaction = async (trx: any) => {
+							const target = await applyWhere(
+								trx.selectFrom(model).select(`${model}.${idField}`).forUpdate(),
+							)
+								.limit(1)
+								.executeTakeFirst();
+							if (!target) return null;
+							const targetId = target[idField] ?? target.id;
+							if (targetId === undefined || targetId === null) return null;
+							const updated = await applyWhere(
+								trx.updateTable(model).set(assignments),
+							)
+								.where(`${model}.${idField}`, "=", targetId)
+								.executeTakeFirst();
+							if (Number(updated.numUpdatedRows) === 0) return null;
+							return (
+								(await trx
+									.selectFrom(model)
+									.selectAll()
+									.where(`${model}.${idField}`, "=", targetId)
+									.limit(1)
+									.executeTakeFirst()) ?? null
+							);
+						};
+						return inTransaction
+							? incrementInTransaction(db)
+							: db.transaction().execute(incrementInTransaction);
+					}
+
+					// Scope the update to a single matching row by targeting
+					// `id IN (SELECT id WHERE guard LIMIT 1)`, mirroring consumeOne. A
+					// bare guarded UPDATE would mutate every matching row, violating the
+					// single-row contract when the guard is non-unique.
+					const selectIds = applyWhere(
+						db.selectFrom(model).select(`${model}.${idField}`),
+					);
+					// SQL Server has no `LIMIT`; a `top(1)` subquery is the
+					// server-correct single-row form. Every other dialect uses
+					// `limit(1)`.
+					const targetIds =
+						config?.type === "mssql" ? selectIds.top(1) : selectIds.limit(1);
+					const updateQuery = db
+						.updateTable(model)
+						.set(assignments)
+						.where(`${model}.${idField}`, "in", targetIds);
+					if (config?.type === "mssql") {
+						return (
+							(await updateQuery.outputAll("inserted").executeTakeFirst()) ??
+							null
+						);
+					}
+					return (await updateQuery.returningAll().executeTakeFirst()) ?? null;
+				},
 				options: config,
 			};
 		};

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -885,10 +885,9 @@ export const kyselyAdapter = (
 					// `limit(1)`.
 					const targetIds =
 						config?.type === "mssql" ? selectIds.top(1) : selectIds.limit(1);
-					const updateQuery = db
-						.updateTable(model)
-						.set(assignments)
-						.where(`${model}.${idField}`, "in", targetIds);
+					const updateQuery = applyWhere(
+						db.updateTable(model).set(assignments),
+					).where(`${model}.${idField}`, "in", targetIds);
 					if (config?.type === "mssql") {
 						return (
 							(await updateQuery.outputAll("inserted").executeTakeFirst()) ??

--- a/packages/memory-adapter/src/memory-adapter.test.ts
+++ b/packages/memory-adapter/src/memory-adapter.test.ts
@@ -1,0 +1,462 @@
+import type { BetterAuthOptions } from "@better-auth/core";
+import type { DBAdapter } from "@better-auth/core/db/adapter";
+import { describe, expect, it } from "vitest";
+import type { MemoryDB } from "./memory-adapter";
+import { memoryAdapter } from "./memory-adapter";
+
+/**
+ * A self-contained plugin model with loosely-typed optional fields. Using a
+ * custom table keeps these adapter-fidelity tests independent of the auth
+ * user/session schema and its required-field validation.
+ */
+const widgetPlugin = {
+	id: "widget-test",
+	schema: {
+		widget: {
+			fields: {
+				name: { type: "string" as const, required: false },
+				tag: { type: "string" as const, required: false },
+				count: { type: "number" as const, required: false },
+				remaining: { type: "number" as const, required: false },
+			},
+		},
+	},
+};
+
+const options: BetterAuthOptions = {
+	plugins: [widgetPlugin as any],
+};
+
+function setup(): { db: MemoryDB; adapter: DBAdapter<BetterAuthOptions> } {
+	const db: MemoryDB = { widget: [] };
+	const adapter = memoryAdapter(db)(options);
+	return { db, adapter };
+}
+
+async function seedWidget(
+	adapter: DBAdapter<BetterAuthOptions>,
+	id: string,
+	name: string,
+) {
+	return adapter.create({
+		model: "widget",
+		data: { id, name },
+		forceAllowId: true,
+	});
+}
+
+describe("memory adapter singular mutation with empty predicate", () => {
+	it("singular update with an empty where is a no-op and leaves every row untouched", async () => {
+		const { adapter } = setup();
+		await seedWidget(adapter, "1", "alice");
+		await seedWidget(adapter, "2", "bob");
+
+		const result = await adapter.update({
+			model: "widget",
+			where: [],
+			update: { name: "overwritten" },
+		});
+
+		expect(result).toBeNull();
+		const rows = await adapter.findMany<{ id: string; name: string }>({
+			model: "widget",
+		});
+		expect(rows.map((r) => r.name).sort()).toEqual(["alice", "bob"]);
+	});
+
+	it("singular delete with an empty where is a no-op and removes no rows", async () => {
+		const { adapter } = setup();
+		await seedWidget(adapter, "1", "alice");
+		await seedWidget(adapter, "2", "bob");
+
+		await adapter.delete({ model: "widget", where: [] });
+
+		const rows = await adapter.findMany<{ id: string }>({ model: "widget" });
+		expect(rows).toHaveLength(2);
+	});
+});
+
+describe("memory adapter updateMany return shape", () => {
+	it("returns the number of affected rows, not a record", async () => {
+		const { adapter } = setup();
+		await seedWidget(adapter, "1", "alice");
+		await seedWidget(adapter, "2", "bob");
+		await seedWidget(adapter, "3", "carol");
+
+		const affected = await adapter.updateMany({
+			model: "widget",
+			where: [{ field: "tag", value: "x" }],
+			update: { tag: "x" },
+		});
+		expect(affected).toBe(0);
+
+		const matched = await adapter.updateMany({
+			model: "widget",
+			where: [
+				{ field: "id", value: "1", connector: "OR" },
+				{ field: "id", value: "2", connector: "OR" },
+			],
+			update: { tag: "grouped" },
+		});
+		expect(matched).toBe(2);
+
+		const all = await adapter.updateMany({
+			model: "widget",
+			where: [],
+			update: { tag: "everyone" },
+		});
+		expect(all).toBe(3);
+	});
+});
+
+describe("memory adapter incrementOne", () => {
+	it("applies a positive delta and returns the updated row", async () => {
+		const { adapter } = setup();
+		await adapter.create({
+			model: "widget",
+			data: { id: "1", name: "alice", count: 5 },
+			forceAllowId: true,
+		});
+
+		const updated = await adapter.incrementOne<{ id: string; count: number }>({
+			model: "widget",
+			where: [{ field: "id", value: "1" }],
+			increment: { count: 3 },
+		});
+
+		expect(updated?.count).toBe(8);
+		const row = await adapter.findOne<{ count: number }>({
+			model: "widget",
+			where: [{ field: "id", value: "1" }],
+		});
+		expect(row?.count).toBe(8);
+	});
+
+	it("applies a negative delta to decrement", async () => {
+		const { adapter } = setup();
+		await adapter.create({
+			model: "widget",
+			data: { id: "1", name: "alice", remaining: 2 },
+			forceAllowId: true,
+		});
+
+		const updated = await adapter.incrementOne<{ remaining: number }>({
+			model: "widget",
+			where: [{ field: "id", value: "1" }],
+			increment: { remaining: -1 },
+		});
+
+		expect(updated?.remaining).toBe(1);
+	});
+
+	it("treats a missing counter field as zero before applying the delta", async () => {
+		const { adapter } = setup();
+		await adapter.create({
+			model: "widget",
+			data: { id: "1", name: "alice" },
+			forceAllowId: true,
+		});
+
+		const updated = await adapter.incrementOne<{ count: number }>({
+			model: "widget",
+			where: [{ field: "id", value: "1" }],
+			increment: { count: 4 },
+		});
+
+		expect(updated?.count).toBe(4);
+	});
+
+	it("applies absolute set assignments alongside increments", async () => {
+		const { adapter } = setup();
+		await adapter.create({
+			model: "widget",
+			data: { id: "1", name: "alice", count: 1 },
+			forceAllowId: true,
+		});
+
+		const updated = await adapter.incrementOne<{
+			count: number;
+			tag: string;
+		}>({
+			model: "widget",
+			where: [{ field: "id", value: "1" }],
+			increment: { count: 1 },
+			set: { tag: "touched" },
+		});
+
+		expect(updated?.count).toBe(2);
+		expect(updated?.tag).toBe("touched");
+	});
+
+	it("mutates only the single guarded row matching the where clause", async () => {
+		const { adapter } = setup();
+		await adapter.create({
+			model: "widget",
+			data: { id: "1", name: "alice", count: 0 },
+			forceAllowId: true,
+		});
+		await adapter.create({
+			model: "widget",
+			data: { id: "2", name: "bob", count: 0 },
+			forceAllowId: true,
+		});
+
+		await adapter.incrementOne({
+			model: "widget",
+			where: [{ field: "id", value: "1" }],
+			increment: { count: 10 },
+		});
+
+		const rows = await adapter.findMany<{ id: string; count: number }>({
+			model: "widget",
+		});
+		const byId = Object.fromEntries(rows.map((r) => [r.id, r.count]));
+		expect(byId["1"]).toBe(10);
+		expect(byId["2"]).toBe(0);
+	});
+
+	it("when the guard matches no row, returns null and mutates nothing", async () => {
+		const { adapter } = setup();
+		await adapter.create({
+			model: "widget",
+			data: { id: "1", name: "alice", remaining: 0 },
+			forceAllowId: true,
+		});
+
+		// The guard `remaining > 0` excludes the row, so no mutation may occur.
+		const updated = await adapter.incrementOne<{ remaining: number }>({
+			model: "widget",
+			where: [
+				{ field: "id", value: "1" },
+				{ field: "remaining", value: 0, operator: "gt" },
+			],
+			increment: { remaining: -1 },
+		});
+
+		expect(updated).toBeNull();
+		const row = await adapter.findOne<{ remaining: number }>({
+			model: "widget",
+			where: [{ field: "id", value: "1" }],
+		});
+		expect(row?.remaining).toBe(0);
+	});
+
+	it("participates in copy-on-write so a failed transaction discards the increment", async () => {
+		const { adapter } = setup();
+		await adapter.create({
+			model: "widget",
+			data: { id: "1", name: "alice", count: 5 },
+			forceAllowId: true,
+		});
+
+		const failed = await adapter
+			.transaction(async (trx) => {
+				await trx.incrementOne({
+					model: "widget",
+					where: [{ field: "id", value: "1" }],
+					increment: { count: 100 },
+				});
+				throw new Error("Simulated failure");
+			})
+			.catch((error) => error);
+
+		expect(failed).toBeInstanceOf(Error);
+		const row = await adapter.findOne<{ count: number }>({
+			model: "widget",
+			where: [{ field: "id", value: "1" }],
+		});
+		expect(row?.count).toBe(5);
+	});
+});
+
+describe("memory adapter transaction isolation", () => {
+	it("a failing transaction must not erase a write made by a concurrent in-flight operation", async () => {
+		const { adapter } = setup();
+
+		let releaseGate: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			releaseGate = resolve;
+		});
+
+		const failingTransaction = adapter
+			.transaction(async (tx) => {
+				await tx.create({
+					model: "widget",
+					data: { id: "tx", name: "in-transaction" },
+					forceAllowId: true,
+				});
+				// Yield so the concurrent write below lands on the live db before
+				// this transaction rolls back.
+				await gate;
+				throw new Error("Simulated failure");
+			})
+			.catch((error) => error);
+
+		// Concurrent write against the live db while the transaction is in flight.
+		await seedWidget(adapter, "outside", "outside-write");
+		releaseGate();
+
+		const error = await failingTransaction;
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toBe("Simulated failure");
+
+		const rows = await adapter.findMany<{ id: string; name: string }>({
+			model: "widget",
+		});
+		// The rollback discarded the transaction's own write but preserved the
+		// concurrent outside write.
+		expect(rows.map((r) => r.id).sort()).toEqual(["outside"]);
+	});
+
+	it("a committing transaction must not erase a write made by a concurrent in-flight operation", async () => {
+		const { adapter } = setup();
+
+		let releaseGate: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			releaseGate = resolve;
+		});
+
+		const committingTransaction = adapter.transaction(async (tx) => {
+			await tx.create({
+				model: "widget",
+				data: { id: "tx", name: "in-transaction" },
+				forceAllowId: true,
+			});
+			// Yield so the concurrent write below lands on the live db before
+			// this transaction commits.
+			await gate;
+			return "committed";
+		});
+
+		// Concurrent write against the live db while the transaction is in flight.
+		await seedWidget(adapter, "outside", "outside-write");
+		releaseGate();
+
+		const result = await committingTransaction;
+		expect(result).toBe("committed");
+
+		const rows = await adapter.findMany<{ id: string; name: string }>({
+			model: "widget",
+		});
+		// The commit applied the transaction's own write and preserved the
+		// concurrent outside write made while it was in flight.
+		expect(rows.map((r) => r.id).sort()).toEqual(["outside", "tx"]);
+	});
+
+	it("a committing transaction's update to one row does not clobber a concurrent update to a different row", async () => {
+		const { adapter } = setup();
+		await seedWidget(adapter, "a", "a-original");
+		await seedWidget(adapter, "b", "b-original");
+
+		let releaseGate: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			releaseGate = resolve;
+		});
+
+		const tx = adapter.transaction(async (trx) => {
+			await trx.update({
+				model: "widget",
+				where: [{ field: "id", value: "a" }],
+				update: { name: "a-from-tx" },
+			});
+			await gate;
+			return "done";
+		});
+
+		// Concurrent update of a different row while the transaction is in flight.
+		await adapter.update({
+			model: "widget",
+			where: [{ field: "id", value: "b" }],
+			update: { name: "b-from-outside" },
+		});
+		releaseGate();
+		await tx;
+
+		const rows = await adapter.findMany<{ id: string; name: string }>({
+			model: "widget",
+		});
+		const byId = Object.fromEntries(rows.map((r) => [r.id, r.name]));
+		expect(byId.a).toBe("a-from-tx");
+		expect(byId.b).toBe("b-from-outside");
+	});
+
+	it("a committing transaction's delete is applied while a concurrent insert survives", async () => {
+		const { adapter } = setup();
+		await seedWidget(adapter, "doomed", "to-be-deleted");
+
+		let releaseGate: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			releaseGate = resolve;
+		});
+
+		const tx = adapter.transaction(async (trx) => {
+			await trx.delete({
+				model: "widget",
+				where: [{ field: "id", value: "doomed" }],
+			});
+			await gate;
+			return "done";
+		});
+
+		await seedWidget(adapter, "fresh", "concurrent-insert");
+		releaseGate();
+		await tx;
+
+		const rows = await adapter.findMany<{ id: string }>({ model: "widget" });
+		expect(rows.map((r) => r.id).sort()).toEqual(["fresh"]);
+	});
+
+	it("uncommitted transaction writes are invisible to operations outside the transaction", async () => {
+		const { adapter } = setup();
+
+		let releaseGate: () => void = () => {};
+		const gate = new Promise<void>((resolve) => {
+			releaseGate = resolve;
+		});
+		let signalWriteDone: () => void = () => {};
+		const writeDone = new Promise<void>((resolve) => {
+			signalWriteDone = resolve;
+		});
+
+		const tx = adapter.transaction(async (trx) => {
+			await trx.create({
+				model: "widget",
+				data: { id: "tx", name: "in-transaction" },
+				forceAllowId: true,
+			});
+			// The transaction's write has landed in its scope; hold here so the
+			// outside read below runs while the write is uncommitted.
+			signalWriteDone();
+			await gate;
+			return "committed";
+		});
+
+		await writeDone;
+		const observedDuringTransaction = (
+			await adapter.findMany<{ id: string }>({ model: "widget" })
+		).length;
+		releaseGate();
+		const result = await tx;
+
+		expect(observedDuringTransaction).toBe(0);
+		expect(result).toBe("committed");
+		// After commit, the row is visible on the live db.
+		const rows = await adapter.findMany<{ id: string }>({ model: "widget" });
+		expect(rows.map((r) => r.id)).toEqual(["tx"]);
+	});
+
+	it("a committed transaction mutates the original db object in place", async () => {
+		const { db, adapter } = setup();
+
+		await adapter.transaction(async (trx) => {
+			await trx.create({
+				model: "widget",
+				data: { id: "committed", name: "kept" },
+				forceAllowId: true,
+			});
+		});
+
+		// The reference the caller passed to memoryAdapter reflects the commit.
+		expect(db.widget?.map((r) => r.id)).toEqual(["committed"]);
+	});
+});

--- a/packages/memory-adapter/src/memory-adapter.ts
+++ b/packages/memory-adapter/src/memory-adapter.ts
@@ -23,398 +23,548 @@ export interface MemoryAdapterConfig {
 	debugLogs?: DBAdapterDebugLogOption | undefined;
 }
 
+/**
+ * Index a table's rows by their `id` for row-level reconciliation. Every
+ * better-auth row carries an `id` (the adapter's join logic already keys on
+ * `record.id`), so the id is a stable identity for the three-way merge.
+ */
+function indexById(rows: any[]): Map<unknown, any> {
+	const byId = new Map<unknown, any>();
+	for (const row of rows) {
+		byId.set(row.id, row);
+	}
+	return byId;
+}
+
+/**
+ * Commit a transaction onto the live database with a three-way merge so a
+ * concurrent write that interleaved at an `await` point survives.
+ *
+ * `base` is the snapshot taken when the transaction started; `clone` is that
+ * snapshot after the transaction mutated it; `target` is the live database as
+ * it stands now (possibly carrying concurrent writes). Replaying only the
+ * `base -> clone` delta onto `target` applies the transaction's own creates,
+ * updates, and deletes without disturbing rows or tables the transaction never
+ * touched. A row the transaction did not change keeps the live version, so a
+ * concurrent edit to a different row is preserved. A row the transaction did
+ * change wins last-writer-wins over a concurrent edit to the same row, which is
+ * acceptable for an in-memory development adapter; isolation is guaranteed only
+ * at row/table granularity.
+ *
+ * `target` is mutated in place so any reference held elsewhere (for example the
+ * `db` object the caller passed to `memoryAdapter`) stays valid.
+ */
+function mergeTransactionInto(
+	target: MemoryDB,
+	base: MemoryDB,
+	clone: MemoryDB,
+): void {
+	const models = new Set([...Object.keys(base), ...Object.keys(clone)]);
+
+	for (const model of models) {
+		// A table present at start but absent after commit was dropped wholesale
+		// by the transaction; mirror that on the live db.
+		if (!(model in clone)) {
+			delete target[model];
+			continue;
+		}
+
+		const baseById = indexById(base[model] ?? []);
+		const cloneRows = clone[model] ?? [];
+		const cloneById = indexById(cloneRows);
+		const liveRows = target[model] ?? [];
+
+		const merged: any[] = [];
+		const placed = new Set<unknown>();
+		for (const liveRow of liveRows) {
+			const id = liveRow.id;
+			const baseRow = baseById.get(id);
+			const cloneRow = cloneById.get(id);
+
+			// Removed by the transaction (present at start, gone after commit):
+			// drop it. A row absent from base was created concurrently and is kept.
+			if (baseRow !== undefined && cloneRow === undefined) {
+				continue;
+			}
+			// Changed by the transaction: take the transaction's version. Unchanged
+			// rows keep the live version, preserving any concurrent edit to them.
+			if (cloneRow !== undefined && rowChanged(baseRow, cloneRow)) {
+				merged.push(cloneRow);
+			} else {
+				merged.push(liveRow);
+			}
+			placed.add(id);
+		}
+
+		// Rows created inside the transaction (absent from base, never seen on the
+		// live db): append in the transaction's insertion order.
+		for (const cloneRow of cloneRows) {
+			if (!baseById.has(cloneRow.id) && !placed.has(cloneRow.id)) {
+				merged.push(cloneRow);
+			}
+		}
+
+		target[model] = merged;
+	}
+}
+
+/**
+ * Whether the transaction mutated a row, comparing its pre-transaction
+ * snapshot to its post-transaction state. Rows hold scalar columns and
+ * adapter-serializable values, so JSON equality reliably tells a
+ * transaction-made edit apart from an untouched row.
+ */
+function rowChanged(baseRow: any, cloneRow: any): boolean {
+	if (baseRow === undefined) return true;
+	return JSON.stringify(baseRow) !== JSON.stringify(cloneRow);
+}
+
 export const memoryAdapter = (
 	db: MemoryDB,
 	config?: MemoryAdapterConfig | undefined,
 ) => {
 	let lazyOptions: BetterAuthOptions | null = null;
-	const adapterCreator = createAdapterFactory({
-		config: {
-			adapterId: "memory",
-			adapterName: "Memory Adapter",
-			usePlural: false,
-			debugLogs: config?.debugLogs || false,
-			supportsArrays: true,
-			customTransformInput(props) {
-				const useNumberId =
-					props.options.advanced?.database?.generateId === "serial";
-				if (useNumberId && props.field === "id" && props.action === "create") {
-					return db[props.model]!.length + 1;
-				}
-				return props.data;
+
+	/**
+	 * Build an adapter factory whose operations read and write `activeDb`.
+	 * The non-transactional adapter targets the live `db`. A transaction
+	 * targets an isolated clone so its uncommitted writes are invisible to
+	 * concurrent operations against the live `db`. A failed transaction leaves
+	 * the live `db` untouched, and a committed one replays only its own
+	 * row/table changes, so a concurrent write that interleaved at an `await`
+	 * point survives either outcome. Isolation is at row/table granularity:
+	 * the in-memory adapter does not serialize writes, so two operations that
+	 * edit the same row resolve last-writer-wins. It is built for development
+	 * and tests, not production concurrency control.
+	 */
+	const buildAdapterFactory = (activeDb: MemoryDB) =>
+		createAdapterFactory({
+			config: {
+				adapterId: "memory",
+				adapterName: "Memory Adapter",
+				usePlural: false,
+				debugLogs: config?.debugLogs || false,
+				supportsArrays: true,
+				customTransformInput(props) {
+					const useNumberId =
+						props.options.advanced?.database?.generateId === "serial";
+					if (
+						useNumberId &&
+						props.field === "id" &&
+						props.action === "create"
+					) {
+						return activeDb[props.model]!.length + 1;
+					}
+					return props.data;
+				},
+				transaction: async (cb) => {
+					// Copy-on-write isolation: run the callback against a clone, then
+					// replay its delta onto the live db on success. On failure the clone
+					// is discarded and the live db is never touched. `base` captures the
+					// pre-transaction state so the commit can apply only the rows the
+					// transaction changed, preserving writes that interleaved at an
+					// `await` point.
+					const base = structuredClone(activeDb);
+					const clone = structuredClone(activeDb);
+					const trxAdapter = buildAdapterFactory(clone)(lazyOptions!);
+					const result = await cb(trxAdapter);
+					mergeTransactionInto(activeDb, base, clone);
+					return result;
+				},
 			},
-			transaction: async (cb) => {
-				const clone = structuredClone(db);
-				try {
-					const r = await cb(adapterCreator(lazyOptions!));
-					return r;
-				} catch (error) {
-					// Rollback changes
-					Object.keys(db).forEach((key) => {
-						db[key] = clone[key]!;
+			adapter: ({
+				getFieldName,
+				getDefaultFieldName,
+				options,
+				getModelName,
+			}) => {
+				const applySortToRecords = (
+					records: any[],
+					sortBy: { field: string; direction: "asc" | "desc" } | undefined,
+					model: string,
+				) => {
+					if (!sortBy) return records;
+					return records.sort((a: any, b: any) => {
+						const field = getFieldName({ model, field: sortBy.field });
+						const aValue = a[field];
+						const bValue = b[field];
+
+						let comparison = 0;
+
+						// Handle null/undefined values
+						if (aValue == null && bValue == null) {
+							comparison = 0;
+						} else if (aValue == null) {
+							comparison = -1;
+						} else if (bValue == null) {
+							comparison = 1;
+						}
+						// Handle string comparison
+						else if (typeof aValue === "string" && typeof bValue === "string") {
+							comparison = aValue.localeCompare(bValue);
+						}
+						// Handle date comparison
+						else if (aValue instanceof Date && bValue instanceof Date) {
+							comparison = aValue.getTime() - bValue.getTime();
+						}
+						// Handle numeric comparison
+						else if (typeof aValue === "number" && typeof bValue === "number") {
+							comparison = aValue - bValue;
+						}
+						// Handle boolean comparison
+						else if (
+							typeof aValue === "boolean" &&
+							typeof bValue === "boolean"
+						) {
+							comparison = aValue === bValue ? 0 : aValue ? 1 : -1;
+						}
+						// Fallback to string comparison
+						else {
+							comparison = String(aValue).localeCompare(String(bValue));
+						}
+
+						return sortBy.direction === "asc" ? comparison : -comparison;
 					});
-					throw error;
-				}
-			},
-		},
-		adapter: ({ getFieldName, getDefaultFieldName, options, getModelName }) => {
-			const applySortToRecords = (
-				records: any[],
-				sortBy: { field: string; direction: "asc" | "desc" } | undefined,
-				model: string,
-			) => {
-				if (!sortBy) return records;
-				return records.sort((a: any, b: any) => {
-					const field = getFieldName({ model, field: sortBy.field });
-					const aValue = a[field];
-					const bValue = b[field];
+				};
 
-					let comparison = 0;
-
-					// Handle null/undefined values
-					if (aValue == null && bValue == null) {
-						comparison = 0;
-					} else if (aValue == null) {
-						comparison = -1;
-					} else if (bValue == null) {
-						comparison = 1;
-					}
-					// Handle string comparison
-					else if (typeof aValue === "string" && typeof bValue === "string") {
-						comparison = aValue.localeCompare(bValue);
-					}
-					// Handle date comparison
-					else if (aValue instanceof Date && bValue instanceof Date) {
-						comparison = aValue.getTime() - bValue.getTime();
-					}
-					// Handle numeric comparison
-					else if (typeof aValue === "number" && typeof bValue === "number") {
-						comparison = aValue - bValue;
-					}
-					// Handle boolean comparison
-					else if (typeof aValue === "boolean" && typeof bValue === "boolean") {
-						comparison = aValue === bValue ? 0 : aValue ? 1 : -1;
-					}
-					// Fallback to string comparison
-					else {
-						comparison = String(aValue).localeCompare(String(bValue));
-					}
-
-					return sortBy.direction === "asc" ? comparison : -comparison;
-				});
-			};
-
-			function convertWhereClause(
-				where: CleanedWhere[],
-				model: string,
-				join?: JoinConfig,
-				select?: string[],
-			): any[] {
-				const baseRecords = (() => {
-					const table = db[model];
-					if (!table) {
-						logger.error(
-							`[MemoryAdapter] Model ${model} not found in the DB`,
-							Object.keys(db),
-						);
-						throw new Error(`Model ${model} not found`);
-					}
-
-					const evalClause = (record: any, clause: CleanedWhere): boolean => {
-						const { field, value, operator, mode = "sensitive" } = clause;
-						const isInsensitive =
-							mode === "insensitive" &&
-							(typeof value === "string" ||
-								(Array.isArray(value) &&
-									value.every((v) => typeof v === "string")));
-
-						switch (operator) {
-							case "in":
-								if (!Array.isArray(value)) {
-									throw new Error("Value must be an array");
-								}
-								if (isInsensitive) {
-									return insensitiveIn(record[field], value);
-								}
-								// @ts-expect-error
-								return value.includes(record[field]);
-							case "not_in":
-								if (!Array.isArray(value)) {
-									throw new Error("Value must be an array");
-								}
-								if (isInsensitive) {
-									return insensitiveNotIn(record[field], value);
-								}
-								// @ts-expect-error
-								return !value.includes(record[field]);
-							case "contains":
-								if (isInsensitive) {
-									return insensitiveContains(record[field], value);
-								}
-								return record[field]?.includes(value);
-							case "starts_with":
-								if (isInsensitive) {
-									return insensitiveStartsWith(record[field], value);
-								}
-								return record[field].startsWith(value);
-							case "ends_with":
-								if (isInsensitive) {
-									return insensitiveEndsWith(record[field], value);
-								}
-								return record[field].endsWith(value);
-							case "ne":
-								return isInsensitive
-									? !insensitiveCompare(record[field], value)
-									: record[field] !== value;
-							case "gt":
-								return value != null && Boolean(record[field] > value);
-							case "gte":
-								return value != null && Boolean(record[field] >= value);
-							case "lt":
-								return value != null && Boolean(record[field] < value);
-							case "lte":
-								return value != null && Boolean(record[field] <= value);
-							default:
-								if (isInsensitive) {
-									return insensitiveCompare(record[field], value);
-								}
-								// Treat undefined and null as equivalent for `eq null`
-								// predicates. Rows created without a nullable field
-								// (the adapter factory's `transformInput` skips
-								// `undefined`) store the field as `undefined`; a
-								// CAS-style `WHERE field IS NULL` predicate from
-								// caller code must match those rows, mirroring SQL
-								// `IS NULL` and Mongo's missing-or-null semantics.
-								if (value === null) {
-									return record[field] == null;
-								}
-								return record[field] === value;
-						}
-					};
-
-					let records = table.filter((record: any) => {
-						if (!where.length || where.length === 0) {
-							return true;
+				function convertWhereClause(
+					where: CleanedWhere[],
+					model: string,
+					join?: JoinConfig,
+					select?: string[],
+				): any[] {
+					const baseRecords = (() => {
+						const table = activeDb[model];
+						if (!table) {
+							logger.error(
+								`[MemoryAdapter] Model ${model} not found in the DB`,
+								Object.keys(activeDb),
+							);
+							throw new Error(`Model ${model} not found`);
 						}
 
-						let result = evalClause(record, where[0]!);
-						for (const clause of where) {
-							const clauseResult = evalClause(record, clause);
+						const evalClause = (record: any, clause: CleanedWhere): boolean => {
+							const { field, value, operator, mode = "sensitive" } = clause;
+							const isInsensitive =
+								mode === "insensitive" &&
+								(typeof value === "string" ||
+									(Array.isArray(value) &&
+										value.every((v) => typeof v === "string")));
 
-							if (clause.connector === "OR") {
-								result = result || clauseResult;
-							} else {
-								result = result && clauseResult;
+							switch (operator) {
+								case "in":
+									if (!Array.isArray(value)) {
+										throw new Error("Value must be an array");
+									}
+									if (isInsensitive) {
+										return insensitiveIn(record[field], value);
+									}
+									// @ts-expect-error
+									return value.includes(record[field]);
+								case "not_in":
+									if (!Array.isArray(value)) {
+										throw new Error("Value must be an array");
+									}
+									if (isInsensitive) {
+										return insensitiveNotIn(record[field], value);
+									}
+									// @ts-expect-error
+									return !value.includes(record[field]);
+								case "contains":
+									if (isInsensitive) {
+										return insensitiveContains(record[field], value);
+									}
+									return record[field]?.includes(value);
+								case "starts_with":
+									if (isInsensitive) {
+										return insensitiveStartsWith(record[field], value);
+									}
+									return record[field].startsWith(value);
+								case "ends_with":
+									if (isInsensitive) {
+										return insensitiveEndsWith(record[field], value);
+									}
+									return record[field].endsWith(value);
+								case "ne":
+									return isInsensitive
+										? !insensitiveCompare(record[field], value)
+										: record[field] !== value;
+								case "gt":
+									return value != null && Boolean(record[field] > value);
+								case "gte":
+									return value != null && Boolean(record[field] >= value);
+								case "lt":
+									return value != null && Boolean(record[field] < value);
+								case "lte":
+									return value != null && Boolean(record[field] <= value);
+								default:
+									if (isInsensitive) {
+										return insensitiveCompare(record[field], value);
+									}
+									// Treat undefined and null as equivalent for `eq null`
+									// predicates. Rows created without a nullable field
+									// (the adapter factory's `transformInput` skips
+									// `undefined`) store the field as `undefined`; a
+									// CAS-style `WHERE field IS NULL` predicate from
+									// caller code must match those rows, mirroring SQL
+									// `IS NULL` and Mongo's missing-or-null semantics.
+									if (value === null) {
+										return record[field] == null;
+									}
+									return record[field] === value;
 							}
+						};
+
+						let records = table.filter((record: any) => {
+							if (!where.length || where.length === 0) {
+								return true;
+							}
+
+							let result = evalClause(record, where[0]!);
+							for (const clause of where) {
+								const clauseResult = evalClause(record, clause);
+
+								if (clause.connector === "OR") {
+									result = result || clauseResult;
+								} else {
+									result = result && clauseResult;
+								}
+							}
+
+							return result;
+						});
+						if (select?.length && select.length > 0) {
+							records = records.map((record: any) =>
+								Object.fromEntries(
+									Object.entries(record).filter(([key]) =>
+										select.includes(getDefaultFieldName({ model, field: key })),
+									),
+								),
+							);
+						}
+						return records;
+					})();
+
+					if (!join) return baseRecords;
+
+					// Group results by base model and nest joined data as arrays
+					const grouped = new Map<string, any>();
+					// Track seen IDs per joined model for O(1) deduplication
+					const seenIds = new Map<string, Set<string>>();
+
+					for (const baseRecord of baseRecords) {
+						const baseId = String(baseRecord.id);
+
+						if (!grouped.has(baseId)) {
+							const nested: Record<string, any> = { ...baseRecord };
+
+							// Initialize joined data structures based on isUnique
+							for (const [joinModel, joinAttr] of Object.entries(join)) {
+								const joinModelName = getModelName(joinModel);
+								if (joinAttr.relation === "one-to-one") {
+									nested[joinModelName] = null;
+								} else {
+									nested[joinModelName] = [];
+									seenIds.set(`${baseId}-${joinModel}`, new Set());
+								}
+							}
+
+							grouped.set(baseId, nested);
 						}
 
-						return result;
-					});
-					if (select?.length && select.length > 0) {
-						records = records.map((record: any) =>
-							Object.fromEntries(
-								Object.entries(record).filter(([key]) =>
-									select.includes(getDefaultFieldName({ model, field: key })),
-								),
-							),
-						);
-					}
-					return records;
-				})();
+						const nestedEntry = grouped.get(baseId)!;
 
-				if (!join) return baseRecords;
-
-				// Group results by base model and nest joined data as arrays
-				const grouped = new Map<string, any>();
-				// Track seen IDs per joined model for O(1) deduplication
-				const seenIds = new Map<string, Set<string>>();
-
-				for (const baseRecord of baseRecords) {
-					const baseId = String(baseRecord.id);
-
-					if (!grouped.has(baseId)) {
-						const nested: Record<string, any> = { ...baseRecord };
-
-						// Initialize joined data structures based on isUnique
+						// Add joined data
 						for (const [joinModel, joinAttr] of Object.entries(join)) {
 							const joinModelName = getModelName(joinModel);
-							if (joinAttr.relation === "one-to-one") {
-								nested[joinModelName] = null;
-							} else {
-								nested[joinModelName] = [];
-								seenIds.set(`${baseId}-${joinModel}`, new Set());
+							const joinTable = activeDb[joinModelName];
+							if (!joinTable) {
+								logger.error(
+									`[MemoryAdapter] JoinOption model ${joinModelName} not found in the DB`,
+									Object.keys(activeDb),
+								);
+								throw new Error(`JoinOption model ${joinModelName} not found`);
 							}
-						}
 
-						grouped.set(baseId, nested);
-					}
-
-					const nestedEntry = grouped.get(baseId)!;
-
-					// Add joined data
-					for (const [joinModel, joinAttr] of Object.entries(join)) {
-						const joinModelName = getModelName(joinModel);
-						const joinTable = db[joinModelName];
-						if (!joinTable) {
-							logger.error(
-								`[MemoryAdapter] JoinOption model ${joinModelName} not found in the DB`,
-								Object.keys(db),
+							const matchingRecords = joinTable.filter(
+								(joinRecord: any) =>
+									joinRecord[joinAttr.on.to] === baseRecord[joinAttr.on.from],
 							);
-							throw new Error(`JoinOption model ${joinModelName} not found`);
-						}
 
-						const matchingRecords = joinTable.filter(
-							(joinRecord: any) =>
-								joinRecord[joinAttr.on.to] === baseRecord[joinAttr.on.from],
-						);
+							if (joinAttr.relation === "one-to-one") {
+								// For unique relationships, store a single object (or null)
+								nestedEntry[joinModelName] = matchingRecords[0] || null;
+							} else {
+								// For non-unique relationships, store array with limit
+								const seenSet = seenIds.get(`${baseId}-${joinModel}`)!;
+								const limit = joinAttr.limit ?? 100;
+								let count = 0;
 
-						if (joinAttr.relation === "one-to-one") {
-							// For unique relationships, store a single object (or null)
-							nestedEntry[joinModelName] = matchingRecords[0] || null;
-						} else {
-							// For non-unique relationships, store array with limit
-							const seenSet = seenIds.get(`${baseId}-${joinModel}`)!;
-							const limit = joinAttr.limit ?? 100;
-							let count = 0;
-
-							for (const matchingRecord of matchingRecords) {
-								if (count >= limit) break;
-								if (!seenSet.has(matchingRecord.id)) {
-									nestedEntry[joinModelName].push(matchingRecord);
-									seenSet.add(matchingRecord.id);
-									count++;
+								for (const matchingRecord of matchingRecords) {
+									if (count >= limit) break;
+									if (!seenSet.has(matchingRecord.id)) {
+										nestedEntry[joinModelName].push(matchingRecord);
+										seenSet.add(matchingRecord.id);
+										count++;
+									}
 								}
 							}
 						}
 					}
+
+					return Array.from(grouped.values());
 				}
-
-				return Array.from(grouped.values());
-			}
-			return {
-				create: async ({ model, data }) => {
-					const useNumberId =
-						options.advanced?.database?.generateId === "serial";
-					if (useNumberId) {
-						// @ts-expect-error
-						data.id = db[getModelName(model)]!.length + 1;
-					}
-					if (!db[model]) {
-						db[model] = [];
-					}
-					db[model]!.push(data);
-					return data;
-				},
-				findOne: async ({ model, where, select, join }) => {
-					const res = convertWhereClause(where, model, join, select);
-					if (join) {
-						// When join is present, res is an array of nested objects
-						const resArray = res as any[];
-						if (!resArray.length) {
-							return null;
+				return {
+					create: async ({ model, data }) => {
+						const useNumberId =
+							options.advanced?.database?.generateId === "serial";
+						if (useNumberId) {
+							// @ts-expect-error
+							data.id = activeDb[getModelName(model)]!.length + 1;
 						}
-						// Return the first nested object
-						return resArray[0];
-					}
-					// Without join, res is an array
-					const resArray = res as any[];
-					const record = resArray[0] || null;
-					return record;
-				},
-				findMany: async ({
-					model,
-					where,
-					sortBy,
-					limit,
-					select,
-					offset,
-					join,
-				}) => {
-					const res = convertWhereClause(where || [], model, join, select);
-
-					if (join) {
-						// When join is present, res is an array of nested objects
+						if (!activeDb[model]) {
+							activeDb[model] = [];
+						}
+						activeDb[model]!.push(data);
+						return data;
+					},
+					findOne: async ({ model, where, select, join }) => {
+						const res = convertWhereClause(where, model, join, select);
+						if (join) {
+							// When join is present, res is an array of nested objects
+							const resArray = res as any[];
+							if (!resArray.length) {
+								return null;
+							}
+							// Return the first nested object
+							return resArray[0];
+						}
+						// Without join, res is an array
 						const resArray = res as any[];
-						if (!resArray.length) {
-							return [];
+						const record = resArray[0] || null;
+						return record;
+					},
+					findMany: async ({
+						model,
+						where,
+						sortBy,
+						limit,
+						select,
+						offset,
+						join,
+					}) => {
+						const res = convertWhereClause(where || [], model, join, select);
+
+						if (join) {
+							// When join is present, res is an array of nested objects
+							const resArray = res as any[];
+							if (!resArray.length) {
+								return [];
+							}
+
+							// Apply sorting to nested objects
+							applySortToRecords(resArray, sortBy, model);
+
+							// Apply offset and limit
+							let paginatedRecords = resArray;
+							if (offset !== undefined) {
+								paginatedRecords = paginatedRecords.slice(offset);
+							}
+							if (limit !== undefined) {
+								paginatedRecords = paginatedRecords.slice(0, limit);
+							}
+
+							return paginatedRecords;
 						}
 
-						// Apply sorting to nested objects
-						applySortToRecords(resArray, sortBy, model);
-
-						// Apply offset and limit
-						let paginatedRecords = resArray;
+						// Without join - original logic
+						const resArray = res as any[];
+						let table = applySortToRecords(resArray, sortBy, model);
 						if (offset !== undefined) {
-							paginatedRecords = paginatedRecords.slice(offset);
+							table = table!.slice(offset);
 						}
 						if (limit !== undefined) {
-							paginatedRecords = paginatedRecords.slice(0, limit);
+							table = table!.slice(0, limit);
 						}
-
-						return paginatedRecords;
-					}
-
-					// Without join - original logic
-					const resArray = res as any[];
-					let table = applySortToRecords(resArray, sortBy, model);
-					if (offset !== undefined) {
-						table = table!.slice(offset);
-					}
-					if (limit !== undefined) {
-						table = table!.slice(0, limit);
-					}
-					return table || [];
-				},
-				count: async ({ model, where }) => {
-					if (where) {
-						const filteredRecords = convertWhereClause(where, model);
-						return filteredRecords.length;
-					}
-					return db[model]!.length;
-				},
-				update: async ({ model, where, update }) => {
-					const res = convertWhereClause(where, model);
-					res.forEach((record) => {
-						Object.assign(record, update);
-					});
-					return res[0] || null;
-				},
-				delete: async ({ model, where }) => {
-					const table = db[model]!;
-					const res = convertWhereClause(where, model);
-					db[model] = table.filter((record) => !res.includes(record));
-				},
-				deleteMany: async ({ model, where }) => {
-					const table = db[model]!;
-					const res = convertWhereClause(where, model);
-					let count = 0;
-					db[model] = table.filter((record) => {
-						if (res.includes(record)) {
-							count++;
-							return false;
+						return table || [];
+					},
+					count: async ({ model, where }) => {
+						if (where) {
+							const filteredRecords = convertWhereClause(where, model);
+							return filteredRecords.length;
 						}
-						return !res.includes(record);
-					});
-					return count;
-				},
-				consumeOne: async ({ model, where }) => {
-					const table = db[model]!;
-					const matches = convertWhereClause(where, model);
-					const target = matches[0];
-					if (!target) return null;
-					db[model] = table.filter((record) => record !== target);
-					return target as any;
-				},
-				updateMany({ model, where, update }) {
-					const res = convertWhereClause(where, model);
-					res.forEach((record) => {
-						Object.assign(record, update);
-					});
-					return res[0] || null;
-				},
-			};
-		},
-	});
+						return activeDb[model]!.length;
+					},
+					update: async ({ model, where, update }) => {
+						// A singular mutation with an empty predicate is a no-op. Match-all
+						// is reserved for updateMany/deleteMany; a singular update must
+						// never mutate every row.
+						if (where.length === 0) {
+							return null;
+						}
+						const res = convertWhereClause(where, model);
+						res.forEach((record) => {
+							Object.assign(record, update);
+						});
+						return res[0] || null;
+					},
+					delete: async ({ model, where }) => {
+						// A singular mutation with an empty predicate is a no-op. Match-all
+						// is reserved for updateMany/deleteMany; a singular delete must
+						// never remove every row.
+						if (where.length === 0) {
+							return;
+						}
+						const table = activeDb[model]!;
+						const res = convertWhereClause(where, model);
+						activeDb[model] = table.filter((record) => !res.includes(record));
+					},
+					deleteMany: async ({ model, where }) => {
+						const table = activeDb[model]!;
+						const res = convertWhereClause(where, model);
+						let count = 0;
+						activeDb[model] = table.filter((record) => {
+							if (res.includes(record)) {
+								count++;
+								return false;
+							}
+							return !res.includes(record);
+						});
+						return count;
+					},
+					consumeOne: async ({ model, where }) => {
+						const table = activeDb[model]!;
+						const matches = convertWhereClause(where, model);
+						const target = matches[0];
+						if (!target) return null;
+						activeDb[model] = table.filter((record) => record !== target);
+						return target as any;
+					},
+					incrementOne: async ({ model, where, increment, set }) => {
+						const target = convertWhereClause(where, model)[0];
+						if (!target) return null;
+						for (const [field, delta] of Object.entries(increment)) {
+							const current =
+								typeof target[field] === "number" ? target[field] : 0;
+							target[field] = current + delta;
+						}
+						if (set) {
+							Object.assign(target, set);
+						}
+						return target as any;
+					},
+					updateMany: async ({ model, where, update }) => {
+						const res = convertWhereClause(where, model);
+						res.forEach((record) => {
+							Object.assign(record, update);
+						});
+						return res.length;
+					},
+				};
+			},
+		});
+
+	const adapterCreator = buildAdapterFactory(db);
 	return (options: BetterAuthOptions) => {
 		lazyOptions = options;
 		return adapterCreator(options);

--- a/packages/mongo-adapter/src/mongodb-adapter.test.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.test.ts
@@ -38,6 +38,91 @@ describe("mongodb-adapter", () => {
 			expect.objectContaining({ includeResultMetadata: true }),
 		);
 	});
+
+	const rateLimitOptions = { rateLimit: { storage: "database" } } as any;
+
+	it("incrementOne applies $inc and $set atomically against the guard filter", async () => {
+		const findOneAndUpdate = vi.fn(async () => ({
+			value: { _id: "counter-id", count: 4, lastRequest: 1700000000000 },
+		}));
+		const db = {
+			collection: vi.fn(() => ({
+				findOneAndUpdate,
+			})),
+		} as any;
+		const adapter = mongodbAdapter(db, { transaction: false })(
+			rateLimitOptions,
+		);
+
+		const result = await adapter.incrementOne({
+			model: "rateLimit",
+			where: [{ field: "count", value: 5, operator: "lt" }],
+			increment: { count: 1 },
+			set: { lastRequest: 1700000000000 },
+		});
+
+		expect(result).toMatchObject({
+			id: "counter-id",
+			count: 4,
+			lastRequest: 1700000000000,
+		});
+		expect(findOneAndUpdate).toHaveBeenCalledWith(
+			{ count: { $lt: 5 } },
+			{ $inc: { count: 1 }, $set: { lastRequest: 1700000000000 } },
+			expect.objectContaining({
+				returnDocument: "after",
+				includeResultMetadata: true,
+			}),
+		);
+	});
+
+	it("incrementOne omits $set when no absolute assignments are provided", async () => {
+		const findOneAndUpdate = vi.fn(async () => ({
+			value: { _id: "counter-id", count: 11 },
+		}));
+		const db = {
+			collection: vi.fn(() => ({
+				findOneAndUpdate,
+			})),
+		} as any;
+		const adapter = mongodbAdapter(db, { transaction: false })(
+			rateLimitOptions,
+		);
+
+		await adapter.incrementOne({
+			model: "rateLimit",
+			where: [{ field: "key", value: "a" }],
+			increment: { count: 1 },
+		});
+
+		expect(findOneAndUpdate).toHaveBeenCalledWith(
+			{ key: "a" },
+			{ $inc: { count: 1 } },
+			expect.anything(),
+		);
+		const updateArg = (findOneAndUpdate.mock.calls[0] as any[])[1];
+		expect(updateArg).not.toHaveProperty("$set");
+	});
+
+	it("incrementOne returns null when the guard matches no document", async () => {
+		const findOneAndUpdate = vi.fn(async () => ({ value: null }));
+		const db = {
+			collection: vi.fn(() => ({
+				findOneAndUpdate,
+			})),
+		} as any;
+		const adapter = mongodbAdapter(db, { transaction: false })(
+			rateLimitOptions,
+		);
+
+		const result = await adapter.incrementOne({
+			model: "rateLimit",
+			where: [{ field: "count", value: 5, operator: "lt" }],
+			increment: { count: 1 },
+		});
+
+		expect(result).toBeNull();
+	});
 });
 
 describe("uuid support", () => {

--- a/packages/mongo-adapter/src/mongodb-adapter.test.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.test.ts
@@ -104,6 +104,67 @@ describe("mongodb-adapter", () => {
 		expect(updateArg).not.toHaveProperty("$set");
 	});
 
+	it("incrementOne omits $inc for guarded set-only updates", async () => {
+		const findOneAndUpdate = vi.fn(async () => ({
+			value: { _id: "counter-id", count: 11, lastRequest: 1700000000000 },
+		}));
+		const db = {
+			collection: vi.fn(() => ({
+				findOneAndUpdate,
+			})),
+		} as any;
+		const adapter = mongodbAdapter(db, { transaction: false })(
+			rateLimitOptions,
+		);
+
+		const result = await adapter.incrementOne({
+			model: "rateLimit",
+			where: [{ field: "key", value: "a" }],
+			increment: {},
+			set: { lastRequest: 1700000000000 },
+		});
+
+		expect(result).toMatchObject({
+			id: "counter-id",
+			count: 11,
+			lastRequest: 1700000000000,
+		});
+		expect(findOneAndUpdate).toHaveBeenCalledWith(
+			{ key: "a" },
+			{ $set: { lastRequest: 1700000000000 } },
+			expect.objectContaining({
+				returnDocument: "after",
+				includeResultMetadata: true,
+			}),
+		);
+		const updateArg = (findOneAndUpdate.mock.calls[0] as any[])[1];
+		expect(updateArg).not.toHaveProperty("$inc");
+	});
+
+	it("incrementOne reads the guarded row without sending an empty update", async () => {
+		const findOne = vi.fn(async () => ({ _id: "counter-id", count: 11 }));
+		const findOneAndUpdate = vi.fn();
+		const db = {
+			collection: vi.fn(() => ({
+				findOne,
+				findOneAndUpdate,
+			})),
+		} as any;
+		const adapter = mongodbAdapter(db, { transaction: false })(
+			rateLimitOptions,
+		);
+
+		const result = await adapter.incrementOne({
+			model: "rateLimit",
+			where: [{ field: "key", value: "a" }],
+			increment: {},
+		});
+
+		expect(result).toMatchObject({ id: "counter-id", count: 11 });
+		expect(findOne).toHaveBeenCalledWith({ key: "a" }, expect.anything());
+		expect(findOneAndUpdate).not.toHaveBeenCalled();
+	});
+
 	it("incrementOne returns null when the guard matches no document", async () => {
 		const findOneAndUpdate = vi.fn(async () => ({ value: null }));
 		const db = {

--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -638,6 +638,23 @@ export const mongodbAdapter = (
 					});
 					return ((doc as any)?.value as any) ?? null;
 				},
+				async incrementOne({ model, where, increment, set }) {
+					const clause = convertWhereClause({ where, model });
+					const update: { $inc: Record<string, number>; $set?: any } = {
+						$inc: increment,
+					};
+					if (set && Object.keys(set).length > 0) {
+						update.$set = set;
+					}
+					const res = await db
+						.collection(model)
+						.findOneAndUpdate(clause, update, {
+							session,
+							returnDocument: "after",
+							includeResultMetadata: true,
+						});
+					return ((res as any)?.value as any) ?? null;
+				},
 			};
 		};
 

--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -640,11 +640,18 @@ export const mongodbAdapter = (
 				},
 				async incrementOne({ model, where, increment, set }) {
 					const clause = convertWhereClause({ where, model });
-					const update: { $inc: Record<string, number>; $set?: any } = {
-						$inc: increment,
-					};
+					const update: {
+						$inc?: Record<string, number>;
+						$set?: Record<string, unknown>;
+					} = {};
+					if (Object.keys(increment).length > 0) {
+						update.$inc = increment;
+					}
 					if (set && Object.keys(set).length > 0) {
 						update.$set = set;
+					}
+					if (!update.$inc && !update.$set) {
+						return db.collection(model).findOne(clause, { session });
 					}
 					const res = await db
 						.collection(model)

--- a/packages/oauth-provider/src/backchannel-logout.test.ts
+++ b/packages/oauth-provider/src/backchannel-logout.test.ts
@@ -497,6 +497,16 @@ describe("oauth back-channel logout - secondaryStorage + preserveSessionInDataba
 			get(key) {
 				return store.get(key) || null;
 			},
+			getAndDelete(key) {
+				const value = store.get(key) || null;
+				store.delete(key);
+				return value;
+			},
+			increment(key) {
+				const count = Number(store.get(key) ?? 0) + 1;
+				store.set(key, String(count));
+				return count;
+			},
 			delete(key) {
 				store.delete(key);
 			},

--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -951,6 +951,212 @@ describe("passkey", async () => {
 	});
 });
 
+describe("passkey ceremony and identity gating", async () => {
+	afterEach(() => {
+		serverMocks.verifyRegistrationResponse.mockReset();
+		serverMocks.verifyAuthenticationResponse.mockReset();
+	});
+
+	// A challenge minted for one ceremony must never be accepted by the other
+	// verifier: the stored challenge carries a ceremony-type marker, and a
+	// registration ceremony cannot consume an authentication challenge.
+	it("rejects a registration that reuses an authentication challenge in pre-auth mode", async () => {
+		const {
+			auth: preAuth,
+			client: preAuthClient,
+			cookieSetter,
+		} = await getTestInstance({
+			plugins: [
+				passkey({
+					registration: {
+						requireSession: false,
+						resolveUser: async () => ({
+							id: "resolved-user-id",
+							name: "resolved@example.com",
+						}),
+					},
+				}),
+			],
+		});
+
+		const headers = new Headers();
+		headers.set("origin", "http://localhost:3000");
+		const setCookie = cookieSetter(headers);
+
+		// Unauthenticated caller obtains an authentication challenge.
+		await preAuthClient.$fetch("/passkey/generate-authenticate-options", {
+			method: "GET",
+			onResponse: setCookie,
+		});
+
+		serverMocks.verifyRegistrationResponse.mockResolvedValue(
+			mockRegistrationVerification,
+		);
+
+		await expect(
+			preAuth.api.verifyPasskeyRegistration({
+				headers,
+				body: { response: mockRegistrationResponse },
+			}),
+		).rejects.toMatchObject({
+			status: "BAD_REQUEST",
+			body: { code: "CHALLENGE_NOT_FOUND" },
+		});
+
+		// The registration verifier must reject before touching the WebAuthn
+		// library or persisting a passkey row.
+		expect(serverMocks.verifyRegistrationResponse).not.toHaveBeenCalled();
+
+		const context = await preAuth.$context;
+		const rows = await context.adapter.findMany<Passkey>({
+			model: "passkey",
+			where: [{ field: "credentialID", value: mockRegistrationResponse.id }],
+		});
+		expect(rows.length).toBe(0);
+	});
+
+	it("rejects an authentication that reuses a registration challenge", async () => {
+		const {
+			auth: sessionAuth,
+			client: sessionClient,
+			cookieSetter,
+			signInWithTestUser,
+		} = await getTestInstance({
+			plugins: [passkey()],
+		});
+
+		const { headers, user } = await signInWithTestUser();
+		headers.set("origin", "http://localhost:3000");
+		const setCookie = cookieSetter(headers);
+
+		const context = await sessionAuth.$context;
+		await context.adapter.create<Omit<Passkey, "id">, Passkey>({
+			model: "passkey",
+			data: {
+				userId: user.id,
+				publicKey: "mockPublicKey",
+				name: "cross-ceremony-passkey",
+				counter: 0,
+				deviceType: "singleDevice",
+				credentialID: "cross-ceremony-credential-id",
+				createdAt: new Date(),
+				backedUp: false,
+				transports: "internal",
+				aaguid: "mockAAGUID",
+			} satisfies Omit<Passkey, "id">,
+		});
+
+		// Obtain a registration challenge, then try to spend it on authentication.
+		await sessionClient.$fetch("/passkey/generate-register-options", {
+			method: "GET",
+			headers,
+			onResponse: setCookie,
+		});
+
+		serverMocks.verifyAuthenticationResponse.mockResolvedValue({
+			verified: true,
+			authenticationInfo: { newCounter: 1 },
+		});
+
+		await expect(
+			sessionAuth.api.verifyPasskeyAuthentication({
+				headers,
+				body: {
+					response: {
+						id: "cross-ceremony-credential-id",
+						rawId: "cross-ceremony-credential-id",
+						response: {
+							clientDataJSON: "mockClientDataJSON",
+							authenticatorData: "mockAuthenticatorData",
+							signature: "mockSignature",
+							userHandle: "mockUserHandle",
+						},
+						type: "public-key" as const,
+						clientExtensionResults: {},
+					},
+				},
+			}),
+		).rejects.toMatchObject({
+			status: "BAD_REQUEST",
+			body: { code: "CHALLENGE_NOT_FOUND" },
+		});
+
+		expect(serverMocks.verifyAuthenticationResponse).not.toHaveBeenCalled();
+	});
+
+	// Even a well-formed registration challenge must not persist a passkey when
+	// the resolved target user id is empty; an empty userId would dangle without
+	// an owning account.
+	it("rejects registration when the resolved target user id is empty", async () => {
+		const {
+			auth: preAuth,
+			client: preAuthClient,
+			cookieSetter,
+		} = await getTestInstance({
+			plugins: [
+				passkey({
+					registration: {
+						requireSession: false,
+						resolveUser: async () => ({
+							id: "seed-user-id",
+							name: "seed@example.com",
+						}),
+					},
+				}),
+			],
+		});
+
+		const headers = new Headers();
+		headers.set("origin", "http://localhost:3000");
+		const setCookie = cookieSetter(headers);
+
+		// Generate a real registration challenge, then overwrite the stored target
+		// user id with an empty string to exercise the final persistence guard.
+		await preAuthClient.$fetch("/passkey/generate-register-options", {
+			method: "GET",
+			onResponse: setCookie,
+		});
+
+		const context = await preAuth.$context;
+		const verifications = await context.adapter.findMany<Verification>({
+			model: "verification",
+		});
+		const challenge = verifications[verifications.length - 1];
+		assert(challenge);
+		const parsed = JSON.parse(challenge.value);
+		await context.adapter.update({
+			model: "verification",
+			where: [{ field: "id", value: challenge.id }],
+			update: {
+				value: JSON.stringify({
+					...parsed,
+					userData: { ...parsed.userData, id: "" },
+				}),
+			},
+		});
+
+		serverMocks.verifyRegistrationResponse.mockResolvedValue(
+			mockRegistrationVerification,
+		);
+
+		await expect(
+			preAuth.api.verifyPasskeyRegistration({
+				headers,
+				body: { response: mockRegistrationResponse },
+			}),
+		).rejects.toMatchObject({
+			status: "BAD_REQUEST",
+			body: { code: "RESOLVED_USER_INVALID" },
+		});
+
+		const rows = await context.adapter.findMany<Passkey>({
+			model: "passkey",
+			where: [{ field: "credentialID", value: mockRegistrationResponse.id }],
+		});
+		expect(rows.length).toBe(0);
+	});
+});
+
 const buildRegistrationVerification = (
 	aaguid: string,
 	credentialID: string,

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -32,6 +32,17 @@ import type {
 } from "./types";
 import { getRpID } from "./utils";
 
+type PasskeyCeremony = "registration" | "authentication";
+
+/**
+ * The stored challenge value tagged with the ceremony that minted it.
+ * Registration and authentication share one cookie and one challenge row, so
+ * the verifiers must reject a challenge minted by the other ceremony.
+ */
+type StoredChallengeValue = WebAuthnChallengeValue & {
+	type?: PasskeyCeremony;
+};
+
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 type RequiredPassKeyOptions = WithRequired<PasskeyOptions, "advanced"> & {
@@ -311,6 +322,7 @@ export const generatePasskeyRegistrationOptions = (
 			await ctx.context.internalAdapter.createVerificationValue({
 				identifier: verificationToken,
 				value: JSON.stringify({
+					type: "registration",
 					expectedChallenge: options.challenge,
 					userData: {
 						id: user.id,
@@ -318,7 +330,7 @@ export const generatePasskeyRegistrationOptions = (
 						displayName: user.displayName,
 					},
 					context: ctx.query?.context ?? null,
-				}),
+				} satisfies StoredChallengeValue),
 				expiresAt: expirationTime,
 			});
 			return ctx.json(options, {
@@ -466,11 +478,12 @@ export const generatePasskeyAuthenticationOptions = (
 					: {}),
 			});
 			const data = {
+				type: "authentication",
 				expectedChallenge: options.challenge,
 				userData: {
 					id: session?.user.id || "",
 				},
-			};
+			} satisfies StoredChallengeValue;
 			const verificationToken = generateRandomString(32);
 			const webAuthnCookie = ctx.context.createAuthCookie(
 				opts.advanced.webAuthnChallengeCookie,
@@ -570,9 +583,18 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) => {
 					PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
 				);
 			}
-			const { expectedChallenge, userData, context } = JSON.parse(
-				data.value,
-			) as WebAuthnChallengeValue;
+			const {
+				type: ceremony,
+				expectedChallenge,
+				userData,
+				context,
+			} = JSON.parse(data.value) as StoredChallengeValue;
+			if (ceremony !== "registration") {
+				throw APIError.from(
+					"BAD_REQUEST",
+					PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
+				);
+			}
 
 			const session = requireSession
 				? ctx.context.session
@@ -638,6 +660,12 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) => {
 					if (!resolvedName) {
 						resolvedName = result?.name?.trim() || undefined;
 					}
+				}
+				if (!targetUserId) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						PASSKEY_ERROR_CODES.RESOLVED_USER_INVALID,
+					);
 				}
 				const pubKey = base64.encode(credential.publicKey);
 				const newPasskey: Omit<Passkey, "id"> = {
@@ -748,9 +776,15 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 					PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
 				);
 			}
-			const { expectedChallenge } = JSON.parse(
+			const { type: ceremony, expectedChallenge } = JSON.parse(
 				data.value,
-			) as WebAuthnChallengeValue;
+			) as StoredChallengeValue;
+			if (ceremony !== "authentication") {
+				throw APIError.from(
+					"BAD_REQUEST",
+					PASSKEY_ERROR_CODES.CHALLENGE_NOT_FOUND,
+				);
+			}
 			const passkey = await ctx.context.adapter.findOne<Passkey>({
 				model: "passkey",
 				where: [

--- a/packages/prisma-adapter/src/prisma-adapter.test.ts
+++ b/packages/prisma-adapter/src/prisma-adapter.test.ts
@@ -8,6 +8,20 @@ describe("prisma-adapter", () => {
 			provider: "sqlite",
 		})({} as BetterAuthOptions);
 
+	// incrementOne mutates numeric counters; declare the fields it touches on an
+	// existing model so the factory's where/input transforms recognize them.
+	const createCounterAdapter = (prisma: Record<string, unknown>) =>
+		prismaAdapter(prisma as never, {
+			provider: "sqlite",
+		})({
+			verification: {
+				additionalFields: {
+					remaining: { type: "number" },
+					lastRefill: { type: "number", required: false },
+				},
+			},
+		} as BetterAuthOptions);
+
 	it("should create prisma adapter", () => {
 		const prisma = {
 			$transaction: vi.fn(),
@@ -249,6 +263,213 @@ describe("prisma-adapter", () => {
 				],
 			},
 		});
+	});
+
+	// A delete that fails for any reason other than the record not existing
+	// (constraint violation, connection loss, permission denial) must surface
+	// the error. Reporting success would hide real data-integrity failures.
+	it("delete propagates non-not-found errors instead of swallowing them", async () => {
+		const failure = Object.assign(new Error("connection refused"), {
+			code: "P1001",
+		});
+		const del = vi.fn().mockRejectedValue(failure);
+		const adapter = createTestAdapter({
+			$transaction: vi.fn(),
+			user: {
+				delete: del,
+			},
+		});
+
+		await expect(
+			adapter.delete({
+				model: "user",
+				where: [{ field: "id", value: "user-id" }],
+			}),
+		).rejects.toThrow("connection refused");
+		expect(del).toHaveBeenCalledTimes(1);
+	});
+
+	// Prisma raises P2025 when the targeted row no longer exists. Deletes are
+	// idempotent, so this specific case is a no-op rather than an error.
+	it("delete treats a not-found (P2025) error as an idempotent no-op", async () => {
+		const failure = Object.assign(
+			new Error("Record to delete does not exist."),
+			{ code: "P2025" },
+		);
+		const del = vi.fn().mockRejectedValue(failure);
+		const adapter = createTestAdapter({
+			$transaction: vi.fn(),
+			user: {
+				delete: del,
+			},
+		});
+
+		await expect(
+			adapter.delete({
+				model: "user",
+				where: [{ field: "id", value: "user-id" }],
+			}),
+		).resolves.toBeUndefined();
+		expect(del).toHaveBeenCalledTimes(1);
+	});
+
+	it("incrementOne keyed on the primary key updates that one row in a single round trip", async () => {
+		const update = vi
+			.fn()
+			.mockResolvedValue({ id: "counter-id", remaining: 4 });
+		const findFirst = vi.fn();
+		const adapter = createCounterAdapter({
+			$transaction: vi.fn(),
+			verification: { findFirst, update },
+		});
+
+		const result = await adapter.incrementOne({
+			model: "verification",
+			where: [{ field: "id", value: "counter-id" }],
+			increment: { remaining: 1 },
+		});
+
+		expect(result).toEqual({ id: "counter-id", remaining: 4 });
+		// No transaction or pre-read: the unique key resolves a single row directly.
+		expect(findFirst).not.toHaveBeenCalled();
+		expect(update).toHaveBeenCalledWith({
+			where: { id: "counter-id" },
+			data: { remaining: { increment: 1 } },
+		});
+	});
+
+	it("incrementOne decrements with a negative delta and applies set values", async () => {
+		const target = { id: "counter-id", remaining: 2 };
+		const txClient = {
+			verification: {
+				findFirst: vi.fn().mockResolvedValue(target),
+				update: vi.fn().mockResolvedValue({
+					id: "counter-id",
+					remaining: 1,
+					lastRefill: 1700,
+				}),
+			},
+		};
+		const transaction = vi.fn(async (cb) => cb(txClient));
+		const adapter = createCounterAdapter({
+			$transaction: transaction,
+			verification: {},
+		});
+
+		const result = await adapter.incrementOne({
+			model: "verification",
+			where: [{ field: "remaining", value: 0, operator: "gt" }],
+			increment: { remaining: -1 },
+			set: { lastRefill: 1700 },
+		});
+
+		expect(result).toEqual({
+			id: "counter-id",
+			remaining: 1,
+			lastRefill: 1700,
+		});
+		expect(txClient.verification.update).toHaveBeenCalledWith({
+			where: {
+				id: "counter-id",
+				AND: [{ remaining: { gt: 0 } }],
+			},
+			data: expect.objectContaining({
+				lastRefill: 1700,
+				remaining: { increment: -1 },
+			}),
+		});
+	});
+
+	// A non-unique guard (e.g. `remaining > 0`) can match many rows, but the
+	// contract mutates at most one. The adapter resolves a single target id and
+	// keys the write on it, so `update` (single-row) runs and `updateMany` never
+	// does, leaving every other matching row untouched.
+	it("incrementOne with a non-unique guard mutates exactly one matching row", async () => {
+		const target = { id: "row-1", remaining: 5 };
+		const update = vi.fn().mockResolvedValue({ id: "row-1", remaining: 4 });
+		const updateMany = vi.fn();
+		const txClient = {
+			verification: {
+				findFirst: vi.fn().mockResolvedValue(target),
+				update,
+				updateMany,
+			},
+		};
+		const transaction = vi.fn(async (cb) => cb(txClient));
+		const adapter = createCounterAdapter({
+			$transaction: transaction,
+			verification: {},
+		});
+
+		const result = await adapter.incrementOne({
+			model: "verification",
+			where: [{ field: "remaining", value: 0, operator: "gt" }],
+			increment: { remaining: -1 },
+		});
+
+		expect(result).toEqual({ id: "row-1", remaining: 4 });
+		expect(updateMany).not.toHaveBeenCalled();
+		expect(update).toHaveBeenCalledTimes(1);
+		expect(update).toHaveBeenCalledWith({
+			where: {
+				id: "row-1",
+				AND: [{ remaining: { gt: 0 } }],
+			},
+			data: { remaining: { increment: -1 } },
+		});
+	});
+
+	it("incrementOne returns null when the guard matches no row", async () => {
+		const update = vi.fn();
+		const txClient = {
+			verification: {
+				findFirst: vi.fn().mockResolvedValue(null),
+				update,
+			},
+		};
+		const transaction = vi.fn(async (cb) => cb(txClient));
+		const adapter = createCounterAdapter({
+			$transaction: transaction,
+			verification: {},
+		});
+
+		const result = await adapter.incrementOne({
+			model: "verification",
+			where: [{ field: "remaining", value: 0, operator: "gt" }],
+			increment: { remaining: -1 },
+		});
+
+		expect(result).toBeNull();
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("incrementOne returns null when a racer invalidated the guard between read and write", async () => {
+		const target = { id: "counter-id", remaining: 1 };
+		const notFound = Object.assign(new Error("Record to update not found."), {
+			code: "P2025",
+		});
+		const txClient = {
+			verification: {
+				findFirst: vi.fn().mockResolvedValue(target),
+				// The guarded update matches no row because a concurrent caller
+				// already drove `remaining` to 0 after the read; Prisma raises P2025.
+				update: vi.fn().mockRejectedValue(notFound),
+			},
+		};
+		const transaction = vi.fn(async (cb) => cb(txClient));
+		const adapter = createCounterAdapter({
+			$transaction: transaction,
+			verification: {},
+		});
+
+		const result = await adapter.incrementOne({
+			model: "verification",
+			where: [{ field: "remaining", value: 0, operator: "gt" }],
+			increment: { remaining: -1 },
+		});
+
+		expect(result).toBeNull();
+		expect(txClient.verification.update).toHaveBeenCalledTimes(1);
 	});
 
 	it("consumeOne does not open a nested transaction from a transaction adapter", async () => {

--- a/packages/prisma-adapter/src/prisma-adapter.ts
+++ b/packages/prisma-adapter/src/prisma-adapter.ts
@@ -602,9 +602,10 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 							where: whereClause,
 						});
 					} catch (e: any) {
+						// Deletes are idempotent: a missing row is a no-op. Any other
+						// failure must propagate instead of reporting success.
 						if (isPrismaNotFoundError(e)) return;
-						// otherwise if it's an unknown error, we want to just log it for debugging.
-						console.log(e);
+						throw e;
 					}
 				},
 				async deleteMany({ model, where }) {
@@ -685,6 +686,87 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 					return inTransaction || typeof db.$transaction !== "function"
 						? claimFromTransaction(db)
 						: db.$transaction(claimFromTransaction);
+				},
+				async incrementOne({ model, where, increment, set }) {
+					if (!db[model]) {
+						throw new BetterAuthError(
+							`Model ${model} does not exist in the database. If you haven't generated the Prisma client, you need to run 'npx prisma generate'`,
+						);
+					}
+
+					// Prisma applies `{ [field]: { increment: delta } }` server-side, so
+					// the read of the current value and the write of `value + delta`
+					// happen in a single statement. The contract mutates at most one
+					// row, so we resolve a single target id and key the write on it the
+					// same way `consumeOne` does, never `updateMany`.
+					const data: Record<string, unknown> = { ...(set ?? {}) };
+					for (const [field, delta] of Object.entries(increment)) {
+						data[field] = { increment: delta };
+					}
+
+					// `prisma.model.update` requires a WhereUniqueInput and returns the
+					// mutated row. When the caller keys on the primary key we update in a
+					// single round trip; otherwise we resolve the target id inside a
+					// transaction and update by id. Either way the original guard stays in
+					// the where, so a racer that invalidated it (e.g. remaining dropped to
+					// 0) yields P2025 and we report no mutation.
+					const hasIdField = where?.some((w) => w.field === "id");
+					if (hasIdField) {
+						const whereClause = convertWhereClause({
+							model,
+							where,
+							action: "update",
+						});
+						try {
+							const row = await db[model]!.update({
+								where: whereClause,
+								data,
+							});
+							return (row as any) ?? null;
+						} catch (e: any) {
+							if (isPrismaNotFoundError(e)) return null;
+							throw e;
+						}
+					}
+
+					const findWhere = convertWhereClause({
+						model,
+						where,
+						action: "findOne",
+					});
+					const mutateInTransaction = async (tx: PrismaClient) => {
+						const target = await (tx as any)[model].findFirst({
+							where: findWhere,
+						});
+						if (!target) return null;
+						try {
+							const row = await (tx as any)[model].update({
+								where: convertWhereClause({
+									model,
+									where: [
+										...where,
+										{
+											field: "id",
+											value: (target as any).id,
+											operator: "eq",
+											connector: "AND",
+											mode: "sensitive",
+										},
+									],
+									action: "update",
+								}),
+								data,
+							});
+							return (row as any) ?? null;
+						} catch (e: any) {
+							if (isPrismaNotFoundError(e)) return null;
+							throw e;
+						}
+					};
+
+					return inTransaction || typeof db.$transaction !== "function"
+						? mutateInTransaction(db)
+						: db.$transaction(mutateInTransaction);
 				},
 				options: config,
 			};

--- a/packages/redis-storage/src/redis-storage.ts
+++ b/packages/redis-storage/src/redis-storage.ts
@@ -44,6 +44,15 @@ if value ~= false then
 end
 return value
 `;
+	// INCR then set EXPIRE only when the counter was just created (value == 1),
+	// so the TTL window is fixed from first creation and never extended.
+	const incrementScript = `
+local value = redis.call("INCR", KEYS[1])
+if value == 1 then
+  redis.call("EXPIRE", KEYS[1], ARGV[1])
+end
+return value
+`;
 
 	const prefixKey = (key: string): string => {
 		return `${keyPrefix}${key}`;
@@ -72,6 +81,11 @@ return value
 			// TODO(redis-6.2-required): require Redis >= 6.2 in the next
 			// breaking branch and remove this Lua compatibility fallback.
 			return client.eval(getAndDeleteScript, 1, prefixedKey);
+		},
+
+		async increment(key: string, ttl: number) {
+			const value = await client.eval(incrementScript, 1, prefixKey(key), ttl);
+			return Number(value);
 		},
 
 		async set(key: string, value: string, ttl?: number | undefined) {

--- a/packages/redis-storage/src/redis-storage.ts
+++ b/packages/redis-storage/src/redis-storage.ts
@@ -84,6 +84,11 @@ return value
 		},
 
 		async increment(key: string, ttl: number) {
+			if (!Number.isInteger(ttl) || ttl <= 0) {
+				throw new TypeError(
+					"Redis storage increment ttl must be a positive integer",
+				);
+			}
 			const value = await client.eval(incrementScript, 1, prefixKey(key), ttl);
 			return Number(value);
 		},

--- a/packages/redis-storage/test/redis-storage.test.ts
+++ b/packages/redis-storage/test/redis-storage.test.ts
@@ -69,4 +69,54 @@ describe("redisStorage", () => {
 		);
 		expect(evalMock).not.toHaveBeenCalled();
 	});
+
+	it("increments atomically and sets the ttl only on creation", async () => {
+		const counters = new Map<string, number>();
+		const ttlByKey = new Map<string, number>();
+		const evalMock = vi.fn(
+			async (_script: string, _numKeys: number, key: string, ttl: string) => {
+				const next = (counters.get(key) ?? 0) + 1;
+				counters.set(key, next);
+				if (next === 1) {
+					ttlByKey.set(key, Number(ttl));
+				}
+				return next;
+			},
+		);
+		const storage = redisStorage({
+			client: { eval: evalMock } as any,
+			keyPrefix: "ba:",
+		});
+
+		await expect(storage.increment!("rate:1", 60)).resolves.toBe(1);
+		expect(ttlByKey.get("ba:rate:1")).toBe(60);
+
+		await expect(storage.increment!("rate:1", 60)).resolves.toBe(2);
+		await expect(storage.increment!("rate:1", 60)).resolves.toBe(3);
+		// TTL captured on creation must not be reset by later increments.
+		expect(ttlByKey.get("ba:rate:1")).toBe(60);
+
+		expect(evalMock).toHaveBeenCalledWith(
+			expect.stringContaining('redis.call("INCR", KEYS[1])'),
+			1,
+			"ba:rate:1",
+			60,
+		);
+	});
+
+	it("only sets the ttl on the call that creates the key", async () => {
+		const evalMock = vi.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+		const storage = redisStorage({
+			client: { eval: evalMock } as any,
+			keyPrefix: "ba:",
+		});
+
+		await expect(storage.increment!("rate:2", 30)).resolves.toBe(1);
+		await expect(storage.increment!("rate:2", 30)).resolves.toBe(2);
+
+		const script = evalMock.mock.calls[0]![0] as string;
+		expect(script).toContain('redis.call("INCR", KEYS[1])');
+		expect(script).toContain("== 1");
+		expect(script).toContain('redis.call("EXPIRE"');
+	});
 });

--- a/packages/redis-storage/test/redis-storage.test.ts
+++ b/packages/redis-storage/test/redis-storage.test.ts
@@ -119,4 +119,23 @@ describe("redisStorage", () => {
 		expect(script).toContain("== 1");
 		expect(script).toContain('redis.call("EXPIRE"');
 	});
+
+	it.each([
+		0,
+		-1,
+		1.5,
+		Number.NaN,
+		Infinity,
+	])("rejects invalid ttl %s before mutating Redis", async (ttl) => {
+		const evalMock = vi.fn();
+		const storage = redisStorage({
+			client: { eval: evalMock } as any,
+			keyPrefix: "ba:",
+		});
+
+		await expect(storage.increment!("rate:invalid", ttl)).rejects.toThrow(
+			"Redis storage increment ttl must be a positive integer",
+		);
+		expect(evalMock).not.toHaveBeenCalled();
+	});
 });

--- a/packages/scim/src/scim-users.test.ts
+++ b/packages/scim/src/scim-users.test.ts
@@ -698,6 +698,16 @@ describe("SCIM", () => {
 					get(key) {
 						return store.get(key) || null;
 					},
+					getAndDelete(key) {
+						const value = store.get(key) || null;
+						store.delete(key);
+						return value;
+					},
+					increment(key) {
+						const count = Number(store.get(key) ?? 0) + 1;
+						store.set(key, String(count));
+						return count;
+					},
 					delete(key) {
 						store.delete(key);
 					},

--- a/packages/sso/src/domain-verification.test.ts
+++ b/packages/sso/src/domain-verification.test.ts
@@ -2,6 +2,7 @@ import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { createAuthClient } from "better-auth/client";
 import { setCookieToHeader } from "better-auth/cookies";
+import type { SecondaryStorage } from "better-auth/db";
 import { bearer, organization } from "better-auth/plugins";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sso } from ".";
@@ -32,11 +33,7 @@ describe("Domain verification", async () => {
 	const createTestAuth = (
 		options?: SSOOptions,
 		betterAuthOptions?: {
-			secondaryStorage?: {
-				set: (key: string, value: string, ttl?: number) => void;
-				get: (key: string) => string | null;
-				delete: (key: string) => void;
-			};
+			secondaryStorage?: SecondaryStorage;
 		},
 	) => {
 		const data: Record<string, any[]> = {
@@ -662,6 +659,16 @@ describe("Domain verification", async () => {
 						},
 						get(key) {
 							return store.get(key) || null;
+						},
+						getAndDelete(key) {
+							const value = store.get(key) || null;
+							store.delete(key);
+							return value;
+						},
+						increment(key) {
+							const count = Number(store.get(key) ?? 0) + 1;
+							store.set(key, String(count));
+							return count;
 						},
 						delete(key) {
 							store.delete(key);

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -270,6 +270,10 @@ export async function processSAMLResponse(
 	});
 
 	// 14. Replay protection
+	// Reserve the assertion id atomically: the first caller writes the tombstone
+	// and proceeds, every later caller (including a concurrent submission) finds
+	// the row already present and is rejected. The deterministic primary key is
+	// the gate, so no separate find/expiry check is needed.
 	const samlContent = (parsedResponse as any).samlContent as string | undefined;
 	const assertionId = samlContent ? extractAssertionId(samlContent) : null;
 
@@ -284,27 +288,21 @@ export async function processSAMLResponse(
 			? new Date(conditions.notOnOrAfter).getTime() + clockSkew
 			: Date.now() + constants.DEFAULT_ASSERTION_TTL_MS;
 
-		const existingAssertion =
-			await ctx.context.internalAdapter.findVerificationValue(
-				`${constants.USED_ASSERTION_KEY_PREFIX}${assertionId}`,
-			);
-
-		let isReplay = false;
-		if (existingAssertion) {
-			try {
-				const stored = JSON.parse(existingAssertion.value);
-				if (stored.expiresAt >= Date.now()) {
-					isReplay = true;
-				}
-			} catch (error) {
-				ctx.context.logger.warn("Failed to parse stored assertion record", {
+		const reserved = await ctx.context.internalAdapter.reserveVerificationValue(
+			{
+				identifier: `${constants.USED_ASSERTION_KEY_PREFIX}${assertionId}`,
+				value: JSON.stringify({
 					assertionId,
-					error,
-				});
-			}
-		}
+					issuer,
+					providerId,
+					usedAt: Date.now(),
+					expiresAt,
+				}),
+				expiresAt: new Date(expiresAt),
+			},
+		);
 
-		if (isReplay) {
+		if (!reserved) {
 			ctx.context.logger.error(
 				"SAML assertion replay detected: assertion ID already used",
 				{ assertionId, issuer, providerId },
@@ -313,18 +311,6 @@ export async function processSAMLResponse(
 				`${samlRedirectUrl}?error=replay_detected&error_description=SAML+assertion+has+already+been+used`,
 			);
 		}
-
-		await ctx.context.internalAdapter.createVerificationValue({
-			identifier: `${constants.USED_ASSERTION_KEY_PREFIX}${assertionId}`,
-			value: JSON.stringify({
-				assertionId,
-				issuer,
-				providerId,
-				usedAt: Date.now(),
-				expiresAt,
-			}),
-			expiresAt: new Date(expiresAt),
-		});
 	} else {
 		ctx.context.logger.warn(
 			"Could not extract assertion ID for replay protection",

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -4780,6 +4780,81 @@ describe("SAML SSO - Assertion Replay Protection", () => {
 		expect(succeeded).toHaveLength(1);
 		expect(failed).toHaveLength(1);
 	});
+
+	it("should issue only one session when the same assertion is submitted concurrently without InResponseTo validation", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [sso({ saml: { enableInResponseToValidation: false } })],
+		});
+
+		const { headers } = await signInWithTestUser();
+
+		await auth.api.registerSSOProvider({
+			body: {
+				providerId: "concurrent-assertion-provider",
+				issuer: "http://localhost:8081",
+				domain: "http://localhost:8081",
+				samlConfig: {
+					entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+					cert: certificate,
+					wantAssertionsSigned: false,
+					signatureAlgorithm: "sha256",
+					digestAlgorithm: "sha256",
+					idpMetadata: {
+						metadata: idpMetadata,
+					},
+					spMetadata: {
+						metadata: spMetadata,
+					},
+					identifierFormat:
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+				},
+			},
+			headers,
+		});
+
+		// The shared mock IdP emits a literal `InResponseTo="null"` value. Disable
+		// that gate here so the assertion-replay tombstone is the only duplicate
+		// guard under test.
+		let samlResponse: any;
+		await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
+			onSuccess: async (context) => {
+				samlResponse = await context.data;
+			},
+		});
+
+		const submit = () =>
+			auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/sp/acs/concurrent-assertion-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: samlResponse.samlResponse,
+							RelayState: "http://localhost:3000/dashboard",
+						}),
+					},
+				),
+			);
+
+		const [first, second] = await Promise.all([submit(), submit()]);
+
+		expect(first.status).toBe(302);
+		expect(second.status).toBe(302);
+
+		const locations = [first, second].map(
+			(res) => res.headers.get("location") || "",
+		);
+		const succeeded = locations.filter((loc) => loc && !loc.includes("error"));
+		const replayed = locations.filter((loc) =>
+			loc.includes("error=replay_detected"),
+		);
+
+		expect(succeeded).toHaveLength(1);
+		expect(replayed).toHaveLength(1);
+	});
 });
 
 describe("SAML SSO - Single Assertion Validation", () => {

--- a/packages/test-utils/src/adapter/create-test-suite.ts
+++ b/packages/test-utils/src/adapter/create-test-suite.ts
@@ -283,6 +283,16 @@ export const createTestSuite = <
 						adapter: ({ getDefaultModelName }) => {
 							adapter.transaction = undefined as any;
 							return {
+								consumeOne: async (args) => {
+									adapter = await helpers.adapter();
+									const res = await adapter.consumeOne(args);
+									return res as any;
+								},
+								incrementOne: async (args) => {
+									adapter = await helpers.adapter();
+									const res = await adapter.incrementOne(args);
+									return res as any;
+								},
 								count: async (args: any) => {
 									adapter = await helpers.adapter();
 									const res = await adapter.count(args);

--- a/test/unit/magic-link-secondary-storage.test.ts
+++ b/test/unit/magic-link-secondary-storage.test.ts
@@ -1,3 +1,4 @@
+import type { SecondaryStorage } from "@better-auth/core/db";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { magicLinkClient } from "better-auth/client/plugins";
 import { magicLink } from "better-auth/plugins";
@@ -8,6 +9,58 @@ interface VerificationEmail {
 	email: string;
 	token: string;
 	url: string;
+}
+
+function createStringSecondaryStorage(
+	store: Map<string, string>,
+): SecondaryStorage {
+	return {
+		set(key, value) {
+			store.set(key, value);
+		},
+		get(key) {
+			return store.get(key) || null;
+		},
+		getAndDelete(key) {
+			const value = store.get(key) || null;
+			store.delete(key);
+			return value;
+		},
+		increment(key) {
+			const count = Number(store.get(key) ?? 0) + 1;
+			store.set(key, String(count));
+			return count;
+		},
+		delete(key) {
+			store.delete(key);
+		},
+	};
+}
+
+function createParsedSecondaryStorage(
+	store: Map<string, unknown>,
+): SecondaryStorage {
+	return {
+		set(key, value) {
+			store.set(key, safeJSONParse<unknown>(value));
+		},
+		get(key) {
+			return store.get(key) ?? null;
+		},
+		getAndDelete(key) {
+			const value = store.get(key) ?? null;
+			store.delete(key);
+			return value;
+		},
+		increment(key) {
+			const count = Number(store.get(key) ?? 0) + 1;
+			store.set(key, count);
+			return count;
+		},
+		delete(key) {
+			store.delete(key);
+		},
+	};
 }
 
 /**
@@ -23,17 +76,7 @@ describe("magic link with secondary storage (string return)", async () => {
 
 	const { testUser, sessionSetter, client } = await getTestInstance(
 		{
-			secondaryStorage: {
-				set(key, value, ttl) {
-					store.set(key, value);
-				},
-				get(key) {
-					return store.get(key) || null;
-				},
-				delete(key) {
-					store.delete(key);
-				},
-			},
+			secondaryStorage: createStringSecondaryStorage(store),
 			rateLimit: {
 				enabled: false,
 			},
@@ -120,17 +163,7 @@ describe("magic link with secondary storage (string return)", async () => {
 			client: c,
 		} = await getTestInstance(
 			{
-				secondaryStorage: {
-					set(key, value, ttl) {
-						attemptStore.set(key, value);
-					},
-					get(key) {
-						return attemptStore.get(key) || null;
-					},
-					delete(key) {
-						attemptStore.delete(key);
-					},
-				},
+				secondaryStorage: createStringSecondaryStorage(attemptStore),
 				rateLimit: { enabled: false },
 				plugins: [
 					magicLink({
@@ -177,17 +210,7 @@ describe("magic link with secondary storage (string return)", async () => {
 
 		const { testUser: tu, client: c } = await getTestInstance(
 			{
-				secondaryStorage: {
-					set(key, value, ttl) {
-						expiredStore.set(key, value);
-					},
-					get(key) {
-						return expiredStore.get(key) || null;
-					},
-					delete(key) {
-						expiredStore.delete(key);
-					},
-				},
+				secondaryStorage: createStringSecondaryStorage(expiredStore),
 				rateLimit: { enabled: false },
 				plugins: [
 					magicLink({
@@ -232,7 +255,7 @@ describe("magic link with secondary storage (string return)", async () => {
  * @see https://github.com/better-auth/better-auth/issues/8228
  */
 describe("magic link with secondary storage (pre-parsed object return)", async () => {
-	const store = new Map<string, any>();
+	const store = new Map<string, unknown>();
 	let verificationEmail: VerificationEmail = {
 		email: "",
 		token: "",
@@ -241,17 +264,7 @@ describe("magic link with secondary storage (pre-parsed object return)", async (
 
 	const { testUser, sessionSetter, client } = await getTestInstance(
 		{
-			secondaryStorage: {
-				set(key, value, ttl) {
-					store.set(key, safeJSONParse(value));
-				},
-				get(key) {
-					return store.get(key) ?? null;
-				},
-				delete(key) {
-					store.delete(key);
-				},
-			},
+			secondaryStorage: createParsedSecondaryStorage(store),
 			rateLimit: {
 				enabled: false,
 			},
@@ -294,7 +307,7 @@ describe("magic link with secondary storage (pre-parsed object return)", async (
 	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-hc7v-x88r-fmh4
 	 */
 	it("consumes the token atomically with pre-parsed storage, INVALID_TOKEN on retries", async () => {
-		const attemptStore = new Map<string, any>();
+		const attemptStore = new Map<string, unknown>();
 		let attemptEmail: VerificationEmail = { email: "", token: "", url: "" };
 
 		const {
@@ -303,17 +316,7 @@ describe("magic link with secondary storage (pre-parsed object return)", async (
 			client: c,
 		} = await getTestInstance(
 			{
-				secondaryStorage: {
-					set(key, value, ttl) {
-						attemptStore.set(key, safeJSONParse(value));
-					},
-					get(key) {
-						return attemptStore.get(key) ?? null;
-					},
-					delete(key) {
-						attemptStore.delete(key);
-					},
-				},
+				secondaryStorage: createParsedSecondaryStorage(attemptStore),
 				rateLimit: { enabled: false },
 				plugins: [
 					magicLink({


### PR DESCRIPTION
Several auth flows depended on state that was checked before the write, so concurrent requests could race past single-use or rate-limit guards.

This makes the atomic state boundary explicit. Custom adapters now need native `consumeOne` and `incrementOne` operations, secondary storage needs atomic consume and increment operations, and custom rate-limit storage now makes one `consume` decision per request. The fallback read-then-delete and read-then-update paths are removed because they could not provide the same one-winner guarantee across processes.

The same boundary is applied to the flows that rely on one-winner semantics: password reset and delete-user tokens, magic links, email and phone OTPs, two-factor OTPs and challenges, device authorization codes, one-time tokens, SIWE nonces, SAML assertion replay reservations, passkey ceremonies, Electron code exchange, database-backed API-key quota/rate limits, and organization invitation claims.

Native adapter implementations and tests cover Drizzle, Kysely, MongoDB, Prisma, memory, and Redis-backed storage. The factory also validates `updateMany` affected-count results so bad adapter implementations fail at the contract boundary instead of leaking ambiguous counts into callers.

Known residual: organization team capacity still has an aggregate phantom-write boundary on adapters without isolated transactions. This PR guards invitation claims and rollback, and it fixes the pre-create capacity check ordering, but portable enforcement of `maximumMembersPerTeam` needs a durable per-team capacity counter/lock or adapter capability metadata for real isolated transactions/advisory locks.
