### PR TITLE
fix(sso): reject OIDC endpoint redirects portably

### DIFF
--- a/.changeset/sso-oidc-manual-redirects.md
+++ b/.changeset/sso-oidc-manual-redirects.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+OIDC SSO now works on Cloudflare Workers when discovery is enabled. Redirecting OIDC discovery, token, userinfo, and JWKS endpoints are rejected with a clear configuration error; configure the final endpoint URL instead.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -287,6 +287,12 @@ trustedOrigins: async (request) => {
 
 See the [`trustedOrigins`](/docs/reference/security#trusted-origins) docs for more information.
 
+#### Redirecting OIDC endpoints
+
+Better Auth does not follow redirects for server-side OIDC requests. Configure the final canonical URL for the discovery, token, userinfo, and JWKS endpoints.
+
+If one of those endpoints returns a `3xx` response, registration or sign-in fails with `oidc_endpoint_redirect`. This keeps endpoint validation tied to the exact URL that Better Auth fetches.
+
 #### Why Discovery Can Fail
 
 Better Auth validates that the IdP's metadata is correct and complete **before** allowing registration. This prevents subtle runtime failures during sign-in or token validation.
@@ -309,6 +315,7 @@ If the Identity Provider is misconfigured or unreachable, registration will fail
 | `discovery_invalid_url`         | The discovery URL is malformed or uses an unsupported protocol                                                                      |
 | `discovery_untrusted_origin`    | The discovery URL or one of the URLs discovered as part of this process was not trusted by your app's trusted origins configuration |
 | `discovery_invalid_json`        | The discovery response is empty or not valid JSON                                                                                   |
+| `oidc_endpoint_redirect`        | The discovery, token, userinfo, or JWKS endpoint returned a redirect; configure the final endpoint URL instead                      |
 | `unsupported_token_auth_method` | The IdP only supports token auth methods that Better Auth doesn't support                                                           |
 
 **Supported token auth methods:**

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -256,6 +256,118 @@ describe("SSO", async () => {
 		expect(callbackURL).toContain("/dashboard");
 	});
 
+	it("should redirect with the token endpoint error description when code exchange fails", async () => {
+		const { headers } = await signInWithTestUser();
+		await auth.api.registerSSOProvider({
+			body: {
+				issuer: server.issuer.url!,
+				domain: "token-error.com",
+				providerId: "token-error-provider",
+				oidcConfig: {
+					clientId: "test",
+					clientSecret: "test",
+					authorizationEndpoint: `${server.issuer.url}/authorize`,
+					tokenEndpoint: `${server.issuer.url}/token`,
+					jwksEndpoint: `${server.issuer.url}/jwks`,
+					discoveryEndpoint: `${server.issuer.url}/.well-known/openid-configuration`,
+				},
+			},
+			headers,
+		});
+
+		const tokenErrorHandler = (tokenEndpointResponse: {
+			body: Record<string, unknown>;
+			statusCode: number;
+		}) => {
+			tokenEndpointResponse.body = {
+				error: "invalid_client",
+				error_description: "client rejected by issuer",
+			};
+			tokenEndpointResponse.statusCode = 401;
+		};
+		server.service.once("beforeResponse", tokenErrorHandler);
+
+		const signInHeaders = new Headers();
+		const res = await authClient.signIn.sso({
+			providerId: "token-error-provider",
+			callbackURL: "/dashboard",
+			fetchOptions: {
+				throw: true,
+				onSuccess: cookieSetter(signInHeaders),
+			},
+		});
+
+		try {
+			const { callbackURL } = await simulateOAuthFlow(res.url, signInHeaders);
+			const redirectURL = new URL(callbackURL, "http://localhost:3000");
+			expect(redirectURL.searchParams.get("error")).toBe("invalid_provider");
+			expect(redirectURL.searchParams.get("error_description")).toBe(
+				"client rejected by issuer",
+			);
+		} finally {
+			server.service.removeListener("beforeResponse", tokenErrorHandler);
+		}
+	});
+
+	it("should redirect with an encoded invalid request when callback has no code", async () => {
+		const { headers } = await signInWithTestUser();
+		await auth.api.registerSSOProvider({
+			body: {
+				issuer: server.issuer.url!,
+				domain: "missing-code.com",
+				providerId: "missing-code-provider",
+				oidcConfig: {
+					clientId: "test",
+					clientSecret: "test",
+					authorizationEndpoint: `${server.issuer.url}/authorize`,
+					tokenEndpoint: `${server.issuer.url}/token`,
+					jwksEndpoint: `${server.issuer.url}/jwks`,
+					discoveryEndpoint: `${server.issuer.url}/.well-known/openid-configuration`,
+				},
+			},
+			headers,
+		});
+
+		const signInHeaders = new Headers();
+		const res = await authClient.signIn.sso({
+			providerId: "missing-code-provider",
+			callbackURL: "/dashboard",
+			fetchOptions: {
+				throw: true,
+				onSuccess: cookieSetter(signInHeaders),
+			},
+		});
+
+		let callbackLocation: string | null = null;
+		await betterFetch(res.url, {
+			method: "GET",
+			redirect: "manual",
+			onError(context) {
+				callbackLocation = context.response.headers.get("location");
+			},
+		});
+		if (!callbackLocation) throw new Error("No callback location found");
+
+		const callbackWithoutCode = new URL(callbackLocation);
+		callbackWithoutCode.searchParams.delete("code");
+
+		let redirectLocation = "";
+		await betterFetch(callbackWithoutCode.toString(), {
+			method: "GET",
+			customFetchImpl,
+			headers: signInHeaders,
+			onError(context) {
+				redirectLocation = context.response.headers.get("location") || "";
+			},
+		});
+
+		const redirectURL = new URL(redirectLocation, "http://localhost:3000");
+		expect(redirectURL.searchParams.get("error")).toBe("invalid_request");
+		expect(redirectURL.searchParams.get("error_description")).toBe(
+			"authorization_code_not_found",
+		);
+	});
+
 	it("should forward additionalParams to the SSO authorization URL", async () => {
 		const res = await authClient.signIn.sso({
 			providerId: "test",

--- a/packages/sso/src/oidc/discovery.test.ts
+++ b/packages/sso/src/oidc/discovery.test.ts
@@ -1,11 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	assertEndpointResolvesPublic,
-	assertOIDCEndpointsResolvePublic,
+	assertServerFetchedOIDCEndpointsAllowed,
 	computeDiscoveryUrl,
 	discoverOIDCConfig,
 	ensureRuntimeDiscovery,
 	fetchDiscoveryDocument,
+	fetchOIDCEndpointResponse,
 	needsRuntimeDiscovery,
 	normalizeDiscoveryUrls,
 	normalizeUrl,
@@ -24,6 +25,16 @@ const { lookupMock } = vi.hoisted(() => ({ lookupMock: vi.fn() }));
 vi.mock("node:dns/promises", () => ({ lookup: lookupMock }));
 
 import { betterFetch } from "@better-fetch/fetch";
+
+beforeEach(() => {
+	vi.mocked(betterFetch).mockReset();
+	lookupMock.mockReset();
+	lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
 
 /**
  * Mock OIDC Discovery Document
@@ -1385,10 +1396,10 @@ describe("resolved-address guard", () => {
 		});
 	});
 
-	describe("assertOIDCEndpointsResolvePublic", () => {
+	describe("assertServerFetchedOIDCEndpointsAllowed", () => {
 		it("checks token, userinfo, and jwks endpoints", async () => {
 			lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
-			await assertOIDCEndpointsResolvePublic(
+			await assertServerFetchedOIDCEndpointsAllowed(
 				{
 					tokenEndpoint: "https://idp.example.com/token",
 					userInfoEndpoint: "https://idp.example.com/userinfo",
@@ -1402,7 +1413,7 @@ describe("resolved-address guard", () => {
 		it("rejects when the userinfo endpoint resolves internally", async () => {
 			lookupMock.mockResolvedValue([{ address: "10.1.2.3", family: 4 }]);
 			await expect(
-				assertOIDCEndpointsResolvePublic(
+				assertServerFetchedOIDCEndpointsAllowed(
 					{ userInfoEndpoint: "https://idp.internal.example/userinfo" },
 					notTrusted,
 				),
@@ -1413,7 +1424,7 @@ describe("resolved-address guard", () => {
 
 		it("rejects a syntactically-private endpoint before any DNS lookup", async () => {
 			await expect(
-				assertOIDCEndpointsResolvePublic(
+				assertServerFetchedOIDCEndpointsAllowed(
 					{ tokenEndpoint: "https://169.254.169.254/token" },
 					notTrusted,
 				),
@@ -1433,10 +1444,62 @@ describe("fetchDiscoveryDocument redirect handling", () => {
 		});
 		await fetchDiscoveryDocument(
 			"https://idp.example.com/.well-known/openid-configuration",
+			undefined,
+			() => true,
 		);
 		expect(betterFetch).toHaveBeenCalledWith(
 			"https://idp.example.com/.well-known/openid-configuration",
-			expect.objectContaining({ redirect: "error" }),
+			expect.objectContaining({ redirect: "manual" }),
+		);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10052
+	 */
+	it("rejects redirect responses after using manual redirect mode", async () => {
+		vi.mocked(betterFetch).mockResolvedValueOnce({
+			data: null,
+			error: { status: 302, statusText: "Found", message: "Found" },
+		});
+		await expect(
+			fetchDiscoveryDocument(
+				"https://idp.example.com/.well-known/openid-configuration",
+				undefined,
+				() => true,
+			),
+		).rejects.toThrow(
+			expect.objectContaining({
+				code: "oidc_endpoint_redirect",
+			}),
+		);
+	});
+});
+
+describe("fetchOIDCEndpointResponse redirect handling", () => {
+	it("uses manual redirect mode and rejects redirect responses", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+			new Response(null, {
+				status: 302,
+				headers: { location: "https://idp.example.com/final-jwks" },
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			fetchOIDCEndpointResponse(
+				"jwksEndpoint",
+				"https://idp.example.com/jwks",
+				{ method: "GET" },
+				() => true,
+			),
+		).rejects.toThrow(
+			expect.objectContaining({
+				code: "oidc_endpoint_redirect",
+			}),
+		);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://idp.example.com/jwks",
+			expect.objectContaining({ redirect: "manual" }),
 		);
 	});
 });

--- a/packages/sso/src/oidc/discovery.ts
+++ b/packages/sso/src/oidc/discovery.ts
@@ -12,7 +12,9 @@ import {
 	classifyHost,
 	isPublicRoutableHost,
 } from "@better-auth/core/utils/host";
+import type { BetterFetchOption } from "@better-fetch/fetch";
 import { betterFetch } from "@better-fetch/fetch";
+import { createRemoteJWKSet, customFetch, jwtVerify } from "jose";
 import type { OIDCConfig } from "../types";
 import type {
 	DiscoverOIDCConfigParams,
@@ -23,6 +25,20 @@ import { DiscoveryError, REQUIRED_DISCOVERY_FIELDS } from "./types";
 
 /** Default timeout for discovery requests (10 seconds) */
 const DEFAULT_DISCOVERY_TIMEOUT = 10000;
+
+type OIDCEndpointName =
+	| "discoveryEndpoint"
+	| "tokenEndpoint"
+	| "userInfoEndpoint"
+	| "jwksEndpoint";
+
+type OIDCConfigEndpointName = OIDCEndpointName | "authorizationEndpoint";
+
+type OIDCEndpointFetchOptions = Omit<BetterFetchOption, "redirect">;
+
+function isHttpRedirectStatus(status: number): boolean {
+	return status >= 300 && status < 400;
+}
 
 /**
  * Main entry point: Discover and hydrate OIDC configuration from an issuer.
@@ -57,7 +73,11 @@ export async function discoverOIDCConfig(
 
 	validateDiscoveryUrl(discoveryUrl, params.isTrustedOrigin);
 
-	const discoveryDoc = await fetchDiscoveryDocument(discoveryUrl, timeout);
+	const discoveryDoc = await fetchDiscoveryDocument(
+		discoveryUrl,
+		timeout,
+		params.isTrustedOrigin,
+	);
 
 	validateDiscoveryDocument(discoveryDoc, issuer);
 
@@ -151,8 +171,8 @@ export function validateDiscoveryUrl(
  * @throws DiscoveryError(discovery_invalid_url)  — malformed URL or non-http(s) scheme
  * @throws DiscoveryError(discovery_private_host) — host is not publicly routable and not allowlisted
  */
-function validateSkipDiscoveryEndpoint(
-	name: string,
+function validateOIDCEndpointUrl(
+	name: OIDCConfigEndpointName,
 	endpoint: string,
 	isTrustedOrigin: (url: string) => boolean,
 ): void {
@@ -169,14 +189,14 @@ function validateSkipDiscoveryEndpoint(
 /**
  * Validate every present OIDC endpoint URL in a registration or update body.
  *
- * Each provided URL is checked with {@link validateSkipDiscoveryEndpoint}.
+ * Each provided URL is checked with {@link validateOIDCEndpointUrl}.
  * Omitted (undefined / null / empty) fields are skipped.
  *
  * @param config - OIDC endpoint URLs from the request body
  * @param isTrustedOrigin - Predicate matching the configured `trustedOrigins`
  * @throws DiscoveryError on the first invalid endpoint
  */
-export function validateSkipDiscoveryEndpoints(
+export function validateOIDCEndpointUrls(
 	config: {
 		authorizationEndpoint?: string | null;
 		tokenEndpoint?: string | null;
@@ -186,7 +206,7 @@ export function validateSkipDiscoveryEndpoints(
 	},
 	isTrustedOrigin: (url: string) => boolean,
 ): void {
-	const fields: Array<[string, string | null | undefined]> = [
+	const fields: Array<[OIDCConfigEndpointName, string | null | undefined]> = [
 		["authorizationEndpoint", config.authorizationEndpoint],
 		["tokenEndpoint", config.tokenEndpoint],
 		["userInfoEndpoint", config.userInfoEndpoint],
@@ -194,7 +214,7 @@ export function validateSkipDiscoveryEndpoints(
 		["discoveryEndpoint", config.discoveryEndpoint],
 	];
 	for (const [name, url] of fields) {
-		if (url) validateSkipDiscoveryEndpoint(name, url, isTrustedOrigin);
+		if (url) validateOIDCEndpointUrl(name, url, isTrustedOrigin);
 	}
 }
 
@@ -202,7 +222,7 @@ export function validateSkipDiscoveryEndpoints(
  * Re-validate an endpoint by resolving its hostname and rejecting any resolved
  * address that is not publicly routable.
  *
- * {@link validateSkipDiscoveryEndpoint} only classifies the literal hostname, so
+ * {@link validateOIDCEndpointUrl} only classifies the literal hostname, so
  * a host like `idp.example` whose DNS record points at `127.0.0.1`,
  * `169.254.169.254`, or an RFC 1918 address passes that check unchanged. This
  * function closes that gap by performing the same RFC 6890 classification on the
@@ -225,13 +245,13 @@ export function validateSkipDiscoveryEndpoints(
  * @throws DiscoveryError(discovery_private_host) if any resolved address is not public
  */
 export async function assertEndpointResolvesPublic(
-	name: string,
+	name: OIDCEndpointName,
 	endpoint: string,
 	isTrustedOrigin: (url: string) => boolean,
 ): Promise<void> {
 	const parsed = parseURL(name, endpoint);
 
-	// Operator opt-in for internal IdPs (mirrors validateSkipDiscoveryEndpoint).
+	// Operator opt-in for internal IdPs (mirrors validateOIDCEndpointUrl).
 	if (isTrustedOrigin(parsed.toString())) return;
 
 	const host = parsed.hostname;
@@ -266,13 +286,23 @@ export async function assertEndpointResolvesPublic(
 }
 
 /**
- * Re-validate, at fetch time, every OIDC endpoint that is fetched server-side
- * (token, userinfo, jwks). Runs the synchronous host classification plus the
- * best-effort DNS resolution check. `authorizationEndpoint` is intentionally
- * excluded — it is a browser redirect target, not a server-side fetch, so these
- * checks don't apply to it.
+ * Validate an OIDC endpoint immediately before a server-side fetch.
  */
-export async function assertOIDCEndpointsResolvePublic(
+export async function assertOIDCEndpointAllowed(
+	name: OIDCEndpointName,
+	endpoint: string,
+	isTrustedOrigin: (url: string) => boolean,
+): Promise<void> {
+	validateOIDCEndpointUrl(name, endpoint, isTrustedOrigin);
+	await assertEndpointResolvesPublic(name, endpoint, isTrustedOrigin);
+}
+
+/**
+ * Re-validate, at fetch time, every OIDC endpoint that is fetched server-side
+ * (token, userinfo, jwks). `authorizationEndpoint` is intentionally excluded
+ * because it is a browser redirect target, not a server-side fetch.
+ */
+export async function assertServerFetchedOIDCEndpointsAllowed(
 	config: {
 		tokenEndpoint?: string | null;
 		userInfoEndpoint?: string | null;
@@ -280,16 +310,119 @@ export async function assertOIDCEndpointsResolvePublic(
 	},
 	isTrustedOrigin: (url: string) => boolean,
 ): Promise<void> {
-	const fields: Array<[string, string | null | undefined]> = [
+	const fields: Array<[OIDCEndpointName, string | null | undefined]> = [
 		["tokenEndpoint", config.tokenEndpoint],
 		["userInfoEndpoint", config.userInfoEndpoint],
 		["jwksEndpoint", config.jwksEndpoint],
 	];
 	for (const [name, url] of fields) {
 		if (!url) continue;
-		validateSkipDiscoveryEndpoint(name, url, isTrustedOrigin);
-		await assertEndpointResolvesPublic(name, url, isTrustedOrigin);
+		await assertOIDCEndpointAllowed(name, url, isTrustedOrigin);
 	}
+}
+
+/**
+ * Convert an explicit HTTP redirect response into the OIDC configuration error
+ * used by all server-side endpoint fetches.
+ */
+function throwRedirectError(
+	name: OIDCEndpointName,
+	endpoint: string,
+	status: number,
+	location: string | null,
+): never {
+	throw new DiscoveryError(
+		"oidc_endpoint_redirect",
+		`The ${name} (${endpoint}) returned an HTTP ${status} redirect. Configure the final OIDC endpoint URL instead of a redirecting URL.`,
+		{ endpoint: name, url: endpoint, status, location },
+	);
+}
+
+/**
+ * Fetch a configured OIDC endpoint without following redirects.
+ *
+ * Every server-side OIDC request goes through this helper so private-host
+ * checks and redirect handling stay consistent across discovery, token, and
+ * userinfo calls.
+ */
+export async function fetchOIDCEndpoint<T>(
+	name: OIDCEndpointName,
+	endpoint: string,
+	options: OIDCEndpointFetchOptions,
+	isTrustedOrigin: (url: string) => boolean,
+) {
+	await assertOIDCEndpointAllowed(name, endpoint, isTrustedOrigin);
+
+	let redirectLocation: string | null = null;
+	const { onError, ...fetchOptions } = options;
+	const response = await betterFetch<T>(endpoint, {
+		...fetchOptions,
+		redirect: "manual",
+		onError: async (context) => {
+			if (isHttpRedirectStatus(context.response.status)) {
+				redirectLocation = context.response.headers.get("location");
+			}
+			await onError?.(context);
+		},
+	});
+
+	if (response.error && isHttpRedirectStatus(response.error.status)) {
+		throwRedirectError(name, endpoint, response.error.status, redirectLocation);
+	}
+
+	return response;
+}
+
+/**
+ * Native-fetch variant for libraries that require a `fetch` implementation,
+ * such as jose's remote JWKS loader.
+ */
+export async function fetchOIDCEndpointResponse(
+	name: OIDCEndpointName,
+	endpoint: string,
+	init: RequestInit,
+	isTrustedOrigin: (url: string) => boolean,
+): Promise<Response> {
+	await assertOIDCEndpointAllowed(name, endpoint, isTrustedOrigin);
+
+	const response = await fetch(endpoint, {
+		...init,
+		redirect: "manual",
+	});
+
+	if (isHttpRedirectStatus(response.status)) {
+		throwRedirectError(
+			name,
+			endpoint,
+			response.status,
+			response.headers.get("location"),
+		);
+	}
+
+	return response;
+}
+
+/**
+ * Validate an OIDC ID token using the same endpoint fetch policy as the rest of
+ * the SSO OIDC flow.
+ */
+export async function validateOIDCIdToken(
+	token: string,
+	jwksEndpoint: string,
+	options: {
+		audience?: string | string[];
+		issuer?: string | string[];
+	},
+	isTrustedOrigin: (url: string) => boolean,
+) {
+	const jwks = createRemoteJWKSet(new URL(jwksEndpoint), {
+		[customFetch]: (url, init) =>
+			fetchOIDCEndpointResponse("jwksEndpoint", url, init, isTrustedOrigin),
+	});
+	return jwtVerify(token, jwks, {
+		audience: options.audience,
+		issuer: options.issuer,
+	});
 }
 
 /**
@@ -303,17 +436,18 @@ export async function assertOIDCEndpointsResolvePublic(
 export async function fetchDiscoveryDocument(
 	url: string,
 	timeout: number = DEFAULT_DISCOVERY_TIMEOUT,
+	isTrustedOrigin: (url: string) => boolean = () => false,
 ): Promise<OIDCDiscoveryDocument> {
 	try {
-		const response = await betterFetch<OIDCDiscoveryDocument>(url, {
-			method: "GET",
-			timeout,
-			// Never auto-follow redirects on this server-side fetch. A redirect
-			// Location is not re-validated against the private-host checks, so a
-			// redirect could send the fetch to an internal/loopback/metadata
-			// address. Reject redirects outright.
-			redirect: "error",
-		});
+		const response = await fetchOIDCEndpoint<OIDCDiscoveryDocument>(
+			"discoveryEndpoint",
+			url,
+			{
+				method: "GET",
+				timeout,
+			},
+			isTrustedOrigin,
+		);
 
 		if (response.error) {
 			const { status } = response.error;
@@ -706,6 +840,6 @@ export async function ensureRuntimeDiscovery(
 			jwksEndpoint: hydrated.jwksEndpoint,
 		};
 	}
-	await assertOIDCEndpointsResolvePublic(resolved, isTrustedOrigin);
+	await assertServerFetchedOIDCEndpointsAllowed(resolved, isTrustedOrigin);
 	return resolved;
 }

--- a/packages/sso/src/oidc/errors.ts
+++ b/packages/sso/src/oidc/errors.ts
@@ -16,6 +16,7 @@ import type { DiscoveryError } from "./types";
  * - discovery_not_found          → 400 BAD_REQUEST
  * - discovery_untrusted_origin   → 400 BAD_REQUEST
  * - discovery_private_host       → 400 BAD_REQUEST
+ * - oidc_endpoint_redirect       → 400 BAD_REQUEST
  * - discovery_invalid_json       → 400 BAD_REQUEST
  * - discovery_incomplete         → 400 BAD_REQUEST
  * - issuer_mismatch              → 400 BAD_REQUEST
@@ -59,6 +60,12 @@ export function mapDiscoveryErrorToAPIError(error: DiscoveryError): APIError {
 			});
 
 		case "discovery_private_host":
+			return new APIError("BAD_REQUEST", {
+				message: error.message,
+				code: error.code,
+			});
+
+		case "oidc_endpoint_redirect":
 			return new APIError("BAD_REQUEST", {
 				message: error.message,
 				code: error.code,

--- a/packages/sso/src/oidc/index.ts
+++ b/packages/sso/src/oidc/index.ts
@@ -11,13 +11,15 @@ export {
 	discoverOIDCConfig,
 	ensureRuntimeDiscovery,
 	fetchDiscoveryDocument,
+	fetchOIDCEndpoint,
 	needsRuntimeDiscovery,
 	normalizeDiscoveryUrls,
 	normalizeUrl,
 	selectTokenEndpointAuthMethod,
 	validateDiscoveryDocument,
 	validateDiscoveryUrl,
-	validateSkipDiscoveryEndpoints,
+	validateOIDCEndpointUrls,
+	validateOIDCIdToken,
 } from "./discovery";
 
 export { mapDiscoveryErrorToAPIError } from "./errors";

--- a/packages/sso/src/oidc/types.ts
+++ b/packages/sso/src/oidc/types.ts
@@ -107,6 +107,8 @@ export type DiscoveryErrorCode =
 	| "discovery_untrusted_origin"
 	/** OIDC endpoint URL (discovery or per-endpoint) points to a host that is not publicly routable (loopback, RFC 1918, link-local, cloud metadata FQDN, etc.) */
 	| "discovery_private_host"
+	/** Server-side OIDC endpoint fetch received an HTTP redirect response */
+	| "oidc_endpoint_redirect"
 	/** Discovery document issuer doesn't match configured issuer */
 	| "issuer_mismatch"
 	/** Discovery document is missing required fields */

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -11,7 +11,7 @@ import { DEFAULT_MAX_SAML_METADATA_SIZE } from "../constants";
 import {
 	DiscoveryError,
 	mapDiscoveryErrorToAPIError,
-	validateSkipDiscoveryEndpoints,
+	validateOIDCEndpointUrls,
 } from "../oidc";
 import {
 	resolveSigningCerts,
@@ -567,7 +567,7 @@ export const updateSSOProvider = (options: SSOOptions) => {
 
 			if (body.oidcConfig) {
 				try {
-					validateSkipDiscoveryEndpoints(body.oidcConfig, (url) =>
+					validateOIDCEndpointUrls(body.oidcConfig, (url) =>
 						ctx.context.isTrustedOrigin(url),
 					);
 				} catch (error) {

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1455,7 +1455,10 @@ async function handleOIDCCallback(
 		if (e instanceof DiscoveryError) {
 			redirectOIDCError("invalid_provider", e.message);
 		}
-		return null;
+		redirectOIDCError(
+			"invalid_provider",
+			getOIDCErrorDescription(e, "token_response_error"),
+		);
 	});
 	if (!tokenResponse) {
 		throw ctx.redirect(

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1213,6 +1213,36 @@ const callbackSSOQuerySchema = z.object({
 	error_description: z.string().optional(),
 });
 
+function getStringErrorField(value: unknown, field: string) {
+	if (!value || typeof value !== "object") return;
+	const fieldValue = (value as Record<string, unknown>)[field];
+	return typeof fieldValue === "string" && fieldValue.length > 0
+		? fieldValue
+		: undefined;
+}
+
+function getOIDCErrorDescription(error: unknown, fallback: string): string {
+	const nestedError =
+		error && typeof error === "object"
+			? (error as Record<string, unknown>).error
+			: undefined;
+	const description =
+		getStringErrorField(nestedError, "error_description") ||
+		getStringErrorField(error, "error_description") ||
+		getStringErrorField(nestedError, "message") ||
+		getStringErrorField(error, "message") ||
+		getStringErrorField(error, "statusText") ||
+		getStringErrorField(nestedError, "error") ||
+		getStringErrorField(error, "error");
+	if (description) return description;
+	if (error && typeof error === "object") {
+		const status = (error as Record<string, unknown>).status;
+		if (typeof status === "number") return `HTTP ${status}`;
+		if (typeof status === "string" && status.length > 0) return status;
+	}
+	return fallback;
+}
+
 /**
  * Core OIDC callback handler logic, shared between the per-provider and
  * shared callback endpoints. Resolves the provider, exchanges the
@@ -1249,10 +1279,9 @@ async function handleOIDCCallback(
 		throw ctx.redirect(`${baseURL}${separator}${params.toString()}`);
 	};
 	if (!code || error) {
-		throw ctx.redirect(
-			`${
-				errorURL || callbackURL
-			}?error=${error}&error_description=${error_description}`,
+		redirectOIDCError(
+			error || "invalid_request",
+			error_description || (error ? error : "authorization_code_not_found"),
 		);
 	}
 	const provider = await resolveOIDCProvider(ctx, options, providerId);
@@ -1409,13 +1438,19 @@ async function handleOIDCCallback(
 			(url) => ctx.context.isTrustedOrigin(url),
 		);
 		if (error) {
-			throw error;
+			redirectOIDCError(
+				"invalid_provider",
+				getOIDCErrorDescription(error, "token_response_error"),
+			);
 		}
 		if (!data) {
 			throw new Error("Token endpoint returned an empty response");
 		}
 		return getOAuth2Tokens(data);
 	})().catch((e) => {
+		if (isAPIError(e)) {
+			throw e;
+		}
 		ctx.context.logger.error("Error validating authorization code", e);
 		if (e instanceof DiscoveryError) {
 			redirectOIDCError("invalid_provider", e.message);

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1,18 +1,17 @@
 import { isAPIError } from "@better-auth/core/utils/is-api-error";
-import { BetterFetchError, betterFetch } from "@better-fetch/fetch";
 import type {
 	PrivateKeyJwtSigningAlgorithm,
 	TokenEndpointAuth,
 } from "better-auth";
 import {
+	authorizationCodeRequest,
 	createAuthorizationURL,
 	createPrivateKeyJwtClientAssertionGetter,
 	generateState,
+	getOAuth2Tokens,
 	HIDE_METADATA,
 	PRIVATE_KEY_JWT_SIGNING_ALGORITHMS,
 	parseState,
-	validateAuthorizationCode,
-	validateToken,
 } from "better-auth";
 import {
 	APIError,
@@ -38,8 +37,10 @@ import {
 	DiscoveryError,
 	discoverOIDCConfig,
 	ensureRuntimeDiscovery,
+	fetchOIDCEndpoint,
 	mapDiscoveryErrorToAPIError,
-	validateSkipDiscoveryEndpoints,
+	validateOIDCEndpointUrls,
+	validateOIDCIdToken,
 } from "../oidc";
 import { validateCertSources, validateConfigAlgorithms } from "../saml";
 import { SAML_ERROR_CODES } from "../saml/error-codes";
@@ -485,7 +486,7 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 
 			if (body.oidcConfig) {
 				try {
-					validateSkipDiscoveryEndpoints(body.oidcConfig, (url) =>
+					validateOIDCEndpointUrls(body.oidcConfig, (url) =>
 						ctx.context.isTrustedOrigin(url),
 					);
 				} catch (error) {
@@ -1238,6 +1239,15 @@ async function handleOIDCCallback(
 	}
 	const { callbackURL, errorURL, newUserURL, requestSignUp, requestedScopes } =
 		stateData;
+	const redirectOIDCError = (error: string, description: string): never => {
+		const baseURL = errorURL || callbackURL;
+		const params = new URLSearchParams({
+			error,
+			error_description: description,
+		});
+		const separator = baseURL.includes("?") ? "&" : "?";
+		throw ctx.redirect(`${baseURL}${separator}${params.toString()}`);
+	};
 	if (!code || error) {
 		throw ctx.redirect(
 			`${
@@ -1306,6 +1316,7 @@ async function handleOIDCCallback(
 		);
 	}
 
+	const tokenEndpoint = config.tokenEndpoint;
 	let tokenEndpointAuth: TokenEndpointAuth =
 		config.tokenEndpointAuthentication === "client_secret_post"
 			? { method: "client_secret_post" }
@@ -1374,25 +1385,40 @@ async function handleOIDCCallback(
 		tokenRequestOptions.clientSecret = config.clientSecret;
 	}
 
-	const tokenResponse = await validateAuthorizationCode({
-		code,
-		codeVerifier: config.pkce ? stateData.codeVerifier : undefined,
-		redirectURI: getOIDCRedirectURI(
-			ctx.context.baseURL,
-			provider.providerId,
-			options,
-		),
-		options: tokenRequestOptions,
-		tokenEndpoint: config.tokenEndpoint,
-		tokenEndpointAuth,
-	}).catch((e) => {
+	const tokenResponse = await (async () => {
+		const { body, headers } = await authorizationCodeRequest({
+			code,
+			codeVerifier: config.pkce ? stateData.codeVerifier : undefined,
+			redirectURI: getOIDCRedirectURI(
+				ctx.context.baseURL,
+				provider.providerId,
+				options,
+			),
+			options: tokenRequestOptions,
+			tokenEndpoint,
+			tokenEndpointAuth,
+		});
+		const { data, error } = await fetchOIDCEndpoint<object>(
+			"tokenEndpoint",
+			tokenEndpoint,
+			{
+				method: "POST",
+				body,
+				headers,
+			},
+			(url) => ctx.context.isTrustedOrigin(url),
+		);
+		if (error) {
+			throw error;
+		}
+		if (!data) {
+			throw new Error("Token endpoint returned an empty response");
+		}
+		return getOAuth2Tokens(data);
+	})().catch((e) => {
 		ctx.context.logger.error("Error validating authorization code", e);
-		if (e instanceof BetterFetchError) {
-			throw ctx.redirect(
-				`${
-					errorURL || callbackURL
-				}?error=invalid_provider&error_description=${e.message}`,
-			);
+		if (e instanceof DiscoveryError) {
+			redirectOIDCError("invalid_provider", e.message);
 		}
 		return null;
 	});
@@ -1417,23 +1443,32 @@ async function handleOIDCCallback(
 	let rawProfile: Record<string, unknown> | undefined;
 
 	if (config.userInfoEndpoint) {
-		const userInfoResponse = await betterFetch<Record<string, unknown>>(
+		const userInfoResponse = await fetchOIDCEndpoint<Record<string, unknown>>(
+			"userInfoEndpoint",
 			config.userInfoEndpoint,
 			{
 				headers: {
 					Authorization: `Bearer ${tokenResponse.accessToken}`,
 				},
-				redirect: "error",
 			},
-		);
+			(url) => ctx.context.isTrustedOrigin(url),
+		).catch((e) => {
+			if (e instanceof DiscoveryError) {
+				redirectOIDCError("invalid_provider", e.message);
+			}
+			throw e;
+		});
 		if (userInfoResponse.error) {
-			throw ctx.redirect(
-				`${errorURL || callbackURL}?error=invalid_provider&error_description=${
-					userInfoResponse.error.message
-				}`,
+			redirectOIDCError(
+				"invalid_provider",
+				userInfoResponse.error.message ||
+					userInfoResponse.error.statusText ||
+					"userinfo_response_error",
 			);
 		}
-		const rawUserInfo = userInfoResponse.data;
+		const rawUserInfo =
+			userInfoResponse.data ??
+			redirectOIDCError("invalid_provider", "userinfo_response_not_found");
 		rawProfile = rawUserInfo;
 		userInfo = {
 			...Object.fromEntries(
@@ -1462,14 +1497,18 @@ async function handleOIDCCallback(
 				}?error=invalid_provider&error_description=jwks_endpoint_not_found`,
 			);
 		}
-		const verified = await validateToken(
+		const verified = await validateOIDCIdToken(
 			tokenResponse.idToken,
 			config.jwksEndpoint,
 			{
 				audience: config.clientId,
 				issuer: provider.issuer,
 			},
+			(url) => ctx.context.isTrustedOrigin(url),
 		).catch((e) => {
+			if (e instanceof DiscoveryError) {
+				redirectOIDCError("invalid_provider", e.message);
+			}
 			ctx.context.logger.error(e);
 			return null;
 		});


### PR DESCRIPTION
OIDC SSO failed on Workers because the SSO fetch policy depended on a redirect mode that workerd rejects.

This keeps the SSRF hardening intact by moving configured OIDC endpoint fetches to explicit manual redirect handling. Discovery, token, userinfo, and JWKS requests now reject 3xx responses instead of relying on platform-specific `redirect: "error"` behavior or default follow behavior.

The token exchange still uses the shared OAuth request builder so private-key JWT authentication and existing token auth rules stay centralized. JWKS verification stays on jose, with SSO supplying the fetch policy through jose's custom fetch hook.

Fixes #10052

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes OIDC SSO work on platforms like Cloudflare Workers by rejecting redirecting endpoints with a portable fetch policy. Also surfaces token endpoint and callback errors clearly in the final redirect.

- **Bug Fixes**
  - Use manual redirect mode for all server-side OIDC requests; throw `oidc_endpoint_redirect` on 3xx.
  - Enforce SSRF checks before each fetch (URL + DNS host), honoring `trustedOrigins`.
  - Centralize policy with `fetchOIDCEndpoint` (and `fetchOIDCEndpointResponse` for JWKS); `jose` uses the custom fetch; add `validateOIDCIdToken`.
  - Callback now uses `authorizationCodeRequest` + `getOAuth2Tokens` with the new fetch policy; preserves token endpoint `error_description`, handles thrown token errors, and returns `invalid_request` when the callback lacks a `code`; `private-key-jwt` remains supported.

- **Migration**
  - Configure final canonical URLs for discovery, token, userinfo, and JWKS. Redirecting endpoints now fail with `oidc_endpoint_redirect`.

<sup>Written for commit 7b35322256ca8539645fb05d13aac6b9999626c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

