### PR TITLE
feat(stripe): add organization seat count filter

### DIFF
--- a/.changeset/seat-count-filter.md
+++ b/.changeset/seat-count-filter.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/stripe": minor
+---
+
+Added `organization.countActiveMembers` to the Stripe plugin. This callback lets you customize how members are counted for auto-managed organization subscription seats, so soft-deleted, suspended, or otherwise inactive members can be excluded from Stripe seat counts.

--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -891,11 +891,12 @@ stripe({
 
 ### Organization Options
 
-| Option                    | Type       | Description                                                                                                |
-| ------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------- |
-| `enabled`                 | `boolean`  | Enable Organization Customer support. **Required.**                                                        |
-| `getCustomerCreateParams` | `function` | Customize Stripe customer creation parameters for organizations. Receives `organization` and context.      |
-| `onCustomerCreate`        | `function` | Called after an organization customer is created. Receives `{ stripeCustomer, organization }` and context. |
+| Option                    | Type       | Description                                                                                                              |
+| ------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`                 | `boolean`  | Enable Organization Customer support. **Required.**                                                                      |
+| `getCustomerCreateParams` | `function` | Customize Stripe customer creation parameters for organizations. Receives `organization` and context.                    |
+| `onCustomerCreate`        | `function` | Called after an organization customer is created. Receives `{ stripeCustomer, organization }` and context.               |
+| `countActiveMembers`      | `function` | Customize the billable member count for auto-managed organization seats. Receives `{ organizationId, getDefaultCount }`. |
 
 ## Advanced Usage
 
@@ -945,6 +946,55 @@ await authClient.subscription.upgrade({
     cancelUrl: "/org/billing"
 });
 ```
+
+#### Counting Billable Organization Seats
+
+When a plan has `seatPriceId`, organization subscriptions use auto-managed seats. By default, the Stripe plugin counts all rows in the `member` table for the organization. Use `organization.countActiveMembers` to customize the billable count, for example to exclude soft-deleted or suspended members:
+
+```ts title="auth.ts"
+plugins: [
+    organization({
+        schema: {
+            member: {
+                additionalFields: {
+                    deletedAt: {
+                        type: "date",
+                        required: false,
+                    },
+                },
+            },
+        },
+    }),
+    stripe({
+        // ... other options
+        subscription: {
+            enabled: true,
+            plans: [
+                {
+                    name: "team",
+                    priceId: "price_team_base",
+                    seatPriceId: "price_team_seat",
+                },
+            ],
+        },
+        organization: {
+            enabled: true,
+            countActiveMembers: async ({ organizationId }) => {
+                const active = await db.member.count({
+                    where: {
+                        organizationId,
+                        deletedAt: null,
+                    },
+                });
+
+                return active;
+            },
+        },
+    }),
+]
+```
+
+`countActiveMembers` must return a positive integer because Stripe subscription item quantities must be at least `1`. Call `getDefaultCount()` if you need to compare against Better Auth's default member count; the default count query runs lazily and is memoized. The callback runs whenever the Stripe plugin counts auto-managed seats during checkout or subscription upgrades, and when Better Auth organization member add, remove, or invitation acceptance hooks sync seats to Stripe. If you update custom member fields outside Better Auth's member lifecycle, trigger your own sync after that update.
 
 #### Authorization
 

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -21,7 +21,12 @@ import type {
 	Subscription,
 	WithStripeCustomerId,
 } from "./types";
-import { escapeStripeSearchValue, getPlans, isActiveOrTrialing } from "./utils";
+import {
+	escapeStripeSearchValue,
+	getPlans,
+	isActiveOrTrialing,
+	resolveOrganizationSeatCount,
+} from "./utils";
 import { PACKAGE_VERSION } from "./version";
 
 declare module "@better-auth/core" {
@@ -184,14 +189,10 @@ export const stripe = <O extends StripeOptions>(options: O) => {
 					}
 
 					try {
-						const memberCount = await ctx.adapter.count({
-							model: "member",
-							where: [
-								{
-									field: "organizationId",
-									value: data.organization.id,
-								},
-							],
+						const memberCount = await resolveOrganizationSeatCount({
+							adapter: ctx.adapter,
+							organizationId: data.organization.id,
+							countActiveMembers: options.organization?.countActiveMembers,
 						});
 
 						const plans = await getPlans(options.subscription);

--- a/packages/stripe/src/routes.ts
+++ b/packages/stripe/src/routes.ts
@@ -30,8 +30,10 @@ import {
 	escapeStripeSearchValue,
 	getPlanByName,
 	getPlans,
+	INVALID_SEAT_COUNT_MESSAGE,
 	isActiveOrTrialing,
 	isPendingCancel,
+	resolveOrganizationSeatCount,
 	resolvePlanItem,
 	resolveQuantity,
 } from "./utils";
@@ -654,9 +656,14 @@ export const upgradeSubscription = (options: StripeOptions) => {
 			);
 			let memberCount = 0;
 			if (isAutoManagedSeats) {
-				memberCount = await ctx.context.adapter.count({
-					model: "member",
-					where: [{ field: "organizationId", value: referenceId }],
+				memberCount = await resolveOrganizationSeatCount({
+					adapter: ctx.context.adapter,
+					organizationId: referenceId,
+					countActiveMembers: options.organization?.countActiveMembers,
+					invalidCountError: () =>
+						ctx.error("BAD_REQUEST", {
+							message: INVALID_SEAT_COUNT_MESSAGE,
+						}),
 				});
 			}
 

--- a/packages/stripe/src/types.ts
+++ b/packages/stripe/src/types.ts
@@ -482,6 +482,24 @@ export interface StripeOptions {
 							ctx: GenericEndpointContext,
 					  ) => Promise<void>)
 					| undefined;
+				/**
+				 * Customize how organization members are counted for
+				 * auto-managed subscription seats.
+				 *
+				 * Return the effective billable member count. The value must be a
+				 * positive integer because Stripe subscription item quantities must
+				 * be at least 1. If not provided, all organization members are counted.
+				 *
+				 * Call `getDefaultCount` to compare against Better Auth's default
+				 * member count. It is resolved lazily and memoized, so custom filters
+				 * that do their own count query don't pay for the default count too.
+				 */
+				countActiveMembers?:
+					| ((data: {
+							organizationId: string;
+							getDefaultCount: () => Promise<number>;
+					  }) => number | Promise<number>)
+					| undefined;
 		  }
 		| undefined;
 	/**

--- a/packages/stripe/src/utils.ts
+++ b/packages/stripe/src/utils.ts
@@ -1,5 +1,40 @@
+import type { DBAdapter } from "@better-auth/core/db/adapter";
 import type Stripe from "stripe";
 import type { StripeOptions, StripePlan, Subscription } from "./types";
+
+export const INVALID_SEAT_COUNT_MESSAGE =
+	"countActiveMembers must return a positive integer";
+
+type CountActiveMembers = NonNullable<
+	NonNullable<StripeOptions["organization"]>["countActiveMembers"]
+>;
+
+export async function resolveOrganizationSeatCount(data: {
+	adapter: Pick<DBAdapter, "count">;
+	organizationId: string;
+	countActiveMembers?: CountActiveMembers | undefined;
+	invalidCountError?: (() => Error) | undefined;
+}) {
+	let defaultCount: Promise<number> | undefined;
+	const getDefaultCount = () => {
+		defaultCount ??= data.adapter.count({
+			model: "member",
+			where: [{ field: "organizationId", value: data.organizationId }],
+		});
+		return defaultCount;
+	};
+
+	const memberCount = data.countActiveMembers
+		? await data.countActiveMembers({
+				organizationId: data.organizationId,
+				getDefaultCount,
+			})
+		: await getDefaultCount();
+	if (!Number.isInteger(memberCount) || memberCount < 1) {
+		throw data.invalidCountError?.() ?? new Error(INVALID_SEAT_COUNT_MESSAGE);
+	}
+	return memberCount;
+}
 
 export async function getPlans(
 	subscriptionOptions: StripeOptions["subscription"],

--- a/packages/stripe/test/seat-based-billing.test.ts
+++ b/packages/stripe/test/seat-based-billing.test.ts
@@ -61,6 +61,11 @@ const buildSeatPlanOptions = (mock: StripeMock) =>
 		},
 	}) satisfies StripeOptions;
 
+const getCheckoutLineItemByPrice = <T extends { price?: string }>(
+	lineItems: T[] | undefined,
+	price: string,
+) => lineItems?.find((item) => item.price === price);
+
 describe("seat-based billing", () => {
 	describe("checkout with auto-managed seats", () => {
 		test("should create checkout with both base plan and seat line items", async ({
@@ -112,11 +117,15 @@ describe("seat-based billing", () => {
 
 			const createCall = stripeMock.checkout.sessions.create.mock.calls[0]?.[0];
 			expect(createCall).toBeDefined();
-			expect(createCall.line_items[0]).toEqual({
+			expect(
+				getCheckoutLineItemByPrice(createCall?.line_items, "price_team_base"),
+			).toEqual({
 				price: "price_team_base",
 				quantity: 1,
 			});
-			expect(createCall.line_items[1]).toMatchObject({
+			expect(
+				getCheckoutLineItemByPrice(createCall?.line_items, "price_team_seat"),
+			).toMatchObject({
 				price: "price_team_seat",
 				quantity: expect.any(Number),
 			});
@@ -187,10 +196,237 @@ describe("seat-based billing", () => {
 
 			const createCall = stripeMock.checkout.sessions.create.mock.calls[0]?.[0];
 			// 1 owner + 2 members = 3
-			expect(createCall.line_items[1]).toMatchObject({
+			expect(
+				getCheckoutLineItemByPrice(createCall?.line_items, "price_team_seat"),
+			).toMatchObject({
 				price: "price_team_seat",
 				quantity: 3,
 			});
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10080
+		 */
+		test("should use filtered member count as checkout seat quantity", async ({
+			stripeMock,
+		}) => {
+			const countActiveMembers = vi.fn(
+				async ({
+					getDefaultCount,
+				}: {
+					organizationId: string;
+					getDefaultCount: () => Promise<number>;
+				}) => (await getDefaultCount()) - 1,
+			);
+			const seatOptions = {
+				...buildSeatPlanOptions(stripeMock),
+				organization: {
+					enabled: true as const,
+					countActiveMembers,
+				},
+			} satisfies StripeOptions;
+			const { client, auth, sessionSetter } = await getTestInstance(
+				{ plugins: [organization(), stripe(seatOptions)] },
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [
+							organizationClient(),
+							stripeClient({ subscription: true }),
+						],
+					},
+				},
+			);
+			const ctx = await auth.$context;
+
+			await client.signUp.email(
+				{
+					email: "checkout-filter@email.com",
+					password: "password",
+					name: "Checkout Filter User",
+				},
+				{ throw: true },
+			);
+			const headers = new Headers();
+			await client.signIn.email(
+				{ email: "checkout-filter@email.com", password: "password" },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			const org = await client.organization.create({
+				name: "Checkout Filter Org",
+				slug: "checkout-filter-org",
+				fetchOptions: { headers },
+			});
+			const orgId = org.data?.id as string;
+
+			for (const email of ["member2@checkout.com", "member3@checkout.com"]) {
+				const member = await ctx.adapter.create({
+					model: "user",
+					data: { email, name: email.split("@")[0] },
+				});
+				await ctx.adapter.create({
+					model: "member",
+					data: {
+						userId: member.id,
+						organizationId: orgId,
+						role: "member",
+						createdAt: new Date(),
+					},
+				});
+			}
+
+			await client.subscription.upgrade({
+				plan: "team",
+				customerType: "organization",
+				referenceId: orgId,
+				fetchOptions: { headers },
+			});
+
+			expect(countActiveMembers).toHaveBeenCalledWith(
+				expect.objectContaining({
+					organizationId: orgId,
+					getDefaultCount: expect.any(Function),
+				}),
+			);
+			expect(countActiveMembers.mock.calls[0]?.[0]).not.toHaveProperty(
+				"defaultCount",
+			);
+			const createCall = stripeMock.checkout.sessions.create.mock.calls[0]?.[0];
+			expect(
+				getCheckoutLineItemByPrice(createCall?.line_items, "price_team_seat"),
+			).toMatchObject({
+				price: "price_team_seat",
+				quantity: 2,
+			});
+		});
+
+		test("should not query the default member count when custom counter does not request it", async ({
+			stripeMock,
+		}) => {
+			const countActiveMembers = vi.fn(async () => 1);
+			const seatOptions = {
+				...buildSeatPlanOptions(stripeMock),
+				organization: {
+					enabled: true as const,
+					countActiveMembers,
+				},
+			} satisfies StripeOptions;
+			const { client, auth, sessionSetter } = await getTestInstance(
+				{ plugins: [organization(), stripe(seatOptions)] },
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [
+							organizationClient(),
+							stripeClient({ subscription: true }),
+						],
+					},
+				},
+			);
+			const ctx = await auth.$context;
+
+			await client.signUp.email(
+				{
+					email: "checkout-lazy-filter@email.com",
+					password: "password",
+					name: "Checkout Lazy Filter User",
+				},
+				{ throw: true },
+			);
+			const headers = new Headers();
+			await client.signIn.email(
+				{ email: "checkout-lazy-filter@email.com", password: "password" },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			const org = await client.organization.create({
+				name: "Checkout Lazy Filter Org",
+				slug: "checkout-lazy-filter-org",
+				fetchOptions: { headers },
+			});
+			const orgId = org.data?.id as string;
+			const countSpy = vi.spyOn(ctx.adapter, "count");
+
+			await client.subscription.upgrade({
+				plan: "team",
+				customerType: "organization",
+				referenceId: orgId,
+				fetchOptions: { headers },
+			});
+
+			expect(countActiveMembers).toHaveBeenCalledWith(
+				expect.objectContaining({
+					organizationId: orgId,
+					getDefaultCount: expect.any(Function),
+				}),
+			);
+			expect(countSpy).not.toHaveBeenCalled();
+			countSpy.mockRestore();
+
+			const createCall = stripeMock.checkout.sessions.create.mock.calls[0]?.[0];
+			expect(
+				getCheckoutLineItemByPrice(createCall?.line_items, "price_team_seat"),
+			).toMatchObject({
+				price: "price_team_seat",
+				quantity: 1,
+			});
+		});
+
+		test("should reject invalid filtered checkout seat counts", async ({
+			stripeMock,
+		}) => {
+			const seatOptions = {
+				...buildSeatPlanOptions(stripeMock),
+				organization: {
+					enabled: true as const,
+					countActiveMembers: async () => 0,
+				},
+			} satisfies StripeOptions;
+			const { client, sessionSetter } = await getTestInstance(
+				{ plugins: [organization(), stripe(seatOptions)] },
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [
+							organizationClient(),
+							stripeClient({ subscription: true }),
+						],
+					},
+				},
+			);
+
+			await client.signUp.email(
+				{
+					email: "invalid-filter@email.com",
+					password: "password",
+					name: "Invalid Filter User",
+				},
+				{ throw: true },
+			);
+			const headers = new Headers();
+			await client.signIn.email(
+				{ email: "invalid-filter@email.com", password: "password" },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			const org = await client.organization.create({
+				name: "Invalid Filter Org",
+				slug: "invalid-filter-org",
+				fetchOptions: { headers },
+			});
+
+			const res = await client.subscription.upgrade({
+				plan: "team",
+				customerType: "organization",
+				referenceId: org.data?.id as string,
+				fetchOptions: { headers },
+			});
+
+			expect(res.error?.message).toBe(
+				"countActiveMembers must return a positive integer",
+			);
+			expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
 		});
 	});
 
@@ -1461,6 +1697,388 @@ describe("seat-based billing", () => {
 			});
 
 			expect(updated?.seats).toBe(8);
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10080
+	 */
+	describe("seat sync with countActiveMembers filter", () => {
+		test("should use filtered member count for seat sync when countActiveMembers is provided", async ({
+			stripeMock,
+		}) => {
+			const seatOptions = buildSeatPlanOptions(stripeMock);
+			stripeMock.subscriptions.retrieve.mockResolvedValue({
+				id: "sub_filter_seat",
+				status: "active",
+				items: {
+					data: [
+						{
+							id: "si_base",
+							price: { id: "price_team_base" },
+							quantity: 1,
+						},
+						{
+							id: "si_seat",
+							price: { id: "price_team_seat" },
+							quantity: 3,
+						},
+					],
+				},
+			});
+
+			const countActiveMembers = vi.fn(
+				async ({
+					getDefaultCount,
+				}: {
+					organizationId: string;
+					getDefaultCount: () => Promise<number>;
+				}) => (await getDefaultCount()) - 1,
+			);
+			const filterSeatOptions = {
+				...seatOptions,
+				organization: {
+					enabled: true as const,
+					countActiveMembers,
+				},
+			} satisfies StripeOptions;
+
+			const { client, auth, sessionSetter } = await getTestInstance(
+				{
+					plugins: [organization(), stripe(filterSeatOptions)],
+				},
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [
+							organizationClient(),
+							stripeClient({ subscription: true }),
+						],
+					},
+				},
+			);
+			const ctx = await auth.$context;
+
+			await client.signUp.email(
+				{
+					email: "filter-owner@test.com",
+					password: "password",
+					name: "Filter Owner",
+				},
+				{ throw: true },
+			);
+			const headers = new Headers();
+			await client.signIn.email(
+				{ email: "filter-owner@test.com", password: "password" },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			const org = await client.organization.create({
+				name: "Filter Seat Org",
+				slug: "filter-seat-org",
+				fetchOptions: { headers },
+			});
+			const orgId = org.data?.id as string;
+
+			await ctx.adapter.update({
+				model: "organization",
+				update: { stripeCustomerId: "cus_filter_seat" },
+				where: [{ field: "id", value: orgId }],
+			});
+			await ctx.adapter.create({
+				model: "subscription",
+				data: {
+					referenceId: orgId,
+					stripeCustomerId: "cus_filter_seat",
+					stripeSubscriptionId: "sub_filter_seat",
+					status: "active",
+					plan: "team",
+					seats: 3,
+				},
+			});
+
+			const newMember = await ctx.adapter.create({
+				model: "user",
+				data: {
+					email: "filter-member@test.com",
+					name: "Filter Member",
+					emailVerified: true,
+				},
+			});
+			await ctx.adapter.create({
+				model: "account",
+				data: {
+					userId: newMember.id,
+					accountId: newMember.id,
+					providerId: "credential",
+					password: await ctx.password.hash("password"),
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+
+			await client.organization.inviteMember({
+				email: "filter-member@test.com",
+				role: "member",
+				organizationId: orgId,
+				fetchOptions: { headers },
+			});
+
+			const newMemberHeaders = new Headers();
+			await client.signIn.email(
+				{ email: "filter-member@test.com", password: "password" },
+				{ throw: true, onSuccess: sessionSetter(newMemberHeaders) },
+			);
+
+			const invitations = await client.organization.listInvitations({
+				fetchOptions: { headers },
+			});
+			const invitationId = invitations.data?.[0]?.id;
+			expect(invitationId).toBeDefined();
+
+			await client.organization.acceptInvitation({
+				invitationId: invitationId!,
+				fetchOptions: { headers: newMemberHeaders },
+			});
+
+			expect(countActiveMembers).toHaveBeenCalledWith(
+				expect.objectContaining({
+					organizationId: orgId,
+					getDefaultCount: expect.any(Function),
+				}),
+			);
+			expect(countActiveMembers.mock.calls[0]?.[0]).not.toHaveProperty(
+				"defaultCount",
+			);
+
+			const updateCall = stripeMock.subscriptions.update.mock.calls[0];
+			expect(updateCall).toBeDefined();
+			const seatItems = updateCall?.[1]?.items;
+			expect(seatItems).toContainEqual(
+				expect.objectContaining({ id: "si_seat", quantity: 1 }),
+			);
+
+			const updatedSub = await ctx.adapter.findOne<Subscription>({
+				model: "subscription",
+				where: [{ field: "stripeSubscriptionId", value: "sub_filter_seat" }],
+			});
+			expect(updatedSub?.seats).toBe(1);
+		});
+
+		test("should fall back to raw count when countActiveMembers is not provided", async ({
+			stripeMock,
+		}) => {
+			const seatOptions = buildSeatPlanOptions(stripeMock);
+			stripeMock.subscriptions.retrieve.mockResolvedValue({
+				id: "sub_no_filter",
+				status: "active",
+				items: {
+					data: [
+						{
+							id: "si_base",
+							price: { id: "price_team_base" },
+							quantity: 1,
+						},
+						{
+							id: "si_seat",
+							price: { id: "price_team_seat" },
+							quantity: 3,
+						},
+					],
+				},
+			});
+
+			const { client, auth, sessionSetter } = await getTestInstance(
+				{
+					plugins: [organization(), stripe(seatOptions)],
+				},
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [
+							organizationClient(),
+							stripeClient({ subscription: true }),
+						],
+					},
+				},
+			);
+			const ctx = await auth.$context;
+
+			await client.signUp.email(
+				{
+					email: "no-filter-owner@test.com",
+					password: "password",
+					name: "No Filter Owner",
+				},
+				{ throw: true },
+			);
+			const headers = new Headers();
+			await client.signIn.email(
+				{ email: "no-filter-owner@test.com", password: "password" },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			const org = await client.organization.create({
+				name: "No Filter Org",
+				slug: "no-filter-org",
+				fetchOptions: { headers },
+			});
+			const orgId = org.data?.id as string;
+
+			await ctx.adapter.update({
+				model: "organization",
+				update: { stripeCustomerId: "cus_no_filter" },
+				where: [{ field: "id", value: orgId }],
+			});
+			await ctx.adapter.create({
+				model: "subscription",
+				data: {
+					referenceId: orgId,
+					stripeCustomerId: "cus_no_filter",
+					stripeSubscriptionId: "sub_no_filter",
+					status: "active",
+					plan: "team",
+					seats: 3,
+				},
+			});
+
+			const memberUser = await ctx.adapter.create({
+				model: "user",
+				data: { email: "no-filter-member@test.com", name: "Member" },
+			});
+			const member = await ctx.adapter.create({
+				model: "member",
+				data: {
+					userId: memberUser.id,
+					organizationId: orgId,
+					role: "member",
+					createdAt: new Date(),
+				},
+			});
+
+			await client.organization.removeMember({
+				memberIdOrEmail: member.id,
+				organizationId: orgId,
+				fetchOptions: { headers },
+			});
+
+			const updateCall = stripeMock.subscriptions.update.mock.calls[0];
+			expect(updateCall).toBeDefined();
+			const seatItems = updateCall?.[1]?.items;
+			expect(seatItems).toContainEqual(
+				expect.objectContaining({ id: "si_seat", quantity: 1 }),
+			);
+		});
+
+		test("should skip seat sync when countActiveMembers returns an invalid count", async ({
+			stripeMock,
+		}) => {
+			const seatOptions = {
+				...buildSeatPlanOptions(stripeMock),
+				organization: {
+					enabled: true as const,
+					countActiveMembers: async () => 0,
+				},
+			} satisfies StripeOptions;
+			stripeMock.subscriptions.retrieve.mockResolvedValue({
+				id: "sub_invalid_filter",
+				status: "active",
+				items: {
+					data: [
+						{
+							id: "si_base",
+							price: { id: "price_team_base" },
+							quantity: 1,
+						},
+						{
+							id: "si_seat",
+							price: { id: "price_team_seat" },
+							quantity: 2,
+						},
+					],
+				},
+			});
+
+			const { client, auth, sessionSetter } = await getTestInstance(
+				{
+					plugins: [organization(), stripe(seatOptions)],
+				},
+				{
+					disableTestUser: true,
+					clientOptions: {
+						plugins: [
+							organizationClient(),
+							stripeClient({ subscription: true }),
+						],
+					},
+				},
+			);
+			const ctx = await auth.$context;
+
+			await client.signUp.email(
+				{
+					email: "invalid-sync-owner@test.com",
+					password: "password",
+					name: "Invalid Sync Owner",
+				},
+				{ throw: true },
+			);
+			const headers = new Headers();
+			await client.signIn.email(
+				{ email: "invalid-sync-owner@test.com", password: "password" },
+				{ throw: true, onSuccess: sessionSetter(headers) },
+			);
+
+			const org = await client.organization.create({
+				name: "Invalid Sync Org",
+				slug: "invalid-sync-org",
+				fetchOptions: { headers },
+			});
+			const orgId = org.data?.id as string;
+
+			await ctx.adapter.update({
+				model: "organization",
+				update: { stripeCustomerId: "cus_invalid_filter" },
+				where: [{ field: "id", value: orgId }],
+			});
+			const sub = await ctx.adapter.create({
+				model: "subscription",
+				data: {
+					referenceId: orgId,
+					stripeCustomerId: "cus_invalid_filter",
+					stripeSubscriptionId: "sub_invalid_filter",
+					status: "active",
+					plan: "team",
+					seats: 2,
+				},
+			});
+
+			const memberUser = await ctx.adapter.create({
+				model: "user",
+				data: { email: "invalid-sync-member@test.com", name: "Member" },
+			});
+			const member = await ctx.adapter.create({
+				model: "member",
+				data: {
+					userId: memberUser.id,
+					organizationId: orgId,
+					role: "member",
+					createdAt: new Date(),
+				},
+			});
+
+			await client.organization.removeMember({
+				memberIdOrEmail: member.id,
+				organizationId: orgId,
+				fetchOptions: { headers },
+			});
+
+			expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+			const storedSub = await ctx.adapter.findOne<Subscription>({
+				model: "subscription",
+				where: [{ field: "id", value: sub.id }],
+			});
+			expect(storedSub?.seats).toBe(2);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Add `organization.countActiveMembers` to the Stripe plugin for custom organization seat billing counts.
- Use the filtered count during checkout, upgrades, and member/invitation seat syncs.
- Validate custom counts as non-negative integers and add docs, tests, and a minor changeset.

Closes #10080

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `organization.countActiveMembers` to `@better-auth/stripe` so apps can filter billable seats for auto-managed organization subscriptions and avoid charging for inactive members. Used in checkout, upgrades, and seat syncs; addresses #10080.

- **New Features**
  - `organization.countActiveMembers({ organizationId, getDefaultCount })` to override seat quantity; must return a positive integer (invalid values are rejected).
  - `resolveOrganizationSeatCount` validates counts and lazily memoizes the default member count; applied across checkout, upgrades, and member/invite seat syncs. Updated docs and tests.

<sup>Written for commit 41f1dd8985e9ae2f3beffe3a1a9585a67fbf0166. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

