### PR TITLE
docs: fix the code block format on the Stripe plugin page

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -308,7 +308,8 @@ const { error } = await authClient.subscription.upgrade({
     successUrl: "/dashboard",
     cancelUrl: "/pricing",
 });
-if(error) {
+
+if (error) {
     alert(error.message);
 }
 ```


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix code example formatting in the Stripe plugin docs by adding a space in `if (error)` to match JS style and improve readability.

<sup>Written for commit d7d9788e8ea2df69265bcbbc7e2ba6a16d8cd510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

