### PR TITLE
fix(generic-oauth): apply and await authorizationUrlParams function form

### DIFF
--- a/.changeset/generic-oauth-authorization-url-params-function.md
+++ b/.changeset/generic-oauth-authorization-url-params-function.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+fix(generic-oauth): apply and await authorizationUrlParams function form

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -2908,9 +2908,8 @@ describe("oauth2", async () => {
 		});
 
 		expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
-		expect(
-			new URL(res.data?.url || "").searchParams.get("resource"),
-		).toBe("https://api.example.com");
+		const url = new URL(res.data?.url || "");
+		expect(url.searchParams.get("resource")).toBe("https://api.example.com");
 	});
 
 	it("should apply authorizationUrlParams provided as an async function", async () => {
@@ -2952,9 +2951,8 @@ describe("oauth2", async () => {
 		});
 
 		expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
-		expect(
-			new URL(res.data?.url || "").searchParams.get("resource"),
-		).toBe("https://api.example.com");
+		const url = new URL(res.data?.url || "");
+		expect(url.searchParams.get("resource")).toBe("https://api.example.com");
 	});
 
 	describe("Duplicate Provider ID Detection", () => {

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -2869,6 +2869,94 @@ describe("oauth2", async () => {
 		expect(session.data?.user.image).toBe(customUserInfo.avatar_url);
 	});
 
+	it("should apply authorizationUrlParams provided as a sync function", async () => {
+		// @see https://github.com/better-auth/better-auth/issues/8741
+		const { customFetchImpl, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "sync-params-provider",
+							clientId: clientId,
+							clientSecret: clientSecret,
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							pkce: true,
+							authorizationUrlParams: () => ({
+								resource: "https://api.example.com",
+							}),
+						},
+					],
+				}),
+			],
+		});
+
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+
+		const headers = new Headers();
+		const res = await authClient.signIn.oauth2({
+			providerId: "sync-params-provider",
+			callbackURL: "http://localhost:3000/dashboard",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
+		expect(
+			new URL(res.data?.url || "").searchParams.get("resource"),
+		).toBe("https://api.example.com");
+	});
+
+	it("should apply authorizationUrlParams provided as an async function", async () => {
+		// @see https://github.com/better-auth/better-auth/issues/8741
+		const { customFetchImpl, cookieSetter } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "async-params-provider",
+							clientId: clientId,
+							clientSecret: clientSecret,
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							pkce: true,
+							authorizationUrlParams: async () => ({
+								resource: "https://api.example.com",
+							}),
+						},
+					],
+				}),
+			],
+		});
+
+		const authClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+
+		const headers = new Headers();
+		const res = await authClient.signIn.oauth2({
+			providerId: "async-params-provider",
+			callbackURL: "http://localhost:3000/dashboard",
+			fetchOptions: {
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
+		expect(
+			new URL(res.data?.url || "").searchParams.get("resource"),
+		).toBe("https://api.example.com");
+	});
+
 	describe("Duplicate Provider ID Detection", () => {
 		it("should warn when duplicate provider IDs are detected", async () => {
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -2869,34 +2869,31 @@ describe("oauth2", async () => {
 		expect(session.data?.user.image).toBe(customUserInfo.avatar_url);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8741
+	 */
 	it("should apply authorizationUrlParams provided as a sync function", async () => {
-		// @see https://github.com/better-auth/better-auth/issues/8741
-		const { customFetchImpl, cookieSetter } = await getTestInstance({
-			plugins: [
-				genericOAuth({
-					config: [
-						{
-							providerId: "sync-params-provider",
-							clientId: clientId,
-							clientSecret: clientSecret,
-							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
-							pkce: true,
-							authorizationUrlParams: () => ({
-								resource: "https://api.example.com",
-							}),
-						},
-					],
-				}),
-			],
-		});
-
-		const authClient = createAuthClient({
-			plugins: [genericOAuthClient()],
-			baseURL: "http://localhost:3000",
-			fetchOptions: {
-				customFetchImpl,
+		const { client: authClient, cookieSetter } = await getTestInstance(
+			{
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "sync-params-provider",
+								clientId: clientId,
+								clientSecret: clientSecret,
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								pkce: true,
+								authorizationUrlParams: () => ({
+									resource: "https://api.example.com",
+								}),
+							},
+						],
+					}),
+				],
 			},
-		});
+			{ clientOptions: { plugins: [genericOAuthClient()] } },
+		);
 
 		const headers = new Headers();
 		const res = await authClient.signIn.oauth2({
@@ -2912,34 +2909,31 @@ describe("oauth2", async () => {
 		expect(url.searchParams.get("resource")).toBe("https://api.example.com");
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8741
+	 */
 	it("should apply authorizationUrlParams provided as an async function", async () => {
-		// @see https://github.com/better-auth/better-auth/issues/8741
-		const { customFetchImpl, cookieSetter } = await getTestInstance({
-			plugins: [
-				genericOAuth({
-					config: [
-						{
-							providerId: "async-params-provider",
-							clientId: clientId,
-							clientSecret: clientSecret,
-							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
-							pkce: true,
-							authorizationUrlParams: async () => ({
-								resource: "https://api.example.com",
-							}),
-						},
-					],
-				}),
-			],
-		});
-
-		const authClient = createAuthClient({
-			plugins: [genericOAuthClient()],
-			baseURL: "http://localhost:3000",
-			fetchOptions: {
-				customFetchImpl,
+		const { client: authClient, cookieSetter } = await getTestInstance(
+			{
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "async-params-provider",
+								clientId: clientId,
+								clientSecret: clientSecret,
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								pkce: true,
+								authorizationUrlParams: async () => ({
+									resource: "https://api.example.com",
+								}),
+							},
+						],
+					}),
+				],
 			},
-		});
+			{ clientOptions: { plugins: [genericOAuthClient()] } },
+		);
 
 		const headers = new Headers();
 		const res = await authClient.signIn.oauth2({
@@ -2953,6 +2947,46 @@ describe("oauth2", async () => {
 		expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
 		const url = new URL(res.data?.url || "");
 		expect(url.searchParams.get("resource")).toBe("https://api.example.com");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8741
+	 */
+	it("should apply authorizationUrlParams function results when linking", async () => {
+		const { client: authClient, signInWithTestUser } = await getTestInstance(
+			{
+				plugins: [
+					genericOAuth({
+						config: [
+							{
+								providerId: "link-params-provider",
+								clientId: clientId,
+								clientSecret: clientSecret,
+								discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+								pkce: true,
+								authorizationUrlParams: async () => ({
+									resource: "https://api.example.com/link",
+								}),
+							},
+						],
+					}),
+				],
+			},
+			{ clientOptions: { plugins: [genericOAuthClient()] } },
+		);
+		const { headers } = await signInWithTestUser();
+
+		const res = await authClient.oauth2.link({
+			providerId: "link-params-provider",
+			callbackURL: "http://localhost:3000/settings",
+			fetchOptions: { headers },
+		});
+
+		expect(res.data?.url).toContain(`http://localhost:${port}/authorize`);
+		const url = new URL(res.data?.url || "");
+		expect(url.searchParams.get("resource")).toBe(
+			"https://api.example.com/link",
+		);
 	});
 
 	describe("Duplicate Provider ID Detection", () => {

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -181,18 +181,9 @@ export const signInWithOAuth2 = (options: GenericOAuthOptions) =>
 					GENERIC_OAUTH_ERROR_CODES.INVALID_OAUTH_CONFIGURATION,
 				);
 			}
-			if (authorizationUrlParams) {
-				const withAdditionalParams = new URL(finalAuthUrl);
-				for (const [paramName, paramValue] of Object.entries(
-					authorizationUrlParams,
-				)) {
-					withAdditionalParams.searchParams.set(paramName, paramValue);
-				}
-				finalAuthUrl = withAdditionalParams.toString();
-			}
 			const additionalParams =
 				typeof authorizationUrlParams === "function"
-					? authorizationUrlParams(ctx)
+					? await authorizationUrlParams(ctx)
 					: authorizationUrlParams;
 
 			const { state, codeVerifier } = await generateState(
@@ -758,7 +749,7 @@ export const oAuth2LinkAccount = (options: GenericOAuthOptions) =>
 
 			const additionalParams =
 				typeof authorizationUrlParams === "function"
-					? authorizationUrlParams(c)
+					? await authorizationUrlParams(c)
 					: authorizationUrlParams;
 
 			const url = await createAuthorizationURL({

--- a/packages/better-auth/src/plugins/generic-oauth/types.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/types.ts
@@ -1,4 +1,4 @@
-import type { GenericEndpointContext } from "@better-auth/core";
+import type { Awaitable, GenericEndpointContext } from "@better-auth/core";
 import type { User } from "@better-auth/core/db";
 import type { OAuth2Tokens, OAuth2UserInfo } from "@better-auth/core/oauth2";
 
@@ -142,12 +142,8 @@ export interface GenericOAuthConfig {
 	 * Warning: Search-params added here overwrite any default params.
 	 */
 	authorizationUrlParams?:
-		| (
-				| Record<string, string>
-				| ((
-						ctx: GenericEndpointContext,
-				  ) => Record<string, string> | Promise<Record<string, string>>)
-		  )
+		| Record<string, string>
+		| ((ctx: GenericEndpointContext) => Awaitable<Record<string, string>>)
 		| undefined;
 	/**
 	 * Additional search-params to add to the tokenUrl.

--- a/packages/better-auth/src/plugins/generic-oauth/types.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/types.ts
@@ -144,7 +144,9 @@ export interface GenericOAuthConfig {
 	authorizationUrlParams?:
 		| (
 				| Record<string, string>
-				| ((ctx: GenericEndpointContext) => Record<string, string>)
+				| ((
+						ctx: GenericEndpointContext,
+				  ) => Record<string, string> | Promise<Record<string, string>>)
 		  )
 		| undefined;
 	/**


### PR DESCRIPTION
## Problem

When `authorizationUrlParams` was given as a function (especially async), its params were silently dropped: a dead `Object.entries(authorizationUrlParams)` loop ran on the raw value (a no-op for functions), and the function call wasn't awaited, so `createAuthorizationURL` received a Promise and added nothing.

## Fix

Remove the dead loop, `await` the function in the sign-in and link paths (matching the `tokenUrlParams` pattern), and widen the type to allow an async return.

## Tests

Added genericOAuth tests asserting the authorization URL contains a function-provided param, for both sync and async functions. Includes a changeset (patch).

Fixes #8741

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes function-based `authorizationUrlParams` in `generic-oauth` so params from sync or async functions are applied to the authorization URL in both sign-in and link flows. Prevents dropped params and aligns with `tokenUrlParams`.

- **Bug Fixes**
  - Await `authorizationUrlParams(ctx)` and pass resolved params to `createAuthorizationURL` in sign-in and link paths; remove the dead `Object.entries` loop.
  - Use `Awaitable<Record<string, string>>` for the function return type (from `@better-auth/core`).
  - Add tests for sync/async functions and for the link flow verifying params are present; tidy assertions for `biome`; include patch changeset.

<sup>Written for commit e443dfa965813bd0e3c79b8f9e906e463226a828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

