### PR TITLE
docs: remove extra spaces in documentation

### DIFF
--- a/docs/content/docs/authentication/discord.mdx
+++ b/docs/content/docs/authentication/discord.mdx
@@ -46,6 +46,7 @@ To sign in with Discord, you can use the `signIn.social` function provided by th
 
 ```ts title="auth-client.ts"
 import { createAuthClient } from "better-auth/client"
+
 const authClient = createAuthClient()
 
 const signIn = async () => {

--- a/docs/content/docs/authentication/discord.mdx
+++ b/docs/content/docs/authentication/discord.mdx
@@ -46,7 +46,7 @@ To sign in with Discord, you can use the `signIn.social` function provided by th
 
 ```ts title="auth-client.ts"
 import { createAuthClient } from "better-auth/client"
-const authClient =  createAuthClient()
+const authClient = createAuthClient()
 
 const signIn = async () => {
     const data = await authClient.signIn.social({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes formatting in the Discord auth docs code sample: removes the double space in `const authClient = createAuthClient()` and adds a newline after the import. Keeps the snippet consistent with `better-auth/client` usage and reduces copy-paste errors.

<sup>Written for commit ea891a6c962ef924fc426254f3ae24639e7e66d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

