### PR TITLE
fix: make guarded state transitions portable on Prisma

### DIFF
--- a/.changeset/guarded-update-portable-cas.md
+++ b/.changeset/guarded-update-portable-cas.md
@@ -2,8 +2,11 @@
 "@better-auth/oauth-provider": patch
 "better-auth": patch
 "@better-auth/core": patch
+"@better-auth/mongo-adapter": patch
 ---
 
 Refresh-token rotation and token revocation, two-factor backup-code regeneration, device-code claiming, and organization invitation acceptance now work on Prisma. Concurrent or repeat requests in these flows could previously return an error on Prisma instead of the expected result.
+
+On MongoDB servers older than 5.0, these flows and other guarded value updates (rate-limit window resets, API-key refills) no longer fail with an empty-update error.
 
 `@better-auth/core`: `incrementOne` now reports a clear error when called with no `increment` and no `set`.

--- a/.changeset/guarded-update-portable-cas.md
+++ b/.changeset/guarded-update-portable-cas.md
@@ -1,0 +1,9 @@
+---
+"@better-auth/oauth-provider": patch
+"better-auth": patch
+"@better-auth/core": patch
+---
+
+Refresh-token rotation and token revocation, two-factor backup-code regeneration, device-code claiming, and organization invitation acceptance now work on Prisma. Concurrent or repeat requests in these flows could previously return an error on Prisma instead of the expected result.
+
+`@better-auth/core`: `incrementOne` now reports a clear error when called with no `increment` and no `set`.

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -678,9 +678,6 @@ describe("device authorization flow", async () => {
 describe("device authorization ownership gate", () => {
 	const ATTACKER_EMAIL = "attacker@example.test";
 	const ATTACKER_PASSWORD = "attacker-password-123";
-	type AdapterUpdateData = Parameters<
-		DBAdapter<BetterAuthOptions>["update"]
-	>[0];
 
 	/**
 	 * @see https://github.com/better-auth/better-auth/security/advisories/GHSA-cq3f-vc6p-68fh
@@ -1053,12 +1050,14 @@ describe("device authorization ownership gate", () => {
 			const baseAdapter = memoryAdapter(memoryDB)(options);
 			adapter = {
 				...baseAdapter,
-				update: async <T>(data: AdapterUpdateData) => {
+				incrementOne: async <T>(
+					data: Parameters<DBAdapter<BetterAuthOptions>["incrementOne"]>[0],
+				) => {
 					if (
 						simulateConcurrentClaim &&
 						concurrentOwnerId &&
 						data.model === "deviceCode" &&
-						data.update.userId
+						(data.set as { userId?: string } | undefined)?.userId
 					) {
 						simulateConcurrentClaim = false;
 						const deviceCodeId = data.where.find(
@@ -1072,7 +1071,7 @@ describe("device authorization ownership gate", () => {
 							});
 						}
 					}
-					return baseAdapter.update<T>(data);
+					return baseAdapter.incrementOne<T>(data);
 				},
 			};
 			return adapter;

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -582,14 +582,15 @@ export const deviceVerify = createAuthEndpoint(
 			deviceCodeRecord.status === "pending"
 		) {
 			const claimedDeviceCodeRecord =
-				await ctx.context.adapter.update<DeviceCode>({
+				await ctx.context.adapter.incrementOne<DeviceCode>({
 					model: "deviceCode",
 					where: [
 						{ field: "id", value: deviceCodeRecord.id },
 						{ field: "status", value: "pending" },
 						{ field: "userId", operator: "eq", value: null },
 					],
-					update: { userId: session.user.id },
+					increment: {},
+					set: { userId: session.user.id },
 				});
 			if (claimedDeviceCodeRecord) {
 				deviceCodeRecord.userId = session.user.id;

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -1146,10 +1146,11 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			if (data.fromStatus) {
 				where.push({ field: "status", value: data.fromStatus });
 			}
-			const invitation = await adapter.update<InferInvitation<O, false>>({
+			const invitation = await adapter.incrementOne<InferInvitation<O, false>>({
 				model: "invitation",
 				where,
-				update: {
+				increment: {},
+				set: {
 					status: data.status,
 				},
 			});

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
@@ -1071,7 +1071,9 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 					? { permission: JSON.stringify(updateData.permission) }
 					: {}),
 			};
-			await ctx.context.adapter.update<OrganizationRole>({
+			// Scoped by organization + role: updateMany applies the multi-clause
+			// filter portably, where a multi-clause `update` does not across adapters.
+			await ctx.context.adapter.updateMany({
 				model: "organizationRole",
 				where: [
 					{

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -355,11 +355,8 @@ export const backupCode2fa = (opts: BackupCodeOptions) => {
 						opts,
 					);
 
-					const updated = await ctx.context.adapter.update({
+					const updated = await ctx.context.adapter.incrementOne({
 						model: twoFactorTable,
-						update: {
-							backupCodes: updatedBackupCodes,
-						},
 						where: [
 							{
 								field: "id",
@@ -370,6 +367,10 @@ export const backupCode2fa = (opts: BackupCodeOptions) => {
 								value: twoFactor.backupCodes,
 							},
 						],
+						increment: {},
+						set: {
+							backupCodes: updatedBackupCodes,
+						},
 					});
 					if (!updated) {
 						throw APIError.fromStatus("CONFLICT", {

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -1450,6 +1450,16 @@ export const createAdapterFactory =
 				increment: Record<string, number>;
 				set?: Record<string, unknown> | undefined;
 			}): Promise<T | null> => {
+				const hasIncrement = Object.keys(unsafeIncrement).length > 0;
+				const hasSet = !!unsafeSet && Object.keys(unsafeSet).length > 0;
+				if (!hasIncrement && !hasSet) {
+					// An empty `increment` and empty `set` compiles to `UPDATE ... SET `
+					// with no assignments, which is a syntax error on kysely, drizzle, and
+					// Prisma. Fail fast with an actionable message instead.
+					throw new BetterAuthError(
+						"incrementOne requires a non-empty `increment` or `set`; both were empty.",
+					);
+				}
 				transactionId++;
 				const thisTransactionId = transactionId;
 				const model = getModelName(unsafeModel);

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -1496,6 +1496,17 @@ export const createAdapterFactory =
 					} else {
 						set = unsafeSet;
 					}
+					// `transformInput` drops unknown-to-schema and `undefined` fields, so
+					// a `set` that was non-empty on input can resolve to nothing. Re-check
+					// after mapping so this never reaches the adapter as an empty UPDATE.
+					if (
+						Object.keys(increment).length === 0 &&
+						(!set || Object.keys(set).length === 0)
+					) {
+						throw new BetterAuthError(
+							"incrementOne resolved to an empty update: every increment/set field was unknown to the schema or transformed away.",
+						);
+					}
 					res = await withSpan(
 						`db incrementOne ${model}`,
 						{

--- a/packages/core/src/db/adapter/increment-one.test.ts
+++ b/packages/core/src/db/adapter/increment-one.test.ts
@@ -377,4 +377,35 @@ describe("createAdapterFactory incrementOne native path", () => {
 		expect(nativeCalls).toBe(1);
 		expect(result?.count).toBe(15);
 	});
+
+	it("throws when `set` resolves to empty after input transform", async () => {
+		const { adapter } = createMemoryAdapter(seed([{ key: "a", count: 0 }]));
+		let nativeCalls = 0;
+		const nativeAdapter: CustomAdapter = {
+			...adapter,
+			incrementOne: async <T>(_args: {
+				model: string;
+				where: CleanedWhere[];
+				increment: Record<string, number>;
+				set?: Record<string, unknown> | undefined;
+			}) => {
+				nativeCalls += 1;
+				return null as T | null;
+			},
+		};
+		const factory = createTestAdapter(nativeAdapter);
+
+		// `bogus` is not a field of the model, so transformInput drops it: the set
+		// resolves to empty alongside the empty increment. The guard must fire
+		// before the adapter runs an empty UPDATE.
+		await expect(
+			factory.incrementOne({
+				model: counterModel,
+				where: [{ field: "key", value: "a" }],
+				increment: {},
+				set: { bogus: 1 },
+			}),
+		).rejects.toThrow();
+		expect(nativeCalls).toBe(0);
+	});
 });

--- a/packages/core/src/db/adapter/increment-one.test.ts
+++ b/packages/core/src/db/adapter/increment-one.test.ts
@@ -275,6 +275,55 @@ describe("createAdapterFactory incrementOne fallback", () => {
 		expect(winners).toHaveLength(1);
 		expect(firstRow(store).count).toBe(0);
 	});
+
+	it("throws when both `increment` and `set` are empty", async () => {
+		const { adapter } = createMemoryAdapter(seed([{ key: "a", count: 0 }]));
+		const factory = createTestAdapter(adapter);
+
+		await expect(
+			factory.incrementOne({
+				model: counterModel,
+				where: [{ field: "key", value: "a" }],
+				increment: {},
+			}),
+		).rejects.toThrow();
+	});
+
+	it("applies a guarded transition via `set` with an empty increment", async () => {
+		const { adapter, store } = createMemoryAdapter(
+			seed([{ key: "a", count: 0, lastRequest: 100 }]),
+		);
+		const factory = createTestAdapter(adapter);
+
+		const won = await factory.incrementOne<{
+			key: string;
+			lastRequest: number;
+		}>({
+			model: counterModel,
+			where: [
+				{ field: "key", value: "a" },
+				{ field: "lastRequest", value: 100 },
+			],
+			increment: {},
+			set: { lastRequest: 200 },
+		});
+		expect(won?.lastRequest).toBe(200);
+		expect(firstRow(store).lastRequest).toBe(200);
+
+		// The guard now misses (lastRequest already moved), so the loser must get
+		// null and the row must not change again.
+		const lost = await factory.incrementOne({
+			model: counterModel,
+			where: [
+				{ field: "key", value: "a" },
+				{ field: "lastRequest", value: 100 },
+			],
+			increment: {},
+			set: { lastRequest: 300 },
+		});
+		expect(lost).toBeNull();
+		expect(firstRow(store).lastRequest).toBe(200);
+	});
 });
 
 describe("createAdapterFactory incrementOne native path", () => {

--- a/packages/mongo-adapter/src/mongodb-adapter.test.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.test.ts
@@ -104,6 +104,35 @@ describe("mongodb-adapter", () => {
 		expect(updateArg).not.toHaveProperty("$set");
 	});
 
+	it("incrementOne omits $inc for a set-only guarded transition", async () => {
+		const findOneAndUpdate = vi.fn(async () => ({
+			value: { _id: "counter-id", lastRequest: 1700000000000 },
+		}));
+		const db = {
+			collection: vi.fn(() => ({
+				findOneAndUpdate,
+			})),
+		} as any;
+		const adapter = mongodbAdapter(db, { transaction: false })(
+			rateLimitOptions,
+		);
+
+		await adapter.incrementOne({
+			model: "rateLimit",
+			where: [{ field: "key", value: "a" }],
+			increment: {},
+			set: { lastRequest: 1700000000000 },
+		});
+
+		expect(findOneAndUpdate).toHaveBeenCalledWith(
+			{ key: "a" },
+			{ $set: { lastRequest: 1700000000000 } },
+			expect.anything(),
+		);
+		const updateArg = (findOneAndUpdate.mock.calls[0] as any[])[1];
+		expect(updateArg).not.toHaveProperty("$inc");
+	});
+
 	it("incrementOne returns null when the guard matches no document", async () => {
 		const findOneAndUpdate = vi.fn(async () => ({ value: null }));
 		const db = {

--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -640,9 +640,13 @@ export const mongodbAdapter = (
 				},
 				async incrementOne({ model, where, increment, set }) {
 					const clause = convertWhereClause({ where, model });
-					const update: { $inc: Record<string, number>; $set?: any } = {
-						$inc: increment,
-					};
+					// Only include operators that carry fields. An empty `$inc: {}`
+					// errors on MongoDB server < 5.0, and a set-only guarded
+					// transition passes an empty `increment`.
+					const update: { $inc?: Record<string, number>; $set?: any } = {};
+					if (Object.keys(increment).length > 0) {
+						update.$inc = increment;
+					}
 					if (set && Object.keys(set).length > 0) {
 						update.$set = set;
 					}

--- a/packages/oauth-provider/src/revoke.ts
+++ b/packages/oauth-provider/src/revoke.ts
@@ -176,7 +176,7 @@ async function revokeRefreshToken(
 	// Atomic compare-and-swap. If a concurrent rotation already revoked
 	// (and re-minted) this row, fail closed and tear down the whole family
 	// so the rotation's offspring cannot be used either.
-	const won = await ctx.context.adapter.update<{ id: string }>({
+	const won = await ctx.context.adapter.incrementOne<{ id: string }>({
 		model: "oauthRefreshToken",
 		where: [
 			{
@@ -189,7 +189,8 @@ async function revokeRefreshToken(
 				value: null,
 			},
 		],
-		update: {
+		increment: {},
+		set: {
 			revoked: new Date(iat * 1000),
 		},
 	});

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -382,13 +382,14 @@ async function createRefreshToken(
 	// with the winner's still-in-flight inserts. Tracked for a follow-up
 	// minor once the adapter contract exposes opt-in transactional
 	// rotation.
-	const won = await ctx.context.adapter.update<{ id: string }>({
+	const won = await ctx.context.adapter.incrementOne<{ id: string }>({
 		model: "oauthRefreshToken",
 		where: [
 			{ field: "id", value: originalRefresh.id },
 			{ field: "revoked", operator: "eq", value: null },
 		],
-		update: {
+		increment: {},
+		set: {
 			revoked: new Date(iat * 1000),
 		},
 	});

--- a/packages/test-utils/src/adapter/suites/basic.ts
+++ b/packages/test-utils/src/adapter/suites/basic.ts
@@ -2148,6 +2148,45 @@ export const getNormalTestSuiteTests = (
 					updatedAt: result!.updatedAt,
 				});
 			},
+		// A guarded single-row transition: set a field only while a non-unique
+		// guard field still holds. This is the portable, race-safe replacement
+		// for a multi-clause `update` whose return was read as a winner/loser
+		// signal (issue #10082); the guard miss must return null without mutating,
+		// on every adapter.
+		"incrementOne - guarded set transition returns the row on a matching guard and null on a guard miss":
+			async () => {
+				const [transitionUser] = await insertRandom("user");
+				const image = "https://example.com/avatar.png";
+
+				const won = await adapter.incrementOne<User>({
+					model: "user",
+					where: [
+						{ field: "id", value: transitionUser.id },
+						{ field: "name", value: transitionUser.name },
+					],
+					increment: {},
+					set: { image },
+				});
+				expect(won).not.toBeNull();
+				expect(won!.image).toBe(image);
+
+				const lost = await adapter.incrementOne<User>({
+					model: "user",
+					where: [
+						{ field: "id", value: transitionUser.id },
+						{ field: "name", value: "name-that-does-not-match" },
+					],
+					increment: {},
+					set: { image: "https://example.com/should-not-apply.png" },
+				});
+				expect(lost).toBeNull();
+
+				const after = await adapter.findOne<User>({
+					model: "user",
+					where: [{ field: "id", value: transitionUser.id }],
+				});
+				expect(after!.image).toBe(image);
+			},
 		"delete - should delete a model": async () => {
 			const [user] = await insertRandom("user");
 			await adapter.delete({

--- a/test/unit/no-multi-clause-adapter-update.test.ts
+++ b/test/unit/no-multi-clause-adapter-update.test.ts
@@ -1,0 +1,167 @@
+import { globSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Structural lock for the adapter compare-and-swap class of bug.
+ *
+ * `DBAdapter.update` is documented as not guaranteed to return the updated row
+ * when more than one `where` clause is provided, so a multi-clause `update`
+ * whose truthy/`null` return is read as a winner/loser signal is non-portable:
+ * it passes on the in-memory adapter but throws or misreports on Prisma. The
+ * race-safe primitive for a guarded single-row transition is `incrementOne`
+ * (`UPDATE ... SET ... WHERE <guard> RETURNING *`, returns the row or `null`).
+ *
+ * This test fails if any consumer calls `adapter.update` with a statically
+ * multi-clause `where` array, so the pattern cannot silently return.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10082
+ */
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// Adapter implementations own `update`; the test suite exercises it directly;
+// the factory and the with-hooks layer forward an arbitrary caller `where`.
+// None of these is a consumer choosing a multi-clause guard.
+const EXCLUDED = [
+	/\/packages\/[^/]*-adapter\//,
+	/\/packages\/test-utils\//,
+	/\/packages\/core\/src\/db\/adapter\/factory\.ts$/,
+	/\/packages\/better-auth\/src\/db\/with-hooks\.ts$/,
+	/\.test\.ts$/,
+	/\.d\.ts$/,
+];
+
+/** Replace string/template/comment spans with equal-length blanks so brace and
+ * bracket counting is not thrown off by punctuation inside them. */
+function blankNonCode(src: string): string {
+	let out = "";
+	let i = 0;
+	const n = src.length;
+	while (i < n) {
+		const c = src[i];
+		const two = src.slice(i, i + 2);
+		if (two === "//") {
+			while (i < n && src[i] !== "\n") {
+				out += " ";
+				i++;
+			}
+			continue;
+		}
+		if (two === "/*") {
+			while (i < n && src.slice(i, i + 2) !== "*/") {
+				out += src[i] === "\n" ? "\n" : " ";
+				i++;
+			}
+			out += "  ";
+			i += 2;
+			continue;
+		}
+		if (c === '"' || c === "'" || c === "`") {
+			const quote = c;
+			out += " ";
+			i++;
+			while (i < n) {
+				if (src[i] === "\\") {
+					out += "  ";
+					i += 2;
+					continue;
+				}
+				if (src[i] === quote) {
+					out += " ";
+					i++;
+					break;
+				}
+				out += src[i] === "\n" ? "\n" : " ";
+				i++;
+			}
+			continue;
+		}
+		out += c;
+		i++;
+	}
+	return out;
+}
+
+/** Count top-level `{ ... }` elements inside the array literal that begins at
+ * `src[open]` (which must be `[`). Returns `null` if `where` is not an inline
+ * array literal (e.g. a variable), where arity cannot be determined statically. */
+function arrayObjectArity(src: string, open: number): number {
+	let depth = 0;
+	let objects = 0;
+	for (let i = open; i < src.length; i++) {
+		const c = src[i];
+		if (c === "[") depth++;
+		else if (c === "]") {
+			depth--;
+			if (depth === 0) break;
+		} else if (c === "{" && depth === 1) {
+			objects++;
+		}
+	}
+	return objects;
+}
+
+const callRe = /\b\w*[Aa]dapter\.update\s*(?:<[^>]*>)?\s*\(/g;
+
+function findViolations(file: string): { line: number; arity: number }[] {
+	const raw = readFileSync(file, "utf8");
+	const code = blankNonCode(raw);
+	const violations: { line: number; arity: number }[] = [];
+	for (const match of code.matchAll(callRe)) {
+		const callStart = match.index! + match[0].length - 1; // at the `(`
+		// Find the `where:` key directly inside the single argument object.
+		let depth = 0;
+		let whereArrayOpen = -1;
+		for (let i = callStart; i < code.length; i++) {
+			const c = code[i];
+			if (c === "(" || c === "{" || c === "[") depth++;
+			else if (c === ")" || c === "}" || c === "]") {
+				depth--;
+				if (depth === 0) break; // end of the call
+			} else if (depth === 2 && code.startsWith("where", i)) {
+				// depth 2 == inside the arg object `{` (depth 1 is the call `(`).
+				const after = code.slice(i + 5).match(/^\s*:\s*/);
+				if (after) {
+					const valueAt = i + 5 + after[0].length;
+					if (code[valueAt] === "[") whereArrayOpen = valueAt;
+					break;
+				}
+			}
+		}
+		if (whereArrayOpen === -1) continue; // no inline `where` array literal
+		const arity = arrayObjectArity(code, whereArrayOpen);
+		if (arity >= 2) {
+			const line = raw.slice(0, match.index).split("\n").length;
+			violations.push({ line, arity });
+		}
+	}
+	return violations;
+}
+
+describe("adapter.update compare-and-swap lock", () => {
+	it("no consumer calls adapter.update with a multi-clause where", () => {
+		const files = globSync("packages/*/src/**/*.ts", {
+			cwd: repoRoot,
+		})
+			.map((f) => resolve(repoRoot, f))
+			.filter((f) => !EXCLUDED.some((re) => re.test(f)));
+
+		const offenders: string[] = [];
+		for (const file of files) {
+			for (const { line, arity } of findViolations(file)) {
+				offenders.push(
+					`${relative(repoRoot, file)}:${line} (where has ${arity} clauses)`,
+				);
+			}
+		}
+
+		expect(
+			offenders,
+			offenders.length
+				? `Multi-clause adapter.update is non-portable (issue #10082). Use adapter.incrementOne for a guarded single-row transition:\n${offenders.join("\n")}`
+				: undefined,
+		).toEqual([]);
+	});
+});

--- a/test/unit/no-multi-clause-adapter-update.test.ts
+++ b/test/unit/no-multi-clause-adapter-update.test.ts
@@ -84,33 +84,68 @@ function blankNonCode(src: string): string {
 	return out;
 }
 
-/** Count top-level `{ ... }` elements inside the array literal that begins at
- * `src[open]` (which must be `[`). Returns `null` if `where` is not an inline
- * array literal (e.g. a variable), where arity cannot be determined statically. */
-function arrayObjectArity(src: string, open: number): number {
+/** Count top-level elements in the array literal that begins at `src[open]`
+ * (which must be `[`), splitting on commas at the array's own nesting depth.
+ * `[{...}, condition]` reads as two clauses even when an element is an
+ * identifier or spread rather than an object literal. */
+function whereClauseCount(src: string, open: number): number {
 	let depth = 0;
-	let objects = 0;
+	let clauses = 0;
+	let segmentHasContent = false;
 	for (let i = open; i < src.length; i++) {
-		const c = src[i];
-		if (c === "[") depth++;
-		else if (c === "]") {
+		const c = src[i]!;
+		if (c === "[" || c === "(" || c === "{") {
+			depth++;
+			if (!(depth === 1 && c === "[")) segmentHasContent = true;
+		} else if (c === "]" || c === ")" || c === "}") {
 			depth--;
-			if (depth === 0) break;
-		} else if (c === "{" && depth === 1) {
-			objects++;
+			if (depth === 0) {
+				if (segmentHasContent) clauses++;
+				break;
+			}
+		} else if (c === "," && depth === 1) {
+			if (segmentHasContent) clauses++;
+			segmentHasContent = false;
+		} else if (!/\s/.test(c)) {
+			segmentHasContent = true;
 		}
 	}
-	return objects;
+	return clauses;
 }
 
-const callRe = /\b\w*[Aa]dapter\.update\s*(?:<[^>]*>)?\s*\(/g;
+// Matches any receiver ending in `adapter`/`Adapter` then `.update`, but not
+// `.updateMany` (the `\b` after `update` fails before `Many`). The optional
+// type-argument list and the opening paren are resolved separately so nested
+// generics like `update<Foo<Bar>>(` are handled.
+const callRe = /\b\w*[Aa]dapter\.update\b/g;
+
+/** From just past `.update`, skip whitespace and an optional balanced `<...>`
+ * type-argument list, and return the index of the call's `(`, or -1 if this
+ * `.update` is not a call. */
+function callParenIndex(src: string, afterUpdate: number): number {
+	let i = afterUpdate;
+	while (i < src.length && /\s/.test(src[i]!)) i++;
+	if (src[i] === "<") {
+		let angle = 0;
+		for (; i < src.length; i++) {
+			if (src[i] === "<") angle++;
+			else if (src[i] === ">" && --angle === 0) {
+				i++;
+				break;
+			}
+		}
+		while (i < src.length && /\s/.test(src[i]!)) i++;
+	}
+	return src[i] === "(" ? i : -1;
+}
 
 function findViolations(file: string): { line: number; arity: number }[] {
 	const raw = readFileSync(file, "utf8");
 	const code = blankNonCode(raw);
 	const violations: { line: number; arity: number }[] = [];
 	for (const match of code.matchAll(callRe)) {
-		const callStart = match.index! + match[0].length - 1; // at the `(`
+		const callStart = callParenIndex(code, match.index! + match[0].length);
+		if (callStart === -1) continue; // a `.update` reference, not a call
 		// Find the `where:` key directly inside the single argument object.
 		let depth = 0;
 		let whereArrayOpen = -1;
@@ -131,7 +166,7 @@ function findViolations(file: string): { line: number; arity: number }[] {
 			}
 		}
 		if (whereArrayOpen === -1) continue; // no inline `where` array literal
-		const arity = arrayObjectArity(code, whereArrayOpen);
+		const arity = whereClauseCount(code, whereArrayOpen);
 		if (arity >= 2) {
 			const line = raw.slice(0, match.index).split("\n").length;
 			violations.push({ line, arity });


### PR DESCRIPTION
Closes #10082.

Five flows pick the winner of a concurrent operation by reading the truthy return of a multi-clause `adapter.update` as a compare-and-swap: refresh-token rotation and revocation, two-factor backup-code regeneration, device-code claiming, and organization invitation acceptance. The adapter contract does not guarantee that return for a multi-clause `where` (its JSDoc: "update may not return the updated data if multiple where clauses are provided"). On Prisma the call does not behave as a reliable compare-and-swap: the request can error and the concurrency guard never holds. The in-memory test adapter returns the matched row regardless of clause count, so the default suite never caught it.

Each site now uses `incrementOne`, the adapter's race-safe guarded single-row update: one `UPDATE ... SET ... WHERE <guard> RETURNING` that returns the row to the winner and `null` to the loser, with a native implementation per adapter. `updateMany` plus an affected-count check was the alternative, but that count is itself unreliable on some adapters, so the single guarded statement is the portable choice.

Two supporting changes: `incrementOne` now throws when given neither `increment` nor `set` (that compiled to an empty `UPDATE` that fails on SQL adapters), and a test fails CI if a multi-clause `adapter.update` is reintroduced anywhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced multi-clause `adapter.update` with `incrementOne` for guarded single-row transitions to make concurrency safe and portable across adapters. Also strengthened the CI lock and `incrementOne` guard to prevent empty updates.

- **Bug Fixes**
  - `@better-auth/oauth-provider` and `better-auth` now use `incrementOne` for compare-and-swap; Prisma no longer errors and losers return null. Organization role update now uses `updateMany`.
  - `@better-auth/core`: `incrementOne` throws if both `increment` and `set` are empty, and re-checks after input transform to block empty UPDATEs.
  - `@better-auth/mongo-adapter`: `incrementOne` omits empty `$inc` so set-only guarded transitions succeed, including on MongoDB < 5.0.

<sup>Written for commit c0c793b065822ce963b197b3aca2cd1d1d8db311. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

