### PR TITLE
chore: add kysely adapter bugs metadata

### DIFF
--- a/packages/kysely-adapter/package.json
+++ b/packages/kysely-adapter/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "license": "MIT",
   "homepage": "https://www.better-auth.com/docs/adapters/kysely",
+  "bugs": {
+    "url": "https://github.com/better-auth/better-auth/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/better-auth/better-auth.git",


### PR DESCRIPTION
## Summary

Adds the missing npm `bugs.url` metadata to `@better-auth/kysely-adapter`, matching the repository issue tracker used by the Better Auth packages.

This is metadata-only; runtime code, dependencies, exports, and build behavior are unchanged.

## Validation

- `npm pkg get name homepage bugs repository --silent`
- `npm pack --dry-run --ignore-scripts --json --silent`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added npm `bugs.url` to `@better-auth/kysely-adapter`, linking to the Better Auth GitHub issues page. Metadata-only change; no runtime, exports, or build behavior affected.

<sup>Written for commit 98c8c717bc76843953954c4a28ea74d75219eae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

