### PR TITLE
fix(oauth-provider): make `redirect_uri` conditional at the token endpoint

### DIFF
--- a/.changeset/oauth-provider-conditional-redirect-uri.md
+++ b/.changeset/oauth-provider-conditional-redirect-uri.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+`redirect_uri` is enforced conditionally at the OAuth token endpoint: required and matched only when the authorization request included one (RFC 6749 §4.1.3), so an authorization code issued without a `redirect_uri` can be exchanged without one. A `redirect_uri` that does not match the code's bound value now returns `invalid_grant` instead of `invalid_request` (RFC 6749 §5.2).

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -33,6 +33,7 @@ import type {
 } from "./types";
 import type { OAuthClient } from "./types/oauth";
 import { verificationValueSchema } from "./types/zod";
+import { storeToken } from "./utils";
 
 type MakeRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 
@@ -576,6 +577,138 @@ describe("oauth token - authorization_code", async () => {
 			deleteMany.mockRestore();
 			loggerError.mockRestore();
 		}
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/10159
+	 *
+	 * RFC 6749 §4.1.3 binds redirect_uri at the token endpoint only when the
+	 * authorization request carried one. The authorize endpoint always records a
+	 * redirect_uri (it delivers the code through it), so a headless code is
+	 * inserted the way authorize.ts persists one to exercise redemption directly.
+	 */
+	describe("redirect_uri conditional (RFC 6749 §4.1.3)", () => {
+		const tokenRequestHeaders = {
+			accept: "application/json",
+			"content-type": "application/x-www-form-urlencoded",
+		};
+
+		async function s256Challenge(verifier: string) {
+			const digest = await crypto.subtle.digest(
+				"SHA-256",
+				new TextEncoder().encode(verifier),
+			);
+			return base64url.encode(new Uint8Array(digest));
+		}
+
+		// Headless first-party / device flows are public clients, so the code is
+		// minted with a PKCE challenge and redeemed with its verifier.
+		async function mintHeadlessCode() {
+			const context = await auth.$context;
+			const session = await auth.api.getSession({ headers });
+			if (!session) throw new Error("test session unavailable");
+			const code = generateRandomString(32, "a-z", "A-Z", "0-9");
+			const codeVerifier = generateRandomString(43, "a-z", "A-Z", "0-9");
+			const now = Date.now();
+			await context.internalAdapter.createVerificationValue({
+				identifier: await storeToken("hashed", code, "authorization_code"),
+				value: JSON.stringify({
+					type: "authorization_code",
+					query: {
+						client_id: oauthClient!.client_id,
+						scope: "openid",
+						code_challenge: await s256Challenge(codeVerifier),
+						code_challenge_method: "S256",
+					},
+					userId: session.user.id,
+					sessionId: session.session.id,
+					authTime: now,
+				}),
+				expiresAt: new Date(now + 600_000),
+			});
+			return { code, codeVerifier };
+		}
+
+		async function mintRedirectBoundCode() {
+			const { url: authUrl } = await createAuthUrl();
+			let callbackRedirectUrl = "";
+			await client.$fetch(authUrl.toString(), {
+				onError(context) {
+					callbackRedirectUrl = context.response.headers.get("Location") || "";
+				},
+			});
+			return new URL(callbackRedirectUrl).searchParams.get("code")!;
+		}
+
+		it("exchanges a headless code that omits redirect_uri", async () => {
+			const { code, codeVerifier } = await mintHeadlessCode();
+			const tokens = await client.oauth2.token(
+				{
+					code,
+					code_verifier: codeVerifier,
+					grant_type: "authorization_code",
+					client_id: oauthClient!.client_id,
+					client_secret: oauthClient!.client_secret,
+				},
+				{ headers: tokenRequestHeaders },
+			);
+			expect(tokens.error).toBeNull();
+			expect(tokens.data?.access_token).toBeDefined();
+		});
+
+		it("rejects a redirect_uri supplied against a headless code with invalid_grant", async () => {
+			const { code, codeVerifier } = await mintHeadlessCode();
+			const tokens = await client.oauth2.token(
+				{
+					code,
+					code_verifier: codeVerifier,
+					grant_type: "authorization_code",
+					client_id: oauthClient!.client_id,
+					client_secret: oauthClient!.client_secret,
+					redirect_uri: redirectUri,
+				},
+				{ headers: tokenRequestHeaders },
+			);
+			expect(tokens.data?.access_token).toBeUndefined();
+			expect((tokens.error as { error?: string } | null)?.error).toBe(
+				"invalid_grant",
+			);
+		});
+
+		it("requires redirect_uri when the code was bound to one", async () => {
+			const code = await mintRedirectBoundCode();
+			const tokens = await client.oauth2.token(
+				{
+					code,
+					grant_type: "authorization_code",
+					client_id: oauthClient!.client_id,
+					client_secret: oauthClient!.client_secret,
+				},
+				{ headers: tokenRequestHeaders },
+			);
+			expect(tokens.data?.access_token).toBeUndefined();
+			expect((tokens.error as { error?: string } | null)?.error).toBe(
+				"invalid_request",
+			);
+		});
+
+		it("rejects a mismatched redirect_uri with invalid_grant", async () => {
+			const code = await mintRedirectBoundCode();
+			const tokens = await client.oauth2.token(
+				{
+					code,
+					grant_type: "authorization_code",
+					client_id: oauthClient!.client_id,
+					client_secret: oauthClient!.client_secret,
+					redirect_uri: "https://attacker.example/callback",
+				},
+				{ headers: tokenRequestHeaders },
+			);
+			expect(tokens.data?.access_token).toBeUndefined();
+			expect((tokens.error as { error?: string } | null)?.error).toBe(
+				"invalid_grant",
+			);
+		});
 	});
 });
 
@@ -3316,6 +3449,25 @@ describe("verificationValueSchema", () => {
 				response_type: "code",
 				client_id: "test-client",
 				redirect_uri: "https://example.com/callback",
+				scope: "openid",
+			},
+			userId: "user-1",
+			sessionId: "session-1",
+		};
+
+		const result = verificationValueSchema.safeParse(value);
+		expect(result.success).toBe(true);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/10159
+	 */
+	it("should validate a headless verification value without redirect_uri", () => {
+		const value: VerificationValue = {
+			type: "authorization_code",
+			query: {
+				response_type: "code",
+				client_id: "test-client",
 				scope: "openid",
 			},
 			userId: "user-1",

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -1102,14 +1102,23 @@ async function checkVerificationValue(
 			error: "invalid_grant",
 		});
 	}
-	if (
-		verificationValue.query?.redirect_uri &&
-		verificationValue.query?.redirect_uri !== redirect_uri
-	) {
-		throw new APIError("BAD_REQUEST", {
-			error_description: "redirect_uri mismatch",
-			error: "invalid_request",
-		});
+	// RFC 6749 §4.1.3: redirect_uri is required at the token endpoint only if it
+	// was present in the authorization request, and then must match. A headless
+	// authorization request (first-party-apps / device-style) carries none, so it
+	// is exchanged without one.
+	if (verificationValue.query?.redirect_uri) {
+		if (!redirect_uri) {
+			throw new APIError("BAD_REQUEST", {
+				error_description: "redirect_uri is required",
+				error: "invalid_request",
+			});
+		}
+		if (verificationValue.query.redirect_uri !== redirect_uri) {
+			throw new APIError("BAD_REQUEST", {
+				error_description: "redirect_uri mismatch",
+				error: "invalid_request",
+			});
+		}
 	}
 	// Prefer the new top-level field, but keep compatibility with legacy values in query.resource.
 	const storedResources =
@@ -1182,12 +1191,9 @@ async function handleAuthorizationCodeGrant(
 			error: "invalid_request",
 		});
 	}
-	if (!redirect_uri) {
-		throw new APIError("BAD_REQUEST", {
-			error_description: "redirect_uri is required",
-			error: "invalid_request",
-		});
-	}
+	// redirect_uri is validated conditionally against the stored code in
+	// checkVerificationValue (RFC 6749 §4.1.3): required and matched only when the
+	// authorization request included one, so headless codes can omit it.
 
 	const isAuthCodeWithSecret = client_id && client_secret;
 	const isAuthCodeWithPkce = client_id && code && code_verifier;

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -1102,23 +1102,32 @@ async function checkVerificationValue(
 			error: "invalid_grant",
 		});
 	}
-	// RFC 6749 §4.1.3: redirect_uri is required at the token endpoint only if it
-	// was present in the authorization request, and then must match. A headless
-	// authorization request (first-party-apps / device-style) carries none, so it
-	// is exchanged without one.
-	if (verificationValue.query?.redirect_uri) {
+	// RFC 6749 §4.1.3: redirect_uri is bound at the token endpoint only when the
+	// authorization request carried one. Enforce an exact correspondence in both
+	// directions: a code minted with a redirect_uri must be redeemed with the
+	// identical value, and a headless code (first-party-apps / device-style)
+	// minted without one must be redeemed without one.
+	const boundRedirectUri = verificationValue.query.redirect_uri;
+	if (boundRedirectUri) {
 		if (!redirect_uri) {
 			throw new APIError("BAD_REQUEST", {
 				error_description: "redirect_uri is required",
 				error: "invalid_request",
 			});
 		}
-		if (verificationValue.query.redirect_uri !== redirect_uri) {
+		if (boundRedirectUri !== redirect_uri) {
 			throw new APIError("BAD_REQUEST", {
+				// RFC 6749 §5.2: a redirect_uri that does not match the one bound to
+				// the code is an invalid grant, not a malformed request.
 				error_description: "redirect_uri mismatch",
-				error: "invalid_request",
+				error: "invalid_grant",
 			});
 		}
+	} else if (redirect_uri) {
+		throw new APIError("BAD_REQUEST", {
+			error_description: "redirect_uri mismatch",
+			error: "invalid_grant",
+		});
 	}
 	// Prefer the new top-level field, but keep compatibility with legacy values in query.resource.
 	const storedResources =

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1532,6 +1532,19 @@ export interface OAuthClientResource {
 }
 
 /**
+ * The authorization request as persisted alongside a minted code. Identical to
+ * {@link OAuthAuthorizationQuery} except `redirect_uri` is optional: a headless
+ * authorization request (first-party-apps / device-style) carries none, and
+ * RFC 6749 §4.1.3 only binds `redirect_uri` at the token endpoint when the
+ * authorization request included one. Mirrors the runtime
+ * `storedAuthorizationQuerySchema`.
+ */
+export interface StoredAuthorizationQuery
+	extends Omit<OAuthAuthorizationQuery, "redirect_uri"> {
+	redirect_uri?: string;
+}
+
+/**
  * Stored within the verification.value field
  * in JSON format.
  *
@@ -1540,7 +1553,7 @@ export interface OAuthClientResource {
  */
 export interface VerificationValue {
 	type: "authorization_code";
-	query: OAuthAuthorizationQuery;
+	query: StoredAuthorizationQuery;
 	sessionId: string;
 	userId: string;
 	resource?: string[];

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -137,8 +137,14 @@ export const authorizationQuerySchema = z
 	})
 	.passthrough();
 
+// redirect_uri stays optional in the stored code: a headless authorization
+// request (e.g. first-party-apps / device-style flows) legitimately omits it,
+// and RFC 6749 §4.1.3 only requires it at the token endpoint when the
+// authorization request carried one. The token endpoint enforces that
+// conditional match; forcing it here would reject valid headless codes as
+// "malformed verification value".
 const storedAuthorizationQuerySchema = authorizationQuerySchema.extend({
-	redirect_uri: SafeUrlSchema,
+	redirect_uri: SafeUrlSchema.optional(),
 });
 
 /**


### PR DESCRIPTION
The token endpoint rejected every authorization-code exchange that omitted `redirect_uri`. Two places enforced it: an unconditional check in the `authorization_code` grant and a stored-code schema that required the field. RFC 6749 §4.1.3 makes the parameter conditional, required at the token endpoint only when the authorization request included one, and then matched. So a code legitimately issued without one could not be redeemed.

Validation now lives in code redemption and requires an exact correspondence both ways. A code bound to a `redirect_uri` must be redeemed with the identical value; a code issued without one must be redeemed without one. `redirect_uri` is optional on both the stored runtime schema and the `StoredAuthorizationQuery` type, so the two no longer disagree. A mismatch returns `invalid_grant`, not `invalid_request`, per RFC 6749 §5.2.

Redirect-based flows are unchanged: the authorize endpoint still records `redirect_uri`, so its codes still require and match it.
