### PR TITLE
fix: honor disableMigration on plugin schema tables

### DIFF
--- a/.changeset/skip-disabled-migration-tables.md
+++ b/.changeset/skip-disabled-migration-tables.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+"auth": patch
+---
+
+Honor `disableMigration` on plugin schema tables. Tables flagged with `disableMigration: true` are now skipped by `better-auth generate` (Drizzle and Prisma output) and by the runtime migrator, instead of being emitted and created anyway. The flag was previously dropped while assembling the table list, so it had no effect.

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -224,6 +224,9 @@ export async function getMigrations(config: BetterAuthOptions) {
 	}[] = [];
 
 	for (const [key, value] of Object.entries(betterAuthSchema)) {
+		if (value.disableMigrations) {
+			continue;
+		}
 		const table = tableMetadata.find((t) => t.name === key);
 		if (!table) {
 			const tIndex = toBeCreated.findIndex((t) => t.table === key);

--- a/packages/better-auth/src/db/get-schema.ts
+++ b/packages/better-auth/src/db/get-schema.ts
@@ -34,6 +34,9 @@ export function getSchema(config: BetterAuthOptions) {
 				...schema[table.modelName]!.fields,
 				...actualFields,
 			};
+			if (table.disableMigrations) {
+				schema[table.modelName]!.disableMigrations = true;
+			}
 			continue;
 		}
 		schema[table.modelName] = {

--- a/packages/better-auth/src/db/get-schema.ts
+++ b/packages/better-auth/src/db/get-schema.ts
@@ -9,6 +9,7 @@ export function getSchema(config: BetterAuthOptions) {
 		{
 			fields: Record<string, DBFieldAttribute>;
 			order: number;
+			disableMigrations?: boolean | undefined;
 		}
 	> = {};
 	for (const key in tables) {
@@ -38,6 +39,7 @@ export function getSchema(config: BetterAuthOptions) {
 		schema[table.modelName] = {
 			fields: actualFields,
 			order: table.order || Infinity,
+			disableMigrations: table.disableMigrations,
 		};
 	}
 	return schema;

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -46,6 +46,9 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 
 	for (const tableKey in tables) {
 		const table = tables[tableKey]!;
+		if (table.disableMigrations) {
+			continue;
+		}
 		const modelName = getModelName(tableKey);
 		const fields = table.fields;
 
@@ -293,6 +296,9 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	let relationsString: string = "";
 	for (const tableKey in tables) {
 		const table = tables[tableKey]!;
+		if (table.disableMigrations) {
+			continue;
+		}
 		const modelName = getModelName(tableKey);
 
 		type Relation = {

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -117,6 +117,9 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 
 	const schema = produceSchema(schemaPrisma, (builder) => {
 		for (const table in tables) {
+			if (tables[table]?.disableMigrations) {
+				continue;
+			}
 			const originalTableName = table;
 			const customModelName = tables[table]?.modelName || table;
 			const modelName = capitalizeFirstLetter(getModelName(customModelName));

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -1684,4 +1684,58 @@ describe("--dialect flag support", () => {
 		expect(schema.code).toContain('provider = "mysql"');
 		expect(schema.fileName).toBe("test.prisma");
 	});
+
+	const pluginWithDisabledMigration = (): BetterAuthPlugin => ({
+		id: "disabled-migration-test",
+		schema: {
+			emittedTable: {
+				fields: {
+					name: { type: "string", required: true },
+				},
+			},
+			skippedTable: {
+				fields: {
+					name: { type: "string", required: true },
+				},
+				disableMigration: true,
+			},
+		},
+	});
+
+	it("should not emit drizzle tables with disableMigration", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: {
+				id: "drizzle",
+				options: {
+					provider: "pg",
+					schema: {},
+				},
+			} as any,
+			options: {
+				database: {} as any,
+				plugins: [pluginWithDisabledMigration()],
+			} as BetterAuthOptions,
+		});
+
+		expect(schema.code).toContain("emittedTable");
+		expect(schema.code).not.toContain("skippedTable");
+	});
+
+	it("should not emit prisma models with disableMigration", async () => {
+		const schema = await generatePrismaSchema({
+			file: "test.prisma",
+			adapter: prismaAdapter(
+				{},
+				{ provider: "postgresql" },
+			)({} as BetterAuthOptions),
+			options: {
+				database: prismaAdapter({}, { provider: "postgresql" }),
+				plugins: [pluginWithDisabledMigration()],
+			},
+		});
+
+		expect(schema.code).toContain("EmittedTable");
+		expect(schema.code).not.toContain("SkippedTable");
+	});
 });

--- a/packages/core/src/db/get-tables.ts
+++ b/packages/core/src/db/get-tables.ts
@@ -15,13 +15,19 @@ export const getAuthTables = (
 						...value.fields,
 					},
 					modelName: value.modelName || key,
+					disableMigrations:
+						value.disableMigration ?? acc[key]?.disableMigrations,
 				};
 			}
 			return acc;
 		},
 		{} as Record<
 			string,
-			{ fields: Record<string, DBFieldAttribute>; modelName: string }
+			{
+				fields: Record<string, DBFieldAttribute>;
+				modelName: string;
+				disableMigrations?: boolean | undefined;
+			}
 		>,
 	);
 

--- a/packages/core/src/db/test/get-tables.test.ts
+++ b/packages/core/src/db/test/get-tables.test.ts
@@ -113,4 +113,52 @@ describe("getAuthTables", () => {
 
 		expect(tables.verification).toBeDefined();
 	});
+
+	it("should propagate disableMigration from a plugin schema onto the table", () => {
+		const tables = getAuthTables({
+			plugins: [
+				{
+					id: "test",
+					schema: {
+						skipped: {
+							fields: { name: { type: "string" } },
+							disableMigration: true,
+						},
+						kept: {
+							fields: { name: { type: "string" } },
+						},
+					},
+				},
+			],
+		});
+
+		expect(tables.skipped!.disableMigrations).toBe(true);
+		expect(tables.kept!.disableMigrations).toBeUndefined();
+	});
+
+	it("should keep disableMigration when plugins accumulate the same table key", () => {
+		const tables = getAuthTables({
+			plugins: [
+				{
+					id: "a",
+					schema: {
+						shared: {
+							fields: { a: { type: "string" } },
+							disableMigration: true,
+						},
+					},
+				},
+				{
+					id: "b",
+					schema: {
+						shared: {
+							fields: { b: { type: "string" } },
+						},
+					},
+				},
+			],
+		});
+
+		expect(tables.shared!.disableMigrations).toBe(true);
+	});
 });


### PR DESCRIPTION
## Summary

`disableMigration: true` on a plugin schema entry had **no effect**. A table flagged with it was still emitted by `better-auth generate` (issue #8347) — and, despite the issue assuming runtime worked, also still created by the runtime migrator.

Root cause: `getAuthTables` (`packages/core/src/db/get-tables.ts`) drops the flag while assembling plugin tables — it only copies `fields` and `modelName`. Since the flag never made it onto the table object, nothing downstream could read it. Confirmed it is never read anywhere: the only reference in source was its type declaration in `core/src/db/plugin.ts`.

Closes #8347.

## Fix

Propagate the flag and honor it everywhere a table is materialized:

- `get-tables.ts` — carry `disableMigration` from the plugin schema onto the table as `disableMigrations` (the name already declared on `BetterAuthDBSchema`).
- `get-schema.ts` — carry it onto the schema entries that the migrator consumes.
- `get-migration.ts` — skip flagged tables when building the create/alter plan (fixes runtime migration and the Kysely SQL generator, which both go through `getMigrations`).
- `generators/drizzle.ts` and `generators/prisma.ts` — skip flagged tables when emitting the schema file.

## Tests

Added to `packages/cli/test/generate.test.ts`: a plugin exposing one normal table and one with `disableMigration: true`, asserting the normal table is emitted and the flagged one is omitted, for both Drizzle and Prisma. Both pass. `pnpm typecheck` is clean.

Note: 7 pre-existing Prisma snapshot tests fail in my environment with whitespace-only diffs (CRLF) — they fail identically on a clean checkout with my changes stashed, so they're unrelated to this change. The Drizzle snapshots and all non-snapshot tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor `disableMigration` on plugin schema tables so flagged tables are skipped by `better-auth generate` (Drizzle/Prisma) and by the runtime migrator, including during schema merges. Closes #8347.

- **Bug Fixes**
  - Carry and preserve the flag through `getAuthTables` and `getSchema` (including when plugins merge on the same table key or `modelName`).
  - Skip flagged tables when building migrations in `getMigrations`.
  - Skip flagged tables in Drizzle and Prisma generators; tests ensure only non-flagged tables are emitted.

<sup>Written for commit 9e68277d791ba0858fa1e7cd62ac4d2a76a5eb20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

