### PR TITLE
fix(oauth-provider): use updateMany for refresh token CAS

### DIFF
--- a/.changeset/oauth-refresh-token-update-many.md
+++ b/.changeset/oauth-refresh-token-update-many.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Use `updateMany` for refresh-token rotation and revocation compare-and-swap checks so adapters that cannot return rows from compound `update` calls, including Prisma, can rotate refresh tokens correctly.

--- a/packages/oauth-provider/src/revoke.ts
+++ b/packages/oauth-provider/src/revoke.ts
@@ -176,7 +176,7 @@ async function revokeRefreshToken(
 	// Atomic compare-and-swap. If a concurrent rotation already revoked
 	// (and re-minted) this row, fail closed and tear down the whole family
 	// so the rotation's offspring cannot be used either.
-	const won = await ctx.context.adapter.update<{ id: string }>({
+	const updated = await ctx.context.adapter.updateMany({
 		model: "oauthRefreshToken",
 		where: [
 			{
@@ -193,7 +193,7 @@ async function revokeRefreshToken(
 			revoked: new Date(iat * 1000),
 		},
 	});
-	if (!won) {
+	if (updated !== 1) {
 		await invalidateRefreshFamily(ctx, clientId, refreshToken.userId);
 		throw new APIError("BAD_REQUEST", {
 			error_description: "refresh token revoked",

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -11,7 +11,7 @@ import {
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
 import { createLocalJWKSet, decodeJwt, jwtVerify } from "jose";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
 import type { OAuthOptions, Scope, VerificationValue } from "./types";
@@ -661,6 +661,57 @@ describe("oauth token - refresh_token", async () => {
 
 		// Always expect a new refresh token
 		expect(tokens?.refresh_token).not.toEqual(newTokens.data?.refresh_token);
+	});
+
+	it("rotates refresh tokens without compound adapter.update", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "profile", "offline_access"];
+		const tokens = await authorizeForRefreshToken(scopes);
+		expect(tokens?.refresh_token).toBeDefined();
+
+		const context = await authorizationServer.$context;
+		const originalUpdate = context.adapter.update.bind(context.adapter);
+		const updateSpy = vi
+			.spyOn(context.adapter, "update")
+			.mockImplementation((async (data: Parameters<typeof originalUpdate>[0]) => {
+				if (data.model === "oauthRefreshToken" && data.where.length > 1) {
+					throw new Error("compound oauthRefreshToken update is not portable");
+				}
+				return originalUpdate(data);
+			}) as typeof context.adapter.update);
+
+		try {
+			const { body, headers } = createRefreshAccessTokenRequest({
+				refreshToken: tokens!.refresh_token!,
+				options: {
+					clientId: oauthClient.client_id,
+					clientSecret: oauthClient.client_secret,
+					redirectURI: redirectUri,
+				},
+			});
+			const newTokens = await client.$fetch<{
+				access_token?: string;
+				refresh_token?: string;
+			}>("/oauth2/token", {
+				method: "POST",
+				body,
+				headers,
+			});
+
+			expect(newTokens.error).toBeNull();
+			expect(newTokens.data?.access_token).toBeDefined();
+			expect(newTokens.data?.refresh_token).toBeDefined();
+			expect(
+				updateSpy.mock.calls.some(
+					([data]) => data.model === "oauthRefreshToken",
+				),
+			).toBe(false);
+		} finally {
+			updateSpy.mockRestore();
+		}
 	});
 
 	it("should preserve auth_time in id_token after refresh (OIDC Core 1.0 Section 12.2)", async ({

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -382,7 +382,7 @@ async function createRefreshToken(
 	// with the winner's still-in-flight inserts. Tracked for a follow-up
 	// minor once the adapter contract exposes opt-in transactional
 	// rotation.
-	const won = await ctx.context.adapter.update<{ id: string }>({
+	const updated = await ctx.context.adapter.updateMany({
 		model: "oauthRefreshToken",
 		where: [
 			{ field: "id", value: originalRefresh.id },
@@ -393,7 +393,7 @@ async function createRefreshToken(
 		},
 	});
 
-	if (!won) {
+	if (updated !== 1) {
 		throw new APIError("BAD_REQUEST", {
 			error_description: "invalid refresh token",
 			error: "invalid_grant",


### PR DESCRIPTION
## Summary

Fixes #10082.

Refresh-token rotation in the OAuth provider was using `adapter.update()` as a compare-and-swap with multiple `where` clauses. That is not portable across adapters: Prisma can reject that compound update shape, and other adapters may return `null` even when the update succeeds.

This PR switches the refresh-token CAS path to `updateMany()` and checks the affected row count instead.

## Changes

- Use `adapter.updateMany()` for refresh-token rotation.
- Use `adapter.updateMany()` for refresh-token revocation as well, since it uses the same CAS pattern.
- Keep the existing “exactly one winner” behavior for concurrent refresh/revoke races.
- Add a regression test that fails if refresh-token rotation relies on compound `adapter.update()`.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix refresh-token rotation and revocation in `@better-auth/oauth-provider` by using `updateMany` for compare-and-swap. This makes rotation work across adapters (including `Prisma`) while keeping the single-winner behavior under concurrency.

- **Bug Fixes**
  - Use `adapter.updateMany()` for refresh-token rotation and revocation and check the affected row count.
  - Add a regression test to prevent using compound `adapter.update()` for refresh tokens.

<sup>Written for commit 0708dc955ddaa27bb5e0222e6de3c7dfa2b6455c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

