### PR TITLE
feat(oauth-provider): allow confidential DCR clients without PKCE

### DIFF
--- a/.changeset/dcr-pkce-policy.md
+++ b/.changeset/dcr-pkce-policy.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+OAuth Provider now lets servers set `clientRegistrationRequirePKCE: false` to allow confidential clients created through Dynamic Client Registration to complete authorization-code flows without PKCE. Public clients and authorization requests with `offline_access` still require PKCE.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1358,11 +1358,11 @@ By default, PKCE is required for all clients. This provides maximum security and
 
 #### Per-Client PKCE Configuration
 
-Individual clients can opt-out of PKCE requirement during registration if needed for compatibility:
+Admin-created confidential clients can opt out of the PKCE requirement if needed for compatibility:
 
-```ts title="register-client.ts"
+```ts title="admin-create-oauth.ts"
 // Register a confidential client that doesn't support PKCE
-const response = await auth.api.createOAuthClient({
+const response = await auth.api.adminCreateOAuthClient({
   headers,
   body: {
     client_name: 'Legacy Backend Service',
@@ -1380,6 +1380,19 @@ The `require_pkce` field:
 * Only applies to confidential clients
 * Ignored for public clients (PKCE always required)
 * Ignored for `offline_access` scope (PKCE always required)
+
+#### Dynamic Client Registration PKCE Configuration
+
+Dynamic client registration does not accept `require_pkce` from client requests. To change the server-owned default for dynamically registered confidential clients, set `clientRegistrationRequirePKCE`.
+
+```ts title="auth.ts"
+oauthProvider({
+  allowDynamicClientRegistration: true,
+  clientRegistrationRequirePKCE: false,
+})
+```
+
+This only applies to confidential clients created through dynamic client registration. Public clients and authorization requests with the `offline_access` scope still require PKCE.
 
 **When to use `require_pkce: false`:**
 

--- a/packages/oauth-provider/src/pkce-optional.test.ts
+++ b/packages/oauth-provider/src/pkce-optional.test.ts
@@ -6,7 +6,7 @@ import {
 } from "better-auth/oauth2";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
-import { beforeAll, describe, expect, it, onTestFinished, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
 import type { OAuthClient } from "./types/oauth";
@@ -355,14 +355,16 @@ describe("PKCE optional - dynamic client registration policy", async () => {
 				search: new URL(consentRedirectUrl, authServerBaseUrl).search,
 			},
 		});
-		onTestFinished(() => {
-			vi.unstubAllGlobals();
-		});
-
-		const consentResponse = await authenticatedClient.oauth2.consent(
-			{ accept: true },
-			{ headers, throw: true },
-		);
+		const consentResponse = await (async () => {
+			try {
+				return await authenticatedClient.oauth2.consent(
+					{ accept: true },
+					{ headers, throw: true },
+				);
+			} finally {
+				vi.unstubAllGlobals();
+			}
+		})();
 		expect(consentResponse.url).toContain("code=");
 		expect(consentResponse.url).toContain(`state=${state}`);
 

--- a/packages/oauth-provider/src/pkce-optional.test.ts
+++ b/packages/oauth-provider/src/pkce-optional.test.ts
@@ -6,7 +6,7 @@ import {
 } from "better-auth/oauth2";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, onTestFinished, vi } from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
 import type { OAuthClient } from "./types/oauth";
@@ -276,6 +276,147 @@ describe("PKCE optional - per-client opt-out", async () => {
 
 		expect(tokenResponse.data?.access_token).toBeDefined();
 		expect(tokenResponse.data?.id_token).toBeDefined();
+	});
+});
+
+describe("PKCE optional - dynamic client registration policy", async () => {
+	const authServerBaseUrl = "http://localhost:3005";
+	const rpBaseUrl = "http://localhost:5005";
+	const { signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				allowUnauthenticatedClientRegistration: true,
+				clientRegistrationRequirePKCE: false,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const authenticatedClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+	const unauthenticatedClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: { customFetchImpl },
+	});
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/callback/${providerId}`;
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8588
+	 */
+	it("confidential DCR client without PKCE should succeed when registration policy disables PKCE", async () => {
+		const registration = await unauthenticatedClient.oauth2.register({
+			redirect_uris: [redirectUri],
+		});
+		expect(registration.data?.client_id).toBeDefined();
+		expect(registration.data?.client_secret).toBeDefined();
+		expect(registration.data?.token_endpoint_auth_method).toBe(
+			"client_secret_basic",
+		);
+		expect(registration.data?.require_pkce).toBe(false);
+
+		const clientId = registration.data!.client_id;
+		const clientSecret = registration.data!.client_secret!;
+		const state = "dcr-no-pkce";
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", clientId);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", state);
+
+		let consentRedirectUrl = "";
+		await authenticatedClient.$fetch(authUrl.toString(), {
+			onError(context) {
+				consentRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(consentRedirectUrl).toContain("/consent");
+		expect(consentRedirectUrl).not.toContain("error=");
+
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(consentRedirectUrl, authServerBaseUrl).search,
+			},
+		});
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const consentResponse = await authenticatedClient.oauth2.consent(
+			{ accept: true },
+			{ headers, throw: true },
+		);
+		expect(consentResponse.url).toContain("code=");
+		expect(consentResponse.url).toContain(`state=${state}`);
+
+		const code = new URL(consentResponse.url).searchParams.get("code")!;
+		const { body: tokenBody, headers: tokenHeaders } =
+			await authorizationCodeRequest({
+				code,
+				redirectURI: redirectUri,
+				options: {
+					clientId,
+					clientSecret,
+					redirectURI: redirectUri,
+				},
+			});
+
+		const tokenResponse = await customFetchImpl(
+			`${authServerBaseUrl}/api/auth/oauth2/token`,
+			{
+				method: "POST",
+				body: tokenBody.toString(),
+				headers: tokenHeaders,
+			},
+		);
+		const tokens = await tokenResponse.json();
+
+		expect(tokenResponse.status).toBe(200);
+		expect(tokens.access_token).toBeDefined();
+		expect(tokens.id_token).toBeDefined();
+	});
+
+	it("public DCR client without PKCE should still fail", async () => {
+		const registration = await unauthenticatedClient.oauth2.register({
+			token_endpoint_auth_method: "none",
+			redirect_uris: [redirectUri],
+		});
+		expect(registration.data?.client_id).toBeDefined();
+		expect(registration.data?.public).toBe(true);
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", registration.data!.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "public-dcr-no-pkce");
+
+		let errorRedirect = "";
+		await authenticatedClient.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirect = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(errorRedirect).toContain("error=invalid_request");
+		expect(errorRedirect).toContain("pkce+is+required+for+public+clients");
 	});
 });
 

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -581,6 +581,13 @@ export async function createOAuthClientEndpoint(
 	const storedClientSecret = clientSecret
 		? await storeClientSecret(ctx, opts, clientSecret)
 		: undefined;
+	const isPKCEOptionalForRegisteredClient =
+		settings.isRegister &&
+		!isPublic &&
+		opts.clientRegistrationRequirePKCE === false;
+	const requirePKCE =
+		body.require_pkce ??
+		(isPKCEOptionalForRegisteredClient ? false : undefined);
 
 	// Create the client with the existing schema
 	const iat = Math.floor(Date.now() / 1000);
@@ -611,6 +618,7 @@ export async function createOAuthClientEndpoint(
 		client_id: clientId,
 		client_secret: storedClientSecret,
 		client_id_issued_at: iat,
+		require_pkce: requirePKCE,
 		public: isPublic,
 		user_id: referenceId ? undefined : session?.session.userId,
 		reference_id: referenceId,

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -713,6 +713,16 @@ export interface OAuthOptions<
 	 */
 	clientRegistrationAllowedScopes?: Scopes;
 	/**
+	 * Whether dynamically registered confidential clients require PKCE by default.
+	 *
+	 * This is server-owned registration policy. Dynamic client registration does
+	 * not accept `require_pkce` from the client request, and public clients or
+	 * authorization requests with `offline_access` still require PKCE.
+	 *
+	 * @default true
+	 */
+	clientRegistrationRequirePKCE?: boolean;
+	/**
 	 * How long a dynamically created confidential client
 	 * should last for.
 	 *


### PR DESCRIPTION
## Summary

Confidential clients created through Dynamic Client Registration could not use authorization-code clients that do not send PKCE, because DCR had no server-owned way to persist the existing `require_pkce: false` client policy.

This adds `clientRegistrationRequirePKCE` as the DCR policy knob for confidential clients. It only changes the default metadata persisted for confidential clients created through DCR; client registration requests still cannot self-disable PKCE, and public clients or authorization requests with `offline_access` continue to require PKCE.

## Changes

- Adds `clientRegistrationRequirePKCE` to the OAuth Provider options.
- Persists `require_pkce: false` for dynamically registered confidential clients when the server opts out.
- Covers confidential and public DCR PKCE behavior in tests.
- Documents the DCR policy separately from admin-created client PKCE configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server-owned policy to allow confidential clients created via Dynamic Client Registration to use authorization-code flow without PKCE by setting `clientRegistrationRequirePKCE: false`. Public clients and requests with `offline_access` still require PKCE, and DCR requests cannot self-disable PKCE.

- **New Features**
  - Add `clientRegistrationRequirePKCE` option to `@better-auth/oauth-provider`.
  - Persist `require_pkce: false` for DCR-created confidential clients when the server opts out.
  - Add tests for confidential/public DCR PKCE behavior and scope the DCR consent window stub.
  - Update docs to separate DCR policy from admin-created client PKCE config and include a setup example.

<sup>Written for commit 195806ffe363acb050dca392961a36357a880725. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

