### PR TITLE
fix(oauth): preserve user on null profile override

### DIFF
--- a/.changeset/oauth-override-user-null.md
+++ b/.changeset/oauth-override-user-null.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Preserve the resolved OAuth user when `overrideUserInfo` returns `null` during account linking.

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -1203,6 +1203,10 @@ describe("oauth2 - override user info on sign-in", async () => {
 
 	const ctx = await auth.$context;
 
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("should update user info when overrideUserInfo is enabled", async () => {
 		const testEmail = "override@example.com";
 
@@ -1269,6 +1273,68 @@ describe("oauth2 - override user info on sign-in", async () => {
 		});
 
 		expect(session.data?.user.name).toBe("Updated Name");
+	});
+
+	it("should preserve the resolved user when overrideUserInfo update returns null", async () => {
+		const testEmail = "override-null@example.com";
+
+		await ctx.adapter.create({
+			model: "user",
+			data: {
+				email: testEmail,
+				name: "Initial Name",
+				emailVerified: true,
+			},
+		});
+
+		const originalUpdate = ctx.adapter.update.bind(ctx.adapter);
+		vi.spyOn(ctx.adapter, "update").mockImplementation(async (payload) => {
+			const result = await originalUpdate(payload);
+			return payload.model === "user" ? null : result;
+		});
+
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async () => {
+				const profile: GoogleProfile = {
+					sub: "google_null_update",
+					email: testEmail,
+					email_verified: true,
+					name: "Updated Name",
+				} as GoogleProfile;
+				const idToken = await signJWT(profile, DEFAULT_SECRET);
+				return HttpResponse.json({
+					access_token: "test_token",
+					id_token: idToken,
+				});
+			}),
+		);
+
+		const oAuthHeaders = new Headers();
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/",
+			fetchOptions: {
+				onSuccess: cookieSetter(oAuthHeaders),
+			},
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test_code" },
+			method: "GET",
+			headers: oAuthHeaders,
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				cookieSetter(oAuthHeaders)(context);
+			},
+		});
+
+		const session = await client.getSession({
+			fetchOptions: {
+				headers: oAuthHeaders,
+			},
+		});
+
+		expect(session.data?.user.email).toBe(testEmail);
 	});
 });
 

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -187,15 +187,23 @@ export async function handleOAuthUserInfo(
 		if (overrideUserInfo) {
 			const { id: _, ...restUserInfo } = userInfo;
 			// update user info from the provider if overrideUserInfo is true
-			user =
-				(await c.context.internalAdapter.updateUser(dbUser.user.id, {
+			const updatedUser = await c.context.internalAdapter.updateUser(
+				dbUser.user.id,
+				{
 					...restUserInfo,
 					email: userInfo.email.toLowerCase(),
 					emailVerified:
 						userInfo.email.toLowerCase() === dbUser.user.email
 							? dbUser.user.emailVerified || userInfo.emailVerified
 							: userInfo.emailVerified,
-				})) ?? user;
+				},
+			);
+			if (updatedUser == null) {
+				logger.warn(
+					"Could not update user info during OAuth sign in; preserving existing user for session.",
+				);
+			}
+			user = updatedUser ?? user;
 		}
 	} else {
 		if (disableSignUp) {

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -187,14 +187,15 @@ export async function handleOAuthUserInfo(
 		if (overrideUserInfo) {
 			const { id: _, ...restUserInfo } = userInfo;
 			// update user info from the provider if overrideUserInfo is true
-			user = await c.context.internalAdapter.updateUser(dbUser.user.id, {
-				...restUserInfo,
-				email: userInfo.email.toLowerCase(),
-				emailVerified:
-					userInfo.email.toLowerCase() === dbUser.user.email
-						? dbUser.user.emailVerified || userInfo.emailVerified
-						: userInfo.emailVerified,
-			});
+			user =
+				(await c.context.internalAdapter.updateUser(dbUser.user.id, {
+					...restUserInfo,
+					email: userInfo.email.toLowerCase(),
+					emailVerified:
+						userInfo.email.toLowerCase() === dbUser.user.email
+							? dbUser.user.emailVerified || userInfo.emailVerified
+							: userInfo.emailVerified,
+				})) ?? user;
 		}
 	} else {
 		if (disableSignUp) {


### PR DESCRIPTION
Preserves the previously resolved user when `overrideUserInfoOnSignIn` runs but the adapter update returns `null`.

The DB adapter contract allows `update` to return `null`; the OAuth sign-in path should not turn that into a failed sign-in after the user and account have already been resolved. This keeps the existing user for session creation when the profile sync cannot return a fresh row.