### PR TITLE
fix(core): reuse active transactions

### DIFF
--- a/.changeset/reentrant-transaction-verification.md
+++ b/.changeset/reentrant-transaction-verification.md
@@ -1,0 +1,6 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+---
+
+Single-use verification flows no longer hang on database adapters that use a one-connection pool. This fixes magic-link verification and similar token checks in connection-limited serverless database setups.

--- a/packages/core/src/context/transaction.test.ts
+++ b/packages/core/src/context/transaction.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { DBAdapter, DBTransactionAdapter } from "../db/adapter";
+import {
+	getCurrentAdapter,
+	queueAfterTransactionHook,
+	runWithAdapter,
+	runWithTransaction,
+} from "./transaction";
+
+function createTransactionHarness() {
+	let transactionCalls = 0;
+	const transactionAdapter = {} as DBTransactionAdapter;
+	const adapter = {
+		transaction: async <R>(
+			callback: (trx: DBTransactionAdapter) => Promise<R>,
+		) => {
+			transactionCalls += 1;
+			return callback(transactionAdapter);
+		},
+	} as DBAdapter;
+
+	return {
+		adapter,
+		transactionAdapter,
+		getTransactionCalls: () => transactionCalls,
+	};
+}
+
+describe("runWithTransaction", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9869
+	 */
+	it("reuses the active transaction for nested calls", async () => {
+		const { adapter, transactionAdapter, getTransactionCalls } =
+			createTransactionHarness();
+		const adapters: DBTransactionAdapter[] = [];
+
+		await runWithTransaction(adapter, async () => {
+			adapters.push(await getCurrentAdapter(adapter));
+
+			await runWithTransaction(adapter, async () => {
+				adapters.push(await getCurrentAdapter(adapter));
+			});
+		});
+
+		expect(getTransactionCalls()).toBe(1);
+		expect(adapters).toEqual([transactionAdapter, transactionAdapter]);
+	});
+
+	it("still opens a transaction from a plain adapter context", async () => {
+		const { adapter, transactionAdapter, getTransactionCalls } =
+			createTransactionHarness();
+		let activeAdapter: DBTransactionAdapter | null = null;
+
+		await runWithAdapter(adapter, () =>
+			runWithTransaction(adapter, async () => {
+				activeAdapter = await getCurrentAdapter(adapter);
+			}),
+		);
+
+		expect(getTransactionCalls()).toBe(1);
+		expect(activeAdapter).toBe(transactionAdapter);
+	});
+
+	it("runs hooks queued by nested calls after the outer transaction finishes", async () => {
+		const { adapter, getTransactionCalls } = createTransactionHarness();
+		let hookRuns = 0;
+		let hookRunsInsideTransaction = 0;
+
+		await runWithTransaction(adapter, async () => {
+			await runWithTransaction(adapter, async () => {
+				await queueAfterTransactionHook(async () => {
+					hookRuns += 1;
+				});
+			});
+
+			hookRunsInsideTransaction = hookRuns;
+		});
+
+		expect(getTransactionCalls()).toBe(1);
+		expect(hookRunsInsideTransaction).toBe(0);
+		expect(hookRuns).toBe(1);
+	});
+});

--- a/packages/core/src/context/transaction.ts
+++ b/packages/core/src/context/transaction.ts
@@ -1,11 +1,15 @@
 import type { AsyncLocalStorage } from "node:async_hooks";
 import { getAsyncLocalStorage } from "@better-auth/core/async_hooks";
 import type { DBAdapter, DBTransactionAdapter } from "../db/adapter";
+import type { BetterAuthOptions } from "../types";
 import { __getBetterAuthGlobal } from "./global";
 
+type StoredAdapter = DBTransactionAdapter<BetterAuthOptions>;
+
 type HookContext = {
-	adapter: DBTransactionAdapter;
+	adapter: StoredAdapter;
 	pendingHooks: Array<() => Promise<void>>;
+	isTransactionActive: boolean;
 };
 
 const ensureAsyncStorage = async () => {
@@ -27,21 +31,29 @@ export const getCurrentDBAdapterAsyncLocalStorage = async () => {
 	return ensureAsyncStorage();
 };
 
-export const getCurrentAdapter = async (
-	fallback: DBTransactionAdapter,
-): Promise<DBTransactionAdapter> => {
+export const getCurrentAdapter = async <
+	Options extends BetterAuthOptions = BetterAuthOptions,
+>(
+	fallback: DBTransactionAdapter<Options>,
+): Promise<DBTransactionAdapter<Options>> => {
 	return ensureAsyncStorage()
 		.then((als) => {
 			const store = als.getStore();
-			return store?.adapter || fallback;
+			return (
+				(store?.adapter as DBTransactionAdapter<Options> | undefined) ||
+				fallback
+			);
 		})
 		.catch(() => {
 			return fallback;
 		});
 };
 
-export const runWithAdapter = async <R>(
-	adapter: DBAdapter,
+export const runWithAdapter = async <
+	R,
+	Options extends BetterAuthOptions = BetterAuthOptions,
+>(
+	adapter: DBAdapter<Options>,
 	fn: () => R,
 ): Promise<R> => {
 	let called = false;
@@ -53,7 +65,14 @@ export const runWithAdapter = async <R>(
 			let error: unknown;
 			let hasError = false;
 			try {
-				result = await als.run({ adapter, pendingHooks }, fn);
+				result = await als.run(
+					{
+						adapter: adapter as unknown as StoredAdapter,
+						pendingHooks,
+						isTransactionActive: false,
+					},
+					fn,
+				);
 			} catch (err) {
 				error = err;
 				hasError = true;
@@ -75,21 +94,35 @@ export const runWithAdapter = async <R>(
 		});
 };
 
-export const runWithTransaction = async <R>(
-	adapter: DBAdapter,
+export const runWithTransaction = async <
+	R,
+	Options extends BetterAuthOptions = BetterAuthOptions,
+>(
+	adapter: DBAdapter<Options>,
 	fn: () => R,
 ): Promise<R> => {
-	let called = true;
+	let called = false;
 	return ensureAsyncStorage()
 		.then(async (als) => {
 			called = true;
+			const store = als.getStore();
+			if (store?.isTransactionActive) {
+				return fn();
+			}
 			const pendingHooks: Array<() => Promise<void>> = [];
 			let result: Awaited<R>;
 			let error: unknown;
 			let hasError = false;
 			try {
 				result = await adapter.transaction(async (trx) => {
-					return als.run({ adapter: trx, pendingHooks }, fn);
+					return als.run(
+						{
+							adapter: trx as unknown as StoredAdapter,
+							pendingHooks,
+							isTransactionActive: true,
+						},
+						fn,
+					);
 				});
 			} catch (e) {
 				hasError = true;

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
+import { runWithTransaction } from "../../context/transaction";
 import type { BetterAuthOptions } from "../../types";
 import { createAdapterFactory } from "./factory";
-import type { CleanedWhere, CustomAdapter } from "./index";
+import type {
+	CleanedWhere,
+	CustomAdapter,
+	DBAdapter,
+	DBTransactionAdapter,
+} from "./index";
 
 function createCustomAdapter(overrides: Partial<CustomAdapter>): CustomAdapter {
 	return {
@@ -21,9 +27,13 @@ function createCustomAdapter(overrides: Partial<CustomAdapter>): CustomAdapter {
 function createTestAdapter({
 	adapter,
 	options = {},
+	transaction,
 }: {
 	adapter: CustomAdapter;
 	options?: BetterAuthOptions;
+	transaction?: <R>(
+		callback: (trx: DBTransactionAdapter<BetterAuthOptions>) => Promise<R>,
+	) => Promise<R>;
 }) {
 	return createAdapterFactory<BetterAuthOptions>({
 		config: {
@@ -42,6 +52,7 @@ function createTestAdapter({
 				}
 				return data;
 			},
+			transaction,
 		},
 		adapter: () => adapter,
 	})({
@@ -142,6 +153,57 @@ describe("createAdapterFactory consumeOne fallback", () => {
 		});
 
 		expect(result).toBeNull();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9869
+	 */
+	it("reuses the active transaction for the fallback", async () => {
+		let transactionCalls = 0;
+		let isTransactionActive = false;
+		let adapter: DBAdapter<BetterAuthOptions> | null = null;
+
+		const transaction = async <R>(
+			callback: (trx: DBTransactionAdapter<BetterAuthOptions>) => Promise<R>,
+		): Promise<R> => {
+			transactionCalls += 1;
+			if (isTransactionActive) {
+				throw new Error("nested transaction");
+			}
+			if (!adapter) {
+				throw new Error("adapter has not been initialized");
+			}
+			isTransactionActive = true;
+			try {
+				return await callback(adapter);
+			} finally {
+				isTransactionActive = false;
+			}
+		};
+
+		adapter = createTestAdapter({
+			transaction,
+			adapter: createCustomAdapter({
+				findMany: async <T>() =>
+					[
+						{
+							id: "verification-id",
+							identifier_text: "stored-token",
+						},
+					] as T[],
+				deleteMany: async () => 1,
+			}),
+		});
+
+		const result = await runWithTransaction(adapter, async () =>
+			adapter!.consumeOne<{ id: string; identifier: string }>({
+				model: "verification",
+				where: [{ field: "identifier", value: "token" }],
+			}),
+		);
+
+		expect(result?.id).toBe("verification-id");
+		expect(transactionCalls).toBe(1);
 	});
 
 	it("throws when deleteMany returns a non-numeric value", async () => {

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -3,6 +3,10 @@ import {
 	ATTR_DB_OPERATION_NAME,
 	withSpan,
 } from "@better-auth/core/instrumentation";
+import {
+	getCurrentAdapter,
+	runWithTransaction,
+} from "../../context/transaction";
 import { createLogger, getColorDepth, TTY_COLORS } from "../../env";
 import { BetterAuthError } from "../../error";
 import type { BetterAuthOptions } from "../../types";
@@ -1364,11 +1368,9 @@ export const createAdapterFactory =
 					// engines with real transaction isolation; race window narrows
 					// (does not close) on adapters that fall through to sequential
 					// execution. Remove this branch when consumeOne becomes required.
-					// FIXME(consume-one-nested-transaction): custom adapters without a
-					// native consumeOne have no portable signal for "already inside a
-					// transaction". First-party adapters mark transaction-scoped
-					// adapters as as-is; make that capability explicit in the next
-					// breaking adapter contract.
+					// Use Better Auth's transaction context here, not a direct adapter
+					// transaction, so callers already inside a transaction keep using
+					// the active transaction adapter.
 					res = await withSpan(
 						`db consumeOne ${model}`,
 						{
@@ -1376,7 +1378,8 @@ export const createAdapterFactory =
 							[ATTR_DB_COLLECTION_NAME]: model,
 						},
 						() =>
-							adapter.transaction(async (trx) => {
+							runWithTransaction(adapter, async () => {
+								const trx = await getCurrentAdapter(adapter);
 								const rows = await trx.findMany<Record<string, any>>({
 									model: unsafeModel,
 									where: unsafeWhere,
@@ -1508,7 +1511,8 @@ export const createAdapterFactory =
 							[ATTR_DB_COLLECTION_NAME]: model,
 						},
 						() =>
-							adapter.transaction(async (trx) => {
+							runWithTransaction(adapter, async () => {
+								const trx = await getCurrentAdapter(adapter);
 								const rows = await trx.findMany<Record<string, any>>({
 									model: unsafeModel,
 									where: unsafeWhere,


### PR DESCRIPTION
Database-backed single-use verification could hang under connection-limited adapters when a consume path entered a transaction and then hit a transaction-based adapter fallback.

This makes Better Auth's transaction context reentrant, so nested transaction scopes join the active transaction adapter instead of asking the database adapter for another transaction. The consume and counter fallbacks now enter that same context, which keeps compatibility for adapters that still rely on the fallback while preserving one atomic unit.

The regression tests cover nested transaction reuse, plain adapter contexts still opening a transaction, deferred hook flushing from nested calls, and the adapter-factory fallback path that previously requested a second transaction.

Fixes #9869

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hanging in single-use verification by making the transaction context reentrant and reusing the active transaction in adapter fallbacks. Restores magic-link and token checks on one-connection database pools while keeping operations atomic.

- **Bug Fixes**
  - Nested transaction scopes now join the active adapter instead of opening a new transaction.
  - `consumeOne` and counter fallbacks run within Better Auth’s transaction context using `runWithTransaction` and `getCurrentAdapter`.
  - Deferred hooks from nested calls flush after the outer transaction completes.
  - Tests cover nested reuse, plain adapter contexts, hook flushing, and the factory fallback path.

Patch releases: `better-auth`, `@better-auth/core`.

<sup>Written for commit 4644a58a943fe73a5889475e097d534118db0968. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

