### PR TITLE
fix(oauth-provider): forward login_hint and custom params from /oauth2/authorize

### DIFF
--- a/.changeset/forward-authorize-hints.md
+++ b/.changeset/forward-authorize-hints.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+The `/oauth2/authorize` endpoint now forwards standard OIDC parameters (e.g. `login_hint`) and custom query parameters to the login/consent pages instead of dropping them. The endpoint's query schema validated against a fixed allow-list and stripped every other parameter before it could be signed, stored in the OAuth state, or forwarded — so `login_hint` and any custom params never reached a custom `loginPage`, and were also lost across the post-login continuation. The query schema now passes through unknown keys, restoring the documented behavior that "all parameters sent to the authorize endpoint (including any custom ones) are signed and verified."

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -386,8 +386,14 @@ describe("oauth", async () => {
 		);
 		expect(data.url).toContain(`client_id=${oauthClient.client_id}`);
 
+		// Standard OIDC params (e.g. login_hint) and custom params should be forwarded
+		// to the login page via the signed query, not silently dropped by validation.
+		const authorizeUrlWithHints = new URL(data.url);
+		authorizeUrlWithHints.searchParams.set("login_hint", "user@example.com");
+		authorizeUrlWithHints.searchParams.set("ext_custom_param", "custom-value");
+
 		let loginRedirectUri = "";
-		await authClient.$fetch(data.url, {
+		await authClient.$fetch(authorizeUrlWithHints.toString(), {
 			method: "GET",
 			onError(ctx) {
 				loginRedirectUri = ctx.response.headers.get("Location") || "";
@@ -398,6 +404,10 @@ describe("oauth", async () => {
 		expect(loginRedirectUri).toContain(
 			`redirect_uri=${encodeURIComponent(oauthClient?.redirect_uris?.at(0)!)}`,
 		);
+		const forwardedParams = new URL(loginRedirectUri, authServerBaseUrl)
+			.searchParams;
+		expect(forwardedParams.get("login_hint")).toBe("user@example.com");
+		expect(forwardedParams.get("ext_custom_param")).toBe("custom-value");
 		vi.stubGlobal("window", {
 			location: {
 				search: new URL(loginRedirectUri, authServerBaseUrl).search,

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -269,28 +269,30 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		"/oauth2/authorize",
 		{
 			method: "GET",
-			query: z.object({
-				response_type: z.enum(["code"]).optional(),
-				client_id: z.string(),
-				redirect_uri: SafeUrlSchema.optional(),
-				scope: z.string().optional(),
-				state: z.string().optional(),
-				request_uri: z.string().optional(),
-				code_challenge: z.string().optional(),
-				code_challenge_method: z.enum(["S256"]).optional(),
-				nonce: z.string().optional(),
-				prompt: z
-					.enum([
-						"none",
-						"consent",
-						"login",
-						"create",
-						"select_account",
-						"login consent",
-						"select_account consent",
-					])
-					.optional(),
-			}),
+			query: z
+				.object({
+					response_type: z.enum(["code"]).optional(),
+					client_id: z.string(),
+					redirect_uri: SafeUrlSchema.optional(),
+					scope: z.string().optional(),
+					state: z.string().optional(),
+					request_uri: z.string().optional(),
+					code_challenge: z.string().optional(),
+					code_challenge_method: z.enum(["S256"]).optional(),
+					nonce: z.string().optional(),
+					prompt: z
+						.enum([
+							"none",
+							"consent",
+							"login",
+							"create",
+							"select_account",
+							"login consent",
+							"select_account consent",
+						])
+						.optional(),
+				})
+				.passthrough(),
 			metadata: {
 				openapi: {
 					description: "Authorize an OAuth2 request",


### PR DESCRIPTION
Fixes #10164

## Summary

The `@better-auth/oauth-provider` `/oauth2/authorize` endpoint validates its query against a fixed, non-passthrough Zod schema ([`packages/oauth-provider/src/oauth.ts`](https://github.com/better-auth/better-auth/blob/main/packages/oauth-provider/src/oauth.ts)). Any parameter outside that allow-list is stripped during validation — including:

- the standard OIDC [`login_hint`](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) parameter, and
- any **custom parameter** a host app passes to its `loginPage` / `consentPage`.

Because the stripped params are removed before the query is signed and persisted into the OAuth state, they never reach a custom `loginPage`, and they're also lost across the post-login continuation (after sign-in the next redirect is rebuilt from the stored state).

This contradicts the documented behavior. The [OAuth Provider docs](https://better-auth.com/docs/plugins/oauth-provider) state:

> To process each redirect step in the login flow, we verify the signed query provided in the initial `/oauth2/authorize` redirect. **All parameters sent to the authorize endpoint (including any custom ones), are signed and verified.**

## Fix

Allow the authorize query schema to pass through unknown keys (`.passthrough()`), so `login_hint` and custom params flow to the login/consent pages and survive the full signed-query lifecycle (forward → store → continuation). `serializeAuthorizationQuery` already serializes every key, so no other change is required.

## Test

Extended the existing generic-OAuth flow test to assert that a `login_hint` and a custom parameter on `/oauth2/authorize` are forwarded to the login redirect.

> Verified end-to-end in a production app using a local patch of this exact change: a custom `loginPage` reads `login_hint` to pre-fill/force the email, and a custom `team_hint` pre-selects an organization — both now survive email-OTP and social sign-in continuations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped parameters in `@better-auth/oauth-provider` /oauth2/authorize. `login_hint` and custom query params are now preserved, signed, and forwarded to login/consent pages and across the post-login continuation.

- **Bug Fixes**
  - Updated authorize query schema to passthrough unknown keys, restoring the documented behavior that all params are signed and verified.
  - Added tests to confirm `login_hint` and a custom param are forwarded to the login redirect.

<sup>Written for commit a81529fd3426d78f2b14ef3d88580623abdb2eec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

