### PR TITLE
docs: add @tinysend/better-auth to community plugins

### DIFF
--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -291,4 +291,15 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/SulimanAbdulrazzaq.png",
 		},
 	},
+	{
+		name: "@tinysend/better-auth",
+		url: "https://github.com/tiny-send/tinysend-better-auth",
+		description:
+			"Send better-auth's verification, reset, magic-link, and OTP emails through tinysend, with replies routed to a real inbox with webhooks and automations.",
+		author: {
+			name: "podviaznikov",
+			github: "podviaznikov",
+			avatar: "https://github.com/podviaznikov.png",
+		},
+	},
 ];


### PR DESCRIPTION
Adds [`@tinysend/better-auth`](https://github.com/tiny-send/tinysend-better-auth) to the community plugins list.

It wires better-auth's email callbacks (verification, password reset, magic link, OTP, 2FA, change-email, invitations) to [tinysend](https://tinysend.com), plus a small plugin for account-security notifications (password/email/2FA changed) that better-auth has no built-in callback for. Zero dependency on the better-auth package — the exported shapes are structurally compatible.

npm: https://www.npmjs.com/package/@tinysend/better-auth

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@tinysend/better-auth` to the community plugins list so developers can discover a plugin that sends better-auth verification, reset, magic-link, and OTP emails through tinysend, plus account-security notifications.

<sup>Written for commit 1c02c42fa7ec6511bcbcde434dfdf84786dc1b2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

