### PR TITLE
fix: normalize consumed verification expiry dates

### DIFF
--- a/.changeset/calm-mysql-verifications.md
+++ b/.changeset/calm-mysql-verifications.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Normalize consumed verification token expiry dates before validation so MySQL/Drizzle rows with string date values remain valid until their actual expiration.

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1,5 +1,9 @@
 import { DatabaseSync } from "node:sqlite";
 import type { GenericEndpointContext } from "@better-auth/core";
+import type {
+	DBAdapter,
+	DBTransactionAdapter,
+} from "@better-auth/core/db/adapter";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { betterAuth } from "../auth/full";
@@ -11,6 +15,7 @@ import type {
 	Session,
 	User,
 } from "../types";
+import { getAdapter } from "./adapter-kysely";
 import { getMigrations } from "./get-migration";
 
 describe("internal adapter test", async () => {
@@ -1511,6 +1516,44 @@ describe("internal adapter test", async () => {
 			return ctx.internalAdapter;
 		}
 
+		function stringifyVerificationExpiresAt<T extends DBTransactionAdapter>(
+			adapter: T,
+		): T {
+			const stringifyRow = <T,>(row: T | null): T | null => {
+				if (
+					row &&
+					typeof row === "object" &&
+					"identifier" in row &&
+					"expiresAt" in row &&
+					(row as { expiresAt: unknown }).expiresAt instanceof Date
+				) {
+					return {
+						...row,
+						expiresAt: (row as { expiresAt: Date }).expiresAt.toISOString(),
+					};
+				}
+				return row;
+			};
+
+			return {
+				...adapter,
+				consumeOne: async (data) =>
+					stringifyRow(await adapter.consumeOne(data)),
+			};
+		}
+
+		function stringifyVerificationExpiresAtInTransactions(
+			adapter: DBAdapter<BetterAuthOptions>,
+		): DBAdapter<BetterAuthOptions> {
+			return {
+				...stringifyVerificationExpiresAt(adapter),
+				transaction: async (callback) =>
+					adapter.transaction((trx) =>
+						callback(stringifyVerificationExpiresAt(trx)),
+					),
+			};
+		}
+
 		it("returns the row to the first caller and null to subsequent reads", async () => {
 			const adapter = await makeAdapter();
 			await adapter.createVerificationValue({
@@ -1525,6 +1568,31 @@ describe("internal adapter test", async () => {
 
 			const second = await adapter.consumeVerificationValue("consume:single");
 			expect(second).toBeNull();
+		});
+
+		it("accepts database verification rows with string expiresAt values", async () => {
+			const database = new DatabaseSync(":memory:");
+			const migrationOptions = { database } satisfies BetterAuthOptions;
+			(await getMigrations(migrationOptions)).runMigrations();
+			const baseAdapter = await getAdapter(migrationOptions);
+			const opts = {
+				database: () =>
+					stringifyVerificationExpiresAtInTransactions(baseAdapter),
+			} satisfies BetterAuthOptions;
+			const ctx = await init(opts);
+
+			await ctx.internalAdapter.createVerificationValue({
+				identifier: "consume:string-date",
+				value: "user-string-date",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+
+			const consumed = await ctx.internalAdapter.consumeVerificationValue(
+				"consume:string-date",
+			);
+			expect(consumed).not.toBeNull();
+			expect(consumed!.value).toBe("user-string-date");
+			expect(consumed!.expiresAt).toBeInstanceOf(Date);
 		});
 
 		it("yields exactly one winner under concurrent consume", async () => {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -35,6 +35,20 @@ function getTTLSeconds(expiresAt: Date | number, now = Date.now()): number {
 	return Math.max(Math.floor((expiresMs - now) / 1000), 0);
 }
 
+function hydrateVerification(raw: unknown): Verification | null {
+	if (!raw) return null;
+	const candidate =
+		typeof raw === "string"
+			? safeJSONParse<Verification>(raw)
+			: typeof raw === "object"
+				? (raw as Verification)
+				: null;
+	if (!candidate) return null;
+	const expiresAt = new Date(candidate.expiresAt);
+	if (!Number.isFinite(expiresAt.getTime())) return null;
+	return { ...candidate, expiresAt };
+}
+
 export const createInternalAdapter = (
 	adapter: DBAdapter<BetterAuthOptions>,
 	ctx: {
@@ -1267,30 +1281,12 @@ export const createInternalAdapter = (
 					? [storedIdentifier, identifier]
 					: [storedIdentifier];
 
-			// After a JSON round-trip `expiresAt` arrives as a string, so coerce
-			// it back to a valid `Date` to match what the DB adapter returns.
-			const hydrateCachedVerification = (raw: unknown): Verification | null => {
-				if (!raw) return null;
-				const candidate =
-					typeof raw === "string"
-						? safeJSONParse<Verification>(raw)
-						: typeof raw === "object"
-							? (raw as Verification)
-							: null;
-				if (!candidate) return null;
-				const expiresAt = new Date(candidate.expiresAt);
-				if (!Number.isFinite(expiresAt.getTime())) return null;
-				return { ...candidate, expiresAt };
-			};
-
 			let consumed: Verification | null = null;
 
 			if (secondaryStorage && !options.verification?.storeInDatabase) {
 				const consumeCacheKey = async (key: string) => {
 					if (secondaryStorage.getAndDelete) {
-						return hydrateCachedVerification(
-							await secondaryStorage.getAndDelete(key),
-						);
+						return hydrateVerification(await secondaryStorage.getAndDelete(key));
 					}
 					if (!warnedNonAtomicConsume) {
 						warnedNonAtomicConsume = true;
@@ -1300,7 +1296,7 @@ export const createInternalAdapter = (
 					}
 					return withVerificationConsumeLock(key, async () => {
 						const raw = await secondaryStorage.get(key);
-						const parsed = hydrateCachedVerification(raw);
+						const parsed = hydrateVerification(raw);
 						if (!parsed) return null;
 						await secondaryStorage.delete(key);
 						return parsed;
@@ -1378,8 +1374,9 @@ export const createInternalAdapter = (
 
 			// Single expiry gate. A row past its `expiresAt` is treated as already
 			// invalid, so callers can rely on a non-null return meaning "valid".
-			if (!consumed || consumed.expiresAt < new Date()) return null;
-			return consumed;
+			const hydrated = hydrateVerification(consumed);
+			if (!hydrated || hydrated.expiresAt < new Date()) return null;
+			return hydrated;
 		},
 		/**
 		 * First-writer-wins create keyed by a deterministic primary key derived


### PR DESCRIPTION
## Summary

Fixes #10054.

Normalizes consumed verification token `expiresAt` values before the post-consume expiry check. Some database adapters, notably MySQL/Drizzle setups, can return date columns as strings. After the atomic verification consumption change, that caused valid reset-password tokens to be consumed and then treated as invalid because `string < Date` coerces to `NaN`.

## Changes

- Extracted shared verification hydration for consumed verification rows.
- Reused it for both secondary-storage and database-backed consume paths.
- Added a regression test that simulates database `consumeOne` returning a string `expiresAt`.
- Added a patch changeset.

## Testing

- `git diff --check` passed.
- Attempted focused Vitest run:
  `pnpm.cmd exec vitest packages/better-auth/src/db/internal-adapter.test.ts -t "accepts database verification rows with string expiresAt values" --run`
  
  Local pnpm execution timed out before producing test output, same package-manager/runtime issue encountered earlier in this workspace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes `expiresAt` when consuming verification tokens to handle string dates from MySQL/`Drizzle`, preventing valid reset-password tokens from being rejected after consumption.
This fixes string-vs-Date comparisons introduced by atomic consume.

- **Bug Fixes**
  - Hydrate consumed verification rows to coerce `expiresAt` to a `Date`.
  - Apply hydration to both secondary storage and database consume paths.
  - Add a regression test that simulates DBs returning string `expiresAt` values.

<sup>Written for commit d56b4f15d864a82a2b4198c5e7d0b96832d19449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

