### PR TITLE
fix: prevent duplicate id token account links

### DIFF
--- a/.changeset/modern-account-links.md
+++ b/.changeset/modern-account-links.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Prevent ID token account linking from attaching a provider account that is already linked to a different user.

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -680,6 +680,9 @@ describe("account", async () => {
 		});
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10214
+	 */
 	it("should reject idToken linkSocial when the provider account belongs to another user", async () => {
 		const {
 			auth: scopedAuth,

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -680,6 +680,95 @@ describe("account", async () => {
 		});
 	});
 
+	it("should reject idToken linkSocial when the provider account belongs to another user", async () => {
+		const {
+			auth: scopedAuth,
+			client: scopedClient,
+			cookieSetter: scopedCookieSetter,
+			signInWithTestUser: scopedSignInWithTestUser,
+		} = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			emailAndPassword: {
+				enabled: true,
+			},
+			account: {
+				accountLinking: {
+					allowDifferentEmails: true,
+				},
+			},
+		});
+		const scopedCtx = await scopedAuth.$context;
+		const googleProvider = scopedCtx.socialProviders.find(
+			(provider) => provider.id === "google",
+		)!;
+		const providerAccountId = "shared-google-provider-account";
+		const providerUser = {
+			id: providerAccountId,
+			name: "Shared Google User",
+			email: "shared-google-user@example.com",
+			emailVerified: true,
+		};
+		vi.spyOn(googleProvider, "verifyIdToken").mockResolvedValue(true);
+		vi.spyOn(googleProvider, "getUserInfo").mockResolvedValue({
+			user: providerUser,
+			data: providerUser,
+		});
+
+		const firstSession = await scopedSignInWithTestUser();
+		await firstSession.runWithUser(async () => {
+			const firstLink = await scopedClient.linkSocial({
+				provider: "google",
+				idToken: { token: "first-id-token" },
+			});
+
+			expect(firstLink.error).toBeNull();
+		});
+
+		const secondHeaders = new Headers();
+		const secondSignUp = await scopedClient.signUp.email(
+			{
+				email: "second-link-target@example.com",
+				password: "password123",
+				name: "Second Link Target",
+			},
+			{
+				onSuccess: scopedCookieSetter(secondHeaders),
+			},
+		);
+		expect(secondSignUp.error).toBeNull();
+
+		const secondLink = await scopedClient.linkSocial(
+			{
+				provider: "google",
+				idToken: { token: "second-id-token" },
+			},
+			{
+				headers: secondHeaders,
+			},
+		);
+
+		expect(secondLink.error?.status).toBe(409);
+		expect(secondLink.error?.code).toBe(
+			BASE_ERROR_CODES.SOCIAL_ACCOUNT_ALREADY_LINKED.code,
+		);
+
+		const linkedAccounts = await scopedCtx.adapter.findMany<Account>({
+			model: "account",
+			where: [
+				{ field: "providerId", value: "google" },
+				{ field: "accountId", value: providerAccountId },
+			],
+		});
+		expect(linkedAccounts).toHaveLength(1);
+		expect(linkedAccounts[0]?.userId).toBe(firstSession.user.id);
+	});
+
 	it("should unlink account", async () => {
 		const { runWithUser } = await signInWithTestUser();
 		await runWithUser(async () => {

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -284,20 +284,25 @@ export const linkSocialAccount = createAuthEndpoint(
 				);
 			}
 
-			const existingAccounts = await c.context.internalAdapter.findAccounts(
-				session.user.id,
-			);
+			const linkedAccount =
+				await c.context.internalAdapter.findAccountByProviderId(
+					linkingUserId,
+					provider.id,
+				);
 
-			const hasBeenLinked = existingAccounts.find(
-				(a) => a.providerId === provider.id && a.accountId === linkingUserId,
-			);
+			if (linkedAccount) {
+				if (linkedAccount.userId === session.user.id) {
+					return c.json({
+						url: "", // this is for type inference
+						status: true,
+						redirect: false,
+					});
+				}
 
-			if (hasBeenLinked) {
-				return c.json({
-					url: "", // this is for type inference
-					status: true,
-					redirect: false,
-				});
+				throw APIError.from(
+					"CONFLICT",
+					BASE_ERROR_CODES.SOCIAL_ACCOUNT_ALREADY_LINKED,
+				);
 			}
 
 			const isTrustedProvider = c.context.trustedProviders.includes(


### PR DESCRIPTION
Fixes #10214

## What changed

- checks the provider-scoped `providerId` + `accountId` mapping before creating an account in the `linkSocial({ idToken })` flow
- keeps repeated linking by the same user idempotent
- returns `SOCIAL_ACCOUNT_ALREADY_LINKED` with `409 Conflict` when that provider account already belongs to a different user
- adds a regression test that links a provider account to one user and verifies a second user cannot attach the same provider account

## Why

The redirect OAuth linking flow already treats the provider account identifier as the ownership key. The direct ID token link flow only checked the current user's accounts before creating a new account row, so two local users could link the same provider identity. In that state, subsequent sign-in can resolve whichever duplicate account is returned first by the adapter/database.

This PR fixes that at the application layer. A database-level unique constraint on `providerId` + `accountId` would be a useful follow-up hardening step, but it likely needs separate discussion because it affects migrations and existing installations that may already contain duplicate rows.

## Validation

- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm vitest packages/better-auth/src/api/routes/account.test.ts --run`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm exec tsc --build packages/better-auth/tsconfig.json`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm exec biome check packages/better-auth/src/api/routes/account.ts packages/better-auth/src/api/routes/account.test.ts .changeset/modern-account-links.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate ID token social account linking by enforcing a single owner per provider account. Linking is idempotent for the same user and returns 409 Conflict when the provider account is already linked to someone else.

- **Bug Fixes**
  - Look up existing provider account via `findAccountByProviderId` before creating a link in `linkSocial({ idToken })`.
  - No-op when the same user relinks the same provider account.
  - Return 409 Conflict with `SOCIAL_ACCOUNT_ALREADY_LINKED` when another user attempts to link it.
  - Add regression test that links once, then verifies the second link fails and only one `account` row exists for the `providerId` + `accountId`, owned by the first user.

<sup>Written for commit d681e513aee08d3fbc940a9c366cfa80c0ee7f51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

