### PR TITLE
fix(session): revoke-other-sessions revokes all other sessions, not a capped window

### DIFF
--- a/.changeset/revoke-other-sessions-unbounded.md
+++ b/.changeset/revoke-other-sessions-unbounded.md
@@ -1,0 +1,6 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+---
+
+Fix `revoke-other-sessions` silently leaving sessions un-revoked. It previously listed the user's sessions and deleted them individually, but `listSessions` is capped at the adapter's `defaultFindManyLimit` (100); a user with more sessions than that limit kept some un-revoked, and because expired sessions are never pruned the capped window could even be entirely expired rows - revoking nothing while still returning `{ status: true }`. It now deletes every other session in a single unbounded query (`internalAdapter.deleteUserSessions(userId, exceptSessionToken)`), which also clears the user's stale/expired session rows.

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -437,6 +437,74 @@ describe("session", async () => {
 		expect(revokeRes.data?.status).toBe(true);
 	});
 
+	it("should revoke all other sessions (active and expired) beyond the find-many limit", async () => {
+		// Regression test: revoke-other-sessions must delete every other session in one unbounded
+		// query. It previously listed sessions (capped at the adapter's `defaultFindManyLimit`) and
+		// deleted those, so a user with more sessions than that limit kept some un-revoked - and
+		// since expired sessions are never pruned, the capped window could even be all-expired,
+		// silently revoking nothing while still returning `{ status: true }`.
+		const findManyLimit = 3;
+		const {
+			client: limitedClient,
+			signInWithTestUser: signIn,
+			db,
+		} = await getTestInstance({
+			advanced: { database: { defaultFindManyLimit: findManyLimit } },
+		});
+
+		const { user, headers } = await signIn();
+
+		// More *active* other sessions than the find-many limit ...
+		const otherActiveCount = findManyLimit * 2 + 1;
+		for (let i = 0; i < otherActiveCount; i++) {
+			await db.create({
+				model: "session",
+				data: {
+					token: `other-active-${i}`,
+					userId: user.id,
+					expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					ipAddress: "",
+					userAgent: "",
+				},
+			});
+		}
+		// ... plus some already-expired rows that should also be cleaned up.
+		for (let i = 0; i < findManyLimit; i++) {
+			await db.create({
+				model: "session",
+				data: {
+					token: `expired-${i}`,
+					userId: user.id,
+					expiresAt: new Date(Date.now() - 1000 * 60 * 60),
+					createdAt: new Date(Date.now() - 1000 * 60 * 60),
+					updatedAt: new Date(Date.now() - 1000 * 60 * 60),
+					ipAddress: "",
+					userAgent: "",
+				},
+			});
+		}
+
+		const res = await limitedClient.revokeOtherSessions({
+			fetchOptions: { headers },
+		});
+		expect(res.data?.status).toBe(true);
+
+		// Only the current session remains - every other session (active and expired) is gone.
+		const remaining = await db.count({
+			model: "session",
+			where: [{ field: "userId", value: user.id }],
+		});
+		expect(remaining).toBe(1);
+
+		// And the current session is still valid.
+		const stillValid = await limitedClient.getSession({
+			fetchOptions: { headers },
+		});
+		expect(stillValid.data).not.toBeNull();
+	});
+
 	it("should return session headers", async () => {
 		const context = await auth.$context;
 		await runWithEndpointContext(

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -913,19 +913,15 @@ export const revokeOtherSessions = createAuthEndpoint(
 				code: "UNAUTHORIZED",
 			});
 		}
-		const sessions = await ctx.context.internalAdapter.listSessions(
+		// Delete every other session for the user in a single query, keeping only the current one.
+		// Listing first would be capped at the adapter's `defaultFindManyLimit` (100); since expired
+		// sessions are never pruned, that window could be entirely expired rows, leaving active
+		// sessions un-revoked while still reporting success (and even with active-only filtering a
+		// user with more than the limit of active sessions would be under-revoked). Deleting by query
+		// is unbounded and also clears the user's stale/expired session rows as a side effect.
+		await ctx.context.internalAdapter.deleteUserSessions(
 			session.user.id,
-		);
-		const activeSessions = sessions.filter((session) => {
-			return session.expiresAt > new Date();
-		});
-		const otherSessions = activeSessions.filter(
-			(session) => session.token !== ctx.context.session.session.token,
-		);
-		await Promise.all(
-			otherSessions.map((session) =>
-				ctx.context.internalAdapter.deleteSession(session.token),
-			),
+			ctx.context.session.session.token,
 		);
 		return ctx.json({
 			status: true,

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -781,19 +781,36 @@ export const createInternalAdapter = (
 				undefined,
 			);
 		},
-		deleteUserSessions: async (userId: string) => {
+		deleteUserSessions: async (userId: string, exceptSessionToken?: string) => {
 			if (secondaryStorage) {
 				const activeSession = await secondaryStorage.get(
 					`active-sessions-${userId}`,
 				);
 				const sessions = activeSession
-					? safeJSONParse<{ token: string }[]>(activeSession)
+					? safeJSONParse<{ token: string; expiresAt: number }[]>(activeSession)
 					: [];
 				if (!sessions) return;
 				for (const session of sessions) {
+					if (session.token === exceptSessionToken) continue;
 					await secondaryStorage.delete(session.token);
 				}
-				await secondaryStorage.delete(`active-sessions-${userId}`);
+				const kept = exceptSessionToken
+					? sessions.filter((session) => session.token === exceptSessionToken)
+					: [];
+				const now = Date.now();
+				const furthestSessionExp = kept
+					.map((session) => session.expiresAt)
+					.sort((a, b) => a - b)
+					.at(-1);
+				if (kept.length > 0 && furthestSessionExp && furthestSessionExp > now) {
+					await secondaryStorage.set(
+						`active-sessions-${userId}`,
+						JSON.stringify(kept),
+						getTTLSeconds(furthestSessionExp, now),
+					);
+				} else {
+					await secondaryStorage.delete(`active-sessions-${userId}`);
+				}
 
 				if (
 					!options.session?.storeSessionInDatabase ||
@@ -808,6 +825,15 @@ export const createInternalAdapter = (
 						field: "userId",
 						value: userId,
 					},
+					...(exceptSessionToken
+						? [
+								{
+									field: "token",
+									value: exceptSessionToken,
+									operator: "ne",
+								} satisfies Where,
+							]
+						: []),
 				],
 				"session",
 				undefined,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -160,8 +160,14 @@ export interface InternalAdapter<
 
 	/**
 	 * Delete every session belonging to a user.
+	 *
+	 * @param userId - The user whose sessions are deleted.
+	 * @param exceptSessionToken - When provided, the session with this token is kept and all others are deleted.
 	 */
-	deleteUserSessions(userId: string): Promise<void>;
+	deleteUserSessions(
+		userId: string,
+		exceptSessionToken?: string,
+	): Promise<void>;
 
 	/**
 	 * Delete sessions by their session tokens.


### PR DESCRIPTION
Problem: revoke-other-sessions deletes from a defaultFindManyLimit-capped list, so users with >100 sessions keep some un-revoked, and an all-expired window revokes nothing while returning success.

Fix: delete by query via deleteUserSessions(userId, exceptSessionToken) (unbounded deleteMany with token ne), handling DB + secondary storage; also prunes expired rows.

Test: fails on main, passes here; full suites green; typecheck clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes revoke-other-sessions to truly revoke every other session for the user, not just a capped window, and cleans up expired sessions so only the current session remains.

- **Bug Fixes**
  - The route now uses `internalAdapter.deleteUserSessions(userId, exceptToken)` for an unbounded delete instead of listing then deleting.
  - Adapter implementation handles DB and secondary storage, prunes expired rows, and keeps the current session. Updates the `active-sessions-*` key TTL when needed.
  - Adds a regression test that creates sessions beyond `defaultFindManyLimit` and verifies only the current session remains.
  - Updates the `InternalAdapter.deleteUserSessions` signature in `@better-auth/core` to accept an optional `exceptSessionToken`.

- **Migration**
  - If you maintain a custom internal adapter, update `deleteUserSessions(userId, exceptSessionToken?)` to ignore the provided token and delete all others (including expired), and update secondary storage accordingly.

<sup>Written for commit 5e799e57bef995d36e94268040d3cc7a0d4caa3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

