### PR TITLE
fix(oauth-provider): return invalid_grant for cross-client refresh tokens

### DIFF
--- a/.changeset/refresh-token-client-binding.md
+++ b/.changeset/refresh-token-client-binding.md
@@ -2,4 +2,4 @@
 "@better-auth/oauth-provider": patch
 ---
 
-Returns `invalid_grant` when a client tries to use a refresh token issued to another OAuth client.
+Refresh-token requests now return `invalid_grant` with an `invalid refresh token` description when a client tries to use a refresh token issued to another OAuth client.

--- a/.changeset/refresh-token-client-binding.md
+++ b/.changeset/refresh-token-client-binding.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Returns `invalid_grant` when a client tries to use a refresh token issued to another OAuth client.

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -838,6 +838,7 @@ describe("oauth token - refresh_token", async () => {
 		});
 		const result = await client.$fetch<{
 			error?: string;
+			error_description?: string;
 		}>("/oauth2/token", {
 			method: "POST",
 			body,
@@ -847,6 +848,10 @@ describe("oauth token - refresh_token", async () => {
 		expect((result.error as { error?: string } | null | undefined)?.error).toBe(
 			"invalid_grant",
 		);
+		expect(
+			(result.error as { error_description?: string } | null | undefined)
+				?.error_description,
+		).toBe("invalid refresh token");
 	});
 
 	it("should preserve auth_time in id_token after refresh (OIDC Core 1.0 Section 12.2)", async ({

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -802,6 +802,53 @@ describe("oauth token - refresh_token", async () => {
 		expect(tokens?.refresh_token).not.toEqual(newTokens.data?.refresh_token);
 	});
 
+	it("rejects refresh token use by a different client with invalid_grant", async ({
+		expect,
+	}) => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const scopes = ["openid", "profile", "offline_access"];
+		const tokens = await authorizeForRefreshToken(scopes);
+		expect(tokens?.refresh_token).toBeDefined();
+
+		const otherRedirectUri = `${rpBaseUrl}/api/auth/callback/other`;
+		const otherClient = await authorizationServer.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				grant_types: ["authorization_code", "refresh_token"],
+				redirect_uris: [otherRedirectUri],
+				skip_consent: true,
+			},
+		});
+		expect(otherClient.client_id).toBeDefined();
+		expect(otherClient.client_secret).toBeDefined();
+
+		const { body, headers: tokenHeaders } = await refreshAccessTokenRequest({
+			refreshToken: tokens!.refresh_token!,
+			options: {
+				clientId: otherClient.client_id,
+				clientSecret: otherClient.client_secret,
+				redirectURI: otherRedirectUri,
+			},
+			extraParams: {
+				scope: scopes.join(" "),
+			},
+		});
+		const result = await client.$fetch<{
+			error?: string;
+		}>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+
+		expect((result.error as { error?: string } | null | undefined)?.error).toBe(
+			"invalid_grant",
+		);
+	});
+
 	it("should preserve auth_time in id_token after refresh (OIDC Core 1.0 Section 12.2)", async ({
 		expect,
 	}) => {

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -1518,7 +1518,7 @@ async function handleRefreshTokenGrant(
 	}
 	if (refreshToken.clientId !== client_id) {
 		throw new APIError("BAD_REQUEST", {
-			error_description: "invalid client_id",
+			error_description: "invalid refresh token",
 			error: "invalid_grant",
 		});
 	}

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -1519,7 +1519,7 @@ async function handleRefreshTokenGrant(
 	if (refreshToken.clientId !== client_id) {
 		throw new APIError("BAD_REQUEST", {
 			error_description: "invalid client_id",
-			error: "invalid_client",
+			error: "invalid_grant",
 		});
 	}
 	if (refreshToken.expiresAt < new Date()) {


### PR DESCRIPTION
Refresh-token redemption authenticated the presented client and then returned `invalid_client` when the refresh token belonged to another OAuth client. Client authentication succeeded in that case; the presented grant is invalid.

This changes the refresh-token grant to return `invalid_grant` with an `invalid refresh token` description for refresh tokens issued to a different OAuth client. That keeps the token endpoint error aligned with invalid refresh-token grants instead of treating valid client credentials as the failure.