### PR TITLE
fix: cloudflare runtime require helper

### DIFF
--- a/.changeset/cloudflare-create-require-runtime.md
+++ b/.changeset/cloudflare-create-require-runtime.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Cloudflare Workers apps can now start when importing Better Auth subpaths such as `better-auth/db`. Beta builds were crashing during module initialization before application code ran.

--- a/.postmortem/cloudflare-create-require-runtime.md
+++ b/.postmortem/cloudflare-create-require-runtime.md
@@ -1,0 +1,109 @@
+# Postmortem: Cloudflare Workers `createRequire` Runtime Helper
+
+## Issue Reference
+
+* [Issue #9983](https://github.com/better-auth/better-auth/issues/9983)
+* [Issue #6690](https://github.com/better-auth/better-auth/issues/6690)
+* [Issue #6665](https://github.com/better-auth/better-auth/issues/6665)
+* [Issue #6638](https://github.com/better-auth/better-auth/issues/6638)
+* [PR #6704](https://github.com/better-auth/better-auth/pull/6704)
+* [PR #9657](https://github.com/better-auth/better-auth/pull/9657)
+
+## Summary
+
+`better-auth@1.7.0-beta.4` and `1.7.0-beta.5` reintroduced the Cloudflare
+Workers startup crash previously seen in the 1.4.6 release line. The published
+`better-auth` package emitted this shared rolldown runtime helper:
+
+```js
+import { createRequire } from "node:module";
+
+var __require = /* @__PURE__ */ createRequire(import.meta.url);
+```
+
+Cloudflare Workers can leave `import.meta.url` undefined in bundled output, so
+the package crashed at module evaluation time before application code ran. The
+crash affected unrelated subpaths such as `better-auth/db` because the helper
+lived in the shared `_virtual/_rolldown/runtime.mjs` file imported by many
+entries, not only by the Node-specific code that needed CommonJS interop.
+
+## Recurrence History
+
+This class of bug has already recurred once:
+
+1. **1.4.6 reports (#6638, #6665, #6690)**: Cloudflare Workers crashed during
+   startup because bundled output eagerly called `createRequire(import.meta.url)`.
+2. **PR #6704**: Added a Cloudflare smoke test that fails if Wrangler output
+   contains `createRequire`, `node:module`, or selected Node-only modules.
+3. **PR #9657**: Added `getHttpTestInstance` to `better-auth/test`. The helper
+   statically imported `listhen`, which pulled in CommonJS-oriented Node server
+   dependencies when the `better-auth` multi-entry package was built.
+4. **1.7.0-beta.4 and beta.5**: The published package again contained the eager
+   shared rolldown `__require` helper. The existing smoke test did not fail
+   because it checked Wrangler's final bundle, not the published package runtime
+   helper itself.
+
+## Root Cause
+
+### Test-only dependencies polluted the shared package runtime
+
+`packages/better-auth/src/test-utils/index.ts` statically re-exported
+`http-test-instance.ts`, and that file statically imported `listhen`.
+
+Because `better-auth/test` is built as an entry in the same `better-auth`
+multi-entry build, rolldown included `listhen` and its transitive dependencies
+under `dist/node_modules/`. Some of those dependencies need CommonJS interop, so
+rolldown added `__require` to the shared runtime helper.
+
+The helper was shared across unrelated entries. A consumer importing
+`better-auth/db` did not import `better-auth/test`, but still evaluated the
+same runtime helper and crashed in Workers.
+
+### The existing smoke test checked the wrong boundary
+
+The Cloudflare smoke test checked `e2e/smoke/test/fixtures/cloudflare/dist/index.js`
+after Wrangler had bundled and tree-shaken the fixture. That is still useful,
+but it did not inspect the built `packages/better-auth/dist/_virtual/_rolldown/runtime.mjs`
+file that npm publishes.
+
+The package runtime helper is the earlier contract boundary. Once it contains an
+eager `createRequire(import.meta.url)`, any downstream bundler that preserves the
+helper can crash even if another fixture bundle happens to tree-shake it away.
+
+## Fix
+
+`getHttpTestInstance` now uses `node:http.createServer()` directly instead of
+`listhen`. The helper only needs an OS-assigned local HTTP port and a
+promise-returning `close()` method, so the external listener dependency was
+unnecessary.
+
+The Cloudflare smoke test now checks two boundaries:
+
+1. Wrangler's final Worker bundle still must not contain `createRequire`,
+   `node:fs`, or `node:module`.
+2. The built `better-auth` rolldown runtime helper must not contain
+   `createRequire`, `node:module`, or `__require`.
+
+## Lesson Learned
+
+1. **Package runtime helpers are part of the edge-runtime contract.** Checking
+   only the final app bundle can miss a published-package regression.
+2. **A test-only export can poison runtime entries in a multi-entry package.**
+   If a subpath is built in the same package, static imports can alter shared
+   helpers used by unrelated subpaths.
+3. **Do not add external listener/server dependencies to `better-auth/test`
+   unless the built package runtime is checked afterward.** Prefer Node built-ins
+   for test helpers when they are sufficient.
+4. **Generated `dist` can be stale locally.** Rebuild before declaring this class
+   fixed or unaffected.
+
+## Prevention
+
+1. Keep the Cloudflare smoke test's direct assertion on
+   `packages/better-auth/dist/_virtual/_rolldown/runtime.mjs`.
+2. When reviewing changes to `packages/better-auth/src/test-utils`, rebuild
+   `better-auth` and scan the generated runtime helper for `createRequire`,
+   `node:module`, and `__require`.
+3. Reject fixes that only guard `createRequire(import.meta.url)` in generated
+   output. The safer fix is to avoid introducing CommonJS interop into the
+   shared runtime helper in the first place.

--- a/e2e/smoke/test/cloudflare.spec.ts
+++ b/e2e/smoke/test/cloudflare.spec.ts
@@ -6,47 +6,69 @@ import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const fixturesDir = fileURLToPath(new URL("./fixtures", import.meta.url));
+const repoDir = fileURLToPath(new URL("../../..", import.meta.url));
+
+const assertContentDoesNotInclude = (
+	fileName: string,
+	content: string,
+	unexpectedContents: Iterable<string>,
+) => {
+	for (const unexpectedContent of unexpectedContents) {
+		assert(
+			!content.includes(unexpectedContent),
+			`${fileName} should not contain "${unexpectedContent}"`,
+		);
+	}
+};
 
 describe("(cloudflare) simple server", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9983
+	 */
 	it("check repo", async (t) => {
-		const cp = spawn("npm", ["run", "check"], {
+		const cp = spawn("pnpm", ["run", "check"], {
 			cwd: join(fixturesDir, "cloudflare"),
 			stdio: "pipe",
 		});
+		let stdout = "";
+		let stderr = "";
 
 		t.after(() => {
-			cp.kill("SIGINT");
+			if (cp.exitCode === null) {
+				cp.kill("SIGINT");
+			}
 		});
 
 		const unexpectedWarnings = new Set(["node:sqlite", "node:async_hooks"]);
+		const exitMarker = "exiting now.";
 
 		cp.stdout.on("data", (data) => {
-			console.log(data.toString());
-			for (const str of unexpectedWarnings) {
-				assert(
-					!data.toString().includes(str),
-					`Output should not contain "${str}"`,
-				);
-			}
+			const text = data.toString();
+			stdout += text;
+			console.log(text);
+			assertContentDoesNotInclude("stdout", stdout, unexpectedWarnings);
 		});
 
 		cp.stderr.on("data", (data) => {
-			console.error(data.toString());
-			for (const str of unexpectedWarnings) {
-				assert(
-					!data.toString().includes(str),
-					`Error output should not contain "${str}"`,
-				);
-			}
+			const text = data.toString();
+			stderr += text;
+			console.error(text);
+			assertContentDoesNotInclude("stderr", stderr, unexpectedWarnings);
 		});
 
-		await new Promise<void>((resolve) => {
-			cp.stdout.on("data", (data) => {
-				if (data.toString().includes("exiting now.")) {
-					resolve();
-				}
-			});
+		const exitCode = await new Promise<number | null>((resolve, reject) => {
+			cp.on("error", reject);
+			cp.on("close", resolve);
 		});
+		assert.equal(
+			exitCode,
+			0,
+			`Cloudflare fixture check failed.\n\nstdout:\n${stdout}\n\nstderr:\n${stderr}`,
+		);
+		assert(
+			stdout.includes(exitMarker),
+			`Cloudflare fixture check exited before Wrangler completed.\n\nstdout:\n${stdout}\n\nstderr:\n${stderr}`,
+		);
 
 		const indexJs = await fs.readFile(
 			join(fixturesDir, "cloudflare", "dist", "index.js"),
@@ -58,11 +80,25 @@ describe("(cloudflare) simple server", () => {
 			"node:fs",
 			"node:module",
 		]);
-		for (const content of unexpectedContents) {
-			assert(
-				!indexJs.includes(content),
-				`index.js should not contain "${content}"`,
-			);
-		}
+		assertContentDoesNotInclude("index.js", indexJs, unexpectedContents);
+
+		const rolldownRuntime = await fs.readFile(
+			join(
+				repoDir,
+				"packages",
+				"better-auth",
+				"dist",
+				"_virtual",
+				"_rolldown",
+				"runtime.mjs",
+			),
+			"utf-8",
+		);
+
+		assertContentDoesNotInclude(
+			"better-auth rolldown runtime",
+			rolldownRuntime,
+			["createRequire", "node:module", "__require"],
+		);
 	});
 });

--- a/packages/better-auth/src/test-utils/http-test-instance.ts
+++ b/packages/better-auth/src/test-utils/http-test-instance.ts
@@ -1,9 +1,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import type {
 	BetterAuthClientOptions,
 	BetterAuthOptions,
 } from "@better-auth/core";
-import { listen } from "listhen";
 import { toNodeHandler } from "../integrations/node";
 import { getTestInstance } from "./test-instance";
 
@@ -11,6 +12,13 @@ type NodeRequestHandler = (
 	req: IncomingMessage,
 	res: ServerResponse,
 ) => unknown | Promise<unknown>;
+
+type TestHttpServer = {
+	url: string;
+	address: AddressInfo;
+	server: ReturnType<typeof createServer>;
+	close: () => Promise<void>;
+};
 
 type GetTestInstanceConfig = NonNullable<Parameters<typeof getTestInstance>[1]>;
 
@@ -31,6 +39,29 @@ export type HttpTestInstanceConfig<C extends BetterAuthClientOptions> = Omit<
 	handler?: (
 		auth: Awaited<ReturnType<typeof getTestInstance>>["auth"],
 	) => NodeRequestHandler;
+};
+
+const closeHttpServer = (server: ReturnType<typeof createServer>) =>
+	new Promise<void>((resolve, reject) => {
+		server.close((error) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolve();
+		});
+	});
+
+const endUnhandledErrorResponse = (res: ServerResponse, error: unknown) => {
+	if (res.writableEnded || res.destroyed) {
+		return;
+	}
+	if (res.headersSent) {
+		res.end();
+		return;
+	}
+	res.statusCode = 500;
+	res.end(error instanceof Error ? error.message : "Internal Server Error");
 };
 
 /**
@@ -56,17 +87,39 @@ export async function getHttpTestInstance<
 		res.end("Test HTTP listener has no handler bound yet");
 	};
 
-	const server = await listen((req, res) => activeHandler(req, res), {
-		port: 0,
+	const nodeServer = createServer((req, res) => {
+		void Promise.resolve(activeHandler(req, res)).catch((error: unknown) => {
+			endUnhandledErrorResponse(res, error);
+		});
 	});
-	const boundPort = server.address?.port;
-	if (typeof boundPort !== "number") {
-		await server.close();
+	await new Promise<void>((resolve, reject) => {
+		const onError = (error: Error) => {
+			nodeServer.off("listening", onListening);
+			reject(error);
+		};
+		const onListening = () => {
+			nodeServer.off("error", onError);
+			resolve();
+		};
+		nodeServer.once("error", onError);
+		nodeServer.once("listening", onListening);
+		nodeServer.listen(0, "127.0.0.1");
+	});
+
+	const address = nodeServer.address();
+	if (!address || typeof address === "string") {
+		await closeHttpServer(nodeServer);
 		throw new Error(
-			"listhen did not report a bound port for the test listener",
+			"HTTP test listener did not report a bound port for the test listener",
 		);
 	}
-	const baseURL = `http://localhost:${boundPort}`;
+	const baseURL = `http://127.0.0.1:${address.port}`;
+	const server: TestHttpServer = {
+		url: baseURL,
+		address,
+		server: nodeServer,
+		close: () => closeHttpServer(nodeServer),
+	};
 
 	try {
 		const instance = await getTestInstance(
@@ -81,7 +134,7 @@ export async function getHttpTestInstance<
 		activeHandler = config?.handler
 			? config.handler(instance.auth as never)
 			: toNodeHandler(instance.auth.handler);
-		return { ...instance, server, baseURL, port: boundPort };
+		return { ...instance, server, baseURL, port: address.port };
 	} catch (error) {
 		await server.close();
 		throw error;


### PR DESCRIPTION
Cloudflare Workers could crash while evaluating Better Auth subpath imports because a test-only listener dependency added CommonJS interop to the package's shared rolldown runtime helper.

This removes that external listener dependency and implements the helper with `node:http`, which keeps the test utility Node-only without changing the published runtime helper for edge imports. The Cloudflare smoke test now checks the published `better-auth` runtime helper directly, in addition to the final Wrangler bundle, so a tree-shaken fixture bundle cannot hide this regression again.

Also records the recurrence history and prevention notes in `.postmortem/cloudflare-create-require-runtime.md`.

Fixes #9983


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Cloudflare Workers crash caused by an eager `createRequire(import.meta.url)` helper leaking into the shared `better-auth` runtime. Replaces the test HTTP server with `node:http` and hardens the Cloudflare smoke test to verify the published runtime and fixture bundle, fixing #9983.

- **Bug Fixes**
  - Replaced `listhen` with `node:http.createServer()` in `better-auth/test` to avoid pulling CJS interop into the shared rolldown runtime.
  - Cloudflare smoke test now asserts both the Wrangler bundle and the built `better-auth` runtime helper contain no `createRequire`, `node:module`, `__require`, or `node:fs`, and verifies a clean exit with no `node:sqlite` or `node:async_hooks` warnings.
  - Added a postmortem and a patch changeset for `better-auth`.

<sup>Written for commit cef0ba312cc6631fbd7a97332444c636483482ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



