### PR TITLE
fix(oauth): allow sign-in for providers that return no email

### DIFF
--- a/.changeset/oauth-allow-sign-up-without-email.md
+++ b/.changeset/oauth-allow-sign-up-without-email.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix(oauth): allow sign-in for providers that return no email via `allowSignUpWithoutEmail`

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -239,7 +239,7 @@ export const callbackOAuth = createAuthEndpoint(
 			throw c.redirect(toRedirectTo);
 		}
 
-		if (!userInfo.email) {
+		if (!userInfo.email && !provider.options?.allowSignUpWithoutEmail) {
 			c.context.logger.error(missingEmailLogMessage(provider.id));
 			redirectOnError(c, resolvedErrorURL, "email_not_found");
 		}

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -239,7 +239,7 @@ export const callbackOAuth = createAuthEndpoint(
 			throw c.redirect(toRedirectTo);
 		}
 
-		if (!userInfo.email && !provider.options?.allowSignUpWithoutEmail) {
+		if (!userInfo.email?.trim() && !provider.options?.allowSignUpWithoutEmail) {
 			c.context.logger.error(missingEmailLogMessage(provider.id));
 			redirectOnError(c, resolvedErrorURL, "email_not_found");
 		}
@@ -263,6 +263,7 @@ export const callbackOAuth = createAuthEndpoint(
 				disableSignUp:
 					(provider.disableImplicitSignUp && !requestSignUp) ||
 					provider.options?.disableSignUp,
+				allowSignUpWithoutEmail: provider.options?.allowSignUpWithoutEmail,
 				overrideUserInfo: provider.options?.overrideUserInfoOnSignIn,
 			});
 		} catch (e) {

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -288,7 +288,7 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 						BASE_ERROR_CODES.FAILED_TO_GET_USER_INFO,
 					);
 				}
-				if (!userInfo.user.email) {
+				if (!userInfo.user.email && !provider.options?.allowSignUpWithoutEmail) {
 					c.context.logger.error(
 						missingEmailLogMessage(c.body.provider, { source: "id_token" }),
 						{ provider: c.body.provider },

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -288,7 +288,10 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 						BASE_ERROR_CODES.FAILED_TO_GET_USER_INFO,
 					);
 				}
-				if (!userInfo.user.email && !provider.options?.allowSignUpWithoutEmail) {
+				if (
+					!userInfo.user.email?.trim() &&
+					!provider.options?.allowSignUpWithoutEmail
+				) {
 					c.context.logger.error(
 						missingEmailLogMessage(c.body.provider, { source: "id_token" }),
 						{ provider: c.body.provider },
@@ -316,6 +319,7 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 					disableSignUp:
 						(provider.disableImplicitSignUp && !c.body.requestSignUp) ||
 						provider.disableSignUp,
+					allowSignUpWithoutEmail: provider.options?.allowSignUpWithoutEmail,
 				});
 				if (data.error) {
 					throw APIError.from("UNAUTHORIZED", {

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -182,6 +182,48 @@ describe("internal adapter test", async () => {
 		expect(hookUserCreateAfter).toHaveBeenCalledOnce();
 		expect(hookUserCreateBefore).toHaveBeenCalledOnce();
 	});
+
+	it("should resolve an OAuth account by userId when the joined user is missing", async () => {
+		const created = await internalAdapter.createOAuthUser(
+			{
+				email: "join-fallback@example.com",
+				name: "Join Fallback",
+				emailVerified: true,
+			},
+			{
+				providerId: "join-fallback-provider",
+				accountId: "join-fallback-account",
+			},
+		);
+		expect(created).not.toBeNull();
+
+		const originalFindOne = authContext.adapter.findOne.bind(
+			authContext.adapter,
+		);
+		const findOneSpy = vi
+			.spyOn(authContext.adapter, "findOne")
+			.mockImplementation(async (query) => {
+				if (query.model === "account" && query.join) {
+					return { ...created!.account, user: null };
+				}
+				return originalFindOne(query);
+			});
+
+		try {
+			const result = await internalAdapter.findOAuthUser(
+				undefined,
+				"join-fallback-account",
+				"join-fallback-provider",
+			);
+
+			expect(result?.user.id).toBe(created!.user.id);
+			expect(result?.accounts).toEqual([
+				expect.objectContaining({ userId: created!.user.id }),
+			]);
+		} finally {
+			findOneSpy.mockRestore();
+		}
+	});
 	it("should find session with custom userId", async () => {
 		const { client, signInWithTestUser } = await getTestInstance({
 			session: {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -849,9 +849,10 @@ export const createInternalAdapter = (
 			accountId: string,
 			providerId: string,
 		) => {
-			const normalizedEmail = email ? email.toLowerCase() : null;
+			const normalizedEmail = email?.trim().toLowerCase() || null;
+			const currentAdapter = await getCurrentAdapter(adapter);
 			// we need to find account first to avoid missing user if the email changed with the provider for the same account
-			const account = await (await getCurrentAdapter(adapter)).findOne<
+			const account = await currentAdapter.findOne<
 				Account & { user: User | null }
 			>({
 				model: "account",
@@ -870,9 +871,15 @@ export const createInternalAdapter = (
 				},
 			});
 			if (account) {
-				if (account.user) {
+				const accountUser =
+					account.user ??
+					(await currentAdapter.findOne<User>({
+						model: "user",
+						where: [{ value: account.userId, field: "id" }],
+					}));
+				if (accountUser) {
 					return {
-						user: account.user,
+						user: accountUser,
 						linkedAccount: account,
 						accounts: [account],
 					};
@@ -880,7 +887,7 @@ export const createInternalAdapter = (
 					if (!normalizedEmail) {
 						return null;
 					}
-					const user = await (await getCurrentAdapter(adapter)).findOne<User>({
+					const user = await currentAdapter.findOne<User>({
 						model: "user",
 						where: [
 							{
@@ -902,7 +909,7 @@ export const createInternalAdapter = (
 				if (!normalizedEmail) {
 					return null;
 				}
-				const user = await (await getCurrentAdapter(adapter)).findOne<User>({
+				const user = await currentAdapter.findOne<User>({
 					model: "user",
 					where: [
 						{
@@ -912,9 +919,7 @@ export const createInternalAdapter = (
 					],
 				});
 				if (user) {
-					const accounts = await (
-						await getCurrentAdapter(adapter)
-					).findMany<Account>({
+					const accounts = await currentAdapter.findMany<Account>({
 						model: "account",
 						where: [
 							{

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -842,10 +842,14 @@ export const createInternalAdapter = (
 			);
 		},
 		findOAuthUser: async (
-			email: string,
+			// `email` is nullable: a provider may return a profile without one
+			// (see #9124). A missing email must never be used as a match key, so
+			// the fall-back user lookup below is skipped entirely in that case.
+			email: string | null | undefined,
 			accountId: string,
 			providerId: string,
 		) => {
+			const normalizedEmail = email ? email.toLowerCase() : null;
 			// we need to find account first to avoid missing user if the email changed with the provider for the same account
 			const account = await (await getCurrentAdapter(adapter)).findOne<
 				Account & { user: User | null }
@@ -873,11 +877,14 @@ export const createInternalAdapter = (
 						accounts: [account],
 					};
 				} else {
+					if (!normalizedEmail) {
+						return null;
+					}
 					const user = await (await getCurrentAdapter(adapter)).findOne<User>({
 						model: "user",
 						where: [
 							{
-								value: email.toLowerCase(),
+								value: normalizedEmail,
 								field: "email",
 							},
 						],
@@ -892,11 +899,14 @@ export const createInternalAdapter = (
 					return null;
 				}
 			} else {
+				if (!normalizedEmail) {
+					return null;
+				}
 				const user = await (await getCurrentAdapter(adapter)).findOne<User>({
 					model: "user",
 					where: [
 						{
-							value: email.toLowerCase(),
+							value: normalizedEmail,
 							field: "email",
 						},
 					],

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -1,3 +1,4 @@
+import type { GenericEndpointContext } from "@better-auth/core";
 import type {
 	DiscordProfile,
 	GoogleProfile,
@@ -18,6 +19,7 @@ import { signJWT } from "../crypto";
 import { getTestInstance } from "../test-utils/test-instance";
 import type { User } from "../types";
 import { DEFAULT_SECRET } from "../utils/constants";
+import { handleOAuthUserInfo } from "./link-account";
 
 let mockEmail = "";
 let mockEmailVerified = true;
@@ -33,6 +35,50 @@ afterEach(() => {
 });
 
 afterAll(() => server.close());
+
+describe("oauth2 - missing email guard", () => {
+	it("rejects a missing email unless the caller explicitly opts in", async () => {
+		const findOAuthUser = vi.fn().mockResolvedValue(null);
+		const createOAuthUser = vi.fn().mockResolvedValue({
+			user: {
+				id: "local-user",
+				email: "placeholder@example.com",
+				name: "No Email",
+				emailVerified: false,
+			},
+			account: { id: "account" },
+		});
+		const createSession = vi.fn().mockResolvedValue({ id: "session" });
+		const ctx = {
+			context: {
+				internalAdapter: {
+					findOAuthUser,
+					createOAuthUser,
+					createSession,
+				},
+				options: {},
+				logger: { error: vi.fn(), warn: vi.fn() },
+			},
+		} as unknown as GenericEndpointContext;
+
+		const result = await handleOAuthUserInfo(ctx, {
+			userInfo: {
+				id: "provider-user",
+				email: "   ",
+				name: "No Email",
+				emailVerified: false,
+			},
+			account: {
+				providerId: "provider",
+				accountId: "provider-user",
+			},
+		});
+
+		expect(result).toMatchObject({ error: "email not found", data: null });
+		expect(findOAuthUser).not.toHaveBeenCalled();
+		expect(createOAuthUser).not.toHaveBeenCalled();
+	});
+});
 
 describe("oauth2 - email verification on link", async () => {
 	const { auth, client, cookieSetter } = await getTestInstance({
@@ -1941,6 +1987,53 @@ describe("oauth2 - providers without email", async () => {
 			});
 
 			expect(redirectLocation).toContain("error=email_not_found");
+		});
+	});
+
+	describe("without mapProfileToUser and with missing-email opt-in", async () => {
+		const { auth, client, cookieSetter } = await getTestInstance(
+			{
+				socialProviders: {
+					discord: {
+						clientId: "test",
+						clientSecret: "test",
+						enabled: true,
+						allowSignUpWithoutEmail: true,
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		it("creates a user through the built-in redirect callback", async () => {
+			mockDiscordToken("920138789012345003", "phoneonly3");
+
+			const headers = new Headers();
+			const signInRes = await client.signIn.social({
+				provider: "discord",
+				callbackURL: "/",
+				fetchOptions: { onSuccess: cookieSetter(headers) },
+			});
+			const state =
+				new URL(signInRes.data!.url!).searchParams.get("state") || "";
+			let redirectLocation = "";
+			await client.$fetch("/callback/discord", {
+				query: { state, code: "test_code" },
+				method: "GET",
+				headers,
+				onError(context) {
+					redirectLocation = context.response.headers.get("location") || "";
+					cookieSetter(headers)(context as any);
+				},
+			});
+
+			expect(redirectLocation).not.toContain("error=");
+			const ctx = await auth.$context;
+			const users = await ctx.internalAdapter.listUsers();
+			expect(users).toHaveLength(1);
+			expect(users[0]?.email).toMatch(
+				/^no-email\+[a-f0-9]{40}@better-auth\.invalid$/,
+			);
 		});
 	});
 });

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -8,12 +8,16 @@ import { isAPIError } from "../utils/is-api-error";
 import { redirectOnError } from "./errors";
 import { setTokenUtil } from "./utils";
 
-// TODO(#9124): v2 widens `User.email` to nullable; every `userInfo.email.toLowerCase()`
-// call below needs null-safety, and `findOAuthUser` must accept a nullable email.
+// A provider may return a profile without an email (see #9124). The local user
+// row still keys on a (non-null) email column until v2 widens it, so a missing
+// email is normalized to an empty string on write while never being used as a
+// match key. Every `userInfo.email` access below is therefore null-safe.
 export async function handleOAuthUserInfo(
 	c: GenericEndpointContext,
 	opts: {
-		userInfo: Omit<User, "createdAt" | "updatedAt">;
+		userInfo: Omit<User, "createdAt" | "updatedAt" | "email"> & {
+			email?: string | null | undefined;
+		};
 		account: Omit<Account, "id" | "userId" | "createdAt" | "updatedAt">;
 		callbackURL?: string | undefined;
 		disableSignUp?: boolean | undefined;
@@ -36,9 +40,11 @@ export async function handleOAuthUserInfo(
 ) {
 	const { userInfo, account, callbackURL, disableSignUp, overrideUserInfo } =
 		opts;
+	// A missing email is passed through as-is; `findOAuthUser` skips the
+	// match-by-email lookup so an emailless profile can't be linked by email.
 	const dbUser = await c.context.internalAdapter
 		.findOAuthUser(
-			userInfo.email.toLowerCase(),
+			userInfo.email?.toLowerCase(),
 			account.accountId,
 			account.providerId,
 		)
@@ -115,7 +121,7 @@ export async function handleOAuthUserInfo(
 			if (
 				userInfo.emailVerified &&
 				!dbUser.user.emailVerified &&
-				userInfo.email.toLowerCase() === dbUser.user.email
+				userInfo.email?.toLowerCase() === dbUser.user.email
 			) {
 				await c.context.internalAdapter.updateUser(dbUser.user.id, {
 					emailVerified: true,
@@ -159,7 +165,7 @@ export async function handleOAuthUserInfo(
 			if (
 				userInfo.emailVerified &&
 				!dbUser.user.emailVerified &&
-				userInfo.email.toLowerCase() === dbUser.user.email
+				userInfo.email?.toLowerCase() === dbUser.user.email
 			) {
 				await c.context.internalAdapter.updateUser(dbUser.user.id, {
 					emailVerified: true,
@@ -169,27 +175,31 @@ export async function handleOAuthUserInfo(
 		if (overrideUserInfo) {
 			const {
 				id: _id,
-				email: _email,
+				email: providerEmail,
 				emailVerified: _emailVerified,
 				name,
 				image,
 				...providerProfile
 			} = userInfo;
+			const normalizedEmail = providerEmail?.toLowerCase();
 			const additionalUserFields = parseAdditionalUserInputFromProviderProfile(
 				c.context.options,
 				providerProfile,
 				"update",
 			);
-			// update user info from the provider if overrideUserInfo is true
+			// A provider that omits an email must not blank out the existing
+			// local email on override; only write it through when present.
 			user = await c.context.internalAdapter.updateUser(dbUser.user.id, {
 				name,
 				image,
 				...additionalUserFields,
-				email: userInfo.email.toLowerCase(),
+				...(normalizedEmail !== undefined && { email: normalizedEmail }),
 				emailVerified:
-					userInfo.email.toLowerCase() === dbUser.user.email
-						? dbUser.user.emailVerified || userInfo.emailVerified
-						: userInfo.emailVerified,
+					normalizedEmail === undefined
+						? dbUser.user.emailVerified
+						: normalizedEmail === dbUser.user.email
+							? dbUser.user.emailVerified || userInfo.emailVerified
+							: userInfo.emailVerified,
 			});
 		}
 	} else {
@@ -230,7 +240,10 @@ export async function handleOAuthUserInfo(
 						name,
 						image,
 						...additionalUserFields,
-						email: userInfo.email.toLowerCase(),
+						// The user table still requires a string email until v2; a
+						// provider that returns none is stored with an empty email
+						// rather than failing the sign-up (see #9124).
+						email: userInfo.email?.toLowerCase() ?? "",
 						emailVerified: userInfo.emailVerified,
 					},
 					accountData,
@@ -242,6 +255,9 @@ export async function handleOAuthUserInfo(
 			if (
 				!userInfo.emailVerified &&
 				user &&
+				// Skip verification mail when the provider returned no email; there
+				// is no address to send it to (see #9124).
+				user.email &&
 				c.context.options.emailVerification?.sendOnSignUp &&
 				c.context.options.emailVerification?.sendVerificationEmail
 			) {

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -9,9 +9,10 @@ import { redirectOnError } from "./errors";
 import { setTokenUtil } from "./utils";
 
 // A provider may return a profile without an email (see #9124). The local user
-// row still keys on a (non-null) email column until v2 widens it, so a missing
-// email is normalized to an empty string on write while never being used as a
-// match key. Every `userInfo.email` access below is therefore null-safe.
+// row still keys on a unique, non-null email column until v2 widens it, so a
+// missing email is normalized to a per-account synthetic placeholder on write
+// while never being used as a match key. Every `userInfo.email` access below is
+// therefore null-safe.
 export async function handleOAuthUserInfo(
 	c: GenericEndpointContext,
 	opts: {
@@ -196,7 +197,10 @@ export async function handleOAuthUserInfo(
 				...(normalizedEmail !== undefined && { email: normalizedEmail }),
 				emailVerified:
 					normalizedEmail === undefined
-						? dbUser.user.emailVerified
+						? // Provider returned no email: nothing about the email changed, so
+						  // preserve the existing verification state instead of letting a
+						  // provider default of `false` silently downgrade a verified user.
+						  dbUser.user.emailVerified
 						: normalizedEmail === dbUser.user.email
 							? dbUser.user.emailVerified || userInfo.emailVerified
 							: userInfo.emailVerified,
@@ -240,10 +244,14 @@ export async function handleOAuthUserInfo(
 						name,
 						image,
 						...additionalUserFields,
-						// The user table still requires a string email until v2; a
-						// provider that returns none is stored with an empty email
-						// rather than failing the sign-up (see #9124).
-						email: userInfo.email?.toLowerCase() ?? "",
+						// The user table still requires a unique, non-null string email
+						// until v2 (see the TODO in core get-tables.ts). When a provider
+						// returns none, store a per-account synthetic placeholder on the
+						// reserved `.invalid` TLD: a literal "" would collide on the unique
+						// index, limiting the feature to a single email-less user. See #9124.
+						email:
+							userInfo.email?.toLowerCase() ??
+							`no-email+${account.providerId}-${userInfo.id}@better-auth.invalid`.toLowerCase(),
 						emailVerified: userInfo.emailVerified,
 					},
 					accountData,
@@ -255,9 +263,10 @@ export async function handleOAuthUserInfo(
 			if (
 				!userInfo.emailVerified &&
 				user &&
-				// Skip verification mail when the provider returned no email; there
-				// is no address to send it to (see #9124).
-				user.email &&
+				// Skip verification mail when the provider returned no email: the stored
+				// address is a synthetic `.invalid` placeholder, so gate on the real
+				// provider email rather than the stored one (see #9124).
+				userInfo.email &&
 				c.context.options.emailVerification?.sendOnSignUp &&
 				c.context.options.emailVerification?.sendVerificationEmail
 			) {

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -1,5 +1,6 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { isDevelopment } from "@better-auth/core/env";
+import { createHash } from "@better-auth/utils/hash";
 import { createEmailVerificationToken } from "../api";
 import { setAccountCookie } from "../cookies/session-store";
 import { parseAdditionalUserInputFromProviderProfile } from "../db";
@@ -7,6 +8,17 @@ import type { Account, User } from "../types";
 import { isAPIError } from "../utils/is-api-error";
 import { redirectOnError } from "./errors";
 import { setTokenUtil } from "./utils";
+
+function normalizeProviderEmail(email: string | null | undefined) {
+	return email?.trim().toLowerCase() || undefined;
+}
+
+async function createSyntheticEmail(providerId: string, accountId: string) {
+	const digest = await createHash("SHA-256", "hex").digest(
+		JSON.stringify([providerId, accountId]),
+	);
+	return `no-email+${digest.slice(0, 40)}@better-auth.invalid`;
+}
 
 // A provider may return a profile without an email (see #9124). The local user
 // row still keys on a unique, non-null email column until v2 widens it, so a
@@ -22,6 +34,7 @@ export async function handleOAuthUserInfo(
 		account: Omit<Account, "id" | "userId" | "createdAt" | "updatedAt">;
 		callbackURL?: string | undefined;
 		disableSignUp?: boolean | undefined;
+		allowSignUpWithoutEmail?: boolean | undefined;
 		overrideUserInfo?: boolean | undefined;
 		isTrustedProvider?: boolean | undefined;
 		/**
@@ -41,11 +54,19 @@ export async function handleOAuthUserInfo(
 ) {
 	const { userInfo, account, callbackURL, disableSignUp, overrideUserInfo } =
 		opts;
+	const normalizedUserInfoEmail = normalizeProviderEmail(userInfo.email);
+	if (!normalizedUserInfoEmail && !opts.allowSignUpWithoutEmail) {
+		return {
+			error: "email not found",
+			data: null,
+			isRegister: false,
+		};
+	}
 	// A missing email is passed through as-is; `findOAuthUser` skips the
 	// match-by-email lookup so an emailless profile can't be linked by email.
 	const dbUser = await c.context.internalAdapter
 		.findOAuthUser(
-			userInfo.email?.toLowerCase(),
+			normalizedUserInfoEmail,
 			account.accountId,
 			account.providerId,
 		)
@@ -122,7 +143,7 @@ export async function handleOAuthUserInfo(
 			if (
 				userInfo.emailVerified &&
 				!dbUser.user.emailVerified &&
-				userInfo.email?.toLowerCase() === dbUser.user.email
+				normalizedUserInfoEmail === dbUser.user.email
 			) {
 				await c.context.internalAdapter.updateUser(dbUser.user.id, {
 					emailVerified: true,
@@ -166,7 +187,7 @@ export async function handleOAuthUserInfo(
 			if (
 				userInfo.emailVerified &&
 				!dbUser.user.emailVerified &&
-				userInfo.email?.toLowerCase() === dbUser.user.email
+				normalizedUserInfoEmail === dbUser.user.email
 			) {
 				await c.context.internalAdapter.updateUser(dbUser.user.id, {
 					emailVerified: true,
@@ -182,7 +203,7 @@ export async function handleOAuthUserInfo(
 				image,
 				...providerProfile
 			} = userInfo;
-			const normalizedEmail = providerEmail?.toLowerCase();
+			const normalizedEmail = normalizeProviderEmail(providerEmail);
 			const additionalUserFields = parseAdditionalUserInputFromProviderProfile(
 				c.context.options,
 				providerProfile,
@@ -198,9 +219,9 @@ export async function handleOAuthUserInfo(
 				emailVerified:
 					normalizedEmail === undefined
 						? // Provider returned no email: nothing about the email changed, so
-						  // preserve the existing verification state instead of letting a
-						  // provider default of `false` silently downgrade a verified user.
-						  dbUser.user.emailVerified
+							// preserve the existing verification state instead of letting a
+							// provider default of `false` silently downgrade a verified user.
+							dbUser.user.emailVerified
 						: normalizedEmail === dbUser.user.email
 							? dbUser.user.emailVerified || userInfo.emailVerified
 							: userInfo.emailVerified,
@@ -250,8 +271,11 @@ export async function handleOAuthUserInfo(
 						// reserved `.invalid` TLD: a literal "" would collide on the unique
 						// index, limiting the feature to a single email-less user. See #9124.
 						email:
-							userInfo.email?.toLowerCase() ??
-							`no-email+${account.providerId}-${userInfo.id}@better-auth.invalid`.toLowerCase(),
+							normalizedUserInfoEmail ??
+							(await createSyntheticEmail(
+								account.providerId,
+								account.accountId,
+							)),
 						emailVerified: userInfo.emailVerified,
 					},
 					accountData,
@@ -266,7 +290,7 @@ export async function handleOAuthUserInfo(
 				// Skip verification mail when the provider returned no email: the stored
 				// address is a synthetic `.invalid` placeholder, so gate on the real
 				// provider email rather than the stored one (see #9124).
-				userInfo.email &&
+				normalizedUserInfoEmail &&
 				c.context.options.emailVerification?.sendOnSignUp &&
 				c.context.options.emailVerification?.sendVerificationEmail
 			) {

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -9,6 +9,7 @@ import { getAwaitableValue } from "../../context/helpers";
 import { parseSetCookieHeader } from "../../cookies";
 import { symmetricDecodeJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
+import type { User } from "../../types";
 import { genericOAuth } from ".";
 import { genericOAuthClient } from "./client";
 import { auth0 } from "./providers/auth0";
@@ -1552,14 +1553,131 @@ describe("oauth2", async () => {
 		});
 	});
 
-	it("creates distinct users for multiple providers that return no email", async () => {
-		// Regression for the unique+required email column: two email-less sign-ups
-		// must not collide on a shared "" placeholder. @see #9124
+	it("treats a whitespace-only provider email as missing", async () => {
+		const { customFetchImpl, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "whitespace-email-test",
+							authorizationUrl: `http://localhost:${port}/authorize`,
+							tokenUrl: `http://localhost:${port}/token`,
+							clientId,
+							clientSecret,
+							pkce: true,
+							allowSignUpWithoutEmail: true,
+							getUserInfo: async () => ({
+								id: "whitespace-email-user",
+								email: "   ",
+								name: "Whitespace Email User",
+								emailVerified: false,
+							}),
+						},
+					],
+				}),
+			],
+		});
+		const headers = new Headers();
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: { customFetchImpl },
+		});
+
+		const signIn = await authClient.signIn.oauth2({
+			providerId: "whitespace-email-test",
+			callbackURL: "http://localhost:3000/dashboard",
+			fetchOptions: { onSuccess: cookieSetter(headers) },
+		});
+		const flow = await simulateOAuthFlow(
+			signIn.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+		const session = await authClient.getSession({
+			fetchOptions: { headers: flow.headers },
+		});
+
+		expect(session.data?.user.email).toMatch(
+			/^no-email\+[a-f0-9]{40}@better-auth\.invalid$/,
+		);
+	});
+
+	it("preserves a linked user's email when the provider later returns whitespace", async () => {
+		let providerEmail = "preserved@example.com";
+		let providerEmailVerified = true;
 		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
 			plugins: [
 				genericOAuth({
-					config: ["a", "b"].map((suffix) => ({
-						providerId: `no-email-multi-${suffix}`,
+					config: [
+						{
+							providerId: "whitespace-override-test",
+							authorizationUrl: `http://localhost:${port}/authorize`,
+							tokenUrl: `http://localhost:${port}/token`,
+							clientId,
+							clientSecret,
+							pkce: true,
+							allowSignUpWithoutEmail: true,
+							overrideUserInfo: true,
+							getUserInfo: async () => ({
+								id: "whitespace-override-user",
+								email: providerEmail,
+								name: "Whitespace Override User",
+								emailVerified: providerEmailVerified,
+							}),
+						},
+					],
+				}),
+			],
+		});
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: { customFetchImpl },
+		});
+		const signIn = async () => {
+			const headers = new Headers();
+			const response = await authClient.signIn.oauth2({
+				providerId: "whitespace-override-test",
+				callbackURL: "http://localhost:3000/dashboard",
+				fetchOptions: { onSuccess: cookieSetter(headers) },
+			});
+			await simulateOAuthFlow(
+				response.data?.url || "",
+				headers,
+				customFetchImpl,
+			);
+		};
+
+		await signIn();
+		providerEmail = "   ";
+		providerEmailVerified = false;
+		await signIn();
+
+		const ctx = await auth.$context;
+		const user = await ctx.adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: "preserved@example.com" }],
+		});
+		expect(user).toMatchObject({
+			email: "preserved@example.com",
+			emailVerified: true,
+		});
+	});
+
+	it("creates distinct users for multiple providers that return no email", async () => {
+		// Regression for the unique+required email column: two email-less sign-ups
+		// must not collide even when their provider/account pairs have the same
+		// delimiter-joined representation. @see #9124
+		const identities = [
+			{ providerId: "no-email-a-b", accountId: "c" },
+			{ providerId: "no-email-a", accountId: "b-c" },
+		];
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: identities.map(({ providerId, accountId }) => ({
+						providerId,
 						authorizationUrl: `http://localhost:${port}/authorize`,
 						tokenUrl: `http://localhost:${port}/token`,
 						clientId: clientId,
@@ -1567,8 +1685,8 @@ describe("oauth2", async () => {
 						pkce: true,
 						allowSignUpWithoutEmail: true,
 						getUserInfo: async () => ({
-							id: `no-email-multi-${suffix}`,
-							name: `No Email ${suffix}`,
+							id: accountId,
+							name: `No Email ${accountId}`,
 							emailVerified: false,
 						}),
 					})),
@@ -1583,10 +1701,10 @@ describe("oauth2", async () => {
 		});
 
 		const emails: (string | undefined)[] = [];
-		for (const suffix of ["a", "b"]) {
+		for (const { providerId } of identities) {
 			const headers = new Headers();
 			const signIn = await authClient.signIn.oauth2({
-				providerId: `no-email-multi-${suffix}`,
+				providerId,
 				callbackURL: "http://localhost:3000/dashboard",
 				newUserCallbackURL: "http://localhost:3000/new_user",
 				fetchOptions: { onSuccess: cookieSetter(headers) },

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1429,6 +1429,125 @@ describe("oauth2", async () => {
 		});
 	});
 
+	it("rejects sign-in when the provider returns no email and allowSignUpWithoutEmail is not set", async () => {
+		// Default behavior must be unchanged: a profile without an email is
+		// rejected at the callback.
+		// @see https://github.com/better-auth/better-auth/issues/9124
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "no-email-rejected-test",
+							authorizationUrl: `http://localhost:${port}/authorize`,
+							tokenUrl: `http://localhost:${port}/token`,
+							clientId: clientId,
+							clientSecret: clientSecret,
+							pkce: true,
+							getUserInfo: async () => ({
+								id: "no-email-rejected",
+								name: "No Email User",
+								emailVerified: false,
+							}),
+						},
+					],
+				}),
+			],
+		});
+		const ctx = await auth.$context;
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: { customFetchImpl },
+		});
+
+		const headers = new Headers();
+		const signIn = await authClient.signIn.oauth2({
+			providerId: "no-email-rejected-test",
+			callbackURL: "http://localhost:3000/dashboard",
+			fetchOptions: { onSuccess: cookieSetter(headers) },
+		});
+		const flow = await simulateOAuthFlow(
+			signIn.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+		expect(flow.callbackURL).toContain("error=email_is_missing");
+
+		const accounts = await ctx.adapter.findMany({
+			model: "account",
+			where: [{ field: "providerId", value: "no-email-rejected-test" }],
+		});
+		expect(accounts).toHaveLength(0);
+	});
+
+	it("completes sign-in when the provider returns no email and allowSignUpWithoutEmail is set", async () => {
+		// A provider that omits an email (e.g. a Discord phone-only account) must
+		// be able to sign in/up when the developer opts in, instead of throwing.
+		// @see https://github.com/better-auth/better-auth/issues/9124
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "no-email-allowed-test",
+							authorizationUrl: `http://localhost:${port}/authorize`,
+							tokenUrl: `http://localhost:${port}/token`,
+							clientId: clientId,
+							clientSecret: clientSecret,
+							pkce: true,
+							allowSignUpWithoutEmail: true,
+							getUserInfo: async () => ({
+								id: "no-email-user",
+								name: "No Email User",
+								emailVerified: false,
+							}),
+						},
+					],
+				}),
+			],
+		});
+		const ctx = await auth.$context;
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: { customFetchImpl },
+		});
+
+		const headers = new Headers();
+		const signIn = await authClient.signIn.oauth2({
+			providerId: "no-email-allowed-test",
+			callbackURL: "http://localhost:3000/dashboard",
+			newUserCallbackURL: "http://localhost:3000/new_user",
+			fetchOptions: { onSuccess: cookieSetter(headers) },
+		});
+		const flow = await simulateOAuthFlow(
+			signIn.data?.url || "",
+			headers,
+			customFetchImpl,
+		);
+		// Sign-in succeeds: the user is created and redirected, not bounced to an
+		// error page.
+		expect(flow.callbackURL).not.toContain("error=");
+		expect(flow.callbackURL).toBe("http://localhost:3000/new_user");
+
+		const session = await authClient.getSession({
+			fetchOptions: { headers: flow.headers },
+		});
+		expect(session.data).not.toBeNull();
+		// The user was created with an empty email rather than failing.
+		expect(session.data?.user.email).toBe("");
+
+		const accounts = await ctx.internalAdapter.findAccounts(
+			session.data?.user.id!,
+		);
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]).toMatchObject({
+			providerId: "no-email-allowed-test",
+			accountId: "no-email-user",
+		});
+	});
+
 	it("completes sign-in when mapProfileToUser derives the account id from a non-standard userinfo field", async () => {
 		server.service.once("beforeUserinfo", (userInfoResponse) => {
 			userInfoResponse.body = {

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -1535,8 +1535,12 @@ describe("oauth2", async () => {
 			fetchOptions: { headers: flow.headers },
 		});
 		expect(session.data).not.toBeNull();
-		// The user was created with an empty email rather than failing.
-		expect(session.data?.user.email).toBe("");
+		// The user is created with a synthetic, per-account placeholder email on the
+		// reserved `.invalid` TLD (the column is unique+required until v2) rather than
+		// failing — and not a literal "" that would collide for a second such user.
+		expect(session.data?.user.email).toMatch(
+			/^no-email\+.*@better-auth\.invalid$/,
+		);
 
 		const accounts = await ctx.internalAdapter.findAccounts(
 			session.data?.user.id!,
@@ -1546,6 +1550,68 @@ describe("oauth2", async () => {
 			providerId: "no-email-allowed-test",
 			accountId: "no-email-user",
 		});
+	});
+
+	it("creates distinct users for multiple providers that return no email", async () => {
+		// Regression for the unique+required email column: two email-less sign-ups
+		// must not collide on a shared "" placeholder. @see #9124
+		const { customFetchImpl, auth, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: ["a", "b"].map((suffix) => ({
+						providerId: `no-email-multi-${suffix}`,
+						authorizationUrl: `http://localhost:${port}/authorize`,
+						tokenUrl: `http://localhost:${port}/token`,
+						clientId: clientId,
+						clientSecret: clientSecret,
+						pkce: true,
+						allowSignUpWithoutEmail: true,
+						getUserInfo: async () => ({
+							id: `no-email-multi-${suffix}`,
+							name: `No Email ${suffix}`,
+							emailVerified: false,
+						}),
+					})),
+				}),
+			],
+		});
+		const ctx = await auth.$context;
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: { customFetchImpl },
+		});
+
+		const emails: (string | undefined)[] = [];
+		for (const suffix of ["a", "b"]) {
+			const headers = new Headers();
+			const signIn = await authClient.signIn.oauth2({
+				providerId: `no-email-multi-${suffix}`,
+				callbackURL: "http://localhost:3000/dashboard",
+				newUserCallbackURL: "http://localhost:3000/new_user",
+				fetchOptions: { onSuccess: cookieSetter(headers) },
+			});
+			const flow = await simulateOAuthFlow(
+				signIn.data?.url || "",
+				headers,
+				customFetchImpl,
+			);
+			// Both sign-ups succeed — the second is not bounced by a unique violation.
+			expect(flow.callbackURL).not.toContain("error=");
+			const session = await authClient.getSession({
+				fetchOptions: { headers: flow.headers },
+			});
+			emails.push(session.data?.user.email);
+		}
+		// Each placeholder is synthetic and unique, so the unique index is satisfied.
+		expect(emails[0]).toMatch(/^no-email\+.*@better-auth\.invalid$/);
+		expect(emails[1]).toMatch(/^no-email\+.*@better-auth\.invalid$/);
+		expect(emails[0]).not.toBe(emails[1]);
+		expect(
+			(await ctx.internalAdapter.listUsers(10, 0)).filter((user) =>
+				user.email.startsWith("no-email+"),
+			),
+		).toHaveLength(2);
 	});
 
 	it("completes sign-in when mapProfileToUser derives the account id from a non-standard userinfo field", async () => {

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -432,8 +432,9 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 					GENERIC_OAUTH_ERROR_CODES.INVALID_OAUTH_CONFIG,
 				);
 			}
-			const userInfo: Omit<User, "createdAt" | "updatedAt"> =
-				await (async function handleUserInfo() {
+			const userInfo: Omit<User, "createdAt" | "updatedAt" | "email"> & {
+				email?: string | null | undefined;
+			} = await (async function handleUserInfo() {
 					const userInfo = (
 						providerConfig.getUserInfo
 							? await providerConfig.getUserInfo(tokens)
@@ -448,7 +449,7 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 					const email = mapUser.email
 						? mapUser.email.toLowerCase()
 						: userInfo.email?.toLowerCase();
-					if (!email) {
+					if (!email && !providerConfig.allowSignUpWithoutEmail) {
 						ctx.context.logger.error(
 							missingEmailLogMessage(providerConfig.providerId, {
 								source: "generic",
@@ -492,7 +493,7 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 				if (
 					ctx.context.options.account?.accountLinking?.allowDifferentEmails !==
 						true &&
-					link.email.toLowerCase() !== userInfo.email.toLowerCase()
+					link.email.toLowerCase() !== userInfo.email?.toLowerCase()
 				) {
 					redirectOnError(ctx, resolvedErrorURL, "email_doesn't_match");
 				}

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -435,60 +435,61 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 			const userInfo: Omit<User, "createdAt" | "updatedAt" | "email"> & {
 				email?: string | null | undefined;
 			} = await (async function handleUserInfo() {
-					const userInfo = (
-						providerConfig.getUserInfo
-							? await providerConfig.getUserInfo(tokens)
-							: await getUserInfo(tokens, finalUserInfoUrl)
-					) as GenericOAuthUserInfo | null;
-					if (!userInfo) {
-						redirectOnError(ctx, resolvedErrorURL, "user_info_is_missing");
-					}
-					const mapUser = providerConfig.mapProfileToUser
-						? await providerConfig.mapProfileToUser(userInfo)
-						: userInfo;
-					const email = mapUser.email
-						? mapUser.email.toLowerCase()
-						: userInfo.email?.toLowerCase();
-					if (!email && !providerConfig.allowSignUpWithoutEmail) {
-						ctx.context.logger.error(
-							missingEmailLogMessage(providerConfig.providerId, {
-								source: "generic",
-							}),
-							userInfo,
-						);
-						redirectOnError(ctx, resolvedErrorURL, "email_is_missing");
-					}
-					const rawId = isNonEmptyOAuthId(mapUser.id)
-						? mapUser.id
-						: isNonEmptyOAuthId(userInfo.id)
-							? userInfo.id
-							: isNonEmptyOAuthId(userInfo.sub)
-								? userInfo.sub
-								: undefined;
-					const id = rawId !== undefined ? String(rawId) : "";
-					// A provider must return a stable account id (e.g. `sub`).
-					// Without one, every account would be stored under the same
-					// empty id, letting different users resolve to the same account.
-					if (!id) {
-						ctx.context.logger.error(
-							"Provider did not return an account id (e.g. `sub`). Unable to sign in.",
-							userInfo,
-						);
-						redirectOnError(ctx, resolvedErrorURL, "id_is_missing");
-					}
-					const name = mapUser.name ? mapUser.name : userInfo.name;
-					if (!name) {
-						ctx.context.logger.error("Unable to get user info", userInfo);
-						redirectOnError(ctx, resolvedErrorURL, "name_is_missing");
-					}
-					return {
-						...userInfo,
-						...mapUser,
-						email,
-						id,
-						name,
-					};
-				})();
+				const userInfo = (
+					providerConfig.getUserInfo
+						? await providerConfig.getUserInfo(tokens)
+						: await getUserInfo(tokens, finalUserInfoUrl)
+				) as GenericOAuthUserInfo | null;
+				if (!userInfo) {
+					redirectOnError(ctx, resolvedErrorURL, "user_info_is_missing");
+				}
+				const mapUser = providerConfig.mapProfileToUser
+					? await providerConfig.mapProfileToUser(userInfo)
+					: userInfo;
+				const email =
+					mapUser.email?.trim().toLowerCase() ||
+					userInfo.email?.trim().toLowerCase() ||
+					undefined;
+				if (!email && !providerConfig.allowSignUpWithoutEmail) {
+					ctx.context.logger.error(
+						missingEmailLogMessage(providerConfig.providerId, {
+							source: "generic",
+						}),
+						userInfo,
+					);
+					redirectOnError(ctx, resolvedErrorURL, "email_is_missing");
+				}
+				const rawId = isNonEmptyOAuthId(mapUser.id)
+					? mapUser.id
+					: isNonEmptyOAuthId(userInfo.id)
+						? userInfo.id
+						: isNonEmptyOAuthId(userInfo.sub)
+							? userInfo.sub
+							: undefined;
+				const id = rawId !== undefined ? String(rawId) : "";
+				// A provider must return a stable account id (e.g. `sub`).
+				// Without one, every account would be stored under the same
+				// empty id, letting different users resolve to the same account.
+				if (!id) {
+					ctx.context.logger.error(
+						"Provider did not return an account id (e.g. `sub`). Unable to sign in.",
+						userInfo,
+					);
+					redirectOnError(ctx, resolvedErrorURL, "id_is_missing");
+				}
+				const name = mapUser.name ? mapUser.name : userInfo.name;
+				if (!name) {
+					ctx.context.logger.error("Unable to get user info", userInfo);
+					redirectOnError(ctx, resolvedErrorURL, "name_is_missing");
+				}
+				return {
+					...userInfo,
+					...mapUser,
+					email,
+					id,
+					name,
+				};
+			})();
 			if (link) {
 				if (
 					ctx.context.options.account?.accountLinking?.allowDifferentEmails !==
@@ -570,6 +571,7 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 					disableSignUp:
 						(providerConfig.disableImplicitSignUp && !requestSignUp) ||
 						providerConfig.disableSignUp,
+					allowSignUpWithoutEmail: providerConfig.allowSignUpWithoutEmail,
 					overrideUserInfo: providerConfig.overrideUserInfo,
 				});
 			} catch (e) {

--- a/packages/better-auth/src/plugins/generic-oauth/types.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/types.ts
@@ -194,8 +194,8 @@ export interface GenericOAuthConfig {
 	 *
 	 * By default the callback rejects a profile without an email. Set this to
 	 * `true` for providers that legitimately omit one so the user is created
-	 * with an empty email instead of failing the flow. A missing email is never
-	 * matched against existing users.
+	 * with a synthetic per-account placeholder email instead of failing the
+	 * flow. A missing email is never matched against existing users.
 	 *
 	 * @see https://github.com/better-auth/better-auth/issues/9124
 	 * @default false

--- a/packages/better-auth/src/plugins/generic-oauth/types.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/types.ts
@@ -189,4 +189,16 @@ export interface GenericOAuthConfig {
 	 * @default false
 	 */
 	overrideUserInfo?: boolean | undefined;
+	/**
+	 * Allow sign-up/sign-in when the provider returns no email.
+	 *
+	 * By default the callback rejects a profile without an email. Set this to
+	 * `true` for providers that legitimately omit one so the user is created
+	 * with an empty email instead of failing the flow. A missing email is never
+	 * matched against existing users.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/9124
+	 * @default false
+	 */
+	allowSignUpWithoutEmail?: boolean | undefined;
 }

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -98,13 +98,16 @@ type OAuthProxyStatePackage = {
  * @internal
  */
 type PassthroughPayload = {
-	userInfo: Omit<User, "createdAt" | "updatedAt">;
+	userInfo: Omit<User, "createdAt" | "updatedAt" | "email"> & {
+		email?: string | null | undefined;
+	};
 	account: Omit<Account, "id" | "userId" | "createdAt" | "updatedAt">;
 	state: string;
 	callbackURL: string;
 	newUserURL?: string;
 	errorURL?: string;
 	disableSignUp?: boolean;
+	allowSignUpWithoutEmail?: boolean;
 	timestamp: number;
 };
 
@@ -268,6 +271,7 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							account: payload.account,
 							callbackURL: payload.callbackURL,
 							disableSignUp: payload.disableSignUp,
+							allowSignUpWithoutEmail: payload.allowSignUpWithoutEmail,
 						});
 					} catch (e) {
 						if (isAPIError(e) && e.body?.code) {
@@ -479,7 +483,10 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							throw redirectOnError(ctx, errorURL, "unable_to_get_user_info");
 						}
 
-						if (!userInfo.email) {
+						if (
+							!userInfo.email?.trim() &&
+							!provider.options?.allowSignUpWithoutEmail
+						) {
 							ctx.context.logger.error("Provider did not return email");
 							throw redirectOnError(ctx, errorURL, "email_not_found");
 						}
@@ -514,6 +521,8 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							disableSignUp:
 								(provider.disableImplicitSignUp && !stateData.requestSignUp) ||
 								provider.options?.disableSignUp,
+							allowSignUpWithoutEmail:
+								provider.options?.allowSignUpWithoutEmail,
 							timestamp: Date.now(),
 						};
 

--- a/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
@@ -676,6 +676,106 @@ describe("oauth-proxy", async () => {
 			expect(previewSessions.length).toBe(1);
 		});
 
+		it("should preserve the missing-email opt-in across proxy passthrough", async () => {
+			const noEmailToken = await signJWT(
+				{
+					email_verified: false,
+					name: "No Email User",
+					picture: "",
+					exp: 1234567890,
+					sub: "proxy-no-email-user",
+					iat: 1234567890,
+					aud: "test",
+					azp: "test",
+					nbf: 1234567890,
+					iss: "test",
+					locale: "en",
+					jti: "proxy-no-email",
+					given_name: "No Email",
+					family_name: "User",
+				} as GoogleProfile,
+				DEFAULT_SECRET,
+			);
+			server.use(
+				http.post("https://oauth2.googleapis.com/token", () =>
+					HttpResponse.json({
+						access_token: "test",
+						refresh_token: "test",
+						id_token: noEmailToken,
+					}),
+				),
+			);
+
+			const production = await getTestInstance(
+				{
+					baseURL: "http://localhost:3000",
+					plugins: [oAuthProxy()],
+					socialProviders: {
+						google: {
+							clientId: "test",
+							clientSecret: "test",
+							allowSignUpWithoutEmail: true,
+						},
+					},
+				},
+				{ disableTestUser: true },
+			);
+			const preview = await getTestInstance(
+				{
+					baseURL: "http://preview.example.com",
+					plugins: [oAuthProxy({ productionURL: "http://localhost:3000" })],
+					socialProviders: {
+						google: {
+							clientId: "test",
+							clientSecret: "test",
+							allowSignUpWithoutEmail: true,
+						},
+					},
+				},
+				{ disableTestUser: true },
+			);
+
+			const signIn = await preview.client.signIn.social(
+				{ provider: "google", callbackURL: "/dashboard" },
+				{ throw: true },
+			);
+			const state = new URL(signIn.url!).searchParams.get("state");
+			let encryptedProfile: string | null = null;
+			let callbackURL: string | null = null;
+			await production.client.$fetch(
+				`/callback/google?code=test&state=${state}`,
+				{
+					onError(context) {
+						const location = context.response.headers.get("location");
+						if (location?.includes("profile=")) {
+							const url = new URL(location);
+							encryptedProfile = url.searchParams.get("profile");
+							callbackURL = url.searchParams.get("callbackURL");
+						}
+					},
+				},
+			);
+			expect(encryptedProfile).toBeTruthy();
+
+			await preview.client.$fetch(
+				`/oauth-proxy-callback?callbackURL=${encodeURIComponent(callbackURL!)}&profile=${encodeURIComponent(encryptedProfile!)}`,
+				{
+					onError(context) {
+						expect(context.response.headers.get("location")).toContain(
+							"/dashboard",
+						);
+					},
+				},
+			);
+
+			const previewCtx = await preview.auth.$context;
+			const users = await previewCtx.internalAdapter.listUsers();
+			expect(users).toHaveLength(1);
+			expect(users[0]?.email).toMatch(
+				/^no-email\+[a-f0-9]+@better-auth\.invalid$/,
+			);
+		});
+
 		it("should forward result.error verbatim instead of collapsing to user_creation_failed", async () => {
 			const production = await getTestInstance(
 				{

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -1069,9 +1069,9 @@ describe("Google Provider — multiple client IDs", async () => {
 	const iosClientId = "456-ios.googleusercontent.com";
 	const androidClientId = "789-android.googleusercontent.com";
 
-	const signIdToken = (audience: string) =>
+	const signIdToken = (audience: string, email = "mobile-user@example.com") =>
 		new SignJWT({
-			email: "mobile-user@example.com",
+			...(email ? { email } : {}),
 			email_verified: true,
 			name: "Mobile User",
 			sub: "google-sub-999",
@@ -1118,6 +1118,34 @@ describe("Google Provider — multiple client IDs", async () => {
 		expect(res.data!.redirect).toBe(false);
 		const data = res.data as { user: { email: string } };
 		expect(data.user.email).toBe("mobile-user@example.com");
+	});
+
+	it("accepts an email-less id token when the provider opts in", async () => {
+		const idToken = await signIdToken(webClientId, "");
+		const { client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: webClientId,
+						clientSecret: "test-secret",
+						allowSignUpWithoutEmail: true,
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const res = await client.signIn.social({
+			provider: "google",
+			idToken: { token: idToken },
+		});
+
+		expect(res.error).toBeNull();
+		expect(res.data?.redirect).toBe(false);
+		const data = res.data as { user: { email: string } };
+		expect(data.user.email).toMatch(
+			/^no-email\+[a-f0-9]{40}@better-auth\.invalid$/,
+		);
 	});
 
 	it("rejects an id token whose audience is not configured", async () => {

--- a/packages/core/src/oauth2/oauth-provider.ts
+++ b/packages/core/src/oauth2/oauth-provider.ts
@@ -235,4 +235,20 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 	 * @default false
 	 */
 	overrideUserInfoOnSignIn?: boolean | undefined;
+	/**
+	 * Allow sign-up/sign-in when the provider returns no email.
+	 *
+	 * By default Better Auth rejects an OAuth sign-in whose profile carries no
+	 * email, since the local user model treats email as the identity anchor.
+	 * Some providers legitimately return no email (e.g. a Discord account
+	 * registered with a phone number only). Set this to `true` to let such a
+	 * user be created/linked with an empty email instead of failing the flow.
+	 *
+	 * When enabled, a missing email is never matched against existing users, so
+	 * an account with no email can't be linked to the wrong user.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/9124
+	 * @default false
+	 */
+	allowSignUpWithoutEmail?: boolean | undefined;
 };

--- a/packages/core/src/oauth2/oauth-provider.ts
+++ b/packages/core/src/oauth2/oauth-provider.ts
@@ -242,10 +242,9 @@ export type ProviderOptions<Profile extends Record<string, any> = any> = {
 	 * email, since the local user model treats email as the identity anchor.
 	 * Some providers legitimately return no email (e.g. a Discord account
 	 * registered with a phone number only). Set this to `true` to let such a
-	 * user be created/linked with an empty email instead of failing the flow.
-	 *
-	 * When enabled, a missing email is never matched against existing users, so
-	 * an account with no email can't be linked to the wrong user.
+	 * user be created with a synthetic per-account placeholder email instead of
+	 * failing the flow. A missing email is never matched against existing users,
+	 * so an account with no email can't be linked to the wrong user.
 	 *
 	 * @see https://github.com/better-auth/better-auth/issues/9124
 	 * @default false

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -169,7 +169,7 @@ export interface InternalAdapter<
 	deleteSessions(sessionTokens: string[]): Promise<void>;
 
 	findOAuthUser(
-		email: string,
+		email: string | null | undefined,
 		accountId: string,
 		providerId: string,
 	): Promise<{


### PR DESCRIPTION
## Problem

OAuth sign-in hard-required an email, blocking providers that legitimately omit one, such as phone-only Discord accounts.

## Fix

Added the opt-in provider option `allowSignUpWithoutEmail` (default `false`). When enabled:

- missing and whitespace-only emails are never used as account-match keys
- users receive a deterministic collision-resistant SHA-256 placeholder on `better-auth.invalid`
- existing email and `emailVerified` values are preserved when a provider later omits email
- account lookup falls back to `account.userId` when a joined user is unavailable
- the opt-in propagates through built-in OAuth, Generic OAuth, direct ID-token sign-in, and OAuth proxy passthrough

Default missing-email rejection remains unchanged without the opt-in. `link-social` is intentionally not relaxed.

## Verification

- Generic OAuth: 78 passed
- OAuth account linking: 29 passed
- Internal adapter: 52 passed
- New proxy, direct ID-token, collision, whitespace, and join-fallback regressions passed
- `pnpm typecheck`
- Commit hooks: Biome and spell checks passed

The full OAuth proxy file additionally requires PostgreSQL on `localhost:5432`; its other 28 tests passed locally.

Fixes #9124