### PR TITLE
chore: revert "fix: allow headerless get session checks (#10053)"

### DIFF
--- a/.changeset/quiet-astro-sessions.md
+++ b/.changeset/quiet-astro-sessions.md
@@ -1,5 +1,0 @@
----
-"better-auth": patch
----
-
-Allow direct `auth.api.getSession()` calls without request headers to return `null` instead of throwing when no session cookies are available, including custom-session responses.

--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -292,7 +292,7 @@ You can also use it with client-side data-fetching libraries like [TanStack Quer
 
 ### Server Side
 
-The server provides a `session` object that you can use to access the session data. Pass the current request headers to read the session from cookies. If no request headers are available, `auth.api.getSession` returns `null`.
+The server provides a `session` object that you can use to access the session data. It requires request headers object to be passed to the `getSession` method.
 
 **Example: Using some popular frameworks**
 
@@ -303,7 +303,7 @@ The server provides a `session` object that you can use to access the session da
     import { headers } from "next/headers";
 
     const session = await auth.api.getSession({
-        headers: await headers() // pass the headers object from the current request
+        headers: await headers() // you need to pass the headers object.
     })
     ```
   </Tab>

--- a/docs/content/docs/integrations/astro.mdx
+++ b/docs/content/docs/integrations/astro.mdx
@@ -118,8 +118,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
 });
 ```
 
-For server islands, prefer reading the session from `Astro.locals` after middleware has populated it, or pass `Astro.request.headers` when calling `auth.api.getSession` directly. A direct `auth.api.getSession` call without a request source returns `null`.
-
 ### Getting session on the server inside `.astro` file
 
 You can use `Astro.locals` to check if the user has session and get the user data from the server side. Here is an example of how you can get the session inside an `.astro` file:

--- a/docs/content/docs/reference/faq.mdx
+++ b/docs/content/docs/reference/faq.mdx
@@ -23,7 +23,7 @@ This page contains frequently asked questions, common issues, and other helpful 
   </Accordion>
 
   <Accordion id="getsession-not-working" title="getSession not working">
-    If you try to call `authClient.getSession` on a server environment (e.g, a Next.js server component), it doesn't work since it can't access the cookies. You can use `auth.api.getSession` instead and pass the request headers when you want it to read the current request cookies. Without a request source, `auth.api.getSession` returns `null`.
+    If you try to call `authClient.getSession` on a server environment (e.g, a Next.js server component), it doesn't work since it can't access the cookies. You can use the `auth.api.getSession` instead and pass the request headers to it.
 
     ```tsx title="server.tsx"
     import { auth } from "./auth";

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -72,13 +72,6 @@ describe("session", async () => {
 		expect(response.data).toBeNull();
 	});
 
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/10044
-	 */
-	it("should return null for direct session checks without a request source", async () => {
-		await expect(auth.api.getSession()).resolves.toBeNull();
-	});
-
 	it("should require a fresh session based on session creation time", async () => {
 		vi.useFakeTimers();
 		const now = new Date("2026-01-01T00:00:00.000Z");

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -36,6 +36,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 			method: ["GET", "POST"],
 			operationId: "getSession",
 			query: getSessionQuerySchema,
+			requireHeaders: true,
 			metadata: {
 				openapi: {
 					operationId: "getSession",

--- a/packages/better-auth/src/api/to-auth-endpoints.test.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.test.ts
@@ -146,22 +146,6 @@ describe("before hook", async () => {
 			expect(res).toMatchObject({ key: "value", name: "headers" });
 		});
 
-		it("should keep requireHeaders endpoints strict without headers", async () => {
-			const endpoints = {
-				headers: createAuthEndpoint(
-					"/strict-headers",
-					{
-						method: "GET",
-						requireHeaders: true,
-					},
-					async (c) => Object.fromEntries(c.headers.entries()),
-				),
-			};
-			const authEndpoints = toAuthEndpoints(endpoints, init({}));
-
-			await expect(authEndpoints.headers()).rejects.toSatisfy(isAPIError);
-		});
-
 		it("should replace existing array when hook provides another array", async () => {
 			const endpoint = {
 				body: createAuthEndpoint(

--- a/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
+++ b/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
@@ -65,13 +65,6 @@ describe("Custom Session Plugin Tests", async () => {
 		expect(session?.newData).toEqual({ message: "Hello, World!" });
 	});
 
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/10044
-	 */
-	it("should return null for direct custom session checks without a request source", async () => {
-		await expect(auth.api.getSession()).resolves.toBeNull();
-	});
-
 	it("should return set cookie headers as separate entries", async () => {
 		const { headers } = await signInWithTestUser();
 		await client.getSession({

--- a/packages/better-auth/src/plugins/custom-session/index.ts
+++ b/packages/better-auth/src/plugins/custom-session/index.ts
@@ -95,6 +95,7 @@ export const customSession = <
 							},
 						},
 					},
+					requireHeaders: true,
 				},
 				async (ctx): Promise<Returns | null> => {
 					const session = await getSession()({


### PR DESCRIPTION
Related to #10053

This reverts commit d009daedc75d0e61eb69e545a6ab40dd75cf541e.