### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "turbo": "^2.9.14",
     "typescript": "catalog:",
     "vitest": "catalog:vitest"
+  },
+  "bugs": {
+    "url": "https://github.com/better-auth/better-auth/issues"
   }
 }


### PR DESCRIPTION
Adds missing package metadata fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing package metadata by setting `bugs.url` in package.json to https://github.com/better-auth/better-auth/issues. Completes npm metadata and addresses META-1485 by directing users and tools to the correct support channel.

<sup>Written for commit caba38f8701c131ea8aaf123754142f1e63698bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

