### PR TITLE
feat(phone-number): add disablePhoneNumberInput option

### DIFF
--- a/.changeset/phone-number-disable-input.md
+++ b/.changeset/phone-number-disable-input.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Add a `disablePhoneNumberInput` option to the phone number plugin. When enabled, `phoneNumber` is treated as a non-writable user field (`input: false`), so it can only be attached to an account through a verified flow — `signUpOnVerification`, or a session-bound `/phone-number/verify` with `updatePhoneNumber: true` — rather than being accepted as plain sign-up or `update-user` input.

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -354,6 +354,24 @@ An object with the following properties:
 
 When enabled, users cannot sign in with their phone number until it has been verified. If an unverified user attempts to sign in, the server will respond with a 401 error (PHONE\_NUMBER\_NOT\_VERIFIED) and automatically trigger an OTP send to start the verification process.
 
+### `disablePhoneNumberInput`
+
+By default `phoneNumber` is a writable user field, so it can be set directly as sign-up or `update-user` input, before it is verified. When `disablePhoneNumberInput` is enabled, `phoneNumber` is marked as `input: false`: it is rejected as plain input (the request returns a `400` error) and can only be attached to an account through a flow that verifies ownership of the number first:
+
+* `signUpOnVerification` — the account is created after the OTP is verified.
+* A session-bound `/phone-number/verify` with `updatePhoneNumber: true` — the number is attached to the already-authenticated user after the OTP is verified.
+
+```ts
+phoneNumber({
+  sendOTP,
+  disablePhoneNumberInput: true,
+})
+```
+
+<Callout type="warn">
+  If your sign-up flow currently sends `phoneNumber` in the sign-up body, move it to a verified flow before enabling this, otherwise those sign-up requests will start returning `400`.
+</Callout>
+
 ## Schema
 
 The plugin requires 2 fields to be added to the user table

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -356,7 +356,7 @@ When enabled, users cannot sign in with their phone number until it has been ver
 
 ### `disablePhoneNumberInput`
 
-By default `phoneNumber` is a writable user field, so it can be set directly as sign-up or `update-user` input, before it is verified. When `disablePhoneNumberInput` is enabled, `phoneNumber` is marked as `input: false`: it is rejected as plain input (the request returns a `400` error) and can only be attached to an account through a flow that verifies ownership of the number first:
+By default `phoneNumber` can be provided in the sign-up body, before it is verified. When `disablePhoneNumberInput` is enabled, `phoneNumber` is marked as `input: false`, so passing it at sign-up is rejected with a `400`. A number can then only be attached to an account through a flow that verifies ownership of it first:
 
 * `signUpOnVerification` — the account is created after the OTP is verified.
 * A session-bound `/phone-number/verify` with `updatePhoneNumber: true` — the number is attached to the already-authenticated user after the OTP is verified.

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -37,17 +37,16 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 		createdAt: "createdAt",
 	};
 
-	// Build a fresh schema (never mutate the shared module-level `schema`).
-	// When `disablePhoneNumberInput` is set, mark `phoneNumber` as `input: false`
-	// so it is only attached to an account through a verified flow rather than
-	// being accepted as plain sign-up/update input.
+	// Clone every field so `mergeSchema` can never mutate the shared
+	// module-level `schema` across plugin instances.
 	const pluginSchema = {
 		user: {
 			fields: {
-				phoneNumber: options?.disablePhoneNumberInput
-					? { ...schema.user.fields.phoneNumber, input: false }
-					: schema.user.fields.phoneNumber,
-				phoneNumberVerified: schema.user.fields.phoneNumberVerified,
+				phoneNumber: {
+					...schema.user.fields.phoneNumber,
+					...(options?.disablePhoneNumberInput ? { input: false } : {}),
+				},
+				phoneNumberVerified: { ...schema.user.fields.phoneNumberVerified },
 			},
 		},
 	} satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -1,5 +1,6 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
+import type { BetterAuthPluginDBSchema } from "@better-auth/core/db";
 import { APIError } from "@better-auth/core/error";
 import { mergeSchema } from "../../db/schema";
 import { PACKAGE_VERSION } from "../../version";
@@ -35,6 +36,21 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 		code: "code",
 		createdAt: "createdAt",
 	};
+
+	// Build a fresh schema (never mutate the shared module-level `schema`).
+	// When `disablePhoneNumberInput` is set, mark `phoneNumber` as `input: false`
+	// so it is only attached to an account through a verified flow rather than
+	// being accepted as plain sign-up/update input.
+	const pluginSchema = {
+		user: {
+			fields: {
+				phoneNumber: options?.disablePhoneNumberInput
+					? { ...schema.user.fields.phoneNumber, input: false }
+					: schema.user.fields.phoneNumber,
+				phoneNumberVerified: schema.user.fields.phoneNumberVerified,
+			},
+		},
+	} satisfies BetterAuthPluginDBSchema;
 
 	return {
 		id: "phone-number",
@@ -95,7 +111,7 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 				opts as RequiredPhoneNumberOptions,
 			),
 		},
-		schema: mergeSchema(schema, options?.schema),
+		schema: mergeSchema(pluginSchema, options?.schema),
 		rateLimit: [
 			{
 				pathMatcher(path) {

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1323,7 +1323,6 @@ describe("phone-number disablePhoneNumberInput", async () => {
 			email: "first@test.com",
 			password: "password123",
 			name: "first",
-			// phoneNumber is no longer a valid sign-up input when the option is on
 			...({ phoneNumber: phoneNumberValue } as Record<string, string>),
 		});
 		expect(res.error?.status).toBe(400);

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1283,3 +1283,79 @@ describe("custom verifyOTP", async () => {
 		expect(user.data?.user.phoneNumberVerified).toBe(true);
 	});
 });
+
+/**
+ * When `disablePhoneNumberInput` is enabled, `phoneNumber` is marked as
+ * `input: false`: it is rejected as plain sign-up/update input and can only be
+ * attached to an account through a verified flow.
+ */
+describe("phone-number disablePhoneNumberInput", async () => {
+	let otp = "";
+
+	const { client, sessionSetter } = await getTestInstance(
+		{
+			plugins: [
+				phoneNumber({
+					async sendOTP({ code }) {
+						otp = code;
+					},
+					disablePhoneNumberInput: true,
+					signUpOnVerification: {
+						getTempEmail(phoneNumber) {
+							return `temp-${phoneNumber}`;
+						},
+					},
+				}),
+			],
+		},
+		{
+			disableTestUser: true,
+			clientOptions: {
+				plugins: [phoneNumberClient()],
+			},
+		},
+	);
+
+	const phoneNumberValue = "+251911121314";
+
+	it("should reject phoneNumber passed as plain sign-up input", async () => {
+		const res = await client.signUp.email({
+			email: "first@test.com",
+			password: "password123",
+			name: "first",
+			// phoneNumber is no longer a valid sign-up input when the option is on
+			...({ phoneNumber: phoneNumberValue } as Record<string, string>),
+		});
+		expect(res.error?.status).toBe(400);
+	});
+
+	it("should let a user attach the number through a verified flow", async () => {
+		const headers = new Headers();
+		await client.signUp.email(
+			{
+				email: "owner@test.com",
+				password: "password123",
+				name: "owner",
+			},
+			{ onSuccess: sessionSetter(headers) },
+		);
+
+		await client.phoneNumber.sendOtp({
+			phoneNumber: phoneNumberValue,
+			fetchOptions: { headers },
+		});
+		const verifyRes = await client.phoneNumber.verify({
+			phoneNumber: phoneNumberValue,
+			code: otp,
+			updatePhoneNumber: true,
+			fetchOptions: { headers },
+		});
+		expect(verifyRes.error).toBe(null);
+
+		const session = await client.getSession({
+			fetchOptions: { headers },
+		});
+		expect(session.data?.user.phoneNumber).toBe(phoneNumberValue);
+		expect(session.data?.user.phoneNumberVerified).toBe(true);
+	});
+});

--- a/packages/better-auth/src/plugins/phone-number/types.ts
+++ b/packages/better-auth/src/plugins/phone-number/types.ts
@@ -77,6 +77,20 @@ export interface PhoneNumberOptions {
 	 */
 	requireVerification?: boolean | undefined;
 	/**
+	 * Treat `phoneNumber` as a non-writable user field (`input: false`).
+	 *
+	 * By default `phoneNumber` can be set directly as sign-up or `update-user`
+	 * input, before it is verified. When this is enabled, it is rejected as
+	 * plain input (the request returns a `400` error) and can only be attached
+	 * to an account through a flow that verifies ownership of the number first:
+	 *
+	 * - `signUpOnVerification` — the account is created after the OTP is verified.
+	 * - a session-bound `/phone-number/verify` with `updatePhoneNumber: true`.
+	 *
+	 * @default false
+	 */
+	disablePhoneNumberInput?: boolean | undefined;
+	/**
 	 * Callback when phone number is verified
 	 */
 	callbackOnVerification?:

--- a/packages/better-auth/src/plugins/phone-number/types.ts
+++ b/packages/better-auth/src/plugins/phone-number/types.ts
@@ -79,10 +79,10 @@ export interface PhoneNumberOptions {
 	/**
 	 * Treat `phoneNumber` as a non-writable user field (`input: false`).
 	 *
-	 * By default `phoneNumber` can be set directly as sign-up or `update-user`
-	 * input, before it is verified. When this is enabled, it is rejected as
-	 * plain input (the request returns a `400` error) and can only be attached
-	 * to an account through a flow that verifies ownership of the number first:
+	 * By default `phoneNumber` can be provided in the sign-up body, before it
+	 * is verified. When this is enabled, passing it at sign-up is rejected with
+	 * a `400` error, so a number can only be attached to an account through a
+	 * flow that verifies ownership of it first:
 	 *
 	 * - `signUpOnVerification` — the account is created after the OTP is verified.
 	 * - a session-bound `/phone-number/verify` with `updatePhoneNumber: true`.


### PR DESCRIPTION
## Summary

Adds an opt-in `disablePhoneNumberInput` option to the phone number plugin. When enabled, the user `phoneNumber` field is treated as non-writable input (`input: false`), so a number can only be attached to an account through a flow that verifies ownership of it first, rather than being accepted as plain sign-up or `update-user` input.

By default `phoneNumber` is a writable user field that can be set directly at sign-up before it is verified. This option lets applications require that a phone number is only ever attached after the OTP for it has been verified.

## Behavior

With `disablePhoneNumberInput: true`:

- Passing `phoneNumber` in the sign-up / `update-user` body is rejected with a `400`.
- A number can still be attached through a verified flow:
  - `signUpOnVerification` — account created after the OTP is verified.
  - a session-bound `/phone-number/verify` with `updatePhoneNumber: true`.

The existing `update-user` before-hook (which already blocks phone-number changes) and the internal verified-attach paths are unaffected, since those bypass input parsing.

The option is **default `false`**, so existing behavior is unchanged unless an app opts in.

```ts
phoneNumber({
  sendOTP,
  disablePhoneNumberInput: true,
})
```

## Notes

- The plugin schema is now built fresh per instance instead of mutating the shared module-level `schema` const.
- Note for `schema` option users: `input` can't be set via the plugin `schema` option (it only renames columns), which is why this is a dedicated option.

## Tests

- New tests covering rejection of `phoneNumber` as plain sign-up input and successful attach via the verified flow.
- Full `phone-number.test.ts` suite passes (36).
- `tsc --build` clean.

## Docs

- Documented the new option in `docs/content/docs/plugins/phone-number.mdx`.