### PR TITLE
fix(drizzle-adapter): return consumed MySQL rows

### DIFF
--- a/.changeset/drizzle-mysql-reset-token.md
+++ b/.changeset/drizzle-mysql-reset-token.md
@@ -1,0 +1,8 @@
+---
+"@better-auth/drizzle-adapter": patch
+"@better-auth/test-utils": patch
+---
+
+Password reset tokens now work with the Drizzle MySQL adapter after they are consumed during reset.
+
+Adapter auth-flow tests now cover password reset and replay rejection, and wrapped adapters exercise their native single-use consume and guarded increment behavior when available.

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -270,6 +270,77 @@ describe("drizzle-adapter", () => {
 		});
 	});
 
+	describe("consumeOne affected-row count", () => {
+		const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
+		const verificationTable = {
+			id: { name: "id" },
+			identifier: { name: "identifier" },
+			value: { name: "value" },
+			expiresAt: { name: "expiresAt" },
+			createdAt: { name: "createdAt" },
+			updatedAt: { name: "updatedAt" },
+		};
+		const verificationRow = {
+			id: "verification-1",
+			identifier: "reset-password:token",
+			value: "user-1",
+			expiresAt: new Date(Date.now() + 60_000),
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+
+		function createMysqlConsumeDb(driverResult: unknown) {
+			const selectLimit = vi.fn().mockResolvedValue([verificationRow]);
+			const selectFor = vi.fn().mockReturnValue({ limit: selectLimit });
+			const selectWhere = vi.fn().mockReturnValue({ for: selectFor });
+			const selectFrom = vi.fn().mockReturnValue({ where: selectWhere });
+			const execute = vi.fn().mockResolvedValue(driverResult);
+			const deleteWhere = vi.fn().mockReturnValue({ execute });
+			const tx = {
+				select: vi.fn().mockReturnValue({ from: selectFrom }),
+				delete: vi.fn().mockReturnValue({ where: deleteWhere }),
+			};
+			const db = {
+				_: { fullSchema: { verification: verificationTable } },
+				transaction: vi
+					.fn()
+					.mockImplementation((fn: (transaction: typeof tx) => unknown) =>
+						fn(tx),
+					),
+			} as Parameters<typeof drizzleAdapter>[0];
+			return { db };
+		}
+
+		it("returns the consumed row for MySQL result-header arrays", async () => {
+			const { db } = createMysqlConsumeDb([{ affectedRows: 1 }]);
+			const adapter = drizzleAdapter(db, { provider: "mysql" })({
+				secret: defaultSecret,
+			});
+
+			const result = await adapter.consumeOne({
+				model: "verification",
+				where: [{ field: "id", value: verificationRow.id }],
+			});
+
+			expect(result).toEqual(verificationRow);
+			expect(db.transaction).toHaveBeenCalledOnce();
+		});
+
+		it("returns null when the MySQL delete does not affect a row", async () => {
+			const { db } = createMysqlConsumeDb([{ affectedRows: 0 }]);
+			const adapter = drizzleAdapter(db, { provider: "mysql" })({
+				secret: defaultSecret,
+			});
+
+			const result = await adapter.consumeOne({
+				model: "verification",
+				where: [{ field: "id", value: verificationRow.id }],
+			});
+
+			expect(result).toBeNull();
+		});
+	});
+
 	describe("incrementOne", () => {
 		const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
 		// `attempts` is a plain numeric column the increment targets; the rest

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -47,12 +47,12 @@ export interface DB {
  * Drizzle's drivers report affected rows under different shapes: postgres-js
  * exposes `rowCount`, mysql2 reports `affectedRows`/`rowsAffected` (sometimes as
  * the first element of a result-header array), and better-sqlite3 uses
- * `changes`. This normalizes those so `updateMany` and `deleteMany` honor the
- * `Promise<number>` adapter contract instead of leaking the raw driver result.
+ * `changes`. This normalizes those so write methods that depend on affected
+ * rows honor the adapter contract instead of leaking the raw driver result.
  */
 function getAffectedRowCount(
 	result: unknown,
-	operation: "updateMany" | "deleteMany",
+	operation: "updateMany" | "deleteMany" | "consumeOne",
 	context: { model: string; where: Where[] },
 ): number {
 	let count: unknown = 0;
@@ -985,12 +985,10 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								.delete(schemaModel)
 								.where(eq(idColumn, targetId))
 								.execute();
-							const count =
-								(delRes &&
-									(delRes.rowsAffected ??
-										delRes.affectedRows ??
-										delRes.changes)) ??
-								0;
+							const count = getAffectedRowCount(delRes, "consumeOne", {
+								model,
+								where,
+							});
 							return count > 0 ? (target as any) : null;
 						};
 						return inTransaction

--- a/packages/test-utils/src/adapter/create-test-suite.ts
+++ b/packages/test-utils/src/adapter/create-test-suite.ts
@@ -255,15 +255,14 @@ export const createTestSuite = <
 
 			let adapter = await helpers.adapter();
 			const wrapperAdapter = (
-				overrideOptions?: BetterAuthOptions | undefined,
+				resolvedOptions?: BetterAuthOptions | undefined,
 			) => {
-				const options = deepmerge(
+				const options =
+					resolvedOptions ??
 					deepmerge(
-						helpers.getBetterAuthOptions(),
 						config?.defaultBetterAuthOptions || {},
-					),
-					overrideOptions || {},
-				);
+						helpers.getBetterAuthOptions(),
+					);
 				const adapterConfig = {
 					adapterId: helpers.adapterDisplayName,
 					...(adapter.options?.adapterConfig || {}),
@@ -317,6 +316,22 @@ export const createTestSuite = <
 									adapter = await helpers.adapter();
 									const res = await adapter.updateMany(args);
 									return res as any;
+								},
+								consumeOne: async <T>(
+									args: Parameters<
+										DBAdapter<BetterAuthOptions>["consumeOne"]
+									>[0],
+								) => {
+									adapter = await helpers.adapter();
+									return adapter.consumeOne<T>(args);
+								},
+								incrementOne: async <T>(
+									args: Parameters<
+										DBAdapter<BetterAuthOptions>["incrementOne"]
+									>[0],
+								) => {
+									adapter = await helpers.adapter();
+									return adapter.incrementOne<T>(args);
 								},
 								createSchema: adapter.createSchema as any,
 								async create({ data, model, select }) {
@@ -625,9 +640,12 @@ export const createTestSuite = <
 					}),
 					getAuth: async () => {
 						adapter = await helpers.adapter();
+						const options = deepmerge(
+							config?.defaultBetterAuthOptions || {},
+							helpers.getBetterAuthOptions(),
+						);
 						const auth = betterAuth({
-							...helpers.getBetterAuthOptions(),
-							...(config?.defaultBetterAuthOptions || {}),
+							...options,
 							database: (options: BetterAuthOptions) => {
 								const adapter = wrapperAdapter(options);
 								return adapter;

--- a/packages/test-utils/src/adapter/suites/auth-flow.ts
+++ b/packages/test-utils/src/adapter/suites/auth-flow.ts
@@ -74,6 +74,73 @@ export const authFlowTestSuite = createTestSuite(
 			expect(result.user).toBeDefined();
 			expect(result.user.id).toBe(signUpResult.user.id);
 		},
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10054
+		 */
+		"should reset password with a single-use token": async () => {
+			let resetToken = "";
+			await modifyBetterAuthOptions(
+				{
+					emailAndPassword: {
+						enabled: true,
+						async sendResetPassword({ token }) {
+							resetToken = token;
+						},
+					},
+				},
+				false,
+			);
+			const auth = await getAuth();
+			const user = await generate("user");
+			const originalPassword = crypto.randomUUID();
+			const newPassword = `${crypto.randomUUID()}-new`;
+
+			const signUpResult = await auth.api.signUpEmail({
+				body: {
+					email: user.email,
+					password: originalPassword,
+					name: user.name,
+					image: user.image || "",
+				},
+			});
+
+			await auth.api.requestPasswordReset({
+				body: {
+					email: user.email,
+					redirectTo: "http://localhost:3000/reset-password",
+				},
+			});
+			expect(resetToken.length).toBeGreaterThan(10);
+
+			const resetResult = await auth.api.resetPassword({
+				body: { token: resetToken, newPassword },
+			});
+			expect(resetResult.status).toBe(true);
+
+			const oldPasswordResult = await tryCatch(
+				auth.api.signInEmail({
+					body: { email: user.email, password: originalPassword },
+				}),
+			);
+			expect(oldPasswordResult.data).toBeNull();
+			expect(oldPasswordResult.error).toBeDefined();
+
+			const newPasswordResult = await auth.api.signInEmail({
+				body: { email: user.email, password: newPassword },
+			});
+			expect(newPasswordResult.user.id).toBe(signUpResult.user.id);
+
+			const replayResult = await tryCatch(
+				auth.api.resetPassword({
+					body: {
+						token: resetToken,
+						newPassword: `${crypto.randomUUID()}-replay`,
+					},
+				}),
+			);
+			expect(replayResult.data).toBeNull();
+			expect(replayResult.error).toBeDefined();
+		},
 		"should successfully get session": async () => {
 			const auth = await getAuth();
 			const user = await generate("user");


### PR DESCRIPTION
Drizzle MySQL could consume a single-use verification row and still report the consume as a miss.

MySQL delete results can arrive as a result-header array, while the native Drizzle `consumeOne` path only read top-level affected-row fields. This keeps the atomic consume design intact and routes that delete metadata through the adapter's shared affected-row normalizer, so the row is returned only when the delete actually affected a row.

Also tightens the adapter test harness so wrapped adapters exercise native single-row primitives instead of masking them behind the fallback implementation.

Fixes #10054



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `consumeOne` in the Drizzle MySQL adapter so a consumed verification row is correctly returned. Password reset tokens now work reliably after consumption.

- **Bug Fixes**
  - Use the shared affected-row normalizer in `consumeOne`, correctly handling MySQL result-header arrays and returning the row only when the delete actually affected a row.

- **Refactors**
  - Expanded tests: adapter unit tests for MySQL result-header arrays and no-op deletes; harness uses native `consumeOne`/`incrementOne`; auth-flow covers password reset and replay rejection; fixes options merge order in `@better-auth/test-utils`.

<sup>Written for commit bd7d6f837861bf1c462d4db2f915bc5b2a3cf0fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



