### PR TITLE
fix: harden forwarded client IP resolution

### DIFF
--- a/.changeset/trusted-forwarded-ip-chains.md
+++ b/.changeset/trusted-forwarded-ip-chains.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+"@better-auth/api-key": patch
+"@better-auth/core": patch
+---
+
+Rate limiting no longer trusts multi-hop `X-Forwarded-For` chains, preventing a client behind an appending proxy from spoofing the leftmost hop to bypass the per-IP rate limit. Single-value IP headers continue to work. To key the real client behind a proxy chain, set `advanced.ipAddress.trustedProxies` to your reverse-proxy IPs or CIDR ranges (the chain is walked right to left, skipping trusted hops), or point `advanced.ipAddress.ipAddressHeaders` at a single trusted client-IP header.

--- a/docs/content/docs/concepts/rate-limit.mdx
+++ b/docs/content/docs/concepts/rate-limit.mdx
@@ -74,6 +74,41 @@ export const auth = betterAuth({
 })
 ```
 
+By default Better Auth does not trust comma-separated forwarded IP chains, since
+the leftmost `X-Forwarded-For` token is client-controlled behind an appending
+proxy. Behind a reverse proxy or load balancer, do one of the following.
+
+Point `ipAddressHeaders` at a single trusted header your proxy sets (for example
+`x-real-ip` or `cf-connecting-ip`):
+
+```ts title="auth.ts"
+export const auth = betterAuth({
+    advanced: {
+        ipAddress: {
+            ipAddressHeaders: ["x-real-ip"],
+        },
+    },
+})
+```
+
+Or list your proxies in `trustedProxies`. Better Auth walks the chain right to
+left, skips the trusted hops, and takes the first untrusted address as the client:
+
+```ts title="auth.ts"
+export const auth = betterAuth({
+    advanced: {
+        ipAddress: {
+            // your proxies' addresses, not a broad private range that also covers clients
+            trustedProxies: ["192.0.2.10", "10.0.0.0/24"],
+        },
+    },
+})
+```
+
+For the forwarded chain to be reliable, requests should reach Better Auth only
+through these proxies, so keep your origin reachable through the proxy rather than
+directly.
+
 #### IPv6 Address Support
 
 Better Auth automatically normalizes IPv6 addresses to prevent bypass attacks where attackers use different representations of the same IPv6 address (e.g., `2001:db8::1` vs `2001:0db8:0000:0000:0000:0000:0000:0001`). This ensures that all representations of the same IPv6 address are treated as the same for rate limiting purposes.

--- a/docs/content/docs/concepts/rate-limit.mdx
+++ b/docs/content/docs/concepts/rate-limit.mdx
@@ -105,9 +105,12 @@ export const auth = betterAuth({
 })
 ```
 
-For the forwarded chain to be reliable, requests should reach Better Auth only
-through these proxies, so keep your origin reachable through the proxy rather than
-directly.
+<Callout type="warning">
+  `trustedProxies` only interprets the forwarded header chain and cannot verify the
+  direct sender. Keep your origin reachable only through these proxies, and make each
+  proxy overwrite or sanitize the forwarded IP headers. Otherwise a client can set
+  `X-Forwarded-For` directly and spoof its address.
+</Callout>
 
 #### IPv6 Address Support
 

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -602,7 +602,7 @@ import { betterAuth } from "better-auth";
 export const auth = betterAuth({
 	advanced: {
 		ipAddress: {
-			ipAddressHeaders: ["x-client-ip", "x-forwarded-for"],
+			ipAddressHeaders: ["x-client-ip", "x-real-ip"],
 			disableIpTracking: false
 		},
 		useSecureCookies: true,
@@ -651,6 +651,9 @@ export const auth = betterAuth({
 ```
 
 * `ipAddress`: IP address configuration for rate limiting and session tracking
+  * `disableIpTracking`: Disable IP address tracking.
+  * `ipAddressHeaders`: Trusted header names to read client IP addresses from.
+  * `trustedProxies`: Reverse-proxy IPs or CIDR ranges. The forwarded chain is walked right to left, trusted hops are skipped, and the first untrusted address is used as the client IP.
 * `useSecureCookies`: By default, cookies are secure in production environments. Set this to `true` to force the `Secure` cookie attribute in all environments.
 * `disableCSRFCheck`: Disable all CSRF protection including origin header validation and Fetch Metadata checks (⚠️ security risk)
 * `disableOriginCheck`: Disable URL validation for `callbackURL`, `redirectTo`, and other redirect URLs (⚠️ security risk)

--- a/docs/content/docs/reference/security.mdx
+++ b/docs/content/docs/reference/security.mdx
@@ -162,6 +162,21 @@ You can configure the IP address header in your Better Auth configuration:
 
 This ensures that Better Auth only accepts IP addresses from your trusted proxy's header, making it more difficult for attackers to bypass rate limiting or other IP-based security measures by spoofing headers.
 
+Behind a proxy chain, list your proxies in `trustedProxies` so Better Auth
+resolves the real client instead of the spoofable leftmost `X-Forwarded-For`
+token:
+
+```typescript
+{
+  advanced: {
+    ipAddress: {
+      // your proxies' addresses, not a broad private range that also covers clients
+      trustedProxies: ['192.0.2.10', '10.0.0.0/24']
+    }
+  }
+}
+```
+
 <Callout type="info">
   **Important**
 

--- a/packages/api-key/src/utils.ts
+++ b/packages/api-key/src/utils.ts
@@ -19,6 +19,8 @@ import { getIPFromHeader } from "@better-auth/core/utils/ip";
 
 const LOCALHOST_IP = "127.0.0.1";
 
+// TODO: this duplicates `better-auth` request-IP resolver. Centralize it
+// behind a shared export so the security-sensitive logic lives in one place.
 export function getIp(
 	req: Request | Headers,
 	options: BetterAuthOptions,

--- a/packages/api-key/src/utils.ts
+++ b/packages/api-key/src/utils.ts
@@ -15,9 +15,8 @@ export function isAPIError(error: unknown): error is APIError {
 
 import type { BetterAuthOptions } from "@better-auth/core";
 import { isDevelopment, isTest } from "@better-auth/core/env";
-import { isValidIP, normalizeIP } from "@better-auth/core/utils/ip";
+import { getIPFromHeader } from "@better-auth/core/utils/ip";
 
-// Localhost IP used for test and development environments
 const LOCALHOST_IP = "127.0.0.1";
 
 export function getIp(
@@ -38,11 +37,12 @@ export function getIp(
 	for (const key of ipHeaders) {
 		const value = "get" in headers ? headers.get(key) : headers[key];
 		if (typeof value === "string") {
-			const ip = value.split(",")[0]!.trim();
-			if (isValidIP(ip)) {
-				return normalizeIP(ip, {
-					ipv6Subnet: options.advanced?.ipAddress?.ipv6Subnet,
-				});
+			const ip = getIPFromHeader(value, {
+				ipv6Subnet: options.advanced?.ipAddress?.ipv6Subnet,
+				trustedProxies: options.advanced?.ipAddress?.trustedProxies,
+			});
+			if (ip) {
+				return ip;
 			}
 		}
 	}

--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -384,7 +384,8 @@ async function resolveRateLimitConfig(req: Request, ctx: AuthContext) {
 		ctx.logger.warn(
 			"Rate limiting could not determine a client IP and is falling back to a " +
 				"single shared per-path bucket. Ensure your runtime forwards a trusted " +
-				"client IP header and configure `advanced.ipAddress.ipAddressHeaders` if needed.",
+				"client IP header, then set `advanced.ipAddress.ipAddressHeaders` or " +
+				"`advanced.ipAddress.trustedProxies` so the address can be resolved.",
 		);
 		ipWarningLogged = true;
 	}

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -389,14 +389,15 @@ describe("missing client IP warning", () => {
 	const warningMessage =
 		"Rate limiting could not determine a client IP and is falling back to a " +
 		"single shared per-path bucket. Ensure your runtime forwards a trusted " +
-		"client IP header and configure `advanced.ipAddress.ipAddressHeaders` if needed.";
+		"client IP header, then set `advanced.ipAddress.ipAddressHeaders` or " +
+		"`advanced.ipAddress.trustedProxies` so the address can be resolved.";
 
 	afterEach(() => {
 		vi.unstubAllEnvs();
 		vi.resetModules();
 	});
 
-	it("should point users to ipAddressHeaders when no client IP is available outside dev/test", async () => {
+	it("should point users to ipAddressHeaders and trustedProxies when no client IP is available outside dev/test", async () => {
 		vi.stubEnv("NODE_ENV", "production");
 		vi.stubEnv("TEST", "false");
 		vi.resetModules();
@@ -422,11 +423,6 @@ describe("missing client IP warning", () => {
 		expect(response.error?.status).not.toBe(429);
 		expect(log).toHaveBeenCalledOnce();
 		expect(log).toHaveBeenCalledWith("warn", warningMessage);
-		expect(
-			log.mock.calls.some(([, message]) =>
-				`${message}`.includes("trustedProxies"),
-			),
-		).toBe(false);
 	});
 
 	it("should fail closed and still enforce the limit when no client IP is available", async () => {

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -460,6 +460,119 @@ describe("missing client IP warning", () => {
 	});
 });
 
+describe("forwarded IP chains", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.resetModules();
+	});
+
+	it("should not key limits by untrusted forwarded chain entries", async () => {
+		vi.stubEnv("NODE_ENV", "production");
+		vi.stubEnv("TEST", "false");
+		vi.resetModules();
+
+		const store = new Map<string, string>();
+		const { getTestInstance: getTestInstanceReloaded } = await import(
+			"../../test-utils/test-instance"
+		);
+		const { client, testUser } = await getTestInstanceReloaded({
+			rateLimit: {
+				enabled: true,
+				window: 10,
+				max: 20,
+			},
+			secondaryStorage: {
+				set(key, value) {
+					store.set(key, value);
+				},
+				get(key) {
+					return store.get(key) || null;
+				},
+				delete(key) {
+					store.delete(key);
+				},
+			},
+		});
+
+		for (let i = 0; i < 4; i++) {
+			const response = await client.signIn.email({
+				email: testUser.email,
+				password: testUser.password,
+				fetchOptions: {
+					headers: {
+						"x-forwarded-for": `198.51.100.${i + 20}, 10.0.0.5`,
+					},
+				},
+			});
+
+			if (i >= 3) {
+				expect(response.error?.status).toBe(429);
+			} else {
+				expect(response.error).toBeNull();
+			}
+		}
+
+		expect(store.has("no-trusted-ip|/sign-in/email")).toBe(true);
+	});
+
+	it("should key the real client when trusted proxies are configured", async () => {
+		vi.stubEnv("NODE_ENV", "production");
+		vi.stubEnv("TEST", "false");
+		vi.resetModules();
+
+		const store = new Map<string, string>();
+		const { getTestInstance: getTestInstanceReloaded } = await import(
+			"../../test-utils/test-instance"
+		);
+		const { client, testUser } = await getTestInstanceReloaded({
+			rateLimit: {
+				enabled: true,
+				window: 10,
+				max: 20,
+			},
+			advanced: {
+				ipAddress: {
+					trustedProxies: ["10.0.0.0/8"],
+				},
+			},
+			secondaryStorage: {
+				set(key, value) {
+					store.set(key, value);
+				},
+				get(key) {
+					return store.get(key) || null;
+				},
+				delete(key) {
+					store.delete(key);
+				},
+			},
+		});
+
+		// `<rotating spoofed>, <real client>, <trusted proxy>`: spoofed rotation
+		// cannot escape the bucket keyed by the constant real client.
+		for (let i = 0; i < 4; i++) {
+			const response = await client.signIn.email({
+				email: testUser.email,
+				password: testUser.password,
+				fetchOptions: {
+					headers: {
+						"x-forwarded-for": `203.0.113.${i + 20}, 198.51.100.10, 10.0.0.5`,
+					},
+				},
+			});
+
+			if (i >= 3) {
+				expect(response.error?.status).toBe(429);
+			} else {
+				expect(response.error).toBeNull();
+			}
+		}
+
+		expect(store.has("198.51.100.10|/sign-in/email")).toBe(true);
+		expect(store.has("no-trusted-ip|/sign-in/email")).toBe(false);
+	});
+});
+
 describe("IPv6 address normalization and rate limiting", () => {
 	it("should normalize IPv6 addresses to canonical form", () => {
 		// All these representations of the same IPv6 address should normalize to the same value

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -12,6 +12,7 @@ import type { OAuthProvider } from "@better-auth/core/oauth2";
 import type { SocialProviders } from "@better-auth/core/social-providers";
 import { socialProviders } from "@better-auth/core/social-providers";
 import { generateId } from "@better-auth/core/utils/id";
+import { findInvalidTrustedProxies } from "@better-auth/core/utils/ip";
 import { createTelemetry } from "@better-auth/telemetry";
 import defu from "defu";
 import type { Entries } from "type-fest";
@@ -197,6 +198,17 @@ Most of the features of Better Auth will not work correctly.`,
 	};
 
 	checkEndpointConflicts(options, logger);
+
+	const trustedProxies = options.advanced?.ipAddress?.trustedProxies;
+	if (trustedProxies && trustedProxies.length > 0) {
+		const invalid = findInvalidTrustedProxies(trustedProxies);
+		if (invalid.length > 0) {
+			logger.warn(
+				`Ignoring invalid \`advanced.ipAddress.trustedProxies\` entries: ${invalid.join(", ")}. Each entry must be an IP address or CIDR range.`,
+			);
+		}
+	}
+
 	const cookies = getCookies(options);
 	const tables = getAuthTables(options);
 	// TODO(#9294): allow registering the same provider multiple times under

--- a/packages/better-auth/src/utils/get-request-ip.ts
+++ b/packages/better-auth/src/utils/get-request-ip.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthOptions } from "@better-auth/core";
 import { isDevelopment, isTest } from "@better-auth/core/env";
-import { isValidIP, normalizeIP } from "@better-auth/core/utils/ip";
+import { getIPFromHeader } from "@better-auth/core/utils/ip";
 
 // Localhost IP used for test and development environments
 const LOCALHOST_IP = "127.0.0.1";
@@ -23,11 +23,12 @@ export function getIp(
 	for (const key of ipHeaders) {
 		const value = "get" in headers ? headers.get(key) : headers[key];
 		if (typeof value === "string") {
-			const ip = value.split(",")[0]!.trim();
-			if (isValidIP(ip)) {
-				return normalizeIP(ip, {
-					ipv6Subnet: options.advanced?.ipAddress?.ipv6Subnet,
-				});
+			const ip = getIPFromHeader(value, {
+				ipv6Subnet: options.advanced?.ipAddress?.ipv6Subnet,
+				trustedProxies: options.advanced?.ipAddress?.trustedProxies,
+			});
+			if (ip) {
+				return ip;
 			}
 		}
 	}

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -240,6 +240,16 @@ export type BetterAuthAdvancedOptions = {
 				 * @default 64
 				 */
 				ipv6Subnet?: number;
+				/**
+				 * Trusted reverse-proxy IPs or CIDR ranges. When set, a forwarded IP
+				 * chain is walked right to left, trusted hops are skipped, and the
+				 * first untrusted address is the client IP. Unset trusts only
+				 * single-value IP headers. Use the actual address or subnet of your
+				 * proxies, not a broad private range that also covers clients.
+				 *
+				 * @example ["192.0.2.10", "10.0.0.0/24"]
+				 */
+				trustedProxies?: string[];
 		  }
 		| undefined;
 	/**

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -247,6 +247,11 @@ export type BetterAuthAdvancedOptions = {
 				 * single-value IP headers. Use the actual address or subnet of your
 				 * proxies, not a broad private range that also covers clients.
 				 *
+				 * This only interprets the forwarded header chain and cannot verify
+				 * the direct sender. It is safe only when your origin is reachable
+				 * through these proxies and clients cannot set forwarded headers
+				 * directly.
+				 *
 				 * @example ["192.0.2.10", "10.0.0.0/24"]
 				 */
 				trustedProxies?: string[];

--- a/packages/core/src/utils/ip.test.ts
+++ b/packages/core/src/utils/ip.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { createRateLimitKey, isValidIP, normalizeIP } from "./ip";
+import {
+	createRateLimitKey,
+	findInvalidTrustedProxies,
+	getIPFromHeader,
+	isValidIP,
+	normalizeIP,
+} from "./ip";
 
 describe("IP Normalization", () => {
 	describe("isValidIP", () => {
@@ -194,6 +200,132 @@ describe("IP Normalization", () => {
 			expect(key1).not.toBe(key2);
 			expect(key1).toBe("192.0.2.1|/sign-in");
 			expect(key2).toBe("192.0.2|.1/sign-in");
+		});
+	});
+
+	describe("Header IP Selection", () => {
+		it("should accept a single trusted header value", () => {
+			expect(getIPFromHeader(" 198.51.100.10 ")).toBe("198.51.100.10");
+		});
+
+		it("should reject forwarded chains without a single trusted header", () => {
+			expect(getIPFromHeader("198.51.100.10, 10.0.0.5")).toBeNull();
+		});
+
+		it("should reject invalid header values", () => {
+			expect(getIPFromHeader("")).toBeNull();
+			expect(getIPFromHeader("not-an-ip")).toBeNull();
+		});
+
+		it("should normalize selected forwarded values", () => {
+			expect(
+				getIPFromHeader("2001:db8::1", {
+					ipv6Subnet: 128,
+				}),
+			).toBe("2001:0db8:0000:0000:0000:0000:0000:0001");
+		});
+	});
+
+	describe("Header IP Selection with trusted proxies", () => {
+		const trustedProxies = ["10.0.0.0/8"];
+
+		it("should take the rightmost untrusted hop, ignoring spoofed left entries", () => {
+			// `<spoofed>, <real client>, <trusted proxy>`: skip trusted, take rightmost untrusted.
+			expect(
+				getIPFromHeader("1.2.3.4, 198.51.100.10, 10.0.0.5", {
+					trustedProxies,
+				}),
+			).toBe("198.51.100.10");
+		});
+
+		it("should not be moved by a rotating spoofed leftmost hop", () => {
+			expect(
+				getIPFromHeader("203.0.113.7, 198.51.100.10, 10.0.0.5", {
+					trustedProxies,
+				}),
+			).toBe("198.51.100.10");
+			expect(
+				getIPFromHeader("203.0.113.8, 198.51.100.10, 10.0.0.5", {
+					trustedProxies,
+				}),
+			).toBe("198.51.100.10");
+		});
+
+		it("should fail closed when every hop is a trusted proxy", () => {
+			expect(
+				getIPFromHeader("10.0.0.9, 10.0.0.5", { trustedProxies }),
+			).toBeNull();
+		});
+
+		it("should fail closed on a malformed rightmost hop", () => {
+			expect(
+				getIPFromHeader("198.51.100.10, not-an-ip", { trustedProxies }),
+			).toBeNull();
+		});
+
+		it("should support CIDR and bare-IP trusted entries", () => {
+			expect(
+				getIPFromHeader("198.51.100.10, 192.0.2.1", {
+					trustedProxies: ["192.0.2.1"],
+				}),
+			).toBe("198.51.100.10");
+		});
+
+		it("should skip trusted IPv6 proxy hops", () => {
+			expect(
+				getIPFromHeader("2001:db8::1, fc00::1", {
+					trustedProxies: ["fc00::/7"],
+					ipv6Subnet: 128,
+				}),
+			).toBe("2001:0db8:0000:0000:0000:0000:0000:0001");
+		});
+
+		it("should not enable chain mode when every entry is malformed", () => {
+			// A malformed-only config must not leave the chain enabled-but-empty,
+			// which would return the real proxy hop as the client. With no valid
+			// proxy the multi-hop chain is unresolvable, so it fails closed.
+			expect(
+				getIPFromHeader("198.51.100.10, 10.0.0.5", {
+					trustedProxies: ["10.0.0.0/8x"],
+				}),
+			).toBeNull();
+		});
+
+		it("should use the valid entries when some are malformed", () => {
+			expect(
+				getIPFromHeader("198.51.100.10, 10.0.0.5", {
+					trustedProxies: ["10.0.0.0/8x", "10.0.0.0/8"],
+				}),
+			).toBe("198.51.100.10");
+		});
+	});
+
+	describe("findInvalidTrustedProxies", () => {
+		it("should accept valid IPs and CIDR ranges", () => {
+			expect(
+				findInvalidTrustedProxies([
+					"10.0.0.5",
+					"10.0.0.0/8",
+					"::1",
+					"fc00::/7",
+					"0.0.0.0/0",
+				]),
+			).toEqual([]);
+		});
+
+		it("should report malformed entries", () => {
+			const invalid = [
+				"10.0.0./8",
+				"10.0.0.0/8x",
+				"10.0.0.0/33",
+				"10.0.0.0/3.5",
+				"10.0.0.0/",
+				"not-an-ip",
+				"",
+			];
+			expect(findInvalidTrustedProxies(["10.0.0.0/8", ...invalid])).toEqual(
+				invalid,
+			);
 		});
 	});
 

--- a/packages/core/src/utils/ip.ts
+++ b/packages/core/src/utils/ip.ts
@@ -196,6 +196,146 @@ export function normalizeIP(
 }
 
 /**
+ * Raw bytes of an IP for CIDR comparison. Returns `null` for an invalid IP.
+ */
+function ipToBytes(ip: string): Uint8Array | null {
+	if (z.ipv4().safeParse(ip).success) {
+		return Uint8Array.from(ip.split(".").map((octet) => Number(octet)));
+	}
+	if (!isIPv6(ip)) {
+		return null;
+	}
+	const mapped = extractIPv4FromMapped(ip);
+	if (mapped) {
+		return Uint8Array.from(mapped.split(".").map((octet) => Number(octet)));
+	}
+	const groups = expandIPv6(ip);
+	const bytes = new Uint8Array(16);
+	for (let i = 0; i < 8; i++) {
+		const group = Number.parseInt(groups[i] ?? "0", 16);
+		bytes[i * 2] = (group >> 8) & 0xff;
+		bytes[i * 2 + 1] = group & 0xff;
+	}
+	return bytes;
+}
+
+// A CIDR prefix length must be decimal digits only, so values like "8x" or
+// "1e3" that `Number()` would otherwise coerce are rejected.
+const CIDR_PREFIX_PATTERN = /^\d+$/;
+
+/**
+ * Parses an IP or `IP/prefix` string into network bytes and a prefix length.
+ * The prefix must be digits only and within the address family. `null` if the
+ * value is not a valid IP or CIDR range, which keeps a malformed entry from
+ * silently behaving like a non-match.
+ */
+function parseCIDR(
+	value: string,
+): { bytes: Uint8Array; prefix: number } | null {
+	const slash = value.lastIndexOf("/");
+	const bytes = ipToBytes(slash === -1 ? value : value.slice(0, slash));
+	if (!bytes) {
+		return null;
+	}
+	const maxBits = bytes.length * 8;
+	if (slash === -1) {
+		return { bytes, prefix: maxBits };
+	}
+	const prefixPart = value.slice(slash + 1);
+	if (!CIDR_PREFIX_PATTERN.test(prefixPart)) {
+		return null;
+	}
+	const prefix = Number(prefixPart);
+	return prefix <= maxBits ? { bytes, prefix } : null;
+}
+
+/**
+ * Whether `ipBytes` falls inside an already-parsed CIDR network.
+ */
+function matchesCIDR(
+	ipBytes: Uint8Array,
+	net: { bytes: Uint8Array; prefix: number },
+): boolean {
+	if (ipBytes.length !== net.bytes.length) {
+		return false;
+	}
+	let bitsRemaining = net.prefix;
+	for (let i = 0; i < ipBytes.length && bitsRemaining > 0; i++) {
+		const take = bitsRemaining >= 8 ? 8 : bitsRemaining;
+		const mask = take === 8 ? 0xff : (0xff << (8 - take)) & 0xff;
+		if (((ipBytes[i] ?? 0) & mask) !== ((net.bytes[i] ?? 0) & mask)) {
+			return false;
+		}
+		bitsRemaining -= 8;
+	}
+	return true;
+}
+
+/**
+ * Trusted-proxy entries that are not a valid IP address or CIDR range.
+ */
+export function findInvalidTrustedProxies(entries: string[]): string[] {
+	return entries.filter((entry) => parseCIDR(entry) === null);
+}
+
+/**
+ * Resolves the client IP from a forwarded header. The leftmost token is spoofable,
+ * so with `trustedProxies` the chain is stripped from the right to the first
+ * untrusted hop. Otherwise only a single-value header is trusted. `null` = shared bucket.
+ */
+export function getIPFromHeader(
+	value: string,
+	options: {
+		ipv6Subnet?: number;
+		trustedProxies?: string[];
+	} = {},
+): string | null {
+	const forwardedIps = value
+		.split(",")
+		.map((ip) => ip.trim())
+		.filter(Boolean);
+	if (forwardedIps.length === 0) {
+		return null;
+	}
+
+	// Parse trusted proxies once, dropping malformed entries so a config typo
+	// cannot leave the chain enabled-but-empty and return a real proxy hop as
+	// the client. With no valid proxy the chain mode does not engage.
+	const trustedProxies = (options.trustedProxies ?? [])
+		.map(parseCIDR)
+		.filter((proxy): proxy is { bytes: Uint8Array; prefix: number } => {
+			return proxy !== null;
+		});
+
+	if (trustedProxies.length > 0) {
+		for (let i = forwardedIps.length - 1; i >= 0; i--) {
+			const ip = forwardedIps[i];
+			const ipBytes = ip ? ipToBytes(ip) : null;
+			// A malformed hop breaks the chain: fail closed.
+			if (!ip || !ipBytes) {
+				return null;
+			}
+			if (trustedProxies.some((proxy) => matchesCIDR(ipBytes, proxy))) {
+				continue;
+			}
+			return normalizeIP(ip, { ipv6Subnet: options.ipv6Subnet });
+		}
+		return null;
+	}
+
+	// Without valid trusted proxies a multi-hop chain is unresolvable.
+	if (forwardedIps.length !== 1) {
+		return null;
+	}
+	const selectedIp = forwardedIps[0];
+	if (!selectedIp || !isValidIP(selectedIp)) {
+		return null;
+	}
+
+	return normalizeIP(selectedIp, { ipv6Subnet: options.ipv6Subnet });
+}
+
+/**
  * Creates a rate limit key from IP and path
  * Uses a separator to prevent collision attacks
  *

--- a/packages/core/src/utils/ip.ts
+++ b/packages/core/src/utils/ip.ts
@@ -281,7 +281,8 @@ export function findInvalidTrustedProxies(entries: string[]): string[] {
 /**
  * Resolves the client IP from a forwarded header. The leftmost token is spoofable,
  * so with `trustedProxies` the chain is stripped from the right to the first
- * untrusted hop. Otherwise only a single-value header is trusted. `null` = shared bucket.
+ * untrusted hop. Otherwise only a single-value header is trusted. Returns `null`
+ * when no trustworthy client IP can be resolved.
  */
 export function getIPFromHeader(
 	value: string,


### PR DESCRIPTION
> [!NOTE]
> Any security-related use of X-Forwarded-For (such as for rate limiting or IP-based access control) must only use IP addresses added by a trusted proxy. Using untrustworthy values can result in rate-limiter avoidance, access-control bypass, memory exhaustion, or other negative security or availability consequences.
> 
> https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For

Systems that have already configured ipAddressHeaders with trusted values are not affected.

Systems behind multiple proxy hops that have not configured ipAddressHeaders will fall back to the default X-Forwarded-For handling and may break as a result of this hardening.

However, that is the intended behavior of this PR.