### PR TITLE
fix(oauth): apply user input rules to provider profiles

### DIFF
--- a/.changeset/oauth-provisioning-input-fields.md
+++ b/.changeset/oauth-provisioning-input-fields.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Extend the user model's field-input rules to OAuth/OIDC user provisioning. Fields marked `input: false` that arrive from a provider profile (including via `mapProfileToUser`) are now silently ignored when a user is created or updated through sign-up and account linking, keeping these server-owned fields under your application's control. Apps that previously relied on a provider to set an `input: false` field will need to populate it server-side instead.

--- a/.changeset/oauth-provisioning-input-fields.md
+++ b/.changeset/oauth-provisioning-input-fields.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Extend the user model's field-input rules to OAuth/OIDC user provisioning. Fields marked `input: false` that arrive from a provider profile (including via `mapProfileToUser`) are now silently ignored when a user is created or updated through sign-up and account linking, keeping these server-owned fields under your application's control. Apps that previously relied on a provider to set an `input: false` field will need to populate it server-side instead.
+OAuth sign-up and account-link profile sync now ignore provider profile values for user fields marked `input: false`. Input-allowed additional fields still persist from `mapProfileToUser`, and schema defaults still apply when OAuth creates a user. Apps that used `mapProfileToUser` to fill `input: false` fields should set those fields in server-side provisioning code instead.

--- a/.changeset/oauth-provisioning-input-fields.md
+++ b/.changeset/oauth-provisioning-input-fields.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": minor
+"better-auth": patch
 ---
 
 Extend the user model's field-input rules to OAuth/OIDC user provisioning. Fields marked `input: false` that arrive from a provider profile (including via `mapProfileToUser`) are now silently ignored when a user is created or updated through sign-up and account linking, keeping these server-owned fields under your application's control. Apps that previously relied on a provider to set an `input: false` field will need to populate it server-side instead.

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -657,7 +657,9 @@ res.user.lang; // > "fr"
   client side.
 </Callout>
 
-If you're using social / OAuth providers, you may want to provide `mapProfileToUser` to map the profile data to the user object. So, you can populate additional fields from the provider's profile.
+If you're using social / OAuth providers, you may want to provide `mapProfileToUser` to map the profile data to the user object. This can populate additional fields from the provider's profile when those fields allow input.
+
+Fields marked `input: false` stay server-owned during OAuth provisioning. Provider profile values for those fields are ignored, and configured `defaultValue` values still apply when OAuth creates a user.
 
 **Example: Mapping Profile to User For `firstName` and `lastName`**
 

--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -420,6 +420,8 @@ A custom function to map the user profile returned from the provider to the user
 
 Useful, if you have additional fields in your user object you want to populate from the provider's profile. Or if you want to change how by default the user object is mapped.
 
+`mapProfileToUser` follows the input rules from `user.additionalFields`. It can populate additional fields that allow input, but provider values for fields marked `input: false` are ignored during OAuth sign-up, sign-in profile override, and account-link profile sync. Use server-side provisioning code to set server-owned fields such as roles, bans, or internal flags.
+
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
 
@@ -442,7 +444,8 @@ export const auth = betterAuth({
 
 <Callout type="info">
   You may want to pass additional fields into the user object in `mapProfileToUser`,
-  to do this, you must configure the `user.additionalFields` [option](/docs/concepts/database#extending-core-schema).
+  to do this, you must configure the `user.additionalFields` [option](/docs/concepts/database#extending-core-schema)
+  and allow those fields as input.
   (The same applies for stateless auth setups)
 </Callout>
 

--- a/docs/content/docs/concepts/users-accounts.mdx
+++ b/docs/content/docs/concepts/users-accounts.mdx
@@ -508,7 +508,7 @@ Users already signed in can manually link their account to additional social pro
   });
   ```
 
-  By default, linking an account leaves the existing user profile untouched. Enable `updateUserInfoOnLink` to copy the provider's profile onto the user each time an account is linked. The synced fields are the same ones persisted on sign-up (`name`, `image`, and any fields your `mapProfileToUser` adds). The user's `email` and `emailVerified` are never changed on a link, so linking a provider can't rebind the account's identity.
+  By default, linking an account leaves the existing user profile untouched. Enable `updateUserInfoOnLink` to copy the provider's profile onto the user each time an account is linked. The synced fields are the same ones persisted on sign-up (`name`, `image`, and any input-allowed fields your `mapProfileToUser` adds). The user's `email` and `emailVerified` are never changed on a link, so linking a provider can't rebind the account's identity.
 
   ```ts title="auth.ts"
   import { betterAuth } from "better-auth";

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -223,8 +223,9 @@ export function parseUserInput(
 }
 
 /**
- * Returns a shallow copy of `user` with any field the user model marks as
+ * Returns a shallow copy of `user` with any field the model marks as
  * non-input (`input: false`) removed.
+ *
  */
 export function stripNonInputUserFields<T extends Record<string, unknown>>(
 	options: BetterAuthOptions,
@@ -232,7 +233,7 @@ export function stripNonInputUserFields<T extends Record<string, unknown>>(
 ): T {
 	const fields = getFields(options, "user", "input");
 	const result: Record<string, unknown> = Object.create(null);
-	for (const key in user) {
+	for (const key of Object.keys(user)) {
 		if (fields[key]?.input === false) continue;
 		result[key] = user[key];
 	}

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -222,6 +222,23 @@ export function parseUserInput(
 	return parseInputData(user, { fields: schema, action });
 }
 
+/**
+ * Returns a shallow copy of `user` with any field the user model marks as
+ * non-input (`input: false`) removed.
+ */
+export function stripNonInputUserFields<T extends Record<string, unknown>>(
+	options: BetterAuthOptions,
+	user: T,
+): T {
+	const fields = getFields(options, "user", "input");
+	const result: Record<string, unknown> = Object.create(null);
+	for (const key in user) {
+		if (fields[key]?.input === false) continue;
+		result[key] = user[key];
+	}
+	return result as T;
+}
+
 export function parseAdditionalUserInput(
 	options: BetterAuthOptions,
 	user?: Record<string, any> | undefined,

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -222,22 +222,20 @@ export function parseUserInput(
 	return parseInputData(user, { fields: schema, action });
 }
 
-/**
- * Returns a shallow copy of `user` with any field the model marks as
- * non-input (`input: false`) removed.
- *
- */
-export function stripNonInputUserFields<T extends Record<string, unknown>>(
+export function parseAdditionalUserInputFromProviderProfile(
 	options: BetterAuthOptions,
-	user: T,
-): T {
-	const fields = getFields(options, "user", "input");
-	const result: Record<string, unknown> = Object.create(null);
-	for (const key of Object.keys(user)) {
-		if (fields[key]?.input === false) continue;
-		result[key] = user[key];
+	profile: Record<string, unknown> = {},
+	action: "create" | "update",
+) {
+	const schema = getFields(options, "user", "input");
+	const allowedProfileFields: Record<string, unknown> = Object.create(null);
+	for (const key of Object.keys(profile)) {
+		if (schema[key]?.input === false) {
+			continue;
+		}
+		allowedProfileFields[key] = profile[key];
 	}
-	return result as T;
+	return parseInputData(allowedProfileFields, { fields: schema, action });
 }
 
 export function parseAdditionalUserInput(

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -1077,6 +1077,11 @@ describe("oauth2 - updateUserInfoOnLink on implicit sign-in link", async () => {
 		user: {
 			additionalFields: {
 				googleSub: { type: "string", required: false },
+				serverManagedField: {
+					type: "string",
+					required: false,
+					input: false,
+				},
 			},
 		},
 		socialProviders: {
@@ -1085,7 +1090,7 @@ describe("oauth2 - updateUserInfoOnLink on implicit sign-in link", async () => {
 				clientSecret: "test",
 				enabled: true,
 				mapProfileToUser(profile: GoogleProfile) {
-					return { googleSub: profile.sub };
+					return { googleSub: profile.sub, serverManagedField: "elevated" };
 				},
 			},
 		},
@@ -1174,16 +1179,122 @@ describe("oauth2 - updateUserInfoOnLink on implicit sign-in link", async () => {
 		});
 		expect(user?.googleSub).toBe("google_implicit_mapped");
 	});
+
+	it("does not copy fields marked input: false from the provider on link", async () => {
+		const testEmail = "implicit-link-input-false@example.com";
+		await ctx.adapter.create({
+			model: "user",
+			data: { email: testEmail, name: "Original Name", emailVerified: true },
+		});
+
+		await signInAndLink(testEmail, "google_link_input_false");
+
+		const user = await ctx.adapter.findOne<
+			User & { googleSub?: string; serverManagedField?: string | null }
+		>({
+			model: "user",
+			where: [{ field: "email", value: testEmail }],
+		});
+		expect(user?.googleSub).toBe("google_link_input_false");
+		expect(user?.serverManagedField ?? null).toBeNull();
+	});
+});
+
+describe("oauth2 - first sign-in provisioning ignores input: false fields", async () => {
+	const { auth, client, cookieSetter } = await getTestInstance({
+		user: {
+			additionalFields: {
+				googleSub: { type: "string", required: false },
+				serverManagedField: {
+					type: "string",
+					required: false,
+					input: false,
+				},
+			},
+		},
+		socialProviders: {
+			google: {
+				clientId: "test",
+				clientSecret: "test",
+				enabled: true,
+				mapProfileToUser(profile: GoogleProfile) {
+					return { googleSub: profile.sub, serverManagedField: "elevated" };
+				},
+			},
+		},
+	});
+
+	const ctx = await auth.$context;
+
+	it("does not copy fields marked input: false from the provider on first sign-in", async () => {
+		const testEmail = "implicit-create-input-false@example.com";
+
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async () => {
+				const profile = {
+					sub: "google_create_input_false",
+					email: testEmail,
+					email_verified: true,
+					name: "Created From Google",
+				} as GoogleProfile;
+				const idToken = await signJWT(profile, DEFAULT_SECRET);
+				return HttpResponse.json({
+					access_token: "test_token",
+					id_token: idToken,
+				});
+			}),
+		);
+
+		const oAuthHeaders = new Headers();
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/",
+			fetchOptions: { onSuccess: cookieSetter(oAuthHeaders) },
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test_code" },
+			method: "GET",
+			headers: oAuthHeaders,
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				cookieSetter(oAuthHeaders)(context as any);
+			},
+		});
+
+		const user = await ctx.adapter.findOne<
+			User & { googleSub?: string; serverManagedField?: string | null }
+		>({
+			model: "user",
+			where: [{ field: "email", value: testEmail }],
+		});
+		// The mapped, input-enabled field is still written...
+		expect(user?.googleSub).toBe("google_create_input_false");
+		// ...while the input: false field is ignored.
+		expect(user?.serverManagedField ?? null).toBeNull();
+	});
 });
 
 describe("oauth2 - override user info on sign-in", async () => {
 	const { auth, client, cookieSetter } = await getTestInstance({
+		user: {
+			additionalFields: {
+				serverManagedField: {
+					type: "string",
+					required: false,
+					input: false,
+				},
+			},
+		},
 		socialProviders: {
 			google: {
 				clientId: "test",
 				clientSecret: "test",
 				enabled: true,
 				overrideUserInfoOnSignIn: true,
+				mapProfileToUser() {
+					return { serverManagedField: "elevated" };
+				},
 			},
 		},
 		account: {
@@ -1268,6 +1379,65 @@ describe("oauth2 - override user info on sign-in", async () => {
 		});
 
 		expect(session.data?.user.name).toBe("Updated Name");
+	});
+
+	it("does not copy fields marked input: false from the provider when overriding", async () => {
+		const testEmail = "override-input-false@example.com";
+
+		await ctx.adapter.create({
+			model: "user",
+			data: {
+				email: testEmail,
+				name: "Initial Name",
+				emailVerified: true,
+			},
+		});
+
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async () => {
+				const profile: GoogleProfile = {
+					sub: "google_override_input_false",
+					email: testEmail,
+					email_verified: true,
+					name: "Updated Name",
+				} as GoogleProfile;
+				const idToken = await signJWT(profile, DEFAULT_SECRET);
+				return HttpResponse.json({
+					access_token: "test_token",
+					id_token: idToken,
+				});
+			}),
+		);
+
+		const oAuthHeaders = new Headers();
+		const signInRes = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/",
+			fetchOptions: {
+				onSuccess: cookieSetter(oAuthHeaders),
+			},
+		});
+		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
+		await client.$fetch("/callback/google", {
+			query: { state, code: "test_code" },
+			method: "GET",
+			headers: oAuthHeaders,
+			onError(context) {
+				expect(context.response.status).toBe(302);
+				cookieSetter(oAuthHeaders)(context as any);
+			},
+		});
+
+		const user = await ctx.adapter.findOne<
+			User & { serverManagedField?: string | null }
+		>({
+			model: "user",
+			where: [{ field: "email", value: testEmail }],
+		});
+		// overrideUserInfo still applied the provider's name...
+		expect(user?.name).toBe("Updated Name");
+		// ...but the input: false field was ignored.
+		expect(user?.serverManagedField ?? null).toBeNull();
 	});
 });
 

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -13,6 +13,7 @@ import {
 	it,
 	vi,
 } from "vitest";
+import * as z from "zod";
 import { signJWT } from "../crypto";
 import { getTestInstance } from "../test-utils/test-instance";
 import type { User } from "../types";
@@ -1086,6 +1087,13 @@ describe("oauth2 - updateUserInfoOnLink on implicit sign-in link", async () => {
 						},
 					},
 				},
+				validatedProfileCode: {
+					type: "string",
+					required: false,
+					validator: {
+						input: z.string().min(3),
+					},
+				},
 				serverManagedField: {
 					type: "string",
 					required: false,
@@ -1102,6 +1110,7 @@ describe("oauth2 - updateUserInfoOnLink on implicit sign-in link", async () => {
 					return {
 						googleSub: profile.sub,
 						profileCode: profile.sub,
+						validatedProfileCode: profile.sub,
 						serverManagedField: "elevated",
 					};
 				},
@@ -1226,6 +1235,36 @@ describe("oauth2 - updateUserInfoOnLink on implicit sign-in link", async () => {
 		});
 		expect(user?.googleSub).toBe("google_link_input_false");
 		expect(user?.serverManagedField ?? null).toBeNull();
+	});
+
+	it("continues linking when mapped profile fields fail validation", async () => {
+		const testEmail = "implicit-link-invalid-profile@example.com";
+		await ctx.adapter.create({
+			model: "user",
+			data: { email: testEmail, name: "Original Name", emailVerified: true },
+		});
+
+		const oAuthHeaders = await signInAndLink(testEmail, "x");
+
+		const session = await client.getSession({
+			fetchOptions: { headers: oAuthHeaders },
+		});
+		expect(session.data?.user.email).toBe(testEmail);
+		expect(session.data?.user.name).toBe("Original Name");
+
+		const accounts = await ctx.adapter.findMany<{ providerId: string }>({
+			model: "account",
+			where: [{ field: "userId", value: session.data!.user.id }],
+		});
+		expect(accounts.find((a) => a.providerId === "google")).toBeTruthy();
+
+		const user = await ctx.adapter.findOne<
+			User & { validatedProfileCode?: string | null }
+		>({
+			model: "user",
+			where: [{ field: "email", value: testEmail }],
+		});
+		expect(user?.validatedProfileCode ?? null).toBeNull();
 	});
 });
 

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -1077,6 +1077,15 @@ describe("oauth2 - updateUserInfoOnLink on implicit sign-in link", async () => {
 		user: {
 			additionalFields: {
 				googleSub: { type: "string", required: false },
+				profileCode: {
+					type: "string",
+					required: false,
+					transform: {
+						input(value) {
+							return typeof value === "string" ? value.toLowerCase() : value;
+						},
+					},
+				},
 				serverManagedField: {
 					type: "string",
 					required: false,
@@ -1090,7 +1099,11 @@ describe("oauth2 - updateUserInfoOnLink on implicit sign-in link", async () => {
 				clientSecret: "test",
 				enabled: true,
 				mapProfileToUser(profile: GoogleProfile) {
-					return { googleSub: profile.sub, serverManagedField: "elevated" };
+					return {
+						googleSub: profile.sub,
+						profileCode: profile.sub,
+						serverManagedField: "elevated",
+					};
 				},
 			},
 		},
@@ -1171,13 +1184,29 @@ describe("oauth2 - updateUserInfoOnLink on implicit sign-in link", async () => {
 			data: { email: testEmail, name: "Original Name", emailVerified: true },
 		});
 
-		await signInAndLink(testEmail, "google_implicit_mapped");
+		const updateUserSpy = vi.spyOn(ctx.internalAdapter, "updateUser");
+		try {
+			await signInAndLink(testEmail, "GOOGLE_IMPLICIT_MAPPED");
 
-		const user = await ctx.adapter.findOne<User & { googleSub?: string }>({
-			model: "user",
-			where: [{ field: "email", value: testEmail }],
-		});
-		expect(user?.googleSub).toBe("google_implicit_mapped");
+			expect(updateUserSpy).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					googleSub: "GOOGLE_IMPLICIT_MAPPED",
+					profileCode: "google_implicit_mapped",
+				}),
+			);
+
+			const user = await ctx.adapter.findOne<
+				User & { googleSub?: string; profileCode?: string }
+			>({
+				model: "user",
+				where: [{ field: "email", value: testEmail }],
+			});
+			expect(user?.googleSub).toBe("GOOGLE_IMPLICIT_MAPPED");
+			expect(user?.profileCode).toBe("google_implicit_mapped");
+		} finally {
+			updateUserSpy.mockRestore();
+		}
 	});
 
 	it("does not copy fields marked input: false from the provider on link", async () => {
@@ -1200,14 +1229,29 @@ describe("oauth2 - updateUserInfoOnLink on implicit sign-in link", async () => {
 	});
 });
 
-describe("oauth2 - first sign-in provisioning ignores input: false fields", async () => {
+describe("oauth2 - first sign-in provisioning applies user input rules", async () => {
 	const { auth, client, cookieSetter } = await getTestInstance({
 		user: {
 			additionalFields: {
 				googleSub: { type: "string", required: false },
+				profileCode: {
+					type: "string",
+					required: false,
+					transform: {
+						input(value) {
+							return typeof value === "string" ? value.toLowerCase() : value;
+						},
+					},
+				},
 				serverManagedField: {
 					type: "string",
 					required: false,
+					input: false,
+				},
+				serverManagedDefault: {
+					type: "string",
+					required: false,
+					defaultValue: "member",
 					input: false,
 				},
 			},
@@ -1218,7 +1262,12 @@ describe("oauth2 - first sign-in provisioning ignores input: false fields", asyn
 				clientSecret: "test",
 				enabled: true,
 				mapProfileToUser(profile: GoogleProfile) {
-					return { googleSub: profile.sub, serverManagedField: "elevated" };
+					return {
+						googleSub: profile.sub,
+						profileCode: "PROVIDER-CODE",
+						serverManagedField: "elevated",
+						serverManagedDefault: "admin",
+					};
 				},
 			},
 		},
@@ -1228,50 +1277,73 @@ describe("oauth2 - first sign-in provisioning ignores input: false fields", asyn
 
 	it("does not copy fields marked input: false from the provider on first sign-in", async () => {
 		const testEmail = "implicit-create-input-false@example.com";
+		const createOAuthUserSpy = vi.spyOn(ctx.internalAdapter, "createOAuthUser");
 
-		server.use(
-			http.post("https://oauth2.googleapis.com/token", async () => {
-				const profile = {
-					sub: "google_create_input_false",
-					email: testEmail,
-					email_verified: true,
-					name: "Created From Google",
-				} as GoogleProfile;
-				const idToken = await signJWT(profile, DEFAULT_SECRET);
-				return HttpResponse.json({
-					access_token: "test_token",
-					id_token: idToken,
-				});
-			}),
-		);
+		try {
+			server.use(
+				http.post("https://oauth2.googleapis.com/token", async () => {
+					const profile = {
+						sub: "google_create_input_false",
+						email: testEmail,
+						email_verified: true,
+						name: "Created From Google",
+					} as GoogleProfile;
+					const idToken = await signJWT(profile, DEFAULT_SECRET);
+					return HttpResponse.json({
+						access_token: "test_token",
+						id_token: idToken,
+					});
+				}),
+			);
 
-		const oAuthHeaders = new Headers();
-		const signInRes = await client.signIn.social({
-			provider: "google",
-			callbackURL: "/",
-			fetchOptions: { onSuccess: cookieSetter(oAuthHeaders) },
-		});
-		const state = new URL(signInRes.data!.url!).searchParams.get("state") || "";
-		await client.$fetch("/callback/google", {
-			query: { state, code: "test_code" },
-			method: "GET",
-			headers: oAuthHeaders,
-			onError(context) {
-				expect(context.response.status).toBe(302);
-				cookieSetter(oAuthHeaders)(context as any);
-			},
-		});
+			const oAuthHeaders = new Headers();
+			const signInRes = await client.signIn.social({
+				provider: "google",
+				callbackURL: "/",
+				fetchOptions: { onSuccess: cookieSetter(oAuthHeaders) },
+			});
+			const state =
+				new URL(signInRes.data!.url!).searchParams.get("state") || "";
+			await client.$fetch("/callback/google", {
+				query: { state, code: "test_code" },
+				method: "GET",
+				headers: oAuthHeaders,
+				onError(context) {
+					expect(context.response.status).toBe(302);
+					cookieSetter(oAuthHeaders)(context as any);
+				},
+			});
 
-		const user = await ctx.adapter.findOne<
-			User & { googleSub?: string; serverManagedField?: string | null }
-		>({
-			model: "user",
-			where: [{ field: "email", value: testEmail }],
-		});
-		// The mapped, input-enabled field is still written...
-		expect(user?.googleSub).toBe("google_create_input_false");
-		// ...while the input: false field is ignored.
-		expect(user?.serverManagedField ?? null).toBeNull();
+			expect(createOAuthUserSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					googleSub: "google_create_input_false",
+					profileCode: "provider-code",
+					serverManagedDefault: "member",
+				}),
+				expect.any(Object),
+			);
+
+			const user = await ctx.adapter.findOne<
+				User & {
+					googleSub?: string;
+					profileCode?: string;
+					serverManagedField?: string | null;
+					serverManagedDefault?: string | null;
+				}
+			>({
+				model: "user",
+				where: [{ field: "email", value: testEmail }],
+			});
+			// The mapped, input-enabled field is still written...
+			expect(user?.googleSub).toBe("google_create_input_false");
+			expect(user?.profileCode).toBe("provider-code");
+			// ...while the input: false provider value is ignored.
+			expect(user?.serverManagedField ?? null).toBeNull();
+			// The schema-owned default still applies on create.
+			expect(user?.serverManagedDefault).toBe("member");
+		} finally {
+			createOAuthUserSpy.mockRestore();
+		}
 	});
 });
 

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -2,6 +2,7 @@ import type { GenericEndpointContext } from "@better-auth/core";
 import { isDevelopment } from "@better-auth/core/env";
 import { createEmailVerificationToken } from "../api";
 import { setAccountCookie } from "../cookies/session-store";
+import { stripNonInputUserFields } from "../db";
 import type { Account, User } from "../types";
 import { isAPIError } from "../utils/is-api-error";
 import { redirectOnError } from "./errors";
@@ -166,7 +167,8 @@ export async function handleOAuthUserInfo(
 			}
 		}
 		if (overrideUserInfo) {
-			const { id: _, ...restUserInfo } = userInfo;
+			const { id: _, ...rest } = userInfo;
+			const restUserInfo = stripNonInputUserFields(c.context.options, rest);
 			// update user info from the provider if overrideUserInfo is true
 			user = await c.context.internalAdapter.updateUser(dbUser.user.id, {
 				...restUserInfo,
@@ -186,7 +188,8 @@ export async function handleOAuthUserInfo(
 			};
 		}
 		try {
-			const { id: _, ...restUserInfo } = userInfo;
+			const { id: _, ...rest } = userInfo;
+			const restUserInfo = stripNonInputUserFields(c.context.options, rest);
 			const accountData = {
 				accessToken: await setTokenUtil(account.accessToken, c.context),
 				refreshToken: await setTokenUtil(account.refreshToken, c.context),
@@ -318,8 +321,9 @@ export async function applyUpdateUserInfoOnLink(
 		id: _id,
 		email: _email,
 		emailVerified: _emailVerified,
-		...profile
+		...rawProfile
 	} = userInfo;
+	const profile = stripNonInputUserFields(c.context.options, rawProfile);
 	try {
 		return await c.context.internalAdapter.updateUser(userId, profile);
 	} catch (e) {

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -2,7 +2,7 @@ import type { GenericEndpointContext } from "@better-auth/core";
 import { isDevelopment } from "@better-auth/core/env";
 import { createEmailVerificationToken } from "../api";
 import { setAccountCookie } from "../cookies/session-store";
-import { stripNonInputUserFields } from "../db";
+import { parseAdditionalUserInputFromProviderProfile } from "../db";
 import type { Account, User } from "../types";
 import { isAPIError } from "../utils/is-api-error";
 import { redirectOnError } from "./errors";
@@ -167,11 +167,24 @@ export async function handleOAuthUserInfo(
 			}
 		}
 		if (overrideUserInfo) {
-			const { id: _, ...rest } = userInfo;
-			const restUserInfo = stripNonInputUserFields(c.context.options, rest);
+			const {
+				id: _id,
+				email: _email,
+				emailVerified: _emailVerified,
+				name,
+				image,
+				...providerProfile
+			} = userInfo;
+			const additionalUserFields = parseAdditionalUserInputFromProviderProfile(
+				c.context.options,
+				providerProfile,
+				"update",
+			);
 			// update user info from the provider if overrideUserInfo is true
 			user = await c.context.internalAdapter.updateUser(dbUser.user.id, {
-				...restUserInfo,
+				name,
+				image,
+				...additionalUserFields,
 				email: userInfo.email.toLowerCase(),
 				emailVerified:
 					userInfo.email.toLowerCase() === dbUser.user.email
@@ -188,8 +201,19 @@ export async function handleOAuthUserInfo(
 			};
 		}
 		try {
-			const { id: _, ...rest } = userInfo;
-			const restUserInfo = stripNonInputUserFields(c.context.options, rest);
+			const {
+				id: _id,
+				email: _email,
+				emailVerified: _emailVerified,
+				name,
+				image,
+				...providerProfile
+			} = userInfo;
+			const additionalUserFields = parseAdditionalUserInputFromProviderProfile(
+				c.context.options,
+				providerProfile,
+				"create",
+			);
 			const accountData = {
 				accessToken: await setTokenUtil(account.accessToken, c.context),
 				refreshToken: await setTokenUtil(account.refreshToken, c.context),
@@ -203,8 +227,11 @@ export async function handleOAuthUserInfo(
 			const { user: createdUser, account: createdAccount } =
 				await c.context.internalAdapter.createOAuthUser(
 					{
-						...restUserInfo,
+						name,
+						image,
+						...additionalUserFields,
 						email: userInfo.email.toLowerCase(),
+						emailVerified: userInfo.emailVerified,
 					},
 					accountData,
 				);
@@ -321,11 +348,21 @@ export async function applyUpdateUserInfoOnLink(
 		id: _id,
 		email: _email,
 		emailVerified: _emailVerified,
-		...rawProfile
+		name,
+		image,
+		...providerProfile
 	} = userInfo;
-	const profile = stripNonInputUserFields(c.context.options, rawProfile);
+	const additionalUserFields = parseAdditionalUserInputFromProviderProfile(
+		c.context.options,
+		providerProfile,
+		"update",
+	);
 	try {
-		return await c.context.internalAdapter.updateUser(userId, profile);
+		return await c.context.internalAdapter.updateUser(userId, {
+			name,
+			image,
+			...additionalUserFields,
+		});
 	} catch (e) {
 		c.context.logger.warn("Could not update user info on account link", e);
 		return undefined;

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -344,20 +344,20 @@ export async function applyUpdateUserInfoOnLink(
 	) {
 		return undefined;
 	}
-	const {
-		id: _id,
-		email: _email,
-		emailVerified: _emailVerified,
-		name,
-		image,
-		...providerProfile
-	} = userInfo;
-	const additionalUserFields = parseAdditionalUserInputFromProviderProfile(
-		c.context.options,
-		providerProfile,
-		"update",
-	);
 	try {
+		const {
+			id: _id,
+			email: _email,
+			emailVerified: _emailVerified,
+			name,
+			image,
+			...providerProfile
+		} = userInfo;
+		const additionalUserFields = parseAdditionalUserInputFromProviderProfile(
+			c.context.options,
+			providerProfile,
+			"update",
+		);
 		return await c.context.internalAdapter.updateUser(userId, {
 			name,
 			image,


### PR DESCRIPTION
## Summary
OAuth provider profiles could write mapped additional user fields without using the same user input schema as other create and update paths. That made server-owned fields depend on whether OAuth or email/password created or updated the user.

This keeps OAuth profile data at the OAuth boundary for core identity fields, while mapped additional fields go through the user input parser before OAuth sign-up, sign-in profile override, and account-link profile sync. The parser preserves input-allowed mapped fields, applies configured defaults and transforms, and ignores provider values for fields marked `input: false`.