### PR TITLE
fix: lazily initialize request state holders

### DIFF
--- a/.changeset/lazy-request-state.md
+++ b/.changeset/lazy-request-state.md
@@ -1,0 +1,6 @@
+---
+"better-auth": patch
+"@better-auth/oauth-provider": patch
+---
+
+Defer OAuth request-state initialization until it is used so single-file bundlers do not crash while importing `better-auth/api` through plugins such as API key.

--- a/packages/better-auth/src/api/state/oauth.test.ts
+++ b/packages/better-auth/src/api/state/oauth.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("oauth request state", () => {
+	afterEach(() => {
+		vi.resetModules();
+		vi.doUnmock("@better-auth/core/context");
+	});
+
+	it("does not initialize request state during module evaluation", async () => {
+		vi.doMock("@better-auth/core/context", async (importOriginal) => ({
+			...(await importOriginal<typeof import("@better-auth/core/context")>()),
+			defineRequestState: vi.fn(() => {
+				throw new Error("request state initialized eagerly");
+			}),
+		}));
+
+		await expect(import("./oauth")).resolves.toBeDefined();
+	});
+});

--- a/packages/better-auth/src/api/state/oauth.ts
+++ b/packages/better-auth/src/api/state/oauth.ts
@@ -1,4 +1,7 @@
-import { defineRequestState } from "@better-auth/core/context";
+import {
+	defineRequestState,
+	type RequestState,
+} from "@better-auth/core/context";
 
 type OAuthState = {
 	callbackURL: string;
@@ -14,12 +17,18 @@ type OAuthState = {
 	[key: string]: any;
 };
 
-const {
-	get: getOAuthState,
-	/**
-	 * @internal This is unsafe to be used directly. Use setOAuthState instead.
-	 */
-	set: setOAuthState,
-} = defineRequestState<OAuthState | null>(() => null);
+let state: RequestState<OAuthState | null> | undefined;
+
+function getOAuthRequestState() {
+	state ??= defineRequestState<OAuthState | null>(() => null);
+	return state;
+}
+
+const getOAuthState = () => getOAuthRequestState().get();
+/**
+ * @internal This is unsafe to be used directly. Use setOAuthState instead.
+ */
+const setOAuthState = (value: OAuthState | null) =>
+	getOAuthRequestState().set(value);
 
 export { getOAuthState, setOAuthState };

--- a/packages/better-auth/src/api/state/should-session-refresh.ts
+++ b/packages/better-auth/src/api/state/should-session-refresh.ts
@@ -1,4 +1,7 @@
-import { defineRequestState } from "@better-auth/core/context";
+import {
+	defineRequestState,
+	type RequestState,
+} from "@better-auth/core/context";
 
 /**
  * State for skipping session refresh
@@ -8,7 +11,16 @@ import { defineRequestState } from "@better-auth/core/context";
  * potential inconsistencies between the session data in the database and the session
  * data stored in cookies.
  */
-const { get: getShouldSkipSessionRefresh, set: setShouldSkipSessionRefresh } =
-	defineRequestState<boolean | null>(() => false);
+let state: RequestState<boolean | null> | undefined;
+
+function getShouldSkipSessionRefreshState() {
+	state ??= defineRequestState<boolean | null>(() => false);
+	return state;
+}
+
+const getShouldSkipSessionRefresh = () =>
+	getShouldSkipSessionRefreshState().get();
+const setShouldSkipSessionRefresh = (value: boolean | null) =>
+	getShouldSkipSessionRefreshState().set(value);
 
 export { getShouldSkipSessionRefresh, setShouldSkipSessionRefresh };

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1,5 +1,8 @@
 import type { GenericEndpointContext } from "@better-auth/core";
-import { defineRequestState } from "@better-auth/core/context";
+import {
+	defineRequestState,
+	type RequestState,
+} from "@better-auth/core/context";
 import { logger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
 import type { DispatchContext } from "better-auth/api";
@@ -54,11 +57,26 @@ declare module "@better-auth/core" {
 	}
 }
 
-export const oAuthState = defineRequestState<{
+type OAuthProviderState = {
 	query?: string;
 	signedQueryIssuedAt?: Date;
 	postLoginClearedForSession?: string;
-} | null>(() => null);
+} | null;
+
+let state: RequestState<OAuthProviderState> | undefined;
+
+function getOAuthProviderRequestState() {
+	state ??= defineRequestState<OAuthProviderState>(() => null);
+	return state;
+}
+
+export const oAuthState: RequestState<OAuthProviderState> = {
+	get ref() {
+		return getOAuthProviderRequestState().ref;
+	},
+	get: () => getOAuthProviderRequestState().get(),
+	set: (value) => getOAuthProviderRequestState().set(value),
+};
 export const getOAuthProviderState = oAuthState.get;
 
 /**


### PR DESCRIPTION
## Summary

Fixes #9896.

Defers request-state initialization for OAuth-related state holders until the state is actually used. This avoids crashing app startup in Bun single-file builds when `better-auth/api` is pulled in indirectly, for example through `@better-auth/api-key`, but OAuth state is never used.

The reported crash happened during module evaluation:
`ReferenceError: defineRequestState is not defined`

## Changes

- Lazily initialize `better-auth` OAuth request state.
- Lazily initialize `should-session-refresh` request state.
- Lazily initialize OAuth provider request state while preserving its exported `RequestState` shape.
- Added a regression test proving the OAuth state module can be imported without eagerly calling `defineRequestState`.
- Added a patch changeset for `better-auth` and `@better-auth/oauth-provider`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazily initialize OAuth and session-refresh request state to prevent Bun single-file startup crashes when `better-auth/api` is imported indirectly (e.g., via `@better-auth/api-key`). Preserves the `RequestState` API surface for `@better-auth/oauth-provider`.

- **Bug Fixes**
  - Lazy init for OAuth request state in `better-auth`.
  - Lazy init for `should-session-refresh` state.
  - Convert `@better-auth/oauth-provider` `oAuthState` to a lazy `RequestState` wrapper (keeps `get/set/ref`).
  - Add regression test to ensure `defineRequestState` isn’t invoked on module import.

- **Dependencies**
  - Patch releases for `better-auth` and `@better-auth/oauth-provider`.

<sup>Written for commit d747d4a9ab501c082b7a21c5b4a55b8c6aa84879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

