### PR TITLE
fix(oauth-provider): reject authorization code replay correctly

### DIFF
--- a/.changeset/code-replay-invalid-grant.md
+++ b/.changeset/code-replay-invalid-grant.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+OAuth Provider authorization-code replay now returns `invalid_grant` with a `400` token response and revokes previously issued opaque tokens from that authorization code.

--- a/packages/oauth-provider/src/schema.test.ts
+++ b/packages/oauth-provider/src/schema.test.ts
@@ -104,6 +104,8 @@ describe("oauth provider schema", () => {
 		);
 		expect(refreshFields.confirmation).toBeDefined();
 		expect(accessFields.confirmation).toBeDefined();
+		expect(refreshFields.authorizationCodeId).toBeDefined();
+		expect(accessFields.authorizationCodeId).toBeDefined();
 
 		// Other sender-constraint/token-format columns are intentionally absent
 		// from the schema.

--- a/packages/oauth-provider/src/schema.ts
+++ b/packages/oauth-provider/src/schema.ts
@@ -351,6 +351,11 @@ export const schema = {
 				type: "string",
 				required: false,
 			},
+			authorizationCodeId: {
+				type: "string",
+				required: false,
+				index: true,
+			},
 			resources: {
 				type: "string[]",
 				required: false,
@@ -435,6 +440,11 @@ export const schema = {
 			referenceId: {
 				type: "string",
 				required: false,
+			},
+			authorizationCodeId: {
+				type: "string",
+				required: false,
+				index: true,
 			},
 			resources: {
 				type: "string[]",

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -460,6 +460,45 @@ describe("oauth token - authorization_code", async () => {
 			"invalid_grant",
 		);
 	});
+
+	it("rejects authorization code replay with invalid_grant and revokes issued tokens", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes: ["openid"],
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const code = new URL(callbackRedirectUrl).searchParams.get("code");
+		expect(code).toBeTruthy();
+
+		const tokens = await validateAuthCode({ code: code!, codeVerifier });
+		expect(tokens.error).toBeNull();
+		expect(tokens.data?.access_token).toBeDefined();
+
+		const replay = await validateAuthCode({ code: code!, codeVerifier });
+		expect(replay.error?.status).toBe(400);
+		expect((replay.error as { error?: string } | undefined)?.error).toBe(
+			"invalid_grant",
+		);
+
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					Authorization: `Bearer ${tokens.data!.access_token}`,
+				},
+			},
+		);
+		expect(userinfo.error?.status).toBe(401);
+	});
 });
 
 describe("oauth token - refresh_token", async () => {

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -461,6 +461,9 @@ describe("oauth token - authorization_code", async () => {
 		);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/10150
+	 */
 	it("rejects authorization code replay with invalid_grant and revokes issued tokens", async () => {
 		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
 			throw Error("beforeAll not run properly");
@@ -500,13 +503,16 @@ describe("oauth token - authorization_code", async () => {
 		expect(userinfo.error?.status).toBe(401);
 	});
 
-	it("rejects authorization code replay with invalid_grant when cleanup fails", async () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/10150
+	 */
+	it("rejects authorization code replay with invalid_grant and still attempts refresh-token cleanup when access-token cleanup fails", async () => {
 		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
 			throw Error("beforeAll not run properly");
 		}
 
 		const { url: authUrl, codeVerifier } = await createAuthUrl({
-			scopes: ["openid"],
+			scopes: ["openid", "offline_access"],
 		});
 
 		let callbackRedirectUrl = "";
@@ -521,6 +527,7 @@ describe("oauth token - authorization_code", async () => {
 		const tokens = await validateAuthCode({ code: code!, codeVerifier });
 		expect(tokens.error).toBeNull();
 		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.refresh_token).toBeDefined();
 
 		const context = await auth.$context;
 		const deleteMany = vi
@@ -539,6 +546,32 @@ describe("oauth token - authorization_code", async () => {
 			expect(loggerError).toHaveBeenCalledWith(
 				"authorization code replay cleanup failed",
 				expect.any(Error),
+			);
+			expect(deleteMany).toHaveBeenNthCalledWith(
+				1,
+				expect.objectContaining({ model: "oauthAccessToken" }),
+			);
+			expect(deleteMany).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({ model: "oauthRefreshToken" }),
+			);
+
+			const { body, headers } = await refreshAccessTokenRequest({
+				refreshToken: tokens.data!.refresh_token!,
+				options: {
+					clientId: oauthClient.client_id,
+					clientSecret: oauthClient.client_secret,
+					redirectURI: redirectUri,
+				},
+			});
+			const refresh = await client.$fetch<{ error?: string }>("/oauth2/token", {
+				method: "POST",
+				body,
+				headers,
+			});
+			expect(refresh.error?.status).toBe(400);
+			expect((refresh.error as { error?: string } | undefined)?.error).toBe(
+				"invalid_grant",
 			);
 		} finally {
 			deleteMany.mockRestore();

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -21,7 +21,7 @@ import {
 	jwtVerify,
 	SignJWT,
 } from "jose";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
 import { confirmationTokenType } from "./token";
@@ -498,6 +498,52 @@ describe("oauth token - authorization_code", async () => {
 			},
 		);
 		expect(userinfo.error?.status).toBe(401);
+	});
+
+	it("rejects authorization code replay with invalid_grant when cleanup fails", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes: ["openid"],
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const code = new URL(callbackRedirectUrl).searchParams.get("code");
+		expect(code).toBeTruthy();
+
+		const tokens = await validateAuthCode({ code: code!, codeVerifier });
+		expect(tokens.error).toBeNull();
+		expect(tokens.data?.access_token).toBeDefined();
+
+		const context = await auth.$context;
+		const deleteMany = vi
+			.spyOn(context.adapter, "deleteMany")
+			.mockRejectedValueOnce(new Error("cleanup failed"));
+		const loggerError = vi
+			.spyOn(context.logger, "error")
+			.mockImplementation(() => undefined);
+
+		try {
+			const replay = await validateAuthCode({ code: code!, codeVerifier });
+			expect(replay.error?.status).toBe(400);
+			expect((replay.error as { error?: string } | undefined)?.error).toBe(
+				"invalid_grant",
+			);
+			expect(loggerError).toHaveBeenCalledWith(
+				"authorization code replay cleanup failed",
+				expect.any(Error),
+			);
+		} finally {
+			deleteMany.mockRestore();
+			loggerError.mockRestore();
+		}
 	});
 });
 

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -468,6 +468,7 @@ async function createOpaqueAccessToken(
 	payload: JWTPayload,
 	resources?: string[],
 	referenceId?: string,
+	authorizationCodeId?: string,
 	refreshId?: string,
 	confirmation?: Confirmation,
 ) {
@@ -484,6 +485,7 @@ async function createOpaqueAccessToken(
 			sessionId: payload?.sid,
 			userId: user?.id,
 			referenceId,
+			authorizationCodeId,
 			resources,
 			refreshId,
 			confirmation,
@@ -545,11 +547,26 @@ export async function invalidateRefreshFamily(
 	});
 }
 
+async function revokeTokensIssuedForAuthorizationCode(
+	ctx: GenericEndpointContext,
+	authorizationCodeId: string,
+) {
+	await ctx.context.adapter.deleteMany({
+		model: "oauthAccessToken",
+		where: [{ field: "authorizationCodeId", value: authorizationCodeId }],
+	});
+	await ctx.context.adapter.deleteMany({
+		model: "oauthRefreshToken",
+		where: [{ field: "authorizationCodeId", value: authorizationCodeId }],
+	});
+}
+
 async function createRefreshToken(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
 	user: User,
 	referenceId: string | undefined,
+	authorizationCodeId: string | undefined,
 	client: SchemaClient<Scope[]>,
 	scopes: string[],
 	payload: JWTPayload,
@@ -575,6 +592,7 @@ async function createRefreshToken(
 		sessionId,
 		userId: user.id,
 		referenceId,
+		authorizationCodeId,
 		authTime,
 		confirmation,
 		scopes,
@@ -647,6 +665,7 @@ async function createRefreshToken(
 
 type CreateUserTokensParams = OAuthTokenIssueParams & {
 	grantType: GrantType;
+	authorizationCodeId?: string;
 };
 
 interface ResourceGrantIssuance {
@@ -885,6 +904,7 @@ async function createUserTokens(
 					opts,
 					user,
 					referenceId,
+					params.authorizationCodeId,
 					client,
 					effectiveScopes,
 					{
@@ -952,6 +972,7 @@ async function createUserTokens(
 					},
 					params?.resources,
 					referenceId,
+					params.authorizationCodeId,
 					earlyRefreshToken?.id,
 					confirmation,
 				),
@@ -963,6 +984,7 @@ async function createUserTokens(
 						opts,
 						user,
 						referenceId,
+						params.authorizationCodeId,
 						client,
 						effectiveScopes,
 						{
@@ -1016,16 +1038,22 @@ async function checkVerificationValue(
 	redirect_uri?: string,
 	resource?: string[],
 ) {
+	const authorizationCodeId = await storeToken(
+		opts.storeTokens,
+		code,
+		"authorization_code",
+	);
 	// Atomic single-use redemption per RFC 6749 §4.1.2. The first caller
 	// receives the row and mints tokens; concurrent racers receive `null`
 	// and fall through to the `invalid_grant` error path (RFC 6749 §5.2).
 	const verification =
 		await ctx.context.internalAdapter.consumeVerificationValue(
-			await storeToken(opts.storeTokens, code, "authorization_code"),
+			authorizationCodeId,
 		);
 
 	if (!verification) {
-		throw new APIError("UNAUTHORIZED", {
+		await revokeTokensIssuedForAuthorizationCode(ctx, authorizationCodeId);
+		throw new APIError("BAD_REQUEST", {
 			error_description: "invalid code",
 			error: "invalid_grant",
 		});
@@ -1035,14 +1063,14 @@ async function checkVerificationValue(
 	try {
 		rawValue = JSON.parse(verification.value);
 	} catch {
-		throw new APIError("UNAUTHORIZED", {
+		throw new APIError("BAD_REQUEST", {
 			error_description: "malformed verification value",
 			error: "invalid_grant",
 		});
 	}
 	const parsed = verificationValueSchema.safeParse(rawValue);
 	if (!parsed.success) {
-		throw new APIError("UNAUTHORIZED", {
+		throw new APIError("BAD_REQUEST", {
 			error_description: "malformed verification value",
 			error: "invalid_grant",
 		});
@@ -1051,9 +1079,9 @@ async function checkVerificationValue(
 	const verificationValue = parsed.data as VerificationValue;
 
 	if (verificationValue.query.client_id !== client_id) {
-		throw new APIError("UNAUTHORIZED", {
+		throw new APIError("BAD_REQUEST", {
 			error_description: "invalid client_id",
-			error: "invalid_client",
+			error: "invalid_grant",
 		});
 	}
 	if (
@@ -1088,6 +1116,7 @@ async function checkVerificationValue(
 		verificationValue,
 		effectiveResources,
 		authorizedResources: storedResources,
+		authorizationCodeId,
 	};
 }
 
@@ -1153,15 +1182,19 @@ async function handleAuthorizationCodeGrant(
 	}
 
 	/** Get and check Verification Value */
-	const { verificationValue, effectiveResources, authorizedResources } =
-		await checkVerificationValue(
-			ctx,
-			opts,
-			code,
-			client_id,
-			redirect_uri,
-			resources,
-		);
+	const {
+		verificationValue,
+		effectiveResources,
+		authorizedResources,
+		authorizationCodeId,
+	} = await checkVerificationValue(
+		ctx,
+		opts,
+		code,
+		client_id,
+		redirect_uri,
+		resources,
+	);
 	const scopes = verificationValue.query.scope?.split(" ");
 	if (!scopes) {
 		throw new APIError("INTERNAL_SERVER_ERROR", {
@@ -1297,6 +1330,7 @@ async function handleAuthorizationCodeGrant(
 		nonce: verificationValue.query?.nonce,
 		authTime,
 		verificationValue,
+		authorizationCodeId,
 		resources: effectiveResources,
 		originalResources: authorizedResources,
 	});
@@ -1542,6 +1576,7 @@ async function handleRefreshTokenGrant(
 		user,
 		grantType: "refresh_token",
 		referenceId: refreshToken.referenceId,
+		authorizationCodeId: refreshToken.authorizationCodeId,
 		sessionId: refreshToken.sessionId,
 		refreshToken,
 		resources: resources ?? refreshToken.resources,

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -551,14 +551,18 @@ async function revokeTokensIssuedForAuthorizationCode(
 	ctx: GenericEndpointContext,
 	authorizationCodeId: string,
 ) {
-	await ctx.context.adapter.deleteMany({
-		model: "oauthAccessToken",
-		where: [{ field: "authorizationCodeId", value: authorizationCodeId }],
-	});
-	await ctx.context.adapter.deleteMany({
-		model: "oauthRefreshToken",
-		where: [{ field: "authorizationCodeId", value: authorizationCodeId }],
-	});
+	try {
+		await ctx.context.adapter.deleteMany({
+			model: "oauthAccessToken",
+			where: [{ field: "authorizationCodeId", value: authorizationCodeId }],
+		});
+		await ctx.context.adapter.deleteMany({
+			model: "oauthRefreshToken",
+			where: [{ field: "authorizationCodeId", value: authorizationCodeId }],
+		});
+	} catch (error) {
+		ctx.context.logger.error("authorization code replay cleanup failed", error);
+	}
 }
 
 async function createRefreshToken(

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -551,18 +551,24 @@ async function revokeTokensIssuedForAuthorizationCode(
 	ctx: GenericEndpointContext,
 	authorizationCodeId: string,
 ) {
-	try {
-		await ctx.context.adapter.deleteMany({
-			model: "oauthAccessToken",
-			where: [{ field: "authorizationCodeId", value: authorizationCodeId }],
-		});
-		await ctx.context.adapter.deleteMany({
-			model: "oauthRefreshToken",
-			where: [{ field: "authorizationCodeId", value: authorizationCodeId }],
-		});
-	} catch (error) {
-		ctx.context.logger.error("authorization code replay cleanup failed", error);
-	}
+	const deleteIssuedTokens = async (
+		model: "oauthAccessToken" | "oauthRefreshToken",
+	) => {
+		try {
+			await ctx.context.adapter.deleteMany({
+				model,
+				where: [{ field: "authorizationCodeId", value: authorizationCodeId }],
+			});
+		} catch (error) {
+			ctx.context.logger.error(
+				"authorization code replay cleanup failed",
+				error,
+			);
+		}
+	};
+
+	await deleteIssuedTokens("oauthAccessToken");
+	await deleteIssuedTokens("oauthRefreshToken");
 }
 
 async function createRefreshToken(

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1720,6 +1720,11 @@ export interface OAuthOpaqueAccessToken<
 	 */
 	referenceId?: string;
 	/**
+	 * Stored authorization-code identifier that produced this token family.
+	 * Used to revoke tokens after authorization-code replay is detected.
+	 */
+	authorizationCodeId?: string;
+	/**
 	 * The refresh token the access token is associated with.
 	 *
 	 * Not available without the "offline_access" scope
@@ -1762,6 +1767,7 @@ export interface OAuthRefreshToken<
 	sessionId?: string;
 	userId: string;
 	referenceId?: string;
+	authorizationCodeId?: string;
 	clientId?: string;
 	expiresAt: Date;
 	createdAt: Date;


### PR DESCRIPTION
Authorization-code replay currently returns the right OAuth error code but the wrong token endpoint HTTP status, and the access token from the first exchange remains usable after replay.

RFC 6749 treats token endpoint grant failures as `400` responses unless client authentication failed. It also requires authorization codes to be single-use and says tokens already issued from a replayed code should be revoked when possible. This keeps client-auth failures separate from grant replay, tracks the authorization-code lineage on opaque token rows, and deletes those rows when the same code is presented again.

JWT access tokens are still stateless once minted, so the revocation path applies to persisted opaque access and refresh tokens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes authorization-code replay handling in `@better-auth/oauth-provider`. The token endpoint now returns 400 `invalid_grant` and revokes previously issued opaque access and refresh tokens from the replayed code.

- **Bug Fixes**
  - Track and index `authorizationCodeId` on access and refresh tokens; propagate it through issuance and refresh flows.
  - On replay, delete tokens by `authorizationCodeId`; access and refresh cleanup run independently, best-effort, and log failures.
  - Map invalid/malformed codes and `client_id` mismatches to 400 `invalid_grant`; keep client-auth errors separate.

<sup>Written for commit 7330a789c927bf139e6f6052fcd2dd2fa9c49d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

