### PR TITLE
fix(expo): avoid native dynamic imports

### DIFF
--- a/.changeset/fix-expo-sdk56-native-client.md
+++ b/.changeset/fix-expo-sdk56-native-client.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/expo": patch
+---
+
+Expo native clients no longer crash in SDK 56 development builds when Better Auth starts network tracking or opens a social sign-in browser session.

--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -52,18 +52,13 @@ Expo is a popular framework for building cross-platform apps with React Native. 
     better-auth @better-auth/expo
     ```
 
-    * And you need to install `expo-network` for network state detection.
+    * Install the Expo modules used by the client plugin.
 
     ```package-install
-    expo-network
+    expo-network expo-linking expo-web-browser expo-constants
     ```
 
-    * <small className="text-xs">(Optional)</small> If you're using the default Expo template, these dependencies are already included, so you can skip this step. Otherwise, if you plan to use our social providers (e.g. Google, Apple), your Expo app requires a few additional dependencies.
-
-    ```package-install
-    expo-linking expo-web-browser expo-constants
-
-    ```
+    If you're using the default Expo template, some of these dependencies may already be included.
   </Step>
 
   <Step>

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -48,7 +48,7 @@ interface ExpoClientOptions {
 	/**
 	 * Options to customize the Expo web browser behavior when opening authentication
 	 * sessions. These are passed directly to `expo-web-browser`'s
-	 * `Browser.openBrowserAsync`.
+	 * `Browser.openAuthSessionAsync`.
 	 *
 	 * For example, on iOS you can use `{ preferEphemeralSession: true }` to prevent
 	 * the authentication session from sharing cookies with the user's default

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -12,6 +12,7 @@ import {
 } from "better-auth/cookies";
 import Constants from "expo-constants";
 import * as Linking from "expo-linking";
+import * as Browser from "expo-web-browser";
 import { Platform } from "react-native";
 import { setupExpoFocusManager } from "./focus-manager";
 import { setupExpoOnlineManager } from "./online-manager";
@@ -63,7 +64,7 @@ interface ExpoClientOptions {
 	 * });
 	 * ```
 	 */
-	webBrowserOptions?: import("expo-web-browser").AuthSessionOpenOptions;
+	webBrowserOptions?: Browser.AuthSessionOpenOptions;
 }
 
 interface StoredCookie {
@@ -462,26 +463,10 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							const callbackURL = JSON.parse(context.request.body)?.callbackURL;
 							const to = callbackURL;
 							const signInURL = context.data?.url;
-							let Browser: typeof import("expo-web-browser") | undefined =
-								undefined;
-							try {
-								Browser = await import("expo-web-browser");
-							} catch {
-								try {
-									Browser = require("expo-web-browser");
-								} catch (error) {
-									throw new Error(
-										'"expo-web-browser" is not installed as a dependency!',
-										{
-											cause: error,
-										},
-									);
-								}
-							}
 
 							if (Platform.OS === "android") {
 								try {
-									Browser!.dismissAuthSession();
+									Browser.dismissAuthSession();
 								} catch {}
 							}
 
@@ -497,7 +482,7 @@ export const expoClient = (opts: ExpoClientOptions) => {
 								params.append("oauthState", oauthStateValue);
 							}
 							const proxyURL = `${context.request.baseURL}/expo-authorization-proxy?${params.toString()}`;
-							const result = await Browser!.openAuthSessionAsync(
+							const result = await Browser.openAuthSessionAsync(
 								proxyURL,
 								to,
 								opts?.webBrowserOptions,

--- a/packages/expo/src/online-manager.ts
+++ b/packages/expo/src/online-manager.ts
@@ -1,5 +1,6 @@
 import type { OnlineListener, OnlineManager } from "better-auth/client";
 import { kOnlineManager } from "better-auth/client";
+import * as Network from "expo-network";
 
 class ExpoOnlineManager implements OnlineManager {
 	listeners = new Set<OnlineListener>();
@@ -20,17 +21,15 @@ class ExpoOnlineManager implements OnlineManager {
 	}
 
 	setup() {
-		import("expo-network")
-			.then(({ addNetworkStateListener }) => {
-				const subscription = addNetworkStateListener((state) => {
-					this.setOnline(!!state.isInternetReachable);
-				});
-				this.unsubscribe = () => subscription.remove();
-			})
-			.catch(() => {
-				// fallback to always online
-				this.setOnline(true);
+		try {
+			const subscription = Network.addNetworkStateListener((state) => {
+				this.setOnline(!!state.isInternetReachable);
 			});
+			this.unsubscribe = () => subscription.remove();
+		} catch {
+			// fallback to always online
+			this.setOnline(true);
+		}
 
 		return () => {
 			this.unsubscribe?.();

--- a/packages/expo/src/online-manager.ts
+++ b/packages/expo/src/online-manager.ts
@@ -1,5 +1,6 @@
 import type { OnlineListener, OnlineManager } from "better-auth/client";
 import { kOnlineManager } from "better-auth/client";
+// @better-auth/expo/client requires expo-network even though the root server entry keeps Expo native peers optional.
 import * as Network from "expo-network";
 
 class ExpoOnlineManager implements OnlineManager {

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -18,6 +18,14 @@ vi.mock("expo-web-browser", async () => {
 	};
 });
 
+vi.mock("expo-network", async () => {
+	return {
+		addNetworkStateListener: vi.fn(() => ({
+			remove: vi.fn(),
+		})),
+	};
+});
+
 vi.mock("react-native", async () => {
 	return {
 		AppState: {
@@ -1466,6 +1474,21 @@ describe("ExpoFocusManager duplicate notification prevention", () => {
 });
 
 describe("ExpoOnlineManager duplicate notification prevention", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10028
+	 */
+	it("should subscribe to expo-network without async module loading", async () => {
+		const expoNetwork = await import("expo-network");
+		const { setupExpoOnlineManager } = await import("../src/online-manager");
+		const onlineManager = setupExpoOnlineManager();
+
+		vi.mocked(expoNetwork.addNetworkStateListener).mockClear();
+		const cleanup = onlineManager.setup();
+
+		expect(expoNetwork.addNetworkStateListener).toHaveBeenCalledTimes(1);
+		cleanup();
+	});
+
 	it("should not notify listeners when setOnline is called with the same value", async () => {
 		const { setupExpoOnlineManager } = await import("../src/online-manager");
 		const onlineManager = setupExpoOnlineManager();


### PR DESCRIPTION
Expo SDK 56 native development builds can fail when Metro evaluates Better Auth's Expo client dynamic imports.

This keeps the existing `@better-auth/expo/client` entry point and uses static Expo module references for the native modules the client already expects. Metro can include those modules in the native bundle instead of relying on lazy module IDs for `expo-network` or `expo-web-browser`.

The package-level optional peer metadata stays unchanged because the root `@better-auth/expo` server plugin does not load these native modules. The docs now list the modules required by the client plugin.

Fixes #10028.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev build crashes on Expo SDK 56 by replacing dynamic native imports in the `@better-auth/expo` client with static imports so Metro bundles required modules. Restores social sign-in and network tracking. Fixes #10028.

- **Bug Fixes**
  - Use static imports for `expo-web-browser` and `expo-network`; remove async import/require paths in the client and online manager.
  - Update tests to assert synchronous subscription to `Network.addNetworkStateListener`.

- **Migration**
  - Install these client dependencies in your app: `expo-network expo-linking expo-web-browser expo-constants` (docs now clearly list these).

<sup>Written for commit 04b023e0614e660e9cf9521a90a58b0e70ed677b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

