### PR TITLE
fix: apply rate limits before plugin requests

### DIFF
--- a/.changeset/twenty-pears-bake.md
+++ b/.changeset/twenty-pears-bake.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Rate limit client requests before plugin request handlers run.

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -301,6 +301,12 @@ export const router = <Option extends BetterAuthOptions>(
 			}
 
 			let currentRequest = req;
+
+			const rateLimitResponse = await onRequestRateLimit(currentRequest, ctx);
+			if (rateLimitResponse) {
+				return rateLimitResponse;
+			}
+
 			for (const plugin of ctx.options.plugins || []) {
 				if (plugin.onRequest) {
 					const response = await withSpan(
@@ -318,11 +324,6 @@ export const router = <Option extends BetterAuthOptions>(
 						currentRequest = response.request;
 					}
 				}
-			}
-
-			const rateLimitResponse = await onRequestRateLimit(currentRequest, ctx);
-			if (rateLimitResponse) {
-				return rateLimitResponse;
 			}
 
 			return currentRequest;

--- a/packages/better-auth/src/plugins/captcha/captcha.test.ts
+++ b/packages/better-auth/src/plugins/captcha/captcha.test.ts
@@ -91,6 +91,56 @@ describe("captcha", async () => {
 		expect(res.error?.status).toBe(400);
 	});
 
+	it("should apply rate limits before verifying captcha tokens", async () => {
+		mockBetterFetch.mockClear();
+		mockBetterFetch.mockResolvedValue({
+			data: {
+				success: false,
+				"error-codes": ["invalid-input-response"],
+			},
+		});
+		const { client, testUser } = await getTestInstance({
+			rateLimit: {
+				enabled: true,
+				customRules: {
+					"/sign-in/email": {
+						window: 10,
+						max: 1,
+					},
+				},
+			},
+			plugins: [
+				captcha({
+					provider: "cloudflare-turnstile",
+					secretKey: "xx-secret-key",
+				}),
+			],
+		});
+
+		const first = await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+			fetchOptions: {
+				headers: {
+					"x-captcha-response": "invalid-captcha-token",
+				},
+			},
+		});
+		const second = await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+			fetchOptions: {
+				headers: {
+					"x-captcha-response": "invalid-captcha-token",
+				},
+			},
+		});
+
+		expect(first.error?.status).toBe(403);
+		expect(second.error?.status).toBe(429);
+		expect(mockBetterFetch).toHaveBeenCalledTimes(1);
+	});
+
 	it("Should return 500 if an unexpected error occurs", async () => {
 		const { client } = await getTestInstance({
 			plugins: [


### PR DESCRIPTION
Rate-limited requests now return before plugin `onRequest` handlers run. This keeps plugin guards, including captcha provider verification, behind the core rate-limit gate.