### PR TITLE
fix: signup email callback URL redirect in API

### DIFF
--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -36,7 +36,7 @@ const { data, error } = await authClient.signUp.email({
         password, // user password -> min 8 characters by default
         name, // user display name
         image, // User image URL (optional)
-        callbackURL: "/dashboard" // A URL to redirect to after the user verifies their email (optional)
+        callbackURL: "/dashboard" // A URL to redirect to (optional)
     }, {
         onRequest: (ctx) => {
             //show loading

--- a/packages/better-auth/src/api/routes/sign-up.ts
+++ b/packages/better-auth/src/api/routes/sign-up.ts
@@ -428,7 +428,13 @@ export const signUpEmail = <O extends BetterAuthOptions>() =>
 					},
 					rememberMe === false,
 				);
+
+				if (ctx.body.callbackURL) {
+					ctx.setHeader("Location", ctx.body.callbackURL);
+				}
+
 				return ctx.json({
+					redirect: !!ctx.body.callbackURL,
 					token: session.token,
 					user: parseUserOutput(ctx.context.options, createdUser) as User<
 						O["user"],


### PR DESCRIPTION
This pull request updates the sign-up flow in the `sign-up.ts` API route to improve how callback URLs are handled after user registration. The main change is to support setting a `Location` header in the response when a callback URL is present, and to indicate in the response JSON whether a redirect should occur only if following resolves to false
```typescript
const shouldSkipAutoSignIn =
					ctx.context.options.emailAndPassword.autoSignIn === false ||
					shouldReturnGenericDuplicateResponse;
```

Callback/redirect handling improvements:

* In `sign-up.ts`, after a successful sign-up, the response now sets a `Location` header if a `callbackURL` is present in the response body, and adds a `redirect` boolean to the JSON response to indicate if a redirect should happen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes callback URL redirects in the email sign-up route by setting the Location header and adding a `redirect` boolean in the JSON when `callbackURL` is present, enabling reliable post-sign-up navigation. Updates docs to clarify `callbackURL` is an optional redirect target.

<sup>Written for commit 39544ad1d1c29c5e50aa3a27155a5bb3f0eb9ac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

