### PR TITLE
fix(docs): add missing `mode` config to Drizzle bigint codegen

### DIFF
--- a/docs/lib/copy-schema/adapter/drizzle.ts
+++ b/docs/lib/copy-schema/adapter/drizzle.ts
@@ -40,7 +40,7 @@ export const drizzleResolver = (options: DrizzleResolverOptions): Resolver => {
 				const number = field.bigint
 					? provider === "sqlite"
 						? `t.blob("${fieldName}", { mode: "bigint" })`
-						: `t.bigint("${fieldName}")`
+						: `t.bigint("${fieldName}", { mode: "number" })`
 					: provider === "mysql"
 						? `t.int("${fieldName}")`
 						: `t.integer("${fieldName}")`;


### PR DESCRIPTION
## What

The "Copy as Drizzle" schema output on the
[rate-limit docs](https://better-auth.com/docs/concepts/rate-limit#schema)
generates this for pg/mysql:

```ts
t.bigint("last_request")
```

Drizzle requires a `mode` config for `bigint` columns
([drizzle bigint docs](https://orm.drizzle.team/docs/column-types/pg#bigint)),
so this fails to compile:

```
TS2345: Argument of type 'string' is not assignable to
parameter of type 'PgBigIntConfig<"bigint" | "number">'
```

<img width="875" height="190" alt="image" src="https://github.com/user-attachments/assets/2d9b016f-4ea8-4499-bd18-60771cbb422a" />

Affects every table with a bigint field. `rateLimit.lastRequest` is the one most users will hit first.

## Fix

One-line change in `docs/lib/copy-schema/adapter/drizzle.ts`:

```diff
- : `t.bigint("${fieldName}")`
+ : `t.bigint("${fieldName}", { mode: "number" })`
```

## How I found it

Setting up `rateLimit: { storage: "database" }` with Drizzle + Postgres,
copied the schema from the docs. TypeScript rejected it immediately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `{ mode: "number" }` to generated `t.bigint("<col>")` for Postgres/MySQL in the docs’ “Copy as Drizzle” code, so snippets type‑check in `drizzle-orm`. Fixes TS2345 errors for bigint fields like `rateLimit.lastRequest`.

<sup>Written for commit 865626a5890f344e0a9b8b8121f7da082b63f532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

