### PR TITLE
fix(oauth-provider): handle OIDC authorization request inputs

### DIFF
--- a/.changeset/authorize-post-request-objects.md
+++ b/.changeset/authorize-post-request-objects.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Adds form-encoded POST support to the OIDC authorization endpoint and explicitly rejects unsupported OpenID Connect request objects with standard `request_not_supported` and `request_uri_not_supported` errors.

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -17,7 +17,7 @@ import {
 	setSignedOAuthQueryParameterNames,
 	signedQueryIssuedAtParam,
 } from "./signed-query";
-import type { OAuthConsent, Scope } from "./types";
+import type { OAuthConsent, OAuthOptions, Scope } from "./types";
 import type { OAuthClient } from "./types/oauth";
 import { verifyOAuthQueryParams } from "./utils";
 
@@ -507,6 +507,49 @@ describe("oauth authorize - request_uri resolution", async () => {
 	const requestUriWithPostLoginMarker = "urn:better-auth:par:post-login";
 	const requestUriWithInvalidMaxAge = "urn:better-auth:par:invalid-max-age";
 	const requestUriWithReorderedPrompt = "urn:better-auth:par:reordered-prompt";
+	type RequestUriResolver = NonNullable<
+		OAuthOptions<Scope[]>["requestUriResolver"]
+	>;
+	type RequestUriResolverInput = Parameters<RequestUriResolver>[0];
+	const requestUriResolver = vi.fn(
+		async ({ requestUri: receivedRequestUri }: RequestUriResolverInput) => {
+			const resolvedParams = {
+				response_type: "code",
+				redirect_uri: redirectUri,
+				scope: "openid",
+				state: "par-state",
+				code_challenge: "a".repeat(43),
+				code_challenge_method: "S256",
+			};
+
+			if (receivedRequestUri === requestUri) {
+				return resolvedParams;
+			}
+
+			if (receivedRequestUri === requestUriWithPostLoginMarker) {
+				return {
+					...resolvedParams,
+					[postLoginClearedParam]: "attacker-session",
+				};
+			}
+
+			if (receivedRequestUri === requestUriWithInvalidMaxAge) {
+				return {
+					...resolvedParams,
+					max_age: "-1",
+				};
+			}
+
+			if (receivedRequestUri === requestUriWithReorderedPrompt) {
+				return {
+					...resolvedParams,
+					prompt: "consent login",
+				};
+			}
+
+			return null;
+		},
+	);
 
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		baseURL: authServerBaseUrl,
@@ -514,43 +557,7 @@ describe("oauth authorize - request_uri resolution", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				requestUriResolver: async ({ requestUri: receivedRequestUri }) => {
-					const resolvedParams = {
-						response_type: "code",
-						redirect_uri: redirectUri,
-						scope: "openid",
-						state: "par-state",
-						code_challenge: "a".repeat(43),
-						code_challenge_method: "S256",
-					};
-
-					if (receivedRequestUri === requestUri) {
-						return resolvedParams;
-					}
-
-					if (receivedRequestUri === requestUriWithPostLoginMarker) {
-						return {
-							...resolvedParams,
-							[postLoginClearedParam]: "attacker-session",
-						};
-					}
-
-					if (receivedRequestUri === requestUriWithInvalidMaxAge) {
-						return {
-							...resolvedParams,
-							max_age: "-1",
-						};
-					}
-
-					if (receivedRequestUri === requestUriWithReorderedPrompt) {
-						return {
-							...resolvedParams,
-							prompt: "consent login",
-						};
-					}
-
-					return null;
-				},
+				requestUriResolver,
 				silenceWarnings: {
 					oauthAuthServerConfig: true,
 					openidConfig: true,
@@ -579,6 +586,26 @@ describe("oauth authorize - request_uri resolution", async () => {
 		});
 		expect(response?.client_id).toBeDefined();
 		oauthClient = response;
+	});
+
+	it("should reject request_uri without client_id before resolver lookup", async () => {
+		requestUriResolver.mockClear();
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("request_uri", requestUri);
+
+		let errorRedirectUrl = "";
+		await unauthenticatedClient.$fetch(authUrl.toString(), {
+			onError(context) {
+				errorRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(requestUriResolver).not.toHaveBeenCalled();
+		const errorRedirect = new URL(errorRedirectUrl, authServerBaseUrl);
+		expect(errorRedirect.searchParams.get("error")).toBe("invalid_request");
+		expect(errorRedirect.searchParams.get("error_description")).toMatch(
+			/client_id/,
+		);
 	});
 
 	it("should sign the resolved PAR parameters for the login redirect", async () => {

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -118,6 +118,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function getStringParameter(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
 function getAuthorizationRequestParameters(
 	ctx: GenericEndpointContext,
 	settings: AuthorizeEndpointSettings | undefined,
@@ -362,14 +366,16 @@ export async function authorizeEndpoint(
 		settings,
 	);
 	ctx.query = query;
-	if (query.request && query.request_uri) {
+	const requestObject = getStringParameter(query.request);
+	const requestUri = getStringParameter(query.request_uri);
+	if (requestObject !== undefined && requestUri !== undefined) {
 		return authorizeRedirectOnError(opts)({
 			error: "invalid_request",
 			error_description: "request and request_uri cannot be used together",
 			ctx,
 		});
 	}
-	if (query.request) {
+	if (requestObject !== undefined) {
 		return authorizeRedirectOnError(opts)({
 			error: "request_not_supported",
 			error_description: "request object not supported",
@@ -378,7 +384,15 @@ export async function authorizeEndpoint(
 	}
 
 	// Resolve request_uri (PAR) before processing
-	if (query.request_uri) {
+	if (requestUri !== undefined) {
+		const clientId = getStringParameter(query.client_id);
+		if (!clientId) {
+			return authorizeRedirectOnError(opts)({
+				error: "invalid_request",
+				error_description: "client_id is required",
+				ctx,
+			});
+		}
 		if (!opts.requestUriResolver) {
 			return authorizeRedirectOnError(opts)({
 				error: "request_uri_not_supported",
@@ -387,8 +401,8 @@ export async function authorizeEndpoint(
 			});
 		}
 		const resolvedParams = await opts.requestUriResolver({
-			requestUri: query.request_uri,
-			clientId: query.client_id ?? "",
+			requestUri,
+			clientId,
 			ctx,
 		});
 		if (!resolvedParams) {
@@ -423,13 +437,6 @@ export async function authorizeEndpoint(
 	await oAuthState.set({
 		query: serializeAuthorizationQuery(query).toString(),
 	});
-
-	if (!query.client_id) {
-		return handleRedirect(
-			ctx,
-			getErrorURL(ctx, "invalid_client", "client_id is required"),
-		);
-	}
 
 	if (!query.response_type) {
 		return authorizeRedirectOnError(opts)({

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -7,6 +7,7 @@ import type { Verification } from "better-auth/db";
 import { APIError } from "better-call";
 import { oAuthState } from "./oauth";
 import type { OAuthErrorCode, OAuthRedirectOnError } from "./oauth-endpoint";
+import { mapIssuesToOAuthError } from "./oauth-endpoint";
 import { resolveResourcePolicy } from "./resources";
 import {
 	canonicalizeOAuthQueryParams,
@@ -106,6 +107,27 @@ function deriveResponseMode(
 		return "fragment";
 	}
 	return "query";
+}
+
+const authorizationQueryErrorCodesByField = {
+	response_type: { invalid: "unsupported_response_type" },
+	resource: { invalid: "invalid_target" },
+} as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getAuthorizationRequestParameters(
+	ctx: GenericEndpointContext,
+	settings: AuthorizeEndpointSettings | undefined,
+): OAuthAuthorizationQuery {
+	const source =
+		ctx.method === "POST" && settings?.isAuthorize === true
+			? ctx.body
+			: ctx.query;
+	const parameters = isRecord(source) ? source : {};
+	return { ...parameters } as unknown as OAuthAuthorizationQuery;
 }
 
 export const handleRedirect = (
@@ -333,14 +355,36 @@ export async function authorizeEndpoint(
 	}
 	const request = ctx.request;
 
+	// Normalize GET query serialization and POST form serialization through one
+	// authorization-request path (OIDC Core §3.1.2.1).
+	let query: OAuthAuthorizationQuery = getAuthorizationRequestParameters(
+		ctx,
+		settings,
+	);
+	ctx.query = query;
+	if (query.request && query.request_uri) {
+		return authorizeRedirectOnError(opts)({
+			error: "invalid_request",
+			error_description: "request and request_uri cannot be used together",
+			ctx,
+		});
+	}
+	if (query.request) {
+		return authorizeRedirectOnError(opts)({
+			error: "request_not_supported",
+			error_description: "request object not supported",
+			ctx,
+		});
+	}
+
 	// Resolve request_uri (PAR) before processing
-	let query: OAuthAuthorizationQuery = ctx.query;
 	if (query.request_uri) {
 		if (!opts.requestUriResolver) {
-			return handleRedirect(
+			return authorizeRedirectOnError(opts)({
+				error: "request_uri_not_supported",
+				error_description: "request_uri not supported",
 				ctx,
-				getErrorURL(ctx, "invalid_request_uri", "request_uri not supported"),
-			);
+			});
 		}
 		const resolvedParams = await opts.requestUriResolver({
 			requestUri: query.request_uri,
@@ -348,14 +392,11 @@ export async function authorizeEndpoint(
 			ctx,
 		});
 		if (!resolvedParams) {
-			return handleRedirect(
+			return authorizeRedirectOnError(opts)({
+				error: "invalid_request_uri",
+				error_description: "request_uri is invalid or expired",
 				ctx,
-				getErrorURL(
-					ctx,
-					"invalid_request_uri",
-					"request_uri is invalid or expired",
-				),
-			);
+			});
 		}
 		// RFC 9126 §4: all params come from the stored request, not the URL.
 		// Only client_id is carried from the authorization URL.
@@ -368,9 +409,12 @@ export async function authorizeEndpoint(
 	ctx.query = query;
 	const parsedQuery = authorizationQuerySchema.safeParse(query);
 	if (!parsedQuery.success) {
+		const mappedError = mapIssuesToOAuthError(
+			parsedQuery.error.issues,
+			authorizationQueryErrorCodesByField,
+		);
 		return authorizeRedirectOnError(opts)({
-			error: "invalid_request",
-			error_description: "invalid authorization request",
+			...mappedError,
 			ctx,
 		});
 	}

--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -349,6 +349,14 @@ describe("oauth metadata", async () => {
 		expect(oauthMetadata).toMatchObject(metadata ?? {});
 	});
 
+	it("should explicitly advertise unsupported request object parameters", async () => {
+		const { auth } = await createTestInstance();
+		const metadata = await auth.api.getOpenIdConfig();
+
+		expect(metadata.request_parameter_supported).toBe(false);
+		expect(metadata.request_uri_parameter_supported).toBe(false);
+	});
+
 	it("should fail if advertised scope invalid", async () => {
 		const advertisedScopes = ["create:test"];
 		expect(() =>

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -188,6 +188,8 @@ export function oidcServerMetadata(
 			return Array.from(new Set<JWSAlgorithms>([primary, ...extras]));
 		})(),
 		end_session_endpoint: `${baseURL}/oauth2/end-session`,
+		request_parameter_supported: false,
+		request_uri_parameter_supported: false,
 		prompt_values_supported: [
 			"login",
 			"consent",

--- a/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
@@ -76,11 +76,14 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 		return { status, body };
 	}
 
-	async function captureRedirect(path: string) {
+	async function captureRedirect(
+		path: string,
+		init: Parameters<typeof client.$fetch>[1] = { method: "GET" },
+	) {
 		let status = 0;
 		let location: string | null = null;
 		await client.$fetch(path, {
-			method: "GET",
+			...init,
 			redirect: "manual",
 			onResponse: async (context) => {
 				status = context.response.status;
@@ -280,6 +283,77 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 			expect(errorUrl.searchParams.get("error_description")).toMatch(
 				/response_type/,
 			);
+		});
+
+		it("form POST authorization request → code redirect", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const state = "post-authorization-state";
+			const body = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				response_type: "code",
+				scope: "openid",
+				state,
+				code_challenge: "a".repeat(43),
+				code_challenge_method: "S256",
+			});
+			const { status, location } = await captureRedirect("/oauth2/authorize", {
+				method: "POST",
+				body,
+				headers: { "content-type": "application/x-www-form-urlencoded" },
+			});
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			const redirectLocation = expectRedirectLocation(location);
+			const callback = new URL(redirectLocation);
+			expect(redirectLocation.startsWith(redirectUri)).toBe(true);
+			expect(callback.searchParams.get("code")).toBeTruthy();
+			expect(callback.searchParams.get("state")).toBe(state);
+			expect(callback.searchParams.get("iss")).toBeTruthy();
+		});
+
+		it("unsupported request object → request_not_supported", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				response_type: "code",
+				scope: "openid",
+				request: "eyJhbGciOiJub25lIn0.eyJzdGF0ZSI6Imp3dC1zdGF0ZSJ9.",
+			}).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			const redirectLocation = expectRedirectLocation(location);
+			const errorUrl = new URL(redirectLocation);
+			expect(redirectLocation.startsWith(redirectUri)).toBe(true);
+			expect(errorUrl.searchParams.get("error")).toBe("request_not_supported");
+			expect(errorUrl.searchParams.get("code")).toBeNull();
+		});
+
+		it("unsupported request_uri without resolver → request_uri_not_supported", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				response_type: "code",
+				scope: "openid",
+				request_uri: "https://rp.example.com/request.jwt",
+			}).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			const redirectLocation = expectRedirectLocation(location);
+			const errorUrl = new URL(redirectLocation);
+			expect(redirectLocation.startsWith(redirectUri)).toBe(true);
+			expect(errorUrl.searchParams.get("error")).toBe(
+				"request_uri_not_supported",
+			);
+			expect(errorUrl.searchParams.get("code")).toBeNull();
 		});
 
 		it("missing client_id → server error page with invalid_request (no RP to trust)", async () => {

--- a/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
@@ -333,6 +333,27 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 			expect(errorUrl.searchParams.get("code")).toBeNull();
 		});
 
+		it("empty request object parameter → request_not_supported", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				response_type: "code",
+				scope: "openid",
+				request: "",
+			}).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			const redirectLocation = expectRedirectLocation(location);
+			const errorUrl = new URL(redirectLocation);
+			expect(redirectLocation.startsWith(redirectUri)).toBe(true);
+			expect(errorUrl.searchParams.get("error")).toBe("request_not_supported");
+			expect(errorUrl.searchParams.get("code")).toBeNull();
+		});
+
 		it("unsupported request_uri without resolver → request_uri_not_supported", async () => {
 			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
 			const qs = new URLSearchParams({
@@ -341,6 +362,29 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 				response_type: "code",
 				scope: "openid",
 				request_uri: "https://rp.example.com/request.jwt",
+			}).toString();
+			const { status, location } = await captureRedirect(
+				`/oauth2/authorize?${qs}`,
+			);
+			expect(status).toBeGreaterThanOrEqual(300);
+			expect(status).toBeLessThan(400);
+			const redirectLocation = expectRedirectLocation(location);
+			const errorUrl = new URL(redirectLocation);
+			expect(redirectLocation.startsWith(redirectUri)).toBe(true);
+			expect(errorUrl.searchParams.get("error")).toBe(
+				"request_uri_not_supported",
+			);
+			expect(errorUrl.searchParams.get("code")).toBeNull();
+		});
+
+		it("empty request_uri parameter without resolver → request_uri_not_supported", async () => {
+			if (!oauthClient?.client_id) throw new Error("beforeAll didn't run");
+			const qs = new URLSearchParams({
+				client_id: oauthClient.client_id,
+				redirect_uri: redirectUri,
+				response_type: "code",
+				scope: "openid",
+				request_uri: "",
 			}).toString();
 			const { status, location } = await captureRedirect(
 				`/oauth2/authorize?${qs}`,

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -308,42 +308,43 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 			metadata: {
 				allowedMediaTypes: ["application/x-www-form-urlencoded"],
 				openapi: {
-					description: "Authorize an OAuth2 request",
+					description:
+						"Authorize an OAuth 2.1 request from query parameters or an application/x-www-form-urlencoded POST body",
 					parameters: [
 						{
 							name: "response_type",
 							in: "query",
 							required: false,
 							schema: { type: "string" },
-							description: "OAuth2 response type (e.g., 'code')",
+							description: "OAuth 2.1 response type (e.g., 'code')",
 						},
 						{
 							name: "client_id",
 							in: "query",
 							required: true,
 							schema: { type: "string" },
-							description: "OAuth2 client ID",
+							description: "OAuth 2.1 client ID",
 						},
 						{
 							name: "redirect_uri",
 							in: "query",
 							required: false,
 							schema: { type: "string", format: "uri" },
-							description: "OAuth2 redirect URI",
+							description: "OAuth 2.1 redirect URI",
 						},
 						{
 							name: "scope",
 							in: "query",
 							required: false,
 							schema: { type: "string" },
-							description: "OAuth2 scopes (space-separated)",
+							description: "OAuth 2.1 scopes (space-separated)",
 						},
 						{
 							name: "state",
 							in: "query",
 							required: false,
 							schema: { type: "string" },
-							description: "OAuth2 state parameter",
+							description: "OAuth 2.1 state parameter",
 						},
 						{
 							name: "request_uri",

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -47,7 +47,6 @@ import { schema } from "./schema";
 import { tokenEndpoint } from "./token";
 import type { OAuthOptions, Scope } from "./types";
 import {
-	authorizationQuerySchema,
 	clientRegistrationRequestSchema,
 	ResourceUriSchema,
 	SafeUrlSchema,
@@ -303,14 +302,11 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 	const oauth2AuthorizeEndpoint = createOAuthEndpoint(
 		"/oauth2/authorize",
 		{
-			method: "GET",
-			query: authorizationQuerySchema,
+			method: ["GET", "POST"],
+			body: z.object({}).passthrough(),
 			redirectOnError: authorizeRedirectOnError(opts),
-			errorCodesByField: {
-				response_type: { invalid: "unsupported_response_type" },
-				resource: { invalid: "invalid_target" },
-			},
 			metadata: {
+				allowedMediaTypes: ["application/x-www-form-urlencoded"],
 				openapi: {
 					description: "Authorize an OAuth2 request",
 					parameters: [

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1316,7 +1316,7 @@ export interface OAuthAuthorizationQuery {
 	 * - "code": authorization code flow.
 	 * Optional in the query when using request_uri (PAR) — resolved from stored params.
 	 */
-	// NEVER SUPPORT "token" or "id_token" - depreciated in oAuth2.1
+	// NEVER SUPPORT "token" or "id_token" - deprecated in OAuth 2.1
 	response_type?: "code";
 	/**
 	 * OpenID Connect Request Object by value.

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1319,6 +1319,13 @@ export interface OAuthAuthorizationQuery {
 	// NEVER SUPPORT "token" or "id_token" - depreciated in oAuth2.1
 	response_type?: "code";
 	/**
+	 * OpenID Connect Request Object by value.
+	 *
+	 * The parameter is parsed so unsupported use can be rejected with
+	 * `request_not_supported`; Better Auth does not process Request Objects yet.
+	 */
+	request?: string;
+	/**
 	 * PAR request_uri. When present, other params are resolved from the stored request.
 	 */
 	request_uri?: string;

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -379,7 +379,7 @@ export interface OAuthClient {
 	token_endpoint_auth_method?: TokenEndpointAuthMethod;
 	grant_types?: GrantType[];
 	response_types?: "code"[];
-	// | "token" // NEVER SUPPORT - depreciated in oAuth2.1
+	// | "token" // NEVER SUPPORT - deprecated in OAuth 2.1
 	//---- RFC6749 Spec ----//
 	public?: boolean;
 	type?: "web" | "native" | "user-agent-based";

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -302,6 +302,23 @@ export interface OIDCMetadata extends AuthServerMetadata {
 	 */
 	end_session_endpoint: string;
 	/**
+	 * Whether the OP supports OpenID Connect Request Objects by value.
+	 *
+	 * @default false
+	 * @see https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+	 */
+	request_parameter_supported?: boolean;
+	/**
+	 * Whether the OP supports OpenID Connect Request Objects by reference.
+	 *
+	 * Discovery defaults this field to true when omitted, so providers that do
+	 * not support it should advertise false explicitly.
+	 *
+	 * @default false
+	 * @see https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+	 */
+	request_uri_parameter_supported?: boolean;
+	/**
 	 * Prompt values supported by this OIDC server
 	 *
 	 * @see https://openid.net/specs/openid-connect-prompt-create-1_0.html#OpenID.Discovery

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -111,6 +111,7 @@ export const authorizationQuerySchema = z
 			.string()
 			.pipe(z.enum(["code"]))
 			.optional(),
+		request: z.string().optional(),
 		request_uri: z.string().optional(),
 		redirect_uri: SafeUrlSchema.optional(),
 		scope: z.string().optional(),

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -116,7 +116,7 @@ export const authorizationQuerySchema = z
 		redirect_uri: SafeUrlSchema.optional(),
 		scope: z.string().optional(),
 		state: z.string().optional(),
-		client_id: z.string(),
+		client_id: z.string().min(1, "client_id is required"),
 		prompt: authorizationPromptSchema.optional(),
 		display: z.string().optional(),
 		ui_locales: z.string().optional(),


### PR DESCRIPTION
Authorization requests previously only had the happy-path GET shape wired through the provider, which left some standard OIDC request forms with inconsistent behavior.

This change aligns the authorization endpoint with the OIDC request surface that Better Auth actually supports:

- accepts form-encoded POST authorization requests through the same validation path as GET requests
- rejects by-value request objects with `request_not_supported`
- rejects unsupported `request_uri` request objects with `request_uri_not_supported`
- advertises request object parameters as unsupported in discovery metadata so clients do not infer support from omitted fields

Request objects are still intentionally unsupported here. The point of this diff is to make unsupported inputs explicit and deterministic, not to implement JAR/request-object processing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds form-encoded POST support to the OIDC authorization endpoint, normalizes GET/POST handling, and rejects unsupported Request Object inputs with clear, standard errors and explicit discovery metadata.

- Accepts form-encoded POST to `/oauth2/authorize` with the same validation as GET; OpenAPI now allows POST and `application/x-www-form-urlencoded`.
- Normalizes request parsing for GET/POST and validates early: `request`+`request_uri` → `invalid_request`; any by-value `request` (including empty) → `request_not_supported`.
- `request_uri`: require `client_id` before resolver lookup (resolver not called without it); no resolver or empty value → `request_uri_not_supported`; invalid/expired → `invalid_request_uri`.
- Maps validation issues to standard codes, e.g. `response_type` → `unsupported_response_type`, `resource` → `invalid_target`.
- Discovery explicitly sets `request_parameter_supported: false` and `request_uri_parameter_supported: false`.

<sup>Written for commit 3c1ce2e86bd4b811f4aee86de6fa6400f6bba396. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

