### PR TITLE
fix(oauth): send Cache-Control: no-store on credential responses

### DIFF
--- a/.changeset/device-authorization-no-store.md
+++ b/.changeset/device-authorization-no-store.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Device authorization responses that carry credentials are now sent with `Cache-Control: no-store` and `Pragma: no-cache`, so intermediaries no longer cache them. This covers the device code response (`/device/code`) and the device token response (`/device/token`).

--- a/.changeset/oauth-provider-no-store.md
+++ b/.changeset/oauth-provider-no-store.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+OAuth responses that carry credentials are now sent with `Cache-Control: no-store`, so proxies, CDNs, and browsers no longer cache them. This covers the token endpoint (access, refresh, and ID tokens), dynamic client registration (the client secret), token introspection, and userinfo.
+
+Dynamic client registration now returns `201 Created` on success, as required by RFC 7591, instead of `200`.

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -406,6 +406,7 @@ export {
 	createAuthEndpoint,
 	createAuthMiddleware,
 	optionsMiddleware,
+	setNoStore,
 } from "@better-auth/core/api";
 export { APIError } from "@better-auth/core/error";
 export { getIp } from "../utils/get-request-ip";

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -163,6 +163,16 @@ describe("device authorization flow", async () => {
 			expect(response.user_code).toMatch(/^[A-Z0-9]{8}$/);
 		});
 
+		// RFC 8628 §3.2: the device authorization response must not be cached.
+		it("should send Cache-Control: no-store on the device code response", async () => {
+			const response = await auth.api.deviceCode({
+				body: { client_id: "test-client" },
+				asResponse: true,
+			});
+			expect(response.headers.get("Cache-Control")).toBe("no-store");
+			expect(response.headers.get("Pragma")).toBe("no-cache");
+		});
+
 		it("should support custom client ID and scope", async () => {
 			const response = await auth.api.deviceCode({
 				body: {
@@ -325,6 +335,27 @@ describe("device authorization flow", async () => {
 				expect(tokenResponse.expires_in).toBeGreaterThan(0);
 				expect(tokenResponse.scope).toBeDefined();
 			}
+		});
+
+		// The device token response carries live credentials and must not be cached.
+		// @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+		it("should send Cache-Control: no-store on the device token response", async () => {
+			const { headers } = await signInWithTestUser();
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: { client_id: "test-client" },
+			});
+			await auth.api.deviceVerify({ query: { user_code }, headers });
+			await auth.api.deviceApprove({ body: { userCode: user_code }, headers });
+			const response = await auth.api.deviceToken({
+				body: {
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					device_code,
+					client_id: "test-client",
+				},
+				asResponse: true,
+			});
+			expect(response.headers.get("Cache-Control")).toBe("no-store");
+			expect(response.headers.get("Pragma")).toBe("no-cache");
 		});
 
 		it("should deny device authorization", async () => {

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -1,4 +1,4 @@
-import { createAuthEndpoint } from "@better-auth/core/api";
+import { createAuthEndpoint, setNoStore } from "@better-auth/core/api";
 import { APIError } from "@better-auth/core/error";
 import * as z from "zod";
 import { getSessionFromCtx } from "../../api/routes/session";
@@ -168,21 +168,15 @@ Follow [rfc8628#section-3.2](https://datatracker.ietf.org/doc/html/rfc8628#secti
 					userCode,
 				);
 
-			return ctx.json(
-				{
-					device_code: deviceCode,
-					user_code: userCode,
-					verification_uri: verificationUri,
-					verification_uri_complete: verificationUriComplete,
-					expires_in: Math.floor(expiresIn / 1000),
-					interval: Math.floor(ms(opts.interval) / 1000),
-				},
-				{
-					headers: {
-						"Cache-Control": "no-store",
-					},
-				},
-			);
+			setNoStore(ctx);
+			return ctx.json({
+				device_code: deviceCode,
+				user_code: userCode,
+				verification_uri: verificationUri,
+				verification_uri_complete: verificationUriComplete,
+				expires_in: Math.floor(expiresIn / 1000),
+				interval: Math.floor(ms(opts.interval) / 1000),
+			});
 		},
 	);
 };
@@ -473,22 +467,15 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 				}
 
 				// Return OAuth 2.0 compliant token response
-				return ctx.json(
-					{
-						access_token: session.token,
-						token_type: "Bearer",
-						expires_in: Math.floor(
-							(new Date(session.expiresAt).getTime() - Date.now()) / 1000,
-						),
-						scope: claimedDeviceCode.scope || "",
-					},
-					{
-						headers: {
-							"Cache-Control": "no-store",
-							Pragma: "no-cache",
-						},
-					},
-				);
+				setNoStore(ctx);
+				return ctx.json({
+					access_token: session.token,
+					token_type: "Bearer",
+					expires_in: Math.floor(
+						(new Date(session.expiresAt).getTime() - Date.now()) / 1000,
+					),
+					scope: claimedDeviceCode.scope || "",
+				});
 			}
 
 			throw new APIError("INTERNAL_SERVER_ERROR", {

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -686,9 +686,7 @@ export const getFullOrganization = <O extends OrganizationOptions>(
 				session.session.activeOrganizationId;
 			// return null if no organization is found to avoid erroring since this is a usual scenario
 			if (!organizationId) {
-				return ctx.json(null, {
-					status: 200,
-				});
+				return ctx.json(null);
 			}
 			const adapter = getOrgAdapter<O>(ctx.context, options);
 			const organization = await adapter.findFullOrganization({

--- a/packages/core/src/api/index.test.ts
+++ b/packages/core/src/api/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { setNoStore } from "./index";
+
+describe("setNoStore", () => {
+	it("applies the no-store cache header pair via setHeader", () => {
+		const headers = new Headers();
+		setNoStore({ setHeader: (key, value) => headers.set(key, value) });
+		expect(headers.get("Cache-Control")).toBe("no-store");
+		expect(headers.get("Pragma")).toBe("no-cache");
+	});
+});

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -183,3 +183,24 @@ export type AuthEndpoint<
 	R,
 > = ReturnType<typeof createAuthEndpoint<Path, Opts, R>>;
 export type AuthMiddleware = ReturnType<typeof createAuthMiddleware>;
+
+/**
+ * Stop intermediaries (proxies, CDNs, browsers) from caching the current
+ * response, which carries credential-bearing bodies: access/refresh tokens, ID
+ * tokens, client secrets, device codes, or token metadata.
+ *
+ * Endpoint handlers run with `asResponse: false`, which makes the second
+ * argument to `ctx.json(body, { headers })` silently discarded. Response headers
+ * reach the wire only through `ctx.setHeader`, so this is the single supported
+ * way to apply the no-store header set, and it keeps the exact pair in one place
+ * instead of hand-copied at every credential endpoint.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.1 token responses
+ * @see https://datatracker.ietf.org/doc/html/rfc7662#section-4 introspection
+ */
+export function setNoStore(ctx: {
+	setHeader: (key: string, value: string) => void;
+}): void {
+	ctx.setHeader("Cache-Control", "no-store");
+	ctx.setHeader("Pragma", "no-cache");
+}

--- a/packages/oauth-provider/src/introspect.test.ts
+++ b/packages/oauth-provider/src/introspect.test.ts
@@ -205,6 +205,34 @@ describe("oauth introspect", async () => {
 		});
 	});
 
+	// Introspection exposes token metadata; per RFC 7662 §4 it should not be
+	// cached.
+	// @see https://datatracker.ietf.org/doc/html/rfc7662#section-4
+	it("should send Cache-Control: no-store on the introspection response", async () => {
+		const tokens = await getTokens();
+		let response: Response | undefined;
+		const introspection = await client.oauth2.introspect(
+			{
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				token: tokens.data?.access_token!,
+				token_type_hint: "access_token",
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+				onResponse(context) {
+					response = context.response;
+				},
+			},
+		);
+		expect(introspection.data).toMatchObject({ active: true });
+		expect(response?.headers.get("Cache-Control")).toBe("no-store");
+		expect(response?.headers.get("Pragma")).toBe("no-cache");
+	});
+
 	it("should pass with token_type_hint access_token and sent opaque access_token", async () => {
 		const tokens = await getTokens();
 		const introspection = await client.oauth2.introspect(

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -10,6 +10,7 @@ import {
 	dispatchAuthEndpoint,
 	getOAuthState,
 	sessionMiddleware,
+	setNoStore,
 } from "better-auth/api";
 import { parseSetCookieHeader } from "better-auth/cookies";
 import { mergeSchema } from "better-auth/db";
@@ -1021,6 +1022,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					},
 				},
 				async (ctx) => {
+					setNoStore(ctx);
 					return introspectEndpoint(ctx, opts);
 				},
 			),
@@ -1221,6 +1223,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					},
 				},
 				async (ctx) => {
+					setNoStore(ctx);
 					return userInfoEndpoint(ctx, opts);
 				},
 			),

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -83,6 +83,24 @@ describe("oauth register", async () => {
 		expect(response.data?.client_secret).toBeDefined();
 	});
 
+	// A successful registration returns 201 Created and must not be cached, since
+	// the body carries the client secret.
+	// @see https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1
+	it("should respond 201 with Cache-Control: no-store on registration", async () => {
+		let response: Response | undefined;
+		const result = await serverClient.$fetch<OAuthClient>("/oauth2/register", {
+			method: "POST",
+			body: { redirect_uris: [redirectUri] },
+			onResponse(context) {
+				response = context.response;
+			},
+		});
+		expect(result.data?.client_id).toBeDefined();
+		expect(response?.status).toBe(201);
+		expect(response?.headers.get("Cache-Control")).toBe("no-store");
+		expect(response?.headers.get("Pragma")).toBe("no-cache");
+	});
+
 	it("should fail authorization_code without response type code", async () => {
 		const response = await serverClient.oauth2.register({
 			// @ts-expect-error testing with a different response type even though unsupported

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -1,5 +1,5 @@
 import type { GenericEndpointContext } from "@better-auth/core";
-import { APIError, getSessionFromCtx } from "better-auth/api";
+import { APIError, getSessionFromCtx, setNoStore } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
 import { toExpJWT } from "better-auth/plugins";
 import { assertClientPrivileges } from "./oauthClient/privileges";
@@ -275,7 +275,10 @@ export async function createOAuthClientEndpoint(
 			updatedAt: new Date(iat * 1000),
 		},
 	});
-	// Format the response according to RFC7591
+	// Format the response according to RFC7591. RFC 7591 Section 3.2.1 mandates
+	// 201 Created on a successful registration.
+	ctx.setStatus(201);
+	setNoStore(ctx);
 	return ctx.json(
 		schemaToOAuth({
 			...client,
@@ -283,13 +286,6 @@ export async function createOAuthClientEndpoint(
 				? (opts.prefix?.clientSecret ?? "") + clientSecret
 				: undefined,
 		}),
-		{
-			status: 201,
-			headers: {
-				"Cache-Control": "no-store",
-				Pragma: "no-cache",
-			},
-		},
 	);
 }
 

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -1397,6 +1397,38 @@ describe("oauth token - client_credentials", async () => {
 		expect(tokens.data?.expires_at).toBeDefined();
 	});
 
+	// Token responses carry live credentials and must not be cached by any
+	// intermediary.
+	// @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+	it("should send Cache-Control: no-store on the token response", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const { body, headers } = createClientCredentialsTokenRequest({
+			scope: "read:posts",
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+		let response: Response | undefined;
+		const tokens = await client.$fetch<{ access_token?: string }>(
+			"/oauth2/token",
+			{
+				method: "POST",
+				body,
+				headers,
+				onResponse(context) {
+					response = context.response;
+				},
+			},
+		);
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(response?.headers.get("Cache-Control")).toBe("no-store");
+		expect(response?.headers.get("Pragma")).toBe("no-cache");
+	});
+
 	it("should match created client scopes", async ({ expect }) => {
 		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
 			throw Error("beforeAll not run properly");

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -1,5 +1,5 @@
 import type { GenericEndpointContext } from "@better-auth/core";
-import { APIError } from "better-auth/api";
+import { APIError, setNoStore } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
 import { generateCodeChallenge } from "better-auth/oauth2";
 import { signJWT, toExpJWT } from "better-auth/plugins";
@@ -613,24 +613,17 @@ async function createUserTokens(
 			: undefined,
 	]);
 
-	return ctx.json(
-		{
-			...customFields,
-			access_token: accessToken,
-			expires_in: exp - iat,
-			expires_at: exp,
-			token_type: "Bearer" as const,
-			refresh_token: refreshToken?.token,
-			scope: scopes.join(" "),
-			id_token: idToken,
-		},
-		{
-			headers: {
-				"Cache-Control": "no-store",
-				Pragma: "no-cache",
-			},
-		},
-	);
+	setNoStore(ctx);
+	return ctx.json({
+		...customFields,
+		access_token: accessToken,
+		expires_in: exp - iat,
+		expires_at: exp,
+		token_type: "Bearer" as const,
+		refresh_token: refreshToken?.token,
+		scope: scopes.join(" "),
+		id_token: idToken,
+	});
 }
 
 /** Checks verification value */

--- a/packages/oauth-provider/src/userinfo.test.ts
+++ b/packages/oauth-provider/src/userinfo.test.ts
@@ -198,6 +198,26 @@ describe("oauth userinfo", async () => {
 		});
 	});
 
+	// Userinfo returns PII, so the response should not be cached by intermediaries.
+	it("should send Cache-Control: no-store on the userinfo response", async () => {
+		const tokens = await getTokens();
+		let response: Response | undefined;
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: tokens.data?.access_token ?? "",
+				},
+				onResponse(context) {
+					response = context.response;
+				},
+			},
+		);
+		expect(userinfo.data?.sub).toBeDefined();
+		expect(response?.headers.get("Cache-Control")).toBe("no-store");
+		expect(response?.headers.get("Pragma")).toBe("no-cache");
+	});
+
 	it("should accept POST with the bearer token in the Authorization header", async () => {
 		const tokens = await getTokens();
 		expect(tokens.data?.access_token).toBeDefined();

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -346,9 +346,7 @@ export const generatePasskeyRegistrationOptions = (
 				} satisfies StoredChallengeValue),
 				expiresAt: expirationTime,
 			});
-			return ctx.json(options, {
-				status: 200,
-			});
+			return ctx.json(options);
 		},
 	);
 };
@@ -516,9 +514,7 @@ export const generatePasskeyAuthenticationOptions = (
 				value: JSON.stringify(data),
 				expiresAt: expirationTime,
 			});
-			return ctx.json(options, {
-				status: 200,
-			});
+			return ctx.json(options);
 		},
 	);
 
@@ -703,9 +699,7 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) => {
 					model: "passkey",
 					data: newPasskey,
 				});
-				return ctx.json(newPasskeyRes, {
-					status: 200,
-				});
+				return ctx.json(newPasskeyRes);
 			} catch (e) {
 				if (e instanceof APIError) throw e;
 				ctx.context.logger.error("Failed to verify registration", e);
@@ -888,15 +882,10 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 					user,
 				});
 
-				return ctx.json(
-					{
-						session: s,
-						user,
-					},
-					{
-						status: 200,
-					},
-				);
+				return ctx.json({
+					session: s,
+					user,
+				});
 			} catch (e) {
 				if (e instanceof APIError) throw e;
 				ctx.context.logger.error("Failed to verify authentication", e);
@@ -963,9 +952,7 @@ export const listPasskeys = createAuthEndpoint(
 			model: "passkey",
 			where: [{ field: "userId", value: ctx.context.session.user.id }],
 		});
-		return ctx.json(passkeys, {
-			status: 200,
-		});
+		return ctx.json(passkeys);
 	},
 );
 
@@ -1127,13 +1114,8 @@ export const updatePasskey = createAuthEndpoint(
 				PASSKEY_ERROR_CODES.FAILED_TO_UPDATE_PASSKEY,
 			);
 		}
-		return ctx.json(
-			{
-				passkey: updatedPasskey,
-			},
-			{
-				status: 200,
-			},
-		);
+		return ctx.json({
+			passkey: updatedPasskey,
+		});
 	},
 );


### PR DESCRIPTION
Every OAuth response that returns credentials was missing `Cache-Control: no-store` on the wire, so tokens, client secrets, and device codes could be cached by any proxy, CDN, or browser. The endpoints passed the header to `ctx.json(body, { headers })`, but handlers dispatch with `asResponse: false`, and in that mode `ctx.json`'s second argument is discarded. The headers were built and silently dropped; only `ctx.setHeader` and `ctx.setStatus` reach the response.

The fix routes the header set through a single `setNoStore` primitive in `@better-auth/core/api` instead of inlining `setHeader` at each site. The no-store pair was already hand-copied across endpoints and had drifted: `/device/code` set `Cache-Control` without `Pragma`. One named call makes the correct pair a single definition, so a new credential endpoint reaches for it rather than re-typing two headers.

This covers the token endpoint, dynamic client registration, introspection, and userinfo, plus the device code and device token responses. Registration additionally returns `201 Created` now; that status was passed the same dropped way and never took effect.

A second commit removes seven `ctx.json(x, { status: 200 })` calls in passkey and organization. They passed a dropped argument that already matched the default, so they were no-ops that modeled the same footgun.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing no-store headers on OAuth/device credential responses and ensures dynamic client registration returns 201 Created. Uses a single `setNoStore` helper so proxies/CDNs/browsers won’t cache tokens, secrets, or PII.

- **Bug Fixes**
  - Send `Cache-Control: no-store` and `Pragma: no-cache` on credential-bearing responses using `setNoStore`.
    - Covers: token (`/oauth2/token`), registration (`/oauth2/register`), introspection (`/oauth2/introspect`), userinfo (`/oauth2/userinfo`), device code (`/device/code`), and device token (`/device/token`).
  - Registration now returns `201 Created` per RFC 7591 (previous status/header args to `ctx.json` were dropped by dispatch).

- **Refactors**
  - Introduced `setNoStore` in `@better-auth/core/api` and re-exported via `better-auth/api`; replaced inlined headers to avoid drift.
  - Removed no-op `ctx.json(..., { status: 200 })` calls in passkey and organization routes.

<sup>Written for commit 4bf11d74fd1daefb0c548a3990c99a3f7b041235. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

