### PR TITLE
feat(CLI): upgrade cmd displays auth schema diff

### DIFF
--- a/packages/cli/src/commands/internal-schema-snapshot.ts
+++ b/packages/cli/src/commands/internal-schema-snapshot.ts
@@ -1,0 +1,87 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { BetterAuthOptions } from "@better-auth/core";
+import { getSchema as bundledGetSchema } from "better-auth/db";
+import { Command } from "commander";
+import * as z from "zod";
+import { getConfig } from "../utils/get-config";
+
+type GetSchema = (config: BetterAuthOptions) => unknown;
+
+/**
+ * Resolve `getSchema` from the user's installed `better-auth/db` (relative to
+ * `cwd`) so the computed schema reflects the user's installed version
+ * (including core table changes), not the version bundled with the CLI.
+ * Falls back to the bundled `getSchema` when resolution fails (e.g. older
+ * versions that don't export it from `better-auth/db`).
+ */
+async function resolveGetSchema(cwd: string): Promise<GetSchema> {
+	try {
+		const require = createRequire(path.join(cwd, "index.js"));
+		const resolved = require.resolve("better-auth/db");
+		const mod = (await import(pathToFileURL(resolved).href)) as {
+			getSchema?: GetSchema;
+		};
+		if (typeof mod.getSchema === "function") {
+			return mod.getSchema;
+		}
+	} catch {}
+	return bundledGetSchema as GetSchema;
+}
+
+/** @internal */
+export async function internalSchemaSnapshotAction(opts: unknown) {
+	const options = z
+		.object({
+			cwd: z.string(),
+			config: z.string().optional(),
+		})
+		.parse(opts);
+
+	const cwd = path.resolve(options.cwd);
+	if (!existsSync(cwd)) {
+		process.stderr.write(`The directory "${cwd}" does not exist.\n`);
+		process.exit(1);
+	}
+
+	const config = await getConfig({
+		cwd,
+		configPath: options.config,
+		shouldThrowOnError: true,
+	}).catch((error: unknown) => {
+		process.stderr.write(
+			`Failed to load auth config: ${
+				error instanceof Error ? error.message : String(error)
+			}\n`,
+		);
+		process.exit(1);
+	});
+
+	if (!config) {
+		process.stderr.write("No auth configuration found.\n");
+		process.exit(1);
+	}
+
+	const getSchema = await resolveGetSchema(cwd);
+	const schema = getSchema(config);
+	process.stdout.write(JSON.stringify(schema));
+	process.exit(0);
+}
+
+/**
+ * Internal helper command used by `upgrade` to capture the config-derived
+ * schema in a fresh process. Not intended for direct use; registered hidden.
+ */
+export const internalSchemaSnapshot = new Command("internal-schema-snapshot")
+	.option(
+		"-c, --cwd <cwd>",
+		"the working directory. defaults to the current directory.",
+		process.cwd(),
+	)
+	.option(
+		"--config <config>",
+		"the path to the configuration file. defaults to the first configuration file found.",
+	)
+	.action(internalSchemaSnapshotAction);

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import chalk from "chalk";
@@ -22,11 +23,230 @@ interface UpgradeEntry {
 	depType: "prod" | "dev";
 }
 
+interface SchemaField {
+	type?: unknown;
+	references?: unknown;
+}
+interface SchemaTable {
+	fields: Record<string, SchemaField>;
+	order?: number;
+}
+type SchemaSnapshot = Record<string, SchemaTable>;
+
+interface FieldEntry {
+	name: string;
+	type: string;
+}
+interface FieldChange {
+	name: string;
+	from: string;
+	to: string;
+}
+interface TableDiff {
+	table: string;
+	addedFields: FieldEntry[];
+	removedFields: FieldEntry[];
+	changedFields: FieldChange[];
+}
+interface SchemaDiff {
+	createdTables: { table: string; fields: FieldEntry[] }[];
+	removedTables: { table: string; fields: FieldEntry[] }[];
+	changedTables: TableDiff[];
+}
+
+function fieldType(field: SchemaField | undefined): string {
+	if (!field || field.type == null) return "unknown";
+	return typeof field.type === "string" ? field.type : String(field.type);
+}
+
+function tableFields(table: SchemaTable | undefined): FieldEntry[] {
+	if (!table?.fields) return [];
+	return Object.entries(table.fields).map(([name, field]) => ({
+		name,
+		type: fieldType(field),
+	}));
+}
+
+/**
+ * Computes a config-level schema diff between two snapshots produced by
+ * {@link captureSchemaSnapshot}. Pure: depends only on its inputs.
+ */
+export function diffSchemas(
+	before: SchemaSnapshot,
+	after: SchemaSnapshot,
+): SchemaDiff {
+	const diff: SchemaDiff = {
+		createdTables: [],
+		removedTables: [],
+		changedTables: [],
+	};
+
+	for (const [table, def] of Object.entries(after)) {
+		if (!before[table]) {
+			diff.createdTables.push({ table, fields: tableFields(def) });
+		}
+	}
+	for (const [table, def] of Object.entries(before)) {
+		if (!after[table]) {
+			diff.removedTables.push({ table, fields: tableFields(def) });
+		}
+	}
+
+	for (const [table, afterDef] of Object.entries(after)) {
+		const beforeDef = before[table];
+		if (!beforeDef) continue;
+		const beforeFields = beforeDef.fields ?? {};
+		const afterFields = afterDef.fields ?? {};
+		const addedFields: FieldEntry[] = [];
+		const removedFields: FieldEntry[] = [];
+		const changedFields: FieldChange[] = [];
+
+		for (const [name, field] of Object.entries(afterFields)) {
+			if (!(name in beforeFields)) {
+				addedFields.push({ name, type: fieldType(field) });
+				continue;
+			}
+			const from = fieldType(beforeFields[name]);
+			const to = fieldType(field);
+			if (from !== to) changedFields.push({ name, from, to });
+		}
+		for (const name of Object.keys(beforeFields)) {
+			if (!(name in afterFields)) {
+				removedFields.push({ name, type: fieldType(beforeFields[name]) });
+			}
+		}
+
+		if (addedFields.length || removedFields.length || changedFields.length) {
+			diff.changedTables.push({
+				table,
+				addedFields,
+				removedFields,
+				changedFields,
+			});
+		}
+	}
+
+	return diff;
+}
+
+export function isSchemaDiffEmpty(diff: SchemaDiff): boolean {
+	return (
+		diff.createdTables.length === 0 &&
+		diff.removedTables.length === 0 &&
+		diff.changedTables.length === 0
+	);
+}
+
+const ANSI_REGEX = /\u001b\[[0-9;]*m/g;
+function visibleLength(text: string): number {
+	return text.replace(ANSI_REGEX, "").length;
+}
+
+/**
+ * Renders a {@link SchemaDiff} as a boxed, color-coded summary using chalk.
+ * Pure: returns the string to print.
+ */
+export function renderSchemaDiffBox(diff: SchemaDiff): string {
+	const lines: string[] = [];
+	lines.push(chalk.bold("Schema changes from upgrade"));
+
+	for (const { table, fields } of diff.createdTables) {
+		lines.push("");
+		lines.push(chalk.green(`+ ${table}`) + chalk.gray(" (new table)"));
+		for (const f of fields) {
+			lines.push(`  ${chalk.green(`+ ${f.name}`)} ${chalk.gray(f.type)}`);
+		}
+	}
+
+	for (const t of diff.changedTables) {
+		lines.push("");
+		lines.push(chalk.yellow(`~ ${t.table}`));
+		for (const f of t.addedFields) {
+			lines.push(`  ${chalk.green(`+ ${f.name}`)} ${chalk.gray(f.type)}`);
+		}
+		for (const f of t.changedFields) {
+			lines.push(
+				`  ${chalk.yellow(`~ ${f.name}`)} ${chalk.gray(
+					`${f.from} -> ${f.to}`,
+				)}`,
+			);
+		}
+		for (const f of t.removedFields) {
+			lines.push(`  ${chalk.red(`- ${f.name}`)} ${chalk.gray(f.type)}`);
+		}
+	}
+
+	for (const { table, fields } of diff.removedTables) {
+		lines.push("");
+		lines.push(chalk.red(`- ${table}`) + chalk.gray(" (removed)"));
+		for (const f of fields) {
+			lines.push(`  ${chalk.red(`- ${f.name}`)} ${chalk.gray(f.type)}`);
+		}
+	}
+
+	const width = lines.reduce((max, l) => Math.max(max, visibleLength(l)), 0);
+	const top = `┌${"─".repeat(width + 2)}┐`;
+	const bottom = `└${"─".repeat(width + 2)}┘`;
+	const body = lines.map((l) => {
+		const pad = " ".repeat(width - visibleLength(l));
+		return `│ ${l}${pad} │`;
+	});
+	return [top, ...body, bottom].join("\n");
+}
+
+/**
+ * Captures the config-derived schema in a fresh process so it reflects the
+ * currently installed better-auth version (module caches in the current
+ * process would otherwise hide post-install changes). Returns `null` when the
+ * snapshot can't be produced, so the upgrade flow can degrade gracefully.
+ */
+function captureSchemaSnapshot({
+	cwd,
+	config,
+}: {
+	cwd: string;
+	config?: string;
+}): Promise<SchemaSnapshot | null> {
+	return new Promise((resolve) => {
+		const entry = process.argv[1];
+		if (!entry) return resolve(null);
+		const args = [
+			...process.execArgv,
+			entry,
+			"internal-schema-snapshot",
+			"--cwd",
+			cwd,
+		];
+		if (config) args.push("--config", config);
+
+		const child = spawn(process.execPath, args, {
+			cwd,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on("data", () => {});
+		child.on("error", () => resolve(null));
+		child.on("close", (code) => {
+			if (code !== 0) return resolve(null);
+			try {
+				resolve(JSON.parse(stdout) as SchemaSnapshot);
+			} catch {
+				resolve(null);
+			}
+		});
+	});
+}
+
 async function upgradeAction(opts: unknown) {
 	const options = z
 		.object({
 			cwd: z.string(),
 			yes: z.boolean().optional(),
+			config: z.string().optional(),
+			skipSchemaDiff: z.boolean().optional(),
 		})
 		.parse(opts);
 
@@ -125,6 +345,10 @@ async function upgradeAction(opts: unknown) {
 
 	const { packageManager } = await detectPackageManager(cwd, packageJson);
 
+	const before = options.skipSchemaDiff
+		? null
+		: await captureSchemaSnapshot({ cwd, config: options.config });
+
 	const prodUpgrades = upgrades
 		.filter((u) => u.depType === "prod")
 		.map((u) => `${u.name}@${u.latest}`);
@@ -160,6 +384,40 @@ async function upgradeAction(opts: unknown) {
 		console.error("Failed to install updates:", error);
 		process.exit(1);
 	}
+
+	if (options.skipSchemaDiff || !before) {
+		return;
+	}
+
+	try {
+		const schemaSpinner = yoctoSpinner({
+			text: "checking for schema changes...",
+		}).start();
+		const after = await captureSchemaSnapshot({ cwd, config: options.config });
+		schemaSpinner.stop();
+
+		if (!after) {
+			return;
+		}
+
+		const diff = diffSchemas(before, after);
+		if (isSchemaDiffEmpty(diff)) {
+			console.log("\nNo schema changes from this upgrade.");
+			return;
+		}
+
+		console.log();
+		console.log(renderSchemaDiffBox(diff));
+		console.log(
+			`\nRun ${chalk.cyan(
+				"npx @better-auth/cli migrate",
+			)} (Kysely) or ${chalk.cyan(
+				"npx @better-auth/cli generate",
+			)} (Prisma/Drizzle) to apply these changes.`,
+		);
+	} catch {
+		// Schema diffing is best-effort; never fail a successful upgrade.
+	}
 }
 
 export const upgrade = new Command("upgrade")
@@ -172,6 +430,15 @@ export const upgrade = new Command("upgrade")
 	.option(
 		"-y, --yes",
 		"automatically accept and upgrade without prompting",
+		false,
+	)
+	.option(
+		"--config <config>",
+		"the path to the configuration file. defaults to the first configuration file found.",
+	)
+	.option(
+		"--skip-schema-diff",
+		"skip showing database schema changes introduced by the upgrade",
 		false,
 	)
 	.action(upgradeAction);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { ai } from "./commands/ai";
 import { generate } from "./commands/generate";
 import { info } from "./commands/info";
 import { init } from "./commands/init";
+import { internalSchemaSnapshot } from "./commands/internal-schema-snapshot";
 import { login, logout } from "./commands/login";
 import { mcp } from "./commands/mcp";
 import { migrate } from "./commands/migrate";
@@ -41,6 +42,7 @@ async function main() {
 		.addCommand(logout)
 		.addCommand(mcp)
 		.addCommand(upgrade)
+		.addCommand(internalSchemaSnapshot, { hidden: true })
 		.version(cliVersion)
 		.description("Better Auth CLI")
 		.action(() => program.help());

--- a/packages/cli/test/upgrade.test.ts
+++ b/packages/cli/test/upgrade.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+	diffSchemas,
+	isSchemaDiffEmpty,
+	renderSchemaDiffBox,
+} from "../src/commands/upgrade";
+
+const field = (type: string) => ({ type });
+
+describe("diffSchemas", () => {
+	it("detects a newly created table", () => {
+		const before = {
+			user: { fields: { id: field("string") }, order: 1 },
+		};
+		const after = {
+			user: { fields: { id: field("string") }, order: 1 },
+			passkey: { fields: { id: field("string") }, order: 2 },
+		};
+		const diff = diffSchemas(before, after);
+		expect(diff.createdTables).toHaveLength(1);
+		expect(diff.createdTables[0]?.table).toBe("passkey");
+		expect(diff.createdTables[0]?.fields).toContainEqual({
+			name: "id",
+			type: "string",
+		});
+		expect(isSchemaDiffEmpty(diff)).toBe(false);
+	});
+
+	it("detects added, removed, and type-changed fields", () => {
+		const before = {
+			user: {
+				fields: {
+					id: field("string"),
+					age: field("number"),
+					legacy: field("string"),
+				},
+			},
+		};
+		const after = {
+			user: {
+				fields: {
+					id: field("string"),
+					age: field("string"),
+					email: field("string"),
+				},
+			},
+		};
+		const diff = diffSchemas(before, after);
+		expect(diff.changedTables).toHaveLength(1);
+		const t = diff.changedTables[0]!;
+		expect(t.addedFields).toEqual([{ name: "email", type: "string" }]);
+		expect(t.removedFields).toEqual([{ name: "legacy", type: "string" }]);
+		expect(t.changedFields).toEqual([
+			{ name: "age", from: "number", to: "string" },
+		]);
+	});
+
+	it("detects a removed table", () => {
+		const before = {
+			user: { fields: { id: field("string") } },
+			old: { fields: { id: field("string") } },
+		};
+		const after = {
+			user: { fields: { id: field("string") } },
+		};
+		const diff = diffSchemas(before, after);
+		expect(diff.removedTables).toHaveLength(1);
+		expect(diff.removedTables[0]?.table).toBe("old");
+	});
+
+	it("reports no changes for identical schemas", () => {
+		const schema = {
+			user: { fields: { id: field("string"), name: field("string") } },
+		};
+		const diff = diffSchemas(schema, schema);
+		expect(isSchemaDiffEmpty(diff)).toBe(true);
+	});
+});
+
+describe("renderSchemaDiffBox", () => {
+	const stripAnsi = (s: string) => s.replace(/\u001b\[[0-9;]*m/g, "");
+
+	it("renders table and field names within a box", () => {
+		const diff = diffSchemas(
+			{ user: { fields: { id: field("string") } } },
+			{
+				user: { fields: { id: field("string"), email: field("string") } },
+				passkey: { fields: { id: field("string") } },
+			},
+		);
+		const out = stripAnsi(renderSchemaDiffBox(diff));
+		expect(out).toContain("Schema changes from upgrade");
+		expect(out).toContain("+ passkey");
+		expect(out).toContain("+ email");
+		expect(out).toContain("┌");
+		expect(out).toContain("┐");
+		expect(out).toContain("└");
+		expect(out).toContain("┘");
+	});
+
+	it("pads every body row to an equal visible width", () => {
+		const diff = diffSchemas(
+			{},
+			{ session: { fields: { token: field("string") } } },
+		);
+		const rows = stripAnsi(renderSchemaDiffBox(diff))
+			.split("\n")
+			.filter((l) => l.startsWith("│"));
+		const widths = new Set(rows.map((r) => r.length));
+		expect(widths.size).toBe(1);
+	});
+});


### PR DESCRIPTION
## WIP

This PR improves the auth cli's `upgrade` cmd to render the schema difference between their prior and the updated better-auth version so that they can see what fields/tables changed before migration