### PR TITLE
fix: handle async auth init rejections

### DIFF
--- a/.changeset/handled-auth-init-rejection.md
+++ b/.changeset/handled-auth-init-rejection.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Handle Better Auth initialization promise rejections immediately so startup configuration errors do not emit unhandled rejection warnings before `$context` or `handler` is awaited.

--- a/packages/better-auth/src/auth/base.ts
+++ b/packages/better-auth/src/auth/base.ts
@@ -16,6 +16,10 @@ export const createBetterAuth = <Options extends BetterAuthOptions>(
 	initFn: (options: Options) => Promise<AuthContext>,
 ): Auth<Options> => {
 	const authContext = initFn(options);
+	// Auth context initialization is awaited lazily by handlers and $context.
+	// Mark the promise as handled immediately so startup config errors don't
+	// emit unhandled rejections before consumers await the original promise.
+	void authContext.catch(() => undefined);
 	const { api } = getEndpoints(authContext, options);
 	const errorCodes = options.plugins?.reduce((acc, plugin) => {
 		if (plugin.$ERROR_CODES) {

--- a/packages/better-auth/src/auth/full.test.ts
+++ b/packages/better-auth/src/auth/full.test.ts
@@ -4,10 +4,11 @@ import {
 	createAuthMiddleware,
 } from "@better-auth/core/api";
 import type { router } from "better-auth/api";
-import { describe, expect, expectTypeOf, test } from "vitest";
+import { describe, expect, expectTypeOf, test, vi } from "vitest";
 import { createAuthClient } from "../client";
 import { getTestInstance } from "../test-utils";
 import type { Auth } from "../types";
+import { createBetterAuth } from "./base";
 import { betterAuth } from "./full";
 
 describe("auth type", () => {
@@ -68,6 +69,33 @@ describe("auth type", () => {
 		type G = E["getSession"];
 		type R = Awaited<ReturnType<G>>;
 		expectTypeOf<R>().toEqualTypeOf<{ data: { message: string } }>();
+	});
+});
+
+describe("auth initialization", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10105
+	 */
+	test("should handle async initialization rejection until context is awaited", async () => {
+		const error = new Error("init failed");
+		const onUnhandledRejection = vi.fn();
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		try {
+			const auth = createBetterAuth({}, async () => {
+				throw error;
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(onUnhandledRejection).not.toHaveBeenCalled();
+			await expect(auth.$context).rejects.toThrow("init failed");
+			await expect(
+				auth.handler(new Request("http://localhost:3000/api/auth/ok")),
+			).rejects.toThrow("init failed");
+		} finally {
+			process.off("unhandledRejection", onUnhandledRejection);
+		}
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes #10105.

This PR prevents Better Auth startup/configuration errors from being reported as unhandled promise rejections before the auth context is actually awaited.

`createBetterAuth` initializes the auth context lazily and exposes the original promise through `$context`. If initialization failed early, for example due to an invalid production config, Node could emit an `unhandledRejection` before any request or `$context` consumer had a chance to await it.

The fix marks the initialization promise as handled immediately with a no-op catch, while preserving the original promise behavior. That means the real initialization error is still thrown when `$context` or `handler` is awaited.

## Changes

- Mark the auth initialization promise as handled inside `createBetterAuth`
- Keep `$context` pointing to the original promise so errors still propagate normally
- Add regression coverage for async initialization rejection handling
- Add a patch changeset


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unhandled promise rejections during `better-auth` async startup. Errors still surface when `$context` or `handler` is awaited.

- **Bug Fixes**
  - Mark the `createBetterAuth` init promise as handled with a no-op `catch`.
  - Keep `$context` as the original promise so startup errors propagate on await.
  - Add a regression test to ensure no `unhandledRejection` is emitted.

<sup>Written for commit 50cf0878fdc6a969e506d9134d616d2b0033d87e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

