### PR TITLE
fix(cli): increase generated BETTER_AUTH_SECRET length from 16 to 32 …

### DIFF
--- a/packages/cli/src/utils/helper.ts
+++ b/packages/cli/src/utils/helper.ts
@@ -25,7 +25,7 @@ export async function tryCatch<T, E = Error>(
 }
 
 export const generateSecretHash = () => {
-	return Crypto.randomBytes(16).toString("hex");
+	return Crypto.randomBytes(32).toString("hex");
 };
 
 export const spawnCommand = (cmd: string, cwd: string = process.cwd()) =>

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -155,7 +155,7 @@ describe("initAction", () => {
 					return { value: true };
 				}
 				if (question.name === "providedSecret") {
-					return { providedSecret: "test-secret-123" };
+					return { providedSecret: "" };
 				}
 				if (question.name === "providedURL") {
 					return { providedURL: "http://localhost:3000" };
@@ -256,6 +256,20 @@ describe("initAction", () => {
 				.then(() => true)
 				.catch(() => false);
 			expect(envExists).toBe(true);
+
+			const envContent = await fs.readFile(envPath, "utf-8");
+
+			const line = envContent
+				.toString()
+				.split("\n")
+				.find((l) => l.startsWith("BETTER_AUTH_SECRET="));
+
+			expect(line).toBeDefined();
+
+			const secret = line!.split("=")[1]?.replaceAll('"', "").trim();
+
+			expect(secret).toBeDefined();
+			expect(secret!.length).toBeGreaterThanOrEqual(64); // 64 characters 32 hex bytes
 		},
 	);
 


### PR DESCRIPTION
If you use the better auth CLI to initialize a Better Auth project, the CLI generates a 16 character symmetric secret. If you use the 16 character symmetric secret it will print warnings stating that its too short and needs to be 32 characters or more.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate a 32‑byte (64‑char hex) `BETTER_AUTH_SECRET` in the CLI instead of 16 to meet the minimum length and remove warnings. Added an init test that leaves `providedSecret` empty and verifies a 64‑char secret is written to `.env`.

<sup>Written for commit f34240c8fa878d8c27e9832280aefbfc80e395fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

