### PR TITLE
feat(oauth-provider): honor requested UserInfo claims via a claim registry

### DIFF
--- a/.changeset/clever-claims-request.md
+++ b/.changeset/clever-claims-request.md
@@ -1,0 +1,9 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+The OIDC provider now honors the `claims.userinfo` authorization request parameter. A client can ask for individual standard claims, and the UserInfo endpoint returns the ones it can supply in addition to the scope-granted claims. The requested claims become part of the user's consent, and `claims_parameter_supported` is advertised in discovery.
+
+A claim requested through `claims.userinfo` is honored for opaque access tokens. With a JWT access token, UserInfo returns only the claims the granted scopes cover, so request the backing scope when a client needs a specific claim.
+
+This adds a `requestedUserInfoClaims` column to the OAuth access-token, refresh-token, and consent tables. Run your database migrations after upgrading.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -619,6 +619,10 @@ Accept or deny user consent for a set of scopes. Note that when denying scopes, 
      * Space-separated list of accepted scopes. If not provided, the originally requested scopes are accepted.
      */
     scope?: string,
+    /**
+     * Accepted OIDC claims request object. If not provided, the originally requested claims are accepted.
+     */
+    claims?: string | Record<string, unknown>,
   }
   ```
 </APIMethod>
@@ -776,7 +780,11 @@ The UserInfo endpoint returns different claims based on the scopes that were gra
 * `profile`: Returns `name`, `picture`, `given_name`, `family_name`
 * `email`: Returns `email` and `email_verified`
 
-The `customUserInfoClaims` function receives the user object, requested scopes array, and the passed access token, allowing you to add additional information to the response.
+The endpoint also honors the OIDC `claims` request parameter for UserInfo. Claims listed under `claims.userinfo` are added to the scope-requested claims when Better Auth or your custom claim logic can supply them, bounded to the names advertised in `claims_supported`. Missing values are omitted from the JSON response rather than returned as `null` or an empty string.
+
+Per-claim selection through `claims.userinfo` applies to opaque access tokens. A JWT access token resolves UserInfo claims from its granted scopes, so an individually requested claim without its backing scope is omitted (OIDC Core §5.5.1). Request the backing scope, or issue an opaque access token, when a client needs a claim that no granted scope covers.
+
+The `customUserInfoClaims` function receives the user object, requested scopes array, requested UserInfo claim names, and the passed access token, allowing you to add additional information to the response.
 
 ### Well-Known
 
@@ -1000,15 +1008,20 @@ oauthProvider({
 })
 ```
 
-The plugin will redirect the user to the specified path with `client_id` and `scope` query parameters. You can use this information to display a custom consent screen. Once the user consents, you can call `oauth2.consent` to complete the authorization.
+The plugin will redirect the user to the specified path with `client_id`, `scope`, and, when requested, `claims` query parameters. Use `scope` and `claims.userinfo` to display the complete access request on your consent screen. Once the user consents, you can call `oauth2.consent` to complete the authorization.
 
 ```ts title="consent-page.ts"
 import { authClient } from "@/lib/auth-client"
 
+const claims = new URLSearchParams(window.location.search).get("claims");
+const requestedClaims = claims ? JSON.parse(claims) : undefined;
+
 const res = await authClient.oauth2.consent({
 	accept: true,
   // optional scopes accepted (if not sent, accepted scopes matches the original request)
-  scope: "openid profile email"
+  scope: "openid profile email",
+  // optional claims accepted (if not sent, accepted claims match the original request)
+  claims: requestedClaims
 });
 ```
 
@@ -1182,7 +1195,7 @@ oauthProvider({
 
 Internally supported claims include \["sub", "iss", "aud", "exp", "iat", "sid", "scope", "azp"].
 
-ID token and UserInfo claims should be namespaced when possible to avoid potential future conflicts. In the authorization code flow, `profile` and `email` request UserInfo claims; they are not added to the ID token unless you add them with `customIdTokenClaims`.
+ID token and UserInfo claims should be namespaced when possible to avoid potential future conflicts. In the authorization code flow, `profile`, `email`, and `claims.userinfo` request UserInfo claims; they are not added to the ID token unless you add them with `customIdTokenClaims`.
 
 `customIdTokenClaims` is additive for protocol-owned ID token claims. Reserved names such as `iss`, `sub`, `aud`, token lifetime claims, `nonce`, `sid`, hash claims, `auth_time`, `acr`, `amr`, and `azp` are stripped at issuance with a warning log. Use namespaced claim names such as `https://example.com/org` for application-specific data.
 
@@ -1207,9 +1220,12 @@ oauthProvider({
     };
   },
   // Additional user info claims
-  customUserInfoClaims: ({ user, scopes, jwt }) => {
+  customUserInfoClaims: ({ user, scopes, requestedClaims, jwt }) => {
     return {
       locale: "en-GB",
+      ...(requestedClaims.includes("website")
+        ? { website: "https://example.com" }
+        : {}),
     };
   },
 })
@@ -1498,7 +1514,7 @@ Three claim surfaces resolve contributions in a fixed order. Across all three, t
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Access token | extension `claims.accessToken` \< per-issuance `accessTokenClaims` \< `customAccessTokenClaims` \< per-resource `customClaims`        | reserved RFC 9068 names (`iss`, `sub`, `aud`, `exp`, `iat`, `jti`, `client_id`, `scope`, `auth_time`, `acr`, `amr`), stripped before signing                                                      |
 | ID token     | subject/authentication claims \< `customIdTokenClaims`; extension and per-issuance `idTokenClaims` are reserved-filtered and additive | reserved OIDC/JWT names (`iss`, `sub`, `aud`, `exp`, `nbf`, `iat`, `jti`, `nonce`, `sid`, `at_hash`, `c_hash`, `s_hash`, `auth_time`, `acr`, `amr`, `azp`) and scope-derived UserInfo claim names |
-| UserInfo     | base identity claims \< extension `claims.userInfo` (additive only) \< `customUserInfoClaims`                                         | `sub` (re-pinned last)                                                                                                                                                                            |
+| UserInfo     | scope and `claims.userinfo` identity claims \< extension `claims.userInfo` (additive only) \< `customUserInfoClaims`                  | `sub` (re-pinned last)                                                                                                                                                                            |
 
 Per-issuance `accessTokenClaims` are JWT-only: an opaque access token persists no per-issuance claims, so they do not reappear at introspection. A claim that must be visible at opaque-token introspection belongs in a grant-type-stable `claims.accessToken` contributor, which the introspection path re-derives.
 
@@ -2354,6 +2370,12 @@ export const oauthConsentTableFields = [
     name: "scopes",
     type: "string[]",
     description: "Array of scopes consented to",
+  },
+  {
+    name: "requestedUserInfoClaims",
+    type: "string[]",
+    description: "Array of OIDC UserInfo claim names consented to",
+    isOptional: true,
   },
   {
     name: "createdAt",

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -1084,6 +1084,7 @@ describe("oauth authorize - consented resources", async () => {
 								clientId: z.string(),
 								scopes: z.array(z.string()),
 								userId: z.string(),
+								requestedUserInfoClaims: z.array(z.string()).optional(),
 							}),
 							use: [sessionMiddleware],
 							metadata: {
@@ -1165,6 +1166,61 @@ describe("oauth authorize - consented resources", async () => {
 		expect(consentRedirectUrl).not.toContain(`${redirectUri}?code=`);
 	});
 
+	it("should re-prompt for consent when stored consent has no requested UserInfo claim", async () => {
+		const dedicatedClient = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: false,
+			},
+		});
+		if (!dedicatedClient?.client_id) {
+			throw Error("unable to create dedicated client");
+		}
+
+		await auth.api.testerCreateConsent({
+			headers,
+			body: {
+				clientId: dedicatedClient.client_id,
+				userId: user.id,
+				scopes: ["openid"],
+			},
+		});
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", dedicatedClient.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "userinfo-claim-consent");
+		authUrl.searchParams.set(
+			"claims",
+			JSON.stringify({
+				userinfo: {
+					email: null,
+				},
+			}),
+		);
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let consentRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				consentRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(consentRedirectUrl).toContain("/consent");
+		expect(consentRedirectUrl).not.toContain(`${redirectUri}?code=`);
+		const consentUrl = new URL(consentRedirectUrl, authServerBaseUrl);
+		expect(JSON.parse(consentUrl.searchParams.get("claims") ?? "{}")).toEqual({
+			userinfo: {
+				email: null,
+			},
+		});
+	});
+
 	it("should persist multiple resource values onto OAuthConsent.resources", async ({
 		onTestFinished,
 	}) => {
@@ -1231,6 +1287,90 @@ describe("oauth authorize - consented resources", async () => {
 			validResource,
 			secondValidResource,
 		]);
+	});
+
+	it("should persist only accepted UserInfo claims onto OAuthConsent", async ({
+		onTestFinished,
+	}) => {
+		const dedicatedClient = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: false,
+			},
+		});
+		if (!dedicatedClient?.client_id) {
+			throw Error("unable to create dedicated client");
+		}
+
+		const authUrl = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		authUrl.searchParams.set("client_id", dedicatedClient.client_id);
+		authUrl.searchParams.set("redirect_uri", redirectUri);
+		authUrl.searchParams.set("response_type", "code");
+		authUrl.searchParams.set("scope", "openid");
+		authUrl.searchParams.set("state", "persist-userinfo-claims");
+		authUrl.searchParams.set(
+			"claims",
+			JSON.stringify({
+				userinfo: {
+					name: null,
+					email: null,
+				},
+			}),
+		);
+		authUrl.searchParams.set("code_challenge", generateRandomString(43));
+		authUrl.searchParams.set("code_challenge_method", "S256");
+
+		let consentRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				consentRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(consentRedirectUrl).toContain("/consent");
+
+		vi.stubGlobal("window", {
+			location: {
+				search: new URL(consentRedirectUrl, authServerBaseUrl).search,
+			},
+		});
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const consentResult = await client.oauth2.consent(
+			{
+				accept: true,
+				claims: {
+					userinfo: {
+						name: null,
+					},
+				},
+			},
+			{
+				throw: true,
+			},
+		);
+
+		expect(consentResult.url).toContain(`${redirectUri}?code=`);
+
+		const context = await auth.$context;
+		const savedConsent = await context.adapter.findOne<OAuthConsent<Scope[]>>({
+			model: "oauthConsent",
+			where: [
+				{
+					field: "clientId",
+					value: dedicatedClient.client_id,
+				},
+				{
+					field: "userId",
+					value: user.id,
+				},
+			],
+		});
+
+		expect(savedConsent?.requestedUserInfoClaims).toEqual(["name"]);
 	});
 
 	it("should return consent_required for prompt=none when requested resource is not covered by prior consent", async () => {

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -6,6 +6,7 @@ import { generateRandomString, makeSignature } from "better-auth/crypto";
 import type { Verification } from "better-auth/db";
 import { APIError } from "better-call";
 import { UNSPECIFIED_ACR } from "./authentication-context";
+import { getRequestedUserInfoClaims } from "./claims-request";
 import { oAuthState } from "./oauth";
 import type { OAuthErrorCode, OAuthRedirectOnError } from "./oauth-endpoint";
 import { mapIssuesToOAuthError } from "./oauth-endpoint";
@@ -16,6 +17,7 @@ import {
 	setSignedOAuthQueryParameterNames,
 	signedQueryIssuedAtParam,
 } from "./signed-query";
+import { getSupportedClaims } from "./standard-claims";
 import type {
 	OAuthAuthorizationQuery,
 	OAuthConsent,
@@ -549,6 +551,10 @@ export async function authorizeEndpoint(
 		requestedScopes = client.scopes ?? opts.scopes ?? [];
 		query.scope = requestedScopes.join(" ");
 	}
+	const requestedUserInfoClaims = getRequestedUserInfoClaims(
+		query.claims,
+		getSupportedClaims(opts),
+	);
 
 	// Validate `resource` (RFC 8707 §2) against the configured resource
 	// entities — fail-fast at /authorize so clients see misconfigured
@@ -808,7 +814,10 @@ export async function authorizeEndpoint(
 
 	if (
 		!consent ||
-		!requestedScopes.every((val) => consent.scopes.includes(val))
+		!requestedScopes.every((val) => consent.scopes.includes(val)) ||
+		!requestedUserInfoClaims.every((claim) =>
+			(consent.requestedUserInfoClaims ?? []).includes(claim),
+		)
 	) {
 		if (promptNone) {
 			return redirectWithPromptNoneError(
@@ -864,6 +873,8 @@ function serializeAuthorizationQuery(query: OAuthAuthorizationQuery) {
 			for (const v of value) {
 				params.append(key, String(v));
 			}
+		} else if (key === "claims" && typeof value === "object") {
+			params.set(key, JSON.stringify(value));
 		} else {
 			params.set(key, String(value));
 		}

--- a/packages/oauth-provider/src/claims-request.ts
+++ b/packages/oauth-provider/src/claims-request.ts
@@ -1,0 +1,77 @@
+import * as z from "zod";
+
+const claimRequestMemberSchema = z.union([
+	z.null(),
+	z.record(z.string(), z.unknown()),
+]);
+
+const claimsRequestObjectSchema = z
+	.object({
+		userinfo: z.record(z.string(), claimRequestMemberSchema).optional(),
+		id_token: z.record(z.string(), claimRequestMemberSchema).optional(),
+	})
+	.passthrough();
+
+function parseClaimsRequestValue(value: unknown) {
+	if (typeof value === "string") {
+		try {
+			return JSON.parse(value) as unknown;
+		} catch {
+			return undefined;
+		}
+	}
+	return value;
+}
+
+function parseClaimsRequestObject(value: unknown) {
+	const parsed = parseClaimsRequestValue(value);
+	const result = claimsRequestObjectSchema.safeParse(parsed);
+	return result.success ? result.data : undefined;
+}
+
+export const claimsRequestParameterSchema = z
+	.union([z.string(), z.record(z.string(), z.unknown())])
+	.superRefine((value, ctx) => {
+		if (!parseClaimsRequestObject(value)) {
+			ctx.addIssue({
+				code: "custom",
+				message: "claims must be a JSON object",
+			});
+		}
+	});
+
+export function getRequestedUserInfoClaims(
+	value: unknown,
+	supportedClaims?: Iterable<string>,
+) {
+	const claimsRequest = parseClaimsRequestObject(value);
+	const userInfoClaims = claimsRequest?.userinfo;
+	if (!userInfoClaims) return [];
+	// `Object.keys` over a parsed object is already unique; no duplicate filtering needed.
+	const names = Object.keys(userInfoClaims);
+	if (!supportedClaims) return names;
+	const allowed = new Set(supportedClaims);
+	return names.filter((name) => allowed.has(name));
+}
+
+export function filterClaimsRequestUserInfoClaims(
+	value: unknown,
+	allowedUserInfoClaims: string[],
+) {
+	const claimsRequest = parseClaimsRequestObject(value);
+	if (!claimsRequest) return undefined;
+	const allowedClaimSet = new Set(allowedUserInfoClaims);
+	const userInfoClaims = Object.fromEntries(
+		Object.entries(claimsRequest.userinfo ?? {}).filter(([claim]) =>
+			allowedClaimSet.has(claim),
+		),
+	);
+	const filteredClaimsRequest = Object.keys(userInfoClaims).length
+		? { ...claimsRequest, userinfo: userInfoClaims }
+		: Object.fromEntries(
+				Object.entries(claimsRequest).filter(([key]) => key !== "userinfo"),
+			);
+	return Object.keys(filteredClaimsRequest).length
+		? filteredClaimsRequest
+		: undefined;
+}

--- a/packages/oauth-provider/src/consent.ts
+++ b/packages/oauth-provider/src/consent.ts
@@ -1,8 +1,13 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError, getSessionFromCtx } from "better-auth/api";
 import { formatErrorURL, getIssuer } from "./authorize";
+import {
+	filterClaimsRequestUserInfoClaims,
+	getRequestedUserInfoClaims,
+} from "./claims-request";
 import type { AuthorizeEndpointCaller } from "./continue";
 import { oAuthState } from "./oauth";
+import { getSupportedClaims } from "./standard-claims";
 import type { OAuthConsent, OAuthOptions, Scope } from "./types";
 import {
 	isSessionFreshForSignedQuery,
@@ -28,6 +33,11 @@ export async function consentEndpoint<Result>(
 	}
 	const query = new URLSearchParams(_query);
 	const originalRequestedScopes = query.get("scope")?.split(" ") ?? [];
+	const supportedClaims = getSupportedClaims(opts);
+	const originalRequestedUserInfoClaims = getRequestedUserInfoClaims(
+		query.get("claims"),
+		supportedClaims,
+	);
 	const clientId = query.get("client_id");
 	if (!clientId) {
 		throw new APIError("BAD_REQUEST", {
@@ -45,6 +55,22 @@ export async function consentEndpoint<Result>(
 				error: "invalid_request",
 			});
 		}
+	}
+	const acceptedClaims = ctx.body.claims as unknown | undefined;
+	const acceptedUserInfoClaims =
+		acceptedClaims !== undefined
+			? getRequestedUserInfoClaims(acceptedClaims, supportedClaims)
+			: originalRequestedUserInfoClaims;
+	if (
+		acceptedClaims !== undefined &&
+		!acceptedUserInfoClaims.every((claim) =>
+			originalRequestedUserInfoClaims.includes(claim),
+		)
+	) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "Claim not originally requested",
+			error: "invalid_request",
+		});
 	}
 
 	// Consent not accepted (ensure it's strictly boolean true)
@@ -112,6 +138,7 @@ export async function consentEndpoint<Result>(
 		clientId: clientId,
 		userId: session?.user.id!,
 		scopes: requestedScopes ?? originalRequestedScopes,
+		requestedUserInfoClaims: acceptedUserInfoClaims,
 		createdAt: new Date(iat * 1000),
 		updatedAt: new Date(iat * 1000),
 		resources: resource.length ? resource : undefined,
@@ -129,6 +156,7 @@ export async function consentEndpoint<Result>(
 				update: {
 					resources: consent.resources,
 					scopes: consent.scopes,
+					requestedUserInfoClaims: consent.requestedUserInfoClaims,
 					updatedAt: new Date(iat * 1000),
 				},
 			})
@@ -143,6 +171,17 @@ export async function consentEndpoint<Result>(
 	// Return authorization code
 	if (requestedScopes) {
 		query.set("scope", consent.scopes.join(" "));
+	}
+	if (acceptedClaims !== undefined) {
+		const claimsRequest = filterClaimsRequestUserInfoClaims(
+			query.get("claims"),
+			acceptedUserInfoClaims,
+		);
+		if (claimsRequest) {
+			query.set("claims", JSON.stringify(claimsRequest));
+		} else {
+			query.delete("claims");
+		}
 	}
 	ctx?.headers?.set("accept", "application/json");
 	let authorizationQuery = removePromptFromQuery(query, "consent");

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -40,6 +40,23 @@ const INVALID_ACCESS_TOKEN_ERROR_DESCRIPTION = "Invalid access token";
 const INVALID_ACCESS_TOKEN_WWW_AUTHENTICATE = `Bearer error="invalid_token", error_description="${INVALID_ACCESS_TOKEN_ERROR_DESCRIPTION}"`;
 
 /**
+ * The result of validating an access token: the RFC 7662 introspection-format
+ * payload, plus the OIDC `claims.userinfo` names the UserInfo endpoint resolves
+ * for this token. The requested claims travel beside the payload, never inside
+ * it, so UserInfo can read them while an introspection response and a resource
+ * server never see them.
+ */
+interface ValidatedAccessToken {
+	payload: JWTPayload;
+	/** Empty for JWT access tokens, which resolve UserInfo claims by scope. */
+	requestedUserInfoClaims: string[];
+}
+
+function inactiveAccessToken(): ValidatedAccessToken {
+	return { payload: { active: false }, requestedUserInfoClaims: [] };
+}
+
+/**
  * IMPORTANT NOTES:
  * Introspection follows RFC7662
  * https://datatracker.ietf.org/doc/html/rfc7662
@@ -241,7 +258,7 @@ async function validateOpaqueAccessToken(
 	opts: OAuthOptions<Scope[]>,
 	token: string,
 	clientId?: string,
-) {
+): Promise<ValidatedAccessToken> {
 	let tokenValue = token;
 	if (opts.prefix?.opaqueAccessToken) {
 		if (tokenValue.startsWith(opts.prefix.opaqueAccessToken)) {
@@ -276,14 +293,10 @@ async function validateOpaqueAccessToken(
 		});
 	}
 	if (!accessToken.expiresAt || accessToken.expiresAt < new Date()) {
-		return {
-			active: false,
-		};
+		return inactiveAccessToken();
 	}
 	if (accessToken.revoked) {
-		return {
-			active: false,
-		};
+		return inactiveAccessToken();
 	}
 
 	const resources = Array.isArray(accessToken.resources)
@@ -294,9 +307,7 @@ async function validateOpaqueAccessToken(
 	if (accessToken.clientId) {
 		client = await getClient(ctx, opts, accessToken.clientId);
 		if (!client || client?.disabled) {
-			return {
-				active: false,
-			};
+			return inactiveAccessToken();
 		}
 		// RFC 7662 §2.1/§4: allow the issuer, or a resource server linked to one
 		// of the token's audience resources; otherwise report inactive.
@@ -307,7 +318,7 @@ async function validateOpaqueAccessToken(
 				audienceResources: resources ?? [],
 			}))
 		) {
-			return { active: false };
+			return inactiveAccessToken();
 		}
 	}
 
@@ -327,7 +338,7 @@ async function validateOpaqueAccessToken(
 			],
 		});
 		if (!session || session.expiresAt < new Date()) {
-			return { active: false };
+			return inactiveAccessToken();
 		}
 	}
 
@@ -346,7 +357,7 @@ async function validateOpaqueAccessToken(
 		resources?.length &&
 		!(await isAudienceClaimAllowed(ctx, opts, resources, [userInfoEndpoint]))
 	) {
-		return { active: false };
+		return inactiveAccessToken();
 	}
 
 	const audienceClaim = resources ? [...resources] : undefined;
@@ -392,20 +403,23 @@ async function validateOpaqueAccessToken(
 		: getJwtPlugin(ctx.context);
 	const jwtPluginOptions = jwtPlugin?.options;
 	return {
-		...accessTokenClaims,
-		active: true,
-		iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
-		aud: toAudienceClaim(audienceClaim),
-		client_id: accessToken.clientId,
-		azp: accessToken.clientId,
-		sub: user?.id,
-		sid: sessionId,
-		exp: Math.floor(new Date(accessToken.expiresAt).getTime() / 1000),
-		iat: Math.floor(new Date(accessToken.createdAt).getTime() / 1000),
-		scope: accessToken.scopes?.join(" "),
-		token_type: confirmationTokenType(accessToken.confirmation),
-		...(accessToken.confirmation ? { cnf: accessToken.confirmation } : {}),
-	} as JWTPayload;
+		payload: {
+			...accessTokenClaims,
+			active: true,
+			iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,
+			aud: toAudienceClaim(audienceClaim),
+			client_id: accessToken.clientId,
+			azp: accessToken.clientId,
+			sub: user?.id,
+			sid: sessionId,
+			exp: Math.floor(new Date(accessToken.expiresAt).getTime() / 1000),
+			iat: Math.floor(new Date(accessToken.createdAt).getTime() / 1000),
+			scope: accessToken.scopes?.join(" "),
+			token_type: confirmationTokenType(accessToken.confirmation),
+			...(accessToken.confirmation ? { cnf: accessToken.confirmation } : {}),
+		} as JWTPayload,
+		requestedUserInfoClaims: accessToken.requestedUserInfoClaims ?? [],
+	};
 }
 
 /**
@@ -517,21 +531,20 @@ function isInactiveTokenError(error: APIError) {
 }
 
 /**
- * We don't know the access token format so we try to validate it
- * as a JWT first, then as an opaque token.
- *
- * @returns RFC7662 introspection format
- *
- * @internal
+ * We don't know the access token format so we try to validate it as a JWT
+ * first, then as an opaque token. Returns the RFC 7662 introspection payload
+ * alongside the per-issuance UserInfo claims the opaque row persisted (empty for
+ * a JWT access token, which resolves UserInfo claims by scope).
  */
-export async function validateAccessToken(
+async function resolveAccessTokenValidation(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
 	token: string,
 	clientId?: string,
-) {
+): Promise<ValidatedAccessToken> {
 	try {
-		return await validateJwtAccessToken(ctx, opts, token, clientId);
+		const payload = await validateJwtAccessToken(ctx, opts, token, clientId);
+		return { payload, requestedUserInfoClaims: [] };
 	} catch (err) {
 		if (err instanceof APIError) {
 			// continue
@@ -555,6 +568,22 @@ export async function validateAccessToken(
 	throw createInvalidAccessTokenError();
 }
 
+/**
+ * Validates an access token (JWT or opaque) and returns its RFC 7662
+ * introspection-format payload.
+ *
+ * @internal
+ */
+export async function validateAccessToken(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	token: string,
+	clientId?: string,
+): Promise<JWTPayload> {
+	return (await resolveAccessTokenValidation(ctx, opts, token, clientId))
+		.payload;
+}
+
 export async function requireActiveAccessToken(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
@@ -563,6 +592,32 @@ export async function requireActiveAccessToken(
 ): Promise<ActiveAccessTokenPayload> {
 	const payload = await validateAccessToken(ctx, opts, token, clientId);
 	if (payload.active) return payload as ActiveAccessTokenPayload;
+	throw createInvalidAccessTokenError();
+}
+
+/**
+ * UserInfo entry point: validates the access token, requires it active, and
+ * returns the introspection payload together with the OIDC `claims.userinfo`
+ * names persisted for the token. Opaque tokens carry the names on their row;
+ * JWT access tokens return an empty list and resolve UserInfo claims by scope.
+ */
+export async function requireActiveAccessTokenWithClaims(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	token: string,
+	clientId?: string,
+): Promise<{
+	payload: ActiveAccessTokenPayload;
+	requestedUserInfoClaims: string[];
+}> {
+	const { payload, requestedUserInfoClaims } =
+		await resolveAccessTokenValidation(ctx, opts, token, clientId);
+	if (payload.active) {
+		return {
+			payload: payload as ActiveAccessTokenPayload,
+			requestedUserInfoClaims,
+		};
+	}
 	throw createInvalidAccessTokenError();
 }
 

--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -27,12 +27,12 @@ describe("oauth metadata", async () => {
 		"sid",
 		"scope",
 		"azp",
-		"email",
-		"email_verified",
 		"name",
 		"picture",
-		"family_name",
 		"given_name",
+		"family_name",
+		"email",
+		"email_verified",
 	];
 
 	async function createTestInstance(opts?: {
@@ -118,6 +118,7 @@ describe("oauth metadata", async () => {
 			backchannel_logout_supported: true,
 			backchannel_logout_session_supported: true,
 			claims_supported: baseClaims,
+			claims_parameter_supported: true,
 			userinfo_endpoint: `${baseURL}/oauth2/userinfo`,
 			subject_types_supported: ["public"],
 			acr_values_supported: ["0"],
@@ -356,6 +357,7 @@ describe("oauth metadata", async () => {
 
 		expect(metadata.request_parameter_supported).toBe(false);
 		expect(metadata.request_uri_parameter_supported).toBe(false);
+		expect(metadata.claims_parameter_supported).toBe(true);
 	});
 
 	it("should advertise the unspecified ACR value by default", async () => {

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -12,6 +12,7 @@ import {
 	getSupportedAuthMethods,
 	getSupportedGrantTypes,
 } from "./extensions";
+import { getSupportedClaims } from "./standard-claims";
 import type { OAuthOptions, Scope } from "./types";
 import type {
 	AuthServerMetadata,
@@ -171,8 +172,8 @@ export function oidcServerMetadata(
 		id_token_signing_alg_values_supported: JWSAlgorithms[] | ["HS256"];
 	} = {
 		...authMetadata,
-		claims_supported:
-			opts?.advertisedMetadata?.claims_supported ?? opts?.claims ?? [],
+		claims_supported: getSupportedClaims(opts),
+		claims_parameter_supported: true,
 		userinfo_endpoint: `${baseURL}/oauth2/userinfo`,
 		subject_types_supported: opts.pairwiseSecret
 			? ["public", "pairwise"]

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -18,6 +18,7 @@ import type { BetterAuthPlugin } from "better-auth/types";
 import * as z from "zod";
 import type { AuthorizeEndpointSettings } from "./authorize";
 import { authorizeEndpoint, authorizeRedirectOnError } from "./authorize";
+import { claimsRequestParameterSchema } from "./claims-request";
 import { consentEndpoint } from "./consent";
 import { continueEndpoint } from "./continue";
 import { validateOAuthProviderExtensions } from "./extensions";
@@ -44,6 +45,7 @@ import {
 } from "./resources";
 import { revokeEndpoint } from "./revoke";
 import { schema } from "./schema";
+import { STANDARD_CLAIM_NAMES, STANDARD_CLAIMS } from "./standard-claims";
 import { tokenEndpoint } from "./token";
 import type { OAuthOptions, Scope } from "./types";
 import {
@@ -146,7 +148,10 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		}
 	}
 
-	// Validate claims
+	// Discovery `claims_supported`: protocol claims that are always present, plus
+	// the standard identity claims whose backing scope is configured. The
+	// identity set is derived from the one claim registry so the advertisement
+	// cannot drift from what UserInfo actually resolves.
 	const claims = new Set([
 		"sub",
 		"iss",
@@ -156,10 +161,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		"sid",
 		"scope",
 		"azp",
-		...(scopes.has("email") ? ["email", "email_verified"] : []),
-		...(scopes.has("profile")
-			? ["name", "picture", "family_name", "given_name"]
-			: []),
+		...STANDARD_CLAIM_NAMES.filter((name) =>
+			scopes.has(STANDARD_CLAIMS[name].scope),
+		),
 	]);
 
 	const opts: O & { claims?: string[] } = {
@@ -730,6 +734,10 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 						scope: z.string().optional().meta({
 							description:
 								"List of accept of accepted space-separated scopes. If none is provided, then all originally requested scopes are accepted.",
+						}),
+						claims: claimsRequestParameterSchema.optional().meta({
+							description:
+								"Accepted OIDC claims request object. If none is provided, then all originally requested claims are accepted.",
 						}),
 						oauth_query: z.string().optional().meta({
 							description: "The redirected page's query parameters",

--- a/packages/oauth-provider/src/schema.ts
+++ b/packages/oauth-provider/src/schema.ts
@@ -360,6 +360,10 @@ export const schema = {
 				type: "string[]",
 				required: false,
 			},
+			requestedUserInfoClaims: {
+				type: "string[]",
+				required: false,
+			},
 			expiresAt: {
 				type: "date",
 			},
@@ -450,6 +454,10 @@ export const schema = {
 				type: "string[]",
 				required: false,
 			},
+			requestedUserInfoClaims: {
+				type: "string[]",
+				required: false,
+			},
 			refreshId: {
 				type: "string",
 				required: false,
@@ -508,6 +516,10 @@ export const schema = {
 				required: false,
 			},
 			resources: {
+				type: "string[]",
+				required: false,
+			},
+			requestedUserInfoClaims: {
 				type: "string[]",
 				required: false,
 			},

--- a/packages/oauth-provider/src/standard-claims.ts
+++ b/packages/oauth-provider/src/standard-claims.ts
@@ -1,0 +1,76 @@
+import type { User } from "better-auth/types";
+import type { OAuthOptions, Scope } from "./types";
+
+/**
+ * The OIDC scope value that requests a standard claim (OIDC Core §5.4).
+ */
+type StandardClaimScope = "profile" | "email";
+
+interface StandardClaimDefinition {
+	/** Scope value that requests this claim (OIDC Core §5.4). */
+	scope: StandardClaimScope;
+	/** Resolves the claim value from the Better Auth user. */
+	resolve: (user: User) => unknown;
+}
+
+function splitDisplayName(name: string): {
+	given?: string;
+	family?: string;
+} {
+	const parts = name.split(" ").filter((part) => part !== "");
+	if (parts.length <= 1) return {};
+	return { given: parts.slice(0, -1).join(" "), family: parts.at(-1) };
+}
+
+/**
+ * The OIDC Standard Claims (OIDC Core §5.1) that Better Auth resolves from its
+ * own user model, each paired with the scope that requests it (§5.4).
+ *
+ * This is the single source for UserInfo scope-claim resolution, individual
+ * `claims.userinfo` resolution, the discovery `claims_supported` advertisement,
+ * and the bound on requested claim names. Adding a standard claim Better Auth
+ * can resolve means adding one entry here, not editing UserInfo, the metadata,
+ * and the plugin init separately.
+ *
+ * These claims are delivered only at the UserInfo endpoint, never the ID token:
+ * the authorization code flow always issues an access token, so §5.4 routes
+ * scope-requested claims to UserInfo. Deployments that support further standard
+ * profile claims (such as `birthdate` or `zoneinfo`) supply them through
+ * `customUserInfoClaims` and advertise them in `claims_supported`.
+ */
+export const STANDARD_CLAIMS = {
+	name: { scope: "profile", resolve: (user) => user.name ?? undefined },
+	picture: { scope: "profile", resolve: (user) => user.image ?? undefined },
+	given_name: {
+		scope: "profile",
+		resolve: (user) => splitDisplayName(user.name).given,
+	},
+	family_name: {
+		scope: "profile",
+		resolve: (user) => splitDisplayName(user.name).family,
+	},
+	email: { scope: "email", resolve: (user) => user.email ?? undefined },
+	email_verified: {
+		scope: "email",
+		resolve: (user) => user.emailVerified ?? false,
+	},
+} satisfies Record<string, StandardClaimDefinition>;
+
+export type StandardClaimName = keyof typeof STANDARD_CLAIMS;
+
+export const STANDARD_CLAIM_NAMES = Object.keys(
+	STANDARD_CLAIMS,
+) as StandardClaimName[];
+
+/**
+ * The claim names this provider advertises it can supply (discovery
+ * `claims_supported`): the operator's `advertisedMetadata.claims_supported`
+ * override when set, otherwise the scope-derived standard set computed at plugin
+ * init. Used both to advertise and to bound requested `claims.userinfo` names so
+ * a client cannot pin arbitrary attacker-controlled strings onto stored tokens.
+ */
+export function getSupportedClaims(
+	opts: OAuthOptions<Scope[]> & { claims?: string[] },
+): string[] {
+	return opts.advertisedMetadata?.claims_supported ?? opts.claims ?? [];
+}

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -3478,6 +3478,43 @@ describe("verificationValueSchema", () => {
 		expect(result.success).toBe(true);
 	});
 
+	it("should validate a verification value with UserInfo claims", () => {
+		const value: VerificationValue = {
+			type: "authorization_code",
+			query: {
+				response_type: "code",
+				client_id: "test-client",
+				redirect_uri: "https://example.com/callback",
+				scope: "openid",
+				claims: JSON.stringify({
+					userinfo: {
+						name: { essential: true },
+					},
+				}),
+			},
+			userId: "user-1",
+			sessionId: "session-1",
+		};
+
+		const result = verificationValueSchema.safeParse(value);
+		expect(result.success).toBe(true);
+	});
+
+	it("should reject a verification value with malformed claims", () => {
+		const result = verificationValueSchema.safeParse({
+			type: "authorization_code",
+			query: {
+				response_type: "code",
+				client_id: "test-client",
+				redirect_uri: "https://example.com/callback",
+				scope: "openid",
+				claims: "not-json",
+			},
+			userId: "user-1",
+			sessionId: "session-1",
+		});
+		expect(result.success).toBe(false);
+	});
 	it("should reject a verification value with wrong type", () => {
 		const result = verificationValueSchema.safeParse({
 			type: "password_reset",

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -17,6 +17,7 @@ import {
 	UNSPECIFIED_ACR,
 } from "./authentication-context";
 import { resolveAccessTokenClaims } from "./claims";
+import { getRequestedUserInfoClaims } from "./claims-request";
 import { getDpopProofJwt, getEndpointUrl } from "./dpop";
 import {
 	collectExtensionIdTokenClaims,
@@ -25,6 +26,7 @@ import {
 } from "./extensions";
 import type { ResolvedResourcePolicy } from "./resources";
 import { resolveResourcePolicy } from "./resources";
+import { getSupportedClaims, STANDARD_CLAIM_NAMES } from "./standard-claims";
 import type {
 	Confirmation,
 	OAuthAuthenticatedClient,
@@ -62,14 +64,14 @@ import {
 	validateClientCredentials,
 } from "./utils";
 
-const ID_TOKEN_SCOPE_CLAIM_GUARDS = {
-	name: undefined,
-	picture: undefined,
-	given_name: undefined,
-	family_name: undefined,
-	email: undefined,
-	email_verified: undefined,
-} satisfies Record<string, undefined>;
+// Seed the ID token with the standard UserInfo claim names set to `undefined`,
+// so a `customIdTokenClaims` or extension contributor cannot inject a
+// scope-gated identity claim into the ID token. Derived from the one claim
+// registry so the guard tracks the standard claims with no separate list.
+const ID_TOKEN_SCOPE_CLAIM_GUARDS: Record<string, undefined> =
+	Object.fromEntries(
+		STANDARD_CLAIM_NAMES.map((name) => [name, undefined] as const),
+	);
 
 /**
  * Token presentation scheme implied by a confirmation: a DPoP key thumbprint
@@ -479,6 +481,7 @@ async function createOpaqueAccessToken(
 	authorizationCodeId?: string,
 	refreshId?: string,
 	confirmation?: Confirmation,
+	requestedUserInfoClaims?: string[],
 ) {
 	const iat = payload.iat ?? Math.floor(Date.now() / 1000);
 	const exp = payload?.exp ?? iat + (opts.accessTokenExpiresIn ?? 3600);
@@ -497,6 +500,9 @@ async function createOpaqueAccessToken(
 			resources,
 			refreshId,
 			confirmation,
+			requestedUserInfoClaims: requestedUserInfoClaims?.length
+				? requestedUserInfoClaims
+				: undefined,
 			scopes,
 			createdAt: new Date(iat * 1000),
 			expiresAt: new Date(exp * 1000),
@@ -592,6 +598,7 @@ async function createRefreshToken(
 	authTime?: Date,
 	resources?: string[],
 	confirmation?: Confirmation,
+	requestedUserInfoClaims?: string[],
 ) {
 	const iat = payload.iat ?? Math.floor(Date.now() / 1000);
 	const exp = payload?.exp ?? iat + (opts.refreshTokenExpiresIn ?? 2592000);
@@ -613,6 +620,9 @@ async function createRefreshToken(
 		authorizationCodeId,
 		authTime,
 		confirmation,
+		requestedUserInfoClaims: requestedUserInfoClaims?.length
+			? requestedUserInfoClaims
+			: undefined,
 		scopes,
 		resources,
 		createdAt: new Date(iat * 1000),
@@ -913,6 +923,10 @@ async function createUserTokens(
 			verificationValue,
 			refreshToken: existingRefreshToken,
 		}));
+	const requestedUserInfoClaims =
+		params.requestedUserInfoClaims ??
+		existingRefreshToken?.requestedUserInfoClaims ??
+		[];
 
 	// Refresh token may need to be created beforehand for id field
 	const earlyRefreshToken =
@@ -934,6 +948,7 @@ async function createUserTokens(
 					authTime,
 					refreshResources,
 					confirmation,
+					requestedUserInfoClaims,
 				)
 			: undefined;
 
@@ -993,6 +1008,7 @@ async function createUserTokens(
 					params.authorizationCodeId,
 					earlyRefreshToken?.id,
 					confirmation,
+					requestedUserInfoClaims,
 				),
 		earlyRefreshToken
 			? earlyRefreshToken
@@ -1014,6 +1030,7 @@ async function createUserTokens(
 						authTime,
 						refreshResources,
 						confirmation,
+						requestedUserInfoClaims,
 					)
 				: undefined,
 	]);
@@ -1355,6 +1372,10 @@ async function handleAuthorizationCodeGrant(
 		verificationValue.authTime != null
 			? normalizeTimestampValue(verificationValue.authTime)
 			: resolveSessionAuthTime(session);
+	const requestedUserInfoClaims = getRequestedUserInfoClaims(
+		verificationValue.query.claims,
+		getSupportedClaims(opts),
+	);
 
 	return createUserTokens(ctx, opts, {
 		client,
@@ -1367,6 +1388,7 @@ async function handleAuthorizationCodeGrant(
 		authTime,
 		verificationValue,
 		authorizationCodeId,
+		requestedUserInfoClaims,
 		resources: effectiveResources,
 		originalResources: authorizedResources,
 	});
@@ -1617,5 +1639,6 @@ async function handleRefreshTokenGrant(
 		refreshToken,
 		resources: resources ?? refreshToken.resources,
 		authTime,
+		requestedUserInfoClaims: refreshToken.requestedUserInfoClaims,
 	});
 }

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -132,6 +132,13 @@ export interface OAuthTokenIssueParams {
 	/** Full original authorized resources for the grant, used to seed refresh tokens. */
 	originalResources?: string[];
 	/**
+	 * OIDC UserInfo claim names requested by the authorization request's
+	 * `claims.userinfo` object. The authorization server persists these names so
+	 * refresh-token rotation and opaque access tokens continue honoring the same
+	 * UserInfo request contract.
+	 */
+	requestedUserInfoClaims?: string[];
+	/**
 	 * Additional JWT access-token claims for this single issuance.
 	 *
 	 * JWT-only: these are baked into the signed token at mint. Opaque access
@@ -349,6 +356,11 @@ export interface OAuthUserInfoExtensionInput {
 	scopes: string[];
 	jwt: JWTPayload;
 	client?: SchemaClient<Scope[]>;
+	/**
+	 * Claim names explicitly requested through the OIDC `claims.userinfo`
+	 * authorization request parameter.
+	 */
+	requestedClaims: string[];
 }
 
 /**
@@ -808,11 +820,16 @@ export interface OAuthOptions<
 	 *
 	 * - `client_id` - The ID of the client.
 	 * - `scope` - The requested scopes.
+	 * - `claims` - The OIDC claims request, when the client requested specific
+	 *   claims. Consent pages should surface `claims.userinfo` names alongside
+	 *   scopes because accepted UserInfo claims can affect the UserInfo response.
 	 * - `code` - The authorization code.
 	 *
 	 * once the user consents, you need to call the `/oauth2/consent` endpoint
-	 * with the code and `accept: true` to complete the authorization. Which will
-	 * then return the client to the `redirect_uri` with the authorization code.
+	 * with the code and `accept: true` to complete the authorization. Include a
+	 * `claims` object if the user accepted only some requested UserInfo claims.
+	 * The endpoint will then return the client to the `redirect_uri` with the
+	 * authorization code.
 	 *
 	 * @example
 	 * ```ts
@@ -1014,6 +1031,11 @@ export interface OAuthOptions<
 		scopes: Scopes;
 		/** The access token payload used in the /userinfo request */
 		jwt: JWTPayload;
+		/**
+		 * Claim names explicitly requested through the OIDC `claims.userinfo`
+		 * authorization request parameter.
+		 */
+		requestedClaims: string[];
 	}) => Awaitable<Record<string, any>>;
 	/**
 	 * Custom claims attached to OIDC id tokens.
@@ -1434,6 +1456,14 @@ export interface OAuthAuthorizationQuery {
 	 */
 	nonce?: string;
 	/**
+	 * OIDC Claims request parameter. In an authorization request it is a
+	 * form-encoded JSON string; Request Object resolvers may provide the parsed
+	 * object form.
+	 *
+	 * @see https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
+	 */
+	claims?: string | Record<string, unknown>;
+	/**
 	 * RFC 9449 authorization request parameter. When present, the authorization
 	 * code is bound to this JWK thumbprint and the token request must present a
 	 * matching DPoP proof.
@@ -1772,6 +1802,11 @@ export interface OAuthOpaqueAccessToken<
 	 */
 	resources?: string[];
 	/**
+	 * OIDC UserInfo claim names requested by the authorization request's
+	 * `claims.userinfo` object.
+	 */
+	requestedUserInfoClaims?: string[];
+	/**
 	 * RFC 7800 `cnf` confirmation that sender-constrains this access token (for
 	 * example DPoP `{ jkt }`). Surfaced as the `cnf` claim at introspection.
 	 */
@@ -1812,6 +1847,11 @@ export interface OAuthRefreshToken<
 	 */
 	resources?: string[];
 	/**
+	 * OIDC UserInfo claim names requested by the authorization request's
+	 * `claims.userinfo` object. Carried forward on rotation.
+	 */
+	requestedUserInfoClaims?: string[];
+	/**
 	 * RFC 7800 `cnf` confirmation that sender-constrains this refresh-token
 	 * family (for example DPoP `{ jkt }`). Carried forward on rotation.
 	 */
@@ -1829,6 +1869,11 @@ export type OAuthConsent<
 	userId: string;
 	resources?: string[];
 	referenceId?: string;
+	/**
+	 * OIDC UserInfo claim names consented from the authorization request's
+	 * `claims.userinfo` object.
+	 */
+	requestedUserInfoClaims?: string[];
 	scopes: Scopes;
 	createdAt: Date;
 	updatedAt: Date;

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -296,6 +296,13 @@ export interface OIDCMetadata extends AuthServerMetadata {
 	 */
 	claims_supported: string[];
 	/**
+	 * Whether the OP supports the OIDC `claims` request parameter.
+	 *
+	 * @default true
+	 * @see https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+	 */
+	claims_parameter_supported?: boolean;
+	/**
 	 * RP-Initiated Logout Endpoint
 	 *
 	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -1,5 +1,6 @@
 import { SafeUrlSchema } from "@better-auth/core/utils/redirect-uri";
 import * as z from "zod";
+import { claimsRequestParameterSchema } from "../claims-request";
 
 /**
  * Re-exported from `@better-auth/core` so every OAuth provider plugin shares one
@@ -130,6 +131,7 @@ export const authorizationQuerySchema = z
 			.pipe(z.enum(["S256"]))
 			.optional(),
 		nonce: z.string().optional(),
+		claims: claimsRequestParameterSchema.optional(),
 		dpop_jkt: dpopJktSchema.optional(),
 		resource: z
 			.union([ResourceUriSchema, z.array(ResourceUriSchema).min(1)])

--- a/packages/oauth-provider/src/userinfo.test.ts
+++ b/packages/oauth-provider/src/userinfo.test.ts
@@ -5,6 +5,7 @@ import {
 	createAuthorizationURL,
 	deriveDpopAth,
 	deriveDpopJkt,
+	refreshAccessTokenRequest,
 } from "better-auth/oauth2";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
@@ -185,6 +186,34 @@ describe("oauth userinfo", async () => {
 			code: url.searchParams.get("code")!,
 			codeVerifier,
 			resource,
+		});
+	}
+
+	async function refreshAccessToken(refreshToken: string) {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const { body, headers } = await refreshAccessTokenRequest({
+			refreshToken,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+		return client.$fetch<{
+			access_token?: string;
+			id_token?: string;
+			refresh_token?: string;
+			expires_in?: number;
+			expires_at?: number;
+			token_type?: string;
+			scope?: string;
+			[key: string]: unknown;
+		}>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers,
 		});
 	}
 
@@ -538,6 +567,128 @@ describe("oauth userinfo", async () => {
 		expect(userinfo.data?.family_name).toBeUndefined();
 		expect(userinfo.data?.email).toBeUndefined();
 		expect(userinfo.data?.email_verified).toBeUndefined();
+	});
+
+	it("returns explicitly requested UserInfo claims without granting the full scope bundle", async () => {
+		const tokens = await getTokens({
+			scopes: ["openid"],
+			additionalParams: {
+				claims: JSON.stringify({
+					userinfo: {
+						name: { essential: true },
+						email: null,
+					},
+				}),
+			},
+		});
+		expect(tokens.data?.access_token).toBeDefined();
+		const accessToken = tokens.data?.access_token;
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: accessToken ?? "",
+				},
+			},
+		);
+
+		expect(userinfo.data).toMatchObject({
+			sub: user.id,
+			name: user.name,
+			email: user.email,
+		});
+		expect(userinfo.data?.given_name).toBeUndefined();
+		expect(userinfo.data?.family_name).toBeUndefined();
+		expect(userinfo.data?.email_verified).toBeUndefined();
+
+		const introspection = await client.oauth2.introspect(
+			{
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				token: accessToken!,
+				token_type_hint: "access_token",
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		expect(introspection.data?.active).toBe(true);
+		// Requested UserInfo claims resolve only at /userinfo; they never surface
+		// in the RFC 7662 introspection response shown to a resource server.
+		const introspectionClaims = introspection.data as
+			| Record<string, unknown>
+			| undefined;
+		expect(introspectionClaims?.name).toBeUndefined();
+		expect(introspectionClaims?.email).toBeUndefined();
+	});
+
+	it("preserves requested UserInfo claims across refresh-token rotation", async () => {
+		const tokens = await getTokens({
+			scopes: ["openid", "offline_access"],
+			additionalParams: {
+				claims: JSON.stringify({
+					userinfo: {
+						name: { essential: true },
+					},
+				}),
+			},
+		});
+		expect(tokens.data?.refresh_token).toBeDefined();
+
+		const refreshedTokens = await refreshAccessToken(
+			tokens.data?.refresh_token ?? "",
+		);
+		expect(refreshedTokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: refreshedTokens.data?.access_token ?? "",
+				},
+			},
+		);
+
+		expect(userinfo.data).toMatchObject({
+			sub: user.id,
+			name: user.name,
+		});
+		expect(userinfo.data?.given_name).toBeUndefined();
+		expect(userinfo.data?.email).toBeUndefined();
+	});
+
+	it("resolves JWT access-token UserInfo claims by scope, omitting individually requested claims", async () => {
+		const tokens = await getTokens(
+			{
+				scopes: ["openid"],
+				additionalParams: {
+					claims: JSON.stringify({
+						userinfo: {
+							name: { essential: true },
+						},
+					}),
+				},
+			},
+			validResource,
+		);
+		expect(tokens.data?.access_token).toBeDefined();
+		const userinfo = await client.$fetch<Record<string, string>>(
+			"/oauth2/userinfo",
+			{
+				headers: {
+					authorization: tokens.data?.access_token ?? "",
+				},
+			},
+		);
+
+		// A JWT access token has no per-issuance row, so a claim requested through
+		// `claims.userinfo` without its backing scope is omitted (OIDC Core
+		// §5.5.1). UserInfo claims for a JWT token come from granted scopes only.
+		expect(userinfo.data).toMatchObject({ sub: user.id });
+		expect(userinfo.data?.name).toBeUndefined();
+		expect(userinfo.data?.email).toBeUndefined();
 	});
 
 	it("should pass provide scoped user information - profile only", async () => {

--- a/packages/oauth-provider/src/userinfo.ts
+++ b/packages/oauth-provider/src/userinfo.ts
@@ -13,33 +13,34 @@ import {
 	collectExtensionUserInfoClaims,
 	hasUserInfoClaimExtension,
 } from "./extensions";
-import { requireActiveAccessToken } from "./introspect";
+import { requireActiveAccessTokenWithClaims } from "./introspect";
+import { STANDARD_CLAIMS } from "./standard-claims";
 import type { OAuthOptions, Scope } from "./types";
 import { getClient, resolveSubjectIdentifier } from "./utils";
 
 /**
- * Provides shared /userinfo and id_token claims functionality
+ * Builds the standard OIDC claims (OIDC Core §5.1) for the UserInfo response.
+ *
+ * A claim is included when its backing scope was granted, or when it was named
+ * individually through the `claims.userinfo` request parameter (§5.4, §5.5).
+ * `sub` is always present. Values come from the one claim registry, so the
+ * advertisement, the scope mapping, and the resolution cannot drift apart.
  *
  * @see https://openid.net/specs/openid-connect-core-1_0.html#NormalClaims
  */
-function userNormalClaims(user: User, scopes: string[]) {
-	const name = user.name.split(" ").filter((v) => v !== "");
-	const profile = {
-		name: user.name ?? undefined,
-		picture: user.image ?? undefined,
-		given_name: name.length > 1 ? name.slice(0, -1).join(" ") : undefined,
-		family_name: name.length > 1 ? name.at(-1) : undefined,
-	};
-	const email = {
-		email: user.email ?? undefined,
-		email_verified: user.emailVerified ?? false,
-	};
-
-	return {
-		sub: user.id ?? undefined,
-		...(scopes.includes("profile") ? profile : {}),
-		...(scopes.includes("email") ? email : {}),
-	};
+function userNormalClaims(
+	user: User,
+	scopes: string[],
+	requestedClaims: string[] = [],
+) {
+	const requested = new Set(requestedClaims);
+	const claims: Record<string, unknown> = { sub: user.id ?? undefined };
+	for (const [name, definition] of Object.entries(STANDARD_CLAIMS)) {
+		if (scopes.includes(definition.scope) || requested.has(name)) {
+			claims[name] = definition.resolve(user);
+		}
+	}
+	return claims;
 }
 
 /**
@@ -118,11 +119,12 @@ export async function userInfoEndpoint(
 			error: "invalid_request",
 		});
 	}
-	const jwt = await requireActiveAccessToken(
-		ctx,
-		opts,
-		accessTokenAuthorization.token,
-	);
+	const { payload: jwt, requestedUserInfoClaims: requestedClaims } =
+		await requireActiveAccessTokenWithClaims(
+			ctx,
+			opts,
+			accessTokenAuthorization.token,
+		);
 
 	// The DPoP `htm`/`htu` check needs the real request method and URL. Without a
 	// `ctx.request` (a programmatic `auth.api` call) the sender-constraint cannot
@@ -179,7 +181,7 @@ export async function userInfoEndpoint(
 		});
 	}
 
-	const baseUserClaims = userNormalClaims(user, scopes ?? []);
+	const baseUserClaims = userNormalClaims(user, scopes ?? [], requestedClaims);
 	const clientId = (jwt.client_id ?? jwt.azp) as string | undefined;
 	// Load the client only when something needs it: pairwise subject resolution
 	// or a UserInfo claim extension. The token was already validated against its
@@ -201,11 +203,17 @@ export async function userInfoEndpoint(
 				scopes,
 				jwt,
 				client: client ?? undefined,
+				requestedClaims,
 			})
 		: {};
 	const additionalInfoUserClaims =
 		opts.customUserInfoClaims && scopes?.length
-			? await opts.customUserInfoClaims({ user, scopes, jwt })
+			? await opts.customUserInfoClaims({
+					user,
+					scopes,
+					jwt,
+					requestedClaims,
+				})
 			: {};
 	return {
 		...baseUserClaims,


### PR DESCRIPTION
The provider advertised the standard UserInfo claims in discovery but resolved only the ones a granted scope implied, so the OIDC `claims.userinfo` request parameter was ignored. Honoring it exposed a scattered claim model: the scope-to-claim mapping was hardcoded in three places with no link between them, so the `claims_supported` advertisement could drift from what UserInfo returned.

This routes UserInfo resolution, the advertisement, and the requested-name bound through one claim registry keyed by claim name. The bound is the advertised set, so a client cannot pin arbitrary strings onto stored token and consent rows.

Requested claims stay as per-issuance state on the opaque access-token and refresh rows rather than inside the JWT access token. Carrying them in the token leaked the names to resource servers, was discouraged by RFC 9068 §2.2.2, and needed bespoke stripping at introspection; the validation result now returns them beside the payload, never inside it. A stateless JWT access token has nowhere to keep them, so it resolves UserInfo claims by scope and omits an individually requested claim no scope covers, as OIDC Core §5.5.1 allows.
