### PR TITLE
fix(expo): send origin for id token link social

### DIFF
--- a/.changeset/curly-expo-origins.md
+++ b/.changeset/curly-expo-origins.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/expo": patch
+---
+
+Send the Expo origin header when linking social accounts with an ID token so native link flows that include a session cookie pass origin validation.

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -522,24 +522,20 @@ export const expoClient = (opts: ExpoClientOptions) => {
 					}
 					options = options || {};
 					options.credentials = "omit";
-					/**
-					 * ID token flow (native sign-in) doesn't need cookie-based auth.
-					 * The ID token itself is cryptographically signed by the provider
-					 * and validated server-side, so no session cookies or origin
-					 * validation is required.
-					 *
-					 * Sending cookie/expo-origin headers for ID token requests triggers
-					 * unnecessary origin checks that fail for custom URL schemes.
-					 */
 					const isIdTokenRequest = options.body?.idToken !== undefined;
 
 					if (isIdTokenRequest) {
-						const cookie = url.includes("/link-social")
+						const isLinkSocial = url.includes("/link-social");
+						// ID token sign-in validates the provider token directly. Link-social
+						// still needs the current session cookie, so it also needs an origin
+						// header for the server-side CSRF check.
+						const cookie = isLinkSocial
 							? getCookie(storage.getItem(cookieName) || "{}")
 							: "";
 						options.headers = {
 							...options.headers,
 							...(cookie ? { cookie } : {}),
+							...(isLinkSocial ? { "expo-origin": getOrigin(scheme!) } : {}),
 							"x-skip-oauth-proxy": "true",
 						};
 					} else {

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -581,7 +581,7 @@ describe("expo", async () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9900
 	 */
-	it("should send cookie for link-social ID token requests", async () => {
+	it("should send cookie and expo-origin for link-social ID token requests", async () => {
 		let cookieHeader: string | null | undefined = null;
 		let expoOriginHeader: string | null | undefined = null;
 		const storage = new Map<string, string>();
@@ -634,7 +634,7 @@ describe("expo", async () => {
 		});
 
 		expect(cookieHeader).toContain("better-auth.session_token=existing-token");
-		expect(expoOriginHeader).toBeNull();
+		expect(expoOriginHeader).toBe("better-auth://");
 	});
 
 	it("should preserve existing cookies on link-social", async () => {


### PR DESCRIPTION
## What changed

- include `expo-origin` for native `/link-social` requests that use `idToken`
- keep regular idToken sign-in requests cookie-free and origin-free
- update the Expo regression test to assert both the session cookie and Expo origin are sent for idToken link-social

## Why

After #9953, Expo link-social idToken requests include the session cookie. That makes Better Auth run origin validation, but the Expo client did not send `expo-origin` on that branch, causing native account-linking requests to fail with `Missing or null Origin` before reaching the link logic.

## Validation

- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm vitest packages/expo/test/expo.test.ts -t "ID token requests|link-social ID token" --run`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm exec tsc --build packages/expo/tsconfig.json`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm exec biome check packages/expo/src/client.ts packages/expo/test/expo.test.ts .changeset/curly-expo-origins.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the `expo-origin` header with native `/link-social` ID token requests in `@better-auth/expo` so origin validation passes; keep other ID token sign-ins cookie-free and origin-free.

- **Bug Fixes**
  - Include the session cookie and `expo-origin` for `/link-social` requests using `idToken`, fixing native account-linking failures after origin checks; tests assert both are sent.
  - Non-`/link-social` `idToken` sign-ins continue to omit cookies and origin headers.

<sup>Written for commit 13e2c50251eba46c79f786ba71f3129368911c0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

