### PR TITLE
fix(last-login-method): record provider for OAuth sign-ins via oAuthProxy

### DIFF
--- a/.changeset/oauth-proxy-last-login-method.md
+++ b/.changeset/oauth-proxy-last-login-method.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The last-login-method plugin now records the provider for OAuth sign-ins that complete through the oAuthProxy plugin. The proxy finishes the session at `/oauth-proxy-callback`, a path the plugin did not recognize, so the `better-auth.last_used_login_method` cookie (and the optional database field) were never set for proxied OAuth logins. The proxy now carries the provider id as a `provider` query param on the callback and verifies it against the decrypted, authenticated profile before creating the session, so the value recorded by the plugin cannot be tampered with.

--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -68,6 +68,19 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 		if (path.startsWith("/callback/") || path.startsWith("/oauth2/callback/")) {
 			return ctx.params?.id || ctx.params?.providerId || path.split("/").pop();
 		}
+		// OAuth proxy flow (oAuthProxy plugin) finishes the session at
+		// /oauth-proxy-callback and carries the provider id as a query param.
+		// The proxy callback verifies it against the decrypted profile before
+		// creating the user/session, so by the time this runs it is trusted.
+		// Still sanitize the read side: only accept a provider-id-shaped token,
+		// so an unexpected value can never become the stored method label.
+		if (path === "/oauth-proxy-callback") {
+			const provider = ctx.query?.provider;
+			return typeof provider === "string" &&
+				/^[a-zA-Z0-9._-]{1,64}$/.test(provider)
+				? provider
+				: null;
+		}
 		// Check for email sign-in/sign-up
 		if (path === "/sign-in/email" || path === "/sign-up/email") {
 			return "email";

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -130,6 +130,10 @@ const oauthProxyQuerySchema = z.object({
 	profile: z.string().optional().meta({
 		description: "Encrypted OAuth profile data",
 	}),
+	provider: z.string().optional().meta({
+		description:
+			"Provider id, verified against the decrypted profile and read by the last-login-method plugin",
+	}),
 });
 
 const oauthCallbackQuerySchema = z.object({
@@ -259,6 +263,23 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 					);
 					if (!stateConsumed) {
 						throw redirectOnError(ctx, errorURL, "state_mismatch");
+					}
+
+					// The `provider` query param is carried in the (user-reachable)
+					// redirect URL and is read by the last-login-method plugin to
+					// record the login method. Verify it against the authenticated
+					// provider id from the decrypted profile before creating the
+					// user or session, so a tampered value can never reach the
+					// last_used_login_method cookie or the lastLoginMethod column.
+					if (
+						ctx.query.provider &&
+						ctx.query.provider !== payload.account.providerId
+					) {
+						ctx.context.logger.error(
+							"OAuth proxy provider mismatch",
+							ctx.query.provider,
+						);
+						throw redirectOnError(ctx, errorURL, "provider_mismatch");
 					}
 
 					let result: Awaited<ReturnType<typeof handleOAuthUserInfo>>;
@@ -524,6 +545,10 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 
 						// Add the profile parameter to proxy callback URL
 						proxyCallbackURL.searchParams.set("profile", encryptedPayload);
+						// Carry the provider id so the last-login-method plugin can
+						// record it on the callback. The callback verifies it against
+						// the decrypted profile before trusting it.
+						proxyCallbackURL.searchParams.set("provider", provider.id);
 
 						// Redirect to preview's oauth-proxy-callback with profile data
 						throw ctx.redirect(proxyCallbackURL.toString());

--- a/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
@@ -14,6 +14,7 @@ import { parseJSON } from "../../client/parser";
 import { signJWT, symmetricDecrypt, symmetricEncrypt } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { DEFAULT_SECRET } from "../../utils/constants";
+import { lastLoginMethod } from "../last-login-method";
 import { oAuthProxy } from ".";
 
 let testIdToken: string;
@@ -674,6 +675,134 @@ describe("oauth-proxy", async () => {
 				previewUsersAfter[0]!.id,
 			);
 			expect(previewSessions.length).toBe(1);
+		});
+
+		it("records the provider as last login method on the proxy callback", async () => {
+			const production = await getTestInstance(
+				{
+					plugins: [
+						oAuthProxy({
+							currentURL: "http://preview.example.com",
+						}),
+						lastLoginMethod(),
+					],
+					socialProviders: {
+						google: {
+							clientId: "test",
+							clientSecret: "test",
+						},
+					},
+				},
+				{
+					disableTestUser: true,
+				},
+			);
+
+			const preview = await getTestInstance(
+				{
+					baseURL: "http://preview.example.com",
+					plugins: [oAuthProxy(), lastLoginMethod()],
+					socialProviders: {
+						google: {
+							clientId: "test",
+							clientSecret: "test",
+						},
+					},
+				},
+				{
+					disableTestUser: true,
+				},
+			);
+
+			const res = await production.client.signIn.social(
+				{
+					provider: "google",
+					callbackURL: "/dashboard",
+				},
+				{
+					throw: true,
+				},
+			);
+
+			const state = new URL(res.url!).searchParams.get("state");
+
+			let encryptedProfile: string | null = null;
+			let callbackURL: string | null = null;
+			let proxyProvider: string | null = null;
+			await production.client.$fetch(
+				`/callback/google?code=test&state=${state}`,
+				{
+					onError(context) {
+						const location = context.response.headers.get("location");
+						if (location && location.includes("profile=")) {
+							const url = new URL(location);
+							encryptedProfile = url.searchParams.get("profile");
+							callbackURL = url.searchParams.get("callbackURL");
+							proxyProvider = url.searchParams.get("provider");
+						}
+					},
+				},
+			);
+
+			// The proxy carries the (server-set) provider id alongside the profile.
+			expect(proxyProvider).toBe("google");
+
+			// Tampering with the provider param must not poison the cookie: it is
+			// verified against the decrypted profile, so a mismatch is rejected
+			// before the session (and therefore the cookie) is created.
+			let tamperedSession: string | undefined;
+			let tamperedCookie: string | undefined;
+			await preview.client.$fetch(
+				`/oauth-proxy-callback?callbackURL=${encodeURIComponent(
+					callbackURL!,
+				)}&profile=${encodeURIComponent(
+					encryptedProfile!,
+				)}&provider=${encodeURIComponent("<img src=x onerror=alert(1)>")}`,
+				{
+					onError(context) {
+						const cookies = context.response.headers.getSetCookie();
+						tamperedSession = cookies.find((c) =>
+							c.startsWith("better-auth.session_token="),
+						);
+						tamperedCookie = cookies.find((c) =>
+							c.startsWith("better-auth.last_used_login_method="),
+						);
+						expect(context.response.headers.get("location")).toContain(
+							"provider_mismatch",
+						);
+					},
+				},
+			);
+			expect(tamperedSession).toBeUndefined();
+			expect(tamperedCookie).toBeUndefined();
+
+			// The mismatch is rejected before the user is created, so a tampered
+			// value cannot poison a freshly created account either.
+			const previewCtx = await preview.auth.$context;
+			expect((await previewCtx.internalAdapter.listUsers()).length).toBe(0);
+
+			// The legitimate, server-set provider value is recorded.
+			let lastLoginCookie: string | undefined;
+			await preview.client.$fetch(
+				`/oauth-proxy-callback?callbackURL=${encodeURIComponent(
+					callbackURL!,
+				)}&profile=${encodeURIComponent(
+					encryptedProfile!,
+				)}&provider=${proxyProvider}`,
+				{
+					onError(context) {
+						lastLoginCookie = context.response.headers
+							.getSetCookie()
+							.find((c) => c.startsWith("better-auth.last_used_login_method="));
+					},
+				},
+			);
+
+			expect(lastLoginCookie).toBeDefined();
+			expect(lastLoginCookie).toContain(
+				"better-auth.last_used_login_method=google",
+			);
+			expect((await previewCtx.internalAdapter.listUsers()).length).toBe(1);
 		});
 
 		it("should forward result.error verbatim instead of collapsing to user_creation_failed", async () => {


### PR DESCRIPTION
## Description

When the `oAuthProxy` plugin is enabled, OAuth sign-ins complete at `/oauth-proxy-callback` (where the proxy calls `setSessionCookie`). The `last-login-method` resolver doesn't recognize that path, so the `better-auth.last_used_login_method` cookie — and the optional `lastLoginMethod` DB field — are never written for proxied OAuth logins. Non-proxied methods work because their completion paths are recognized (same class of bug as #6128 for passkey and #6022 for SIWE).

The provider id is only available inside the **encrypted** `profile` payload at the proxy callback, and the resolver runs synchronously, so it can't decrypt it. This PR has the proxy surface the (non-sensitive) provider id as a `provider` query param on the callback redirect, which the resolver then reads.

## Testing

Added a regression test that runs the full proxy flow with `lastLoginMethod()` enabled and asserts the cookie is set to the provider id. It fails on `main` (`expected null to be 'google'`) and passes with this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record the last login method for OAuth sign-ins that go through `oAuthProxy`. The proxy now passes a verified `provider` to `/oauth-proxy-callback`, so the cookie and optional DB field are set safely.

- **Bug Fixes**
  - `oAuthProxy`: include a `provider` param on redirects to `/oauth-proxy-callback` and verify it against the decrypted profile before creating the user/session; reject mismatches with `provider_mismatch`.
  - `last-login-method`: recognize `/oauth-proxy-callback`, read `provider`, and persist it; only accept provider-id-shaped tokens.
  - Tests: full proxy flow asserts the cookie is set; tampered `provider` is rejected before any user/session is created (no session, no cookie).

<sup>Written for commit e1717d68410cdc2f4de5e5102b32d811f7efa4be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

