### PR TITLE
feat(totp): add secretEncoding option for RFC 6238 migration compatibility

### DIFF
--- a/.changeset/totp-rfc6238-secret-encoding.md
+++ b/.changeset/totp-rfc6238-secret-encoding.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Add `secretEncoding` option to the TOTP plugin to support RFC 6238-compliant secret handling. When set to `"raw"`, the stored base32 secret is decoded to raw bytes before HMAC key derivation, matching the convention used by Google Authenticator, Authy, Lucia, Auth.js, oslo, otplib, and speakeasy. This unblocks migration of existing TOTP enrollments from RFC-compliant libraries to Better Auth without forced re-enrollment. Default is `"string"` (existing behavior, no breaking change).

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -1,6 +1,7 @@
 import { createAuthEndpoint } from "@better-auth/core/api";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import { createOTP } from "@better-auth/utils/otp";
+import { base32 } from "@better-auth/utils/base32";
 import * as z from "zod";
 import { sessionMiddleware } from "../../../api";
 import { setSessionCookie } from "../../../cookies";
@@ -47,6 +48,23 @@ export type TOTPOptions = {
 	 * Disable totp
 	 */
 	disable?: boolean | undefined;
+	/**
+	 * How the stored secret is interpreted as an HMAC key.
+	 *
+	 * - `"string"` (default): current behavior — the secret string is encoded
+	 *   with TextEncoder before being used as the HMAC key. Works correctly
+	 *   for fresh Better Auth enrollments.
+	 *
+	 * - `"raw"`: RFC 6238 compliant — the stored secret is treated as a
+	 *   base32-encoded string and decoded to raw bytes before use as the HMAC
+	 *   key. This matches the convention used by Google Authenticator, Authy,
+	 *   Lucia, Auth.js, oslo, otplib, speakeasy, and most other libraries.
+	 *   Use this when migrating existing TOTP enrollments from RFC-compliant
+	 *   libraries to Better Auth.
+	 *
+	 * @default "string"
+	 */
+	secretEncoding?: "string" | "raw" | undefined;
 };
 
 const generateTOTPBodySchema = z.object({
@@ -72,6 +90,23 @@ const verifyTOTPBodySchema = z.object({
 		})
 		.optional(),
 });
+
+/**
+ * Resolves a stored TOTP secret to the value passed to createOTP.
+ *
+ * In "raw" mode the stored value is a base32 string (RFC 6238 convention).
+ * We decode it to raw bytes and convert to a latin-1 string so that
+ * TextEncoder.encode() inside createHMAC produces the same byte sequence
+ * that authenticator apps derive from base32_decode(secret).
+ */
+function resolveSecret(
+	secret: string,
+	encoding: "string" | "raw" | undefined,
+): string {
+	if (encoding !== "raw") return secret;
+	const raw = base32.decode(secret);
+	return String.fromCharCode(...raw);
+}
 
 export const totp2fa = (options?: TOTPOptions | undefined) => {
 	const opts = {
@@ -209,7 +244,7 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 				}
 				await ctx.context.password.checkPassword(user.id, ctx);
 			}
-			const totpURI = createOTP(secret, {
+			const totpURI = createOTP(resolveSecret(secret, options?.secretEncoding), {
 				digits: opts.digits,
 				period: opts.period,
 			}).url(options?.issuer || ctx.context.appName, user.email);
@@ -285,7 +320,7 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 				key: ctx.context.secretConfig,
 				data: twoFactor.secret,
 			});
-			const status = await createOTP(decrypted, {
+			const status = await createOTP(resolveSecret(decrypted, options?.secretEncoding), {
 				period: opts.period,
 				digits: opts.digits,
 			}).verify(ctx.body.code);

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -2536,3 +2536,81 @@ describe("backup codes storage configurations", () => {
 		});
 	}
 });
+
+describe("two factor - secretEncoding: raw (RFC 6238 migration)", async () => {
+	const { testUser, customFetchImpl, sessionSetter, db, auth } =
+		await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [
+				twoFactor({
+					totpOptions: {
+						secretEncoding: "raw",
+					},
+				}),
+			],
+		});
+
+	const headers = new Headers();
+	const client = createAuthClient({
+		plugins: [twoFactorClient()],
+		fetchOptions: {
+			customFetchImpl,
+			baseURL: "http://localhost:3000/api/auth",
+		},
+	});
+
+	it("should verify a TOTP code generated from raw bytes (RFC 6238 convention)", async () => {
+		await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+			fetchOptions: { onSuccess: sessionSetter(headers) },
+		});
+
+		// Simulate a secret from a RFC-6238-compliant library (e.g. Lucia, oslo):
+		// raw bytes stored as a base32 string.
+		const { base32 } = await import("@better-auth/utils/base32");
+		const rawBytes = new Uint8Array(20).fill(42); // deterministic for testing
+		const base32Secret = base32.encode(rawBytes);
+
+		// Enable 2FA and inject the RFC-style secret directly into the DB,
+		// as a migration would do.
+		const enableRes = await auth.api.enableTwoFactor({
+			headers,
+			body: { password: testUser.password },
+		});
+		expect(enableRes).toBeDefined();
+
+		const twoFactorRow = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: testUser.id }],
+		});
+		expect(twoFactorRow).toBeDefined();
+
+		// Overwrite the stored secret with the RFC-style base32 secret (post-migration state).
+		await db.update({
+			model: "twoFactor",
+			update: { secret: base32Secret },
+			where: [{ field: "id", value: twoFactorRow!.id }],
+		});
+
+		// Generate the expected TOTP code using raw bytes directly (what the
+		// authenticator app does after base32-decoding the QR secret).
+		const rawAsLatin1 = String.fromCharCode(...rawBytes);
+		const expectedCode = await createOTP(rawAsLatin1, { digits: 6, period: 30 }).totp();
+
+		const verifyRes = await auth.api.verifyTOTP({
+			headers,
+			body: { code: expectedCode },
+		});
+		expect(verifyRes).toBeDefined();
+	});
+
+	it("default secretEncoding (string) behavior is unchanged", async () => {
+		// Fresh enrollment without secretEncoding: "raw" should still work.
+		const { auth: authDefault } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [twoFactor({})],
+		});
+		expect(authDefault).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Problem
The `twoFactor` TOTP plugin derives the HMAC key via `TextEncoder.encode(secret)`, which diverges from RFC 6238 convention. Libraries like Lucia, Auth.js, oslo, otplib, speakeasy, and all major authenticator apps (Google Authenticator, Authy, 1Password) use `base32_decode(secret)` as the HMAC key. This makes it impossible to migrate existing TOTP enrollments to Better Auth without forcing users to re-enroll.

Closes #9944

## What does this PR do?
Adds a `secretEncoding` option to `TOTPOptions`:

- `"string"` (default): existing behavior — no breaking change for current users
- `"raw"`: decodes the stored base32 secret to raw bytes before HMAC key derivation, matching RFC 6238 convention

## Migration example
```ts
twoFactor({
  totpOptions: {
    secretEncoding: "raw", // enable for migrated users
  },
})


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a secretEncoding option to the TOTP 2FA plugin to support RFC 6238-compliant secrets and enable migration from libraries like `otplib`, `speakeasy`, `Lucia`, `Auth.js`, and `oslo` without forcing re-enrollment. Default behavior stays the same.

- New Features
  - `TOTPOptions.secretEncoding`: `"string"` (default) keeps current behavior; `"raw"` base32‑decodes the stored secret before HMAC to match authenticator apps (Google Authenticator, Authy, 1Password).
  - Applied in both setup and verification; tests cover migration flow.

- Migration
  - If your stored TOTP secrets are base32 strings from RFC 6238 libraries (e.g., `otplib`, `speakeasy`, `oslo`, `Lucia`, `Auth.js`), set `twoFactor({ totpOptions: { secretEncoding: "raw" } })`. No changes needed otherwise.

<sup>Written for commit 66c6e6863b5e6dbd93a424e37b6e44a398facda7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

