### PR TITLE
docs: render fallback for MDX components missing from synced beta content

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -23,6 +23,7 @@ import {
 	ForkButton,
 	GenerateSecret,
 } from "@/components/docs/mdx-components";
+import { collectMissingMdxFallbacks } from "@/components/docs/missing-mdx-fallback";
 import { Callout } from "@/components/ui/callout";
 import type { DocsVersion } from "@/lib/docs-versions";
 import {
@@ -60,6 +61,72 @@ export default async function Page({
 	const scope = (href: string | undefined) => scopeDocsHref(href, version);
 	const DefaultAnchor = defaultMdxComponents.a;
 
+	const mdxComponents = {
+		...defaultMdxComponents,
+		Step,
+		Steps,
+		Tab,
+		Tabs,
+		Accordion,
+		Accordions,
+		File,
+		Files,
+		Folder,
+		TypeTable,
+		APIMethod,
+		DatabaseTable,
+		ForkButton,
+		AddToCursor,
+		Features,
+		Endpoint,
+		GenerateSecret,
+		DividerText,
+		Callout: ({
+			children,
+			type,
+			...props
+		}: {
+			children: React.ReactNode;
+			type?: "info" | "warn" | "error" | "success" | "warning";
+			[key: string]: any;
+		}) => (
+			<Callout type={type} {...props}>
+				{children}
+			</Callout>
+		),
+		iframe: (props: React.ComponentProps<"iframe">) => (
+			<iframe
+				title="Embedded content"
+				{...props}
+				className="w-full h-[500px]"
+			/>
+		),
+		a: (props: React.ComponentProps<"a">) => (
+			<DefaultAnchor {...props} href={scope(props.href)} />
+		),
+		Link: ({
+			href,
+			className,
+			...props
+		}: React.ComponentProps<typeof Link>) => (
+			<Link
+				href={typeof href === "string" ? (scope(href) ?? href) : href}
+				className={cn("font-medium underline underline-offset-4", className)}
+				{...props}
+			/>
+		),
+	};
+
+	// Beta content is synced from another branch, so it may reference MDX
+	// components this branch doesn't have. Fall back instead of failing the build.
+	const fallbackComponents =
+		version.slug === "beta"
+			? collectMissingMdxFallbacks(
+					await page.data.getText("processed"),
+					mdxComponents,
+				)
+			: undefined;
+
 	return (
 		<DocsPage
 			toc={toc}
@@ -95,66 +162,7 @@ export default async function Page({
 				</div>
 			</div>
 			<DocsBody>
-				<MDX
-					components={{
-						...defaultMdxComponents,
-						Step,
-						Steps,
-						Tab,
-						Tabs,
-						Accordion,
-						Accordions,
-						File,
-						Files,
-						Folder,
-						TypeTable,
-						APIMethod,
-						DatabaseTable,
-						ForkButton,
-						AddToCursor,
-						Features,
-						Endpoint,
-						GenerateSecret,
-						DividerText,
-						Callout: ({
-							children,
-							type,
-							...props
-						}: {
-							children: React.ReactNode;
-							type?: "info" | "warn" | "error" | "success" | "warning";
-							[key: string]: any;
-						}) => (
-							<Callout type={type} {...props}>
-								{children}
-							</Callout>
-						),
-						iframe: (props: React.ComponentProps<"iframe">) => (
-							<iframe
-								title="Embedded content"
-								{...props}
-								className="w-full h-[500px]"
-							/>
-						),
-						a: (props: React.ComponentProps<"a">) => (
-							<DefaultAnchor {...props} href={scope(props.href)} />
-						),
-						Link: ({
-							href,
-							className,
-							...props
-						}: React.ComponentProps<typeof Link>) => (
-							<Link
-								href={typeof href === "string" ? (scope(href) ?? href) : href}
-								className={cn(
-									"font-medium underline underline-offset-4",
-									className,
-								)}
-								{...props}
-							/>
-						),
-					}}
-				/>
+				<MDX components={{ ...fallbackComponents, ...mdxComponents }} />
 			</DocsBody>
 		</DocsPage>
 	);

--- a/docs/components/docs/missing-mdx-fallback.tsx
+++ b/docs/components/docs/missing-mdx-fallback.tsx
@@ -1,0 +1,39 @@
+import type { ComponentType } from "react";
+import { Callout } from "@/components/ui/callout";
+
+/**
+ * Beta docs content is synced from another branch at build time (see
+ * scripts/sync-beta-content.ts), so it can reference MDX components that
+ * don't exist in this branch's app code — e.g. a component that was removed
+ * on `main` while the beta branch still uses it. Rendering such a page would
+ * throw "Expected component `X` to be defined" and fail the whole build.
+ *
+ * This scans the page's markdown for component-like JSX tags and returns a
+ * fallback for every tag the app doesn't provide, so cross-branch drift
+ * degrades to a visible note instead of a failed deploy.
+ */
+const JSX_COMPONENT_TAG = /<([A-Z][A-Za-z0-9]*)/g;
+
+export function collectMissingMdxFallbacks(
+	markdown: string,
+	provided: Record<string, unknown>,
+): Record<string, ComponentType> {
+	const fallbacks: Record<string, ComponentType> = {};
+	for (const [, name] of markdown.matchAll(JSX_COMPONENT_TAG)) {
+		if (name in provided || name in fallbacks) continue;
+		console.warn(
+			`[docs-beta] MDX component \`${name}\` is not provided by this branch; rendering a fallback`,
+		);
+		fallbacks[name] = MissingMdxComponent;
+	}
+	return fallbacks;
+}
+
+function MissingMdxComponent() {
+	return (
+		<Callout type="warn">
+			This section relies on an interactive component that isn't available in
+			this version of the docs.
+		</Callout>
+	);
+}


### PR DESCRIPTION
## Problem

The Vercel docs build on `main` failed while prerendering `/docs/beta/authentication/apple`:

```
Error: Expected component `GenerateAppleJwt` to be defined: you likely forgot to import, pass, or provide it.
```

**Root cause:** `/docs/beta/*` content is synced from the `next` branch at build time (`scripts/sync-beta-content.ts`), while the app code rendering it comes from the deploying branch. #9938 removed the `GenerateAppleJwt` component from `main`'s app code, but `next`'s `apple.mdx` still used `<GenerateAppleJwt />` at deploy time, so the beta page crashed the entire build.

`next` has since been re-synced so today's content no longer triggers it, but the failure mode is structural: it recurs any time a component is removed/renamed on `main` (or added on `next`) while the two branches are out of sync — and it takes down the whole docs deploy.

## Fix

For beta pages only, scan the page's processed markdown for component-like JSX tags (`<PascalCase`) and provide a fallback component for any tag the app doesn't supply. Cross-branch drift now degrades to a visible callout ("This section relies on an interactive component that isn't available in this version of the docs.") plus a build-log warning, instead of a failed deploy.

Stable pages are unchanged: their content and components ship from the same commit, so a missing component there should still fail the build loudly.

## Verification

- Reproduced the exact Vercel failure locally: `main` app code + pre-sync `next` content (with `<GenerateAppleJwt />`) → identical prerender crash
- With this fix, the same build passes; `/docs/beta/authentication/apple` renders the heading with the fallback callout, and `/docs/authentication/apple` (stable) is byte-identical to before
- `tsc --noEmit` passes in `docs/`