### PR TITLE
feat(oauth): enforce no-store on credential responses via a declarative flag

### DIFF
--- a/.changeset/oauth-no-store-headers.md
+++ b/.changeset/oauth-no-store-headers.md
@@ -4,6 +4,6 @@
 "better-auth": patch
 ---
 
-OAuth and device-authorization responses that carry credentials now consistently send `Cache-Control: no-store` and `Pragma: no-cache`, so proxies, CDNs, and browsers never cache them. This covers the token, introspection, and userinfo endpoints, dynamic and admin client registration, and the device code and device token responses, including the error responses from those endpoints.
+OAuth and device-authorization responses that carry credentials now consistently send `Cache-Control: no-store` and `Pragma: no-cache`, so proxies, CDNs, and browsers never cache them. This covers the token, introspection, and userinfo endpoints, dynamic and admin client registration, client secret rotation, and the device code and device token responses, including the error responses from those endpoints.
 
 Endpoints declare this with `metadata: { noStore: true }`, and the header set is exported from `@better-auth/core` as `NO_STORE_HEADERS` for responses built by hand.

--- a/.changeset/oauth-no-store-headers.md
+++ b/.changeset/oauth-no-store-headers.md
@@ -1,0 +1,9 @@
+---
+"@better-auth/core": minor
+"@better-auth/oauth-provider": patch
+"better-auth": patch
+---
+
+OAuth and device-authorization responses that carry credentials now consistently send `Cache-Control: no-store` and `Pragma: no-cache`, so proxies, CDNs, and browsers never cache them. This covers the token, introspection, and userinfo endpoints, dynamic and admin client registration, and the device code and device token responses, including the error responses from those endpoints.
+
+Endpoints declare this with `metadata: { noStore: true }`, and the header set is exported from `@better-auth/core` as `NO_STORE_HEADERS` for responses built by hand.

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -405,6 +405,7 @@ export {
 	type AuthMiddleware,
 	createAuthEndpoint,
 	createAuthMiddleware,
+	NO_STORE_HEADERS,
 	optionsMiddleware,
 } from "@better-auth/core/api";
 export { APIError } from "@better-auth/core/error";

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -284,6 +284,36 @@ describe("device authorization flow", async () => {
 	});
 
 	describe("device approval flow", () => {
+		// RFC 8628 §3.2: the device authorization response must not be cached.
+		it("sends no-store on the device code response", async () => {
+			const response = await auth.api.deviceCode({
+				body: { client_id: "test-client" },
+				asResponse: true,
+			});
+			expect(response.headers.get("Cache-Control")).toBe("no-store");
+			expect(response.headers.get("Pragma")).toBe("no-cache");
+		});
+
+		// The device token response carries live credentials.
+		it("sends no-store on the device token response", async () => {
+			const { headers } = await signInWithTestUser();
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: { client_id: "test-client" },
+			});
+			await auth.api.deviceVerify({ query: { user_code }, headers });
+			await auth.api.deviceApprove({ body: { userCode: user_code }, headers });
+			const response = await auth.api.deviceToken({
+				body: {
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					device_code,
+					client_id: "test-client",
+				},
+				asResponse: true,
+			});
+			expect(response.headers.get("Cache-Control")).toBe("no-store");
+			expect(response.headers.get("Pragma")).toBe("no-cache");
+		});
+
 		it("should approve device and create session", async () => {
 			// First, sign in as a user
 			const { headers } = await signInWithTestUser();

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -59,6 +59,7 @@ export const deviceCode = (opts: DeviceAuthorizationOptions) => {
 			body: deviceCodeBodySchema,
 			error: deviceCodeErrorSchema,
 			metadata: {
+				noStore: true,
 				openapi: {
 					description: `Request a device and user code
 
@@ -168,21 +169,14 @@ Follow [rfc8628#section-3.2](https://datatracker.ietf.org/doc/html/rfc8628#secti
 					userCode,
 				);
 
-			return ctx.json(
-				{
-					device_code: deviceCode,
-					user_code: userCode,
-					verification_uri: verificationUri,
-					verification_uri_complete: verificationUriComplete,
-					expires_in: Math.floor(expiresIn / 1000),
-					interval: Math.floor(ms(opts.interval) / 1000),
-				},
-				{
-					headers: {
-						"Cache-Control": "no-store",
-					},
-				},
-			);
+			return ctx.json({
+				device_code: deviceCode,
+				user_code: userCode,
+				verification_uri: verificationUri,
+				verification_uri_complete: verificationUriComplete,
+				expires_in: Math.floor(expiresIn / 1000),
+				interval: Math.floor(ms(opts.interval) / 1000),
+			});
 		},
 	);
 };
@@ -225,6 +219,7 @@ export const deviceToken = (opts: DeviceAuthorizationOptions) =>
 			body: deviceTokenBodySchema,
 			error: deviceTokenErrorSchema,
 			metadata: {
+				noStore: true,
 				openapi: {
 					description: `Exchange device code for access token
 
@@ -474,22 +469,14 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 				}
 
 				// Return OAuth 2.0 compliant token response
-				return ctx.json(
-					{
-						access_token: session.token,
-						token_type: "Bearer",
-						expires_in: Math.floor(
-							(new Date(session.expiresAt).getTime() - Date.now()) / 1000,
-						),
-						scope: claimedDeviceCode.scope || "",
-					},
-					{
-						headers: {
-							"Cache-Control": "no-store",
-							Pragma: "no-cache",
-						},
-					},
-				);
+				return ctx.json({
+					access_token: session.token,
+					token_type: "Bearer",
+					expires_in: Math.floor(
+						(new Date(session.expiresAt).getTime() - Date.now()) / 1000,
+					),
+					scope: claimedDeviceCode.scope || "",
+				});
 			}
 
 			throw new APIError("INTERNAL_SERVER_ERROR", {

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -17,10 +17,12 @@ import { isAPIError } from "../utils/is-api-error";
  * caching a response body. Credential-bearing responses (access/refresh tokens,
  * ID tokens, client secrets, device codes) must carry them.
  *
- * Set `metadata: { noStore: true }` on an endpoint to apply these to every
- * response it produces, success and thrown error alike (see
- * {@link createAuthEndpoint}). Spread them into a hand-built `Response` or
- * `APIError`'s headers for the rare endpoint that constructs its own response.
+ * Set `metadata: { noStore: true }` on an endpoint and {@link createAuthEndpoint}
+ * applies these to the responses its handler produces: the success body and any
+ * error the handler throws. A request rejected by schema or media-type
+ * validation before the handler runs is not covered, and carries no credentials
+ * to protect. Spread them into a hand-built `Response` or `APIError`'s headers
+ * for the rare endpoint that constructs its own response.
  *
  * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
  */
@@ -120,8 +122,10 @@ export function createAuthEndpoint<
 
 	// Endpoints that return credentials declare `metadata: { noStore: true }`.
 	// Emit the no-store headers at the boundary, before the handler runs, so they
-	// land on every response: a success harvests `responseHeaders`, and a thrown
-	// error carries the same headers through `attachResponseHeadersToAPIError`.
+	// land on every response the handler produces: a success harvests
+	// `responseHeaders`, and a thrown error carries the same headers through
+	// `attachResponseHeadersToAPIError`. Validation that rejects the request
+	// before the handler runs is not covered (and returns no credentials).
 	const noStore =
 		(options as { metadata?: { noStore?: boolean } }).metadata?.noStore ===
 		true;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -13,6 +13,23 @@ import type { AuthContext } from "../types";
 import { isAPIError } from "../utils/is-api-error";
 
 /**
+ * Response headers that forbid any intermediary (proxy, CDN, browser) from
+ * caching a response body. Credential-bearing responses (access/refresh tokens,
+ * ID tokens, client secrets, device codes) must carry them.
+ *
+ * Set `metadata: { noStore: true }` on an endpoint to apply these to every
+ * response it produces, success and thrown error alike (see
+ * {@link createAuthEndpoint}). Spread them into a hand-built `Response` or
+ * `APIError`'s headers for the rare endpoint that constructs its own response.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+ */
+export const NO_STORE_HEADERS = {
+	"Cache-Control": "no-store",
+	Pragma: "no-cache",
+} as const;
+
+/**
  * Better-call's createEndpoint re-throws APIError without exposing the headers
  * accumulated on ctx.responseHeaders (e.g. Set-Cookie from deleteSessionCookie
  * before throw). Attach them to the error via kAPIErrorHeaderSymbol — matching
@@ -101,8 +118,21 @@ export function createAuthEndpoint<
 	const handler: EndpointHandler<Path, Opts, R> =
 		typeof handlerOrOptions === "function" ? handlerOrOptions : handlerOrNever;
 
+	// Endpoints that return credentials declare `metadata: { noStore: true }`.
+	// Emit the no-store headers at the boundary, before the handler runs, so they
+	// land on every response: a success harvests `responseHeaders`, and a thrown
+	// error carries the same headers through `attachResponseHeadersToAPIError`.
+	const noStore =
+		(options as { metadata?: { noStore?: boolean } }).metadata?.noStore ===
+		true;
+
 	// todo: prettify the code, we want to call `runWithEndpointContext` to top level
 	const wrapped: EndpointHandler<Path, Opts, R> = async (ctx) => {
+		if (noStore) {
+			for (const [name, value] of Object.entries(NO_STORE_HEADERS)) {
+				ctx.setHeader(name, value);
+			}
+		}
 		const runtimeCtx = ctx as unknown as { responseHeaders?: Headers };
 		try {
 			return await runWithEndpointContext(ctx as any, () => handler(ctx));

--- a/packages/core/src/api/no-store.test.ts
+++ b/packages/core/src/api/no-store.test.ts
@@ -1,0 +1,49 @@
+import { APIError, kAPIErrorHeaderSymbol } from "better-call";
+import { describe, expect, it } from "vitest";
+import { createAuthEndpoint } from "./index";
+
+describe("createAuthEndpoint metadata.noStore", () => {
+	it("applies the no-store headers to a successful response", async () => {
+		const endpoint = createAuthEndpoint(
+			"/no-store-success",
+			{ method: "GET", metadata: { noStore: true } },
+			async () => ({ ok: true }),
+		);
+		const result = (await endpoint({ returnHeaders: true })) as {
+			headers: Headers;
+			response: unknown;
+		};
+		expect(result.response).toEqual({ ok: true });
+		expect(result.headers.get("Cache-Control")).toBe("no-store");
+		expect(result.headers.get("Pragma")).toBe("no-cache");
+	});
+
+	it("attaches the no-store headers to a thrown error", async () => {
+		const endpoint = createAuthEndpoint(
+			"/no-store-error",
+			{ method: "GET", metadata: { noStore: true } },
+			async () => {
+				throw new APIError("BAD_REQUEST", { error: "nope" });
+			},
+		);
+		const error = (await endpoint({}).catch((e) => e)) as APIError & {
+			[kAPIErrorHeaderSymbol]?: Headers;
+		};
+		expect(error).toBeInstanceOf(APIError);
+		const headers = error[kAPIErrorHeaderSymbol];
+		expect(headers?.get("Cache-Control")).toBe("no-store");
+		expect(headers?.get("Pragma")).toBe("no-cache");
+	});
+
+	it("leaves responses untouched without the flag", async () => {
+		const endpoint = createAuthEndpoint(
+			"/plain",
+			{ method: "GET" },
+			async () => ({ ok: true }),
+		);
+		const result = (await endpoint({ returnHeaders: true })) as {
+			headers: Headers;
+		};
+		expect(result.headers.get("Cache-Control")).toBeNull();
+	});
+});

--- a/packages/oauth-provider/src/no-store.test.ts
+++ b/packages/oauth-provider/src/no-store.test.ts
@@ -1,0 +1,146 @@
+import { clientCredentialsTokenRequest } from "@better-auth/core/oauth2";
+import { createAuthClient } from "better-auth/client";
+import { jwt } from "better-auth/plugins/jwt";
+import { getTestInstance } from "better-auth/test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { oauthProviderClient } from "./client";
+import { oauthProvider } from "./oauth";
+import type { OAuthClient } from "./types/oauth";
+
+describe("oauth credential responses carry no-store", async () => {
+	const baseURL = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL,
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
+			}),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL,
+		fetchOptions: { customFetchImpl, headers },
+	});
+
+	const redirectUri = `${rpBaseUrl}/api/auth/callback/test`;
+	let oauthClient: OAuthClient | null = null;
+
+	beforeAll(async () => {
+		oauthClient = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				grant_types: ["client_credentials"],
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(oauthClient?.client_secret).toBeDefined();
+	});
+
+	// RFC 6749 §5.1: the token response carries live credentials.
+	it("sets no-store on a successful token response", async () => {
+		const { body, headers: reqHeaders } = await clientCredentialsTokenRequest({
+			options: {
+				clientId: oauthClient!.client_id!,
+				clientSecret: oauthClient!.client_secret!,
+				redirectURI: redirectUri,
+			},
+		});
+		let response: Response | undefined;
+		const tokens = await client.$fetch<{ access_token?: string }>(
+			"/oauth2/token",
+			{
+				method: "POST",
+				body,
+				headers: reqHeaders,
+				onResponse(context) {
+					response = context.response;
+				},
+			},
+		);
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(response?.headers.get("Cache-Control")).toBe("no-store");
+		expect(response?.headers.get("Pragma")).toBe("no-cache");
+	});
+
+	// The flag applies to thrown errors too: an unknown client reaches the
+	// handler, which rejects it, and the error response is still no-store.
+	it("sets no-store on a token error response", async () => {
+		const { body, headers: reqHeaders } = await clientCredentialsTokenRequest({
+			options: {
+				clientId: "client-that-does-not-exist",
+				clientSecret: "wrong",
+				redirectURI: redirectUri,
+			},
+		});
+		let response: Response | undefined;
+		await client.$fetch("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: reqHeaders,
+			onResponse(context) {
+				response = context.response;
+			},
+		});
+		expect(response?.status).toBeGreaterThanOrEqual(400);
+		expect(response?.headers.get("Cache-Control")).toBe("no-store");
+		expect(response?.headers.get("Pragma")).toBe("no-cache");
+	});
+
+	// RFC 7591 §3.2.1: registration returns 201 and a client_secret to protect.
+	it("sets 201 and no-store on a registration response", async () => {
+		let response: Response | undefined;
+		const result = await client.$fetch<OAuthClient>("/oauth2/register", {
+			method: "POST",
+			body: { redirect_uris: [redirectUri] },
+			onResponse(context) {
+				response = context.response;
+			},
+		});
+		expect(result.data?.client_id).toBeDefined();
+		expect(response?.status).toBe(201);
+		expect(response?.headers.get("Cache-Control")).toBe("no-store");
+		expect(response?.headers.get("Pragma")).toBe("no-cache");
+	});
+
+	// Introspection exposes token metadata; Better Auth marks it no-store.
+	it("sets no-store on the introspection response", async () => {
+		const { body, headers: reqHeaders } = await clientCredentialsTokenRequest({
+			options: {
+				clientId: oauthClient!.client_id!,
+				clientSecret: oauthClient!.client_secret!,
+				redirectURI: redirectUri,
+			},
+		});
+		const tokens = await client.$fetch<{ access_token?: string }>(
+			"/oauth2/token",
+			{ method: "POST", body, headers: reqHeaders },
+		);
+		let response: Response | undefined;
+		await client.oauth2.introspect(
+			{
+				client_id: oauthClient!.client_id,
+				client_secret: oauthClient!.client_secret,
+				token: tokens.data?.access_token ?? "",
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+				onResponse(context) {
+					response = context.response;
+				},
+			},
+		);
+		expect(response?.headers.get("Cache-Control")).toBe("no-store");
+		expect(response?.headers.get("Pragma")).toBe("no-cache");
+	});
+});

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -858,6 +858,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						resource: { invalid: "invalid_target" },
 					},
 					metadata: {
+						noStore: true,
 						allowedMediaTypes: ["application/x-www-form-urlencoded"],
 						openapi: {
 							description: "Obtain an OAuth2.1 access token",
@@ -1032,6 +1033,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						token_type_hint: z.string().optional(),
 					}),
 					metadata: {
+						noStore: true,
 						allowedMediaTypes: ["application/x-www-form-urlencoded"],
 						openapi: {
 							description: "Introspect an OAuth2 access or refresh token",
@@ -1246,6 +1248,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				{
 					method: ["GET", "POST"],
 					metadata: {
+						noStore: true,
 						openapi: {
 							description:
 								"Get OpenID Connect user information (UserInfo endpoint)",
@@ -1425,6 +1428,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 					},
 					defaultError: "invalid_client_metadata",
 					metadata: {
+						noStore: true,
 						openapi: {
 							description: "Register an OAuth2 application",
 							responses: {

--- a/packages/oauth-provider/src/oauthClient/endpoints.test.ts
+++ b/packages/oauth-provider/src/oauthClient/endpoints.test.ts
@@ -192,14 +192,23 @@ describe("oauthClient", async () => {
 	});
 
 	it("should rotate the client secret", async () => {
-		const client = await authClient.oauth2.client.rotateSecret({
-			client_id: oauthClient.client_id,
-		});
+		let response: Response | undefined;
+		const client = await authClient.oauth2.client.rotateSecret(
+			{ client_id: oauthClient.client_id },
+			{
+				onResponse(context) {
+					response = context.response;
+				},
+			},
+		);
 		const { client_secret, ...check } = client.data ?? {};
 		const { client_secret: clientSecret, ...expected } = oauthClient;
 		expect(client_secret).toBeDefined();
 		expect(client_secret).not.toBe(clientSecret);
 		expect(check).toMatchObject(expected);
+		// The rotated secret must not be cached.
+		expect(response?.headers.get("Cache-Control")).toBe("no-store");
+		expect(response?.headers.get("Pragma")).toBe("no-cache");
 		oauthClient = client.data!;
 	});
 

--- a/packages/oauth-provider/src/oauthClient/index.ts
+++ b/packages/oauth-provider/src/oauthClient/index.ts
@@ -63,6 +63,7 @@ export const adminCreateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 				metadata: z.record(z.string(), z.unknown()).optional(),
 			}),
 			metadata: {
+				noStore: true,
 				SERVER_ONLY: true,
 				openapi: {
 					description: "Register an OAuth2 application",
@@ -254,6 +255,7 @@ export const createOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 				dpop_bound_access_tokens: z.boolean().optional(),
 			}),
 			metadata: {
+				noStore: true,
 				openapi: {
 					description: "Register an OAuth2 application",
 					responses: {

--- a/packages/oauth-provider/src/oauthClient/index.ts
+++ b/packages/oauth-provider/src/oauthClient/index.ts
@@ -583,6 +583,7 @@ export const rotateClientSecret = (opts: OAuthOptions<Scope[]>) =>
 				client_id: z.string(),
 			}),
 			metadata: {
+				noStore: true,
 				openapi: {
 					description: "Rotates a confidential client's secret",
 				},

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -1,7 +1,7 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { runWithTransaction } from "@better-auth/core/context";
 import { isLoopbackHost } from "@better-auth/core/utils/host";
-import { APIError, getSessionFromCtx } from "better-auth/api";
+import { APIError, getSessionFromCtx, NO_STORE_HEADERS } from "better-auth/api";
 import { generateRandomString } from "better-auth/crypto";
 import { toExpJWT } from "better-auth/plugins";
 import {
@@ -22,11 +22,7 @@ import type {
 	OAuthClient,
 	TokenEndpointAuthMethod,
 } from "./types/oauth";
-import {
-	OAUTH_NO_STORE_HEADERS,
-	parseClientMetadata,
-	storeClientSecret,
-} from "./utils";
+import { parseClientMetadata, storeClientSecret } from "./utils";
 import { isPrivateHostname } from "./utils/client-assertion";
 import { authorizeInitialAccessToken } from "./utils/initial-access-token";
 
@@ -131,7 +127,7 @@ export async function registerEndpoint(
 			},
 			{
 				"WWW-Authenticate": "Bearer",
-				...OAUTH_NO_STORE_HEADERS,
+				...NO_STORE_HEADERS,
 			},
 		);
 	}
@@ -661,14 +657,10 @@ export async function createOAuthClientEndpoint(
 			resources;
 	}
 	// A newly created client is a 201 on every path (DCR and admin alike). The
-	// response carries a client_secret, so it must not be cached (RFC 7591
-	// §3.2.1). setStatus/setHeader are the reliable way to set these here: the
-	// json `status`/`headers` options are dropped on the dispatched (asResponse:
-	// false) path that serves HTTP requests.
+	// response carries a client_secret; every endpoint that reaches here declares
+	// `metadata: { noStore: true }`, so the no-store headers are applied at the
+	// boundary (RFC 7591 §3.2.1). Only the created status is set here.
 	ctx.setStatus(201);
-	for (const [name, value] of Object.entries(OAUTH_NO_STORE_HEADERS)) {
-		ctx.setHeader(name, value);
-	}
 	return ctx.json(responseBody);
 }
 

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -989,25 +989,17 @@ async function createUserTokens(
 			)
 		: undefined;
 
-	return ctx.json(
-		{
-			...customFields,
-			...(params.tokenResponse ?? {}),
-			access_token: accessToken,
-			expires_in: exp - iat,
-			expires_at: exp,
-			token_type: confirmationTokenType(confirmation),
-			refresh_token: refreshToken?.token,
-			scope: effectiveScopes.join(" "),
-			id_token: idToken,
-		},
-		{
-			headers: {
-				"Cache-Control": "no-store",
-				Pragma: "no-cache",
-			},
-		},
-	);
+	return ctx.json({
+		...customFields,
+		...(params.tokenResponse ?? {}),
+		access_token: accessToken,
+		expires_in: exp - iat,
+		expires_at: exp,
+		token_type: confirmationTokenType(confirmation),
+		refresh_token: refreshToken?.token,
+		scope: effectiveScopes.join(" "),
+		id_token: idToken,
+	});
 }
 
 /** Checks verification value */

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -37,18 +37,6 @@ export {
 } from "../signed-query";
 
 /**
- * Headers required on OAuth token and registration responses so credentials are
- * never cached by intermediaries.
- *
- * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
- * @see https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1
- */
-export const OAUTH_NO_STORE_HEADERS = {
-	"Cache-Control": "no-store",
-	Pragma: "no-cache",
-} as const;
-
-/**
  * Extracts the credentials from an `Authorization: Bearer <token>` header.
  *
  * Returns `undefined` when the header is absent or carries a non-Bearer scheme,

--- a/packages/oauth-provider/src/utils/initial-access-token.ts
+++ b/packages/oauth-provider/src/utils/initial-access-token.ts
@@ -1,4 +1,5 @@
 import type { GenericEndpointContext } from "@better-auth/core";
+import { NO_STORE_HEADERS } from "better-auth/api";
 import { APIError } from "better-call";
 import type {
 	ClientRegistrationRequest,
@@ -6,7 +7,7 @@ import type {
 	OAuthOptions,
 	Scope,
 } from "../types";
-import { OAUTH_NO_STORE_HEADERS, parseBearerToken } from "./index";
+import { parseBearerToken } from "./index";
 
 /**
  * Builds an RFC 6750 §3 Bearer challenge for the registration endpoint. The
@@ -26,7 +27,7 @@ function registrationBearerError(
 		{ error, error_description: errorDescription },
 		{
 			"WWW-Authenticate": `Bearer error="${error}"`,
-			...OAUTH_NO_STORE_HEADERS,
+			...NO_STORE_HEADERS,
 		},
 	);
 }


### PR DESCRIPTION
Credential-bearing OAuth and device responses must not be cached, but `next` applied no-store inconsistently. The token and device endpoints passed the header to `ctx.json`'s second argument, which is discarded on the dispatched (`asResponse: false`) path, so it never reached the wire. Introspection and userinfo set nothing. Only registration worked, through a hand-rolled `setHeader` loop.

Rather than patch each site, an endpoint now declares `metadata: { noStore: true }` and `createAuthEndpoint` emits the header set at the boundary. This covers the success response and every thrown error uniformly: the error path reuses the existing `kAPIErrorHeaderSymbol` propagation, so an `unsupported_grant_type` or `invalid_client` response is no-store too. The header set moves to `@better-auth/core` as `NO_STORE_HEADERS`, retiring the oauth-provider-local `OAUTH_NO_STORE_HEADERS`, so device-authorization and any plugin share one definition instead of each plugin keeping its own.

Flagged endpoints: token, introspection, userinfo, dynamic and admin client registration, and device code and token. Schema-validation errors (a malformed body, which carries no credentials) are intentionally left uncovered, since covering them would apply no-store to every oauth endpoint's validation path.

Supersedes #10062, which fixed a subset of this on `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a simple `metadata: { noStore: true }` flag to enforce no-store caching on all credential-bearing OAuth and device responses, including client secret rotation. Unifies the header set as `NO_STORE_HEADERS` in `@better-auth/core`.

- New Features
  - `createAuthEndpoint` honors `metadata: { noStore: true }` to add `Cache-Control: no-store` and `Pragma: no-cache` to handler success and error responses.
  - Export `NO_STORE_HEADERS` from `@better-auth/core`; remove provider-local `OAUTH_NO_STORE_HEADERS`.
  - Apply to token, introspection, userinfo, dynamic/admin client registration, client secret rotation, and device code/token endpoints.

- Bug Fixes
  - No-store headers now reach the wire for token and device endpoints (previously dropped by `ctx.json` on the dispatched path).
  - Introspection and userinfo now send no-store.
  - Error responses (e.g., `unsupported_grant_type`, `invalid_client`) also send no-store.
  - Client secret rotation responses are no-store (were cacheable).

<sup>Written for commit 01b7159131aaf07efd10a21b9eafdc0f616587a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

