### PR TITLE
feat(google): add `includeGrantedScopes` option

### DIFF
--- a/.changeset/silver-gardens-wander.md
+++ b/.changeset/silver-gardens-wander.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Add `includeGrantedScopes` option to the Google provider. Set to `false` to omit `include_granted_scopes=true` from the authorization URL so each OAuth flow requests only its own scopes instead of accumulating prior grants. Defaults to `true`, preserving current behavior.

--- a/.changeset/silver-gardens-wander.md
+++ b/.changeset/silver-gardens-wander.md
@@ -2,4 +2,4 @@
 "@better-auth/core": patch
 ---
 
-Add `includeGrantedScopes` option to the Google provider. Set to `false` to omit `include_granted_scopes=true` from the authorization URL so each OAuth flow requests only its own scopes instead of accumulating prior grants. Defaults to `true`, preserving current behavior.
+Add `includeGrantedScopes` option to the Google provider. Set to `false` to omit `include_granted_scopes=true` from the authorization URL by default so each OAuth flow requests only its own scopes instead of accumulating prior grants. Defaults to `true`, preserving current behavior; call-time `additionalParams` still wins for single-flow overrides.

--- a/.cspell.jsonc
+++ b/.cspell.jsonc
@@ -101,6 +101,7 @@
 		"e2e/smoke/test/fixtures/cloudflare/worker-configuration.d.ts",
 		"*.config.js",
 		"*.config.ts",
+		"docker-compose.override.yml",
 		"*.json",
 		".gitignore",
 		// locale translation files contain non-English text that CSpell doesn't recognize

--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -187,6 +187,22 @@ This will trigger a new OAuth flow that requests the additional scopes. After co
   provider.
 </Callout>
 
+### Disable incremental authorization
+
+By default, Better Auth sends `include_granted_scopes=true` to Google's authorization endpoint so newly issued access tokens cover scopes from prior grants in addition to the ones requested for the current flow. Set `includeGrantedScopes: false` if each OAuth flow should request only its own scopes.
+
+```ts
+socialProviders: {
+    google: {
+        clientId: process.env.GOOGLE_CLIENT_ID as string,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+        includeGrantedScopes: false, // [!code highlight]
+    },
+}
+```
+
+See Google's [Incremental authorization](https://developers.google.com/identity/protocols/oauth2/web-server#incrementalAuth) docs for the underlying parameter behavior.
+
 ### Always get refresh token
 
 Google only issues a refresh token the first time a user consents to your app.

--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -201,6 +201,8 @@ socialProviders: {
 }
 ```
 
+Call-time `additionalParams.include_granted_scopes` still follows the general OAuth parameter precedence rules and can override this provider default for a single flow.
+
 See Google's [Incremental authorization](https://developers.google.com/identity/protocols/oauth2/web-server#incrementalAuth) docs for the underlying parameter behavior.
 
 ### Always get refresh token

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -3510,6 +3510,31 @@ describe("Google Provider - includeGrantedScopes", async () => {
 		expect(authUrl.searchParams.get("include_granted_scopes")).toBe("true");
 	});
 
+	it("does not let additionalParams disable `include_granted_scopes`", async () => {
+		const { client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			additionalParams: {
+				include_granted_scopes: "false",
+			},
+		});
+
+		const authUrl = new URL(signInRes.data!.url!);
+		expect(authUrl.searchParams.get("include_granted_scopes")).toBe("true");
+	});
+
 	it("omits `include_granted_scopes` from the authorization URL when disabled", async () => {
 		const { client } = await getTestInstance(
 			{
@@ -3536,5 +3561,31 @@ describe("Google Provider - includeGrantedScopes", async () => {
 		expect(authUrl.searchParams.get("scope")).toContain(
 			"https://www.googleapis.com/auth/drive.file",
 		);
+	});
+
+	it("does not let additionalParams re-enable `include_granted_scopes`", async () => {
+		const { client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+						includeGrantedScopes: false,
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			additionalParams: {
+				include_granted_scopes: "true",
+			},
+		});
+
+		const authUrl = new URL(signInRes.data!.url!);
+		expect(authUrl.searchParams.has("include_granted_scopes")).toBe(false);
 	});
 });

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -3510,7 +3510,7 @@ describe("Google Provider - includeGrantedScopes", async () => {
 		expect(authUrl.searchParams.get("include_granted_scopes")).toBe("true");
 	});
 
-	it("does not let additionalParams disable `include_granted_scopes`", async () => {
+	it("lets additionalParams disable `include_granted_scopes` for a single flow", async () => {
 		const { client } = await getTestInstance(
 			{
 				socialProviders: {
@@ -3532,7 +3532,7 @@ describe("Google Provider - includeGrantedScopes", async () => {
 		});
 
 		const authUrl = new URL(signInRes.data!.url!);
-		expect(authUrl.searchParams.get("include_granted_scopes")).toBe("true");
+		expect(authUrl.searchParams.get("include_granted_scopes")).toBe("false");
 	});
 
 	it("omits `include_granted_scopes` from the authorization URL when disabled", async () => {
@@ -3563,7 +3563,7 @@ describe("Google Provider - includeGrantedScopes", async () => {
 		);
 	});
 
-	it("does not let additionalParams re-enable `include_granted_scopes`", async () => {
+	it("lets additionalParams re-enable `include_granted_scopes` for a single flow", async () => {
 		const { client } = await getTestInstance(
 			{
 				socialProviders: {
@@ -3586,6 +3586,6 @@ describe("Google Provider - includeGrantedScopes", async () => {
 		});
 
 		const authUrl = new URL(signInRes.data!.url!);
-		expect(authUrl.searchParams.has("include_granted_scopes")).toBe(false);
+		expect(authUrl.searchParams.get("include_granted_scopes")).toBe("true");
 	});
 });

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -3460,3 +3460,81 @@ describe("account.scope path-dependent semantics", async () => {
 		expect(after[0]!.scope).toBe(accumulatedScope);
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/9326
+ */
+describe("Google Provider - includeGrantedScopes", async () => {
+	it("includes `include_granted_scopes=true` in the authorization URL by default", async () => {
+		const { client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+		});
+
+		const authUrl = new URL(signInRes.data!.url!);
+		expect(authUrl.searchParams.get("include_granted_scopes")).toBe("true");
+	});
+
+	it("includes `include_granted_scopes=true` when explicitly enabled", async () => {
+		const { client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+						includeGrantedScopes: true,
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+		});
+
+		const authUrl = new URL(signInRes.data!.url!);
+		expect(authUrl.searchParams.get("include_granted_scopes")).toBe("true");
+	});
+
+	it("omits `include_granted_scopes` from the authorization URL when disabled", async () => {
+		const { client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+						includeGrantedScopes: false,
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/callback",
+			scopes: ["https://www.googleapis.com/auth/drive.file"],
+		});
+
+		const authUrl = new URL(signInRes.data!.url!);
+		expect(authUrl.searchParams.has("include_granted_scopes")).toBe(false);
+		expect(authUrl.searchParams.get("scope")).toContain("openid");
+		expect(authUrl.searchParams.get("scope")).toContain(
+			"https://www.googleapis.com/auth/drive.file",
+		);
+	});
+});

--- a/packages/core/src/social-providers/google.ts
+++ b/packages/core/src/social-providers/google.ts
@@ -96,6 +96,11 @@ export const google = (options: GoogleOptions) => {
 				: ["email", "profile", "openid"];
 			if (options.scope) _scopes.push(...options.scope);
 			if (scopes) _scopes.push(...scopes);
+			const authorizationParams = Object.fromEntries(
+				Object.entries(additionalParams ?? {}).filter(
+					([key]) => key !== "include_granted_scopes",
+				),
+			);
 			const url = await createAuthorizationURL({
 				id: "google",
 				options,
@@ -110,10 +115,10 @@ export const google = (options: GoogleOptions) => {
 				loginHint,
 				hd: options.hd,
 				additionalParams: {
+					...authorizationParams,
 					...(options.includeGrantedScopes === false
 						? {}
 						: { include_granted_scopes: "true" }),
-					...(additionalParams ?? {}),
 				},
 			});
 			return url;

--- a/packages/core/src/social-providers/google.ts
+++ b/packages/core/src/social-providers/google.ts
@@ -56,6 +56,17 @@ export interface GoogleOptions extends ProviderOptions<GoogleProfile> {
 	 * can be used to restrict sign-in to a Workspace domain.
 	 */
 	hd?: string | undefined;
+	/**
+	 * Whether to send `include_granted_scopes=true` to Google's authorization
+	 * endpoint, which lets new access tokens cover scopes from prior grants
+	 * in addition to the ones requested for this flow. Set to `false` when
+	 * each OAuth flow should request only its own scopes.
+	 *
+	 * Defaults to `true`.
+	 *
+	 * @see https://developers.google.com/identity/protocols/oauth2/web-server#incrementalAuth
+	 */
+	includeGrantedScopes?: boolean | undefined;
 }
 
 export const google = (options: GoogleOptions) => {
@@ -99,7 +110,9 @@ export const google = (options: GoogleOptions) => {
 				loginHint,
 				hd: options.hd,
 				additionalParams: {
-					include_granted_scopes: "true",
+					...(options.includeGrantedScopes === false
+						? {}
+						: { include_granted_scopes: "true" }),
 					...(additionalParams ?? {}),
 				},
 			});

--- a/packages/core/src/social-providers/google.ts
+++ b/packages/core/src/social-providers/google.ts
@@ -96,11 +96,12 @@ export const google = (options: GoogleOptions) => {
 				: ["email", "profile", "openid"];
 			if (options.scope) _scopes.push(...options.scope);
 			if (scopes) _scopes.push(...scopes);
-			const authorizationParams = Object.fromEntries(
-				Object.entries(additionalParams ?? {}).filter(
-					([key]) => key !== "include_granted_scopes",
-				),
-			);
+			const authorizationParams: Record<string, string> = {};
+			for (const [key, value] of Object.entries(additionalParams ?? {})) {
+				if (key !== "include_granted_scopes") {
+					authorizationParams[key] = value;
+				}
+			}
 			const url = await createAuthorizationURL({
 				id: "google",
 				options,

--- a/packages/core/src/social-providers/google.ts
+++ b/packages/core/src/social-providers/google.ts
@@ -96,12 +96,6 @@ export const google = (options: GoogleOptions) => {
 				: ["email", "profile", "openid"];
 			if (options.scope) _scopes.push(...options.scope);
 			if (scopes) _scopes.push(...scopes);
-			const authorizationParams: Record<string, string> = {};
-			for (const [key, value] of Object.entries(additionalParams ?? {})) {
-				if (key !== "include_granted_scopes") {
-					authorizationParams[key] = value;
-				}
-			}
 			const url = await createAuthorizationURL({
 				id: "google",
 				options,
@@ -116,10 +110,10 @@ export const google = (options: GoogleOptions) => {
 				loginHint,
 				hd: options.hd,
 				additionalParams: {
-					...authorizationParams,
 					...(options.includeGrantedScopes === false
 						? {}
 						: { include_granted_scopes: "true" }),
+					...(additionalParams ?? {}),
 				},
 			});
 			return url;


### PR DESCRIPTION
Google always sent `include_granted_scopes=true`, which made incremental auth the only behavior available for Google OAuth flows.

This adds `includeGrantedScopes` to the Google provider. It defaults to current behavior and lets callers set `false` to omit the parameter so each flow requests only its own scopes. Existing `additionalParams` still merge into the authorization URL.

Fixes #9326.
Replaces #9353.
Refs #9383.