### PR TITLE
fix(organization): update session context when setting the active organization

### DIFF
--- a/.changeset/fix-organization-set-active-session-context.md
+++ b/.changeset/fix-organization-set-active-session-context.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix(organization): update session context when setting the active organization

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -4183,4 +4183,29 @@ describe("organization set-active updates session context", async () => {
 		expect(observed.session).toBe(organizationId);
 		expect(observed.newSession).toBe(organizationId);
 	});
+
+	it("reflects a cleared active organization (organizationId: null)", async () => {
+		// The clear branch (organizationId === null) received the same fix, so the
+		// after-hook must observe the cleared value rather than the stale id.
+		const { headers } = await signInWithTestUser();
+
+		const org = await auth.api.createOrganization({
+			headers,
+			body: { name: "Clear Probe Org", slug: "clear-probe-org" },
+		});
+		const organizationId = org?.id as string;
+		expect(organizationId).toBeTruthy();
+
+		await auth.api.setActiveOrganization({
+			headers,
+			body: { organizationId },
+		});
+		await auth.api.setActiveOrganization({
+			headers,
+			body: { organizationId: null },
+		});
+
+		expect(observed.session).toBeNull();
+		expect(observed.newSession).toBeNull();
+	});
 });

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -1,3 +1,5 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
+import { createAuthMiddleware } from "@better-auth/core/api";
 import type { APIError } from "@better-auth/core/error";
 import { memoryAdapter } from "@better-auth/memory-adapter";
 import type { Prettify } from "better-call";
@@ -4122,5 +4124,63 @@ describe("delete cascade rollback", async () => {
 			],
 		});
 		expect(teamMemberCount).toBe(1);
+	});
+});
+
+/**
+ * After-hooks and subsequent middleware must observe the new active
+ * organization on the session context once `set-active` has run. Previously
+ * only the cookie (and `ctx.context.newSession`) reflected the change while
+ * `ctx.context.session` stayed stale, breaking downstream hook logic.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/4708
+ */
+describe("organization set-active updates session context", async () => {
+	const observed: {
+		session: string | null | undefined;
+		newSession: string | null | undefined;
+	} = { session: undefined, newSession: undefined };
+
+	const setActiveProbe = {
+		id: "set-active-probe",
+		hooks: {
+			after: [
+				{
+					matcher: (ctx) => ctx.path === "/organization/set-active",
+					handler: createAuthMiddleware(async (ctx) => {
+						observed.session =
+							ctx.context.session?.session.activeOrganizationId ?? null;
+						observed.newSession =
+							ctx.context.newSession?.session.activeOrganizationId ?? null;
+					}),
+				},
+			],
+		},
+	} satisfies BetterAuthPlugin;
+
+	const { auth, signInWithTestUser } = await getTestInstance({
+		plugins: [organization(), setActiveProbe],
+	});
+
+	it("reflects the new active organization in session and newSession", async () => {
+		const { headers } = await signInWithTestUser();
+
+		const org = await auth.api.createOrganization({
+			headers,
+			body: { name: "Probe Org", slug: "probe-org" },
+		});
+		const organizationId = org?.id as string;
+		expect(organizationId).toBeTruthy();
+
+		await auth.api.setActiveOrganization({
+			headers,
+			body: { organizationId },
+		});
+
+		// `setSessionCookie` already keeps `ctx.context.newSession` in sync; the
+		// fix additionally keeps `ctx.context.session` in sync so after-hooks see
+		// the new active organization rather than the stale middleware value.
+		expect(observed.session).toBe(organizationId);
+		expect(observed.newSession).toBe(organizationId);
 	});
 });

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -798,6 +798,16 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 					session: updatedSession,
 					user: session.user,
 				});
+				// Keep the current session context in sync so after-hooks and
+				// subsequent middleware observe the cleared active organization.
+				// `setSessionCookie` already updates `ctx.context.newSession`.
+				// @see https://github.com/better-auth/better-auth/issues/4708
+				if (updatedSession) {
+					ctx.context.session = {
+						session: updatedSession,
+						user: session.user,
+					};
+				}
 				return ctx.json(null);
 			}
 
@@ -856,6 +866,16 @@ export const setActiveOrganization = <O extends OrganizationOptions>(
 				session: updatedSession,
 				user: session.user,
 			});
+			// Keep the current session context in sync so after-hooks and
+			// subsequent middleware observe the new active organization.
+			// `setSessionCookie` already updates `ctx.context.newSession`.
+			// @see https://github.com/better-auth/better-auth/issues/4708
+			if (updatedSession) {
+				ctx.context.session = {
+					session: updatedSession,
+					user: session.user,
+				};
+			}
 			type OrganizationReturn = O["teams"] extends { enabled: true }
 				? {
 						members: InferMember<O>[];


### PR DESCRIPTION
## Problem

`setActiveOrganization` refreshed the session cookie (and `newSession`) but left `ctx.context.session` stale, so after-hooks and subsequent middleware still saw the previous `activeOrganizationId`.

## Fix

Re-sync `ctx.context.session` with the updated session after the cookie is set, matching the pattern used in the session/mcp/oidc routes. Guarded for the null adapter return. Response shape unchanged.

## Tests

Added an after-hook test in `organization.test.ts` asserting the session context reflects the new active org after `setActiveOrganization`. Includes a changeset (patch).

Fixes #4708

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `setActiveOrganization` keeps the in-request session context in sync so after-hooks and middleware see the correct `activeOrganizationId`. Fixes #4708.

- **Bug Fixes**
  - Re-sync `ctx.context.session` with the updated session after `setSessionCookie` for both set and clear (`organizationId: null`) paths; response shape unchanged.
  - Added after-hook tests to confirm `session` and `newSession` reflect the new active org and the cleared state.

<sup>Written for commit a167c5bd7a9f60276136a734592f0338b97ec2c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

