### PR TITLE
fix(cli): skip `Unsupported()` fields when regenerating prisma schema

### DIFF
--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -242,7 +242,7 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 						within: prismaModel.properties,
 					});
 					if (isAlreadyExist) {
-						if (fieldType) {
+						if (fieldType && typeof isAlreadyExist.fieldType === "string") {
 							const fieldTypeParts = getFieldTypeParts(fieldType);
 							const existingFieldTypeParts = getFieldTypeParts(
 								isAlreadyExist.fieldType,


### PR DESCRIPTION
Fixing typecheck

Related to https://github.com/better-auth/better-auth/pull/9729