### PR TITLE
ci: verify npm time metadata after publish

### DIFF
--- a/.github/scripts/verify-npm-packument-time.ts
+++ b/.github/scripts/verify-npm-packument-time.ts
@@ -1,0 +1,87 @@
+type PublishedPackage = {
+	name: string;
+	version: string;
+};
+
+type Packument = {
+	time?: Record<string, string>;
+};
+
+const MAX_ATTEMPTS = 6;
+const RETRY_DELAY_MS = 10_000;
+
+function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function registryUrl(packageName: string) {
+	const encoded = packageName.startsWith("@")
+		? `@${encodeURIComponent(packageName.slice(1))}`
+		: encodeURIComponent(packageName);
+	return `https://registry.npmjs.org/${encoded}`;
+}
+
+function parsePublishedPackages(): PublishedPackage[] {
+	const raw = process.env.PUBLISHED_PACKAGES;
+	if (!raw) {
+		console.error("PUBLISHED_PACKAGES is required");
+		process.exit(1);
+	}
+
+	const parsed = JSON.parse(raw) as PublishedPackage[];
+	return parsed.filter((pkg) => pkg.name && pkg.version);
+}
+
+async function fetchPackument(pkg: PublishedPackage): Promise<Packument> {
+	const response = await fetch(registryUrl(pkg.name));
+	if (!response.ok) {
+		throw new Error(
+			`npm registry returned ${response.status} for ${pkg.name}`,
+		);
+	}
+	return (await response.json()) as Packument;
+}
+
+function hasReleaseTime(pkg: PublishedPackage, packument: Packument) {
+	return Boolean(packument.time?.created && packument.time?.[pkg.version]);
+}
+
+async function verifyPackage(pkg: PublishedPackage) {
+	let lastError: unknown;
+
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		try {
+			const packument = await fetchPackument(pkg);
+			if (hasReleaseTime(pkg, packument)) {
+				console.log(
+					`Verified npm time metadata for ${pkg.name}@${pkg.version}`,
+				);
+				return;
+			}
+			lastError = new Error(
+				`missing time metadata for ${pkg.name}@${pkg.version}`,
+			);
+		} catch (error) {
+			lastError = error;
+		}
+
+		if (attempt < MAX_ATTEMPTS) {
+			console.log(
+				`Waiting for npm time metadata for ${pkg.name}@${pkg.version} (${attempt}/${MAX_ATTEMPTS})`,
+			);
+			await sleep(RETRY_DELAY_MS);
+		}
+	}
+
+	throw lastError;
+}
+
+async function main() {
+	const packages = parsePublishedPackages();
+	await Promise.all(packages.map(verifyPackage));
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,12 @@ jobs:
           VERSION=$(jq -r '.version' packages/better-auth/package.json)
           gh pr edit "$PR_NUMBER" --title "chore: release v${VERSION}"
 
+      - name: Verify npm time metadata
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: node .github/scripts/verify-npm-packument-time.ts
+
       - name: Generate raw release notes
         id: raw-notes
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

Related to #10043.

Adds a release-time verification step that checks every package published by Changesets has npm packument `time` metadata, including the specific published version timestamp. This catches registry metadata problems like pnpm’s `[ERR_PNPM_MISSING_TIME]` before users hit them with `minimumReleaseAge`.

Note: the current npm registry metadata for `@better-auth/prisma-adapter@1.6.18` now includes `time`, so this PR prevents recurrence rather than changing package runtime code.

## Changes

- Added `.github/scripts/verify-npm-packument-time.ts`.
- Wired it into the release workflow after successful `changesets publish`.
- The verifier retries to allow npm registry propagation, then fails the release if `time.created` or `time[version]` is missing.

## Testing

- `git diff --check` passed.
- Verified script locally against current npm metadata:

  `PUBLISHED_PACKAGES='[{"name":"@better-auth/prisma-adapter","version":"1.6.18"}]' node .github/scripts/verify-npm-packument-time.ts`

  Output: `Verified npm time metadata for @better-auth/prisma-adapter@1.6.18`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a post-publish check in the release workflow to verify npm packument `time` metadata for each package published by `changesets` (both `time.created` and `time[version]`). The step retries during registry propagation and fails the release if missing, preventing `pnpm` `[ERR_PNPM_MISSING_TIME]` and keeping `minimumReleaseAge` reliable.

<sup>Written for commit dfdc2650bd7955958a2754e6ce9540439b2bf3c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

