### PR TITLE
chore: add prisma adapter bugs metadata

### DIFF
--- a/packages/prisma-adapter/package.json
+++ b/packages/prisma-adapter/package.json
@@ -10,6 +10,9 @@
     "url": "git+https://github.com/better-auth/better-auth.git",
     "directory": "packages/prisma-adapter"
   },
+  "bugs": {
+    "url": "https://github.com/better-auth/better-auth/issues"
+  },
   "keywords": [
     "auth",
     "prisma",


### PR DESCRIPTION
Adds npm bugs metadata for @better-auth/prisma-adapter so npm users and tooling can find the Better Auth issue tracker directly.\n\nValidation:\n- Parsed packages/prisma-adapter/package.json with Node JSON.parse\n- Ran git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add npm bugs metadata to `@better-auth/prisma-adapter` to point users and tooling to the Better Auth issue tracker. This lets npm and CLIs display the correct issues URL.

<sup>Written for commit 1b12a87844bdeee6dca1346491aa745b929bc89e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

