### PR TITLE
feat(oauth-provider): expose sessionId to `id_token` claim contributors

### DIFF
--- a/.changeset/claim-input-session-id.md
+++ b/.changeset/claim-input-session-id.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+OAuth Provider claim contributors registered through `extendOAuthProvider` now receive the issuing session id. A `claims.idToken` or `claims.accessToken` contributor reads it from `input.sessionId` to derive per-session claims on the `authorization_code` and `refresh_token` grants. It is undefined where there is no session, such as `client_credentials`, opaque-token introspection, or a session that was deleted.

--- a/packages/oauth-provider/src/claim-authority.integration.test.ts
+++ b/packages/oauth-provider/src/claim-authority.integration.test.ts
@@ -23,7 +23,7 @@ import {
 	resetSeedStateForTests,
 	seedResourcesOnce,
 } from "./resources";
-import type { OAuthOptions, Scope } from "./types";
+import type { OAuthClaimExtensionInput, OAuthOptions, Scope } from "./types";
 import type { OAuthClient } from "./types/oauth";
 
 const authServerBaseUrl = "http://localhost:3000";
@@ -496,4 +496,46 @@ describe("introspection — pairwise sub across clients", async () => {
 		expect(issuerView.data?.sub).not.toBe(harness.user.id);
 		expect(resourceServerView.data?.sub).toBe(issuerView.data?.sub);
 	});
+});
+
+describe("id_token claim input — sessionId", async () => {
+	// A `claims.idToken` contributor resolves per-session authentication context
+	// for the ID token. On a session-backed grant (authorization_code) it receives
+	// the issuing session's id, so it can look up that context without re-deriving
+	// it from the request.
+	let capturedInput: OAuthClaimExtensionInput | undefined;
+	const harness = await bootHarness({
+		extensions: [
+			{
+				claims: {
+					idToken: (input) => {
+						capturedInput = input;
+						return { session_probe: "captured" };
+					},
+				},
+			},
+		],
+	});
+	let oauthClient: OAuthClient;
+
+	beforeAll(async () => {
+		oauthClient = await harness.registerClient();
+	});
+
+	it("passes the issuing session id to a claims.idToken contributor on authorization_code", async () => {
+		capturedInput = undefined;
+		await harness.mintToken(oauthClient);
+
+		const input = capturedInput as OAuthClaimExtensionInput | undefined;
+		expect(input).toBeDefined();
+		expect(input?.grantType).toBe("authorization_code");
+		expect(typeof input?.sessionId).toBe("string");
+		expect(input?.sessionId).not.toBe("");
+	});
+
+	// No client_credentials assertion: that grant issues no ID token, so the
+	// idToken claim path never runs for it and the contributor is never invoked
+	// with a client_credentials input to inspect. The JSDoc on
+	// `OAuthClaimExtensionInput.sessionId` documents the absence for grants with
+	// no user session.
 });

--- a/packages/oauth-provider/src/claims.test.ts
+++ b/packages/oauth-provider/src/claims.test.ts
@@ -2,7 +2,12 @@ import type { GenericEndpointContext } from "@better-auth/core";
 import { logger } from "@better-auth/core/env";
 import { describe, expect, it, vi } from "vitest";
 import { resolveAccessTokenClaims } from "./claims";
-import type { OAuthOptions, SchemaClient, Scope } from "./types";
+import type {
+	OAuthClaimExtensionInput,
+	OAuthOptions,
+	SchemaClient,
+	Scope,
+} from "./types";
 
 function optsWith(
 	customAccessTokenClaims?: OAuthOptions<Scope[]>["customAccessTokenClaims"],
@@ -22,6 +27,7 @@ const baseInput = {
 	referenceId: undefined,
 	metadata: undefined,
 	grantType: undefined,
+	sessionId: undefined,
 	perRequestClaims: undefined,
 };
 
@@ -99,5 +105,27 @@ describe("resolveAccessTokenClaims", () => {
 			referenceId: "ref-1",
 			metadata: { plan: "pro" },
 		});
+	});
+
+	it("passes sessionId to an access-token extension contributor", async () => {
+		let received: OAuthClaimExtensionInput | undefined;
+		await resolveAccessTokenClaims({
+			...baseInput,
+			opts: {
+				extensions: [
+					{
+						claims: {
+							accessToken: (input: OAuthClaimExtensionInput) => {
+								received = input;
+								return {};
+							},
+						},
+					},
+				],
+			} as unknown as OAuthOptions<Scope[]>,
+			sessionId: "sess-123",
+			resourcePolicyClaims: {},
+		});
+		expect(received?.sessionId).toBe("sess-123");
 	});
 });

--- a/packages/oauth-provider/src/claims.ts
+++ b/packages/oauth-provider/src/claims.ts
@@ -86,6 +86,13 @@ export interface AccessTokenClaimsInput {
 	 */
 	grantType: GrantType | undefined;
 	/**
+	 * Session the tokens are issued for, when one is available. Set at issuance
+	 * for the session-backed grants; `undefined` at introspection, since the
+	 * opaque-token row carries no live session. Best-effort, mirroring the field
+	 * on {@link OAuthClaimExtensionInput}.
+	 */
+	sessionId: string | undefined;
+	/**
 	 * Per-issuance claims a grant handler supplied via `accessTokenClaims`.
 	 * Available only at issuance; `undefined` at introspection.
 	 */
@@ -122,6 +129,7 @@ export async function resolveAccessTokenClaims(
 		referenceId,
 		metadata,
 		grantType,
+		sessionId,
 		perRequestClaims,
 		resourcePolicyClaims,
 	} = input;
@@ -133,6 +141,7 @@ export async function resolveAccessTokenClaims(
 		scopes,
 		grantType,
 		referenceId,
+		sessionId,
 		resources,
 		metadata,
 	});

--- a/packages/oauth-provider/src/claims.ts
+++ b/packages/oauth-provider/src/claims.ts
@@ -85,12 +85,7 @@ export interface AccessTokenClaimsInput {
 	 * contributed access-token claims must be grant-type-stable.
 	 */
 	grantType: GrantType | undefined;
-	/**
-	 * Session the tokens are issued for, when one is available. Set at issuance
-	 * for the session-backed grants; `undefined` at introspection, since the
-	 * opaque-token row carries no live session. Best-effort, mirroring the field
-	 * on {@link OAuthClaimExtensionInput}.
-	 */
+	/** Session the tokens are issued for; `undefined` at introspection. See {@link OAuthClaimExtensionInput.sessionId}. */
 	sessionId: string | undefined;
 	/**
 	 * Per-issuance claims a grant handler supplied via `accessTokenClaims`.

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -376,6 +376,7 @@ async function validateOpaqueAccessToken(
 				client,
 				scopes: accessToken.scopes ?? [],
 				grantType: undefined,
+				sessionId: undefined,
 				resources,
 				referenceId: accessToken.referenceId,
 				metadata: parseClientMetadata(client.metadata),

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -840,6 +840,7 @@ async function createUserTokens(
 						scopes: effectiveScopes,
 						grantType,
 						referenceId,
+						sessionId,
 						resources: params.resources,
 						metadata,
 					})),

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -908,6 +908,7 @@ async function createUserTokens(
 				client,
 				scopes: effectiveScopes,
 				grantType,
+				sessionId,
 				resources: params.resources,
 				referenceId,
 				metadata,

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -330,6 +330,14 @@ export interface OAuthClaimExtensionInput {
 	scopes: string[];
 	grantType?: GrantType;
 	referenceId?: string;
+	/**
+	 * Identifier of the session the tokens are issued for. Present on the
+	 * authorization_code and refresh_token grants (absent for grants with no
+	 * user session, such as client_credentials). A contributor uses it to
+	 * resolve per-session authentication context for the ID token without
+	 * re-deriving it from the request.
+	 */
+	sessionId?: string;
 	resources?: string[];
 	/** Parsed client metadata, as returned by `parseClientMetadata`. */
 	metadata?: Record<string, unknown>;

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -331,11 +331,16 @@ export interface OAuthClaimExtensionInput {
 	grantType?: GrantType;
 	referenceId?: string;
 	/**
-	 * Identifier of the session the tokens are issued for. Present on the
-	 * authorization_code and refresh_token grants (absent for grants with no
-	 * user session, such as client_credentials). A contributor uses it to
-	 * resolve per-session authentication context for the ID token without
-	 * re-deriving it from the request.
+	 * Identifier of the session the tokens are issued for. It is set when a
+	 * session is available: on the authorization_code grant, and on the
+	 * refresh_token grant when the refresh token is still linked to a live
+	 * session. Resolution is best-effort, so it MAY be undefined even on a
+	 * refresh flow if that session was deleted or unlinked (for example a row
+	 * cleared by `onDelete: "set null"`). It is always absent for grants with no
+	 * user session, such as client_credentials. A contributor MUST treat it as
+	 * possibly undefined and uses it, when present, to resolve per-session
+	 * authentication context for the ID token without re-deriving it from the
+	 * request.
 	 */
 	sessionId?: string;
 	resources?: string[];

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -331,16 +331,10 @@ export interface OAuthClaimExtensionInput {
 	grantType?: GrantType;
 	referenceId?: string;
 	/**
-	 * Identifier of the session the tokens are issued for. It is set when a
-	 * session is available: on the authorization_code grant, and on the
-	 * refresh_token grant when the refresh token is still linked to a live
-	 * session. Resolution is best-effort, so it MAY be undefined even on a
-	 * refresh flow if that session was deleted or unlinked (for example a row
-	 * cleared by `onDelete: "set null"`). It is always absent for grants with no
-	 * user session, such as client_credentials, and at opaque-token
-	 * introspection re-derivation. A contributor MUST treat it as possibly
-	 * undefined and uses it, when present, to resolve per-session authentication
-	 * context for the issued claims without re-deriving it from the request.
+	 * Session the tokens are issued for, when one is available. Best-effort:
+	 * set on the session-backed grants (authorization_code, refresh_token),
+	 * undefined otherwise (client_credentials, introspection, or a session that
+	 * was deleted or unlinked). Treat as possibly undefined.
 	 */
 	sessionId?: string;
 	resources?: string[];

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -337,10 +337,10 @@ export interface OAuthClaimExtensionInput {
 	 * session. Resolution is best-effort, so it MAY be undefined even on a
 	 * refresh flow if that session was deleted or unlinked (for example a row
 	 * cleared by `onDelete: "set null"`). It is always absent for grants with no
-	 * user session, such as client_credentials. A contributor MUST treat it as
-	 * possibly undefined and uses it, when present, to resolve per-session
-	 * authentication context for the ID token without re-deriving it from the
-	 * request.
+	 * user session, such as client_credentials, and at opaque-token
+	 * introspection re-derivation. A contributor MUST treat it as possibly
+	 * undefined and uses it, when present, to resolve per-session authentication
+	 * context for the issued claims without re-deriving it from the request.
 	 */
 	sessionId?: string;
 	resources?: string[];


### PR DESCRIPTION
ID-token claim contributors registered through `extendOAuthProvider`'s `claims.idToken` receive an `OAuthClaimExtensionInput` that carries `referenceId` but not `sessionId`. On the authorization_code and refresh_token grants the session identifier is exactly what a contributor needs to resolve per-session authentication context for the id_token, and the provider already holds it in scope where it collects extension id-token claims. This adds an optional `sessionId` to that input and passes the existing value through.

Without it, a contributor that derives an id-token claim from the session (an authentication-context or assurance claim, say) has no session handle on a plain authorization_code login. It is pushed into a weaker per-user lookup, or has to re-derive the session from the request.

`sessionId` is optional and additive. It is populated for the session-backed grants (authorization_code, refresh_token) and is absent where there is no user session (client_credentials) and for opaque-token introspection re-derivation, so a contributor treats it as possibly undefined. Existing contributors are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose an optional `sessionId` to claim contributors in `@better-auth/oauth-provider` so per-session claims can be derived without extra lookups. Provided to `claims.idToken` and `claims.accessToken` for session-backed grants; absent when no user session exists or during introspection.

- **New Features**
  - Added `sessionId?: string` to `OAuthClaimExtensionInput`.
  - Passed to `claims.idToken` and `claims.accessToken`; set on `authorization_code`, best‑effort on `refresh_token`; omitted for `client_credentials` and opaque-token introspection.
  - Updated tests for both claim paths and added a changeset; no breaking changes.

<sup>Written for commit 1044477e1443d53fa91e7753c899e037be4e3a0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

