### PR TITLE
chore: add missing metadata fields to package.json

### DIFF
--- a/packages/drizzle-adapter/package.json
+++ b/packages/drizzle-adapter/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@better-auth/drizzle-adapter",
   "version": "1.6.18",
+  "bugs": {
+    "url": "https://github.com/better-auth/better-auth/issues"
+  },
   "description": "Drizzle adapter for Better Auth",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/drizzle-adapter/package.json`.

Fixes npm tooling unable to resolve package metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing bugs.url to the `@better-auth/drizzle-adapter` package metadata so npm and other tooling can find the issue tracker. Fixes metadata resolution errors and shows the issues link on npm.

<sup>Written for commit 315579c39a5fcccd7f530dab655741b1aad679c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

