### PR TITLE
feat(captcha)!: support wildcard endpoint matching

### DIFF
--- a/.changeset/captcha-wildcard-endpoints.md
+++ b/.changeset/captcha-wildcard-endpoints.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+The captcha plugin now requires endpoint entries to match full auth paths unless they use wildcard patterns. This prevents requests like `/sign-in//email` from bypassing captcha while preserving trailing-slash matches like `/sign-in/email/`. To protect multiple routes, replace partial paths like `/sign-in` with explicit wildcards such as `/sign-in/*` or `/sign-in/**`.

--- a/docs/content/docs/plugins/captcha.mdx
+++ b/docs/content/docs/plugins/captcha.mdx
@@ -88,7 +88,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 
 * **`provider` (required)**: your captcha provider.
 * **`secretKey` (required)**: your provider's secret key used for the server-side validation.
-* `endpoints` (optional): replaces the default array of paths where captcha verification is enforced. If set, only the specified paths will be protected. Default is `["/sign-up/email", "/sign-in/email", "/request-password-reset"]`.
+* `endpoints` (optional): replaces the default array of paths where captcha verification is enforced. If set, only the specified paths will be protected. Paths match exactly unless they include wildcards, such as `/sign-in/*` for one segment or `/sign-in/**` for nested routes. Default is `["/sign-up/email", "/sign-in/email", "/request-password-reset"]`.
 * `minScore` (optional - only *Google ReCAPTCHA v3*): minimum score threshold. Default is `0.5`.
 * `siteKey` (optional - only *hCaptcha* and *CaptchaFox*): prevents tokens issued on one sitekey from being redeemed elsewhere.
 * `siteVerifyURLOverride` (optional): overrides endpoint URL for the captcha verification request.

--- a/packages/better-auth/src/plugins/captcha/captcha.test.ts
+++ b/packages/better-auth/src/plugins/captcha/captcha.test.ts
@@ -517,5 +517,177 @@ describe("captcha", async () => {
 				code: "MISSING_RESPONSE",
 			});
 		});
+
+		it("should still apply captcha when a protected pathname contains duplicate slashes", async () => {
+			const { auth } = await getTestInstance({
+				plugins: [
+					captcha({
+						provider: "cloudflare-turnstile",
+						secretKey: "xx-secret-key",
+					}),
+				],
+			});
+
+			const res = await auth.handler(
+				new Request("http://localhost:3000/api/auth/sign-in//email", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						email: "test@test.com",
+						password: "test123456",
+					}),
+				}),
+			);
+
+			expect(res.status).toBe(400);
+			expect(await res.json()).toMatchObject({
+				code: "MISSING_RESPONSE",
+			});
+		});
+
+		it("should still apply captcha when a protected pathname has a trailing slash", async () => {
+			const { auth } = await getTestInstance({
+				plugins: [
+					captcha({
+						provider: "cloudflare-turnstile",
+						secretKey: "xx-secret-key",
+					}),
+				],
+			});
+
+			const res = await auth.handler(
+				new Request("http://localhost:3000/api/auth/sign-in/email/", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						email: "test@test.com",
+						password: "test123456",
+					}),
+				}),
+			);
+
+			expect(res.status).toBe(400);
+			expect(await res.json()).toMatchObject({
+				code: "MISSING_RESPONSE",
+			});
+		});
+
+		it("should not treat partial endpoint paths as matches", async () => {
+			const { client } = await getTestInstance({
+				plugins: [
+					captcha({
+						provider: "cloudflare-turnstile",
+						secretKey: "xx-secret-key",
+						endpoints: ["/sign-in"],
+					}),
+				],
+			});
+
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+			});
+
+			expect(res.error).toBeNull();
+			expect(res.data?.user?.email).toBe("test@test.com");
+		});
+
+		it("should not apply captcha to sub-routes of default protected endpoints", async () => {
+			const { auth } = await getTestInstance({
+				plugins: [
+					captcha({
+						provider: "cloudflare-turnstile",
+						secretKey: "xx-secret-key",
+					}),
+				],
+			});
+
+			const res = await auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sign-in/email/extra-segment",
+					{
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify({}),
+					},
+				),
+			);
+
+			expect(res.status).not.toBe(400);
+		});
+	});
+
+	describe("wildcard endpoints", () => {
+		it("should apply captcha to single-segment wildcard matches", async () => {
+			const { auth } = await getTestInstance({
+				plugins: [
+					captcha({
+						provider: "cloudflare-turnstile",
+						secretKey: "xx-secret-key",
+						endpoints: ["/sign-in/*"],
+					}),
+				],
+			});
+
+			const res = await auth.handler(
+				new Request("http://localhost:3000/api/auth/sign-in/email-otp", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({}),
+				}),
+			);
+
+			expect(res.status).toBe(400);
+			expect(await res.json()).toMatchObject({
+				code: "MISSING_RESPONSE",
+			});
+		});
+
+		it("should not match nested routes with a single-segment wildcard", async () => {
+			const { auth } = await getTestInstance({
+				plugins: [
+					captcha({
+						provider: "cloudflare-turnstile",
+						secretKey: "xx-secret-key",
+						endpoints: ["/sign-in/*"],
+					}),
+				],
+			});
+
+			const res = await auth.handler(
+				new Request("http://localhost:3000/api/auth/sign-in/social/google", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({}),
+				}),
+			);
+
+			expect(res.status).not.toBe(400);
+		});
+
+		it("should apply captcha to nested routes with a multi-segment wildcard", async () => {
+			const { auth } = await getTestInstance({
+				plugins: [
+					captcha({
+						provider: "cloudflare-turnstile",
+						secretKey: "xx-secret-key",
+						endpoints: ["/sign-in/**"],
+					}),
+				],
+			});
+
+			const res = await auth.handler(
+				new Request("http://localhost:3000/api/auth/sign-in/social/google", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({}),
+				}),
+			);
+
+			expect(res.status).toBe(400);
+			expect(await res.json()).toMatchObject({
+				code: "MISSING_RESPONSE",
+			});
+		});
 	});
 });

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -1,6 +1,7 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { getIp } from "../../utils/get-request-ip";
 import { middlewareResponse } from "../../utils/middleware-response";
+import { wildcardMatch } from "../../utils/wildcard";
 import { PACKAGE_VERSION } from "../../version";
 import { defaultEndpoints, Providers, siteVerifyMap } from "./constants";
 import { EXTERNAL_ERROR_CODES, INTERNAL_ERROR_CODES } from "./error-codes";
@@ -18,6 +19,20 @@ import * as verifyHandlers from "./verify-handlers";
 
 export type * from "./types";
 
+const normalizeEndpointPath = (pathname: string, basePath: string) => {
+	const pathWithoutBase = pathname.startsWith(basePath)
+		? pathname.slice(basePath.length)
+		: pathname;
+	let normalizedPathname = pathWithoutBase.replace(/\/{2,}/g, "/");
+	if (!normalizedPathname.startsWith("/")) {
+		normalizedPathname = `/${normalizedPathname}`;
+	}
+	if (normalizedPathname.length > 1 && normalizedPathname.endsWith("/")) {
+		normalizedPathname = normalizedPathname.slice(0, -1);
+	}
+	return normalizedPathname;
+};
+
 export const captcha = (options: CaptchaOptions) =>
 	({
 		id: "captcha",
@@ -31,30 +46,13 @@ export const captcha = (options: CaptchaOptions) =>
 
 				const url = new URL(request.url);
 				const basePath = ctx.options.basePath ?? "/api/auth";
-				let pathname = url.pathname.replace(basePath, "");
+				const pathname = normalizeEndpointPath(url.pathname, basePath);
 
-				// remove trailing or leading slashes & add leading slash if not present
-				if (pathname.endsWith("//")) pathname = pathname.slice(0, -1);
-				if (pathname.startsWith("//")) pathname = pathname.slice(1);
-				if (!pathname.startsWith("/")) pathname = "/" + pathname;
-
-				// we don't want to accidentally block email-otp endpoint.
-				const exemptPaths = ["/sign-in/email-otp"].reduce<string[]>(
-					(acc, curr) => {
-						// if custom endpoints include an exempt path, we don't include the exempt path in the exempt paths array
-						if (options.endpoints?.length && options.endpoints.includes(curr)) {
-							return acc;
-						}
-						return [...acc, curr];
-					},
-					[],
+				const match = endpoints.some((endpoint) =>
+					endpoint.includes("*")
+						? wildcardMatch(endpoint)(pathname)
+						: endpoint === pathname,
 				);
-				const match = endpoints.some((endpoint) => {
-					return (
-						pathname.includes(endpoint) &&
-						!exemptPaths.some((p) => pathname.includes(p))
-					);
-				});
 
 				if (!match) {
 					return undefined;

--- a/packages/better-auth/src/plugins/captcha/types.ts
+++ b/packages/better-auth/src/plugins/captcha/types.ts
@@ -4,6 +4,10 @@ export type Provider = (typeof Providers)[keyof typeof Providers];
 
 export interface BaseCaptchaOptions {
 	secretKey: string;
+	/**
+	 * Paths where captcha verification is enforced. Paths match exactly unless
+	 * they include wildcards, such as `/sign-in/*` or `/sign-in/**`.
+	 */
 	endpoints?: string[] | undefined;
 	siteVerifyURLOverride?: string | undefined;
 }


### PR DESCRIPTION
> [!IMPORTANT]
> _**Behavior change:**_
> 
> If you relied on substring matching in captcha endpoints, replace those entries with exact paths or explicit wildcards.
> 
> This is more flexible and accurate, and aligns with other matching patterns in the project.

- Closes #9599