### PR TITLE
fix(oauth-provider): accept UserInfo form-body tokens

### DIFF
--- a/.changeset/userinfo-form-body-token.md
+++ b/.changeset/userinfo-form-body-token.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Allows OIDC UserInfo `POST` requests to send bearer access tokens in an `application/x-www-form-urlencoded` request body.

--- a/.changeset/userinfo-form-body-token.md
+++ b/.changeset/userinfo-form-body-token.md
@@ -2,4 +2,4 @@
 "@better-auth/oauth-provider": patch
 ---
 
-Allows OIDC UserInfo `POST` requests to send bearer access tokens in an `application/x-www-form-urlencoded` request body.
+OIDC UserInfo `POST` requests now accept bearer access tokens in an `application/x-www-form-urlencoded` request body. Requests that send bearer tokens in both the Authorization header and form body now return `invalid_request`.

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1244,8 +1244,15 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				"/oauth2/userinfo",
 				{
 					method: ["GET", "POST"],
+					body: z
+						.object({
+							access_token: z.string().optional(),
+						})
+						.passthrough()
+						.optional(),
 					metadata: {
 						noStore: true,
+						allowedMediaTypes: ["application/x-www-form-urlencoded"],
 						openapi: {
 							description:
 								"Get OpenID Connect user information (UserInfo endpoint)",

--- a/packages/oauth-provider/src/userinfo.test.ts
+++ b/packages/oauth-provider/src/userinfo.test.ts
@@ -318,6 +318,47 @@ describe("oauth userinfo", async () => {
 		expect(userinfo.data).toMatchObject({ sub: user.id });
 	});
 
+	it("should accept POST with the bearer token in the form body", async () => {
+		const tokens = await getTokens();
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({
+					access_token: tokens.data?.access_token ?? "",
+				}),
+			},
+		);
+		expect(userinfo.data).toMatchObject({ sub: user.id });
+	});
+
+	it("should reject UserInfo requests with bearer tokens in both header and body", async () => {
+		const tokens = await getTokens();
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				method: "POST",
+				headers: {
+					authorization: `Bearer ${tokens.data?.access_token ?? ""}`,
+					"content-type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({
+					access_token: tokens.data?.access_token ?? "",
+				}),
+			},
+		);
+
+		expect(userinfo.error?.status).toBe(400);
+		expect(
+			(userinfo.error as { error?: string } | null | undefined)?.error,
+		).toBe("invalid_request");
+	});
+
 	/**
 	 * Programmatic callers have no `ctx.request`, so userinfo must resolve the
 	 * bearer token from `ctx.headers` for both transports.
@@ -351,7 +392,7 @@ describe("oauth userinfo", async () => {
 			expect(err.statusCode).toBe(401);
 			expect(err.body).toMatchObject({
 				error: "invalid_request",
-				error_description: "authorization header not found",
+				error_description: "access token not found",
 			});
 		}
 	});

--- a/packages/oauth-provider/src/userinfo.test.ts
+++ b/packages/oauth-provider/src/userinfo.test.ts
@@ -357,6 +357,10 @@ describe("oauth userinfo", async () => {
 		expect(
 			(userinfo.error as { error?: string } | null | undefined)?.error,
 		).toBe("invalid_request");
+		expect(
+			(userinfo.error as { error_description?: string } | null | undefined)
+				?.error_description,
+		).toBe("Multiple access token transport methods are not allowed");
 	});
 
 	/**
@@ -457,6 +461,36 @@ describe("oauth userinfo", async () => {
 			},
 		);
 		expect(bearerUserinfo.error?.status).toBe(401);
+
+		const bodyTokenUserinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({
+					access_token: tokens.data?.access_token ?? "",
+				}),
+			},
+		);
+		expect(bodyTokenUserinfo.error?.status).toBe(401);
+		expect(
+			(
+				bodyTokenUserinfo.error as {
+					error?: string;
+					error_description?: string;
+				} | null
+			)?.error,
+		).toBe("invalid_token");
+		expect(
+			(
+				bodyTokenUserinfo.error as {
+					error?: string;
+					error_description?: string;
+				} | null
+			)?.error_description,
+		).toBe("DPoP-bound access token requires the DPoP authorization scheme");
 
 		const userinfoDpopProof = await createDpopProof({
 			privateKey: dpopKey.privateKey,

--- a/packages/oauth-provider/src/userinfo.ts
+++ b/packages/oauth-provider/src/userinfo.ts
@@ -72,27 +72,31 @@ export function pickClaims(
 
 function getUserInfoAccessToken(ctx: GenericEndpointContext) {
 	const authorization = ctx.headers?.get("authorization");
-	const accessTokenAuthorization = parseAccessTokenAuthorization(authorization);
-	const headerToken = accessTokenAuthorization?.token;
+	const headerAccessTokenAuthorization =
+		parseAccessTokenAuthorization(authorization);
 	const bodyToken =
 		ctx.request?.method === "POST"
 			? ((ctx.body as { access_token?: string } | undefined)?.access_token ??
 				undefined)
 			: undefined;
 
-	if (headerToken && bodyToken) {
+	if (headerAccessTokenAuthorization && bodyToken) {
 		throw new APIError("BAD_REQUEST", {
 			error_description:
-				"Multiple bearer token transport methods are not allowed",
+				"Multiple access token transport methods are not allowed",
 			error: "invalid_request",
 		});
 	}
 
+	const bodyAccessTokenAuthorization = bodyToken
+		? { scheme: "Bearer" as const, token: bodyToken }
+		: undefined;
+	const accessTokenAuthorization =
+		headerAccessTokenAuthorization ?? bodyAccessTokenAuthorization;
+
 	return {
-		authorization:
-			accessTokenAuthorization ??
-			(bodyToken ? { scheme: "Bearer" as const, token: bodyToken } : undefined),
-		token: headerToken ?? bodyToken,
+		authorization: accessTokenAuthorization,
+		token: accessTokenAuthorization?.token,
 	};
 }
 
@@ -106,19 +110,19 @@ export async function userInfoEndpoint(
 	// TODO: converge on parseBearerToken (utils) once we decide whether userinfo
 	// should keep accepting a non-Bearer Authorization value as a bare token; the
 	// shared parser is strict and would reject that fallback.
-	const { authorization: accessTokenAuthorization, token: accessToken } =
+	const { authorization: accessTokenAuthorization } =
 		getUserInfoAccessToken(ctx);
-	if (!accessToken) {
+	if (!accessTokenAuthorization?.token) {
 		throw new APIError("UNAUTHORIZED", {
 			error_description: "access token not found",
 			error: "invalid_request",
 		});
 	}
-	const jwt = await requireActiveAccessToken(ctx, opts, accessToken);
-	const accessTokenPresentation = accessTokenAuthorization ?? {
-		scheme: "Bearer" as const,
-		token: accessToken,
-	};
+	const jwt = await requireActiveAccessToken(
+		ctx,
+		opts,
+		accessTokenAuthorization.token,
+	);
 
 	// The DPoP `htm`/`htu` check needs the real request method and URL. Without a
 	// `ctx.request` (a programmatic `auth.api` call) the sender-constraint cannot
@@ -134,7 +138,7 @@ export async function userInfoEndpoint(
 	try {
 		await enforceDpopBinding({
 			payload: jwt,
-			authorization: accessTokenPresentation,
+			authorization: accessTokenAuthorization,
 			proofJwt: getDpopProofJwt(ctx),
 			method: ctx.request?.method ?? "GET",
 			url: getEndpointUrl(ctx, "/oauth2/userinfo"),

--- a/packages/oauth-provider/src/userinfo.ts
+++ b/packages/oauth-provider/src/userinfo.ts
@@ -70,6 +70,32 @@ export function pickClaims(
 	return next;
 }
 
+function getUserInfoAccessToken(ctx: GenericEndpointContext) {
+	const authorization = ctx.headers?.get("authorization");
+	const accessTokenAuthorization = parseAccessTokenAuthorization(authorization);
+	const headerToken = accessTokenAuthorization?.token;
+	const bodyToken =
+		ctx.request?.method === "POST"
+			? ((ctx.body as { access_token?: string } | undefined)?.access_token ??
+				undefined)
+			: undefined;
+
+	if (headerToken && bodyToken) {
+		throw new APIError("BAD_REQUEST", {
+			error_description:
+				"Multiple bearer token transport methods are not allowed",
+			error: "invalid_request",
+		});
+	}
+
+	return {
+		authorization:
+			accessTokenAuthorization ??
+			(bodyToken ? { scheme: "Bearer" as const, token: bodyToken } : undefined),
+		token: headerToken ?? bodyToken,
+	};
+}
+
 /**
  * Handles the /oauth2/userinfo endpoint
  */
@@ -80,19 +106,19 @@ export async function userInfoEndpoint(
 	// TODO: converge on parseBearerToken (utils) once we decide whether userinfo
 	// should keep accepting a non-Bearer Authorization value as a bare token; the
 	// shared parser is strict and would reject that fallback.
-	const authorization = ctx.headers?.get("authorization");
-	const accessTokenAuthorization = parseAccessTokenAuthorization(authorization);
-	if (!accessTokenAuthorization?.token) {
+	const { authorization: accessTokenAuthorization, token: accessToken } =
+		getUserInfoAccessToken(ctx);
+	if (!accessToken) {
 		throw new APIError("UNAUTHORIZED", {
-			error_description: "authorization header not found",
+			error_description: "access token not found",
 			error: "invalid_request",
 		});
 	}
-	const jwt = await requireActiveAccessToken(
-		ctx,
-		opts,
-		accessTokenAuthorization.token,
-	);
+	const jwt = await requireActiveAccessToken(ctx, opts, accessToken);
+	const accessTokenPresentation = accessTokenAuthorization ?? {
+		scheme: "Bearer" as const,
+		token: accessToken,
+	};
 
 	// The DPoP `htm`/`htu` check needs the real request method and URL. Without a
 	// `ctx.request` (a programmatic `auth.api` call) the sender-constraint cannot
@@ -108,7 +134,7 @@ export async function userInfoEndpoint(
 	try {
 		await enforceDpopBinding({
 			payload: jwt,
-			authorization: accessTokenAuthorization,
+			authorization: accessTokenPresentation,
 			proofJwt: getDpopProofJwt(ctx),
 			method: ctx.request?.method ?? "GET",
 			url: getEndpointUrl(ctx, "/oauth2/userinfo"),


### PR DESCRIPTION
The UserInfo endpoint accepted bearer access tokens from the Authorization header but rejected the RFC 6750 form-body transport. OIDC UserInfo is a bearer-token protected resource endpoint, and some clients send `access_token` in an `application/x-www-form-urlencoded` POST body.

This adds the form-body path for POST requests while preserving the Authorization header path as the primary transport. Requests that send bearer tokens in both places now fail with `invalid_request`, matching RFC 6750's one-transport rule.

DPoP-bound access tokens still require the DPoP Authorization scheme; sending such a token in the form body fails closed.