### PR TITLE
fix(cookies): chunk session cache near size limit

### DIFF
--- a/.changeset/tall-cookies-split.md
+++ b/.changeset/tall-cookies-split.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Chunk session cache cookies using the shared cookie size threshold so values near the browser limit are split before cookie attributes push them over the limit.

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1,4 +1,8 @@
-import type { BetterAuthOptions } from "@better-auth/core";
+import type {
+	BetterAuthOptions,
+	GenericEndpointContext,
+} from "@better-auth/core";
+import type { Session, User } from "@better-auth/core/db";
 import type { GoogleProfile } from "@better-auth/core/social-providers";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { base64Url } from "@better-auth/utils/base64";
@@ -21,6 +25,7 @@ import {
 	getCookies,
 	getSessionCookie,
 	parseCookies,
+	setCookieCache,
 } from "../cookies";
 import { signJWT, symmetricDecodeJWT } from "../crypto";
 import { getTestInstance } from "../test-utils/test-instance";
@@ -814,6 +819,76 @@ describe("getSessionCookie", async () => {
 
 		// Verify that chunking happened (instead of logging an error and not caching)
 		expect(hasCookieChunks).toBe(true);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8585
+	 */
+	it("should chunk session cache cookies before attributes push them over the browser limit", async () => {
+		const setCookie = vi.fn();
+		const sessionDataCookieName = "better-auth.session_data";
+		const cookieAttributes = {
+			httpOnly: true,
+			path: "/",
+			sameSite: "lax" as const,
+			maxAge: 60 * 5,
+		};
+
+		await setCookieCache(
+			{
+				headers: new Headers(),
+				setCookie,
+				context: {
+					logger: {
+						debug: vi.fn(),
+					},
+					secret: "better-auth.secret",
+					options: {
+						session: {
+							additionalFields: {
+								largeField: {
+									type: "string",
+								},
+							},
+							cookieCache: {
+								enabled: true,
+							},
+						},
+					},
+					authCookies: {
+						sessionData: {
+							name: sessionDataCookieName,
+							attributes: cookieAttributes,
+						},
+					},
+				},
+			} as unknown as GenericEndpointContext,
+			{
+				session: {
+					id: "session-id",
+					token: "session-token",
+					userId: "user-id",
+					expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					largeField: "x".repeat(2500),
+				} as unknown as Session & Record<string, unknown>,
+				user: {
+					id: "user-id",
+					email: "cookie-cache@example.com",
+					emailVerified: true,
+					name: "Cookie Cache",
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				} satisfies User,
+			},
+			false,
+		);
+
+		const cookieNames = setCookie.mock.calls.map(([name]) => name);
+		expect(cookieNames).toContain(`${sessionDataCookieName}.0`);
+		expect(cookieNames).toContain(`${sessionDataCookieName}.1`);
+		expect(cookieNames).not.toContain(sessionDataCookieName);
 	});
 });
 

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -235,27 +235,13 @@ export async function setCookieCache(
 		);
 	}
 
-	// Check if we need to chunk the cookie (only if it exceeds 4093 bytes)
-	if (data.length > 4093) {
-		const sessionStore = createSessionStore(
-			ctx.context.authCookies.sessionData.name,
-			options,
-			ctx,
-		);
-		const cookies = sessionStore.chunk(data, options);
-		sessionStore.setCookies(cookies);
-	} else {
-		const sessionStore = createSessionStore(
-			ctx.context.authCookies.sessionData.name,
-			options,
-			ctx,
-		);
-		if (sessionStore.hasChunks()) {
-			const cleanCookies = sessionStore.clean();
-			sessionStore.setCookies(cleanCookies);
-		}
-		ctx.setCookie(ctx.context.authCookies.sessionData.name, data, options);
-	}
+	const sessionStore = createSessionStore(
+		ctx.context.authCookies.sessionData.name,
+		options,
+		ctx,
+	);
+	const cookies = sessionStore.chunk(data, options);
+	sessionStore.setCookies(cookies);
 
 	// Keep the account cookie in sync, unless this response already set a
 	// fresh one that the stale request copy would downgrade or expire.


### PR DESCRIPTION
Fixes #8585

Session cookie cache values were only chunked when the encoded value exceeded 4093 bytes. That misses values that are still below 4093 on their own but exceed the browser cookie limit once the cookie name and attributes are included.

This uses the existing session store chunker for session cache writes so the same cookie-size threshold is applied consistently. The chunker still emits a single cookie for small values and cleans stale chunks when needed.

Verification:

- npx -y pnpm@11.1.1 vitest packages/better-auth/src/cookies/cookies.test.ts -t "should chunk session cache cookies before attributes push them over the browser limit" --run
- npx -y pnpm@11.1.1 vitest packages/better-auth/src/cookies/cookies.test.ts -t "chunk" --run
- npx -y pnpm@11.1.1 exec biome check packages/better-auth/src/cookies/index.ts packages/better-auth/src/cookies/cookies.test.ts .changeset/tall-cookies-split.md
- npx -y pnpm@11.1.1 --filter better-auth typecheck
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the shared session store chunker for session cache cookies so values near the size limit are split before cookie name and attributes push them over the browser limit. This prevents cache writes from failing and aligns behavior with session cookies in `better-auth`.

- **Bug Fixes**
  - Route `setCookieCache` through the session store chunker to apply the full cookie-size threshold (including name and attributes), not just 4093-byte payloads.
  - Clean stale chunks and emit a single cookie for small values; added tests for the near-limit case.

<sup>Written for commit f8f0170215f6c714080a0ab23e7474c870cab0cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

