### PR TITLE
fix(origin-check): allow tilde in relative callback URLs

### DIFF
--- a/.changeset/relative-callback-url-tilde.md
+++ b/.changeset/relative-callback-url-tilde.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Allow `~` in relative callback URLs validated by trusted origin checks.

--- a/packages/better-auth/src/auth/trusted-origins.test.ts
+++ b/packages/better-auth/src/auth/trusted-origins.test.ts
@@ -15,7 +15,7 @@ async function createAuthTestInstance(overrides?: Partial<BetterAuthOptions>) {
 					method: "GET",
 					query: z.object({
 						url: z.string(),
-						allowRelativePaths: z.coerce.boolean().optional(),
+						allowRelativePaths: z.stringbool().optional(),
 					}),
 				},
 				async (ctx) => {
@@ -193,6 +193,22 @@ describe("trusted origins", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10022
 		 */
+		it("should reject relative paths with tildes when relative paths are disabled", async () => {
+			const { isTrustedOrigin } = await createAuthTestInstance();
+
+			await expect(isTrustedOrigin("/my-team/~settings/account")).resolves.toBe(
+				false,
+			);
+			await expect(
+				isTrustedOrigin("/my-team/~settings/account", {
+					allowRelativePaths: false,
+				}),
+			).resolves.toBe(false);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10022
+		 */
 		it("should allow relative paths with tildes", async () => {
 			const { isTrustedOrigin } = await createAuthTestInstance();
 
@@ -221,9 +237,11 @@ describe("trusted origins", () => {
 			const { isTrustedOrigin } = await createAuthTestInstance();
 
 			const maliciousPatterns = [
+				"/%2f/evil.com",
+				"/%2F/evil.com",
+				"/%5c/evil.com",
 				"/%5C/evil.com",
 				`/\\/\\/evil.com`,
-				"/%5C/evil.com",
 				"/..%2F..%2Fevil.com",
 				"javascript:alert('xss')",
 				"data:text/html,<script>alert('xss')</script>",

--- a/packages/better-auth/src/auth/trusted-origins.test.ts
+++ b/packages/better-auth/src/auth/trusted-origins.test.ts
@@ -190,6 +190,25 @@ describe("trusted origins", () => {
 			).resolves.toBe(true);
 		});
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10022
+		 */
+		it("should allow relative paths with tildes", async () => {
+			const { isTrustedOrigin } = await createAuthTestInstance();
+
+			await expect(
+				isTrustedOrigin("/my-team/~settings/account", {
+					allowRelativePaths: true,
+				}),
+			).resolves.toBe(true);
+
+			await expect(
+				isTrustedOrigin("/~settings?next=/~account", {
+					allowRelativePaths: true,
+				}),
+			).resolves.toBe(true);
+		});
+
 		it("should reject urls with double dash", async () => {
 			const { isTrustedOrigin } = await createAuthTestInstance();
 

--- a/packages/better-auth/src/auth/trusted-origins.ts
+++ b/packages/better-auth/src/auth/trusted-origins.ts
@@ -19,7 +19,9 @@ export const matchesOriginPattern = (
 		if (settings?.allowRelativePaths) {
 			return (
 				url.startsWith("/") &&
-				/^\/(?!\/|\\|%2f|%5c)[\w\-.\+/@~]*(?:\?[\w\-.\+/=&%@~]*)?$/.test(url)
+				/^\/(?!\/|\\|%2[fF]|%5[cC])[\w\-.\+/@~]*(?:\?[\w\-.\+/=&%@~]*)?$/.test(
+					url,
+				)
 			);
 		}
 

--- a/packages/better-auth/src/auth/trusted-origins.ts
+++ b/packages/better-auth/src/auth/trusted-origins.ts
@@ -19,7 +19,7 @@ export const matchesOriginPattern = (
 		if (settings?.allowRelativePaths) {
 			return (
 				url.startsWith("/") &&
-				/^\/(?!\/|\\|%2f|%5c)[\w\-.\+/@]*(?:\?[\w\-.\+/=&%@]*)?$/.test(url)
+				/^\/(?!\/|\\|%2f|%5c)[\w\-.\+/@~]*(?:\?[\w\-.\+/=&%@~]*)?$/.test(url)
 			);
 		}
 


### PR DESCRIPTION
Allow `~` in relative callback URL validation and add regression coverage.
Fixes #10022.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `~` in relative callback URL validation for trusted origin checks in `better-auth`. Fixes #10022.

- **Bug Fixes**
  - Expand regex in matchesOriginPattern to accept `~` in path and query when `allowRelativePaths` is true, and make encoded slash/backslash guards case-insensitive (`%2f/%2F`, `%5c/%5C`).
  - Add tests for tilde in paths and query, including rejection when relative paths are disabled and new encoded slash/backslash vectors; include patch changeset for `better-auth`.

<sup>Written for commit 7edd845b445333fdbe11227e77ec91768cfeb795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

