### PR TITLE
feat(oauth-provider): add validateRedirectURI for dynamic redirect URIs

### DIFF
--- a/.changeset/oauth-provider-validate-redirect-uri.md
+++ b/.changeset/oauth-provider-validate-redirect-uri.md
@@ -5,12 +5,22 @@
 feat(oauth-provider): add `validateRedirectURI` to authorize dynamic redirect URIs
 
 Adds an optional `validateRedirectURI` hook to the OAuth provider options. It is
-consulted during `/authorize` only after the built-in exact-match and RFC 8252
-loopback-IP checks fail, letting servers accept a `redirect_uri` that isn't in
-the client's registered `redirectUris` — for dynamic or ephemeral targets (e.g.
-per-branch preview deployments) whose hostnames can't be pre-registered.
+consulted as a last resort, only after the built-in checks fail, letting servers
+accept a redirect target that isn't in the client's registered list — for dynamic
+or ephemeral targets (e.g. per-branch preview deployments) whose hostnames can't
+be pre-registered.
 
-The hook receives the endpoint `ctx`, the resolved `client`, and the requested
-`redirectURI`, and returns a boolean. A declined or unhandled URI still fails
-with `invalid_redirect`, and the error is sent to the auth server's error page,
-never the untrusted target.
+The hook receives the endpoint `ctx`, the resolved `client`, the requested
+`redirectURI`, and a `type` discriminator, and returns a boolean. It covers two
+flows:
+
+- `type: "authorize"` — the `redirect_uri` at `/oauth2/authorize`, consulted after
+  the exact-match and RFC 8252 loopback-IP checks against `redirectUris` fail. A
+  declined URI fails with `invalid_redirect`, sent to the auth server's error page,
+  never the untrusted target.
+- `type: "logout"` — the `post_logout_redirect_uri` at RP-Initiated Logout,
+  consulted after the exact-match check against `postLogoutRedirectUris` fails. A
+  declined URI ends the session without redirecting to the untrusted target.
+
+Because `"authorize"` delivers the authorization code, validate it most strictly;
+only relax rules for `"logout"`, never the reverse.

--- a/.changeset/oauth-provider-validate-redirect-uri.md
+++ b/.changeset/oauth-provider-validate-redirect-uri.md
@@ -1,0 +1,16 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+feat(oauth-provider): add `validateRedirectURI` to authorize dynamic redirect URIs
+
+Adds an optional `validateRedirectURI` hook to the OAuth provider options. It is
+consulted during `/authorize` only after the built-in exact-match and RFC 8252
+loopback-IP checks fail, letting servers accept a `redirect_uri` that isn't in
+the client's registered `redirectUris` — for dynamic or ephemeral targets (e.g.
+per-branch preview deployments) whose hostnames can't be pre-registered.
+
+The hook receives the endpoint `ctx`, the resolved `client`, and the requested
+`redirectURI`, and returns a boolean. A declined or unhandled URI still fails
+with `invalid_redirect`, and the error is sent to the auth server's error page,
+never the untrusted target.

--- a/.changeset/oauth-provider-validate-redirect-uri.md
+++ b/.changeset/oauth-provider-validate-redirect-uri.md
@@ -2,25 +2,5 @@
 "@better-auth/oauth-provider": minor
 ---
 
-feat(oauth-provider): add `validateRedirectURI` to authorize dynamic redirect URIs
-
-Adds an optional `validateRedirectURI` hook to the OAuth provider options. It is
-consulted as a last resort, only after the built-in checks fail, letting servers
-accept a redirect target that isn't in the client's registered list — for dynamic
-or ephemeral targets (e.g. per-branch preview deployments) whose hostnames can't
-be pre-registered.
-
-The hook receives the endpoint `ctx`, the resolved `client`, the requested
-`redirectURI`, and a `type` discriminator, and returns a boolean. It covers two
-flows:
-
-- `type: "authorize"` — the `redirect_uri` at `/oauth2/authorize`, consulted after
-  the exact-match and RFC 8252 loopback-IP checks against `redirectUris` fail. A
-  declined URI fails with `invalid_redirect`, sent to the auth server's error page,
-  never the untrusted target.
-- `type: "logout"` — the `post_logout_redirect_uri` at RP-Initiated Logout,
-  consulted after the exact-match check against `postLogoutRedirectUris` fails. A
-  declined URI ends the session without redirecting to the untrusted target.
-
-Because `"authorize"` delivers the authorization code, validate it most strictly;
-only relax rules for `"logout"`, never the reverse.
+OAuth Provider now accepts an optional `validateRedirectURI` hook that authorizes redirect targets which aren't in a client's registered list, for dynamic or ephemeral hosts such as per-branch preview deployments. It runs only as a last resort, after the built-in checks fail, and covers both the `redirect_uri` at `/oauth2/authorize` and the `post_logout_redirect_uri` at RP-Initiated Logout (distinguished by a `type` argument). A declined URI is rejected without redirecting to the untrusted target.
+</content>

--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -26,4 +26,3 @@ Abdulrazzaq
 rethrowing
 dedupe
 redirector
-exfiltration

--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -25,3 +25,5 @@ Suliman
 Abdulrazzaq
 rethrowing
 dedupe
+redirector
+exfiltration

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -717,6 +717,8 @@ await auth.api.adminCreateOAuthClient({
   If `disableJwtPlugin: true`, public clients will never be able to logout using this endpoint since no `id_token` is sent.
 </Callout>
 
+A `post_logout_redirect_uri` must exactly match one of the client's registered `postLogoutRedirectUris`. To authorize unregistered post-logout targets dynamically, see [Dynamic Redirect URIs](#dynamic-redirect-uris).
+
 ### Back-Channel Logout
 
 [Back-Channel Logout](https://openid.net/specs/openid-connect-backchannel-1_0.html) is the server-to-server counterpart to RP-Initiated Logout: when a user's session ends at the OP (sign-out, `/oauth2/end-session`, admin revoke, etc.), the OP POSTs a signed Logout Token to each registered Relying Party so they can terminate their own session state and revoke bound API access.
@@ -1139,6 +1141,34 @@ await client.oauth2.oauth2Continue({
   postLogin: true,
 });
 ```
+
+### Dynamic Redirect URIs
+
+By default, redirect URIs are validated by exact string match against the client's registered URIs: `redirectUris` at the [Authorize Endpoint](#authorize-endpoint) and `postLogoutRedirectUris` at the [End Session Endpoint](#end-session-endpoint), plus [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252) loopback-IP equivalence for native clients. Anything else is rejected.
+
+For dynamic or ephemeral targets that cannot be pre-registered, such as per-branch preview deployments whose hostnames carry a per-session hash, provide the `validateRedirectURI` function. It is consulted only as a last resort, after the built-in exact-match checks fail. Returning `true` accepts the requested URI as if it were registered.
+
+The function receives the endpoint `ctx`, the resolved `client`, the requested `redirectURI`, and a `type` that identifies which flow is asking:
+
+* `"authorize"`: validates the `redirect_uri` at `/oauth2/authorize`. Returning `true` delivers the authorization code to the requested URI.
+* `"logout"`: validates the `post_logout_redirect_uri` at RP-Initiated Logout. Returning `true` redirects the user agent there (with `state` echoed) after the session ends.
+
+```ts title="auth.ts"
+oauthProvider({
+  validateRedirectURI: ({ client, redirectURI, type }) => { // [!code highlight]
+    const url = new URL(redirectURI);
+    if (url.protocol !== "https:") return false;
+    // Bind to the specific client and an exact host allow-list.
+    return url.hostname.endsWith(`.${client.clientId}.preview.example.com`);
+  },
+})
+```
+
+When the function declines (or is not set), the request fails with `invalid_redirect`. The error is shown on the authorization server's error page and is never sent to the untrusted target, so a declined URI never receives an authorization code or a logout redirect.
+
+<Callout type="warn">
+  A permissive matcher is an open redirector. For `type: "authorize"` it also leaks the authorization code, which is an account-takeover vector, so validate most strictly there. For both types, bind validation to the specific `client`, require an exact scheme and host allow-list, and never accept apex wildcards or user-controlled hosts. Branch on `type` only to make `"logout"` more permissive than `"authorize"`, never the reverse.
+</Callout>
 
 ### Cached Trusted Clients
 

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -1430,7 +1430,11 @@ describe("oauth authorize - validateRedirectURI", async () => {
 		"https://branch-xyz789.preview.example.com/api/auth/oauth2/callback/test";
 
 	// Records every call so we can assert the hook receives the client + URI.
-	const seen: { redirectURI: string; clientId: string }[] = [];
+	const seen: {
+		redirectURI: string;
+		clientId: string;
+		type: "authorize" | "logout";
+	}[] = [];
 
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		baseURL: authServerBaseUrl,
@@ -1439,8 +1443,8 @@ describe("oauth authorize - validateRedirectURI", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
-				validateRedirectURI: ({ client, redirectURI }) => {
-					seen.push({ redirectURI, clientId: client.clientId });
+				validateRedirectURI: ({ client, redirectURI, type }) => {
+					seen.push({ redirectURI, clientId: client.clientId, type });
 					try {
 						const url = new URL(redirectURI);
 						return (
@@ -1507,10 +1511,12 @@ describe("oauth authorize - validateRedirectURI", async () => {
 		expect(callbackRedirectUrl).toContain("code=");
 		expect(callbackRedirectUrl).toContain("state=preview-state");
 		expect(callbackRedirectUrl).not.toContain("error=invalid_redirect");
-		// The hook was consulted with the requested URI and the resolved client.
+		// The hook was consulted with the requested URI, the resolved client, and
+		// the flow type.
 		expect(seen.at(-1)).toEqual({
 			redirectURI: previewRedirectUri,
 			clientId: oauthClient.client_id,
+			type: "authorize",
 		});
 	});
 

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -1421,3 +1421,130 @@ describe("oauth authorize - consented resources", async () => {
 		expect(callbackRedirectUrl).not.toContain("/consent");
 	});
 });
+
+describe("oauth authorize - validateRedirectURI", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const rpBaseUrl = "http://localhost:5000";
+	// An unregistered, dynamic redirect target (e.g. a per-branch preview deploy).
+	const previewRedirectUri =
+		"https://branch-xyz789.preview.example.com/api/auth/oauth2/callback/test";
+
+	// Records every call so we can assert the hook receives the client + URI.
+	const seen: { redirectURI: string; clientId: string }[] = [];
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: { oauthAuthServerConfig: true, openidConfig: true },
+				validateRedirectURI: ({ client, redirectURI }) => {
+					seen.push({ redirectURI, clientId: client.clientId });
+					try {
+						const url = new URL(redirectURI);
+						return (
+							url.protocol === "https:" &&
+							url.hostname.endsWith(".preview.example.com")
+						);
+					} catch {
+						return false;
+					}
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: {
+			customFetchImpl,
+			headers,
+		},
+	});
+
+	let oauthClient: OAuthClient | null;
+	const providerId = "test";
+	const registeredRedirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	beforeAll(async () => {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: { redirect_uris: [registeredRedirectUri], skip_consent: true },
+		});
+		expect(response?.client_id).toBeDefined();
+		oauthClient = response;
+	});
+
+	it("accepts an unregistered redirect_uri that validateRedirectURI approves", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(64);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: previewRedirectUri,
+			state: "preview-state",
+			scopes: ["openid"],
+			responseType: "code",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		expect(callbackRedirectUrl).toContain(previewRedirectUri);
+		expect(callbackRedirectUrl).toContain("code=");
+		expect(callbackRedirectUrl).toContain("state=preview-state");
+		expect(callbackRedirectUrl).not.toContain("error=invalid_redirect");
+		// The hook was consulted with the requested URI and the resolved client.
+		expect(seen.at(-1)).toEqual({
+			redirectURI: previewRedirectUri,
+			clientId: oauthClient.client_id,
+		});
+	});
+
+	it("rejects an unregistered redirect_uri that validateRedirectURI declines", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const untrustedRedirectUri = "https://attacker.example.org/callback";
+		const codeVerifier = generateRandomString(64);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: untrustedRedirectUri,
+			state: "rejected-state",
+			scopes: ["openid"],
+			responseType: "code",
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+			codeVerifier,
+		});
+
+		let location = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				location = context.response.headers.get("Location") || "";
+			},
+		});
+
+		// A declined URI must never receive the code: the error goes to the auth
+		// server's own error page, not the untrusted redirect target.
+		expect(location).not.toContain("attacker.example.org");
+		expect(location).not.toContain("code=");
+		expect(location).toContain("error=invalid_redirect");
+	});
+});

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -528,6 +528,7 @@ export async function authorizeEndpoint(
 			ctx,
 			client,
 			redirectURI: query.redirect_uri,
+			type: "authorize",
 		});
 		if (accepted) {
 			redirectUri = query.redirect_uri;

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -515,10 +515,24 @@ export async function authorizeEndpoint(
 		);
 	}
 
-	const redirectUri = findRegisteredRedirectUri(
+	let redirectUri = findRegisteredRedirectUri(
 		client.redirectUris,
 		query.redirect_uri,
 	);
+	// Last resort: let the server authorize a redirect_uri that isn't registered
+	// (e.g. a dynamic/ephemeral preview deployment). Only consulted when the
+	// built-in checks above did not match, and the implementer is responsible for
+	// validating it strictly — see `validateRedirectURI` in the plugin options.
+	if (!redirectUri && query.redirect_uri && opts.validateRedirectURI) {
+		const accepted = await opts.validateRedirectURI({
+			ctx,
+			client,
+			redirectURI: query.redirect_uri,
+		});
+		if (accepted) {
+			redirectUri = query.redirect_uri;
+		}
+	}
 	if (!redirectUri || !query.redirect_uri) {
 		return handleRedirect(
 			ctx,

--- a/packages/oauth-provider/src/logout.test.ts
+++ b/packages/oauth-provider/src/logout.test.ts
@@ -23,6 +23,15 @@ describe("oauth logout", async () => {
 	const rpBaseUrl = "http://localhost:5000";
 	const state = "123";
 	const scopes = ["openid", "email", "profile", "offline_access"];
+	// An unregistered, dynamic post-logout target (e.g. a per-branch preview deploy).
+	const previewLogoutRedirectUri =
+		"https://branch-xyz789.preview.example.com/logout/callback";
+	// Records every validateRedirectURI call so we can assert the flow type.
+	const seen: {
+		redirectURI: string;
+		clientId: string;
+		type: "authorize" | "logout";
+	}[] = [];
 
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		baseURL: baseUrl,
@@ -36,6 +45,18 @@ describe("oauth logout", async () => {
 					openidConfig: true,
 				},
 				scopes,
+				validateRedirectURI: ({ client, redirectURI, type }) => {
+					seen.push({ redirectURI, clientId: client.clientId, type });
+					try {
+						const url = new URL(redirectURI);
+						return (
+							url.protocol === "https:" &&
+							url.hostname.endsWith(".preview.example.com")
+						);
+					} catch {
+						return false;
+					}
+				},
 			}),
 			jwt(),
 		],
@@ -376,6 +397,135 @@ describe("oauth logout", async () => {
 		expect(logoutRedirectRes).toContain(logoutRedirectUri);
 		expect(logoutRedirectRes).toContain("state=123");
 		expect(logoutRes.error?.status).toBe(302);
+	});
+
+	it("accepts an unregistered post_logout_redirect_uri that validateRedirectURI approves", async () => {
+		// Register a client WITHOUT the preview URI so the exact-match check fails
+		// and the validateRedirectURI hook is consulted as a last resort.
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				enable_end_session: true,
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+			options: {
+				clientId: response.client_id,
+				clientSecret: response.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			headers,
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const tokens = await validateAuthCode({
+			code: new URL(callbackRedirectUrl).searchParams.get("code")!,
+			codeVerifier,
+			options: {
+				clientId: response.client_id,
+				clientSecret: response.client_secret,
+			},
+		});
+		expect(tokens.data?.id_token).toBeDefined();
+
+		let logoutRedirectRes = "";
+		const logoutRes = await client.oauth2.endSession(
+			{
+				query: {
+					id_token_hint: tokens.data?.id_token!,
+					post_logout_redirect_uri: previewLogoutRedirectUri,
+					state: "123",
+				},
+			},
+			{
+				onResponse(ctx) {
+					logoutRedirectRes = ctx.response.headers.get("Location") || "";
+				},
+			},
+		);
+		expect(logoutRedirectRes).toContain(previewLogoutRedirectUri);
+		expect(logoutRedirectRes).toContain("state=123");
+		expect(logoutRes.error?.status).toBe(302);
+		// The hook was consulted with the logout flow type and the resolved client.
+		expect(seen.at(-1)).toEqual({
+			redirectURI: previewLogoutRedirectUri,
+			clientId: response.client_id,
+			type: "logout",
+		});
+	});
+
+	it("rejects an unregistered post_logout_redirect_uri that validateRedirectURI declines", async () => {
+		const untrustedLogoutUri = "https://attacker.example.org/logout";
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				enable_end_session: true,
+				skip_consent: true,
+			},
+		});
+		expect(response?.client_id).toBeDefined();
+
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			scopes,
+			options: {
+				clientId: response.client_id,
+				clientSecret: response.client_secret,
+				redirectURI: redirectUri,
+			},
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			headers,
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const tokens = await validateAuthCode({
+			code: new URL(callbackRedirectUrl).searchParams.get("code")!,
+			codeVerifier,
+			options: {
+				clientId: response.client_id,
+				clientSecret: response.client_secret,
+			},
+		});
+		expect(tokens.data?.id_token).toBeDefined();
+
+		let logoutRedirectRes = "";
+		await client.oauth2.endSession(
+			{
+				query: {
+					id_token_hint: tokens.data?.id_token!,
+					post_logout_redirect_uri: untrustedLogoutUri,
+					state: "123",
+				},
+			},
+			{
+				onResponse(ctx) {
+					logoutRedirectRes = ctx.response.headers.get("Location") || "";
+				},
+			},
+		);
+		// A declined URI must never receive a redirect: the session still ends, but
+		// the user agent is not sent to the untrusted host.
+		expect(logoutRedirectRes).toBe("");
+		expect(logoutRedirectRes).not.toContain("attacker.example.org");
+		expect(seen.at(-1)).toEqual({
+			redirectURI: untrustedLogoutUri,
+			clientId: response.client_id,
+			type: "logout",
+		});
 	});
 });
 

--- a/packages/oauth-provider/src/logout.ts
+++ b/packages/oauth-provider/src/logout.ts
@@ -461,7 +461,21 @@ export async function rpInitiatedLogoutEndpoint(
 
 	if (post_logout_redirect_uri) {
 		const registeredUris = client.postLogoutRedirectUris;
-		if (registeredUris?.includes(post_logout_redirect_uri)) {
+		let accepted = registeredUris?.includes(post_logout_redirect_uri) ?? false;
+		// Last resort: let the server authorize a post_logout_redirect_uri that
+		// isn't registered (e.g. a dynamic/ephemeral preview deployment). Only
+		// consulted when the exact-match check above did not match, and the
+		// implementer is responsible for validating it strictly — see
+		// `validateRedirectURI` in the plugin options.
+		if (!accepted && opts.validateRedirectURI) {
+			accepted = await opts.validateRedirectURI({
+				ctx,
+				client,
+				redirectURI: post_logout_redirect_uri,
+				type: "logout",
+			});
+		}
+		if (accepted) {
 			const redirectUri = new URL(post_logout_redirect_uri);
 			if (state) {
 				redirectUri.searchParams.set("state", state);

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -788,38 +788,50 @@ export interface OAuthOptions<
 		session?: Session & Record<string, unknown>;
 	}) => Awaitable<boolean | undefined>;
 	/**
-	 * Authorize a `redirect_uri` that is NOT among the client's registered
-	 * `redirectUris`.
+	 * Authorize a redirect URI that is NOT among the client's registered URIs.
 	 *
-	 * Called during `/authorize` ONLY after the built-in checks fail — i.e. the
-	 * requested URI did not exactly match any registered URI and was not an
-	 * RFC 8252 loopback-IP equivalent of one. Return `true` to accept the
-	 * requested URI as though it were registered; the authorization code is then
-	 * delivered to it.
+	 * Consulted in two flows, distinguished by `type`:
+	 *
+	 * - `"authorize"` — validates the `redirect_uri` at `/oauth2/authorize`.
+	 *   Called ONLY after the built-in checks fail, i.e. the requested URI did
+	 *   not exactly match any registered `redirectUris` entry and was not an
+	 *   RFC 8252 loopback-IP equivalent of one. Returning `true` delivers the
+	 *   authorization code to the requested URI as though it were registered.
+	 *
+	 * - `"logout"` — validates the `post_logout_redirect_uri` at RP-Initiated
+	 *   Logout. Called ONLY after the requested URI failed to exactly match any
+	 *   registered `postLogoutRedirectUris` entry. Returning `true` redirects the
+	 *   user agent there (with `state` echoed) after the session ends.
 	 *
 	 * Use this for dynamic or ephemeral redirect targets that cannot be
 	 * pre-registered — for example per-branch preview deployments whose
 	 * hostnames are not known ahead of time.
 	 *
-	 * SECURITY: the `redirect_uri` is where the authorization code is sent. A
-	 * permissive matcher is an open-redirector and authorization-code
-	 * exfiltration vector. Validate strictly: bind to the specific `client`,
-	 * require an exact scheme and host allow-list, and never accept apex
-	 * wildcards or user-controlled hosts.
+	 * SECURITY: a permissive matcher is an open redirector. For `"authorize"` it
+	 * additionally leaks the authorization code (an account-takeover vector), so
+	 * the bar is higher there. Validate strictly for BOTH types: bind to the
+	 * specific `client`, require an exact scheme and host allow-list, and never
+	 * accept apex wildcards or user-controlled hosts. Branch on `type` only to
+	 * make logout MORE permissive than authorize, never the reverse.
 	 *
 	 * @example
-	 * validateRedirectURI: ({ client, redirectURI }) => {
+	 * validateRedirectURI: ({ client, redirectURI, type }) => {
 	 * 	const url = new URL(redirectURI);
-	 * 	return (
-	 * 		url.protocol === "https:" &&
-	 * 		url.hostname.endsWith(`.${client.clientId}.preview.example.com`)
-	 * 	);
+	 * 	if (url.protocol !== "https:") return false;
+	 * 	return url.hostname.endsWith(`.${client.clientId}.preview.example.com`);
 	 * }
 	 */
 	validateRedirectURI?: (context: {
 		ctx: GenericEndpointContext;
 		client: SchemaClient<Scopes>;
 		redirectURI: string;
+		/**
+		 * Which flow is requesting validation:
+		 * - `"authorize"` — the `redirect_uri` at `/oauth2/authorize`. Delivers
+		 *   the authorization code, so validate most strictly.
+		 * - `"logout"` — the `post_logout_redirect_uri` at RP-Initiated Logout.
+		 */
+		type: "authorize" | "logout";
 	}) => Awaitable<boolean>;
 	/**
 	 * List default scopes when using the token endpoint's

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -788,6 +788,40 @@ export interface OAuthOptions<
 		session?: Session & Record<string, unknown>;
 	}) => Awaitable<boolean | undefined>;
 	/**
+	 * Authorize a `redirect_uri` that is NOT among the client's registered
+	 * `redirectUris`.
+	 *
+	 * Called during `/authorize` ONLY after the built-in checks fail — i.e. the
+	 * requested URI did not exactly match any registered URI and was not an
+	 * RFC 8252 loopback-IP equivalent of one. Return `true` to accept the
+	 * requested URI as though it were registered; the authorization code is then
+	 * delivered to it.
+	 *
+	 * Use this for dynamic or ephemeral redirect targets that cannot be
+	 * pre-registered — for example per-branch preview deployments whose
+	 * hostnames are not known ahead of time.
+	 *
+	 * SECURITY: the `redirect_uri` is where the authorization code is sent. A
+	 * permissive matcher is an open-redirector and authorization-code
+	 * exfiltration vector. Validate strictly: bind to the specific `client`,
+	 * require an exact scheme and host allow-list, and never accept apex
+	 * wildcards or user-controlled hosts.
+	 *
+	 * @example
+	 * validateRedirectURI: ({ client, redirectURI }) => {
+	 * 	const url = new URL(redirectURI);
+	 * 	return (
+	 * 		url.protocol === "https:" &&
+	 * 		url.hostname.endsWith(`.${client.clientId}.preview.example.com`)
+	 * 	);
+	 * }
+	 */
+	validateRedirectURI?: (context: {
+		ctx: GenericEndpointContext;
+		client: SchemaClient<Scopes>;
+		redirectURI: string;
+	}) => Awaitable<boolean>;
+	/**
 	 * List default scopes when using the token endpoint's
 	 * grant type "client_credentials". This is used
 	 * only when oauthClients are stored in the database

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -807,13 +807,6 @@ export interface OAuthOptions<
 	 * pre-registered — for example per-branch preview deployments whose
 	 * hostnames are not known ahead of time.
 	 *
-	 * SECURITY: a permissive matcher is an open redirector. For `"authorize"` it
-	 * additionally leaks the authorization code (an account-takeover vector), so
-	 * the bar is higher there. Validate strictly for BOTH types: bind to the
-	 * specific `client`, require an exact scheme and host allow-list, and never
-	 * accept apex wildcards or user-controlled hosts. Branch on `type` only to
-	 * make logout MORE permissive than authorize, never the reverse.
-	 *
 	 * @example
 	 * validateRedirectURI: ({ client, redirectURI, type }) => {
 	 * 	const url = new URL(redirectURI);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an optional `validateRedirectURI` hook to `@better-auth/oauth-provider` for dynamic or ephemeral redirect targets. It runs only after built-in exact-match checks (and RFC 8252 loopback for native apps) fail, and supports both authorize (`redirect_uri`) and RP-Initiated Logout (`post_logout_redirect_uri`).

- **New Features**
  - New `validateRedirectURI({ ctx, client, redirectURI, type })` option where `type` is `"authorize"` or `"logout"`. Called only when the requested URI isn’t in the client’s registered list.
  - If it returns `true`: authorize delivers the code to that URI; logout redirects there with `state`. If `false`/unset: authorize fails with `invalid_redirect` and does not redirect; logout ends the session without redirecting to the untrusted host.

<sup>Written for commit 5062699975a5c39e747afb26483bbcd494f641b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

