### PR TITLE
docs: fix open in markdown url

### DIFF
--- a/docs/app/docs/[[...slug]]/page.client.tsx
+++ b/docs/app/docs/[[...slug]]/page.client.tsx
@@ -53,15 +53,9 @@ const cache = new Map<string, string>();
 const tocAction =
 	"inline-flex items-center gap-1.5 px-2 py-1 text-[11px] uppercase tracking-wider whitespace-nowrap transition-all duration-200 text-foreground/60 hover:text-foreground border border-transparent hover:border-foreground/10 hover:bg-foreground/5 cursor-pointer select-none [&_svg]:size-3";
 
-function CopyMdLinkButton({ rawMdUrl }: { rawMdUrl: string }) {
+function CopyMdLinkButton({ markdownUrl }: { markdownUrl: URL }) {
 	const [checked, onClick] = useCopyButton(() => {
-		const url = new URL(
-			rawMdUrl,
-			typeof window !== "undefined"
-				? window.location.origin
-				: "https://better-auth.com",
-		);
-		return navigator.clipboard.writeText(url.toString());
+		return navigator.clipboard.writeText(markdownUrl.toString());
 	});
 
 	return (
@@ -119,11 +113,7 @@ export function LLMCopyButton({ rawUrl }: { rawUrl: string }) {
 	);
 }
 
-export function ViewOptions(props: {
-	markdownUrl: string;
-	githubUrl: string;
-	rawMdUrl: string;
-}) {
+export function ViewOptions(props: { markdownUrl: string; githubUrl: string }) {
 	const markdownUrl = new URL(
 		props.markdownUrl,
 		typeof window !== "undefined"
@@ -160,7 +150,7 @@ export function ViewOptions(props: {
 				<ChevronDown />
 			</PopoverTrigger>
 			<PopoverContent className="flex flex-col p-1 min-w-[200px]">
-				<CopyMdLinkButton rawMdUrl={props.rawMdUrl} />
+				<CopyMdLinkButton markdownUrl={markdownUrl} />
 				{[
 					{
 						title: "GitHub",

--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -88,9 +88,8 @@ export default async function Page({
 				<div className="flex flex-wrap items-center gap-2 not-prose lg:shrink-0">
 					<LLMCopyButton rawUrl={`${rawBase}/${page.path}`} />
 					<ViewOptions
-						markdownUrl={`${page.url}.mdx`}
+						markdownUrl={`/llms.txt${page.url}.md`}
 						githubUrl={`${githubBase}/${page.path}`}
-						rawMdUrl={`/llms.txt${page.url}.md`}
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
## What changed

Fixes the docs Open in markdown URL so it points to the generated `/llms.txt/*.md` endpoint instead of appending `.mdx` to the rendered docs URL, which produced broken links like `https://better-auth.com/docs/introduction.mdx`.

The Copy MD Link action and AI-provider prompts now use the same generated markdown endpoint URL.

## Validation

- `pnpm typecheck`
- Manually with `pnpm -F docs build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken "Open in Markdown" links in docs by using the generated `/llms.txt/*.md` endpoint instead of appending `.mdx`. Also makes the Copy MD Link and LLM copy actions share the same markdown URL.

- **Bug Fixes**
  - "Open in Markdown" now points to `/llms.txt{page.url}.md` (was `{page.url}.mdx`).
  - Unifies Copy MD Link and LLM copy to the same endpoint and simplifies clipboard logic.

<sup>Written for commit 26d4fc6197e5f141ebb87cf6a15162308383f064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

