### PR TITLE
fix(google): align hosted-domain validation across sign-in flows

### DIFF
--- a/.changeset/one-tap-hosted-domain.md
+++ b/.changeset/one-tap-hosted-domain.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Apply the configured Google hosted domain (`hd`) on the One Tap server callback, matching the redirect sign-in flow.

--- a/.changeset/one-tap-hosted-domain.md
+++ b/.changeset/one-tap-hosted-domain.md
@@ -1,5 +1,8 @@
 ---
+"@better-auth/core": patch
 "better-auth": patch
 ---
 
-Apply the configured Google hosted domain (`hd`) on the One Tap server callback, matching the redirect sign-in flow.
+Google sign-in now accepts `hd: "*"` to allow any Google Workspace hosted domain while still rejecting tokens with no hosted-domain claim.
+
+Google One Tap now applies the configured Google hosted-domain restriction before creating a session.

--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -145,6 +145,22 @@ await authClient.signIn.social({
   The array only expands ID token audience verification. The authorization code flow still uses the first entry paired with the single `clientSecret` and `redirectURI`, so those cannot vary per platform within one provider block.
 </Callout>
 
+### Restrict Sign-In to Google Workspace
+
+Set `hd` on the Google provider to require a verified Google Workspace hosted-domain claim. Google also receives this value as an account-selection hint, but Better Auth enforces the returned ID token/profile claim after Google signs the response.
+
+```ts title="auth.ts"
+socialProviders: {
+    google: {
+        clientId: process.env.GOOGLE_CLIENT_ID as string,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+        hd: "company.com", // [!code highlight]
+    },
+}
+```
+
+Set `hd: "*"` to allow any Google Workspace hosted domain. Tokens with no `hd` claim are rejected whenever `hd` is configured.
+
 ### Always ask to select an account
 
 If you want to always ask the user to select an account, you pass the `prompt` parameter to the provider, setting it to `select_account`.

--- a/docs/content/docs/plugins/one-tap.mdx
+++ b/docs/content/docs/plugins/one-tap.mdx
@@ -205,6 +205,21 @@ When using button mode, pass a `button` object to the `oneTap` action with the f
 * `disableSignUp`: Disable the sign-up option, allowing only existing users to sign in. Default is false.
 * `clientId`: Optionally, pass a client ID here if it is not provided in your social provider configuration.
 
+<Callout type="info">
+  **Restricting to a Google Workspace domain (`hd`)**
+
+  The One Tap callback applies the hosted-domain restriction from
+  `socialProviders.google.hd`, matching the standard Google sign-in flow:
+  when `hd` is set, a token whose `hd` claim is missing or does not match is
+  rejected.
+
+  This value is read from `socialProviders.google`, so the restriction only
+  applies when you configure the Google provider. If you set up One Tap with
+  only `oneTap({ clientId })` and no `socialProviders.google`, no
+  hosted-domain restriction is applied. To restrict One Tap sign-in to a
+  Workspace domain, configure `socialProviders.google` with `hd`.
+</Callout>
+
 ### Authorized JavaScript origins
 
 Ensure you have configured the Authorized JavaScript origins (e.g., [http://localhost:3000](http://localhost:3000), [https://example.com](https://example.com)) for your Client ID in the Google Cloud Console. This is a required step for the Google One Tap API, and it will not function correctly unless your origins are correctly set.

--- a/docs/content/docs/plugins/one-tap.mdx
+++ b/docs/content/docs/plugins/one-tap.mdx
@@ -210,8 +210,9 @@ When using button mode, pass a `button` object to the `oneTap` action with the f
 
   The One Tap callback applies the hosted-domain restriction from
   `socialProviders.google.hd`, matching the standard Google sign-in flow:
-  when `hd` is set, a token whose `hd` claim is missing or does not match is
-  rejected.
+  when `hd` is set to a domain, a token whose `hd` claim is missing or does
+  not match is rejected. Set `hd: "*"` to allow any Google Workspace hosted
+  domain while still rejecting tokens with no `hd` claim.
 
   This value is read from `socialProviders.google`, so the restriction only
   applies when you configure the Google provider. If you set up One Tap with

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -133,6 +133,11 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 					// matches the redirect sign-in flow, which rejects tokens whose
 					// `hd` claim is missing or does not equal the configured value.
 					if (googleProvider?.hd && payload.hd !== googleProvider.hd) {
+						ctx.context.logger.error(
+							`Google One Tap sign-in rejected: id token hosted domain (hd) "${
+								payload.hd ?? "<missing>"
+							}" does not match the configured "hd" option "${googleProvider.hd}".`,
+						);
 						throw new APIError("BAD_REQUEST", {
 							message: "invalid id token",
 						});

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -129,6 +129,14 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 							message: "invalid id token",
 						});
 					}
+					// Apply the configured Google hosted domain (`hd`) so One Tap
+					// matches the redirect sign-in flow, which rejects tokens whose
+					// `hd` claim is missing or does not equal the configured value.
+					if (googleProvider?.hd && payload.hd !== googleProvider.hd) {
+						throw new APIError("BAD_REQUEST", {
+							message: "invalid id token",
+						});
+					}
 					const {
 						email: rawEmail,
 						email_verified,

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -1,6 +1,10 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import type { GoogleProfile } from "@better-auth/core/social-providers";
+import {
+	isGoogleHostedDomainAllowed,
+	verifyGoogleIdToken,
+} from "@better-auth/core/social-providers";
 import * as z from "zod";
 import { APIError } from "../../api";
 import { setSessionCookie } from "../../cookies";
@@ -110,33 +114,31 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 								"Google client ID is required for One Tap. Set it on the oneTap plugin (clientId) or on socialProviders.google.",
 						});
 					}
-					let payload: any;
-					try {
-						const JWKS = createRemoteJWKSet(
-							new URL("https://www.googleapis.com/oauth2/v3/certs"),
-						);
-						const { payload: verifiedPayload } = await jwtVerify(
-							idToken,
-							JWKS,
-							{
-								issuer: ["https://accounts.google.com", "accounts.google.com"],
-								audience,
-							},
-						);
-						payload = verifiedPayload;
-					} catch {
+					const payload = (await verifyGoogleIdToken({
+						token: idToken,
+						audience,
+					})) as Partial<GoogleProfile> | null;
+					if (!payload) {
+						throw new APIError("BAD_REQUEST", {
+							message: "invalid id token",
+						});
+					}
+					if (!payload.sub) {
 						throw new APIError("BAD_REQUEST", {
 							message: "invalid id token",
 						});
 					}
 					// Apply the configured Google hosted domain (`hd`) so One Tap
 					// matches the redirect sign-in flow, which rejects tokens whose
-					// `hd` claim is missing or does not equal the configured value.
-					if (googleProvider?.hd && payload.hd !== googleProvider.hd) {
+					// `hd` claim is missing or outside the configured restriction.
+					const configuredHostedDomain = googleProvider?.hd;
+					if (
+						!isGoogleHostedDomainAllowed(configuredHostedDomain, payload.hd)
+					) {
 						ctx.context.logger.error(
 							`Google One Tap sign-in rejected: id token hosted domain (hd) "${
 								payload.hd ?? "<missing>"
-							}" does not match the configured "hd" option "${googleProvider.hd}".`,
+							}" does not satisfy the configured "hd" option "${configuredHostedDomain}".`,
 						);
 						throw new APIError("BAD_REQUEST", {
 							message: "invalid id token",

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -1,6 +1,29 @@
+// cspell:ignore AQAB
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { oneTap } from "./index";
+
+vi.mock("@better-fetch/fetch", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@better-fetch/fetch")>();
+	return {
+		...actual,
+		betterFetch: vi.fn(async () => ({
+			data: {
+				keys: [
+					{
+						kid: "test-google-key",
+						alg: "RS256",
+						kty: "RSA",
+						use: "sig",
+						n: "test-modulus",
+						e: "AQAB",
+					},
+				],
+			},
+			error: null,
+		})),
+	};
+});
 
 const defaultVerifiedPayload = {
 	email: "one-tap-user@example.com",
@@ -16,7 +39,11 @@ vi.mock("jose", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("jose")>();
 	return {
 		...actual,
-		createRemoteJWKSet: vi.fn(() => async () => undefined),
+		decodeProtectedHeader: vi.fn(() => ({
+			kid: "test-google-key",
+			alg: "RS256",
+		})),
+		importJWK: vi.fn(async () => ({})),
 		jwtVerify: vi.fn(async () => ({
 			payload: verifiedPayload,
 			protectedHeader: { alg: "RS256" },
@@ -534,6 +561,55 @@ describe("one-tap hosted domain (hd)", async () => {
 
 		expect(res.error).toBeFalsy();
 		expect(res.data?.token).toBeTruthy();
+	});
+
+	it("accepts any Workspace hd when the configured value is a wildcard", async () => {
+		verifiedPayload.email = "one-tap-hd-wildcard@company.com";
+		verifiedPayload.sub = "one-tap-hd-wildcard-sub";
+		(verifiedPayload as Record<string, unknown>).hd = "company.com";
+
+		const { client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					...withHd,
+					hd: "*",
+				},
+			},
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{ token?: string }>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error).toBeFalsy();
+		expect(res.data?.token).toBeTruthy();
+	});
+
+	it("rejects a token with no hd when the configured value is a wildcard", async () => {
+		verifiedPayload.email = "one-tap-hd-wildcard-missing@example.com";
+		verifiedPayload.sub = "one-tap-hd-wildcard-missing-sub";
+
+		const { client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					...withHd,
+					hd: "*",
+				},
+			},
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error?.status).toBe(400);
 	});
 
 	it("ignores the token hd when no hosted domain is configured", async () => {

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -462,3 +462,102 @@ describe("one-tap audience enforcement", async () => {
 		);
 	});
 });
+
+describe("one-tap hosted domain (hd)", async () => {
+	afterEach(() => {
+		Object.assign(verifiedPayload, defaultVerifiedPayload);
+		(verifiedPayload as Record<string, unknown>).hd = undefined;
+	});
+
+	const withHd = {
+		clientId: "test-client",
+		clientSecret: "test-secret",
+		enabled: true,
+		hd: "company.com",
+	};
+
+	it("rejects a token whose hd does not match the configured value", async () => {
+		verifiedPayload.email = "one-tap-hd-mismatch@other.com";
+		verifiedPayload.sub = "one-tap-hd-mismatch-sub";
+		(verifiedPayload as Record<string, unknown>).hd = "other.com";
+
+		const { client } = await getTestInstance({
+			socialProviders: { google: withHd },
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error?.status).toBe(400);
+	});
+
+	it("rejects a token with no hd when one is configured", async () => {
+		verifiedPayload.email = "one-tap-hd-missing@company.com";
+		verifiedPayload.sub = "one-tap-hd-missing-sub";
+
+		const { client } = await getTestInstance({
+			socialProviders: { google: withHd },
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error?.status).toBe(400);
+	});
+
+	it("accepts a token whose hd matches the configured value", async () => {
+		verifiedPayload.email = "one-tap-hd-match@company.com";
+		verifiedPayload.sub = "one-tap-hd-match-sub";
+		(verifiedPayload as Record<string, unknown>).hd = "company.com";
+
+		const { client } = await getTestInstance({
+			socialProviders: { google: withHd },
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{ token?: string }>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error).toBeFalsy();
+		expect(res.data?.token).toBeTruthy();
+	});
+
+	it("ignores the token hd when no hosted domain is configured", async () => {
+		verifiedPayload.email = "one-tap-no-hd-config@anywhere.com";
+		verifiedPayload.sub = "one-tap-no-hd-config-sub";
+		(verifiedPayload as Record<string, unknown>).hd = "anywhere.com";
+
+		const { client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+				},
+			},
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{ token?: string }>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error).toBeFalsy();
+		expect(res.data?.token).toBeTruthy();
+	});
+});

--- a/packages/core/src/social-providers/google.test.ts
+++ b/packages/core/src/social-providers/google.test.ts
@@ -111,6 +111,38 @@ describe("google hosted domain (hd) enforcement", () => {
 			);
 		});
 
+		it("accepts any Workspace hd when hd is configured as a wildcard", async () => {
+			const { publicJWK, token } = await createSignedGoogleToken({
+				hd: "example.com",
+			});
+			mockGoogleJwks(publicJWK);
+
+			const provider = google({
+				clientId: CLIENT_ID,
+				clientSecret: CLIENT_SECRET,
+				hd: "*",
+			});
+
+			await expect(provider.verifyIdToken(token, undefined)).resolves.toBe(
+				true,
+			);
+		});
+
+		it("rejects a token missing the hd claim when hd is configured as a wildcard", async () => {
+			const { publicJWK, token } = await createSignedGoogleToken({});
+			mockGoogleJwks(publicJWK);
+
+			const provider = google({
+				clientId: CLIENT_ID,
+				clientSecret: CLIENT_SECRET,
+				hd: "*",
+			});
+
+			await expect(provider.verifyIdToken(token, undefined)).resolves.toBe(
+				false,
+			);
+		});
+
 		it("does not require an hd claim when hd is not configured", async () => {
 			const { publicJWK, token } = await createSignedGoogleToken({});
 			mockGoogleJwks(publicJWK);
@@ -163,6 +195,36 @@ describe("google hosted domain (hd) enforcement", () => {
 				clientId: CLIENT_ID,
 				clientSecret: CLIENT_SECRET,
 				hd: "example.com",
+			});
+
+			const result = await provider.getUserInfo({
+				idToken,
+				accessToken: "access",
+			});
+			expect(result).toBeNull();
+		});
+
+		it("returns the user for any Workspace hd when hd is configured as a wildcard", async () => {
+			const idToken = await encodeGoogleToken({ hd: "example.com" });
+			const provider = google({
+				clientId: CLIENT_ID,
+				clientSecret: CLIENT_SECRET,
+				hd: "*",
+			});
+
+			const result = await provider.getUserInfo({
+				idToken,
+				accessToken: "access",
+			});
+			expect(result?.user.email).toBe("user@example.com");
+		});
+
+		it("returns null when the hd claim is missing and hd is configured as a wildcard", async () => {
+			const idToken = await encodeGoogleToken({});
+			const provider = google({
+				clientId: CLIENT_ID,
+				clientSecret: CLIENT_SECRET,
+				hd: "*",
 			});
 
 			const result = await provider.getUserInfo({

--- a/packages/core/src/social-providers/google.ts
+++ b/packages/core/src/social-providers/google.ts
@@ -1,4 +1,5 @@
 import { betterFetch } from "@better-fetch/fetch";
+import type { JWTPayload } from "jose";
 import { decodeJwt, decodeProtectedHeader, importJWK, jwtVerify } from "jose";
 import { logger } from "../env";
 import { APIError, BetterAuthError } from "../error";
@@ -52,11 +53,66 @@ export interface GoogleOptions extends ProviderOptions<GoogleProfile> {
 	 *
 	 * This is sent to Google as the `hd` authorization hint and, when set, is
 	 * also enforced against the `hd` claim of the returned id token/profile.
-	 * Sign-in is rejected when the claim is missing or does not match, so this
-	 * can be used to restrict sign-in to a Workspace domain.
+	 * Set `hd: "*"` to require any Workspace hosted-domain claim. Sign-in is
+	 * rejected when the claim is missing or does not satisfy this restriction.
 	 */
 	hd?: string | undefined;
 }
+
+const GOOGLE_ID_TOKEN_MAX_AGE = "1h";
+
+export interface VerifyGoogleIdTokenOptions {
+	token: string;
+	audience: string | string[];
+	nonce?: string | undefined;
+}
+
+/**
+ * Verifies a Google ID token against Google's issuer, audience, signature,
+ * expiry, and maximum token age.
+ */
+export const verifyGoogleIdToken = async ({
+	token,
+	audience,
+	nonce,
+}: VerifyGoogleIdTokenOptions): Promise<JWTPayload | null> => {
+	try {
+		const { kid, alg: jwtAlg } = decodeProtectedHeader(token);
+		if (!kid || !jwtAlg) return null;
+
+		const publicKey = await getGooglePublicKey(kid);
+		const { payload: jwtClaims } = await jwtVerify(token, publicKey, {
+			algorithms: [jwtAlg],
+			issuer: ["https://accounts.google.com", "accounts.google.com"],
+			audience,
+			maxTokenAge: GOOGLE_ID_TOKEN_MAX_AGE,
+		});
+
+		if (nonce && jwtClaims.nonce !== nonce) {
+			return null;
+		}
+
+		return jwtClaims;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Checks whether Google's verified `hd` claim satisfies the configured hosted
+ * domain restriction. `hd: "*"` accepts any Google Workspace hosted domain.
+ */
+export const isGoogleHostedDomainAllowed = (
+	configuredHostedDomain: string | undefined,
+	tokenHostedDomain: unknown,
+) => {
+	if (!configuredHostedDomain) return true;
+	if (typeof tokenHostedDomain !== "string" || !tokenHostedDomain) {
+		return false;
+	}
+	if (configuredHostedDomain === "*") return true;
+	return tokenHostedDomain === configuredHostedDomain;
+};
 
 export const google = (options: GoogleOptions) => {
 	return {
@@ -133,38 +189,16 @@ export const google = (options: GoogleOptions) => {
 				return options.verifyIdToken(token, nonce);
 			}
 
-			// Verify JWT integrity
-			// See https://developers.google.com/identity/sign-in/web/backend-auth#verify-the-integrity-of-the-id-token
-
-			try {
-				const { kid, alg: jwtAlg } = decodeProtectedHeader(token);
-				if (!kid || !jwtAlg) return false;
-
-				const publicKey = await getGooglePublicKey(kid);
-				const { payload: jwtClaims } = await jwtVerify(token, publicKey, {
-					algorithms: [jwtAlg],
-					issuer: ["https://accounts.google.com", "accounts.google.com"],
-					audience: options.clientId,
-					maxTokenAge: "1h",
-				});
-
-				if (nonce && jwtClaims.nonce !== nonce) {
-					return false;
-				}
-
-				// Google's `hd` authorization parameter is only a UI hint and can
-				// be removed or changed by the user. When a hosted domain is
-				// configured, the `hd` claim in the verified id token is the
-				// authoritative value and must match, otherwise accounts outside
-				// the workspace domain would be accepted.
-				if (options.hd && jwtClaims.hd !== options.hd) {
-					return false;
-				}
-
-				return true;
-			} catch {
+			const jwtClaims = await verifyGoogleIdToken({
+				token,
+				audience: options.clientId,
+				nonce,
+			});
+			if (!jwtClaims) {
 				return false;
 			}
+
+			return isGoogleHostedDomainAllowed(options.hd, jwtClaims.hd);
 		},
 		async getUserInfo(token) {
 			if (options.getUserInfo) {
@@ -174,15 +208,14 @@ export const google = (options: GoogleOptions) => {
 				return null;
 			}
 			const user = decodeJwt(token.idToken) as GoogleProfile;
-			// Enforce the configured hosted domain on the callback profile path
-			// as well. The `hd` claim must be present and match, since the
-			// authorization-time `hd` hint does not restrict which account signs
-			// in.
-			if (options.hd && user.hd !== options.hd) {
+			// Enforce the configured hosted domain on the callback profile path.
+			// The authorization-time `hd` value is only a UI hint; the verified
+			// token/profile claim is the authoritative Workspace signal.
+			if (!isGoogleHostedDomainAllowed(options.hd, user.hd)) {
 				logger.error(
 					`Google sign-in rejected: id token hosted domain (hd) "${
 						user.hd ?? "<missing>"
-					}" does not match the configured "hd" option "${options.hd}".`,
+					}" does not satisfy the configured "hd" option "${options.hd}".`,
 				);
 				return null;
 			}


### PR DESCRIPTION
## Summary

Google One Tap accepted Google ID tokens whose hosted-domain claim would be rejected by the regular Google sign-in paths.

This change routes One Tap through the shared Google ID-token verifier and hosted-domain predicate owned by the Google provider. Keeping the policy in one provider-owned place avoids exact-match drift between redirect sign-in, direct ID-token sign-in, and One Tap.

The hosted-domain predicate also models Google Workspace wildcard semantics: `hd: "*"` requires a verified non-empty `hd` claim, while a configured concrete domain still requires an exact claim match.

## Details

- Apply the same hosted-domain predicate in redirect sign-in, direct ID-token sign-in, and One Tap.
- Keep Google ID-token issuer, audience, signature, expiry, and token-age verification in one helper.
- Document `hd` on the Google provider and clarify how One Tap inherits it from `socialProviders.google`.