### PR TITLE
fix(cli): serialize array additionalField defaultValue in drizzle generator

### DIFF
--- a/.changeset/fresh-icons-fall.md
+++ b/.changeset/fresh-icons-fall.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+fix(cli): serialize array additionalField defaultValue in drizzle generator

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -248,6 +248,19 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 									}
 								} else if (typeof attr.defaultValue === "string") {
 									type += `.default("${attr.defaultValue}")`;
+								} else if (Array.isArray(attr.defaultValue)) {
+									// Stringify each element so a `["customer"]` default emits
+									// `.default(["customer"])` rather than `.default(customer)`
+									// from JS's implicit Array#toString.
+									const elements = attr.defaultValue
+										.map((value) => JSON.stringify(value))
+										.join(", ");
+									type += `.default([${elements}])`;
+								} else if (
+									typeof attr.defaultValue === "object" &&
+									attr.defaultValue !== null
+								) {
+									type += `.default(${JSON.stringify(attr.defaultValue)})`;
 								} else {
 									type += `.default(${attr.defaultValue})`;
 								}

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -927,6 +927,63 @@ describe("Enum field support in Drizzle schemas", () => {
 	});
 });
 
+describe("Drizzle array defaultValue serialization", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10046
+	 */
+	it("emits a JS array literal for string[] additionalField defaultValue", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: {
+				id: "drizzle",
+				options: { provider: "pg", schema: {} },
+			} as any,
+			options: {
+				database: {} as any,
+				user: {
+					additionalFields: {
+						roles: {
+							type: "string[]",
+							required: true,
+							defaultValue: ["customer"],
+							input: false,
+						},
+					},
+				},
+			} as BetterAuthOptions,
+		});
+		expect(schema.code).toContain(
+			'roles: text("roles").array().default(["customer"]).notNull()',
+		);
+		expect(schema.code).not.toContain(".default(customer)");
+	});
+
+	it("emits a JS array literal for number[] additionalField defaultValue", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: {
+				id: "drizzle",
+				options: { provider: "pg", schema: {} },
+			} as any,
+			options: {
+				database: {} as any,
+				user: {
+					additionalFields: {
+						scores: {
+							type: "number[]",
+							required: true,
+							defaultValue: [1, 2, 3],
+						},
+					},
+				},
+			} as BetterAuthOptions,
+		});
+		expect(schema.code).toContain(
+			'scores: integer("scores").array().default([1, 2, 3]).notNull()',
+		);
+	});
+});
+
 describe("usePlural schema generation", () => {
 	it("should generate drizzle schema with usePlural option", async () => {
 		const schema = await generateDrizzleSchema({


### PR DESCRIPTION
Closes #10046.

`better-auth generate` produced syntactically broken Drizzle output for any `additionalField` with an array default. With a `roles: { type: "string[]", defaultValue: ["customer"] }` field the generator emitted `roles: text("roles").array().default(customer).notNull()` — `customer` interpreted as a bare identifier, not a string. The cause is the final `else` in the default-value serializer (around line 249 of `packages/cli/src/generators/drizzle.ts`): it relies on JS coercion, and `["customer"]` coerces via `Array#toString` to `"customer"`.

Added an `Array.isArray` branch (mirroring the Prisma generator's pattern) that `JSON.stringify`s each element and joins with `, ` inside `[]`, plus a fall-through `typeof === "object"` branch for non-array JSON defaults so we don't emit `[object Object]` from a `{ premium: true }` default. The existing primitive branches (boolean / number / string / function / sql) are unchanged.

Output before / after for the repro:

```diff
- roles: text("roles").array().default(customer).notNull()
+ roles: text("roles").array().default(["customer"]).notNull()
```

## Tests

Two regressions in `packages/cli/test/generate.test.ts`, both gated on the issue with the `@see` comment style described in `CLAUDE.md`:

- `string[]` field with `defaultValue: ["customer"]` → emits `default(["customer"])` and **does not** contain `default(customer)`
- `number[]` field with `defaultValue: [1, 2, 3]` → emits `default([1, 2, 3])`

Both pass with the fix; the first fails against `main`. Targeted run:

```
pnpm --filter @better-auth/cli exec vitest run test/generate.test.ts -t "array defaultValue"
# Tests  2 passed | 56 skipped (58)
```

`pnpm typecheck` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Drizzle schema generation in `@better-auth/cli` for `additionalField` array defaults so the output is valid Drizzle code. Arrays now emit a JS array literal (e.g., default(["customer"])) instead of an unquoted identifier.

- **Bug Fixes**
  - Handle `Array.isArray(defaultValue)` by JSON-stringifying each element and emitting `[... ]`.
  - JSON-stringify non-null object defaults to avoid `[object Object]`.

- **Dependencies**
  - Added changeset for `auth` patch release.

<sup>Written for commit 6daeaf35d04c89eb52307ddaad7cb843d08409c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

