### PR TITLE
fix: route account-linking logs through the configured logger

### DIFF
--- a/.changeset/oauth-account-linking-logger.md
+++ b/.changeset/oauth-account-linking-logger.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix(oauth): route account-linking logs through the configured logger

--- a/.changeset/oauth-account-linking-logger.md
+++ b/.changeset/oauth-account-linking-logger.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-fix(oauth): route account-linking logs through the configured logger
+OAuth account-linking and create-user error logs now respect a custom `logger` configured in `betterAuth()`, instead of always being written to the default console logger.

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -1768,22 +1768,13 @@ describe("oauth2 - accountLinking.requireLocalEmailVerified: false opt-out", asy
 });
 
 /**
- * Account-linking diagnostics in `handleOAuthUserInfo` must be routed through
- * the configured context logger (`c.context.logger`), not a static console
- * logger, so a developer who supplies a custom `logger.log` can capture,
- * filter, or silence them.
- *
  * @see https://github.com/better-auth/better-auth/issues/9959
  */
 describe("oauth2 - account-linking logs use the configured logger", async () => {
-	const logs: { level: string; message: string }[] = [];
+	const log = vi.fn();
 	const { auth, client, cookieSetter } = await getTestInstance({
 		socialProviders: {
-			google: {
-				clientId: "test",
-				clientSecret: "test",
-				enabled: true,
-			},
+			google: { clientId: "test", clientSecret: "test", enabled: true },
 		},
 		emailAndPassword: {
 			enabled: true,
@@ -1794,43 +1785,16 @@ describe("oauth2 - account-linking logs use the configured logger", async () => 
 				trustedProviders: ["google"],
 			},
 		},
-		logger: {
-			log(level, message) {
-				logs.push({ level, message });
-			},
-		},
+		logger: { log },
 	});
 
 	const ctx = await auth.$context;
 
-	it("routes the failed-link error through the custom logger, not console", async () => {
-		const testEmail = "logger-link-fail@example.com";
-
-		const signUpRes = await client.signUp.email({
-			email: testEmail,
-			password: "password123",
-			name: "Logger Test User",
-		});
-		const userId = signUpRes.data!.user.id;
-
-		// Pre-verify the local user so the link is permitted and execution reaches
-		// the `linkAccount` call rather than being rejected as account_not_linked.
-		await ctx.adapter.update({
-			model: "user",
-			where: [{ field: "id", value: userId }],
-			update: { emailVerified: true },
-		});
-
-		// Force the link to throw so `handleOAuthUserInfo` hits its catch branch,
-		// which logs "Unable to link account" via c.context.logger.error.
-		vi.spyOn(ctx.internalAdapter, "linkAccount").mockRejectedValueOnce(
-			new Error("boom"),
-		);
-
+	async function signInWithGoogle(email: string) {
 		server.use(
 			http.post("https://oauth2.googleapis.com/token", async () => {
 				const profile: GoogleProfile = {
-					email: testEmail,
+					email,
 					email_verified: true,
 					name: "Logger Test User",
 					picture: "https://example.com/photo.jpg",
@@ -1846,34 +1810,52 @@ describe("oauth2 - account-linking logs use the configured logger", async () => 
 					given_name: "Logger",
 					family_name: "User",
 				};
-				const idToken = await signJWT(profile, DEFAULT_SECRET);
 				return HttpResponse.json({
 					access_token: "test_access_token",
 					refresh_token: "test_refresh_token",
-					id_token: idToken,
+					id_token: await signJWT(profile, DEFAULT_SECRET),
 				});
 			}),
 		);
-
-		const oAuthHeaders = new Headers();
+		const headers = new Headers();
 		const signInRes = await client.signIn.social({
 			provider: "google",
 			callbackURL: "/",
-			fetchOptions: { onSuccess: cookieSetter(oAuthHeaders) },
+			fetchOptions: { onSuccess: cookieSetter(headers) },
 		});
 		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
 		await client.$fetch("/callback/google", {
 			query: { state, code: "test_code" },
 			method: "GET",
-			headers: oAuthHeaders,
+			headers,
+		});
+	}
+
+	it("forwards the failed-link error to the custom logger", async () => {
+		const email = "logger-link-fail@example.com";
+		const { data } = await client.signUp.email({
+			email,
+			password: "password123",
+			name: "Logger Test User",
 		});
 
-		// The custom logger — not just console — received the diagnostic.
-		const linkError = logs.find(
-			(entry) =>
-				entry.level === "error" &&
-				entry.message.includes("Unable to link account"),
+		// Pre-verify so the link passes the gate and reaches `linkAccount`.
+		await ctx.adapter.update({
+			model: "user",
+			where: [{ field: "id", value: data!.user.id }],
+			update: { emailVerified: true },
+		});
+		// Force the link to throw, hitting the `c.context.logger.error` branch.
+		vi.spyOn(ctx.internalAdapter, "linkAccount").mockRejectedValueOnce(
+			new Error("boom"),
 		);
-		expect(linkError).toBeDefined();
+
+		await signInWithGoogle(email);
+
+		expect(log).toHaveBeenCalledWith(
+			"error",
+			"Unable to link account",
+			expect.anything(),
+		);
 	});
 });

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -1766,3 +1766,114 @@ describe("oauth2 - accountLinking.requireLocalEmailVerified: false opt-out", asy
 		expect(promoted?.emailVerified).toBe(true);
 	});
 });
+
+/**
+ * Account-linking diagnostics in `handleOAuthUserInfo` must be routed through
+ * the configured context logger (`c.context.logger`), not a static console
+ * logger, so a developer who supplies a custom `logger.log` can capture,
+ * filter, or silence them.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/9959
+ */
+describe("oauth2 - account-linking logs use the configured logger", async () => {
+	const logs: { level: string; message: string }[] = [];
+	const { auth, client, cookieSetter } = await getTestInstance({
+		socialProviders: {
+			google: {
+				clientId: "test",
+				clientSecret: "test",
+				enabled: true,
+			},
+		},
+		emailAndPassword: {
+			enabled: true,
+		},
+		account: {
+			accountLinking: {
+				enabled: true,
+				trustedProviders: ["google"],
+			},
+		},
+		logger: {
+			log(level, message) {
+				logs.push({ level, message });
+			},
+		},
+	});
+
+	const ctx = await auth.$context;
+
+	it("routes the failed-link error through the custom logger, not console", async () => {
+		const testEmail = "logger-link-fail@example.com";
+
+		const signUpRes = await client.signUp.email({
+			email: testEmail,
+			password: "password123",
+			name: "Logger Test User",
+		});
+		const userId = signUpRes.data!.user.id;
+
+		// Pre-verify the local user so the link is permitted and execution reaches
+		// the `linkAccount` call rather than being rejected as account_not_linked.
+		await ctx.adapter.update({
+			model: "user",
+			where: [{ field: "id", value: userId }],
+			update: { emailVerified: true },
+		});
+
+		// Force the link to throw so `handleOAuthUserInfo` hits its catch branch,
+		// which logs "Unable to link account" via c.context.logger.error.
+		vi.spyOn(ctx.internalAdapter, "linkAccount").mockRejectedValueOnce(
+			new Error("boom"),
+		);
+
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async () => {
+				const profile: GoogleProfile = {
+					email: testEmail,
+					email_verified: true,
+					name: "Logger Test User",
+					picture: "https://example.com/photo.jpg",
+					exp: 1234567890,
+					sub: "google_logger_link_fail",
+					iat: 1234567890,
+					aud: "test",
+					azp: "test",
+					nbf: 1234567890,
+					iss: "test",
+					locale: "en",
+					jti: "test",
+					given_name: "Logger",
+					family_name: "User",
+				};
+				const idToken = await signJWT(profile, DEFAULT_SECRET);
+				return HttpResponse.json({
+					access_token: "test_access_token",
+					refresh_token: "test_refresh_token",
+					id_token: idToken,
+				});
+			}),
+		);
+
+		const oAuthHeaders = new Headers();
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/",
+			fetchOptions: { onSuccess: cookieSetter(oAuthHeaders) },
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test_code" },
+			method: "GET",
+			headers: oAuthHeaders,
+		});
+
+		// The custom logger — not just console — received the diagnostic.
+		const linkError = logs.find(
+			(entry) =>
+				entry.level === "error" &&
+				entry.message.includes("Unable to link account"),
+		);
+		expect(linkError).toBeDefined();
+	});
+});

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -1,5 +1,5 @@
 import type { GenericEndpointContext } from "@better-auth/core";
-import { isDevelopment, logger } from "@better-auth/core/env";
+import { isDevelopment } from "@better-auth/core/env";
 import { createEmailVerificationToken } from "../api";
 import { setAccountCookie } from "../cookies/session-store";
 import type { Account, User } from "../types";
@@ -42,7 +42,7 @@ export async function handleOAuthUserInfo(
 			account.providerId,
 		)
 		.catch((e) => {
-			logger.error(
+			c.context.logger.error(
 				"Better auth was unable to query your database.\nError: ",
 				e,
 			);
@@ -78,7 +78,7 @@ export async function handleOAuthUserInfo(
 				accountLinking?.disableImplicitLinking === true
 			) {
 				if (isDevelopment()) {
-					logger.warn(
+					c.context.logger.warn(
 						`User already exist but account isn't linked to ${account.providerId}. To read more about how account linking works in Better Auth see https://www.better-auth.com/docs/concepts/users-accounts#account-linking.`,
 					);
 				}
@@ -100,7 +100,7 @@ export async function handleOAuthUserInfo(
 					scope: account.scope,
 				});
 			} catch (e) {
-				logger.error("Unable to link account", e);
+				c.context.logger.error("Unable to link account", e);
 				return {
 					error: "unable to link account",
 					data: null,
@@ -236,7 +236,7 @@ export async function handleOAuthUserInfo(
 				);
 			}
 		} catch (e: any) {
-			logger.error(e);
+			c.context.logger.error(e);
 			if (isAPIError(e)) {
 				return {
 					error: e.message,


### PR DESCRIPTION
## Problem

`handleOAuthUserInfo` logged via the static console `logger`, so a custom `betterAuth({ logger })` couldn't capture, filter, or silence OAuth create-user / account-link messages — inconsistent with the sibling `applyUpdateUserInfoOnLink`, which already uses the context logger.

## Fix

Switch those calls to `ctx.context.logger` and drop the now-unused `logger` import (keeping `isDevelopment`).

## Tests

Added a test in `link-account.test.ts` that configures a custom `logger.log`, forces the link-error path, and asserts the custom logger received the message. Includes a changeset (patch).

Fixes #9959

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route OAuth account-linking and create-user logs through the configured context logger in `better-auth`, so custom `betterAuth({ logger })` can capture, filter, or silence them. Removes console logger usage in `handleOAuthUserInfo`; fixes #9959.

- **Bug Fixes**
  - Use `c.context.logger.*` in `handleOAuthUserInfo` for DB errors, dev warnings, and link errors.
  - Remove unused `logger` import from `@better-auth/core/env` (keep `isDevelopment`).
  - Add a regression test using `vi.fn` and `toHaveBeenCalledWith` to confirm the custom logger gets "Unable to link account" on a failed link.
  - Include a patch changeset with user-facing wording.

<sup>Written for commit 22607d8f165a84086e8b3617258eef3ca49a961a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

