### PR TITLE
fix(oauth-provider): request JSON so passkey works during an oauth flow

### DIFF
--- a/.changeset/passkey-oauth-provider-accept.md
+++ b/.changeset/passkey-oauth-provider-accept.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+fix(oauth-provider): intercept passkey verification so passkey works with oauth-provider

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -199,6 +199,55 @@ describe("oauth signed query signatures", () => {
 			"custom_authorization_context",
 		);
 	});
+
+	it("should set accept: application/json when injecting the oauth query", async () => {
+		const signedParams = await createSignedParams("test-secret");
+
+		vi.stubGlobal("window", {
+			location: {
+				search: `?${signedParams.toString()}`,
+			},
+		});
+
+		const plugin = oauthProviderClient();
+		const onRequest = plugin.fetchPlugins[0]?.hooks?.onRequest;
+		// Mirrors the passkey verify request that resumes the oauth flow.
+		const ctx = {
+			method: "POST",
+			headers: new Headers({
+				"content-type": "application/json",
+			}),
+			body: JSON.stringify({ response: {} }),
+		};
+
+		await onRequest?.(ctx as Parameters<NonNullable<typeof onRequest>>[0]);
+
+		const body = JSON.parse(String(ctx.body));
+		expect(body.oauth_query).toBeDefined();
+		expect(ctx.headers.get("accept")).toBe("application/json");
+	});
+
+	it("should not touch the accept header when there is no oauth query to inject", async () => {
+		vi.stubGlobal("window", {
+			location: {
+				search: "",
+			},
+		});
+
+		const plugin = oauthProviderClient();
+		const onRequest = plugin.fetchPlugins[0]?.hooks?.onRequest;
+		const ctx = {
+			method: "POST",
+			headers: new Headers({
+				"content-type": "application/json",
+			}),
+			body: "{}",
+		};
+
+		await onRequest?.(ctx as Parameters<NonNullable<typeof onRequest>>[0]);
+
+		expect(ctx.headers.get("accept")).toBeNull();
+	});
 });
 
 describe("oauth authorize - unauthenticated", async () => {

--- a/packages/oauth-provider/src/client.ts
+++ b/packages/oauth-provider/src/client.ts
@@ -33,6 +33,10 @@ export const oauthProviderClient = () => {
 								...body,
 								oauth_query: buildSignedOAuthQuery(window.location.search),
 							});
+							// Force a JSON response so endpoints that resume the oauth
+							// flow mid-request (eg /passkey/verify-authentication) return
+							// a JSON redirect body instead of throwing a 302 redirect.
+							headers.set("accept", "application/json");
 						}
 					},
 				},


### PR DESCRIPTION
## Summary

Fixes #8081 — passkey authentication breaks when the `oauth-provider` plugin is active.

The oauth-provider **client** plugin's `onRequest` hook injects a signed `oauth_query` into eligible requests so the server can resume the authorize flow. On the server, when a session cookie is set during that intercepted request, authorize re-runs and ends in `handleRedirect`, which returns a JSON `{ redirect, url }` body **only** when the request accepts JSON — otherwise it issues a 302. The passkey client posts `/passkey/verify-authentication` without an `accept: application/json` header, so mid-flow it received a 302 instead of the JSON redirect the OIDC client expects, and the passkey sign-in broke.

## Fix

In the client `onRequest` hook, set `accept: application/json` on the request whenever an `oauth_query` is injected. This is path-agnostic, so it also covers `/passkey/verify-registration` and any other auth endpoint that participates in an OAuth flow, matching the plugin's existing intercept-all design (rather than hardcoding a path list). Requests with no active oauth flow are untouched.

## Tests

Added two cases to `oauth-provider/src/authorize.test.ts` (alongside the existing `onRequest`-hook signature test): the `accept` header is set when an `oauth_query` is injected, and left untouched when there's no oauth flow. Changeset included.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `accept: application/json` on intercepted requests in the `@better-auth/oauth-provider` client so passkey flows receive JSON redirects instead of 302s. Fixes #8081.

- **Bug Fixes**
  - When injecting `oauth_query`, the client now sets `accept: application/json` to ensure mid-flow redirects return JSON (covers `/passkey/verify-authentication` and `/passkey/verify-registration`).
  - Added tests to confirm the header is set only when an OAuth flow is active.

<sup>Written for commit 70e72125cc265f16597b92a697070e23f7ebf7b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

