### PR TITLE
fix(device-authorization)!: add lookup indexes

### DIFF
--- a/.changeset/device-authorization-indexes.md
+++ b/.changeset/device-authorization-indexes.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Add indexes for device authorization lookup fields.

--- a/.changeset/device-authorization-indexes.md
+++ b/.changeset/device-authorization-indexes.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": patch
+"better-auth": minor
 ---
 
-Add indexes for device authorization lookup fields.
+Device Authorization now creates database indexes for device and user code lookups. Codes longer than 191 characters are rejected. Existing MySQL and SQL Server installations must convert these columns to bounded strings and resolve oversized values before running the migration.

--- a/docs/components/docs/mdx-components.tsx
+++ b/docs/components/docs/mdx-components.tsx
@@ -96,6 +96,7 @@ interface Field {
 	isForeignKey?: boolean;
 	isOptional?: boolean;
 	isUnique?: boolean;
+	isIndexed?: boolean;
 	references?: {
 		model: string;
 		field: string;
@@ -255,6 +256,7 @@ function fieldToDBField(field: Field): DBFieldAttribute {
 		required: field.isPrimaryKey ? true : !field.isOptional,
 		references,
 		unique: field.isUnique ?? false,
+		index: field.isIndexed ?? false,
 		bigint,
 	};
 }
@@ -460,7 +462,7 @@ export function DatabaseTable({
 									{field.type}
 								</span>
 							</div>
-							<div className="px-4 py-2">
+							<div className="px-4 py-2 flex flex-wrap items-center gap-1.5">
 								{field.isPrimaryKey && (
 									<span className="inline-flex items-center gap-1 font-mono text-[13px] text-amber-600 dark:text-amber-500 uppercase">
 										<Key className="size-2.5" />
@@ -473,9 +475,16 @@ export function DatabaseTable({
 										FK
 									</span>
 								)}
-								{!field.isPrimaryKey && !field.isForeignKey && (
-									<span className="text-foreground/20 uppercase">-</span>
+								{field.isIndexed && (
+									<span className="inline-flex items-center gap-1 font-mono text-[13px] text-emerald-600 dark:text-emerald-500 uppercase">
+										IDX
+									</span>
 								)}
+								{!field.isPrimaryKey &&
+									!field.isForeignKey &&
+									!field.isIndexed && (
+										<span className="text-foreground/20 uppercase">-</span>
+									)}
 							</div>
 							<div className="px-4 py-2 text-[13px] text-foreground/70 leading-relaxed">
 								{field.description}

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -594,13 +594,13 @@ authenticateCLI().catch((err) => {
 
 **interval**: The minimum polling interval. Default: `"5s"` (5 seconds).
 
-**userCodeLength**: The length of the user code. Default: `8`.
+**userCodeLength**: The length of the user code. Maximum: `191`. Default: `8`.
 
-**deviceCodeLength**: The length of the device code. Default: `40`.
+**deviceCodeLength**: The length of the device code. Maximum: `191`. Default: `40`.
 
-**generateDeviceCode**: Custom function to generate device codes. Returns a string or `Promise<string>`.
+**generateDeviceCode**: Custom function to generate device codes. Returns a string or `Promise<string>` with at most 191 characters.
 
-**generateUserCode**: Custom function to generate user codes. Returns a string or `Promise<string>`.
+**generateUserCode**: Custom function to generate user codes. Returns a string or `Promise<string>` with at most 191 characters.
 
 **validateClient**: Function to validate client IDs. Takes a clientId and returns boolean or `Promise<boolean>`.
 
@@ -622,7 +622,11 @@ The plugin requires a new table to store device authorization data.
 
 Table Name: `deviceCode`
 
-`deviceCode` and `userCode` are indexed by the generated schema because the device token, verification, approval, and denial flows use them as lookup fields.
+`deviceCode` and `userCode` are indexed by the generated schema because the device token, verification, approval, and denial flows use them as lookup fields. Both values are limited to 191 characters so these indexes remain portable across supported databases.
+
+<Callout type="warn">
+  Existing MySQL and SQL Server installations may use unbounded columns for these values. Before running the migration, convert `deviceCode` and `userCode` to strings bounded at 191 characters and resolve any longer values. The migration stops with an error when the existing columns cannot support portable indexes.
+</Callout>
 
 export const deviceCodeTableFields = [
 	{

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -622,6 +622,8 @@ The plugin requires a new table to store device authorization data.
 
 Table Name: `deviceCode`
 
+`deviceCode` and `userCode` are indexed by the generated schema because the device token, verification, approval, and denial flows use them as lookup fields.
+
 export const deviceCodeTableFields = [
 	{
 		name: "id",
@@ -633,11 +635,13 @@ export const deviceCodeTableFields = [
 		name: "deviceCode",
 		type: "string",
 		description: "The device verification code",
+		isIndexed: true,
 	},
 	{
 		name: "userCode",
 		type: "string",
 		description: "The user-friendly code for verification",
+		isIndexed: true,
 	},
 	{
 		name: "userId",

--- a/docs/lib/copy-schema/adapter/drizzle.ts
+++ b/docs/lib/copy-schema/adapter/drizzle.ts
@@ -1,5 +1,5 @@
 import type { Resolver } from "../types";
-import { filterIndexes, getIndexName, getTypeFactory } from "../utils";
+import { filterNonUniqueIndexes, getIndexName, getTypeFactory } from "../utils";
 
 export type DrizzleResolverOptions = {
 	/**
@@ -54,7 +54,7 @@ export const drizzleResolver = (options: DrizzleResolverOptions): Resolver => {
 								: field.references
 									? `t.varchar("${fieldName}", { length: 36 })`
 									: provider === "mysql" && field.index
-										? `t.varchar("${fieldName}", { length: 255 })`
+										? `t.varchar("${fieldName}", { length: 191 })`
 										: `t.text("${fieldName}")`,
 					boolean:
 						provider === "sqlite"
@@ -110,12 +110,12 @@ export const drizzleResolver = (options: DrizzleResolverOptions): Resolver => {
 				table.push(`\t${field.fieldName}: ${value},`);
 			}
 
-			const indexes = filterIndexes(ctx.schema);
+			const indexes = filterNonUniqueIndexes(ctx.schema);
 			if (indexes.length > 0) {
 				table.push("}, (table) => [");
 				for (const field of indexes) {
 					table.push(
-						`\tt.${field.unique ? "uniqueIndex" : "index"}("${getIndexName(ctx.schema.modelName, field)}").on(table.${field.fieldName}),`,
+						`\tt.index("${getIndexName(ctx.schema.modelName, field)}").on(table.${field.fieldName}),`,
 					);
 				}
 				table.push("]);");

--- a/docs/lib/copy-schema/adapter/drizzle.ts
+++ b/docs/lib/copy-schema/adapter/drizzle.ts
@@ -1,5 +1,5 @@
 import type { Resolver } from "../types";
-import { getTypeFactory } from "../utils";
+import { filterIndexes, getIndexName, getTypeFactory } from "../utils";
 
 export type DrizzleResolverOptions = {
 	/**
@@ -53,7 +53,9 @@ export const drizzleResolver = (options: DrizzleResolverOptions): Resolver => {
 								? `t.varchar("${fieldName}", { length: 255 })`
 								: field.references
 									? `t.varchar("${fieldName}", { length: 36 })`
-									: `t.text("${fieldName}")`,
+									: provider === "mysql" && field.index
+										? `t.varchar("${fieldName}", { length: 255 })`
+										: `t.text("${fieldName}")`,
 					boolean:
 						provider === "sqlite"
 							? `t.integer("${fieldName}")`
@@ -108,7 +110,18 @@ export const drizzleResolver = (options: DrizzleResolverOptions): Resolver => {
 				table.push(`\t${field.fieldName}: ${value},`);
 			}
 
-			table.push("});");
+			const indexes = filterIndexes(ctx.schema);
+			if (indexes.length > 0) {
+				table.push("}, (table) => [");
+				for (const field of indexes) {
+					table.push(
+						`\tt.${field.unique ? "uniqueIndex" : "index"}("${getIndexName(ctx.schema.modelName, field)}").on(table.${field.fieldName}),`,
+					);
+				}
+				table.push("]);");
+			} else {
+				table.push("});");
+			}
 
 			return [...imports, "", ...table].join("\n");
 		},

--- a/docs/lib/copy-schema/adapter/prisma.ts
+++ b/docs/lib/copy-schema/adapter/prisma.ts
@@ -1,5 +1,10 @@
 import type { Resolver } from "../types";
-import { capitalize, getTypeFactory } from "../utils";
+import {
+	capitalize,
+	filterIndexes,
+	getIndexName,
+	getTypeFactory,
+} from "../utils";
 
 export type PrismaResolverOptions = {
 	/**
@@ -97,6 +102,13 @@ export const prismaResolver = (options: PrismaResolverOptions): Resolver => {
 					lines.push(`\t${additionalLine}`);
 				}
 				lines.push(`\t${newLine}`);
+			}
+			for (const field of filterIndexes(ctx.schema)) {
+				if (!field.unique) {
+					lines.push(
+						`\t@@index([${field.fieldName}], map: "${getIndexName(ctx.schema.modelName, field)}")`,
+					);
+				}
 			}
 			lines.push(
 				`\t@@map("${ctx.schema.modelName}${options.usePlural ? "s" : ""}")`,

--- a/docs/lib/copy-schema/adapter/prisma.ts
+++ b/docs/lib/copy-schema/adapter/prisma.ts
@@ -1,7 +1,7 @@
 import type { Resolver } from "../types";
 import {
 	capitalize,
-	filterIndexes,
+	filterNonUniqueIndexes,
 	getIndexName,
 	getTypeFactory,
 } from "../utils";
@@ -103,12 +103,10 @@ export const prismaResolver = (options: PrismaResolverOptions): Resolver => {
 				}
 				lines.push(`\t${newLine}`);
 			}
-			for (const field of filterIndexes(ctx.schema)) {
-				if (!field.unique) {
-					lines.push(
-						`\t@@index([${field.fieldName}], map: "${getIndexName(ctx.schema.modelName, field)}")`,
-					);
-				}
+			for (const field of filterNonUniqueIndexes(ctx.schema)) {
+				lines.push(
+					`\t@@index([${field.fieldName}], map: "${getIndexName(ctx.schema.modelName, field)}")`,
+				);
 			}
 			lines.push(
 				`\t@@map("${ctx.schema.modelName}${options.usePlural ? "s" : ""}")`,

--- a/docs/lib/copy-schema/dialects/mssql.ts
+++ b/docs/lib/copy-schema/dialects/mssql.ts
@@ -3,7 +3,12 @@ import type {
 	Resolver,
 	ResolverHandlerContext,
 } from "../types";
-import { filterForeignKeys, getTypeFactory } from "../utils";
+import {
+	filterForeignKeys,
+	filterIndexes,
+	getIndexName,
+	getTypeFactory,
+} from "../utils";
 
 type CustomResolverContext = ResolverHandlerContext & {
 	getType: ReturnType<typeof getTypeFactory>;
@@ -39,6 +44,9 @@ const formatForeignKey = (field: DBFieldAttribute) => {
 	return newLine;
 };
 
+const formatIndex = (field: DBFieldAttribute, tableName: string) =>
+	`CREATE ${field.unique ? "UNIQUE " : ""}INDEX [${getIndexName(tableName, field)}] ON [${tableName}] ([${field.fieldName}]);`;
+
 export const mssqlResolver = {
 	handler: (ctx) => {
 		const getType = getTypeFactory((field) => ({
@@ -47,7 +55,9 @@ export const mssqlResolver = {
 					? "varchar(255)"
 					: field.references
 						? "varchar(36)"
-						: "varchar(8000)",
+						: field.index
+							? "varchar(255)"
+							: "varchar(8000)",
 			boolean: "smallint",
 			number: field.bigint ? "bigint" : "integer",
 			date: "datetime2(3)",
@@ -86,6 +96,9 @@ export const mssqlResolver = {
 			lines.push(`\t);`);
 		}
 		lines.push("END;");
+		for (const field of filterIndexes(ctx.schema)) {
+			lines.push(formatIndex(field, ctx.schema.modelName));
+		}
 		return lines.join("\n");
 	},
 } satisfies Resolver;

--- a/docs/lib/copy-schema/dialects/mssql.ts
+++ b/docs/lib/copy-schema/dialects/mssql.ts
@@ -5,7 +5,7 @@ import type {
 } from "../types";
 import {
 	filterForeignKeys,
-	filterIndexes,
+	filterNonUniqueIndexes,
 	getIndexName,
 	getTypeFactory,
 } from "../utils";
@@ -58,7 +58,7 @@ const formatIndex = (field: DBFieldAttribute, tableName: string) => {
 		`\t\t\tAND object_id = OBJECT_ID(N'${tableObject}')`,
 		"\t)",
 		"BEGIN",
-		`\tCREATE ${field.unique ? "UNIQUE " : ""}INDEX [${indexName}] ON [${tableName}] ([${field.fieldName}]);`,
+		`\tCREATE INDEX [${indexName}] ON [${tableName}] ([${field.fieldName}]);`,
 		"END;",
 	].join("\n");
 };
@@ -112,7 +112,7 @@ export const mssqlResolver = {
 			lines.push(`\t);`);
 		}
 		lines.push("END;");
-		for (const field of filterIndexes(ctx.schema)) {
+		for (const field of filterNonUniqueIndexes(ctx.schema)) {
 			lines.push(formatIndex(field, ctx.schema.modelName));
 		}
 		return lines.join("\n");

--- a/docs/lib/copy-schema/dialects/mssql.ts
+++ b/docs/lib/copy-schema/dialects/mssql.ts
@@ -44,8 +44,24 @@ const formatForeignKey = (field: DBFieldAttribute) => {
 	return newLine;
 };
 
-const formatIndex = (field: DBFieldAttribute, tableName: string) =>
-	`CREATE ${field.unique ? "UNIQUE " : ""}INDEX [${getIndexName(tableName, field)}] ON [${tableName}] ([${field.fieldName}]);`;
+const escapeSqlString = (value: string) => value.replace(/'/g, "''");
+
+const formatIndex = (field: DBFieldAttribute, tableName: string) => {
+	const indexName = getIndexName(tableName, field);
+	const tableObject = escapeSqlString(tableName);
+	return [
+		`IF OBJECT_ID(N'${tableObject}') IS NOT NULL`,
+		"\tAND NOT EXISTS (",
+		"\t\tSELECT 1",
+		"\t\tFROM sys.indexes",
+		`\t\tWHERE name = N'${escapeSqlString(indexName)}'`,
+		`\t\t\tAND object_id = OBJECT_ID(N'${tableObject}')`,
+		"\t)",
+		"BEGIN",
+		`\tCREATE ${field.unique ? "UNIQUE " : ""}INDEX [${indexName}] ON [${tableName}] ([${field.fieldName}]);`,
+		"END;",
+	].join("\n");
+};
 
 export const mssqlResolver = {
 	handler: (ctx) => {

--- a/docs/lib/copy-schema/dialects/mysql.ts
+++ b/docs/lib/copy-schema/dialects/mysql.ts
@@ -3,7 +3,12 @@ import type {
 	Resolver,
 	ResolverHandlerContext,
 } from "../types";
-import { filterForeignKeys, getTypeFactory } from "../utils";
+import {
+	filterForeignKeys,
+	filterIndexes,
+	getIndexName,
+	getTypeFactory,
+} from "../utils";
 
 type CustomResolverContext = ResolverHandlerContext & {
 	getType: ReturnType<typeof getTypeFactory>;
@@ -42,6 +47,9 @@ const formatForeignKey = (field: DBFieldAttribute) => {
 	return newLine;
 };
 
+const formatIndex = (field: DBFieldAttribute, tableName: string) =>
+	`CREATE ${field.unique ? "UNIQUE " : ""}INDEX \`${getIndexName(tableName, field)}\` ON \`${tableName}\` (\`${field.fieldName}\`);`;
+
 export const mysqlResolver = {
 	handler: (ctx) => {
 		const getType = getTypeFactory((field) => ({
@@ -49,7 +57,9 @@ export const mysqlResolver = {
 				? "varchar(255)"
 				: field.references
 					? "varchar(36)"
-					: "text",
+					: field.index
+						? "varchar(255)"
+						: "text",
 			boolean: "boolean",
 			number: field.bigint ? "bigint" : "integer",
 			date: "timestamp(3)",
@@ -86,6 +96,9 @@ export const mysqlResolver = {
 		}
 		if (ctx.mode === "create") {
 			lines.push(`);`);
+		}
+		for (const field of filterIndexes(ctx.schema)) {
+			lines.push(formatIndex(field, ctx.schema.modelName));
 		}
 		return lines.join("\n");
 	},

--- a/docs/lib/copy-schema/dialects/mysql.ts
+++ b/docs/lib/copy-schema/dialects/mysql.ts
@@ -47,8 +47,20 @@ const formatForeignKey = (field: DBFieldAttribute) => {
 	return newLine;
 };
 
-const formatIndex = (field: DBFieldAttribute, tableName: string) =>
-	`CREATE ${field.unique ? "UNIQUE " : ""}INDEX \`${getIndexName(tableName, field)}\` ON \`${tableName}\` (\`${field.fieldName}\`);`;
+const escapeSqlString = (value: string) => value.replace(/'/g, "''");
+
+const formatIndex = (field: DBFieldAttribute, tableName: string) => {
+	const indexName = getIndexName(tableName, field);
+	const createIndex = `CREATE ${field.unique ? "UNIQUE " : ""}INDEX \`${indexName}\` ON \`${tableName}\` (\`${field.fieldName}\`)`;
+	return [
+		`SET @table_exists = (SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '${escapeSqlString(tableName)}');`,
+		`SET @index_exists = (SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = '${escapeSqlString(tableName)}' AND index_name = '${escapeSqlString(indexName)}');`,
+		`SET @create_index_sql = IF(@table_exists > 0 AND @index_exists = 0, '${escapeSqlString(createIndex)}', 'SELECT 1');`,
+		"PREPARE create_index_stmt FROM @create_index_sql;",
+		"EXECUTE create_index_stmt;",
+		"DEALLOCATE PREPARE create_index_stmt;",
+	].join("\n");
+};
 
 export const mysqlResolver = {
 	handler: (ctx) => {

--- a/docs/lib/copy-schema/dialects/mysql.ts
+++ b/docs/lib/copy-schema/dialects/mysql.ts
@@ -5,7 +5,7 @@ import type {
 } from "../types";
 import {
 	filterForeignKeys,
-	filterIndexes,
+	filterNonUniqueIndexes,
 	getIndexName,
 	getTypeFactory,
 } from "../utils";
@@ -51,12 +51,12 @@ const escapeSqlString = (value: string) => value.replace(/'/g, "''");
 
 const formatIndexedColumn = (field: DBFieldAttribute) =>
 	field.type === "string"
-		? `\`${field.fieldName}\`(255)`
+		? `\`${field.fieldName}\`(191)`
 		: `\`${field.fieldName}\``;
 
 const formatIndex = (field: DBFieldAttribute, tableName: string) => {
 	const indexName = getIndexName(tableName, field);
-	const createIndex = `CREATE ${field.unique ? "UNIQUE " : ""}INDEX \`${indexName}\` ON \`${tableName}\` (${formatIndexedColumn(field)})`;
+	const createIndex = `CREATE INDEX \`${indexName}\` ON \`${tableName}\` (${formatIndexedColumn(field)})`;
 	return [
 		`SET @table_exists = (SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '${escapeSqlString(tableName)}');`,
 		`SET @index_exists = (SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = '${escapeSqlString(tableName)}' AND index_name = '${escapeSqlString(indexName)}');`,
@@ -75,7 +75,7 @@ export const mysqlResolver = {
 				: field.references
 					? "varchar(36)"
 					: field.index
-						? "varchar(255)"
+						? "varchar(191)"
 						: "text",
 			boolean: "boolean",
 			number: field.bigint ? "bigint" : "integer",
@@ -114,7 +114,7 @@ export const mysqlResolver = {
 		if (ctx.mode === "create") {
 			lines.push(`);`);
 		}
-		for (const field of filterIndexes(ctx.schema)) {
+		for (const field of filterNonUniqueIndexes(ctx.schema)) {
 			lines.push(formatIndex(field, ctx.schema.modelName));
 		}
 		return lines.join("\n");

--- a/docs/lib/copy-schema/dialects/mysql.ts
+++ b/docs/lib/copy-schema/dialects/mysql.ts
@@ -49,9 +49,14 @@ const formatForeignKey = (field: DBFieldAttribute) => {
 
 const escapeSqlString = (value: string) => value.replace(/'/g, "''");
 
+const formatIndexedColumn = (field: DBFieldAttribute) =>
+	field.type === "string"
+		? `\`${field.fieldName}\`(255)`
+		: `\`${field.fieldName}\``;
+
 const formatIndex = (field: DBFieldAttribute, tableName: string) => {
 	const indexName = getIndexName(tableName, field);
-	const createIndex = `CREATE ${field.unique ? "UNIQUE " : ""}INDEX \`${indexName}\` ON \`${tableName}\` (\`${field.fieldName}\`)`;
+	const createIndex = `CREATE ${field.unique ? "UNIQUE " : ""}INDEX \`${indexName}\` ON \`${tableName}\` (${formatIndexedColumn(field)})`;
 	return [
 		`SET @table_exists = (SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '${escapeSqlString(tableName)}');`,
 		`SET @index_exists = (SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = '${escapeSqlString(tableName)}' AND index_name = '${escapeSqlString(indexName)}');`,

--- a/docs/lib/copy-schema/dialects/postgresql.ts
+++ b/docs/lib/copy-schema/dialects/postgresql.ts
@@ -5,7 +5,7 @@ import type {
 } from "../types";
 import {
 	filterForeignKeys,
-	filterIndexes,
+	filterNonUniqueIndexes,
 	getIndexName,
 	getTypeFactory,
 } from "../utils";
@@ -45,7 +45,7 @@ const formatForeignKey = (field: DBFieldAttribute) => {
 };
 
 const formatIndex = (field: DBFieldAttribute, tableName: string) =>
-	`CREATE ${field.unique ? "UNIQUE " : ""}INDEX IF NOT EXISTS "${getIndexName(tableName, field)}" ON "${tableName}" ("${field.fieldName}");`;
+	`CREATE INDEX IF NOT EXISTS "${getIndexName(tableName, field)}" ON "${tableName}" ("${field.fieldName}");`;
 
 export const postgresqlResolver = {
 	handler: (ctx) => {
@@ -86,7 +86,7 @@ export const postgresqlResolver = {
 		if (ctx.mode === "create") {
 			lines.push(`);`);
 		}
-		for (const field of filterIndexes(ctx.schema)) {
+		for (const field of filterNonUniqueIndexes(ctx.schema)) {
 			lines.push(formatIndex(field, ctx.schema.modelName));
 		}
 		return lines.join("\n");

--- a/docs/lib/copy-schema/dialects/postgresql.ts
+++ b/docs/lib/copy-schema/dialects/postgresql.ts
@@ -3,7 +3,12 @@ import type {
 	Resolver,
 	ResolverHandlerContext,
 } from "../types";
-import { filterForeignKeys, getTypeFactory } from "../utils";
+import {
+	filterForeignKeys,
+	filterIndexes,
+	getIndexName,
+	getTypeFactory,
+} from "../utils";
 
 type CustomResolverContext = ResolverHandlerContext & {
 	getType: ReturnType<typeof getTypeFactory>;
@@ -38,6 +43,9 @@ const formatForeignKey = (field: DBFieldAttribute) => {
 	newLine += ",";
 	return newLine;
 };
+
+const formatIndex = (field: DBFieldAttribute, tableName: string) =>
+	`CREATE ${field.unique ? "UNIQUE " : ""}INDEX IF NOT EXISTS "${getIndexName(tableName, field)}" ON "${tableName}" ("${field.fieldName}");`;
 
 export const postgresqlResolver = {
 	handler: (ctx) => {
@@ -77,6 +85,9 @@ export const postgresqlResolver = {
 		}
 		if (ctx.mode === "create") {
 			lines.push(`);`);
+		}
+		for (const field of filterIndexes(ctx.schema)) {
+			lines.push(formatIndex(field, ctx.schema.modelName));
 		}
 		return lines.join("\n");
 	},

--- a/docs/lib/copy-schema/dialects/sqlite.ts
+++ b/docs/lib/copy-schema/dialects/sqlite.ts
@@ -3,7 +3,12 @@ import type {
 	Resolver,
 	ResolverHandlerContext,
 } from "../types";
-import { filterForeignKeys, getTypeFactory } from "../utils";
+import {
+	filterForeignKeys,
+	filterIndexes,
+	getIndexName,
+	getTypeFactory,
+} from "../utils";
 
 type CustomResolverContext = ResolverHandlerContext & {
 	getType: ReturnType<typeof getTypeFactory>;
@@ -38,6 +43,9 @@ const formatForeignKey = (field: DBFieldAttribute) => {
 	newLine += ",";
 	return newLine;
 };
+
+const formatIndex = (field: DBFieldAttribute, tableName: string) =>
+	`CREATE ${field.unique ? "UNIQUE " : ""}INDEX IF NOT EXISTS "${getIndexName(tableName, field)}" ON "${tableName}" ("${field.fieldName}");`;
 
 export const sqliteResolver = {
 	handler: (ctx) => {
@@ -80,6 +88,9 @@ export const sqliteResolver = {
 		}
 		if (ctx.mode === "create") {
 			lines.push(`);`);
+		}
+		for (const field of filterIndexes(ctx.schema)) {
+			lines.push(formatIndex(field, ctx.schema.modelName));
 		}
 		return lines.join("\n");
 	},

--- a/docs/lib/copy-schema/dialects/sqlite.ts
+++ b/docs/lib/copy-schema/dialects/sqlite.ts
@@ -5,7 +5,7 @@ import type {
 } from "../types";
 import {
 	filterForeignKeys,
-	filterIndexes,
+	filterNonUniqueIndexes,
 	getIndexName,
 	getTypeFactory,
 } from "../utils";
@@ -45,7 +45,7 @@ const formatForeignKey = (field: DBFieldAttribute) => {
 };
 
 const formatIndex = (field: DBFieldAttribute, tableName: string) =>
-	`CREATE ${field.unique ? "UNIQUE " : ""}INDEX IF NOT EXISTS "${getIndexName(tableName, field)}" ON "${tableName}" ("${field.fieldName}");`;
+	`CREATE INDEX IF NOT EXISTS "${getIndexName(tableName, field)}" ON "${tableName}" ("${field.fieldName}");`;
 
 export const sqliteResolver = {
 	handler: (ctx) => {
@@ -89,7 +89,7 @@ export const sqliteResolver = {
 		if (ctx.mode === "create") {
 			lines.push(`);`);
 		}
-		for (const field of filterIndexes(ctx.schema)) {
+		for (const field of filterNonUniqueIndexes(ctx.schema)) {
 			lines.push(formatIndex(field, ctx.schema.modelName));
 		}
 		return lines.join("\n");

--- a/docs/lib/copy-schema/index.test.ts
+++ b/docs/lib/copy-schema/index.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { drizzleResolver } from "./adapter/drizzle";
+import { prismaResolver } from "./adapter/prisma";
+import { copySchema } from "./index";
+import type { DBSchema } from "./types";
+import { getIndexName } from "./utils";
+
+const schema = {
+	modelName: "deviceCode",
+	fields: [
+		{ fieldName: "id", type: "string", required: true },
+		{
+			fieldName: "deviceCode",
+			type: "string",
+			required: true,
+			index: true,
+		},
+		{ fieldName: "userCode", type: "string", required: true, index: true },
+		{
+			fieldName: "uniqueCode",
+			type: "string",
+			required: true,
+			unique: true,
+			index: true,
+		},
+	],
+} satisfies DBSchema;
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10025
+ */
+describe("copySchema indexes", () => {
+	it("generates portable non-unique SQL indexes", () => {
+		const mysql = copySchema(schema, {
+			dialect: "mysql",
+			mode: "create",
+		}).result;
+
+		expect(mysql).toContain("`deviceCode` varchar(191)");
+		expect(mysql).toContain("`deviceCode`(191)");
+		expect(mysql).toContain("`userCode`(191)");
+		expect(mysql).not.toContain("uniqueCode_idx");
+
+		for (const dialect of ["sqlite", "postgresql", "mssql"] as const) {
+			const result = copySchema(schema, { dialect, mode: "create" }).result;
+			expect(result).toContain("deviceCode_idx");
+			expect(result).toContain("userCode_idx");
+			expect(result).not.toContain("uniqueCode_idx");
+		}
+	});
+
+	it("preserves the same index contract in Prisma and Drizzle", () => {
+		const prisma = copySchema(schema, {
+			dialect: prismaResolver({ provider: "mysql" }),
+			mode: "create",
+		}).result;
+		expect(prisma).toContain("@@index([deviceCode]");
+		expect(prisma).not.toContain("@@index([uniqueCode]");
+
+		const drizzle = copySchema(schema, {
+			dialect: drizzleResolver({ provider: "mysql" }),
+			mode: "create",
+		}).result;
+		expect(drizzle).toContain('varchar("device_code", { length: 191 })');
+		expect(drizzle).toContain(".on(table.deviceCode)");
+		expect(drizzle).not.toContain(".on(table.uniqueCode)");
+	});
+
+	it("keeps generated index names within the portable byte limit", () => {
+		const indexName = getIndexName(
+			"deviceAuthorizationCodeWithAnExtremelyLongTableName",
+			{
+				fieldName: "deviceAuthorizationCodeWithAnExtremelyLongFieldName",
+				type: "string",
+				index: true,
+			},
+		);
+
+		expect(new TextEncoder().encode(indexName).byteLength).toBeLessThanOrEqual(
+			63,
+		);
+	});
+});

--- a/docs/lib/copy-schema/types.ts
+++ b/docs/lib/copy-schema/types.ts
@@ -71,6 +71,7 @@ export type DBFieldAttribute = {
 	unique?: boolean;
 	/**
 	 * If the field should be indexed.
+	 * @default false
 	 */
 	index?: boolean;
 	/**

--- a/docs/lib/copy-schema/types.ts
+++ b/docs/lib/copy-schema/types.ts
@@ -70,6 +70,10 @@ export type DBFieldAttribute = {
 	};
 	unique?: boolean;
 	/**
+	 * If the field should be indexed.
+	 */
+	index?: boolean;
+	/**
 	 * If the field should be a bigint on the database instead of integer.
 	 */
 	bigint?: boolean;

--- a/docs/lib/copy-schema/utils.ts
+++ b/docs/lib/copy-schema/utils.ts
@@ -1,5 +1,32 @@
 import type { DBFieldAttribute } from "./types";
 
+const MAX_DATABASE_INDEX_NAME_BYTES = 63;
+
+function getUtf8ByteLength(value: string) {
+	return new TextEncoder().encode(value).length;
+}
+
+function truncateUtf8(value: string, maxBytes: number) {
+	let result = "";
+	let byteLength = 0;
+	for (const character of value) {
+		const characterByteLength = getUtf8ByteLength(character);
+		if (byteLength + characterByteLength > maxBytes) break;
+		result += character;
+		byteLength += characterByteLength;
+	}
+	return result;
+}
+
+function getStableIndexNameHash(value: string) {
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < value.length; index++) {
+		hash ^= value.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
 export function getTypeFactory(
 	getTypeMap: (
 		field: DBFieldAttribute,
@@ -42,12 +69,25 @@ export function filterForeignKeys({ fields }: { fields: DBFieldAttribute[] }) {
 	return fields.filter(({ references }) => !!references);
 }
 
-export function filterIndexes({ fields }: { fields: DBFieldAttribute[] }) {
-	return fields.filter(({ index }) => !!index);
+export function filterNonUniqueIndexes({
+	fields,
+}: {
+	fields: DBFieldAttribute[];
+}) {
+	return fields.filter(({ index, unique }) => !!index && !unique);
 }
 
 export function getIndexName(tableName: string, field: DBFieldAttribute) {
-	return `${tableName}_${field.fieldName}_${field.unique ? "uidx" : "idx"}`;
+	const generatedName = `${tableName}_${field.fieldName}_idx`;
+	if (getUtf8ByteLength(generatedName) <= MAX_DATABASE_INDEX_NAME_BYTES) {
+		return generatedName;
+	}
+
+	const suffix = `_${getStableIndexNameHash(generatedName)}_idx`;
+	return `${truncateUtf8(
+		`${tableName}_${field.fieldName}`,
+		MAX_DATABASE_INDEX_NAME_BYTES - getUtf8ByteLength(suffix),
+	)}${suffix}`;
 }
 
 export function capitalize(str: string) {

--- a/docs/lib/copy-schema/utils.ts
+++ b/docs/lib/copy-schema/utils.ts
@@ -42,6 +42,14 @@ export function filterForeignKeys({ fields }: { fields: DBFieldAttribute[] }) {
 	return fields.filter(({ references }) => !!references);
 }
 
+export function filterIndexes({ fields }: { fields: DBFieldAttribute[] }) {
+	return fields.filter(({ index }) => !!index);
+}
+
+export function getIndexName(tableName: string, field: DBFieldAttribute) {
+	return `${tableName}_${field.fieldName}_${field.unique ? "uidx" : "idx"}`;
+}
+
 export function capitalize(str: string) {
 	return str.charAt(0).toUpperCase() + str.slice(1);
 }

--- a/docs/vitest.config.ts
+++ b/docs/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({});

--- a/packages/better-auth/src/db/get-migration-schema.test.ts
+++ b/packages/better-auth/src/db/get-migration-schema.test.ts
@@ -758,4 +758,72 @@ describe("index generation for columns added to existing tables", () => {
 		const sql = await second.compileMigrations();
 		expect(sql).toBe(";");
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10025
+	 */
+	it("should add table indexes to existing device authorization columns", async () => {
+		const db = new DatabaseSync(":memory:");
+		const baseConfig: BetterAuthOptions = {
+			database: db,
+			plugins: [
+				{
+					id: "old-device-code",
+					schema: {
+						deviceCode: {
+							fields: {
+								deviceCode: {
+									type: "string",
+									required: true,
+								},
+								userCode: {
+									type: "string",
+									required: true,
+								},
+							},
+						},
+					},
+				},
+			],
+		};
+
+		const initial = await getMigrations(baseConfig);
+		await initial.runMigrations();
+
+		const upgradedConfig: BetterAuthOptions = {
+			...baseConfig,
+			plugins: [
+				{
+					id: "new-device-code",
+					schema: {
+						deviceCode: {
+							fields: {
+								deviceCode: {
+									type: "string",
+									required: true,
+								},
+								userCode: {
+									type: "string",
+									required: true,
+								},
+							},
+							indexes: [{ fields: ["deviceCode"] }, { fields: ["userCode"] }],
+						},
+					},
+				},
+			],
+		};
+
+		const migration = await getMigrations(upgradedConfig);
+		const sql = await migration.compileMigrations();
+
+		expect(migration.toBeAdded).toEqual([]);
+		expect(sql).toContain('create index "deviceCode_deviceCode_idx"');
+		expect(sql).toContain('create index "deviceCode_userCode_idx"');
+
+		await migration.runMigrations();
+
+		const repeated = await getMigrations(upgradedConfig);
+		await expect(repeated.compileMigrations()).resolves.toBe(";");
+	});
 });

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -797,12 +797,10 @@ export async function getMigrations(config: BetterAuthOptions) {
 						? "varchar(255)"
 						: field.references
 							? "varchar(36)"
-							: field.index
-								? "varchar(255)"
-								: // mssql deprecated `text`, and the alternative is `varchar(max)`.
-									// Kysely type interface doesn't support `text`, so we set this to `varchar(8000)` as
-									// that's the max length for `varchar`
-									"varchar(8000)",
+							: // mssql deprecated `text`, and the alternative is `varchar(max)`.
+								// Kysely type interface doesn't support `text`, so we set this to `varchar(8000)` as
+								// that's the max length for `varchar`
+								"varchar(8000)",
 			},
 			boolean: {
 				sqlite: "integer",

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -797,10 +797,12 @@ export async function getMigrations(config: BetterAuthOptions) {
 						? "varchar(255)"
 						: field.references
 							? "varchar(36)"
-							: // mssql deprecated `text`, and the alternative is `varchar(max)`.
-								// Kysely type interface doesn't support `text`, so we set this to `varchar(8000)` as
-								// that's the max length for `varchar`
-								"varchar(8000)",
+							: field.index
+								? "varchar(255)"
+								: // mssql deprecated `text`, and the alternative is `varchar(max)`.
+									// Kysely type interface doesn't support `text`, so we set this to `varchar(8000)` as
+									// that's the max length for `varchar`
+									"varchar(8000)",
 			},
 			boolean: {
 				sqlite: "integer",

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -38,6 +38,18 @@ describe("device authorization plugin input validation", () => {
 			}
 		`);
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10025
+	 */
+	it("should reject generated code lengths that exceed indexed columns", () => {
+		expect(() =>
+			deviceAuthorizationOptionsSchema.parse({ deviceCodeLength: 192 }),
+		).toThrow();
+		expect(() =>
+			deviceAuthorizationOptionsSchema.parse({ userCodeLength: 192 }),
+		).toThrow();
+	});
 });
 
 describe("client validation", async () => {
@@ -1213,6 +1225,46 @@ describe("device authorization with custom options", async () => {
 		});
 		expect(response.device_code).toBe(customDeviceCode);
 		expect(response.user_code).toBe(customUserCode);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10025
+	 */
+	it.each([
+		{
+			label: "device",
+			options: {
+				generateDeviceCode: () => "d".repeat(192),
+				generateUserCode: () => "USERCODE",
+			},
+		},
+		{
+			label: "user",
+			options: {
+				generateDeviceCode: () => "device-code",
+				generateUserCode: () => "u".repeat(192),
+			},
+		},
+	])("should reject an oversized custom $label code", async ({
+		label,
+		options,
+	}) => {
+		const { auth } = await getTestInstance({
+			plugins: [deviceAuthorization(options)],
+		});
+
+		await expect(
+			auth.api.deviceCode({
+				body: {
+					client_id: "test-client",
+				},
+			}),
+		).rejects.toMatchObject({
+			body: {
+				error: "invalid_request",
+				error_description: `Generated ${label} code must be at most 191 characters`,
+			},
+		});
 	});
 
 	it("should respect custom expiration time", async () => {

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -1267,6 +1267,57 @@ describe("device authorization with custom options", async () => {
 		});
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10025
+	 */
+	it.each([
+		"device",
+		"user",
+	] as const)("should reject a non-string custom %s code", async (label) => {
+		const options = deviceAuthorizationOptionsSchema.parse(
+			label === "device"
+				? { generateDeviceCode: () => 42 }
+				: { generateUserCode: () => 42 },
+		);
+		const { auth } = await getTestInstance({
+			plugins: [deviceAuthorization(options)],
+		});
+
+		await expect(
+			auth.api.deviceCode({
+				body: {
+					client_id: "test-client",
+				},
+			}),
+		).rejects.toMatchObject({
+			body: {
+				error: "invalid_request",
+				error_description: `Generated ${label} code must be a string`,
+			},
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10025
+	 */
+	it("should count Unicode code points when validating custom codes", async () => {
+		const customDeviceCode = "🦋".repeat(191);
+		const { auth } = await getTestInstance({
+			plugins: [
+				deviceAuthorization({
+					generateDeviceCode: () => customDeviceCode,
+				}),
+			],
+		});
+
+		const response = await auth.api.deviceCode({
+			body: {
+				client_id: "test-client",
+			},
+		});
+		expect(response.device_code).toBe(customDeviceCode);
+	});
+
 	it("should respect custom expiration time", async () => {
 		const { auth } = await getTestInstance({
 			plugins: [

--- a/packages/better-auth/src/plugins/device-authorization/index.ts
+++ b/packages/better-auth/src/plugins/device-authorization/index.ts
@@ -13,7 +13,7 @@ import {
 	deviceToken,
 	deviceVerify,
 } from "./routes";
-import { schema } from "./schema";
+import { DEVICE_AUTHORIZATION_CODE_MAX_LENGTH, schema } from "./schema";
 
 declare module "@better-auth/core" {
 	interface BetterAuthPluginRegistry<AuthOptions, Options> {
@@ -54,17 +54,19 @@ export const deviceAuthorizationOptionsSchema = z.object({
 		.number()
 		.int()
 		.positive()
+		.max(DEVICE_AUTHORIZATION_CODE_MAX_LENGTH)
 		.default(40)
 		.describe(
-			"Length of the device code to be generated. Default is 40 characters.",
+			`Length of the device code to be generated. Must be at most ${DEVICE_AUTHORIZATION_CODE_MAX_LENGTH} characters. Default is 40 characters.`,
 		),
 	userCodeLength: z
 		.number()
 		.int()
 		.positive()
+		.max(DEVICE_AUTHORIZATION_CODE_MAX_LENGTH)
 		.default(8)
 		.describe(
-			"Length of the user code to be generated. Default is 8 characters.",
+			`Length of the user code to be generated. Must be at most ${DEVICE_AUTHORIZATION_CODE_MAX_LENGTH} characters. Default is 8 characters.`,
 		),
 	generateDeviceCode: z
 		.custom<() => string | Promise<string>>(

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -12,8 +12,14 @@ import { DEVICE_AUTHORIZATION_CODE_MAX_LENGTH } from "./schema";
 /* cspell:disable-next-line */
 const defaultCharset = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 
-function validateGeneratedCode(code: string, label: "device" | "user") {
-	if (code.length > DEVICE_AUTHORIZATION_CODE_MAX_LENGTH) {
+function validateGeneratedCode(code: unknown, label: "device" | "user") {
+	if (typeof code !== "string") {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_request",
+			error_description: `Generated ${label} code must be a string`,
+		});
+	}
+	if (Array.from(code).length > DEVICE_AUTHORIZATION_CODE_MAX_LENGTH) {
 		throw new APIError("BAD_REQUEST", {
 			error: "invalid_request",
 			error_description: `Generated ${label} code must be at most ${DEVICE_AUTHORIZATION_CODE_MAX_LENGTH} characters`,

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -7,9 +7,20 @@ import { ms } from "../../utils/time";
 import type { DeviceAuthorizationOptions } from ".";
 import { DEVICE_AUTHORIZATION_ERROR_CODES } from "./error-codes";
 import type { DeviceCode } from "./schema";
+import { DEVICE_AUTHORIZATION_CODE_MAX_LENGTH } from "./schema";
 
 /* cspell:disable-next-line */
 const defaultCharset = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+function validateGeneratedCode(code: string, label: "device" | "user") {
+	if (code.length > DEVICE_AUTHORIZATION_CODE_MAX_LENGTH) {
+		throw new APIError("BAD_REQUEST", {
+			error: "invalid_request",
+			error_description: `Generated ${label} code must be at most ${DEVICE_AUTHORIZATION_CODE_MAX_LENGTH} characters`,
+		});
+	}
+	return code;
+}
 
 const deviceCodeBodySchema = z.object({
 	client_id: z.string().meta({
@@ -40,17 +51,17 @@ const deviceCodeErrorSchema = z.object({
 
 export const deviceCode = (opts: DeviceAuthorizationOptions) => {
 	const generateDeviceCode = async () => {
-		if (opts.generateDeviceCode) {
-			return opts.generateDeviceCode();
-		}
-		return defaultGenerateDeviceCode(opts.deviceCodeLength);
+		const code = opts.generateDeviceCode
+			? await opts.generateDeviceCode()
+			: defaultGenerateDeviceCode(opts.deviceCodeLength);
+		return validateGeneratedCode(code, "device");
 	};
 
 	const generateUserCode = async () => {
-		if (opts.generateUserCode) {
-			return opts.generateUserCode();
-		}
-		return defaultGenerateUserCode(opts.userCodeLength);
+		const code = opts.generateUserCode
+			? await opts.generateUserCode()
+			: defaultGenerateUserCode(opts.userCodeLength);
+		return validateGeneratedCode(code, "user");
 	};
 	return createAuthEndpoint(
 		"/device/code",

--- a/packages/better-auth/src/plugins/device-authorization/schema.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/schema.test.ts
@@ -6,16 +6,9 @@ describe("device authorization schema", () => {
 	 * @see https://github.com/better-auth/better-auth/issues/10025
 	 */
 	it("indexes device authorization lookup fields", () => {
-		const deviceCodeSchema = schema as Record<
-			string,
-			{ fields: Record<string, { index?: boolean; unique?: boolean }> }
-		>;
-
-		for (const fieldName of ["deviceCode", "userCode"] as const) {
-			const field = deviceCodeSchema.deviceCode?.fields[fieldName];
-
-			expect(field?.index).toBe(true);
-			expect(field?.unique).not.toBe(true);
-		}
+		expect(schema.deviceCode.indexes).toEqual([
+			{ fields: ["deviceCode"] },
+			{ fields: ["userCode"] },
+		]);
 	});
 });

--- a/packages/better-auth/src/plugins/device-authorization/schema.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/schema.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { schema } from "./schema";
+
+describe("device authorization schema", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10025
+	 */
+	it("indexes device authorization lookup fields", () => {
+		const deviceCodeSchema = schema as Record<
+			string,
+			{ fields: Record<string, { index?: boolean; unique?: boolean }> }
+		>;
+
+		for (const fieldName of ["deviceCode", "userCode"] as const) {
+			const field = deviceCodeSchema.deviceCode?.fields[fieldName];
+
+			expect(field?.index).toBe(true);
+			expect(field?.unique).not.toBe(true);
+		}
+	});
+});

--- a/packages/better-auth/src/plugins/device-authorization/schema.ts
+++ b/packages/better-auth/src/plugins/device-authorization/schema.ts
@@ -1,18 +1,18 @@
 import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import * as z from "zod";
 
+export const DEVICE_AUTHORIZATION_CODE_MAX_LENGTH = 191;
+
 export const schema = {
 	deviceCode: {
 		fields: {
 			deviceCode: {
 				type: "string",
 				required: true,
-				index: true,
 			},
 			userCode: {
 				type: "string",
 				required: true,
-				index: true,
 			},
 			userId: {
 				type: "string",
@@ -43,6 +43,7 @@ export const schema = {
 				required: false,
 			},
 		},
+		indexes: [{ fields: ["deviceCode"] }, { fields: ["userCode"] }],
 	},
 } satisfies BetterAuthPluginDBSchema;
 

--- a/packages/better-auth/src/plugins/device-authorization/schema.ts
+++ b/packages/better-auth/src/plugins/device-authorization/schema.ts
@@ -7,10 +7,12 @@ export const schema = {
 			deviceCode: {
 				type: "string",
 				required: true,
+				index: true,
 			},
 			userCode: {
 				type: "string",
 				required: true,
+				index: true,
 			},
 			userId: {
 				type: "string",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		projects: ["./packages/*", "./test", "./e2e/*"],
+		projects: ["./packages/*", "./test", "./e2e/*", "./docs"],
 	},
 	ssr: {
 		resolve: {


### PR DESCRIPTION
Device Authorization resolves `deviceCode` and `userCode` during token, verification, approval, and denial requests, but generated schemas leave both lookup paths unindexed. This adds portable table-level indexes through the shared database-index contract so schema generation and migration use the same definition.

## What changes

- **Schema contract**: `deviceCode` and `userCode` receive non-unique lookup indexes with portable, bounded names.
- **Migration behavior**: existing schemas receive missing indexes when their columns satisfy the target database's index-key limits.
- **Generated schemas**: SQL, Prisma, and Drizzle output preserve the same non-unique index semantics, and the documentation table exposes the indexed fields.
- **Code bounds**: configured and custom-generated device and user codes are limited to 191 characters, matching the portable MySQL index contract.

> [!IMPORTANT]
> Existing MySQL and SQL Server installations may use unbounded `deviceCode` and `userCode` columns. Before running the migration, convert both columns to strings bounded at 191 characters and resolve longer values. The migration stops with an actionable error instead of creating a non-portable index.

## Review focus

- The device-authorization schema uses the shared table-level index boundary rather than field-local migration logic.
- The migration remains idempotent and does not duplicate unique constraints.
- Documentation generators emit only non-unique explicit indexes; unique fields remain represented by their column constraints.

Closes #10025
