### PR TITLE
docs: add agent issue triage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,16 @@ This is the Better Auth repository - a comprehensive authentication framework fo
 - JSDoc comments for public APIs
 - Plugins should be as independent as possible. When working on a plugin, prefer modifying the plugin over changing core.
 
+## Issue Triage and Architecture
+
+- A reproducible error is not automatically a bug. First prove the behavior violates Better Auth's documented contract, TypeScript contract, or established runtime semantics.
+- Before changing public API behavior, check existing docs, generated/inferred types, endpoint metadata, release history, and git history for the relevant code path. Treat long-standing metadata such as `requireHeaders`, `requireRequest`, endpoint method, schema, and middleware as part of the API contract.
+- For regression claims, compare the exact reported versions or tags. If the behavior existed before the claimed version, classify it as expected behavior, documentation gap, or integration misuse unless another contract proves otherwise.
+- Distinguish invalid usage from valid empty state. Example: a server session check without request headers is invalid usage; a server session check with headers but no session cookie is a valid request that returns `null`.
+- Do not weaken TypeScript guidance to make runtime behavior more permissive unless that is the explicit architectural decision. Optional input types can hide integration bugs from users and agents.
+- Prefer docs or clearer error messages over API-contract changes when the current behavior is intentional but confusing.
+- When reviewing or patching external issue PRs, validate both the issue and the proposed fix against the surrounding contract before improving the PR. If the PR changes a long-standing contract, call that out before pushing changes.
+
 ## Testing
 
 - Most tests use Vitest; some under `e2e/` use Playwright
@@ -53,7 +63,7 @@ This is the Better Auth repository - a comprehensive authentication framework fo
 ## Important Development Notes
 
 - Bug fixes and new features MUST include tests
-- For bug fixes: if the issue is reproducible in a test, write a failing test first, then implement the fix
+  - For bug fixes: after confirming the reproducible behavior violates the intended contract, write a failing test first, then implement the fix
 - Update docs (`docs/content/docs/`) when changing public API
 - Ensure `pnpm typecheck` passes before finishing
 - DO NOT COMMIT unless the user explicitly asks


### PR DESCRIPTION
Adds guidance for agents to validate issue reports against docs, types, endpoint metadata, and history before treating reproducible behavior as a bug.

This keeps API-contract changes explicit during issue and PR triage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add guidance to `AGENTS.md`: prove a contract violation (docs, types, endpoint metadata, history) before calling a bug; check regressions; avoid weakening TS types; prefer docs/errors to changes. Tighten bug-fix note: confirm violation, then write a failing test.

<sup>Written for commit d4e9fce7ab9ff46bb7753310b57fa5ebd4083cea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

