### PR TITLE
feat(oauth-provider): support protected dynamic client registration

### DIFF
--- a/.changeset/protected-oauth-registration.md
+++ b/.changeset/protected-oauth-registration.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+Machine clients can now register without a user session. Send an RFC 7591 initial access token in the `Authorization: Bearer` header to `POST /oauth2/register`, and validate it with the new `validateInitialAccessToken` option. This provisions public or confidential clients directly, each optionally tagged with an owner `referenceId`.
+
+The client-creation endpoints now return `201 Created` for a newly created client. They previously responded `200 OK`.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1242,6 +1242,37 @@ oauthProvider({
   For MCP, [`software_statement` and `jwks_uri`](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1032) may be added as an alternative for public client identification in the future.
 </Callout>
 
+Protected dynamic client registration allows machine callers to register public or confidential clients without a Better Auth user session. Issue an RFC 7591 initial access token out of band, then validate the token from the `Authorization: Bearer <token>` header. Defining `validateInitialAccessToken` enables this path; while it is undefined, a Bearer token sent to the registration endpoint is rejected.
+
+```ts title="auth.ts"
+import { createHash, timingSafeEqual } from "node:crypto"
+
+const digest = (value: string) => createHash("sha256").update(value).digest()
+
+oauthProvider({
+  allowDynamicClientRegistration: true,
+  validateInitialAccessToken: async ({ initialAccessToken, clientMetadata }) => {
+    // Compare in constant time; hashing both sides keeps the lengths equal.
+    const expected = digest(process.env.CLIENT_REGISTRATION_TOKEN ?? "")
+    if (!timingSafeEqual(digest(initialAccessToken), expected)) {
+      return false
+    }
+
+    return {
+      referenceId: "infra-provisioner",
+    }
+  },
+})
+```
+
+Return an object with a `referenceId` to attach application ownership metadata to the created client, or return `false` to reject the token. Omitting `referenceId` creates an unowned client. The `clientMetadata` passed to the callback is the submitted request, self-asserted and not yet fully validated, so treat it as untrusted input.
+
+Token issuance, expiration, and revocation stay in your application because RFC 7591 leaves initial access token lifecycle policy to the authorization server. This is separate from RFC 7592 registration management tokens.
+
+<Callout type="info">
+  With the [Bearer](/docs/plugins/bearer) plugin enabled, an `Authorization: Bearer` value that resolves to a valid user session is handled as that session, not as an initial access token.
+</Callout>
+
 #### Dynamic Client Registration Expiration
 
 You can set an expiration time for how long a dynamically registered confidential client should last for. By default, dynamically registered confidential clients do not expire.

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -48,6 +48,7 @@ import { tokenEndpoint } from "./token";
 import type { OAuthOptions, Scope } from "./types";
 import {
 	authorizationQuerySchema,
+	clientRegistrationRequestSchema,
 	ResourceUriSchema,
 	SafeUrlSchema,
 } from "./types/zod";
@@ -1395,57 +1396,21 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				"/oauth2/register",
 				{
 					method: "POST",
-					body: z.object({
-						redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
-						scope: z.string().optional(),
-						client_name: z.string().optional(),
-						client_uri: z.string().optional(),
-						logo_uri: z.string().optional(),
-						contacts: z.array(z.string().min(1)).min(1).optional(),
-						tos_uri: z.string().optional(),
-						policy_uri: z.string().optional(),
-						software_id: z.string().optional(),
-						software_version: z.string().optional(),
-						software_statement: z.string().optional(),
-						post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
-						backchannel_logout_uri: SafeUrlSchema.optional(),
-						backchannel_logout_session_required: z.boolean().optional(),
-						token_endpoint_auth_method: z.string().trim().min(1).optional(),
-						jwks: z
-							.union([
-								z.array(z.record(z.string(), z.unknown())).min(1),
-								z.object({
-									keys: z.array(z.record(z.string(), z.unknown())).min(1),
-								}),
-							])
-							.optional(),
-						jwks_uri: z.string().optional(),
-						grant_types: z.array(z.string().trim().min(1)).min(1).optional(),
-						response_types: z.array(z.enum(["code"])).optional(),
-						type: z.enum(["web", "native", "user-agent-based"]).optional(),
-						subject_type: z.enum(["public", "pairwise"]).optional(),
-						// RFC 7591 §2 extension: declare the resources this client
-						// will request. Each must reference an existing oauthResource
-						// row; the registration handler links them on success.
-						resources: z.array(z.string().min(1)).optional(),
-						skip_consent: z
-							.never({
-								error:
-									"skip_consent cannot be set during dynamic client registration",
-							})
-							.optional(),
-					}),
+					body: clientRegistrationRequestSchema,
 					errorCodesByField: {
 						redirect_uris: "invalid_redirect_uri",
 						post_logout_redirect_uris: "invalid_redirect_uri",
 						software_statement: "invalid_software_statement",
+						// RFC 8707 §2: a malformed resource indicator is invalid_target,
+						// matching the existence check in registerEndpoint.
+						resources: "invalid_target",
 					},
 					defaultError: "invalid_client_metadata",
 					metadata: {
 						openapi: {
 							description: "Register an OAuth2 application",
 							responses: {
-								"200": {
+								"201": {
 									description: "OAuth2 application registered successfully",
 									content: {
 										"application/json": {

--- a/packages/oauth-provider/src/oauthClient/index.ts
+++ b/packages/oauth-provider/src/oauthClient/index.ts
@@ -65,7 +65,7 @@ export const adminCreateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 				openapi: {
 					description: "Register an OAuth2 application",
 					responses: {
-						"200": {
+						"201": {
 							description: "OAuth2 application registered successfully",
 							content: {
 								"application/json": {
@@ -253,7 +253,7 @@ export const createOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 				openapi: {
 					description: "Register an OAuth2 application",
 					responses: {
-						"200": {
+						"201": {
 							description: "OAuth2 application registered successfully",
 							content: {
 								"application/json": {

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -1,9 +1,11 @@
+import { APIError } from "better-auth/api";
 import { createAuthClient } from "better-auth/client";
 import { generateRandomString } from "better-auth/crypto";
 import {
 	authorizationCodeRequest,
 	createAuthorizationURL,
 } from "better-auth/oauth2";
+import { bearer } from "better-auth/plugins";
 import { jwt } from "better-auth/plugins/jwt";
 import type { Organization } from "better-auth/plugins/organization";
 import { organization } from "better-auth/plugins/organization";
@@ -12,6 +14,7 @@ import { beforeAll, describe, expect, it, onTestFinished, vi } from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
 import { resetSeedStateForTests } from "./resources";
+import type { OAuthOptions } from "./types";
 import type { OAuthClient } from "./types/oauth";
 
 describe("oauth register", async () => {
@@ -274,6 +277,23 @@ describe("oauth register", async () => {
 			where: [{ field: "clientId", value: clientId! }],
 		});
 		expect(links.length).toBe(1);
+	});
+
+	it("rejects a registration resource that is not a valid RFC 8707 URI", async () => {
+		const response = await serverClient.$fetch<OAuthClient>(
+			"/oauth2/register",
+			{
+				method: "POST",
+				body: {
+					redirect_uris: [redirectUri],
+					resources: ["not-a-uri"],
+				},
+			},
+		);
+		expect(response.error?.status).toBe(400);
+		expect((response.error as { error?: string } | null)?.error).toBe(
+			"invalid_target",
+		);
 	});
 
 	it("lazy-seeds configured resources before DCR validation", async () => {
@@ -859,5 +879,510 @@ describe("oauth register - skip_consent blocked", async () => {
 			redirect_uris: ["http://localhost:5000/callback"],
 		});
 		expect(res.data?.client_id).toBeDefined();
+	});
+});
+
+describe("oauth register - protected dynamic registration", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const validInitialAccessToken = "valid-initial-registration-token";
+	const validateInitialAccessToken = vi.fn<
+		NonNullable<OAuthOptions["validateInitialAccessToken"]>
+	>(({ initialAccessToken, clientMetadata }) => {
+		if (
+			initialAccessToken === validInitialAccessToken &&
+			clientMetadata.client_name === "Machine Client"
+		) {
+			return { referenceId: "infra-provisioner" };
+		}
+
+		return false;
+	});
+	const { customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				validateInitialAccessToken,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/callback/${providerId}`;
+
+	it("should create confidential clients with a valid initial access token", async () => {
+		const response = await customFetchImpl(
+			`${authServerBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${validInitialAccessToken}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					redirect_uris: [redirectUri],
+					grant_types: ["client_credentials"],
+				}),
+			},
+		);
+		expect(response.status).toBe(201);
+		// The success response carries a client_secret, so it must not be cached.
+		expect(response.headers.get("Cache-Control")).toBe("no-store");
+
+		const body = (await response.json()) as OAuthClient;
+		expect(body.client_id).toBeDefined();
+		expect(body.client_secret).toBeDefined();
+		expect(body.grant_types).toEqual(["client_credentials"]);
+		expect(body.reference_id).toBe("infra-provisioner");
+		expect(body.user_id).toBeUndefined();
+		expect(body.token_endpoint_auth_method).toBe("client_secret_basic");
+		expect(validateInitialAccessToken).toHaveBeenCalledWith(
+			expect.objectContaining({
+				initialAccessToken: validInitialAccessToken,
+				clientMetadata: expect.objectContaining({
+					client_name: "Machine Client",
+					grant_types: ["client_credentials"],
+				}),
+			}),
+		);
+	});
+
+	it("should reject invalid initial access tokens", async () => {
+		const response = await customFetchImpl(
+			`${authServerBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: "Bearer invalid-initial-registration-token",
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					redirect_uris: [redirectUri],
+				}),
+			},
+		);
+		expect(response.status).toBe(401);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			'Bearer error="invalid_token"',
+		);
+		expect(response.headers.get("Cache-Control")).toBe("no-store");
+		expect(response.headers.get("Pragma")).toBe("no-cache");
+
+		const body = (await response.json()) as { error?: string };
+		expect(body.error).toBe("invalid_token");
+	});
+
+	it("should reject malformed initial access token headers", async () => {
+		const response = await customFetchImpl(
+			`${authServerBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: "Bearer",
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					redirect_uris: [redirectUri],
+				}),
+			},
+		);
+		expect(response.status).toBe(400);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			'Bearer error="invalid_request"',
+		);
+		expect(response.headers.get("Cache-Control")).toBe("no-store");
+		expect(response.headers.get("Pragma")).toBe("no-cache");
+
+		const body = (await response.json()) as { error?: string };
+		expect(body.error).toBe("invalid_request");
+	});
+
+	it("should reject initial access tokens when validation is not configured", async () => {
+		const noValidatorAuthServerBaseUrl = "http://localhost:3001";
+		const { customFetchImpl: customFetchWithoutValidator } =
+			await getTestInstance({
+				baseURL: noValidatorAuthServerBaseUrl,
+				plugins: [
+					jwt(),
+					oauthProvider({
+						loginPage: "/login",
+						consentPage: "/consent",
+						allowDynamicClientRegistration: true,
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+				],
+			});
+
+		const response = await customFetchWithoutValidator(
+			`${noValidatorAuthServerBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${validInitialAccessToken}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					redirect_uris: [redirectUri],
+				}),
+			},
+		);
+		expect(response.status).toBe(401);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			'Bearer error="invalid_token"',
+		);
+		expect(response.headers.get("Cache-Control")).toBe("no-store");
+		expect(response.headers.get("Pragma")).toBe("no-cache");
+
+		const body = (await response.json()) as { error?: string };
+		expect(body.error).toBe("invalid_token");
+	});
+
+	it("should register a confidential client_credentials client without redirect_uris", async () => {
+		const response = await customFetchImpl(
+			`${authServerBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${validInitialAccessToken}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					grant_types: ["client_credentials"],
+				}),
+			},
+		);
+		expect(response.status).toBe(201);
+
+		const body = (await response.json()) as OAuthClient;
+		expect(body.client_id).toBeDefined();
+		expect(body.client_secret).toBeDefined();
+		expect(body.grant_types).toEqual(["client_credentials"]);
+	});
+
+	it("should reject an authorization_code registration without redirect_uris", async () => {
+		const response = await customFetchImpl(
+			`${authServerBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${validInitialAccessToken}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					grant_types: ["authorization_code"],
+				}),
+			},
+		);
+		expect(response.status).toBe(400);
+
+		const body = (await response.json()) as { error?: string };
+		expect(body.error).toBe("invalid_redirect_uri");
+	});
+
+	it("should answer a no-credentials request with a bare Bearer challenge", async () => {
+		const response = await customFetchImpl(
+			`${authServerBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					redirect_uris: [redirectUri],
+				}),
+			},
+		);
+		expect(response.status).toBe(401);
+		// RFC 6750 §3.1: a request with no credentials gets a bare challenge with
+		// no error code.
+		expect(response.headers.get("WWW-Authenticate")).toBe("Bearer");
+		expect(response.headers.get("Cache-Control")).toBe("no-store");
+
+		const body = (await response.json()) as { error?: string };
+		expect(body.error).toBeUndefined();
+	});
+
+	it("should create an unowned client when the validator returns no referenceId", async () => {
+		const ownerlessBaseUrl = "http://localhost:3002";
+		const { customFetchImpl: ownerlessFetch } = await getTestInstance({
+			baseURL: ownerlessBaseUrl,
+			plugins: [
+				jwt(),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					allowDynamicClientRegistration: true,
+					validateInitialAccessToken: () => ({}),
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+				}),
+			],
+		});
+
+		const response = await ownerlessFetch(
+			`${ownerlessBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${validInitialAccessToken}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					grant_types: ["client_credentials"],
+				}),
+			},
+		);
+		expect(response.status).toBe(201);
+
+		const body = (await response.json()) as OAuthClient;
+		expect(body.client_id).toBeDefined();
+		expect(body.reference_id).toBeUndefined();
+		expect(body.user_id).toBeUndefined();
+	});
+
+	it("should fail closed when the validator throws", async () => {
+		const throwingBaseUrl = "http://localhost:3003";
+		const { customFetchImpl: throwingFetch } = await getTestInstance({
+			baseURL: throwingBaseUrl,
+			plugins: [
+				jwt(),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					allowDynamicClientRegistration: true,
+					validateInitialAccessToken: () => {
+						throw new Error("validator failure");
+					},
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+				}),
+			],
+		});
+
+		const response = await throwingFetch(
+			`${throwingBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${validInitialAccessToken}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					redirect_uris: [redirectUri],
+				}),
+			},
+		);
+		expect(response.status).toBe(500);
+		// The validator's thrown message must not leak; it is contained as a
+		// generic server_error.
+		const body = (await response.json()) as {
+			error?: string;
+			error_description?: string;
+		};
+		expect(body.error).toBe("server_error");
+		expect(body.error_description).not.toContain("validator failure");
+	});
+
+	it("passes through an APIError the validator throws", async () => {
+		const apiErrorBaseUrl = "http://localhost:3006";
+		const { customFetchImpl: apiErrorFetch } = await getTestInstance({
+			baseURL: apiErrorBaseUrl,
+			plugins: [
+				jwt(),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					allowDynamicClientRegistration: true,
+					validateInitialAccessToken: () => {
+						throw new APIError("FORBIDDEN", {
+							error: "access_denied",
+							error_description: "tenant suspended",
+						});
+					},
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+				}),
+			],
+		});
+
+		const response = await apiErrorFetch(
+			`${apiErrorBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${validInitialAccessToken}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					redirect_uris: [redirectUri],
+				}),
+			},
+		);
+		// A deliberately-thrown APIError shapes the response; it is not swallowed
+		// into the generic server_error.
+		expect(response.status).toBe(403);
+		const body = (await response.json()) as { error?: string };
+		expect(body.error).toBe("access_denied");
+	});
+
+	it("should not consult the validator for session-backed registration", async () => {
+		const sessionBaseUrl = "http://localhost:3004";
+		const sessionValidator = vi.fn<
+			NonNullable<OAuthOptions["validateInitialAccessToken"]>
+		>(() => ({ referenceId: "from-token" }));
+		const {
+			customFetchImpl: sessionFetch,
+			signInWithTestUser: signInSessionUser,
+		} = await getTestInstance({
+			baseURL: sessionBaseUrl,
+			plugins: [
+				jwt(),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					allowDynamicClientRegistration: true,
+					validateInitialAccessToken: sessionValidator,
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+				}),
+			],
+		});
+		const { headers } = await signInSessionUser();
+		const sessionClient = createAuthClient({
+			plugins: [oauthProviderClient()],
+			baseURL: sessionBaseUrl,
+			fetchOptions: { customFetchImpl: sessionFetch, headers },
+		});
+
+		// A logged-in user (session cookie, no Authorization header) registers
+		// through the session path, so the initial access token validator is never
+		// consulted and the client is owned by the user.
+		const response = await sessionClient.oauth2.register({
+			client_name: "Session Client",
+			redirect_uris: [redirectUri],
+		});
+
+		expect(response.data?.client_id).toBeDefined();
+		expect(sessionValidator).not.toHaveBeenCalled();
+		expect(response.data?.reference_id).toBeUndefined();
+		expect(response.data?.user_id).toBeDefined();
+	});
+
+	it("with the bearer plugin: a session bearer is the session, a non-session bearer is an initial access token", async () => {
+		const bearerBaseUrl = "http://localhost:3005";
+		const bearerIat = "bearer-precedence-initial-access-token";
+		const bearerValidator = vi.fn<
+			NonNullable<OAuthOptions["validateInitialAccessToken"]>
+		>(({ initialAccessToken }) =>
+			initialAccessToken === bearerIat
+				? { referenceId: "infra-provisioner" }
+				: false,
+		);
+		const {
+			client,
+			testUser,
+			customFetchImpl: bearerFetch,
+		} = await getTestInstance({
+			baseURL: bearerBaseUrl,
+			plugins: [
+				bearer(),
+				jwt(),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					allowDynamicClientRegistration: true,
+					validateInitialAccessToken: bearerValidator,
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+				}),
+			],
+		});
+
+		// The bearer plugin returns the session token in the set-auth-token header.
+		let sessionBearer = "";
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{
+				onSuccess: (ctx) => {
+					sessionBearer = ctx.response.headers.get("set-auth-token") ?? "";
+				},
+			},
+		);
+		expect(sessionBearer.length).toBeGreaterThan(0);
+
+		// A bearer that resolves to a session takes the session path: the validator
+		// is not consulted and the client is owned by the user.
+		const sessionResponse = await bearerFetch(
+			`${bearerBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${sessionBearer}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Session Bearer Client",
+					redirect_uris: [redirectUri],
+				}),
+			},
+		);
+		expect(sessionResponse.status).toBe(201);
+		expect(bearerValidator).not.toHaveBeenCalled();
+		const sessionBody = (await sessionResponse.json()) as OAuthClient;
+		expect(sessionBody.user_id).toBeDefined();
+		expect(sessionBody.reference_id).toBeUndefined();
+
+		// A bearer that does not resolve to a session is treated as an initial
+		// access token: the validator authorizes it and tags the owner.
+		const tokenResponse = await bearerFetch(
+			`${bearerBaseUrl}/api/auth/oauth2/register`,
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${bearerIat}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({
+					client_name: "Machine Client",
+					grant_types: ["client_credentials"],
+				}),
+			},
+		);
+		expect(tokenResponse.status).toBe(201);
+		expect(bearerValidator).toHaveBeenCalledWith(
+			expect.objectContaining({ initialAccessToken: bearerIat }),
+		);
+		const tokenBody = (await tokenResponse.json()) as OAuthClient;
+		expect(tokenBody.reference_id).toBe("infra-provisioner");
+		expect(tokenBody.user_id).toBeUndefined();
 	});
 });

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -11,14 +11,24 @@ import {
 } from "./extensions";
 import { assertClientPrivileges } from "./oauthClient/privileges";
 import { buildClientResourceLinkId, getResource } from "./resources";
-import type { OAuthOptions, SchemaClient, Scope } from "./types";
+import type {
+	ClientRegistrationRequest,
+	OAuthOptions,
+	SchemaClient,
+	Scope,
+} from "./types";
 import type {
 	GrantType,
 	OAuthClient,
 	TokenEndpointAuthMethod,
 } from "./types/oauth";
-import { parseClientMetadata, storeClientSecret } from "./utils";
+import {
+	OAUTH_NO_STORE_HEADERS,
+	parseClientMetadata,
+	storeClientSecret,
+} from "./utils";
 import { isPrivateHostname } from "./utils/client-assertion";
+import { authorizeInitialAccessToken } from "./utils/initial-access-token";
 
 /**
  * Resolves the auth method and type for unauthenticated DCR.
@@ -90,16 +100,43 @@ export async function registerEndpoint(
 		});
 	}
 
+	// Resolve a session first. With the bearer plugin enabled it consumes the
+	// Authorization header (a valid bearer becomes the session); only when no
+	// session is resolved do we treat an Authorization: Bearer value as an
+	// RFC 7591 initial access token.
 	const session = await getSessionFromCtx(ctx);
+	const tokenAuthorization = session
+		? undefined
+		: await authorizeInitialAccessToken(
+				ctx,
+				opts,
+				body as ClientRegistrationRequest,
+			);
+	const isTokenAuthorized = Boolean(tokenAuthorization);
 
-	if (!(session || opts.allowUnauthenticatedClientRegistration)) {
-		throw new APIError("UNAUTHORIZED", {
-			error: "invalid_token",
-			error_description: "Authentication required for client registration",
-		});
+	if (
+		!(
+			session ||
+			isTokenAuthorized ||
+			opts.allowUnauthenticatedClientRegistration
+		)
+	) {
+		// No session, no token, and open registration disabled. A presented but
+		// invalid token already threw above, so this is the no-credentials case:
+		// answer with a bare RFC 6750 §3.1 Bearer challenge and no error code.
+		throw new APIError(
+			"UNAUTHORIZED",
+			{
+				error_description: "Authentication required for client registration",
+			},
+			{
+				"WWW-Authenticate": "Bearer",
+				...OAUTH_NO_STORE_HEADERS,
+			},
+		);
 	}
 
-	if (!session) {
+	if (!session && !isTokenAuthorized) {
 		if (body.grant_types?.includes("client_credentials")) {
 			throw new APIError("BAD_REQUEST", {
 				error: "invalid_client_metadata",
@@ -154,6 +191,8 @@ export async function registerEndpoint(
 
 	return createOAuthClientEndpoint(ctx, opts, {
 		isRegister: true,
+		session,
+		referenceId: tokenAuthorization?.referenceId,
 		resources: requestedResources.length > 0 ? requestedResources : undefined,
 	});
 }
@@ -467,6 +506,18 @@ export async function createOAuthClientEndpoint(
 	settings: {
 		isRegister: boolean;
 		/**
+		 * Owner reference resolved by the caller (e.g. from an initial access
+		 * token) to attach to the new client. Takes precedence over
+		 * `clientReference`.
+		 */
+		referenceId?: string;
+		/**
+		 * Session already resolved by the caller, threaded to avoid resolving it
+		 * twice. The DCR path provides it (possibly `null`); admin callers omit it
+		 * and it is resolved here (cached by `sessionMiddleware`).
+		 */
+		session?: Awaited<ReturnType<typeof getSessionFromCtx>>;
+		/**
 		 * Pre-validated resource identifiers to link the new client to. Used
 		 * by the DCR registration path (RFC 7591 §2 extension). Validation
 		 * (existence, disabled) is the caller's responsibility — this branch
@@ -476,20 +527,17 @@ export async function createOAuthClientEndpoint(
 	},
 ) {
 	const body = applyOAuthClientRegistrationDefaults(ctx.body as OAuthClient);
-	const session = await getSessionFromCtx(ctx);
+	const session =
+		settings.session !== undefined
+			? settings.session
+			: await getSessionFromCtx(ctx);
 
-	// Single authorization chokepoint for OAuth client creation. Every creation
-	// route reaches this function, so the create gate lives here rather than in
-	// each caller. Dynamic registration may be anonymous when
-	// allowUnauthenticatedClientRegistration is enabled, and registerEndpoint
-	// constrains that path to public clients, so it is authorized only when a
-	// session is present. Every other creation route requires an authorized
-	// session; assertClientPrivileges throws when none is present.
-	if (settings.isRegister) {
-		if (session) {
-			await assertClientPrivileges(ctx, session, opts, "create");
-		}
-	} else {
+	// Single authorization chokepoint for OAuth client creation. Admin creation
+	// always requires create privileges. DCR re-checks them only for
+	// session-backed requests; non-session DCR was already authorized in
+	// registerEndpoint (a valid initial access token, or open registration
+	// constrained to public clients).
+	if (!settings.isRegister || session) {
 		await assertClientPrivileges(ctx, session, opts, "create");
 	}
 
@@ -521,12 +569,18 @@ export async function createOAuthClientEndpoint(
 
 	// Create the client with the existing schema
 	const iat = Math.floor(Date.now() / 1000);
-	const referenceId = opts.clientReference
-		? await opts.clientReference({
-				user: session?.user,
-				session: session?.session,
-			})
-		: undefined;
+	// Ownership has one source per path: a caller-supplied referenceId (e.g. from
+	// the initial access token) wins; otherwise a session-backed creation may
+	// resolve one via clientReference. clientReference is never called without a
+	// session, so it cannot misattribute a token-registered client.
+	const referenceId =
+		settings.referenceId ??
+		(session && opts.clientReference
+			? await opts.clientReference({
+					user: session.user,
+					session: session.session,
+				})
+			: undefined);
 	const schema = oauthToSchema({
 		...body,
 		redirect_uris: body.redirect_uris ?? [],
@@ -597,13 +651,16 @@ export async function createOAuthClientEndpoint(
 		(responseBody as OAuthClient & { resources?: string[] }).resources =
 			resources;
 	}
-	return ctx.json(responseBody, {
-		status: 201,
-		headers: {
-			"Cache-Control": "no-store",
-			Pragma: "no-cache",
-		},
-	});
+	// A newly created client is a 201 on every path (DCR and admin alike). The
+	// response carries a client_secret, so it must not be cached (RFC 7591
+	// §3.2.1). setStatus/setHeader are the reliable way to set these here: the
+	// json `status`/`headers` options are dropped on the dispatched (asResponse:
+	// false) path that serves HTTP requests.
+	ctx.setStatus(201);
+	for (const [name, value] of Object.entries(OAUTH_NO_STORE_HEADERS)) {
+		ctx.setHeader(name, value);
+	}
+	return ctx.json(responseBody);
 }
 
 /**

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -12,6 +12,7 @@ import type {
 	TokenEndpointAuthMethod,
 	TokenType,
 } from "./oauth";
+import type { ClientRegistrationRequest } from "./zod";
 
 export type {
 	AuthMethod,
@@ -25,6 +26,7 @@ export type {
 	TokenEndpointAuthMethod,
 	TokenType,
 } from "./oauth";
+export type { ClientRegistrationRequest } from "./zod";
 
 export type StoreTokenType =
 	| "access_token"
@@ -389,6 +391,21 @@ export interface OAuthProviderExtension {
 	clientDiscovery?: ClientDiscovery | ClientDiscovery[];
 }
 
+/**
+ * Result of authorizing an RFC 7591 initial access token, returned by
+ * {@link OAuthOptions.validateInitialAccessToken}.
+ */
+export interface InitialAccessTokenAuthorization {
+	/**
+	 * Ownership reference to attach to the created OAuth client.
+	 *
+	 * Associates machine-provisioned clients with an organization, team, tenant,
+	 * or other application-level owner. Omit to create an unowned client (the
+	 * client is stored with neither a `user_id` nor a `reference_id`).
+	 */
+	referenceId?: string;
+}
+
 export interface OAuthOptions<
 	Scopes extends readonly Scope[] = InternallySupportedScopes[],
 > {
@@ -583,11 +600,50 @@ export interface OAuthOptions<
 	 */
 	allowUnauthenticatedClientRegistration?: boolean;
 	/**
-	 * Allow dynamic client registration.
+	 * Allow dynamic client registration (RFC 7591) at `POST /oauth2/register`.
+	 *
+	 * Once enabled, a registration request is authorized through one of three
+	 * modes:
+	 * - session-backed: a logged-in user with client-create privileges.
+	 * - token-backed: a valid initial access token, when
+	 *   {@link OAuthOptions.validateInitialAccessToken} is defined.
+	 * - open public-only: unauthenticated registration constrained to public
+	 *   clients, when {@link OAuthOptions.allowUnauthenticatedClientRegistration}
+	 *   is enabled.
 	 *
 	 * @default false
 	 */
 	allowDynamicClientRegistration?: boolean;
+	/**
+	 * Validates an RFC 7591 initial access token for protected dynamic client
+	 * registration, read from the `Authorization: Bearer <token>` header on
+	 * `POST /oauth2/register`.
+	 *
+	 * Return an {@link InitialAccessTokenAuthorization} (optionally carrying a
+	 * `referenceId` owner) to authorize the registration, or `false` to reject
+	 * the token. Defining this callback enables the token-backed registration
+	 * mode; while it is undefined, a Bearer token presented to the endpoint is
+	 * rejected rather than downgraded to open registration.
+	 *
+	 * `clientMetadata` is the schema-validated request body. It is self-asserted
+	 * (RFC 7591 §5) and not yet semantically validated, so a request authorized
+	 * here may still be rejected by a later metadata check. Compare the token in
+	 * constant time; issuance, storage, expiration, and revocation are
+	 * deployment-specific in RFC 7591 and belong in your application.
+	 *
+	 * `headers` is the raw request `Headers`, available to correlate the token
+	 * with other request context (a tenant header, a forwarded client identity).
+	 *
+	 * With the `bearer` plugin enabled, a Bearer value that resolves to a valid
+	 * user session is handled as that session, not as an initial access token.
+	 *
+	 * @see InitialAccessTokenAuthorization
+	 */
+	validateInitialAccessToken?: (context: {
+		initialAccessToken: string;
+		headers: Headers;
+		clientMetadata: ClientRegistrationRequest;
+	}) => Awaitable<InitialAccessTokenAuthorization | false>;
 	/**
 	 * OAuth/OIDC extension points used by companion plugins to add protocol
 	 * grants, client authentication methods, metadata, claims, and client-id

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -148,3 +148,69 @@ export const verificationValueSchema = z
 		resource: z.array(z.string()).optional(),
 	})
 	.passthrough();
+
+/**
+ * Request body accepted at `POST /oauth2/register` (RFC 7591 §2 client
+ * metadata). This is the single source of truth for the registration contract:
+ * the endpoint validates against it and {@link ClientRegistrationRequest} is
+ * inferred from it, so the type a `validateInitialAccessToken` callback receives
+ * always matches what is actually validated. `grant_types` and
+ * `token_endpoint_auth_method` are open strings because extensions can register
+ * custom values. Server-assigned fields (`client_id`, `client_secret`, the
+ * issued/expiry timestamps) and internal state (`disabled`, `reference_id`) are
+ * never part of a registration request.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7591#section-2
+ */
+export const clientRegistrationRequestSchema = z.object({
+	redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
+	scope: z.string().optional(),
+	client_name: z.string().optional(),
+	client_uri: z.string().optional(),
+	logo_uri: z.string().optional(),
+	contacts: z.array(z.string().min(1)).min(1).optional(),
+	tos_uri: z.string().optional(),
+	policy_uri: z.string().optional(),
+	software_id: z.string().optional(),
+	software_version: z.string().optional(),
+	software_statement: z.string().optional(),
+	post_logout_redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
+	backchannel_logout_uri: SafeUrlSchema.optional(),
+	backchannel_logout_session_required: z.boolean().optional(),
+	token_endpoint_auth_method: z.string().trim().min(1).optional(),
+	jwks: z
+		.union([
+			z.array(z.record(z.string(), z.unknown())).min(1),
+			z.object({
+				keys: z.array(z.record(z.string(), z.unknown())).min(1),
+			}),
+		])
+		.optional(),
+	jwks_uri: z.string().optional(),
+	grant_types: z.array(z.string().trim().min(1)).min(1).optional(),
+	response_types: z.array(z.enum(["code"])).optional(),
+	type: z.enum(["web", "native", "user-agent-based"]).optional(),
+	subject_type: z.enum(["public", "pairwise"]).optional(),
+	// RFC 7591 §2 extension: declare the RFC 8707 resource indicators this client
+	// will request. Each must be a valid resource URI matching an existing
+	// oauthResource row; the registration handler links them on success.
+	resources: z.array(ResourceUriSchema).optional(),
+	skip_consent: z
+		.never({
+			error: "skip_consent cannot be set during dynamic client registration",
+		})
+		.optional(),
+});
+
+/**
+ * Client metadata as submitted in an RFC 7591 §2 registration request, inferred
+ * from {@link clientRegistrationRequestSchema}. Every value is self-asserted by
+ * the caller (RFC 7591 §5) and is the raw request before registration defaults
+ * are applied, so a `validateInitialAccessToken` callback should treat it as
+ * untrusted and not assume defaulted fields are present.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7591#section-2
+ */
+export type ClientRegistrationRequest = z.infer<
+	typeof clientRegistrationRequestSchema
+>;

--- a/packages/oauth-provider/src/userinfo.ts
+++ b/packages/oauth-provider/src/userinfo.ts
@@ -69,6 +69,9 @@ export async function userInfoEndpoint(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
 ) {
+	// TODO: converge on parseBearerToken (utils) once we decide whether userinfo
+	// should keep accepting a non-Bearer Authorization value as a bare token; the
+	// shared parser is strict and would reject that fallback.
 	const authorization = ctx.headers?.get("authorization");
 	const token =
 		typeof authorization === "string" && authorization?.startsWith("Bearer ")

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -36,6 +36,47 @@ export {
 	signedQueryIssuedAtParam,
 } from "../signed-query";
 
+/**
+ * Headers required on OAuth token and registration responses so credentials are
+ * never cached by intermediaries.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+ * @see https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1
+ */
+export const OAUTH_NO_STORE_HEADERS = {
+	"Cache-Control": "no-store",
+	Pragma: "no-cache",
+} as const;
+
+/**
+ * Extracts the credentials from an `Authorization: Bearer <token>` header.
+ *
+ * Returns `undefined` when the header is absent or carries a non-Bearer scheme,
+ * leaving the caller to decide whether that is an error. Throws an
+ * `invalid_request` `APIError` when the Bearer scheme is present but the
+ * credentials are missing or the header carries extra parts. The scheme match
+ * is case-insensitive and the credentials are the single token after it.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
+ * @see https://datatracker.ietf.org/doc/html/rfc7235#section-2.1
+ */
+export function parseBearerToken(
+	authorization: string | null | undefined,
+): string | undefined {
+	if (!authorization) return undefined;
+	const [scheme, credentials, ...extraParts] = authorization
+		.trim()
+		.split(/\s+/);
+	if (scheme?.toLowerCase() !== "bearer") return undefined;
+	if (!credentials || extraParts.length > 0) {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_request",
+			error_description: "Malformed Bearer Authorization header",
+		});
+	}
+	return credentials;
+}
+
 class TTLCache<K, V extends { expiresAt?: Date }> {
 	private cache = new Map<K, V>();
 	constructor() {}

--- a/packages/oauth-provider/src/utils/initial-access-token.ts
+++ b/packages/oauth-provider/src/utils/initial-access-token.ts
@@ -1,0 +1,104 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import { APIError } from "better-call";
+import type {
+	ClientRegistrationRequest,
+	InitialAccessTokenAuthorization,
+	OAuthOptions,
+	Scope,
+} from "../types";
+import { OAUTH_NO_STORE_HEADERS, parseBearerToken } from "./index";
+
+/**
+ * Builds an RFC 6750 §3 Bearer challenge for the registration endpoint. The
+ * `error` code maps to the status per RFC 6750 §3.1 (`invalid_request` → 400,
+ * `invalid_token` → 401) and is echoed in both the `WWW-Authenticate` challenge
+ * and the JSON body.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6750#section-3
+ */
+function registrationBearerError(
+	status: "BAD_REQUEST" | "UNAUTHORIZED",
+	error: "invalid_request" | "invalid_token",
+	errorDescription: string,
+) {
+	return new APIError(
+		status,
+		{ error, error_description: errorDescription },
+		{
+			"WWW-Authenticate": `Bearer error="${error}"`,
+			...OAUTH_NO_STORE_HEADERS,
+		},
+	);
+}
+
+/**
+ * Resolves an RFC 7591 initial access token from the request and authorizes it
+ * against the deployment-supplied validator.
+ *
+ * Returns the authorization (optionally carrying a `referenceId`) when a valid
+ * token is present, or `undefined` when no Bearer credentials were sent so the
+ * caller can fall back to session or open registration. Throws an RFC 6750
+ * Bearer challenge when the header is malformed, no validator is configured, or
+ * the token is rejected.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7591#section-3
+ */
+export async function authorizeInitialAccessToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	clientMetadata: ClientRegistrationRequest,
+): Promise<InitialAccessTokenAuthorization | undefined> {
+	const headers = ctx.headers;
+	let initialAccessToken: string | undefined;
+	try {
+		initialAccessToken = parseBearerToken(headers?.get("authorization"));
+	} catch {
+		throw registrationBearerError(
+			"BAD_REQUEST",
+			"invalid_request",
+			"Malformed initial access token Authorization header",
+		);
+	}
+	if (!initialAccessToken || !headers) {
+		return undefined;
+	}
+
+	// Reject a presented token when no validator is wired up rather than letting
+	// it fall through to the weaker open-registration path (fail-closed). The
+	// description stays generic so an unauthenticated caller cannot distinguish
+	// "no validator configured" from "token rejected".
+	if (!opts.validateInitialAccessToken) {
+		throw registrationBearerError(
+			"UNAUTHORIZED",
+			"invalid_token",
+			"Invalid initial access token",
+		);
+	}
+
+	let authorization: InitialAccessTokenAuthorization | false;
+	try {
+		authorization = await opts.validateInitialAccessToken({
+			initialAccessToken,
+			headers,
+			clientMetadata,
+		});
+	} catch (error) {
+		// A deployment validator may deliberately throw an APIError to shape its
+		// own response. Anything else is unexpected, so fail closed with a generic
+		// server_error rather than letting the thrown message or stack surface.
+		if (error instanceof APIError) throw error;
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error: "server_error",
+			error_description: "Initial access token validation failed",
+		});
+	}
+	if (!authorization) {
+		throw registrationBearerError(
+			"UNAUTHORIZED",
+			"invalid_token",
+			"Invalid initial access token",
+		);
+	}
+
+	return authorization;
+}


### PR DESCRIPTION
OAuth provider dynamic registration supported user-session registration and open public-client registration, but not protected machine provisioning. Provisioning services were left with either a user-session dependency or direct database writes.

This treats a valid RFC 7591 initial access token, sent as `Authorization: Bearer` to `POST /oauth2/register`, as registration authority, then routes the request through the existing client-creation path. Deployments supply the `validateInitialAccessToken` callback and own token issuance, expiration, and revocation. That avoids building a partial token store into the plugin, and matches RFC 7591's model for initial access tokens. Session-backed admin creation keeps its privilege gate; open unauthenticated registration stays limited to public clients.

The callback receives the schema-validated request as `clientMetadata`, typed from the single schema the endpoint validates, so custom grant types and authentication methods still pass through.

Also corrects the client-creation endpoints: they returned 200 instead of 201 and left the secret-bearing response cacheable, because the JSON response status and headers were dropped on the dispatched request path.

Does not implement RFC 7592 registration management tokens

Fixes #3821
Fixes #8588
