### PR TITLE
fix(access): aggregate permissions across multiple roles in hasPermission

### DIFF
--- a/.changeset/aggregate-roles-has-permission.md
+++ b/.changeset/aggregate-roles-has-permission.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix(access): aggregate permissions across multiple roles in hasPermission

--- a/packages/better-auth/src/plugins/access/access.test.ts
+++ b/packages/better-auth/src/plugins/access/access.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { createAccessControl, role } from "./access";
 import type { Role } from "./types";
+import { hasPermission } from "../admin/has-permission";
 
 describe("access", () => {
 	const statements = {
@@ -283,5 +284,42 @@ describe("access control across multiple roles", () => {
 
 		const failed = authorizeAcross([roleA], { ui: ["view"] });
 		expect(failed.success).toBe(false);
+	});
+
+	it("the real admin hasPermission merges comma-separated roles", () => {
+		// Exercise the actual exported admin `hasPermission` (not the local helper
+		// above), so a regression in the production merge path is caught rather than
+		// silently passing against a re-implementation. @see #3011
+		const options = { roles: { roleA, roleB } };
+		expect(
+			hasPermission({
+				role: "roleA,roleB",
+				options,
+				permissions: { project: ["create"] },
+			}),
+		).toBe(true);
+		expect(
+			hasPermission({
+				role: "roleA,roleB",
+				options,
+				permissions: { ui: ["view"] },
+			}),
+		).toBe(true);
+		// A permission neither role grants is denied.
+		expect(
+			hasPermission({
+				role: "roleA,roleB",
+				options,
+				permissions: { project: ["delete"] },
+			}),
+		).toBe(false);
+		// A single role only authorizes its own statements.
+		expect(
+			hasPermission({
+				role: "roleA",
+				options,
+				permissions: { ui: ["view"] },
+			}),
+		).toBe(false);
 	});
 });

--- a/packages/better-auth/src/plugins/access/access.test.ts
+++ b/packages/better-auth/src/plugins/access/access.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
-import { createAccessControl } from "./access";
+import { createAccessControl, role } from "./access";
+import type { Role } from "./types";
 
 describe("access", () => {
 	const statements = {
@@ -223,5 +224,64 @@ describe("access", () => {
 			success: false,
 			error: 'unauthorized to access resource "project"',
 		});
+	});
+});
+
+/**
+ * Permissions must be evaluated against the union of all the roles a user
+ * holds. A user with two roles, each granting a different permission, should
+ * be authorized for the combined set.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/3011
+ */
+describe("access control across multiple roles", () => {
+	const statements = {
+		project: ["create", "read", "update", "delete"],
+		ui: ["view", "edit"],
+	} as const;
+	const ac = createAccessControl(statements);
+
+	const roleA = ac.newRole({ project: ["create"] });
+	const roleB = ac.newRole({ ui: ["view"] });
+
+	// Mirrors how `hasPermissionFn`/`hasPermission` merge the statements of all
+	// of a user's roles into a single set before authorizing.
+	const authorizeAcross = (
+		roles: Role<any>[],
+		permissions: Record<string, string[]>,
+	) => {
+		const mergedStatements: Record<string, string[]> = {};
+		for (const r of roles) {
+			for (const [resource, actions] of Object.entries(r.statements)) {
+				const existing = mergedStatements[resource] ?? [];
+				mergedStatements[resource] = [
+					...new Set([...existing, ...(actions as readonly string[])]),
+				];
+			}
+		}
+		return role(mergedStatements).authorize(permissions);
+	};
+
+	it("should grant a permission set provided across different roles", () => {
+		const response = authorizeAcross([roleA, roleB], {
+			project: ["create"],
+			ui: ["view"],
+		});
+		expect(response.success).toBe(true);
+	});
+
+	it("should fail for a permission that none of the roles grant", () => {
+		const response = authorizeAcross([roleA, roleB], {
+			project: ["delete"],
+		});
+		expect(response.success).toBe(false);
+	});
+
+	it("should still authorize when only a single role is held", () => {
+		const response = authorizeAcross([roleA], { project: ["create"] });
+		expect(response.success).toBe(true);
+
+		const failed = authorizeAcross([roleA], { ui: ["view"] });
+		expect(failed.success).toBe(false);
 	});
 });

--- a/packages/better-auth/src/plugins/admin/has-permission.ts
+++ b/packages/better-auth/src/plugins/admin/has-permission.ts
@@ -1,3 +1,4 @@
+import { role } from "../access";
 import { defaultRoles } from "./access";
 import type { AdminOptions } from "./types";
 
@@ -20,12 +21,23 @@ export const hasPermission = (
 	}
 	const roles = (input.role || input.options?.defaultRole || "user").split(",");
 	const acRoles = input.options?.roles || defaultRoles;
-	for (const role of roles) {
-		const _role = acRoles[role as keyof typeof acRoles];
-		const result = _role?.authorize(input.permissions);
-		if (result?.success) {
-			return true;
+
+	// Merge the statements of every role the user holds into a single set so a
+	// permission is granted if *any* of the roles grants it, rather than
+	// requiring a single role to grant all requested permissions.
+	// @see https://github.com/better-auth/better-auth/issues/3011
+	const mergedStatements: Record<string, string[]> = {};
+	for (const r of roles) {
+		const _role = acRoles[r as keyof typeof acRoles];
+		if (!_role) continue;
+		for (const [resource, actions] of Object.entries(_role.statements)) {
+			const existing = mergedStatements[resource] ?? [];
+			mergedStatements[resource] = [
+				...new Set([...existing, ...(actions as readonly string[])]),
+			];
 		}
 	}
-	return false;
+
+	const result = role(mergedStatements).authorize(input.permissions);
+	return result.success;
 };

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -1794,6 +1794,67 @@ describe("access control", async () => {
 });
 
 /**
+ * A user holding several roles should be authorized against the union of those
+ * roles' permissions, even when each individual permission is granted by a
+ * different role.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/3011
+ */
+describe("access control across multiple roles", async () => {
+	const ac = createAccessControl({
+		project: ["create", "read", "update", "delete"],
+		sales: ["create", "read", "update", "delete"],
+		...defaultStatements,
+	});
+	// Two roles that each grant a permission the other does not.
+	const projectManager = ac.newRole({ project: ["create"] });
+	const salesManager = ac.newRole({ sales: ["create"] });
+
+	const { customFetchImpl } = await getTestInstance({
+		plugins: [
+			organization({
+				ac,
+				roles: { projectManager, salesManager },
+			}),
+		],
+	});
+
+	const authClient = createAuthClient({
+		baseURL: "http://localhost:3000",
+		plugins: [
+			organizationClient({
+				ac,
+				roles: { projectManager, salesManager },
+			}),
+		],
+		fetchOptions: { customFetchImpl },
+	});
+	const { checkRolePermission } = authClient.organization;
+
+	it("should grant permissions provided by different roles", async () => {
+		const authorized = await checkRolePermission({
+			// comma-separated roles are merged into a single permission set
+			role: "projectManager,salesManager" as "projectManager",
+			permissions: {
+				project: ["create"],
+				sales: ["create"],
+			},
+		});
+		expect(authorized).toBe(true);
+	});
+
+	it("should fail for a permission that none of the roles grant", async () => {
+		const authorized = await checkRolePermission({
+			role: "projectManager,salesManager" as "projectManager",
+			permissions: {
+				project: ["delete"],
+			},
+		});
+		expect(authorized).toBe(false);
+	});
+});
+
+/**
  * @see https://github.com/better-auth/better-auth/issues/7822
  */
 describe("dynamic access control should merge DB permissions with built-in roles", async () => {

--- a/packages/better-auth/src/plugins/organization/permission.ts
+++ b/packages/better-auth/src/plugins/organization/permission.ts
@@ -1,4 +1,4 @@
-import type { Role } from "../access";
+import { role, type Role } from "../access";
 import type { OrganizationOptions } from "./types";
 
 export const hasPermissionFn = (
@@ -16,14 +16,24 @@ export const hasPermissionFn = (
 	const allowCreatorsAllPermissions = input.allowCreatorAllPermissions || false;
 	if (isCreator && allowCreatorsAllPermissions) return true;
 
-	for (const role of roles) {
-		const _role = acRoles[role as keyof typeof acRoles];
-		const result = _role?.authorize(input.permissions);
-		if (result?.success) {
-			return true;
+	// Merge the statements of every role the user holds into a single set so a
+	// permission is granted if *any* of the roles grants it, rather than
+	// requiring a single role to grant all requested permissions.
+	// @see https://github.com/better-auth/better-auth/issues/3011
+	const mergedStatements: Record<string, string[]> = {};
+	for (const r of roles) {
+		const _role = acRoles[r as keyof typeof acRoles];
+		if (!_role) continue;
+		for (const [resource, actions] of Object.entries(_role.statements)) {
+			const existing = mergedStatements[resource] ?? [];
+			mergedStatements[resource] = [
+				...new Set([...existing, ...(actions as readonly string[])]),
+			];
 		}
 	}
-	return false;
+
+	const result = role(mergedStatements).authorize(input.permissions);
+	return result.success;
 };
 
 export type PermissionExclusive = {


### PR DESCRIPTION
## Problem

`hasPermission` checked each role independently, so a user whose required permissions were split across two roles (role A grants X, role B grants Y) was denied when requesting `{X, Y}`.

## Fix

Merge the statements of all the user's roles into one set before authorizing, so a permission is granted if any role grants it. Applied to both the organization and admin plugins. AND/OR connector semantics and the single-role case are preserved.

## Tests

Added unit coverage in `access.test.ts` (two roles, different permissions) and an integration test in `organization.test.ts` via `checkRolePermission`. Includes a changeset (patch).

Fixes #3011

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix permission checks to aggregate permissions across all roles a user holds. Users with permissions split across roles are now correctly authorized in both admin and organization flows.

- **Bug Fixes**
  - Merge statements from all roles, then authorize once; preserves AND/OR semantics and single-role behavior.
  - Applied in `admin/has-permission.ts` and `organization/permission.ts`.
  - Added unit tests incl. a direct check of exported admin `hasPermission` with comma-separated roles, plus an org integration test.
  - Released as a patch via changeset for `better-auth`.
  - Fixes #3011.

<sup>Written for commit 713fac3fa25e6eb027792d128f01d631c9cacc9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

