### PR TITLE
fix: harden provider identity validation (One Tap, Microsoft, SSO, WeChat, Reddit)

### DIFF
--- a/.changeset/microsoft-tenant-restriction.md
+++ b/.changeset/microsoft-tenant-restriction.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Microsoft Entra ID sign-in now honors the configured tenant restriction. `tenantId: "organizations"` rejects personal Microsoft accounts, and `tenantId: "consumers"` rejects work and school accounts. Both were accepted before.

--- a/.changeset/one-tap-require-client-id.md
+++ b/.changeset/one-tap-require-client-id.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Google One Tap now requires a configured Google client ID and rejects the sign-in callback when none is set. A Google ID token issued for a different application is no longer accepted. Set the client ID on the `oneTap` plugin or on `socialProviders.google`.

--- a/.changeset/reddit-placeholder-email-domain.md
+++ b/.changeset/reddit-placeholder-email-domain.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+A Reddit user with no email now receives a non-routable placeholder address (`<id>@reddit.invalid`) instead of one on the real `reddit.com` domain, so it cannot match a deliverable mailbox. The address stays unverified, and `mapProfileToUser` can supply a real email.

--- a/.changeset/sso-email-verified-strict.md
+++ b/.changeset/sso-email-verified-strict.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+With `trustEmailVerified` enabled, an OIDC `email_verified` claim or mapped SAML attribute whose value is the string `"false"` is no longer treated as a verified email. Only a boolean `true` or the string `"true"` counts as verified.

--- a/.changeset/wechat-default-email.md
+++ b/.changeset/wechat-default-email.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+WeChat sign-in now succeeds with the documented default setup, which previously failed because WeChat returns no email address. The created user receives a stable, unverified placeholder email; supply a real one with `mapProfileToUser`.

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -94,21 +94,33 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 				},
 				async (ctx) => {
 					const { idToken } = ctx.body;
+					const googleProvider =
+						typeof ctx.context.options.socialProviders?.google === "function"
+							? await ctx.context.options.socialProviders?.google()
+							: ctx.context.options.socialProviders?.google;
+					// Fail closed on a missing audience: without an expected client ID,
+					// jose verifies Google's signature and issuer but not that the token
+					// was minted for this relying party, so a token issued to a different
+					// Google client would be accepted. Resolve and require it before
+					// verification.
+					const audience = options?.clientId || googleProvider?.clientId;
+					if (!audience || (Array.isArray(audience) && audience.length === 0)) {
+						throw new APIError("BAD_REQUEST", {
+							message:
+								"Google client ID is required for One Tap. Set it on the oneTap plugin (clientId) or on socialProviders.google.",
+						});
+					}
 					let payload: any;
 					try {
 						const JWKS = createRemoteJWKSet(
 							new URL("https://www.googleapis.com/oauth2/v3/certs"),
 						);
-						const googleProvider =
-							typeof ctx.context.options.socialProviders?.google === "function"
-								? await ctx.context.options.socialProviders?.google()
-								: ctx.context.options.socialProviders?.google;
 						const { payload: verifiedPayload } = await jwtVerify(
 							idToken,
 							JWKS,
 							{
 								issuer: ["https://accounts.google.com", "accounts.google.com"],
-								audience: options?.clientId || googleProvider?.clientId,
+								audience,
 							},
 						);
 						payload = verifiedPayload;

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -415,3 +415,50 @@ describe("one-tap callbackURL origin validation", async () => {
 		expect(res.error?.status).not.toBe(403);
 	});
 });
+
+describe("one-tap audience enforcement", async () => {
+	it("rejects the callback when no Google client ID is configured", async () => {
+		// No `socialProviders.google` and no `oneTap({ clientId })`, so there is no
+		// expected audience. Without one, jose would verify Google's signature but
+		// not that the token was minted for this app, so the request must fail
+		// closed before verification rather than accept a cross-client token.
+		// (`socialProviders: {}` overrides the test default, which configures
+		// google with a client id.)
+		const { client } = await getTestInstance({
+			socialProviders: {},
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number; message?: string } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error?.status).toBe(400);
+		expect(res.error?.message).toContain("Google client ID is required");
+	});
+
+	it("accepts the oneTap-level clientId as the audience without a Google provider", async () => {
+		const { client } = await getTestInstance({
+			socialProviders: {},
+			plugins: [oneTap({ clientId: "explicit-one-tap-client" })],
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number; message?: string } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		// The audience guard is satisfied, so the request is not rejected for a
+		// missing client ID (verification proceeds via the mocked jose).
+		expect(res.error?.message ?? "").not.toContain(
+			"Google client ID is required",
+		);
+	});
+});

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -2079,6 +2079,7 @@ describe("Microsoft Provider", async () => {
 		)
 			.setProtectedHeader({ alg: "RS256", kid: msKid })
 			.setIssuedAt()
+			.setIssuer("https://login.microsoftonline.com/ms-tenant-789/v2.0")
 			.setAudience("test-ms-client-id-token")
 			.setExpirationTime("1h")
 			.sign(rsaKeyPair.privateKey);
@@ -2189,6 +2190,7 @@ describe("Microsoft Provider", async () => {
 			sub: "ms-tenant-user",
 			email: "tenant@outlook.com",
 			name: "Tenant User",
+			tid: tenantId,
 		};
 
 		const validToken = await new SignJWT(
@@ -2613,7 +2615,8 @@ describe("Reddit Provider — profile email mapping", async () => {
 		// Without a mapped email the provider derives a unique, per-user
 		// synthetic email from the Reddit user id rather than falling back to
 		// the shared oauth_client_id, so users can never collide on one address.
-		expect(result?.user.email).toBe("reddit-user-123@reddit.com");
+		// The non-routable `.invalid` domain keeps it from matching a real mailbox.
+		expect(result?.user.email).toBe("reddit-user-123@reddit.invalid");
 		expect(result?.user.email).not.toBe(profile.oauth_client_id);
 		expect(result?.user.emailVerified).toBe(false);
 	});

--- a/packages/core/src/social-providers/microsoft-entra-id.test.ts
+++ b/packages/core/src/social-providers/microsoft-entra-id.test.ts
@@ -1,0 +1,131 @@
+import type { JWK } from "jose";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@better-fetch/fetch", () => ({
+	betterFetch: vi.fn(),
+}));
+
+import { betterFetch } from "@better-fetch/fetch";
+
+import { microsoft } from "./microsoft-entra-id";
+
+const mockedBetterFetch = vi.mocked(betterFetch);
+
+const CLIENT_ID = "ms-app";
+const AUTHORITY = "https://login.microsoftonline.com";
+const CONSUMER_TENANT_ID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+const WORK_TENANT_ID = "11111111-2222-3333-4444-555555555555";
+const KID = "ms-test-key";
+
+let privateKey: CryptoKey;
+let publicJWK: JWK;
+
+beforeEach(async () => {
+	const keyPair = await generateKeyPair("RS256", { extractable: true });
+	privateKey = keyPair.privateKey;
+	publicJWK = await exportJWK(keyPair.publicKey);
+	publicJWK.kid = KID;
+	publicJWK.alg = "RS256";
+	publicJWK.use = "sig";
+
+	mockedBetterFetch.mockReset();
+	// getMicrosoftPublicKey resolves the signing key from the discovery endpoint.
+	mockedBetterFetch.mockResolvedValue({
+		data: { keys: [publicJWK] },
+		error: null,
+	} as Awaited<ReturnType<typeof betterFetch>>);
+});
+
+async function signMicrosoftToken(opts: {
+	tid: string;
+	/** Defaults to the issuer Microsoft would mint for `tid`. */
+	iss?: string;
+	audience?: string;
+}) {
+	const iss = opts.iss ?? `${AUTHORITY}/${opts.tid}/v2.0`;
+	return new SignJWT({ tid: opts.tid, sub: "ms-user-1" })
+		.setProtectedHeader({ alg: "RS256", kid: KID })
+		.setIssuer(iss)
+		.setAudience(opts.audience ?? CLIENT_ID)
+		.setIssuedAt()
+		.setExpirationTime("1h")
+		.sign(privateKey);
+}
+
+describe("microsoft.verifyIdToken tenant enforcement", () => {
+	it("rejects a consumer-tenant token when restricted to organizations", async () => {
+		const provider = microsoft({
+			clientId: CLIENT_ID,
+			tenantId: "organizations",
+		});
+		const token = await signMicrosoftToken({ tid: CONSUMER_TENANT_ID });
+		await expect(provider.verifyIdToken(token, undefined)).resolves.toBe(false);
+	});
+
+	it("rejects a work-tenant token when restricted to consumers", async () => {
+		const provider = microsoft({
+			clientId: CLIENT_ID,
+			tenantId: "consumers",
+		});
+		const token = await signMicrosoftToken({ tid: WORK_TENANT_ID });
+		await expect(provider.verifyIdToken(token, undefined)).resolves.toBe(false);
+	});
+
+	it("accepts a work-tenant token under organizations", async () => {
+		const provider = microsoft({
+			clientId: CLIENT_ID,
+			tenantId: "organizations",
+		});
+		const token = await signMicrosoftToken({ tid: WORK_TENANT_ID });
+		await expect(provider.verifyIdToken(token, undefined)).resolves.toBe(true);
+	});
+
+	it("accepts a consumer-tenant token under consumers", async () => {
+		const provider = microsoft({
+			clientId: CLIENT_ID,
+			tenantId: "consumers",
+		});
+		const token = await signMicrosoftToken({ tid: CONSUMER_TENANT_ID });
+		await expect(provider.verifyIdToken(token, undefined)).resolves.toBe(true);
+	});
+
+	it("accepts any tenant under common", async () => {
+		const provider = microsoft({ clientId: CLIENT_ID, tenantId: "common" });
+		await expect(
+			provider.verifyIdToken(
+				await signMicrosoftToken({ tid: WORK_TENANT_ID }),
+				undefined,
+			),
+		).resolves.toBe(true);
+		await expect(
+			provider.verifyIdToken(
+				await signMicrosoftToken({ tid: CONSUMER_TENANT_ID }),
+				undefined,
+			),
+		).resolves.toBe(true);
+	});
+
+	it("rejects a token whose issuer does not name its own tenant", async () => {
+		const provider = microsoft({ clientId: CLIENT_ID, tenantId: "common" });
+		// Valid signature and audience, but the issuer points at a different tenant
+		// than the `tid` claim, which Microsoft never does.
+		const token = await signMicrosoftToken({
+			tid: WORK_TENANT_ID,
+			iss: `${AUTHORITY}/${CONSUMER_TENANT_ID}/v2.0`,
+		});
+		await expect(provider.verifyIdToken(token, undefined)).resolves.toBe(false);
+	});
+
+	it("rejects a token with a non-string tid", async () => {
+		const provider = microsoft({ clientId: CLIENT_ID, tenantId: "common" });
+		const token = await new SignJWT({ sub: "ms-user-1" })
+			.setProtectedHeader({ alg: "RS256", kid: KID })
+			.setIssuer(`${AUTHORITY}/${WORK_TENANT_ID}/v2.0`)
+			.setAudience(CLIENT_ID)
+			.setIssuedAt()
+			.setExpirationTime("1h")
+			.sign(privateKey);
+		await expect(provider.verifyIdToken(token, undefined)).resolves.toBe(false);
+	});
+});

--- a/packages/core/src/social-providers/microsoft-entra-id.test.ts
+++ b/packages/core/src/social-providers/microsoft-entra-id.test.ts
@@ -117,6 +117,16 @@ describe("microsoft.verifyIdToken tenant enforcement", () => {
 		await expect(provider.verifyIdToken(token, undefined)).resolves.toBe(false);
 	});
 
+	it("accepts a valid token when the authority is configured with a trailing slash", async () => {
+		const provider = microsoft({
+			clientId: CLIENT_ID,
+			tenantId: "common",
+			authority: `${AUTHORITY}/`,
+		});
+		const token = await signMicrosoftToken({ tid: WORK_TENANT_ID });
+		await expect(provider.verifyIdToken(token, undefined)).resolves.toBe(true);
+	});
+
 	it("rejects a token with a non-string tid", async () => {
 		const provider = microsoft({ clientId: CLIENT_ID, tenantId: "common" });
 		const token = await new SignJWT({ sub: "ms-user-1" })

--- a/packages/core/src/social-providers/microsoft-entra-id.ts
+++ b/packages/core/src/social-providers/microsoft-entra-id.ts
@@ -12,6 +12,14 @@ import {
 } from "../oauth2";
 
 /**
+ * Microsoft's fixed tenant id for personal (consumer) Microsoft accounts. Every
+ * personal-account token carries it as the `tid` claim, so it distinguishes the
+ * consumer account class from work/school tenants.
+ * @see https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
+ */
+const MICROSOFT_CONSUMER_TENANT_ID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+
+/**
  * @see [Microsoft Identity Platform - Optional claims reference](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims-reference)
  */
 export interface MicrosoftEntraIDProfile extends Record<string, any> {
@@ -226,6 +234,30 @@ export const microsoft = (options: MicrosoftOptions) => {
 				);
 
 				if (nonce && jwtClaims.nonce !== nonce) {
+					return false;
+				}
+
+				// The multi-tenant endpoints (common/organizations/consumers) skip
+				// jose's issuer check above because the issuer varies per tenant, and
+				// the organizations and consumers JWKS sets overlap. Enforce the tenant
+				// binding explicitly so a token from a disallowed account class cannot
+				// pass: the issuer must name the token's own tenant, and the account
+				// class must match the configured restriction.
+				// @see https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
+				const tid = jwtClaims.tid;
+				if (
+					typeof tid !== "string" ||
+					jwtClaims.iss !== `${authority}/${tid}/v2.0`
+				) {
+					return false;
+				}
+				if (
+					tenant === "organizations" &&
+					tid === MICROSOFT_CONSUMER_TENANT_ID
+				) {
+					return false;
+				}
+				if (tenant === "consumers" && tid !== MICROSOFT_CONSUMER_TENANT_ID) {
 					return false;
 				}
 

--- a/packages/core/src/social-providers/microsoft-entra-id.ts
+++ b/packages/core/src/social-providers/microsoft-entra-id.ts
@@ -151,7 +151,12 @@ export interface MicrosoftOptions
 
 export const microsoft = (options: MicrosoftOptions) => {
 	const tenant = options.tenantId || "common";
-	const authority = options.authority || "https://login.microsoftonline.com";
+	// Trim any trailing slash so endpoint URLs and the issuer comparison below
+	// never produce a double slash (e.g. a configured `https://host/` would make
+	// the expected issuer `https://host//<tid>/v2.0` and reject every token).
+	const authority = (
+		options.authority || "https://login.microsoftonline.com"
+	).replace(/\/+$/, "");
 	const authorizationEndpoint = `${authority}/${tenant}/oauth2/v2.0/authorize`;
 	const tokenEndpoint = `${authority}/${tenant}/oauth2/v2.0/token`;
 	return {

--- a/packages/core/src/social-providers/microsoft-entra-id.ts
+++ b/packages/core/src/social-providers/microsoft-entra-id.ts
@@ -153,10 +153,12 @@ export const microsoft = (options: MicrosoftOptions) => {
 	const tenant = options.tenantId || "common";
 	// Trim any trailing slash so endpoint URLs and the issuer comparison below
 	// never produce a double slash (e.g. a configured `https://host/` would make
-	// the expected issuer `https://host//<tid>/v2.0` and reject every token).
-	const authority = (
-		options.authority || "https://login.microsoftonline.com"
-	).replace(/\/+$/, "");
+	// the expected issuer `https://host//<tid>/v2.0` and reject every token). A
+	// loop avoids a trailing-slash regex, which is a polynomial-ReDoS shape.
+	let authority = options.authority || "https://login.microsoftonline.com";
+	while (authority.endsWith("/")) {
+		authority = authority.slice(0, -1);
+	}
 	const authorizationEndpoint = `${authority}/${tenant}/oauth2/v2.0/authorize`;
 	const tokenEndpoint = `${authority}/${tenant}/oauth2/v2.0/token`;
 	return {

--- a/packages/core/src/social-providers/reddit.test.ts
+++ b/packages/core/src/social-providers/reddit.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@better-fetch/fetch", () => ({
+	betterFetch: vi.fn(),
+}));
+
+import { betterFetch } from "@better-fetch/fetch";
+
+import { reddit } from "./reddit";
+
+const mockedBetterFetch = vi.mocked(betterFetch);
+
+const options = {
+	clientId: "reddit-app",
+	clientSecret: "reddit-secret",
+};
+
+function profileResponse(profile: Record<string, unknown>) {
+	return { data: profile, error: null } as Awaited<
+		ReturnType<typeof betterFetch>
+	>;
+}
+
+describe("reddit.getUserInfo (no provider email)", () => {
+	beforeEach(() => {
+		mockedBetterFetch.mockReset();
+	});
+
+	it("synthesizes a non-routable placeholder email and never trusts oauth_client_id", async () => {
+		mockedBetterFetch.mockResolvedValue(
+			profileResponse({
+				id: "reddit-user-1",
+				name: "spez",
+				icon_img: "https://example.com/avatar.png",
+				has_verified_email: true,
+				oauth_client_id: "shared-app-client-id",
+				verified: true,
+			}),
+		);
+		const provider = reddit(options);
+		const res = await provider.getUserInfo({
+			accessToken: "access-token",
+		} as any);
+
+		expect(res?.user.email).toBe("reddit-user-1@reddit.invalid");
+		// `has_verified_email` describes the user's real Reddit email, not the
+		// synthetic placeholder, so the placeholder must never be marked verified.
+		expect(res?.user.emailVerified).toBe(false);
+		// The OAuth app's client id must never become the user's identity anchor.
+		expect(res?.user.email).not.toContain("shared-app-client-id");
+	});
+
+	it("gives distinct users distinct placeholder emails", async () => {
+		const provider = reddit(options);
+
+		mockedBetterFetch.mockResolvedValue(
+			profileResponse({
+				id: "user-a",
+				name: "a",
+				icon_img: null,
+				has_verified_email: true,
+				oauth_client_id: "same-client",
+				verified: true,
+			}),
+		);
+		const a = await provider.getUserInfo({ accessToken: "t-a" } as any);
+
+		mockedBetterFetch.mockResolvedValue(
+			profileResponse({
+				id: "user-b",
+				name: "b",
+				icon_img: null,
+				has_verified_email: true,
+				oauth_client_id: "same-client",
+				verified: true,
+			}),
+		);
+		const b = await provider.getUserInfo({ accessToken: "t-b" } as any);
+
+		expect(a?.user.email).toBe("user-a@reddit.invalid");
+		expect(b?.user.email).toBe("user-b@reddit.invalid");
+		expect(a?.user.email).not.toBe(b?.user.email);
+	});
+
+	it("lets mapProfileToUser supply a real email", async () => {
+		mockedBetterFetch.mockResolvedValue(
+			profileResponse({
+				id: "reddit-user-2",
+				name: "mapped",
+				icon_img: null,
+				has_verified_email: true,
+				oauth_client_id: "client",
+				verified: true,
+			}),
+		);
+		const provider = reddit({
+			...options,
+			mapProfileToUser: () => ({ email: "real@example.com" }),
+		});
+		const res = await provider.getUserInfo({ accessToken: "t" } as any);
+
+		expect(res?.user.email).toBe("real@example.com");
+	});
+});

--- a/packages/core/src/social-providers/reddit.ts
+++ b/packages/core/src/social-providers/reddit.ts
@@ -104,7 +104,11 @@ export const reddit = (options: RedditOptions) => {
 			}
 
 			const userMap = await options.mapProfileToUser?.(profile);
-			const email = userMap?.email || `${profile.id}@reddit.com`;
+			// Reddit's identity scope does not return an email. Synthesize a stable,
+			// non-routable placeholder (RFC 2606 `.invalid`) keyed to the user's
+			// Reddit id rather than the routable `reddit.com`, which could collide
+			// with a real address. Left unverified; `mapProfileToUser` can override.
+			const email = userMap?.email || `${profile.id}@reddit.invalid`;
 			return {
 				user: {
 					id: profile.id,

--- a/packages/core/src/social-providers/wechat.test.ts
+++ b/packages/core/src/social-providers/wechat.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@better-fetch/fetch", () => ({
+	betterFetch: vi.fn(),
+}));
+
+import { betterFetch } from "@better-fetch/fetch";
+
+import { wechat } from "./wechat";
+
+const mockedBetterFetch = vi.mocked(betterFetch);
+
+const options = {
+	clientId: "wx-app",
+	clientSecret: "wx-secret",
+};
+
+function profileResponse(profile: Record<string, unknown>) {
+	return { data: profile, error: null } as Awaited<
+		ReturnType<typeof betterFetch>
+	>;
+}
+
+describe("wechat.getUserInfo (no provider email)", () => {
+	beforeEach(() => {
+		mockedBetterFetch.mockReset();
+	});
+
+	it("synthesizes a non-routable placeholder email keyed to unionid", async () => {
+		mockedBetterFetch.mockResolvedValue(
+			profileResponse({
+				openid: "open-123",
+				unionid: "union-abc",
+				nickname: "WeChat User",
+				headimgurl: "https://example.com/avatar.png",
+			}),
+		);
+		const provider = wechat(options);
+		const res = await provider.getUserInfo({
+			accessToken: "access-token",
+			openid: "open-123",
+		} as any);
+
+		expect(res?.user.email).toBe("union-abc@wechat.invalid");
+		expect(res?.user.emailVerified).toBe(false);
+		expect(res?.user.id).toBe("union-abc");
+	});
+
+	it("falls back to openid for the placeholder when unionid is absent", async () => {
+		mockedBetterFetch.mockResolvedValue(
+			profileResponse({
+				openid: "open-456",
+				nickname: "No Union",
+				headimgurl: "https://example.com/avatar.png",
+			}),
+		);
+		const provider = wechat(options);
+		const res = await provider.getUserInfo({
+			accessToken: "access-token",
+			openid: "open-456",
+		} as any);
+
+		expect(res?.user.email).toBe("open-456@wechat.invalid");
+		expect(res?.user.emailVerified).toBe(false);
+	});
+
+	it("lets mapProfileToUser supply a real email", async () => {
+		mockedBetterFetch.mockResolvedValue(
+			profileResponse({
+				openid: "open-789",
+				unionid: "union-xyz",
+				nickname: "Mapped User",
+				headimgurl: "https://example.com/avatar.png",
+			}),
+		);
+		const provider = wechat({
+			...options,
+			mapProfileToUser: () => ({ email: "real@example.com" }),
+		});
+		const res = await provider.getUserInfo({
+			accessToken: "access-token",
+			openid: "open-789",
+		} as any);
+
+		expect(res?.user.email).toBe("real@example.com");
+	});
+
+	it("returns null when the token carries no openid", async () => {
+		const provider = wechat(options);
+		const res = await provider.getUserInfo({
+			accessToken: "access-token",
+		} as any);
+
+		expect(res).toBeNull();
+		expect(mockedBetterFetch).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/social-providers/wechat.ts
+++ b/packages/core/src/social-providers/wechat.ts
@@ -200,7 +200,14 @@ export const wechat = (options: WeChatOptions) => {
 				user: {
 					id: profile.unionid || profile.openid || openid,
 					name: profile.nickname,
-					email: profile.email || null,
+					// WeChat does not return an email, and the OAuth callback rejects a
+					// missing one, so the default sign-in would always fail. Synthesize a
+					// stable, non-routable placeholder (RFC 2606 `.invalid`) keyed to the
+					// user's WeChat id, left unverified. Applications that collect a real
+					// email override it via `mapProfileToUser`.
+					email:
+						profile.email ||
+						`${profile.unionid || profile.openid || openid}@wechat.invalid`,
 					image: profile.headimgurl,
 					emailVerified: false,
 					...userMap,

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -20,7 +20,11 @@ import type {
 	SSOOptions,
 	SSOProvider,
 } from "../types";
-import { safeJsonParse, validateEmailDomain } from "../utils";
+import {
+	parseProviderEmailVerified,
+	safeJsonParse,
+	validateEmailDomain,
+} from "../utils";
 import { createIdP, createSP, findSAMLProvider } from "./helpers";
 
 type RelayState = Awaited<ReturnType<typeof parseRelayState>>;
@@ -389,7 +393,7 @@ export async function processSAMLResponse(
 			extract.nameID,
 		emailVerified:
 			options?.trustEmailVerified && mapping.emailVerified
-				? ((attr(mapping.emailVerified) || false) as boolean)
+				? parseProviderEmailVerified(attr(mapping.emailVerified))
 				: false,
 	};
 	if (!userInfo.id || !userInfo.email) {
@@ -431,7 +435,7 @@ export async function processSAMLResponse(
 				email: userInfo.email as string,
 				name: (userInfo.name || userInfo.email) as string,
 				id: userInfo.id as string,
-				emailVerified: Boolean(userInfo.emailVerified),
+				emailVerified: userInfo.emailVerified,
 			},
 			account: {
 				providerId,
@@ -482,7 +486,7 @@ export async function processSAMLResponse(
 			providerId,
 			accountId: userInfo.id as string,
 			email: userInfo.email as string,
-			emailVerified: Boolean(userInfo.emailVerified),
+			emailVerified: userInfo.emailVerified,
 			rawAttributes: attributes,
 		},
 		provider,

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -49,6 +49,7 @@ import type {
 import {
 	domainMatches,
 	normalizePem,
+	parseProviderEmailVerified,
 	safeJsonParse,
 	validateEmailDomain,
 } from "../utils";
@@ -1608,9 +1609,9 @@ async function handleOIDCCallback(
 			id: rawUserInfo[mapping.id || "sub"] as string | undefined,
 			email: rawUserInfo[mapping.email || "email"] as string | undefined,
 			emailVerified: options?.trustEmailVerified
-				? (rawUserInfo[mapping.emailVerified || "email_verified"] as
-						| boolean
-						| undefined)
+				? parseProviderEmailVerified(
+						rawUserInfo[mapping.emailVerified || "email_verified"],
+					)
 				: false,
 			name: rawUserInfo[mapping.name || "name"] as string | undefined,
 			image: rawUserInfo[mapping.image || "picture"] as string | undefined,
@@ -1653,7 +1654,9 @@ async function handleOIDCCallback(
 			id: idToken[mapping.id || "sub"],
 			email: idToken[mapping.email || "email"],
 			emailVerified: options?.trustEmailVerified
-				? idToken[mapping.emailVerified || "email_verified"]
+				? parseProviderEmailVerified(
+						idToken[mapping.emailVerified || "email_verified"],
+					)
 				: false,
 			name: idToken[mapping.name || "name"],
 			image: idToken[mapping.image || "picture"],

--- a/packages/sso/src/utils.test.ts
+++ b/packages/sso/src/utils.test.ts
@@ -1,5 +1,41 @@
 import { describe, expect, it } from "vitest";
-import { getHostnameFromDomain, validateEmailDomain } from "./utils";
+import {
+	getHostnameFromDomain,
+	parseProviderEmailVerified,
+	validateEmailDomain,
+} from "./utils";
+
+describe("parseProviderEmailVerified", () => {
+	it('treats only boolean true and the string "true" as verified', () => {
+		expect(parseProviderEmailVerified(true)).toBe(true);
+		expect(parseProviderEmailVerified("true")).toBe(true);
+	});
+
+	it('treats the string "false" as unverified (the coercion bug)', () => {
+		expect(parseProviderEmailVerified("false")).toBe(false);
+	});
+
+	it("treats every other value as unverified", () => {
+		for (const value of [
+			false,
+			"False",
+			"TRUE",
+			"0",
+			"1",
+			0,
+			1,
+			"",
+			" ",
+			undefined,
+			null,
+			{},
+			[],
+			["true"],
+		]) {
+			expect(parseProviderEmailVerified(value)).toBe(false);
+		}
+	});
+});
 
 /**
  * @see https://github.com/better-auth/better-auth/issues/7324

--- a/packages/sso/src/utils.ts
+++ b/packages/sso/src/utils.ts
@@ -45,6 +45,18 @@ export const domainMatches = (searchDomain: string, domainList: string) => {
 };
 
 /**
+ * Strictly parse a provider-supplied email-verification claim.
+ *
+ * OIDC userInfo, OIDC id-token, and SAML attribute values are frequently
+ * strings, so a loose `Boolean(value)` or truthy fallback treats the string
+ * `"false"` as verified. Only a boolean `true` or the exact string `"true"`
+ * count as verified; every other value, including `"false"`, `"0"`, `""`,
+ * numbers, arrays, and objects, is unverified.
+ */
+export const parseProviderEmailVerified = (value: unknown): boolean =>
+	value === true || value === "true";
+
+/**
  * Validates email domain against allowed domain(s).
  * Supports comma-separated domains for multi-domain SSO.
  */


### PR DESCRIPTION
Several provider sign-in paths accepted provider-supplied identity data without fully validating it. Each item below closes one such gap.

- **Google One Tap** treated the expected audience as optional. With no Google client ID configured it verified the token's signature and issuer but not that the token was minted for this app, so a token issued to another Google client was accepted. The callback now resolves a client ID and fails closed when none is configured.
- **Microsoft Entra ID** skipped issuer validation for the `organizations` and `consumers` tenant modes. Those two key sets overlap, so the account-class restriction was not actually enforced. Verification now binds the token to its own tenant and rejects the disallowed account class.
- **SSO** read OIDC `email_verified` claims and SAML attributes loosely. Since the values arrive as strings, `"false"` passed as verified. They are now parsed so only a real `true` counts.
- **WeChat** returns no email while the OAuth callback requires one, so the documented default sign-in could never complete. It now supplies a stable placeholder email, still overridable through `mapProfileToUser`.
- **Reddit's** placeholder email for users without a Reddit email used the routable `reddit.com` domain. It now uses a non-routable `.invalid` domain so it cannot match a real mailbox.

Each change only rejects tokens or claim values that were never legitimately valid, or makes a broken default work, so a correctly configured integration sees no behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened identity validation for Google One Tap, Microsoft Entra ID, SSO, WeChat, and Reddit. Tokens are now audience- and tenant‑bound, email verification is parsed strictly, and providers without emails use safe, non‑routable placeholders.

- **Bug Fixes**
  - Google One Tap: require a Google client ID and enforce the ID token audience; reject the callback when none is set.
  - Microsoft Entra ID: enforce tenant restriction for `organizations` and `consumers`; bind issuer to the token’s tenant; accept and safely trim a trailing slash in `authority`; reject the disallowed account class.
  - SSO (OIDC/SAML): parse `email_verified` strictly; only boolean true or the string "true" counts as verified.
  - WeChat: synthesize a stable, unverified `.invalid` placeholder email so the default flow works; overridable via `mapProfileToUser`.
  - Reddit: use a non‑routable `.invalid` placeholder email for users without a Reddit email; stays unverified and overridable.

- **Migration**
  - One Tap: set the Google client ID on the `oneTap` plugin (`clientId`) or on `socialProviders.google`.

<sup>Written for commit 1d2762431aeb6bdaaa2999582f29feed65376d3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

