### PR TITLE
chore: add zod-compiler

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -535,7 +535,7 @@
     "vite": "^7.3.2",
     "vitest": "catalog:vitest",
     "vue": "^3.5.29",
-    "zod-compiler": "^1.10.1"
+    "zod-compiler": "^1.10.2"
   },
   "peerDependencies": {
     "@lynx-js/react": "*",

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -23,7 +23,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/_virtual/*"
+  ],
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
@@ -509,6 +511,9 @@
   },
   "devDependencies": {
     "@lynx-js/react": "^0.116.3",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^1.30.0",
+    "@opentelemetry/sdk-trace-node": "^1.30.0",
     "@sveltejs/kit": "^2.60.1",
     "@tanstack/react-start": "^1.168.4",
     "@tanstack/solid-start": "^1.168.4",
@@ -516,9 +521,6 @@
     "@types/google.accounts": "^0.0.18",
     "@types/pg": "^8.16.0",
     "@types/react": "catalog:react19",
-    "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/sdk-trace-base": "^1.30.0",
-    "@opentelemetry/sdk-trace-node": "^1.30.0",
     "happy-dom": "^20.8.9",
     "listhen": "^1.9.0",
     "msw": "^2.12.10",
@@ -532,7 +534,8 @@
     "typescript": "catalog:",
     "vite": "^7.3.2",
     "vitest": "catalog:vitest",
-    "vue": "^3.5.29"
+    "vue": "^3.5.29",
+    "zod-compiler": "^1.10.0"
   },
   "peerDependencies": {
     "@lynx-js/react": "*",

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -535,7 +535,7 @@
     "vite": "^7.3.2",
     "vitest": "catalog:vitest",
     "vue": "^3.5.29",
-    "zod-compiler": "^1.10.0"
+    "zod-compiler": "^1.10.1"
   },
   "peerDependencies": {
     "@lynx-js/react": "*",

--- a/packages/better-auth/tsdown.config.ts
+++ b/packages/better-auth/tsdown.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "tsdown";
+import zodCompiler from "zod-compiler/rolldown";
 
 export default defineConfig({
+	plugins: [zodCompiler()],
 	dts: { build: true, incremental: true },
 	format: ["esm"],
 	entry: [

--- a/packages/better-auth/vitest.config.ts
+++ b/packages/better-auth/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineProject } from "vitest/config";
+import zodCompiler from "zod-compiler/vite";
 
 export default defineProject({
+	plugins: [zodCompiler()],
 	test: {
 		testTimeout: 10_000,
 		execArgv: ["--expose-gc"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1024,8 +1024,8 @@ importers:
         specifier: ^3.5.29
         version: 3.5.29(typescript@5.9.3)
       zod-compiler:
-        specifier: ^1.10.0
-        version: 1.10.0(zod@4.3.6)
+        specifier: ^1.10.1
+        version: 1.10.1(zod@4.3.6)
 
   packages/cli:
     dependencies:
@@ -14457,8 +14457,8 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod-compiler@1.10.0:
-    resolution: {integrity: sha512-pgsork296ncUoTG2+Qg8XV4fL/R3jcZUjaYHrwApwBybUm7y5o+kljXgivmceZ8WWbKAMGGbkoRp6ucXlNFkBQ==}
+  zod-compiler@1.10.1:
+    resolution: {integrity: sha512-549Mzmsy4VAZVl0kH7NljS//QniNkRR/ikZBH6eSg3N/ySUn0JAFJf22JIGj0TSguS+kc++BkLTIwglqIDpCpA==}
     hasBin: true
     peerDependencies:
       zod: ^4.0.0
@@ -29422,7 +29422,7 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod-compiler@1.10.0(zod@4.3.6):
+  zod-compiler@1.10.1(zod@4.3.6):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1024,8 +1024,8 @@ importers:
         specifier: ^3.5.29
         version: 3.5.29(typescript@5.9.3)
       zod-compiler:
-        specifier: ^1.10.1
-        version: 1.10.1(zod@4.3.6)
+        specifier: ^1.10.2
+        version: 1.10.2(zod@4.3.6)
 
   packages/cli:
     dependencies:
@@ -14457,8 +14457,8 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod-compiler@1.10.1:
-    resolution: {integrity: sha512-549Mzmsy4VAZVl0kH7NljS//QniNkRR/ikZBH6eSg3N/ySUn0JAFJf22JIGj0TSguS+kc++BkLTIwglqIDpCpA==}
+  zod-compiler@1.10.2:
+    resolution: {integrity: sha512-zBTE7qZSWAd9Vxh1D7MeyUXH+zFpo6bND2PYqhH1uEXTshCbVAnUBTfd9qKszUJGbN3imt6554O9TMSEXuLbHA==}
     hasBin: true
     peerDependencies:
       zod: ^4.0.0
@@ -29422,7 +29422,7 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod-compiler@1.10.1(zod@4.3.6):
+  zod-compiler@1.10.2(zod@4.3.6):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1023,6 +1023,9 @@ importers:
       vue:
         specifier: ^3.5.29
         version: 3.5.29(typescript@5.9.3)
+      zod-compiler:
+        specifier: ^1.10.0
+        version: 1.10.0(zod@4.3.6)
 
   packages/cli:
     dependencies:
@@ -9606,6 +9609,9 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   getenv@2.0.0:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
     engines: {node: '>=6'}
@@ -14450,6 +14456,12 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
+
+  zod-compiler@1.10.0:
+    resolution: {integrity: sha512-pgsork296ncUoTG2+Qg8XV4fL/R3jcZUjaYHrwApwBybUm7y5o+kljXgivmceZ8WWbKAMGGbkoRp6ucXlNFkBQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^4.0.0
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -19546,7 +19558,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.19.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.31.1
       magic-string: 0.30.21
       source-map-js: 1.2.1
@@ -20436,7 +20448,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(@vitest/coverage-istanbul@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.8.9)(msw@2.12.10(@types/node@25.3.2)(typescript@5.9.3))(vite@6.4.2(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.8.9)(msw@2.12.10(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -20539,7 +20551,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(@vitest/coverage-istanbul@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.8.9)(msw@2.12.10(@types/node@25.3.2)(typescript@5.9.3))(vite@6.4.2(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.8.9)(msw@2.12.10(@types/node@25.9.1)(typescript@5.9.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -21191,7 +21203,7 @@ snapshots:
       dotenv: 16.6.1
       exsolve: 1.0.8
       giget: 2.0.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 1.0.0
@@ -21225,7 +21237,7 @@ snapshots:
       dotenv: 17.3.1
       exsolve: 1.0.8
       giget: 3.2.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 2.1.0
@@ -23176,6 +23188,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   getenv@2.0.0: {}
 
   giget@2.0.0:
@@ -24244,7 +24260,7 @@ snapshots:
       get-port-please: 3.2.0
       h3: 1.15.10
       http-shutdown: 1.2.2
-      jiti: 2.6.1
+      jiti: 2.7.0
       mlly: 1.8.2
       node-forge: 1.4.0
       pathe: 2.0.3
@@ -25636,7 +25652,7 @@ snapshots:
       hookable: 5.5.3
       httpxy: 0.5.1
       ioredis: 5.10.1
-      jiti: 2.6.1
+      jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
       listhen: 1.10.0
@@ -28596,7 +28612,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       defu: 6.1.7
-      jiti: 2.6.1
+      jiti: 2.7.0
       knitwork: 1.3.0
       scule: 1.3.0
 
@@ -29405,6 +29421,17 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod-compiler@1.10.0(zod@4.3.6):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      get-tsconfig: 4.14.0
+      jiti: 2.7.0
+      magic-string: 0.30.21
+      picomatch: 4.0.4
+      unplugin: 3.0.0
+      zod: 4.3.6
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -100,6 +100,7 @@ minimumReleaseAgeExclude:
   - '@better-auth/*'
   - '@better-fetch/fetch'
   - 'better-call'
+  - 'zod-compiler'
 
 patchedDependencies:
   '@changesets/assemble-release-plan': patches/@changesets__assemble-release-plan.patch


### PR DESCRIPTION
https://github.com/gajus/zod-compiler compiles Zod schemas at build time to 2-75x time faster express

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compile Zod schemas at build time using `zod-compiler` to cut runtime cost and speed up validation (observed 2–75x faster). Enabled in both build (`tsdown`) and test (`vitest`) flows.

- **Refactors**
  - Integrated `zod-compiler` plugins in `tsdown.config.ts` (rolldown) and `vitest.config.ts` (vite).
  - Marked `./dist/_virtual/*` as `sideEffects` to prevent tree-shaking of compiled virtual modules.

- **Dependencies**
  - Bumped to `zod-compiler@^1.10.2` and refreshed lockfile.
  - Added `zod-compiler` to `pnpm-workspace.yaml` `minimumReleaseAgeExclude`.

<sup>Written for commit 4f8b8608904623211c9d81b03eba7870aea4a4b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

