### PR TITLE
fix(ci): scope Compose services per job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,16 +175,23 @@ jobs:
         run: docker compose down --volumes --remove-orphans
 
       - name: Start Docker Containers
-        run: docker compose up -d --wait --wait-timeout 60
+        env:
+          COMPOSE_SERVICES: postgres postgres-kysely mongodb
+        run: |
+          read -r -a compose_services <<< "$COMPOSE_SERVICES"
+          docker compose up -d --wait --wait-timeout 60 "${compose_services[@]}"
 
       - name: Test
         run: pnpm coverage
 
       - name: Docker Compose Diagnostics
         if: failure() && hashFiles('docker-compose.yml') != ''
+        env:
+          COMPOSE_SERVICES: postgres postgres-kysely mongodb
         run: |
+          read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose ps --all || true
-          docker compose logs --no-color mssql || true
+          docker compose logs --no-color "${compose_services[@]}" || true
 
       - name: Stop Docker Containers
         if: always() && hashFiles('docker-compose.yml') != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x, 24.x]
+    env:
+      COMPOSE_SERVICES: postgres postgres-kysely mongodb
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -175,8 +177,6 @@ jobs:
         run: docker compose down --volumes --remove-orphans
 
       - name: Start Docker Containers
-        env:
-          COMPOSE_SERVICES: postgres postgres-kysely mongodb
         run: |
           read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose up -d --wait --wait-timeout 60 "${compose_services[@]}"
@@ -186,8 +186,6 @@ jobs:
 
       - name: Docker Compose Diagnostics
         if: failure() && hashFiles('docker-compose.yml') != ''
-        env:
-          COMPOSE_SERVICES: postgres postgres-kysely mongodb
         run: |
           read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose ps --all || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,8 @@ jobs:
         node-version: [22.x, 24.x]
     permissions:
       contents: read
+    env:
+      COMPOSE_SERVICES: redis
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -62,8 +64,6 @@ jobs:
         run: docker compose down --volumes --remove-orphans
 
       - name: Start Docker Containers
-        env:
-          COMPOSE_SERVICES: redis
         run: |
           read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose up -d --wait --wait-timeout 60 "${compose_services[@]}"
@@ -79,8 +79,6 @@ jobs:
 
       - name: Docker Compose Diagnostics
         if: failure() && hashFiles('docker-compose.yml') != ''
-        env:
-          COMPOSE_SERVICES: redis
         run: |
           read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose ps --all || true
@@ -95,6 +93,8 @@ jobs:
     runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'better-auth/better-auth' || github.event_name != 'pull_request' && github.repository == 'better-auth/better-auth') && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
+    env:
+      COMPOSE_SERVICES: postgres
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -127,8 +127,6 @@ jobs:
         run: docker compose down --volumes --remove-orphans
 
       - name: Start Docker Containers
-        env:
-          COMPOSE_SERVICES: postgres
         run: |
           read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose up -d --wait --wait-timeout 60 "${compose_services[@]}"
@@ -138,8 +136,6 @@ jobs:
 
       - name: Docker Compose Diagnostics
         if: failure() && hashFiles('docker-compose.yml') != ''
-        env:
-          COMPOSE_SERVICES: postgres
         run: |
           read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose ps --all || true
@@ -169,6 +165,8 @@ jobs:
             compose_services: "mongodb"
           - packages: "@better-auth-test/prisma-adapter"
             compose_services: "postgres-prisma mysql-prisma"
+    env:
+      COMPOSE_SERVICES: ${{ matrix.compose_services }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -199,8 +197,6 @@ jobs:
 
       - name: Start Docker Containers
         if: matrix.compose_services != ''
-        env:
-          COMPOSE_SERVICES: ${{ matrix.compose_services }}
         run: |
           read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose up -d --wait --wait-timeout 60 "${compose_services[@]}"
@@ -212,8 +208,6 @@ jobs:
 
       - name: Docker Compose Diagnostics
         if: failure() && hashFiles('docker-compose.yml') != '' && matrix.compose_services != ''
-        env:
-          COMPOSE_SERVICES: ${{ matrix.compose_services }}
         run: |
           read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose ps --all || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,11 @@ jobs:
         run: docker compose down --volumes --remove-orphans
 
       - name: Start Docker Containers
-        run: docker compose up -d --wait --wait-timeout 60
+        env:
+          COMPOSE_SERVICES: redis
+        run: |
+          read -r -a compose_services <<< "$COMPOSE_SERVICES"
+          docker compose up -d --wait --wait-timeout 60 "${compose_services[@]}"
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
@@ -75,9 +79,12 @@ jobs:
 
       - name: Docker Compose Diagnostics
         if: failure() && hashFiles('docker-compose.yml') != ''
+        env:
+          COMPOSE_SERVICES: redis
         run: |
+          read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose ps --all || true
-          docker compose logs --no-color mssql || true
+          docker compose logs --no-color "${compose_services[@]}" || true
 
       - name: Stop Docker Containers
         if: always() && hashFiles('docker-compose.yml') != ''
@@ -120,16 +127,23 @@ jobs:
         run: docker compose down --volumes --remove-orphans
 
       - name: Start Docker Containers
-        run: docker compose up -d --wait --wait-timeout 60
+        env:
+          COMPOSE_SERVICES: postgres
+        run: |
+          read -r -a compose_services <<< "$COMPOSE_SERVICES"
+          docker compose up -d --wait --wait-timeout 60 "${compose_services[@]}"
 
       - name: Integration
         run: pnpm e2e:integration --filter=./e2e/integration
 
       - name: Docker Compose Diagnostics
         if: failure() && hashFiles('docker-compose.yml') != ''
+        env:
+          COMPOSE_SERVICES: postgres
         run: |
+          read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose ps --all || true
-          docker compose logs --no-color mssql || true
+          docker compose logs --no-color "${compose_services[@]}" || true
 
       - name: Stop Docker Containers
         if: always() && hashFiles('docker-compose.yml') != ''
@@ -142,7 +156,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        packages: [ "@better-auth-test/adapter-factory", "@better-auth-test/drizzle-adapter", "@better-auth-test/kysely-prisma-adapter", "@better-auth-test/memory-adapter", "@better-auth-test/mongo-adapter", "@better-auth-test/prisma-adapter" ]
+        include:
+          - packages: "@better-auth-test/adapter-factory"
+            compose_services: ""
+          - packages: "@better-auth-test/drizzle-adapter"
+            compose_services: "postgres mysql"
+          - packages: "@better-auth-test/kysely-prisma-adapter"
+            compose_services: "postgres-kysely mysql-kysely postgres-kysely2 mssql"
+          - packages: "@better-auth-test/memory-adapter"
+            compose_services: ""
+          - packages: "@better-auth-test/mongo-adapter"
+            compose_services: "mongodb"
+          - packages: "@better-auth-test/prisma-adapter"
+            compose_services: "postgres-prisma mysql-prisma"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -172,7 +198,12 @@ jobs:
         run: docker compose down --volumes --remove-orphans
 
       - name: Start Docker Containers
-        run: docker compose up -d --wait --wait-timeout 60
+        if: matrix.compose_services != ''
+        env:
+          COMPOSE_SERVICES: ${{ matrix.compose_services }}
+        run: |
+          read -r -a compose_services <<< "$COMPOSE_SERVICES"
+          docker compose up -d --wait --wait-timeout 60 "${compose_services[@]}"
 
       - name: Adapter Integration
         env:
@@ -180,10 +211,13 @@ jobs:
         run: pnpm e2e:integration --filter="$FILTER"
 
       - name: Docker Compose Diagnostics
-        if: failure() && hashFiles('docker-compose.yml') != ''
+        if: failure() && hashFiles('docker-compose.yml') != '' && matrix.compose_services != ''
+        env:
+          COMPOSE_SERVICES: ${{ matrix.compose_services }}
         run: |
+          read -r -a compose_services <<< "$COMPOSE_SERVICES"
           docker compose ps --all || true
-          docker compose logs --no-color mssql || true
+          docker compose logs --no-color "${compose_services[@]}" || true
 
       - name: Stop Docker Containers
         if: always() && hashFiles('docker-compose.yml') != ''


### PR DESCRIPTION
CI was starting the full Compose stack before jobs that only needed a subset of services, so an MSSQL image pull failure could block unrelated smoke, integration, coverage, and adapter runs.

This makes each job declare the Compose services it needs:
- coverage starts Postgres, Kysely Postgres, and MongoDB;
- smoke starts Redis;
- integration starts Postgres;
- adapter integration maps each package to its required services and skips Compose for adapter-factory and memory.

MSSQL remains covered by the Kysely adapter matrix entry, where the MSSQL test actually runs. Diagnostics use the same declared services, so failures include logs for the relevant containers instead of MSSQL by default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope Docker Compose services per CI job and declare them once at the job level. This prevents MSSQL pull failures from blocking unrelated jobs and keeps start/diagnostics steps consistent.

- **Bug Fixes**
  - Each job sets `COMPOSE_SERVICES` and passes only those to `docker compose up` and `logs`.
  - Service scopes: coverage (postgres, postgres-kysely, mongodb), smoke (redis), integration (postgres). Adapter matrix maps per package; skip Compose for `@better-auth-test/adapter-factory` and `@better-auth-test/memory-adapter`; keep MSSQL only under `@better-auth-test/kysely-prisma-adapter`.
  - Skip Compose and diagnostics when the service list is empty.

- **Refactors**
  - Declare `COMPOSE_SERVICES` at the job level in `ci.yml` and `e2e.yml` so both start and diagnostics steps read the same value.

<sup>Written for commit 3b074f7a7d8b75e9d1bb4a18743074e2b7dd05c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

