### PR TITLE
chore(ci): ignore compose override in spellcheck

### DIFF
--- a/.cspell.jsonc
+++ b/.cspell.jsonc
@@ -101,6 +101,7 @@
 		"e2e/smoke/test/fixtures/cloudflare/worker-configuration.d.ts",
 		"*.config.js",
 		"*.config.ts",
+		"docker-compose.override.yml",
 		"*.json",
 		".gitignore"
 	]


### PR DESCRIPTION
## Summary

The release PR lint job is failing in `pnpm lint:spell` because the self-hosted runner leaves a `docker-compose.override.yml` in the checkout. CSpell scans `.` and flags MySQL daemon/engine terms from that runner-local override (`mysqld`, `innodb`), even though the file is not part of the repo or the release diff.

This adds `docker-compose.override.yml` to CSpell `ignorePaths`, matching the existing pattern for generated and local-only files while keeping the dictionary unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop CI spellcheck failures by ignoring the runner-generated `docker-compose.override.yml`. Added this file to `.cspell.jsonc` `ignorePaths`; no dictionary or code changes.

<sup>Written for commit 02a548e7fb36f9d01543c6318e32d32cc7f02ebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

