### PR TITLE
fix(oauth): preserve account.scope across re-auth and refresh

### DIFF
--- a/.changeset/quiet-pandas-merge.md
+++ b/.changeset/quiet-pandas-merge.md
@@ -1,0 +1,6 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+---
+
+Preserve previously granted OAuth scopes across sign-in re-authentication and refresh-token requests. `account.scope` now accumulates monotonically: newly granted scopes are merged in only when added via `linkSocial`, and providers returning a narrower scope claim than the user has granted no longer shrink the stored value.

--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -509,6 +509,10 @@ Users already signed in can manually link their account to additional social pro
   });
   ```
 
+  <Callout type="info">
+    Newly granted scopes are merged into `account.scope`, so prior grants survive incremental authorization. Sign-in re-authentication and refresh-token responses do not modify `account.scope`.
+  </Callout>
+
   You can also link accounts using ID tokens directly, without redirecting to the provider's OAuth flow:
 
   ```ts

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -201,6 +201,59 @@ describe("account", async () => {
 		});
 	});
 
+	it("should not expose empty scope tokens from stored empty account scope", async () => {
+		const {
+			auth,
+			client: scopedClient,
+			testUser,
+			cookieSetter,
+		} = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+				},
+			},
+		});
+		const headers = new Headers();
+		await scopedClient.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{ onSuccess: cookieSetter(headers) },
+		);
+		const session = await scopedClient.getSession({
+			fetchOptions: { headers },
+		});
+		const accountId = "empty-scope-google-account";
+		const testCtx = await auth.$context;
+		await testCtx.internalAdapter.createAccount({
+			userId: session.data!.user.id,
+			providerId: "google",
+			accountId,
+			accessToken: "access-token",
+			scope: "",
+		});
+
+		const accounts = await scopedClient.listAccounts({
+			fetchOptions: { headers },
+		});
+		const googleAccount = accounts.data?.find(
+			(account) => account.accountId === accountId,
+		);
+		expect(googleAccount?.scopes).toEqual([]);
+
+		const accessToken = await scopedClient.getAccessToken(
+			{
+				providerId: "google",
+				accountId,
+			},
+			{ headers },
+		);
+		expect(accessToken.data?.scopes).toEqual([]);
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/8345
 	 */

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -892,9 +892,9 @@ export const refreshToken = createAuthEndpoint(
 				providerId === accountData.providerId &&
 				ctx.context.options.account?.storeAccountCookie
 			) {
-				const updateData = updatedAccount ?? {
+				const updateData = {
 					...accountData,
-					...updatedTokenData,
+					...(updatedAccount ?? updatedTokenData),
 				};
 				await setAccountCookie(ctx, updateData);
 			}

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -33,6 +33,14 @@ import {
 	sessionMiddleware,
 } from "./session";
 
+function parseStoredScopes(scope: string | null | undefined): string[] {
+	if (!scope) return [];
+	return scope
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
 export const listUserAccounts = createAuthEndpoint(
 	"/list-accounts",
 	{
@@ -107,7 +115,7 @@ export const listUserAccounts = createAuthEndpoint(
 				const { scope, ...parsed } = parseAccountOutput(c.context.options, a);
 				return {
 					...parsed,
-					scopes: scope?.split(",") || [],
+					scopes: parseStoredScopes(scope),
 				};
 			}),
 		);
@@ -646,7 +654,7 @@ async function getValidAccessToken(
 				newTokens?.accessToken ??
 				(await decryptOAuthToken(account.accessToken ?? "", ctx.context)),
 			accessTokenExpiresAt,
-			scopes: account.scope?.split(",") ?? [],
+			scopes: parseStoredScopes(account.scope),
 			idToken: newTokens?.idToken ?? account.idToken ?? undefined,
 		};
 	} catch (_error) {

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -860,13 +860,17 @@ export const refreshToken = createAuthEndpoint(
 				tokens.refreshTokenExpiresAt ?? account.refreshTokenExpiresAt;
 
 			if (account.id) {
+				/**
+				 * `scope` intentionally omitted. Refresh response may be narrower.
+				 *
+				 * @see {@link Account.scope}
+				 */
 				const updateData = {
 					...(account || {}),
 					accessToken: await setTokenUtil(tokens.accessToken, ctx.context),
 					refreshToken: resolvedRefreshToken,
 					accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 					refreshTokenExpiresAt: resolvedRefreshTokenExpiresAt,
-					scope: tokens.scopes?.join(",") || account.scope,
 					idToken: tokens.idToken || account.idToken,
 				};
 				await ctx.context.internalAdapter.updateAccount(account.id, updateData);
@@ -883,7 +887,6 @@ export const refreshToken = createAuthEndpoint(
 					refreshToken: resolvedRefreshToken,
 					accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 					refreshTokenExpiresAt: resolvedRefreshTokenExpiresAt,
-					scope: tokens.scopes?.join(",") || accountData.scope,
 					idToken: tokens.idToken || accountData.idToken,
 				};
 				await setAccountCookie(ctx, updateData);

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -866,6 +866,14 @@ export const refreshToken = createAuthEndpoint(
 				: refreshToken;
 			const resolvedRefreshTokenExpiresAt =
 				tokens.refreshTokenExpiresAt ?? account.refreshTokenExpiresAt;
+			const updatedTokenData: Partial<Account> = {
+				accessToken: await setTokenUtil(tokens.accessToken, ctx.context),
+				refreshToken: resolvedRefreshToken,
+				accessTokenExpiresAt: tokens.accessTokenExpiresAt,
+				refreshTokenExpiresAt: resolvedRefreshTokenExpiresAt,
+				idToken: tokens.idToken || account.idToken,
+			};
+			let updatedAccount: Account | null = null;
 
 			if (account.id) {
 				/**
@@ -873,15 +881,10 @@ export const refreshToken = createAuthEndpoint(
 				 *
 				 * @see {@link Account.scope}
 				 */
-				const updateData = {
-					...(account || {}),
-					accessToken: await setTokenUtil(tokens.accessToken, ctx.context),
-					refreshToken: resolvedRefreshToken,
-					accessTokenExpiresAt: tokens.accessTokenExpiresAt,
-					refreshTokenExpiresAt: resolvedRefreshTokenExpiresAt,
-					idToken: tokens.idToken || account.idToken,
-				};
-				await ctx.context.internalAdapter.updateAccount(account.id, updateData);
+				updatedAccount = await ctx.context.internalAdapter.updateAccount(
+					account.id,
+					updatedTokenData,
+				);
 			}
 
 			if (
@@ -889,22 +892,19 @@ export const refreshToken = createAuthEndpoint(
 				providerId === accountData.providerId &&
 				ctx.context.options.account?.storeAccountCookie
 			) {
-				const updateData = {
+				const updateData = updatedAccount ?? {
 					...accountData,
-					accessToken: await setTokenUtil(tokens.accessToken, ctx.context),
-					refreshToken: resolvedRefreshToken,
-					accessTokenExpiresAt: tokens.accessTokenExpiresAt,
-					refreshTokenExpiresAt: resolvedRefreshTokenExpiresAt,
-					idToken: tokens.idToken || accountData.idToken,
+					...updatedTokenData,
 				};
 				await setAccountCookie(ctx, updateData);
 			}
+			const responseScope = updatedAccount?.scope ?? account.scope;
 			return ctx.json({
 				accessToken: tokens.accessToken,
 				refreshToken: tokens.refreshToken ?? decryptedRefreshToken,
 				accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 				refreshTokenExpiresAt: resolvedRefreshTokenExpiresAt,
-				scope: tokens.scopes?.join(",") || account.scope,
+				scope: responseScope,
 				idToken: tokens.idToken || account.idToken,
 				providerId: account.providerId,
 				accountId: account.accountId,

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -1,5 +1,6 @@
 import { createAuthEndpoint } from "@better-auth/core/api";
 import type { OAuth2Tokens } from "@better-auth/core/oauth2";
+import { mergeScopes } from "@better-auth/core/oauth2";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import * as z from "zod";
 import { getAwaitableValue } from "../../context/helpers";
@@ -295,6 +296,7 @@ export const callbackOAuth = createAuthEndpoint(
 						OAUTH_CALLBACK_ERROR_CODES.ACCOUNT_ALREADY_LINKED_TO_DIFFERENT_USER,
 					);
 				}
+				const mergedScope = mergeScopes(existingAccount.scope, tokens.scopes);
 				const updateData = Object.fromEntries(
 					Object.entries({
 						accessToken: await setTokenUtil(tokens.accessToken, c.context),
@@ -302,7 +304,7 @@ export const callbackOAuth = createAuthEndpoint(
 						idToken: tokens.idToken,
 						accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 						refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
-						scope: tokens.scopes?.join(","),
+						scope: mergedScope || undefined,
 					}).filter(([_, value]) => value !== undefined),
 				);
 				await c.context.internalAdapter.updateAccount(

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -144,6 +144,11 @@ export async function handleOAuthUserInfo(
 				source: { ...source, action: "sign-in" },
 			});
 
+			/**
+			 * `scope` intentionally omitted. Updated only via linkSocial.
+			 *
+			 * @see {@link Account.scope}
+			 */
 			const freshTokens =
 				c.context.options.account?.updateAccountOnSignIn !== false
 					? Object.fromEntries(
@@ -156,7 +161,6 @@ export async function handleOAuthUserInfo(
 								),
 								accessTokenExpiresAt: account.accessTokenExpiresAt,
 								refreshTokenExpiresAt: account.refreshTokenExpiresAt,
-								scope: account.scope,
 							}).filter(([_, value]) => value !== undefined),
 						)
 					: {};

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -3393,7 +3393,57 @@ describe("account.scope path-dependent semantics", async () => {
 				}),
 			),
 		);
-		await client.$fetch("/refresh-token", {
+		const refresh = await client.$fetch<{ scope?: string }>("/refresh-token", {
+			body: {
+				accountId: accounts[0]!.accountId,
+				providerId: "google",
+			},
+			headers,
+			method: "POST",
+			onError(c) {
+				cookieSetter(headers)(c as any);
+			},
+		});
+		expect(refresh.data?.scope).toContain(
+			"https://www.googleapis.com/auth/drive.readonly",
+		);
+
+		const after = await ctx.internalAdapter.findAccounts(userId);
+		expect(after[0]!.scope).toContain(
+			"https://www.googleapis.com/auth/drive.readonly",
+		);
+	});
+
+	it("does not write stale account cookie scope on /refresh-token", async () => {
+		const headers = new Headers();
+		const idToken = await buildIdToken("scope-refresh-cookie-sub");
+
+		mockGoogleTokenResponse(idToken, "openid email");
+		await completeSignIn(headers);
+
+		const session = await client.getSession({ fetchOptions: { headers } });
+		const userId = session.data!.user.id;
+		const accounts = await ctx.internalAdapter.findAccounts(userId);
+		const accumulatedScope =
+			"openid,email,profile,https://www.googleapis.com/auth/drive.readonly";
+		await ctx.internalAdapter.updateAccount(accounts[0]!.id, {
+			scope: accumulatedScope,
+		});
+
+		// The account cookie still has the original narrower scope. Refresh must
+		// not write that stale cookie scope back over the stored accumulated grant.
+		mswServer.use(
+			http.post("https://oauth2.googleapis.com/token", () =>
+				HttpResponse.json({
+					access_token: "cookie-refreshed-access-token",
+					refresh_token: "cookie-refreshed-refresh-token",
+					token_type: "Bearer",
+					expires_in: 3600,
+					scope: "openid email",
+				}),
+			),
+		);
+		const refresh = await client.$fetch<{ scope?: string }>("/refresh-token", {
 			body: {
 				accountId: accounts[0]!.accountId,
 				providerId: "google",
@@ -3405,9 +3455,8 @@ describe("account.scope path-dependent semantics", async () => {
 			},
 		});
 
+		expect(refresh.data?.scope).toBe(accumulatedScope);
 		const after = await ctx.internalAdapter.findAccounts(userId);
-		expect(after[0]!.scope).toContain(
-			"https://www.googleapis.com/auth/drive.readonly",
-		);
+		expect(after[0]!.scope).toBe(accumulatedScope);
 	});
 });

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -3205,3 +3205,209 @@ describe("Reddit Provider — profile email mapping", async () => {
 		expect(result?.user.emailVerified).toBe(false);
 	});
 });
+
+/**
+ * `account.scope` is the user's accumulated grant set: linkSocial unions
+ * new scopes; re-auth and refresh-token responses never narrow the stored
+ * set, regardless of what the provider echoes.
+ *
+ * @see https://github.com/better-auth/better-auth/pull/3013
+ */
+describe("account.scope path-dependent semantics", async () => {
+	const { client, cookieSetter, auth } = await getTestInstance(
+		{
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+				},
+			},
+		},
+		{ disableTestUser: true },
+	);
+	const ctx = await auth.$context;
+
+	const buildIdToken = (sub: string) =>
+		signJWT(
+			{
+				email: `${sub}@email.com`,
+				email_verified: true,
+				name: "Scope User",
+				picture: "https://test.com/picture.png",
+				exp: 1234567890,
+				sub,
+				iat: 1234567890,
+				aud: "test",
+				azp: "test",
+				nbf: 1234567890,
+				iss: "test",
+				locale: "en",
+				jti: "test",
+				given_name: "Scope",
+				family_name: "User",
+			} satisfies GoogleProfile,
+			DEFAULT_SECRET,
+		);
+
+	function mockGoogleTokenResponse(
+		idToken: string,
+		responseScope: string | undefined,
+	) {
+		mswServer.use(
+			http.post("https://oauth2.googleapis.com/token", () =>
+				HttpResponse.json({
+					access_token: "test-access-token",
+					refresh_token: "test-refresh-token",
+					id_token: idToken,
+					token_type: "Bearer",
+					expires_in: 3600,
+					...(responseScope !== undefined ? { scope: responseScope } : {}),
+				}),
+			),
+		);
+	}
+
+	async function completeSignIn(headers: Headers) {
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			fetchOptions: { onSuccess: cookieSetter(headers) },
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test" },
+			method: "GET",
+			headers,
+			onError(c) {
+				cookieSetter(headers)(c as any);
+			},
+		});
+	}
+
+	it("preserves stored scope on sign-in re-authentication when token claim is narrower", async () => {
+		const headers = new Headers();
+		const idToken = await buildIdToken("scope-reauth-sub");
+
+		// Initial sign-in with full granted scope set.
+		mockGoogleTokenResponse(
+			idToken,
+			"openid email profile https://www.googleapis.com/auth/drive.readonly",
+		);
+		await completeSignIn(headers);
+
+		const session = await client.getSession({ fetchOptions: { headers } });
+		const userId = session.data!.user.id;
+		const initial = await ctx.internalAdapter.findAccounts(userId);
+		expect(initial[0]!.scope).toContain(
+			"https://www.googleapis.com/auth/drive.readonly",
+		);
+
+		// Re-sign-in echoing only a subset.
+		mockGoogleTokenResponse(idToken, "openid email");
+		await completeSignIn(headers);
+
+		const after = await ctx.internalAdapter.findAccounts(userId);
+		expect(after[0]!.scope).toContain(
+			"https://www.googleapis.com/auth/drive.readonly",
+		);
+	});
+
+	it("unions stored scope with newly granted scopes on linkSocial incremental authorization", async () => {
+		const headers = new Headers();
+		const idToken = await buildIdToken("scope-link-sub");
+
+		mockGoogleTokenResponse(idToken, "openid email profile");
+		await completeSignIn(headers);
+
+		const session = await client.getSession({ fetchOptions: { headers } });
+		const userId = session.data!.user.id;
+		const initial = await ctx.internalAdapter.findAccounts(userId);
+		expect(initial[0]!.scope?.split(",").sort()).toEqual([
+			"email",
+			"openid",
+			"profile",
+		]);
+
+		// linkSocial requesting a new scope; provider echoes only that scope.
+		mockGoogleTokenResponse(
+			idToken,
+			"https://www.googleapis.com/auth/drive.readonly",
+		);
+		const linkRes = await client.linkSocial(
+			{
+				provider: "google",
+				callbackURL: "/callback",
+				scopes: ["https://www.googleapis.com/auth/drive.readonly"],
+			},
+			{ headers, onSuccess: cookieSetter(headers) },
+		);
+		if (!linkRes.data || !("url" in linkRes.data) || !linkRes.data.url) {
+			throw new Error(
+				`linkSocial did not return an authorization URL: ${JSON.stringify(linkRes)}`,
+			);
+		}
+		const linkState = new URL(linkRes.data.url).searchParams.get("state") || "";
+		await client.$fetch("/callback/google", {
+			query: { state: linkState, code: "test" },
+			method: "GET",
+			headers,
+			onError(c) {
+				cookieSetter(headers)(c as any);
+			},
+		});
+
+		const after = await ctx.internalAdapter.findAccounts(userId);
+		const merged = after[0]!.scope?.split(",") ?? [];
+		expect(merged).toContain("openid");
+		expect(merged).toContain("email");
+		expect(merged).toContain("profile");
+		expect(merged).toContain("https://www.googleapis.com/auth/drive.readonly");
+	});
+
+	it("preserves stored scope on /refresh-token when the refresh response is narrower", async () => {
+		const headers = new Headers();
+		const idToken = await buildIdToken("scope-refresh-sub");
+
+		mockGoogleTokenResponse(
+			idToken,
+			"openid email profile https://www.googleapis.com/auth/drive.readonly",
+		);
+		await completeSignIn(headers);
+
+		const session = await client.getSession({ fetchOptions: { headers } });
+		const userId = session.data!.user.id;
+		const accounts = await ctx.internalAdapter.findAccounts(userId);
+		expect(accounts[0]!.scope).toContain(
+			"https://www.googleapis.com/auth/drive.readonly",
+		);
+
+		// Refresh response narrower than stored (RFC 6749 Section 1.5).
+		mswServer.use(
+			http.post("https://oauth2.googleapis.com/token", () =>
+				HttpResponse.json({
+					access_token: "refreshed-access-token",
+					refresh_token: "refreshed-refresh-token",
+					token_type: "Bearer",
+					expires_in: 3600,
+					scope: "openid email",
+				}),
+			),
+		);
+		await client.$fetch("/refresh-token", {
+			body: {
+				accountId: accounts[0]!.accountId,
+				providerId: "google",
+			},
+			headers,
+			method: "POST",
+			onError(c) {
+				cookieSetter(headers)(c as any);
+			},
+		});
+
+		const after = await ctx.internalAdapter.findAccounts(userId);
+		expect(after[0]!.scope).toContain(
+			"https://www.googleapis.com/auth/drive.readonly",
+		);
+	});
+});

--- a/packages/core/src/db/schema/account.ts
+++ b/packages/core/src/db/schema/account.ts
@@ -23,7 +23,10 @@ export const accountSchema = coreSchema.extend({
 	 */
 	refreshTokenExpiresAt: z.date().nullish(),
 	/**
-	 * The scopes that the user has authorized
+	 * The set of OAuth scopes the user has granted to this account, stored
+	 * as a comma-separated list. Represents the accumulated grant rather
+	 * than the latest token's `scope` claim, since per RFC 6749 Section 1.5 a
+	 * token's scope may be narrower than the user's grant.
 	 */
 	scope: z.string().nullish(),
 	/**

--- a/packages/core/src/oauth2/index.ts
+++ b/packages/core/src/oauth2/index.ts
@@ -84,6 +84,7 @@ export {
 	generateCodeChallenge,
 	getOAuth2Tokens,
 	getPrimaryClientId,
+	mergeScopes,
 } from "./utils";
 export {
 	authorizationCodeRequest,

--- a/packages/core/src/oauth2/refresh-access-token.test.ts
+++ b/packages/core/src/oauth2/refresh-access-token.test.ts
@@ -6,7 +6,7 @@ vi.mock("@better-fetch/fetch", () => ({
 
 import { betterFetch } from "@better-fetch/fetch";
 import { refreshAccessToken } from "./refresh-access-token";
-import { parseScopeField } from "./utils";
+import { mergeScopes, parseScopeField } from "./utils";
 
 const mockedBetterFetch = vi.mocked(betterFetch);
 
@@ -184,5 +184,18 @@ describe("parseScopeField", () => {
 		expect(parseScopeField("")).toEqual([]);
 		expect(parseScopeField(undefined)).toEqual([]);
 		expect(parseScopeField({ scope: "openid" })).toEqual([]);
+	});
+});
+
+describe("mergeScopes", () => {
+	it("normalizes stored and incoming scopes before merging", () => {
+		expect(
+			mergeScopes("openid, email,,profile ", [
+				"email",
+				" offline_access ",
+				"",
+				"openid",
+			]),
+		).toBe("openid,email,profile,offline_access");
 	});
 });

--- a/packages/core/src/oauth2/utils.ts
+++ b/packages/core/src/oauth2/utils.ts
@@ -65,6 +65,19 @@ export function applyDefaultAccessTokenExpiry(
 }
 
 /**
+ * Compute the union of stored and incoming OAuth scopes, preserving
+ * stored insertion order and dropping duplicates.
+ */
+export function mergeScopes(
+	stored: string | null | undefined,
+	incoming: string[] | undefined,
+): string {
+	const existing = stored ? stored.split(",").filter(Boolean) : [];
+	const next = incoming ?? [];
+	return [...new Set([...existing, ...next])].join(",");
+}
+
+/**
  * Return the provider's primary Client ID: the single string, or the entry at
  * array index 0 for the cross-platform form used by ID token audience
  * verification. Index 0 is the designated primary and pairs with

--- a/packages/core/src/oauth2/utils.ts
+++ b/packages/core/src/oauth2/utils.ts
@@ -72,8 +72,13 @@ export function mergeScopes(
 	stored: string | null | undefined,
 	incoming: string[] | undefined,
 ): string {
-	const existing = stored ? stored.split(",").filter(Boolean) : [];
-	const next = incoming ?? [];
+	const existing = stored
+		? stored
+				.split(",")
+				.map((scope) => scope.trim())
+				.filter(Boolean)
+		: [];
+	const next = (incoming ?? []).map((scope) => scope.trim()).filter(Boolean);
 	return [...new Set([...existing, ...next])].join(",");
 }
 


### PR DESCRIPTION
OAuth `account.scope` should represent the accumulated grant for an account, not whatever scope string the latest token response echoes.

This keeps returning sign-in and refresh-token updates from overwriting stored scope with a narrower token scope, and only merges new scopes when `linkSocial` completes an incremental authorization flow. The docs and schema comment now describe `account.scope` as the accumulated OAuth grant set.

Refs #9382.