### PR TITLE
fix(admin): use authoritative session reads for authorization

### DIFF
--- a/.changeset/cold-planets-wait.md
+++ b/.changeset/cold-planets-wait.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Currently if the auth server has cookie cache then grabbing the session could return a stale cache value, while this is fine in most cases, in critical areas like the admin endpoints where we check for their role or ban status we must grab their session data straight from DB rather than relying on the client cache.
+Admin permission changes and bans now take effect immediately for admin APIs, even when session cookie cache is enabled. Sensitive session checks also continue to work in stateless apps where signed cookies are the session record.

--- a/.changeset/cold-planets-wait.md
+++ b/.changeset/cold-planets-wait.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Currently if the auth server has cookie cache then grabbing the session could return a stale cache value, while this is fine in most cases, in critical areas like the admin endpoints where we check for their role or ban status we must grab their session data straight from DB rather than relying on the client cache.

--- a/packages/better-auth/src/api/routes/session-api.test.ts
+++ b/packages/better-auth/src/api/routes/session-api.test.ts
@@ -21,7 +21,11 @@ import { admin } from "../../plugins/admin";
 import { organization } from "../../plugins/organization";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { getDate } from "../../utils/date";
-import { freshSessionMiddleware, getSessionFromCtx } from "./session";
+import {
+	freshSessionMiddleware,
+	getAuthoritativeSessionFromCtx,
+	getSessionFromCtx,
+} from "./session";
 
 describe("session", async () => {
 	const { client, testUser, sessionSetter, cookieSetter, auth } =
@@ -2389,5 +2393,43 @@ describe("forced strict session validation", async () => {
 			headers,
 		});
 		expect(res.error?.status).toBe(401);
+	});
+
+	it("uses the signed cookie as the authoritative session record without a server store", async () => {
+		const { auth, client, testUser, cookieSetter } = await getTestInstance({
+			database: undefined,
+			session: {
+				cookieCache: {
+					enabled: true,
+					strategy: "jwe",
+				},
+			},
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+		const cachedSession = await client.getSession({
+			fetchOptions: { headers, onSuccess: cookieSetter(headers) },
+		});
+		expect(cachedSession.data).not.toBeNull();
+
+		const ctx = await auth.$context;
+		ctx.session = null;
+		await ctx.internalAdapter.deleteSession(cachedSession.data!.session.token);
+		const endpointCtx = {
+			context: ctx,
+			headers,
+			query: {},
+		} as unknown as GenericEndpointContext;
+
+		await runWithRequestState(new WeakMap(), async () => {
+			await runWithEndpointContext(endpointCtx, async () => {
+				const session = await getAuthoritativeSessionFromCtx(endpointCtx);
+				expect(session?.user.email).toBe(testUser.email);
+			});
+		});
 	});
 });

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -601,6 +601,27 @@ export const getSessionFromCtx = async <
 };
 
 /**
+ * Reads the session from the source that can authorize sensitive work.
+ *
+ * Stateful deployments must re-read the server-side session store because an
+ * earlier hook may have populated `ctx.context.session` from cookie cache.
+ * Stateless deployments keep the signed cookie as the session record.
+ */
+export const getAuthoritativeSessionFromCtx = async <
+	U extends Record<string, any> = Record<string, any>,
+	S extends Record<string, any> = Record<string, any>,
+>(
+	ctx: GenericEndpointContext,
+) => {
+	if (!isStateful(ctx)) {
+		return getSessionFromCtx<U, S>(ctx);
+	}
+
+	ctx.context.session = null;
+	return getSessionFromCtx<U, S>(ctx, { disableCookieCache: true });
+};
+
+/**
  * The middleware forces the endpoint to require a valid session.
  */
 export const sessionMiddleware = createAuthMiddleware(async (ctx) => {
@@ -617,12 +638,11 @@ export const sessionMiddleware = createAuthMiddleware(async (ctx) => {
 });
 
 /**
- * This middleware forces the endpoint to require a valid session and ignores cookie cache.
+ * This middleware forces the endpoint to require a valid authoritative session.
  * This should be used for sensitive operations like password changes, account deletion, etc.
- * to ensure that revoked sessions cannot be used even if they're still cached in cookies.
  */
 export const sensitiveSessionMiddleware = createAuthMiddleware(async (ctx) => {
-	const session = await getSessionFromCtx(ctx, { disableCookieCache: true });
+	const session = await getAuthoritativeSessionFromCtx(ctx);
 	if (!session?.session) {
 		throw APIError.from("UNAUTHORIZED", {
 			message: "Unauthorized",

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -2428,3 +2428,153 @@ describe("Admin plugin id-token sign-in", async () => {
 		expect(res.error?.message).toBe("Custom banned user message");
 	});
 });
+
+/**
+ * Regression: admin authorization must reflect live DB role/ban state rather
+ * than a (possibly stale) cookie-cache snapshot. With `session.cookieCache`
+ * enabled, `adminMiddleware` previously authorized off the cached
+ * `user.role` / `user.banned`, so a demoted or banned admin retained admin
+ * privileges until the cache `maxAge` expired (default 5 min) - enough to
+ * re-escalate their own role or impersonate users.
+ */
+describe("admin authorization is revocation-aware with cookie cache", async () => {
+	const { signInWithTestUser, customFetchImpl, cookieSetter } =
+		await getTestInstance(
+			{
+				plugins: [admin()],
+				session: {
+					cookieCache: {
+						enabled: true,
+						maxAge: 300,
+					},
+				},
+				databaseHooks: {
+					user: {
+						create: {
+							before: async (user) => ({
+								data: {
+									...user,
+									emailVerified: true,
+									...(user.name === "Admin" ? { role: "admin" } : {}),
+								},
+							}),
+						},
+					},
+				},
+			},
+			{
+				testUser: {
+					name: "Admin",
+				},
+			},
+		);
+	const client = createAuthClient({
+		fetchOptions: {
+			customFetchImpl,
+		},
+		plugins: [adminClient()],
+		baseURL: "http://localhost:3000",
+	});
+
+	const { headers: rootHeaders } = await signInWithTestUser();
+
+	// Captures the full cookie set, including the `session_data` cookie cache
+	// snapshot, unlike `signInWithUser` which only keeps `session_token`.
+	async function signInCapturingCache(email: string, password: string) {
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email, password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+		return headers;
+	}
+
+	it("should reject privileged calls from a demoted admin holding a cached admin snapshot", async () => {
+		const attacker = {
+			name: "Admin",
+			email: "attacker-demote@test.com",
+			password: "password",
+		};
+		const victim = {
+			name: "Victim",
+			email: "victim-demote@test.com",
+			password: "password",
+		};
+		const { data: attackerData } = await client.signUp.email(attacker);
+		const { data: victimData } = await client.signUp.email(victim);
+		const attackerId = attackerData?.user.id!;
+		const victimId = victimData?.user.id!;
+
+		const attackerHeaders = await signInCapturingCache(
+			attacker.email,
+			attacker.password,
+		);
+
+		// Root demotes the attacker to a regular user in the DB.
+		const demote = await client.admin.setRole(
+			{ userId: attackerId, role: "user" },
+			{ headers: rootHeaders },
+		);
+		expect(demote.data?.user.role).toBe("user");
+
+		// Control proof: the default (cached) session still reports admin,
+		// confirming the cookie cache snapshot is stale and exercised here.
+		const cachedSession = await client.getSession({
+			fetchOptions: { headers: attackerHeaders },
+		});
+		expect((cachedSession.data?.user as UserWithRole)?.role).toBe("admin");
+
+		// Self re-escalation must be rejected: authorization reads live role.
+		const reEscalate = await client.admin.setRole(
+			{ userId: attackerId, role: "admin" },
+			{ headers: attackerHeaders },
+		);
+		expect(reEscalate.error?.status).toBe(403);
+
+		// Impersonation must be rejected too.
+		const impersonate = await client.admin.impersonateUser(
+			{ userId: victimId },
+			{ headers: attackerHeaders },
+		);
+		expect(impersonate.error?.status).toBe(403);
+
+		// And the DB role must remain `user` (re-escalation did not persist).
+		const liveSession = await client.getSession({
+			fetchOptions: {
+				headers: attackerHeaders,
+				query: { disableCookieCache: true },
+			},
+		});
+		expect((liveSession.data?.user as UserWithRole)?.role).toBe("user");
+	});
+
+	it("should reject a banned admin within the cookie-cache window", async () => {
+		const attacker = {
+			name: "Admin",
+			email: "attacker-ban@test.com",
+			password: "password",
+		};
+		const { data: attackerData } = await client.signUp.email(attacker);
+		const attackerId = attackerData?.user.id!;
+
+		const attackerHeaders = await signInCapturingCache(
+			attacker.email,
+			attacker.password,
+		);
+
+		// Root bans the attacker, which deletes their DB session rows.
+		const ban = await client.admin.banUser(
+			{ userId: attackerId },
+			{ headers: rootHeaders },
+		);
+		expect(ban.data?.user.banned).toBe(true);
+
+		// The cached `session_data` cookie is still present, but the live DB
+		// lookup finds no session, so admin routes reject immediately.
+		const listUsers = await client.admin.listUsers({
+			query: { limit: 10 },
+			fetchOptions: { headers: attackerHeaders },
+		});
+		expect(listUsers.error?.status).toBe(401);
+	});
+});

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -1,3 +1,4 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
 import { BetterAuthError } from "@better-auth/core/error";
 import type { GoogleProfile } from "@better-auth/core/social-providers";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
@@ -12,6 +13,7 @@ import {
 	it,
 	vi,
 } from "vitest";
+import { createAuthMiddleware, getSessionFromCtx } from "../../api";
 import { createAuthClient } from "../../client";
 import { signJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
@@ -2430,18 +2432,29 @@ describe("Admin plugin id-token sign-in", async () => {
 });
 
 /**
- * Regression: admin authorization must reflect live DB role/ban state rather
- * than a (possibly stale) cookie-cache snapshot. With `session.cookieCache`
- * enabled, `adminMiddleware` previously authorized off the cached
- * `user.role` / `user.banned`, so a demoted or banned admin retained admin
- * privileges until the cache `maxAge` expired (default 5 min) - enough to
- * re-escalate their own role or impersonate users.
+ * @see https://github.com/better-auth/better-auth/pull/10187
  */
 describe("admin authorization is revocation-aware with cookie cache", async () => {
+	const preloadCachedSessionPlugin = {
+		id: "preload-cached-session",
+		hooks: {
+			before: [
+				{
+					matcher(ctx) {
+						return ctx.path?.startsWith("/admin/") === true;
+					},
+					handler: createAuthMiddleware(async (ctx) => {
+						await getSessionFromCtx(ctx);
+					}),
+				},
+			],
+		},
+	} satisfies BetterAuthPlugin;
+
 	const { signInWithTestUser, customFetchImpl, cookieSetter } =
 		await getTestInstance(
 			{
-				plugins: [admin()],
+				plugins: [preloadCachedSessionPlugin, admin()],
 				session: {
 					cookieCache: {
 						enabled: true,
@@ -2530,6 +2543,12 @@ describe("admin authorization is revocation-aware with cookie cache", async () =
 			{ headers: attackerHeaders },
 		);
 		expect(reEscalate.error?.status).toBe(403);
+
+		const permissionCheck = await client.admin.hasPermission(
+			{ permissions: { user: ["set-role"] } },
+			{ headers: attackerHeaders },
+		);
+		expect(permissionCheck.data?.success).toBe(false);
 
 		// Impersonation must be rejected too.
 		const impersonate = await client.admin.impersonateUser(

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -2540,10 +2540,8 @@ describe("admin authorization is revocation-aware with cookie cache", async () =
 
 		// And the DB role must remain `user` (re-escalation did not persist).
 		const liveSession = await client.getSession({
-			fetchOptions: {
-				headers: attackerHeaders,
-				query: { disableCookieCache: true },
-			},
+			query: { disableCookieCache: true },
+			fetchOptions: { headers: attackerHeaders },
 		});
 		expect((liveSession.data?.user as UserWithRole)?.role).toBe("user");
 	});

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -7,7 +7,7 @@ import type { Where } from "@better-auth/core/db/adapter";
 import { whereOperators } from "@better-auth/core/db/adapter";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import * as z from "zod";
-import { getSessionFromCtx } from "../../api";
+import { getAuthoritativeSessionFromCtx, getSessionFromCtx } from "../../api";
 import {
 	deleteSessionCookie,
 	expireCookie,
@@ -31,8 +31,7 @@ import type {
  * Will also provide additional types on the user to include role types.
  */
 const adminMiddleware = createAuthMiddleware(async (ctx) => {
-	// Force a DB-backed session read so authorization always reflects live role/ban state.
-	const session = await getSessionFromCtx(ctx, { disableCookieCache: true });
+	const session = await getAuthoritativeSessionFromCtx(ctx);
 	if (!session) {
 		throw APIError.fromStatus("UNAUTHORIZED");
 	}
@@ -334,11 +333,9 @@ export const createUser = <O extends AdminOptions>(opts: O) =>
 			},
 		},
 		async (ctx) => {
-			// `disableCookieCache` so the privilege check below authorizes off
-			// live role state rather than a stale cookie-cache snapshot.
-			const session = await getSessionFromCtx<{ role: string }>(ctx, {
-				disableCookieCache: true,
-			});
+			const session = await getAuthoritativeSessionFromCtx<{ role: string }>(
+				ctx,
+			);
 			if (!session && (ctx.request || ctx.headers)) {
 				throw ctx.error("UNAUTHORIZED");
 			}
@@ -1861,7 +1858,7 @@ export const userHasPermission = <O extends AdminOptions>(opts: O) => {
 					message: "invalid permission check. no permission(s) were passed.",
 				});
 			}
-			const session = await getSessionFromCtx(ctx);
+			const session = await getAuthoritativeSessionFromCtx(ctx);
 
 			if (!session && (ctx.request || ctx.headers)) {
 				throw new APIError("UNAUTHORIZED");

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -31,7 +31,8 @@ import type {
  * Will also provide additional types on the user to include role types.
  */
 const adminMiddleware = createAuthMiddleware(async (ctx) => {
-	const session = await getSessionFromCtx(ctx);
+	// Force a DB-backed session read so authorization always reflects live role/ban state.
+	const session = await getSessionFromCtx(ctx, { disableCookieCache: true });
 	if (!session) {
 		throw APIError.fromStatus("UNAUTHORIZED");
 	}
@@ -333,7 +334,11 @@ export const createUser = <O extends AdminOptions>(opts: O) =>
 			},
 		},
 		async (ctx) => {
-			const session = await getSessionFromCtx<{ role: string }>(ctx);
+			// `disableCookieCache` so the privilege check below authorizes off
+			// live role state rather than a stale cookie-cache snapshot.
+			const session = await getSessionFromCtx<{ role: string }>(ctx, {
+				disableCookieCache: true,
+			});
 			if (!session && (ctx.request || ctx.headers)) {
 				throw ctx.error("UNAUTHORIZED");
 			}


### PR DESCRIPTION
Admin authorization could still use stale session data when session cookie cache was enabled, letting a demoted or banned admin keep passing privileged checks until the cache expired.

This adds `getAuthoritativeSessionFromCtx` for sensitive session reads. The helper rereads the server-side session store when a durable store exists, but keeps the signed cookie as the authority for stateless deployments. Admin middleware, `createUser`, `userHasPermission`, and the shared sensitive-session middleware now use that path so earlier hooks cannot pin authorization to a cached context session.