### PR TITLE
feat(better-auth): add better-auth/plugins/one-tap subpath export

### DIFF
--- a/.changeset/one-tap-subpath-export.md
+++ b/.changeset/one-tap-subpath-export.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Add `better-auth/plugins/one-tap` subpath export so the One Tap plugin can be imported individually like every other plugin (e.g. `one-time-token`, `jwt`, `magic-link`). The build already emitted the artifact; only the `package.json` `exports` field was missing.

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -281,6 +281,11 @@
       "types": "./dist/plugins/organization/access/index.d.mts",
       "default": "./dist/plugins/organization/access/index.mjs"
     },
+    "./plugins/one-tap": {
+      "dev-source": "./src/plugins/one-tap/index.ts",
+      "types": "./dist/plugins/one-tap/index.d.mts",
+      "default": "./dist/plugins/one-tap/index.mjs"
+    },
     "./plugins/one-time-token": {
       "dev-source": "./src/plugins/one-time-token/index.ts",
       "types": "./dist/plugins/one-time-token/index.d.mts",


### PR DESCRIPTION
## What

The One Tap plugin is already built (`tsdown` config lists `./src/plugins/one-tap/index.ts` as an entry; `dist/plugins/one-tap/index.mjs` ships with the package) and documented alongside every other plugin (`docs/content/docs/plugins/one-tap.mdx`), but the `package.json` `exports` field never declared the `./plugins/one-tap` subpath. So while consumers can write

```ts
import { magicLink } from "better-auth/plugins/magic-link"
import { oneTimeToken } from "better-auth/plugins/one-time-token"
```

the analogous import for One Tap fails at module resolution:

```ts
import { oneTap } from "better-auth/plugins/one-tap"
// → ERR_PACKAGE_PATH_NOT_EXPORTED
```

Today they have to fall back to the umbrella `better-auth/plugins` re-export, which pulls in the rest of the plugin barrel and defeats tree-shaking for users who only need one plugin.

## What I changed

- `packages/better-auth/package.json` — added the `"./plugins/one-tap"` entry, formatted to match the surrounding plugin exports.
- `.changeset/one-tap-subpath-export.md` — `patch` changeset describing the change.

No source change. The `dist/plugins/one-tap/index.{mjs,d.mts}` artifacts referenced by the new entry already exist on `main` — I verified after a fresh `pnpm build` from `packages/better-auth`.

Fixes #10172.

## Test plan

- [x] `pnpm typecheck` from `packages/better-auth` passes (export field is pure metadata, no runtime impact).
- [x] After build, `node -e "import('better-auth/plugins/one-tap').then(m => console.log(Object.keys(m)))"` resolves to the exported `oneTap` function instead of `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- [x] All other plugin imports continue to work unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `better-auth/plugins/one-tap` subpath export so `oneTap` can be imported directly. This aligns with other plugins and enables proper tree-shaking for one-tap-only usage.

<sup>Written for commit 613dc89bdc958ddbe589357d8a37fa604d79fc2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

