### PR TITLE
fix(oauth-provider): redirect missing `response_type` errors

### DIFF
--- a/.changeset/authorize-missing-response-type.md
+++ b/.changeset/authorize-missing-response-type.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+OAuth Provider authorization requests that omit `response_type` now return `invalid_request` to the verified client redirect URI instead of falling back to the provider error page.

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -388,10 +388,11 @@ export async function authorizeEndpoint(
 	}
 
 	if (!query.response_type) {
-		return handleRedirect(
+		return authorizeRedirectOnError(opts)({
+			error: "invalid_request",
+			error_description: "response_type is required",
 			ctx,
-			getErrorURL(ctx, "invalid_request", "response_type is required"),
-		);
+		});
 	}
 
 	const promptSet = ctx.query?.prompt

--- a/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
@@ -260,6 +260,28 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 			expect(errorUrl.searchParams.get("iss")).toBeTruthy();
 		});
 
+		it("missing response_type with unregistered redirect_uri → server error page", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: "https://evil.example.com/callback",
+				state: "s",
+			}).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			const redirectLocation = expectRedirectLocation(location);
+			expect(redirectLocation.startsWith(redirectUri)).toBe(false);
+			expect(redirectLocation).not.toContain("evil.example.com");
+			const errorUrl = new URL(redirectLocation);
+			expect(errorUrl.searchParams.get("error")).toBe("invalid_request");
+			expect(errorUrl.searchParams.get("error_description")).toMatch(
+				/response_type/,
+			);
+		});
+
 		it("missing client_id → server error page with invalid_request (no RP to trust)", async () => {
 			const qs = new URLSearchParams({
 				redirect_uri: redirectUri,

--- a/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
@@ -236,6 +236,30 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 			);
 		});
 
+		it("missing response_type with trusted redirect_uri → invalid_request", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const state = "missing-response-type";
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				state,
+			}).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			const redirectLocation = expectRedirectLocation(location);
+			expect(redirectLocation.startsWith(redirectUri)).toBe(true);
+			const errorUrl = new URL(redirectLocation);
+			expect(errorUrl.searchParams.get("error")).toBe("invalid_request");
+			expect(errorUrl.searchParams.get("error_description")).toMatch(
+				/response_type/,
+			);
+			expect(errorUrl.searchParams.get("state")).toBe(state);
+			expect(errorUrl.searchParams.get("iss")).toBeTruthy();
+		});
+
 		it("missing client_id → server error page with invalid_request (no RP to trust)", async () => {
 			const qs = new URLSearchParams({
 				redirect_uri: redirectUri,


### PR DESCRIPTION
Missing `response_type` currently falls back to the provider error page even when the request already identifies a registered client redirect URI.

RFC 6749 makes `response_type` required, but its authorization-code error redirect rule only forbids automatic redirect when `redirect_uri` is missing, invalid, or mismatching, or when `client_id` is missing or invalid. Once those are trusted, `invalid_request` belongs on the client redirect URI so clients can handle the failed authorization request.

This change routes that branch through the existing trusted authorize-error redirect resolver, preserving the provider error page for requests where Better Auth cannot trust a client redirect URI.

References:
- RFC 6749 section 3.1.1: https://www.rfc-editor.org/rfc/rfc6749#section-3.1.1
- RFC 6749 section 4.1.2.1: https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth authorize flow so requests missing `response_type` redirect to the verified client `redirect_uri` with `invalid_request` instead of showing the provider error page. Aligns with RFC 6749 when `client_id` and `redirect_uri` are valid.

- **Bug Fixes**
  - Missing `response_type` now uses the trusted error redirect, preserving `state` and including `iss`.
  - Provider error page is still used when the redirect cannot be trusted (missing/invalid `client_id` or `redirect_uri`).
  - Added integration tests for both trusted and unregistered `redirect_uri` paths.

<sup>Written for commit aaa928f19b25d2e6ae2c105ff633f4594cb8f64e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

