### PR TITLE
fix(origin-check): allow tilde in relative callbackURL validation

### DIFF
--- a/packages/better-auth/src/auth/trusted-origins.test.ts
+++ b/packages/better-auth/src/auth/trusted-origins.test.ts
@@ -190,6 +190,24 @@ describe("trusted origins", () => {
 			).resolves.toBe(true);
 		});
 
+		it("should allow relative paths with tildes", async () => {
+			const { isTrustedOrigin } = await createAuthTestInstance();
+
+			// `~` is an RFC 3986 unreserved character and is commonly used in
+			// route segments (e.g. `/~settings`). See issue #10022.
+			await expect(
+				isTrustedOrigin("/my-team/~settings/account", {
+					allowRelativePaths: true,
+				}),
+			).resolves.toBe(true);
+
+			await expect(
+				isTrustedOrigin("/dashboard?redirect=/~home", {
+					allowRelativePaths: true,
+				}),
+			).resolves.toBe(true);
+		});
+
 		it("should reject urls with double dash", async () => {
 			const { isTrustedOrigin } = await createAuthTestInstance();
 

--- a/packages/better-auth/src/auth/trusted-origins.ts
+++ b/packages/better-auth/src/auth/trusted-origins.ts
@@ -19,7 +19,7 @@ export const matchesOriginPattern = (
 		if (settings?.allowRelativePaths) {
 			return (
 				url.startsWith("/") &&
-				/^\/(?!\/|\\|%2f|%5c)[\w\-.\+/@]*(?:\?[\w\-.\+/=&%@]*)?$/.test(url)
+				/^\/(?!\/|\\|%2f|%5c)[\w\-.\+/@~]*(?:\?[\w\-.\+/=&%@~]*)?$/.test(url)
 			);
 		}
 


### PR DESCRIPTION
## Problem

Fixes #10022.

Relative `callbackURL` values containing a tilde (`~`) were rejected by the origin check, even though `~` is a valid path character and the URL is same-origin/relative.

## Fix

Allow the tilde character in the relative callbackURL validation so legitimate relative paths (e.g. user-home-style routes) pass the origin check while absolute/cross-origin URLs remain blocked.

## Tests

Added coverage for relative callbackURLs containing `~` being accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `~` in relative `callbackURL` validation so same-origin paths like `/~settings` pass the origin check. Fixes #10022.

- **Bug Fixes**
  - Update regex in `matchesOriginPattern` to permit `~` in path and query when `allowRelativePaths` is true.
  - Add tests covering `/my-team/~settings/account` and `?redirect=/~home`.

<sup>Written for commit 7499b3548096b3910a4277586045bf5346446c8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

