### PR TITLE
feat(api-key): add soft delete

### DIFF
--- a/.changeset/many-kiwis-design.md
+++ b/.changeset/many-kiwis-design.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/api-key": minor
+---
+
+Add `softDelete` option to API key plugin. When enabled, deleting an API key (or expiring/exhausting one) sets `enabled: false` instead of removing the row. Configurable per `configId`.

--- a/docs/content/docs/plugins/api-key/index.mdx
+++ b/docs/content/docs/plugins/api-key/index.mdx
@@ -16,6 +16,7 @@ The API Key plugin allows you to create and manage API keys for your application
 * [Secondary storage support](/docs/plugins/api-key/advanced#storage-modes) for high-performance API key lookups
 * [Multiple configurations](/docs/plugins/api-key/advanced#multiple-configurations) for different API key types
 * [Organization-owned API keys](/docs/plugins/api-key/advanced#organization-owned-api-keys) in addition to user-owned keys
+* [Soft delete support](/docs/plugins/api-key/reference#api-key-plugin-options) for audit trails and key recovery
 
 ## Installation
 
@@ -318,6 +319,10 @@ Otherwise, you'll receive the API Key details, except for the `key` value itself
 ***
 
 ### Delete an API Key
+
+<Callout>
+  When `softDelete` is enabled in the plugin configuration, the delete endpoint disables the key (`enabled: false`) instead of removing it. The key will still appear in list results but will be rejected on verification. This also applies to expired and exhausted keys.
+</Callout>
 
 <APIMethod path="/api-key/delete" method="POST" requireSession note="This endpoint is attempting to delete the API key from the perspective of the user. It will check if the user's ID matches the key owner to be able to delete it. If you want to delete a key without these checks, we recommend you use an ORM to directly mutate your DB instead.">
   ```ts

--- a/docs/content/docs/plugins/api-key/reference.mdx
+++ b/docs/content/docs/plugins/api-key/reference.mdx
@@ -294,6 +294,12 @@ Disable hashing of the API key.
   Storing API keys in plaintext makes them vulnerable to database breaches, potentially exposing all your users' API keys.
 </Callout>
 
+`softDelete` <span className="opacity-70">`boolean`</span>
+
+When enabled, deleting an API key sets `enabled` to `false` instead of removing the row. Expired and exhausted keys follow the same behavior. This is useful for audit trails or allowing key recovery. Default is `false`.
+
+Can be configured per `configId` when using multiple configurations.
+
 ***
 
 ## Permissions

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -4934,6 +4934,195 @@ describe("api-key", async () => {
 	});
 });
 
+describe("soft delete", async () => {
+	const { auth, signInWithTestUser } = await getTestInstance(
+		{
+			plugins: [
+				apiKey({
+					softDelete: true,
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [apiKeyClient()],
+			},
+		},
+	);
+	const { headers, user } = await signInWithTestUser();
+
+	it("should disable key instead of removing it", async () => {
+		const apiKey = await auth.api.createApiKey({
+			body: { userId: user.id },
+		});
+
+		const result = await auth.api.deleteApiKey({
+			body: { keyId: apiKey.id },
+			headers,
+		});
+
+		expect(result.success).toBe(true);
+
+		const fetched = await auth.api.getApiKey({
+			query: { id: apiKey.id },
+			headers,
+		});
+
+		expect(fetched.enabled).toBe(false);
+	});
+
+	it("should reject verification of a soft-deleted key", async () => {
+		const apiKey = await auth.api.createApiKey({
+			body: { userId: user.id },
+		});
+
+		await auth.api.deleteApiKey({
+			body: { keyId: apiKey.id },
+			headers,
+		});
+
+		const result = await auth.api.verifyApiKey({
+			body: { key: apiKey.key },
+		});
+
+		expect(result.valid).toBe(false);
+		expect(result.error?.code).toBe("KEY_DISABLED");
+	});
+
+	it("should disable expired key instead of removing it", async () => {
+		vi.useRealTimers();
+		const apiKey = await auth.api.createApiKey({
+			body: { userId: user.id, expiresIn: 60 * 60 * 24 },
+		});
+
+		vi.useFakeTimers();
+		await vi.advanceTimersByTimeAsync(1000 * 60 * 60 * 24 * 2);
+
+		const result = await auth.api.verifyApiKey({
+			body: { key: apiKey.key },
+		});
+
+		expect(result.error?.code).toBe("KEY_EXPIRED");
+		vi.useRealTimers();
+
+		const fetched = await auth.api.getApiKey({
+			query: { id: apiKey.id },
+			headers,
+		});
+
+		expect(fetched.enabled).toBe(false);
+	});
+
+	it("should disable exhausted key instead of removing it", async () => {
+		const apiKey = await auth.api.createApiKey({
+			body: { userId: user.id, remaining: 1 },
+		});
+
+		await auth.api.verifyApiKey({
+			body: { key: apiKey.key },
+		});
+
+		const result = await auth.api.verifyApiKey({
+			body: { key: apiKey.key },
+		});
+
+		expect(result.error?.code).toBe("USAGE_EXCEEDED");
+
+		const fetched = await auth.api.getApiKey({
+			query: { id: apiKey.id },
+			headers,
+		});
+
+		expect(fetched.enabled).toBe(false);
+	});
+
+	describe("mixed soft/hard delete configurations", async () => {
+		const { auth: mixedAuth, signInWithTestUser: mixedSignInWithTestUser } =
+			await getTestInstance(
+				{
+					plugins: [
+						apiKey([
+							{
+								configId: "soft",
+								softDelete: true,
+							},
+							{
+								configId: "hard",
+								softDelete: false,
+							},
+						]),
+					],
+				},
+				{
+					clientOptions: {
+						plugins: [apiKeyClient()],
+					},
+				},
+			);
+		const { headers: mixedHeaders, user: mixedUser } =
+			await mixedSignInWithTestUser();
+
+		it("should soft-delete expired keys for soft config and hard-delete for hard config", async () => {
+			vi.useRealTimers();
+			const softKey = await mixedAuth.api.createApiKey({
+				body: {
+					configId: "soft",
+					userId: mixedUser.id,
+					expiresIn: 60 * 60 * 24,
+				},
+			});
+			const hardKey = await mixedAuth.api.createApiKey({
+				body: {
+					configId: "hard",
+					userId: mixedUser.id,
+					expiresIn: 60 * 60 * 24,
+				},
+			});
+
+			vi.useFakeTimers();
+			await vi.advanceTimersByTimeAsync(1000 * 60 * 60 * 24 * 2);
+
+			await mixedAuth.api.deleteAllExpiredApiKeys();
+			vi.useRealTimers();
+
+			const softFetched = await mixedAuth.api.getApiKey({
+				query: { id: softKey.id, configId: "soft" },
+				headers: mixedHeaders,
+			});
+
+			expect(softFetched.enabled).toBe(false);
+
+			try {
+				await mixedAuth.api.getApiKey({
+					query: { id: hardKey.id, configId: "hard" },
+					headers: mixedHeaders,
+				});
+				expect.fail("Should have thrown an error");
+			} catch (error: any) {
+				expect(isAPIError(error)).toBe(true);
+				expect(error.body?.code).toBe("KEY_NOT_FOUND");
+			}
+		});
+	});
+
+	it("should still list soft-deleted keys", async () => {
+		const apiKey = await auth.api.createApiKey({
+			body: { userId: user.id },
+		});
+
+		await auth.api.deleteApiKey({
+			body: { keyId: apiKey.id },
+			headers,
+		});
+
+		const list = await auth.api.listApiKeys({ headers });
+		const found = list.apiKeys.find((k) => k.id === apiKey.id);
+
+		expect(found).toBeDefined();
+		expect(found?.enabled).toBe(false);
+	});
+});
+
 describe("listApiKeys with integer user.id (postgres + serial)", async () => {
 	const testUserEmail = `api-key-serial-${crypto.randomUUID()}@test.com`;
 	const { auth, signInWithTestUser } = await getTestInstance(

--- a/packages/api-key/src/index.ts
+++ b/packages/api-key/src/index.ts
@@ -104,6 +104,7 @@ export function apiKey(
 			fallbackToDatabase: config?.fallbackToDatabase ?? false,
 			customStorage: config?.customStorage,
 			deferUpdates: config?.deferUpdates ?? false,
+			softDelete: config?.softDelete ?? false,
 		})),
 	] as PredefinedApiKeyOptions[];
 
@@ -209,14 +210,15 @@ export function apiKey(
 							expectedConfigId: config.configId,
 						});
 
-						const cleanupTask = deleteAllExpiredApiKeys(ctx.context).catch(
-							(err) => {
-								ctx.context.logger.error(
-									"Failed to delete expired API keys:",
-									err,
-								);
-							},
-						);
+						const cleanupTask = deleteAllExpiredApiKeys(
+							ctx.context,
+							configurations,
+						).catch((err) => {
+							ctx.context.logger.error(
+								"Failed to delete expired API keys:",
+								err,
+							);
+						});
 						if (config.deferUpdates) {
 							ctx.context.runInBackground(cleanupTask);
 						}

--- a/packages/api-key/src/routes/create-api-key.ts
+++ b/packages/api-key/src/routes/create-api-key.ts
@@ -123,6 +123,7 @@ export function createApiKey({
 	schema: ReturnType<typeof apiKeySchema>;
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
+		configurations: PredefinedApiKeyOptions[],
 		byPassLastCheckTime?: boolean | undefined,
 	): void;
 }) {
@@ -419,7 +420,7 @@ export function createApiKey({
 				throw APIError.from("BAD_REQUEST", ERROR_CODES.NAME_REQUIRED);
 			}
 
-			deleteAllExpiredApiKeys(ctx.context);
+			deleteAllExpiredApiKeys(ctx.context, configurations);
 
 			const key = await keyGenerator({
 				length: opts.defaultKeyLength,

--- a/packages/api-key/src/routes/delete-all-expired-api-keys.ts
+++ b/packages/api-key/src/routes/delete-all-expired-api-keys.ts
@@ -1,11 +1,15 @@
 import type { AuthContext } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
+import type { PredefinedApiKeyOptions } from ".";
 
 export function deleteAllExpiredApiKeysEndpoint({
+	configurations,
 	deleteAllExpiredApiKeys,
 }: {
+	configurations: PredefinedApiKeyOptions[];
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
+		configurations: PredefinedApiKeyOptions[],
 		byPassLastCheckTime?: boolean | undefined,
 	): Promise<void>;
 }) {
@@ -15,7 +19,7 @@ export function deleteAllExpiredApiKeysEndpoint({
 		},
 		async (ctx) => {
 			try {
-				await deleteAllExpiredApiKeys(ctx.context, true);
+				await deleteAllExpiredApiKeys(ctx.context, configurations, true);
 			} catch (error) {
 				ctx.context.logger.error(
 					"[API KEY PLUGIN] Failed to delete expired API keys:",

--- a/packages/api-key/src/routes/delete-api-key.ts
+++ b/packages/api-key/src/routes/delete-api-key.ts
@@ -7,6 +7,7 @@ import { API_KEY_TABLE_NAME, API_KEY_ERROR_CODES as ERROR_CODES } from "..";
 import {
 	deleteApiKey as deleteApiKeyFromStorage,
 	getApiKeyById,
+	setApiKey,
 } from "../adapter";
 import { checkOrgApiKeyPermission } from "../org-authorization";
 import type { apiKeySchema } from "../schema";
@@ -36,6 +37,7 @@ export function deleteApiKey({
 	schema: ReturnType<typeof apiKeySchema>;
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
+		configurations: PredefinedApiKeyOptions[],
 		byPassLastCheckTime?: boolean | undefined,
 	): void;
 }) {
@@ -134,36 +136,51 @@ export function deleteApiKey({
 			}
 
 			try {
-				if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
-					await deleteApiKeyFromStorage(ctx, apiKey, opts);
-					await ctx.context.adapter.delete<ApiKey>({
-						model: API_KEY_TABLE_NAME,
-						where: [
-							{
-								field: "id",
-								value: apiKey.id,
-							},
-						],
-					});
-				} else if (opts.storage === "database") {
-					await ctx.context.adapter.delete<ApiKey>({
-						model: API_KEY_TABLE_NAME,
-						where: [
-							{
-								field: "id",
-								value: apiKey.id,
-							},
-						],
-					});
+				if (opts.softDelete) {
+					const disabledKey = {
+						...apiKey,
+						enabled: false,
+						updatedAt: new Date(),
+					};
+
+					if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
+						await setApiKey(ctx, disabledKey, opts);
+						await ctx.context.adapter.update<ApiKey>({
+							model: API_KEY_TABLE_NAME,
+							update: { enabled: false, updatedAt: new Date() },
+							where: [{ field: "id", value: apiKey.id }],
+						});
+					} else if (opts.storage === "database") {
+						await ctx.context.adapter.update<ApiKey>({
+							model: API_KEY_TABLE_NAME,
+							update: { enabled: false, updatedAt: new Date() },
+							where: [{ field: "id", value: apiKey.id }],
+						});
+					} else {
+						await setApiKey(ctx, disabledKey, opts);
+					}
 				} else {
-					await deleteApiKeyFromStorage(ctx, apiKey, opts);
+					if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
+						await deleteApiKeyFromStorage(ctx, apiKey, opts);
+						await ctx.context.adapter.delete<ApiKey>({
+							model: API_KEY_TABLE_NAME,
+							where: [{ field: "id", value: apiKey.id }],
+						});
+					} else if (opts.storage === "database") {
+						await ctx.context.adapter.delete<ApiKey>({
+							model: API_KEY_TABLE_NAME,
+							where: [{ field: "id", value: apiKey.id }],
+						});
+					} else {
+						await deleteApiKeyFromStorage(ctx, apiKey, opts);
+					}
 				}
 			} catch (error: any) {
 				throw APIError.fromStatus("INTERNAL_SERVER_ERROR", {
 					message: error?.message,
 				});
 			}
-			deleteAllExpiredApiKeys(ctx.context);
+			deleteAllExpiredApiKeys(ctx.context, configurations);
 			return ctx.json({
 				success: true,
 			});

--- a/packages/api-key/src/routes/get-api-key.ts
+++ b/packages/api-key/src/routes/get-api-key.ts
@@ -34,6 +34,7 @@ export function getApiKey({
 	schema: ReturnType<typeof apiKeySchema>;
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
+		configurations: PredefinedApiKeyOptions[],
 		byPassLastCheckTime?: boolean | undefined,
 	): void;
 }) {
@@ -225,7 +226,7 @@ export function getApiKey({
 				throw APIError.from("NOT_FOUND", ERROR_CODES.KEY_NOT_FOUND);
 			}
 
-			deleteAllExpiredApiKeys(ctx.context);
+			deleteAllExpiredApiKeys(ctx.context, configurations);
 
 			// Migrate legacy double-stringified metadata if needed
 			const metadata = await migrateDoubleStringifiedMetadata(

--- a/packages/api-key/src/routes/index.ts
+++ b/packages/api-key/src/routes/index.ts
@@ -31,6 +31,7 @@ export type PredefinedApiKeyOptions = ApiKeyConfigurationOptions &
 			| "storage"
 			| "fallbackToDatabase"
 			| "deferUpdates"
+			| "softDelete"
 		>
 	> & {
 		keyExpiration: Required<
@@ -99,6 +100,7 @@ let lastChecked: Date | null = null;
 
 export async function deleteAllExpiredApiKeys(
 	ctx: AuthContext,
+	configurations: PredefinedApiKeyOptions[],
 	byPassLastCheckTime = false,
 ): Promise<void> {
 	if (lastChecked && !byPassLastCheckTime) {
@@ -109,25 +111,66 @@ export async function deleteAllExpiredApiKeys(
 		}
 	}
 	lastChecked = new Date();
-	await ctx.adapter
-		.deleteMany({
-			model: API_KEY_TABLE_NAME,
-			where: [
-				{
-					field: "expiresAt" satisfies keyof ApiKey,
-					operator: "lt",
-					value: new Date(),
-				},
-				{
-					field: "expiresAt",
-					operator: "ne",
-					value: null,
-				},
-			],
-		})
-		.catch((error) => {
-			ctx.logger.error(`Failed to delete expired API keys:`, error);
-		});
+
+	const expiredWhere = [
+		{
+			field: "expiresAt" satisfies keyof ApiKey,
+			operator: "lt" as const,
+			value: new Date(),
+		},
+		{
+			field: "expiresAt" satisfies keyof ApiKey,
+			operator: "ne" as const,
+			value: null,
+		},
+	];
+
+	const hardDeleteConfigIds = configurations
+		.filter((c) => !c.softDelete)
+		.map((c) => c.configId ?? "default");
+	const softDeleteConfigIds = configurations
+		.filter((c) => c.softDelete)
+		.map((c) => c.configId ?? "default");
+
+	const pending: Promise<unknown>[] = [];
+
+	if (softDeleteConfigIds.length > 0) {
+		pending.push(
+			ctx.adapter.updateMany({
+				model: API_KEY_TABLE_NAME,
+				update: { enabled: false, updatedAt: new Date() },
+				where: [
+					...expiredWhere,
+					{ field: "enabled", value: true },
+					{
+						field: "configId" satisfies keyof ApiKey,
+						operator: "in",
+						value: softDeleteConfigIds,
+					},
+				],
+			}),
+		);
+	}
+
+	if (hardDeleteConfigIds.length > 0) {
+		pending.push(
+			ctx.adapter.deleteMany({
+				model: API_KEY_TABLE_NAME,
+				where: [
+					...expiredWhere,
+					{
+						field: "configId" satisfies keyof ApiKey,
+						operator: "in",
+						value: hardDeleteConfigIds,
+					},
+				],
+			}),
+		);
+	}
+
+	await Promise.all(pending).catch((error) => {
+		ctx.logger.error(`Failed to delete expired API keys:`, error);
+	});
 }
 
 export function createApiKeyRoutes({
@@ -171,6 +214,7 @@ export function createApiKeyRoutes({
 			deleteAllExpiredApiKeys,
 		}),
 		deleteAllExpiredApiKeys: deleteAllExpiredApiKeysEndpoint({
+			configurations,
 			deleteAllExpiredApiKeys,
 		}),
 	};

--- a/packages/api-key/src/routes/list-api-keys.ts
+++ b/packages/api-key/src/routes/list-api-keys.ts
@@ -86,6 +86,7 @@ export function listApiKeys({
 	schema: ReturnType<typeof apiKeySchema>;
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
+		configurations: PredefinedApiKeyOptions[],
 		byPassLastCheckTime?: boolean | undefined,
 	): void;
 }) {
@@ -365,7 +366,7 @@ export function listApiKeys({
 				paginatedApiKeys = paginatedApiKeys.slice(0, limit);
 			}
 
-			deleteAllExpiredApiKeys(ctx.context);
+			deleteAllExpiredApiKeys(ctx.context, configurations);
 
 			// Build response with parsed metadata (synchronous, no DB calls)
 			const returningApiKeys = paginatedApiKeys.map((apiKey) => {

--- a/packages/api-key/src/routes/update-api-key.ts
+++ b/packages/api-key/src/routes/update-api-key.ts
@@ -113,6 +113,7 @@ export function updateApiKey({
 	schema: ReturnType<typeof apiKeySchema>;
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
+		configurations: PredefinedApiKeyOptions[],
 		byPassLastCheckTime?: boolean | undefined,
 	): void;
 }) {
@@ -475,7 +476,7 @@ export function updateApiKey({
 				});
 			}
 
-			deleteAllExpiredApiKeys(ctx.context);
+			deleteAllExpiredApiKeys(ctx.context, configurations);
 
 			// Migrate legacy double-stringified metadata if needed
 			const migratedMetadata = await migrateDoubleStringifiedMetadata(

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -83,19 +83,44 @@ export async function validateApiKey({
 		const expiresAt = new Date(apiKey.expiresAt).getTime();
 		if (now > expiresAt) {
 			const deleteExpiredKey = async () => {
-				if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
-					await deleteApiKey(ctx, apiKey, opts);
-					await ctx.context.adapter.delete({
-						model: API_KEY_TABLE_NAME,
-						where: [{ field: "id", value: apiKey.id }],
-					});
-				} else if (opts.storage === "secondary-storage") {
-					await deleteApiKey(ctx, apiKey, opts);
+				if (opts.softDelete) {
+					const disabledKey = {
+						...apiKey,
+						enabled: false,
+						updatedAt: new Date(),
+					};
+
+					if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
+						await setApiKey(ctx, disabledKey, opts);
+						await ctx.context.adapter.update({
+							model: API_KEY_TABLE_NAME,
+							update: { enabled: false, updatedAt: new Date() },
+							where: [{ field: "id", value: apiKey.id }],
+						});
+					} else if (opts.storage === "secondary-storage") {
+						await setApiKey(ctx, disabledKey, opts);
+					} else {
+						await ctx.context.adapter.update({
+							model: API_KEY_TABLE_NAME,
+							update: { enabled: false, updatedAt: new Date() },
+							where: [{ field: "id", value: apiKey.id }],
+						});
+					}
 				} else {
-					await ctx.context.adapter.delete({
-						model: API_KEY_TABLE_NAME,
-						where: [{ field: "id", value: apiKey.id }],
-					});
+					if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
+						await deleteApiKey(ctx, apiKey, opts);
+						await ctx.context.adapter.delete({
+							model: API_KEY_TABLE_NAME,
+							where: [{ field: "id", value: apiKey.id }],
+						});
+					} else if (opts.storage === "secondary-storage") {
+						await deleteApiKey(ctx, apiKey, opts);
+					} else {
+						await ctx.context.adapter.delete({
+							model: API_KEY_TABLE_NAME,
+							where: [{ field: "id", value: apiKey.id }],
+						});
+					}
 				}
 			};
 
@@ -135,19 +160,44 @@ export async function validateApiKey({
 
 	if (apiKey.remaining === 0 && apiKey.refillAmount === null) {
 		const deleteExhaustedKey = async () => {
-			if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
-				await deleteApiKey(ctx, apiKey, opts);
-				await ctx.context.adapter.delete({
-					model: API_KEY_TABLE_NAME,
-					where: [{ field: "id", value: apiKey.id }],
-				});
-			} else if (opts.storage === "secondary-storage") {
-				await deleteApiKey(ctx, apiKey, opts);
+			if (opts.softDelete) {
+				const disabledKey = {
+					...apiKey,
+					enabled: false,
+					updatedAt: new Date(),
+				};
+
+				if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
+					await setApiKey(ctx, disabledKey, opts);
+					await ctx.context.adapter.update({
+						model: API_KEY_TABLE_NAME,
+						update: { enabled: false, updatedAt: new Date() },
+						where: [{ field: "id", value: apiKey.id }],
+					});
+				} else if (opts.storage === "secondary-storage") {
+					await setApiKey(ctx, disabledKey, opts);
+				} else {
+					await ctx.context.adapter.update({
+						model: API_KEY_TABLE_NAME,
+						update: { enabled: false, updatedAt: new Date() },
+						where: [{ field: "id", value: apiKey.id }],
+					});
+				}
 			} else {
-				await ctx.context.adapter.delete({
-					model: API_KEY_TABLE_NAME,
-					where: [{ field: "id", value: apiKey.id }],
-				});
+				if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
+					await deleteApiKey(ctx, apiKey, opts);
+					await ctx.context.adapter.delete({
+						model: API_KEY_TABLE_NAME,
+						where: [{ field: "id", value: apiKey.id }],
+					});
+				} else if (opts.storage === "secondary-storage") {
+					await deleteApiKey(ctx, apiKey, opts);
+				} else {
+					await ctx.context.adapter.delete({
+						model: API_KEY_TABLE_NAME,
+						where: [{ field: "id", value: apiKey.id }],
+					});
+				}
 			}
 		};
 
@@ -282,6 +332,7 @@ export function verifyApiKey({
 	schema: ReturnType<typeof apiKeySchema>;
 	deleteAllExpiredApiKeys(
 		ctx: AuthContext,
+		configurations: PredefinedApiKeyOptions[],
 		byPassLastCheckTime?: boolean | undefined,
 	): Promise<void>;
 }) {
@@ -336,12 +387,14 @@ export function verifyApiKey({
 
 				if (opts.deferUpdates) {
 					ctx.context.runInBackground(
-						deleteAllExpiredApiKeys(ctx.context).catch((err) => {
-							ctx.context.logger.error(
-								"Failed to delete expired API keys:",
-								err,
-							);
-						}),
+						deleteAllExpiredApiKeys(ctx.context, configurations).catch(
+							(err) => {
+								ctx.context.logger.error(
+									"Failed to delete expired API keys:",
+									err,
+								);
+							},
+						),
 					);
 				}
 			} catch (error) {

--- a/packages/api-key/src/types.ts
+++ b/packages/api-key/src/types.ts
@@ -277,6 +277,13 @@ export interface ApiKeyConfigurationOptions {
 	 */
 	deferUpdates?: boolean | undefined;
 	/**
+	 * When enabled, deleting an API key sets `enabled` to `false` instead of
+	 * removing the row. Expired-key cleanup follows the same behavior.
+	 *
+	 * @default false
+	 */
+	softDelete?: boolean | undefined;
+	/**
 	 * What the API key references. This determines ownership over the API key.
 	 *
 	 * @default "user"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a soft-delete option to the API Key plugin. When enabled, deletes and cleanup disable keys (`enabled: false`) instead of removing rows to improve auditability and allow recovery.

- **New Features**
  - Added `softDelete` option to `@better-auth/api-key` (default false), configurable per `configId`.
  - Applies to manual deletes, expired keys, and usage-exhausted keys; verification returns KEY_DISABLED.
  - Disabled keys still appear in list/get; cleanup endpoint and background tasks honor per-config soft vs hard delete across all storage modes.
  - Updated docs and added comprehensive tests.

<sup>Written for commit de1b3723803e8eed84e3247053d65ef5d53e8060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

