### PR TITLE
fix(two-factor): cap verification attempts on TOTP and backup codes

### DIFF
--- a/.changeset/two-factor-verify-attempt-cap.md
+++ b/.changeset/two-factor-verify-attempt-cap.md
@@ -3,3 +3,5 @@
 ---
 
 Two-factor verification now locks out after five wrong codes per sign-in challenge for TOTP and backup codes. Once the limit is reached the challenge is rejected with `TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE`, and a new sign-in is required to try again.
+
+During a rolling deploy, two-factor challenges issued by the previous version may prompt the user to sign in again; this clears once the deploy completes.

--- a/.changeset/two-factor-verify-attempt-cap.md
+++ b/.changeset/two-factor-verify-attempt-cap.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Two-factor verification now locks out after five wrong codes per sign-in challenge for TOTP and backup codes. Once the limit is reached the challenge is rejected with `TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE`, and a new sign-in is required to try again.

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -9,13 +9,14 @@ import { generateRandomString } from "../../../crypto/random";
 import { parseUserOutput } from "../../../db/schema";
 import { shouldRequirePassword } from "../../../utils/password";
 import { PACKAGE_VERSION } from "../../../version";
+import { DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS } from "../constant";
 import { TWO_FACTOR_ERROR_CODES } from "../error-code";
 import type {
 	TwoFactorProvider,
 	TwoFactorTable,
 	UserWithTwoFactor,
 } from "../types";
-import { verifyTwoFactor } from "../verify-two-factor";
+import { beginTwoFactorAttempt, verifyTwoFactor } from "../verify-two-factor";
 
 export interface BackupCodeOptions {
 	/**
@@ -318,8 +319,9 @@ export const backupCode2fa = (opts: BackupCodeOptions) => {
 					},
 				},
 				async (ctx) => {
-					const { session, valid } = await verifyTwoFactor(ctx);
+					const { session, valid, key } = await verifyTwoFactor(ctx);
 					const user = session.user as UserWithTwoFactor;
+					const isSignIn = !session.session;
 					const twoFactor = await ctx.context.adapter.findOne<TwoFactorTable>({
 						model: twoFactorTable,
 						where: [
@@ -335,6 +337,15 @@ export const backupCode2fa = (opts: BackupCodeOptions) => {
 							TWO_FACTOR_ERROR_CODES.BACKUP_CODES_NOT_ENABLED,
 						);
 					}
+					// Enforce the per-challenge attempt budget on the sign-in path.
+					// The re-verify branch (already authenticated) has no counter.
+					const attempt = isSignIn
+						? await beginTwoFactorAttempt(
+								ctx,
+								key,
+								DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS,
+							)
+						: null;
 					const validate = await verifyBackupCode(
 						{
 							backupCodes: twoFactor.backupCodes,
@@ -344,6 +355,7 @@ export const backupCode2fa = (opts: BackupCodeOptions) => {
 						opts,
 					);
 					if (!validate.status || !validate.updated) {
+						await attempt?.recordFailure();
 						throw APIError.from(
 							"UNAUTHORIZED",
 							TWO_FACTOR_ERROR_CODES.INVALID_BACKUP_CODE,

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -16,7 +16,7 @@ import type {
 	TwoFactorTable,
 	UserWithTwoFactor,
 } from "../types";
-import { beginTwoFactorAttempt, verifyTwoFactor } from "../verify-two-factor";
+import { verifyTwoFactor } from "../verify-two-factor";
 
 export interface BackupCodeOptions {
 	/**
@@ -319,7 +319,7 @@ export const backupCode2fa = (opts: BackupCodeOptions) => {
 					},
 				},
 				async (ctx) => {
-					const { session, valid, key } = await verifyTwoFactor(ctx);
+					const { session, valid, beginAttempt } = await verifyTwoFactor(ctx);
 					const user = session.user as UserWithTwoFactor;
 					const isSignIn = !session.session;
 					const twoFactor = await ctx.context.adapter.findOne<TwoFactorTable>({
@@ -338,13 +338,9 @@ export const backupCode2fa = (opts: BackupCodeOptions) => {
 						);
 					}
 					// Enforce the per-challenge attempt budget on the sign-in path.
-					// The re-verify branch (already authenticated) has no counter.
+					// The re-verify branch (already authenticated) is not gated.
 					const attempt = isSignIn
-						? await beginTwoFactorAttempt(
-								ctx,
-								key,
-								DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS,
-							)
+						? await beginAttempt(DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS)
 						: null;
 					const validate = await verifyBackupCode(
 						{

--- a/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/backup-codes/index.ts
@@ -342,14 +342,21 @@ export const backupCode2fa = (opts: BackupCodeOptions) => {
 					const attempt = isSignIn
 						? await beginAttempt(DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS)
 						: null;
-					const validate = await verifyBackupCode(
-						{
-							backupCodes: twoFactor.backupCodes,
-							code: ctx.body.code,
-						},
-						ctx.context.secretConfig,
-						opts,
-					);
+					let validate: Awaited<ReturnType<typeof verifyBackupCode>>;
+					try {
+						validate = await verifyBackupCode(
+							{
+								backupCodes: twoFactor.backupCodes,
+								code: ctx.body.code,
+							},
+							ctx.context.secretConfig,
+							opts,
+						);
+					} catch (error) {
+						// A server error before the code is checked must not spend the slot.
+						await attempt?.restore();
+						throw error;
+					}
 					if (!validate.status || !validate.updated) {
 						await attempt?.recordFailure();
 						throw APIError.from(

--- a/packages/better-auth/src/plugins/two-factor/constant.ts
+++ b/packages/better-auth/src/plugins/two-factor/constant.ts
@@ -1,3 +1,16 @@
 export const TWO_FACTOR_COOKIE_NAME = "two_factor";
 export const TRUST_DEVICE_COOKIE_NAME = "trust_device";
 export const TRUST_DEVICE_COOKIE_MAX_AGE = 30 * 24 * 60 * 60; // 30 days
+
+/**
+ * Wrong guesses allowed per sign-in 2FA challenge before it locks out.
+ * `verify-otp` reads its own `OTPOptions.allowedAttempts`; `verify-totp` and
+ * `verify-backup-code` share this constant so a single challenge cannot absorb
+ * unlimited guesses.
+ *
+ * TODO(totp-attempt-cap): the per-sign-in-attempt budget in the two-factor
+ * rewrite (RFC 0012 / PR #9278) replaces this per-challenge counter with a
+ * configurable `maxVerificationAttempts` on the `signInAttempt` table that
+ * covers all factors uniformly. Drop this constant when that lands on this line.
+ */
+export const DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS = 5;

--- a/packages/better-auth/src/plugins/two-factor/constant.ts
+++ b/packages/better-auth/src/plugins/two-factor/constant.ts
@@ -2,15 +2,5 @@ export const TWO_FACTOR_COOKIE_NAME = "two_factor";
 export const TRUST_DEVICE_COOKIE_NAME = "trust_device";
 export const TRUST_DEVICE_COOKIE_MAX_AGE = 30 * 24 * 60 * 60; // 30 days
 
-/**
- * Wrong guesses allowed per sign-in 2FA challenge before it locks out.
- * `verify-otp` reads its own `OTPOptions.allowedAttempts`; `verify-totp` and
- * `verify-backup-code` share this constant so a single challenge cannot absorb
- * unlimited guesses.
- *
- * TODO(totp-attempt-cap): the per-sign-in-attempt budget in the two-factor
- * rewrite (RFC 0012 / PR #9278) replaces this per-challenge counter with a
- * configurable `maxVerificationAttempts` on the `signInAttempt` table that
- * covers all factors uniformly. Drop this constant when that lands on this line.
- */
+// TODO(totp-attempt-cap): replace with a configurable budget shared across factors.
 export const DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS = 5;

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -490,10 +490,19 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 							},
 						);
 						const identifier = `2fa-${generateRandomString(20)}`;
+						const expiresAt = new Date(Date.now() + maxAge * 1000);
 						await ctx.context.internalAdapter.createVerificationValue({
 							value: data.user.id,
 							identifier,
-							expiresAt: new Date(Date.now() + maxAge * 1000),
+							expiresAt,
+						});
+						// Per-challenge attempt counter, consumed atomically by
+						// verify-totp and verify-backup-code as the race gate so a
+						// concurrent burst cannot exceed the budget.
+						await ctx.context.internalAdapter.createVerificationValue({
+							value: "0",
+							identifier: `2fa-attempts-${identifier}`,
+							expiresAt,
 						});
 						await ctx.setSignedCookie(
 							twoFactorCookie.name,

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -490,23 +490,10 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 							},
 						);
 						const identifier = `2fa-${generateRandomString(20)}`;
-						const expiresAt = new Date(Date.now() + maxAge * 1000);
 						await ctx.context.internalAdapter.createVerificationValue({
 							value: data.user.id,
 							identifier,
-							expiresAt,
-						});
-						// Shared attempt-budget counter for verify-totp and
-						// verify-backup-code (verify-otp keeps its own counter on the
-						// code row). A distinct prefix from `2fa-otp-${key}` avoids
-						// colliding when a challenge offers both factors.
-						// TODO(totp-attempt-cap): superseded by the per-sign-in-attempt
-						// budget in the two-factor rewrite (RFC 0012 / PR #9278); remove
-						// this row when that lands on this line.
-						await ctx.context.internalAdapter.createVerificationValue({
-							value: "0",
-							identifier: `2fa-attempts-${identifier}`,
-							expiresAt,
+							expiresAt: new Date(Date.now() + maxAge * 1000),
 						});
 						await ctx.setSignedCookie(
 							twoFactorCookie.name,

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -490,10 +490,23 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 							},
 						);
 						const identifier = `2fa-${generateRandomString(20)}`;
+						const expiresAt = new Date(Date.now() + maxAge * 1000);
 						await ctx.context.internalAdapter.createVerificationValue({
 							value: data.user.id,
 							identifier,
-							expiresAt: new Date(Date.now() + maxAge * 1000),
+							expiresAt,
+						});
+						// Shared attempt-budget counter for verify-totp and
+						// verify-backup-code (verify-otp keeps its own counter on the
+						// code row). A distinct prefix from `2fa-otp-${key}` avoids
+						// colliding when a challenge offers both factors.
+						// TODO(totp-attempt-cap): superseded by the per-sign-in-attempt
+						// budget in the two-factor rewrite (RFC 0012 / PR #9278); remove
+						// this row when that lands on this line.
+						await ctx.context.internalAdapter.createVerificationValue({
+							value: "0",
+							identifier: `2fa-attempts-${identifier}`,
+							expiresAt,
 						});
 						await ctx.setSignedCookie(
 							twoFactorCookie.name,

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -15,7 +15,7 @@ import type {
 	TwoFactorTable,
 	UserWithTwoFactor,
 } from "../types";
-import { beginTwoFactorAttempt, verifyTwoFactor } from "../verify-two-factor";
+import { verifyTwoFactor } from "../verify-two-factor";
 
 export type TOTPOptions = {
 	/**
@@ -259,7 +259,8 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 					code: "TOTP_NOT_CONFIGURED",
 				});
 			}
-			const { session, valid, invalid, key } = await verifyTwoFactor(ctx);
+			const { session, valid, invalid, beginAttempt } =
+				await verifyTwoFactor(ctx);
 			const user = session.user as UserWithTwoFactor;
 			const isSignIn = !session.session;
 			const twoFactor = await ctx.context.adapter.findOne<TwoFactorTable>({
@@ -283,14 +284,9 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 				);
 			}
 			// Enforce the per-challenge attempt budget on the sign-in path. The
-			// re-verify branch (already authenticated, e.g. enabling TOTP) has no
-			// challenge counter, so it is not gated.
+			// re-verify branch (already authenticated) is not gated.
 			const attempt = isSignIn
-				? await beginTwoFactorAttempt(
-						ctx,
-						key,
-						DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS,
-					)
+				? await beginAttempt(DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS)
 				: null;
 			const decrypted = await symmetricDecrypt({
 				key: ctx.context.secretConfig,

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -8,13 +8,14 @@ import { symmetricDecrypt } from "../../../crypto";
 import { shouldRequirePassword } from "../../../utils/password";
 import { PACKAGE_VERSION } from "../../../version";
 import type { BackupCodeOptions } from "../backup-codes";
+import { DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS } from "../constant";
 import { TWO_FACTOR_ERROR_CODES } from "../error-code";
 import type {
 	TwoFactorProvider,
 	TwoFactorTable,
 	UserWithTwoFactor,
 } from "../types";
-import { verifyTwoFactor } from "../verify-two-factor";
+import { beginTwoFactorAttempt, verifyTwoFactor } from "../verify-two-factor";
 
 export type TOTPOptions = {
 	/**
@@ -258,7 +259,7 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 					code: "TOTP_NOT_CONFIGURED",
 				});
 			}
-			const { session, valid, invalid } = await verifyTwoFactor(ctx);
+			const { session, valid, invalid, key } = await verifyTwoFactor(ctx);
 			const user = session.user as UserWithTwoFactor;
 			const isSignIn = !session.session;
 			const twoFactor = await ctx.context.adapter.findOne<TwoFactorTable>({
@@ -281,6 +282,16 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 					TWO_FACTOR_ERROR_CODES.TOTP_NOT_ENABLED,
 				);
 			}
+			// Enforce the per-challenge attempt budget on the sign-in path. The
+			// re-verify branch (already authenticated, e.g. enabling TOTP) has no
+			// challenge counter, so it is not gated.
+			const attempt = isSignIn
+				? await beginTwoFactorAttempt(
+						ctx,
+						key,
+						DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS,
+					)
+				: null;
 			const decrypted = await symmetricDecrypt({
 				key: ctx.context.secretConfig,
 				data: twoFactor.secret,
@@ -290,6 +301,7 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 				digits: opts.digits,
 			}).verify(ctx.body.code);
 			if (!status) {
+				await attempt?.recordFailure();
 				return invalid("INVALID_CODE");
 			}
 

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -288,14 +288,21 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 			const attempt = isSignIn
 				? await beginAttempt(DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS)
 				: null;
-			const decrypted = await symmetricDecrypt({
-				key: ctx.context.secretConfig,
-				data: twoFactor.secret,
-			});
-			const status = await createOTP(decrypted, {
-				period: opts.period,
-				digits: opts.digits,
-			}).verify(ctx.body.code);
+			let status: boolean;
+			try {
+				const decrypted = await symmetricDecrypt({
+					key: ctx.context.secretConfig,
+					data: twoFactor.secret,
+				});
+				status = await createOTP(decrypted, {
+					period: opts.period,
+					digits: opts.digits,
+				}).verify(ctx.body.code);
+			} catch (error) {
+				// A server error before the code is checked must not spend the slot.
+				await attempt?.restore();
+				throw error;
+			}
 			if (!status) {
 				await attempt?.recordFailure();
 				return invalid("INVALID_CODE");

--- a/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
@@ -57,11 +57,19 @@ async function setupTwoFactorChallenge() {
 		return convertSetCookieToCookie(signIn.headers);
 	}
 
-	return { auth, secret, backupCodes: enrollment.backupCodes, startChallenge };
+	return {
+		auth,
+		db,
+		userId,
+		secret,
+		backupCodes: enrollment.backupCodes,
+		startChallenge,
+	};
 }
 
 describe("two-factor security: TOTP enforces a per-challenge attempt cap", async () => {
-	const { auth, secret, startChallenge } = await setupTwoFactorChallenge();
+	const { auth, db, userId, secret, startChallenge } =
+		await setupTwoFactorChallenge();
 
 	function verifyTotp(challengeHeaders: Headers, code: string) {
 		return auth.api.verifyTOTP({
@@ -122,6 +130,38 @@ describe("two-factor security: TOTP enforces a per-challenge attempt cap", async
 			(body) => body.message === TWO_FACTOR_ERROR_CODES.INVALID_CODE.message,
 		).length;
 		expect(processed).toBeLessThanOrEqual(DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS);
+	});
+
+	it("a server error during verification does not spend an attempt slot", async () => {
+		const challengeHeaders = await startChallenge();
+		const row = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: userId }],
+		});
+		const validSecret = row!.secret;
+
+		// Corrupt the stored secret so verification throws a server error mid-flight
+		// (not a wrong-code result).
+		await db.update({
+			model: "twoFactor",
+			where: [{ field: "userId", value: userId }],
+			update: { secret: "not-a-valid-encrypted-secret" },
+		});
+		await verifyTotp(challengeHeaders, "000000").catch(() => undefined);
+
+		// The slot was restored, so the same challenge still works once the
+		// transient failure clears. Without the restore the consumed counter would
+		// reject the correct code as an invalid two-factor cookie.
+		await db.update({
+			model: "twoFactor",
+			where: [{ field: "userId", value: userId }],
+			update: { secret: validSecret },
+		});
+		const ok = await verifyTotp(
+			challengeHeaders,
+			await createOTP(secret).totp(),
+		);
+		expect(ok.status).toBe(200);
 	});
 });
 

--- a/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
@@ -101,6 +101,28 @@ describe("two-factor security: TOTP enforces a per-challenge attempt cap", async
 			TWO_FACTOR_ERROR_CODES.INVALID_TWO_FACTOR_COOKIE.message,
 		);
 	});
+
+	it("a concurrent burst cannot exceed the attempt budget", async () => {
+		const challengeHeaders = await startChallenge();
+		const burst = DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS * 4;
+
+		const results = await Promise.all(
+			Array.from({ length: burst }, () =>
+				verifyTotp(challengeHeaders, "111111"),
+			),
+		);
+		const bodies = await Promise.all(
+			results.map((res) => res.json() as Promise<{ message?: string }>),
+		);
+		// No wrong code mints a session.
+		expect(results.some((res) => res.status === 200)).toBe(false);
+		// The atomic consume gate serializes the burst, so at most the budget is
+		// actually spent on guesses; the rest lose the race and are rejected.
+		const processed = bodies.filter(
+			(body) => body.message === TWO_FACTOR_ERROR_CODES.INVALID_CODE.message,
+		).length;
+		expect(processed).toBeLessThanOrEqual(DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS);
+	});
 });
 
 describe("two-factor security: backup codes enforce a per-challenge attempt cap", async () => {

--- a/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
@@ -141,13 +141,13 @@ describe("two-factor security: TOTP enforces a per-challenge attempt cap", async
 		const validSecret = row!.secret;
 
 		// Corrupt the stored secret so verification throws a server error mid-flight
-		// (not a wrong-code result).
+		// (not a wrong-code result); the attempt must actually error.
 		await db.update({
 			model: "twoFactor",
 			where: [{ field: "userId", value: userId }],
 			update: { secret: "not-a-valid-encrypted-secret" },
 		});
-		await verifyTotp(challengeHeaders, "000000").catch(() => undefined);
+		await expect(verifyTotp(challengeHeaders, "000000")).rejects.toThrow();
 
 		// The slot was restored, so the same challenge still works once the
 		// transient failure clears. Without the restore the consumed counter would

--- a/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
@@ -1,0 +1,180 @@
+import { createOTP } from "@better-auth/utils/otp";
+import { describe, expect, it } from "vitest";
+import { symmetricDecrypt } from "../../crypto";
+import { convertSetCookieToCookie } from "../../test-utils/headers";
+import { getTestInstance } from "../../test-utils/test-instance";
+import type { User } from "../../types";
+import { DEFAULT_SECRET } from "../../utils/constants";
+import { TWO_FACTOR_ERROR_CODES, twoFactor } from ".";
+import { DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS } from "./constant";
+import type { TwoFactorTable } from "./types";
+
+/**
+ * A single 2FA sign-in challenge must grant only a bounded number of guesses.
+ * `verify-otp` already consumes its code row and caps attempts; `verify-totp`
+ * and `verify-backup-code` had no per-challenge cap, so one live challenge could
+ * absorb unlimited guesses against the TOTP code space (or the backup-code set)
+ * for the full challenge TTL. These tests pin the parity: after the shared
+ * attempt budget is spent the challenge locks out with a 400, while a single
+ * wrong guess stays a 401.
+ */
+
+describe("two-factor security: TOTP enforces a per-challenge attempt cap", async () => {
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [twoFactor()],
+	});
+	const { headers } = await signInWithTestUser();
+	const dbUser = await db.findOne<User>({
+		model: "user",
+		where: [{ field: "email", value: testUser.email }],
+	});
+	const userId = dbUser?.id as string;
+	const enrollment = await auth.api.enableTwoFactor({
+		body: { password: testUser.password },
+		headers,
+	});
+	if (!enrollment.totpURI) {
+		throw new Error("expected totp enrollment");
+	}
+	const row = await db.findOne<TwoFactorTable>({
+		model: "twoFactor",
+		where: [{ field: "userId", value: userId }],
+	});
+	const secret = await symmetricDecrypt({
+		key: DEFAULT_SECRET,
+		data: row!.secret,
+	});
+	await auth.api.verifyTOTP({
+		body: { code: await createOTP(secret).totp() },
+		headers,
+	});
+
+	async function startChallenge(): Promise<Headers> {
+		const signIn = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			asResponse: true,
+		});
+		expect(signIn.status).toBe(200);
+		return convertSetCookieToCookie(signIn.headers);
+	}
+
+	function verifyTotp(challengeHeaders: Headers, code: string) {
+		return auth.api.verifyTOTP({
+			body: { code },
+			headers: challengeHeaders,
+			asResponse: true,
+		});
+	}
+
+	it("counts wrong codes up to the limit then locks out", async () => {
+		const challengeHeaders = await startChallenge();
+
+		for (let i = 0; i < DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS; i++) {
+			const res = await verifyTotp(challengeHeaders, "000000");
+			expect(res.status).toBe(401);
+			const json = (await res.json()) as { message: string };
+			expect(json.message).toBe(TWO_FACTOR_ERROR_CODES.INVALID_CODE.message);
+		}
+
+		// Budget spent: even the correct code is locked out.
+		const locked = await verifyTotp(
+			challengeHeaders,
+			await createOTP(secret).totp(),
+		);
+		expect(locked.status).toBe(400);
+		const lockedJson = (await locked.json()) as { message: string };
+		expect(lockedJson.message).toBe(
+			TWO_FACTOR_ERROR_CODES.TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE.message,
+		);
+	});
+
+	it("a concurrent burst of wrong codes cannot exceed the attempt budget", async () => {
+		const challengeHeaders = await startChallenge();
+		const burst = DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS * 4;
+
+		const results = await Promise.all(
+			Array.from({ length: burst }, () =>
+				verifyTotp(challengeHeaders, "111111"),
+			),
+		);
+		// No wrong code mints a session, and the consume gate serializes the
+		// burst so at most `allowedAttempts` guesses are ever processed; the rest
+		// lose the race and are rejected with a 400 without advancing the budget.
+		const accepted = results.filter((res) => res.status === 200).length;
+		expect(accepted).toBe(0);
+		const processed = results.filter((res) => res.status === 401).length;
+		expect(processed).toBeLessThanOrEqual(DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS);
+	});
+});
+
+describe("two-factor security: backup codes enforce a per-challenge attempt cap", async () => {
+	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [twoFactor()],
+	});
+	const { headers } = await signInWithTestUser();
+	const dbUser = await db.findOne<User>({
+		model: "user",
+		where: [{ field: "email", value: testUser.email }],
+	});
+	const userId = dbUser?.id as string;
+	const enrollment = await auth.api.enableTwoFactor({
+		body: { password: testUser.password },
+		headers,
+	});
+	const backupCode = enrollment.backupCodes?.[0];
+	if (!backupCode) {
+		throw new Error("expected backup codes from enrollment");
+	}
+	const row = await db.findOne<TwoFactorTable>({
+		model: "twoFactor",
+		where: [{ field: "userId", value: userId }],
+	});
+	const secret = await symmetricDecrypt({
+		key: DEFAULT_SECRET,
+		data: row!.secret,
+	});
+	await auth.api.verifyTOTP({
+		body: { code: await createOTP(secret).totp() },
+		headers,
+	});
+
+	async function startChallenge(): Promise<Headers> {
+		const signIn = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			asResponse: true,
+		});
+		expect(signIn.status).toBe(200);
+		return convertSetCookieToCookie(signIn.headers);
+	}
+
+	function verifyBackup(challengeHeaders: Headers, code: string) {
+		return auth.api.verifyBackupCode({
+			body: { code },
+			headers: challengeHeaders,
+			asResponse: true,
+		});
+	}
+
+	it("counts wrong backup codes up to the limit then locks out", async () => {
+		const challengeHeaders = await startChallenge();
+
+		for (let i = 0; i < DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS; i++) {
+			const res = await verifyBackup(challengeHeaders, "0000-0000");
+			expect(res.status).toBe(401);
+			const json = (await res.json()) as { message: string };
+			expect(json.message).toBe(
+				TWO_FACTOR_ERROR_CODES.INVALID_BACKUP_CODE.message,
+			);
+		}
+
+		// Budget spent: even a real backup code is locked out.
+		const locked = await verifyBackup(challengeHeaders, backupCode);
+		expect(locked.status).toBe(400);
+		const lockedJson = (await locked.json()) as { message: string };
+		expect(lockedJson.message).toBe(
+			TWO_FACTOR_ERROR_CODES.TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE.message,
+		);
+	});
+});

--- a/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
@@ -14,12 +14,10 @@ import type { TwoFactorTable } from "./types";
  * `verify-otp` already consumes its code row and caps attempts; `verify-totp`
  * and `verify-backup-code` had no per-challenge cap, so one live challenge could
  * absorb unlimited guesses against the TOTP code space (or the backup-code set)
- * for the full challenge TTL. These tests pin the parity: after the shared
- * attempt budget is spent the challenge locks out with a 400, while a single
- * wrong guess stays a 401.
+ * for the full challenge TTL.
  */
 
-describe("two-factor security: TOTP enforces a per-challenge attempt cap", async () => {
+async function setupTwoFactorChallenge() {
 	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
 		secret: DEFAULT_SECRET,
 		plugins: [twoFactor()],
@@ -59,6 +57,12 @@ describe("two-factor security: TOTP enforces a per-challenge attempt cap", async
 		return convertSetCookieToCookie(signIn.headers);
 	}
 
+	return { auth, secret, backupCodes: enrollment.backupCodes, startChallenge };
+}
+
+describe("two-factor security: TOTP enforces a per-challenge attempt cap", async () => {
+	const { auth, secret, startChallenge } = await setupTwoFactorChallenge();
+
 	function verifyTotp(challengeHeaders: Headers, code: string) {
 		return auth.api.verifyTOTP({
 			body: { code },
@@ -67,7 +71,7 @@ describe("two-factor security: TOTP enforces a per-challenge attempt cap", async
 		});
 	}
 
-	it("counts wrong codes up to the limit then locks out", async () => {
+	it("locks out after the limit and cancels the challenge", async () => {
 		const challengeHeaders = await startChallenge();
 
 		for (let i = 0; i < DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS; i++) {
@@ -87,66 +91,23 @@ describe("two-factor security: TOTP enforces a per-challenge attempt cap", async
 		expect(lockedJson.message).toBe(
 			TWO_FACTOR_ERROR_CODES.TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE.message,
 		);
-	});
 
-	it("a concurrent burst of wrong codes cannot exceed the attempt budget", async () => {
-		const challengeHeaders = await startChallenge();
-		const burst = DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS * 4;
-
-		const results = await Promise.all(
-			Array.from({ length: burst }, () =>
-				verifyTotp(challengeHeaders, "111111"),
-			),
+		// Lockout cancels the challenge itself, so a further attempt is no longer
+		// a code check but an invalid (consumed) cookie.
+		const afterLockout = await verifyTotp(challengeHeaders, "000000");
+		expect(afterLockout.status).toBe(401);
+		const afterJson = (await afterLockout.json()) as { message: string };
+		expect(afterJson.message).toBe(
+			TWO_FACTOR_ERROR_CODES.INVALID_TWO_FACTOR_COOKIE.message,
 		);
-		// No wrong code mints a session, and the consume gate serializes the
-		// burst so at most `allowedAttempts` guesses are ever processed; the rest
-		// lose the race and are rejected with a 400 without advancing the budget.
-		const accepted = results.filter((res) => res.status === 200).length;
-		expect(accepted).toBe(0);
-		const processed = results.filter((res) => res.status === 401).length;
-		expect(processed).toBeLessThanOrEqual(DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS);
 	});
 });
 
 describe("two-factor security: backup codes enforce a per-challenge attempt cap", async () => {
-	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
-		secret: DEFAULT_SECRET,
-		plugins: [twoFactor()],
-	});
-	const { headers } = await signInWithTestUser();
-	const dbUser = await db.findOne<User>({
-		model: "user",
-		where: [{ field: "email", value: testUser.email }],
-	});
-	const userId = dbUser?.id as string;
-	const enrollment = await auth.api.enableTwoFactor({
-		body: { password: testUser.password },
-		headers,
-	});
-	const backupCode = enrollment.backupCodes?.[0];
+	const { auth, backupCodes, startChallenge } = await setupTwoFactorChallenge();
+	const backupCode = backupCodes?.[0];
 	if (!backupCode) {
 		throw new Error("expected backup codes from enrollment");
-	}
-	const row = await db.findOne<TwoFactorTable>({
-		model: "twoFactor",
-		where: [{ field: "userId", value: userId }],
-	});
-	const secret = await symmetricDecrypt({
-		key: DEFAULT_SECRET,
-		data: row!.secret,
-	});
-	await auth.api.verifyTOTP({
-		body: { code: await createOTP(secret).totp() },
-		headers,
-	});
-
-	async function startChallenge(): Promise<Headers> {
-		const signIn = await auth.api.signInEmail({
-			body: { email: testUser.email, password: testUser.password },
-			asResponse: true,
-		});
-		expect(signIn.status).toBe(200);
-		return convertSetCookieToCookie(signIn.headers);
 	}
 
 	function verifyBackup(challengeHeaders: Headers, code: string) {

--- a/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
@@ -534,8 +534,11 @@ describe("two-factor security: 2FA challenge is single-use and expiry-bounded", 
 			}),
 		]);
 
+		// The attempt-budget gate consumes the per-challenge counter before the
+		// code check, so the concurrent loser is rejected there with a 400
+		// (matching verify-otp), while exactly one verification mints a session.
 		const statuses = [first.status, second.status].sort();
-		expect(statuses).toEqual([200, 401]);
+		expect(statuses).toEqual([200, 400]);
 
 		const sessionsAfter = await countSessions();
 		expect(sessionsAfter.length).toBe(sessionsBefore.length + 1);

--- a/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
@@ -534,11 +534,8 @@ describe("two-factor security: 2FA challenge is single-use and expiry-bounded", 
 			}),
 		]);
 
-		// The attempt-budget gate consumes the per-challenge counter before the
-		// code check, so the concurrent loser is rejected there with a 400
-		// (matching verify-otp), while exactly one verification mints a session.
 		const statuses = [first.status, second.status].sort();
-		expect(statuses).toEqual([200, 400]);
+		expect(statuses).toEqual([200, 401]);
 
 		const sessionsAfter = await countSessions();
 		expect(sessionsAfter.length).toBe(sessionsBefore.length + 1);

--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -135,6 +135,44 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 				user,
 			},
 			key: signedTwoFactorCookie,
+			beginAttempt: async (allowedAttempts: number) => {
+				const identifier = `2fa-attempts-${signedTwoFactorCookie}`;
+				const consumed = await ctx.context.internalAdapter
+					.consumeVerificationValue(identifier)
+					.catch(() => null);
+				let attempts = 0;
+				if (consumed) {
+					const parsed = Number(consumed.value);
+					// A corrupt counter fails closed (treated as spent).
+					attempts =
+						Number.isInteger(parsed) && parsed >= 0 ? parsed : allowedAttempts;
+				}
+				if (attempts >= allowedAttempts) {
+					// Budget spent: cancel the whole challenge so every factor must
+					// start a new sign-in, and clear the now-dead cookie.
+					await ctx.context.internalAdapter
+						.consumeVerificationValue(signedTwoFactorCookie)
+						.catch(() => {});
+					expireCookie(ctx, twoFactorCookie);
+					throw APIError.from(
+						"BAD_REQUEST",
+						TWO_FACTOR_ERROR_CODES.TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE,
+					);
+				}
+				return {
+					recordFailure: async () => {
+						// A write failure must not mask the wrong-code response; the
+						// rate limit backstops the un-incremented budget.
+						await ctx.context.internalAdapter
+							.createVerificationValue({
+								value: `${attempts + 1}`,
+								identifier,
+								expiresAt: verificationToken.expiresAt,
+							})
+							.catch(() => {});
+					},
+				};
+			},
 		};
 	}
 	return {
@@ -147,53 +185,9 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 		invalid,
 		session,
 		key: `${session.user.id}!${session.session.id}`,
-	};
-}
-
-/**
- * Consume the per-challenge attempt counter for a sign-in 2FA verification and
- * enforce the attempt budget. The counter row (`2fa-attempts-${key}`) is created
- * alongside the challenge in the sign-in after-hook.
- *
- * `verify-otp` keeps its own counter on the code row; this covers `verify-totp`
- * and `verify-backup-code`, which have no per-code row to ride a counter on.
- *
- * The consume is the atomic race gate: the first concurrent submission wins the
- * row, every other racer (and a spent or expired counter) receives `null`, so a
- * burst of guesses cannot be raced past the budget. Returns a `recordFailure`
- * callback the caller invokes on a wrong code to re-arm the counter under the
- * original challenge expiry; a correct code leaves the row consumed so the
- * challenge cannot be reused.
- *
- * TODO(totp-attempt-cap): superseded by the per-sign-in-attempt budget in the
- * two-factor rewrite (RFC 0012 / PR #9278), which unifies all factors on the
- * `signInAttempt` table. Remove this helper with the per-challenge counter.
- */
-export async function beginTwoFactorAttempt(
-	ctx: GenericEndpointContext,
-	key: string,
-	allowedAttempts: number,
-) {
-	const identifier = `2fa-attempts-${key}`;
-	const consumed =
-		await ctx.context.internalAdapter.consumeVerificationValue(identifier);
-	const attempts = consumed ? Number.parseInt(consumed.value, 10) || 0 : 0;
-	if (!consumed || attempts >= allowedAttempts) {
-		// No counter row means the challenge is expired or the budget is already
-		// spent; either way the challenge is locked. Leaving a spent row consumed
-		// keeps it locked for every later submission.
-		throw APIError.from(
-			"BAD_REQUEST",
-			TWO_FACTOR_ERROR_CODES.TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE,
-		);
-	}
-	return {
-		recordFailure: async () => {
-			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${attempts + 1}`,
-				identifier,
-				expiresAt: consumed.expiresAt,
-			});
-		},
+		// Re-verification is already authenticated, so it carries no attempt cap.
+		beginAttempt: async (_allowedAttempts: number) => ({
+			recordFailure: async () => {},
+		}),
 	};
 }

--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -149,3 +149,51 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 		key: `${session.user.id}!${session.session.id}`,
 	};
 }
+
+/**
+ * Consume the per-challenge attempt counter for a sign-in 2FA verification and
+ * enforce the attempt budget. The counter row (`2fa-attempts-${key}`) is created
+ * alongside the challenge in the sign-in after-hook.
+ *
+ * `verify-otp` keeps its own counter on the code row; this covers `verify-totp`
+ * and `verify-backup-code`, which have no per-code row to ride a counter on.
+ *
+ * The consume is the atomic race gate: the first concurrent submission wins the
+ * row, every other racer (and a spent or expired counter) receives `null`, so a
+ * burst of guesses cannot be raced past the budget. Returns a `recordFailure`
+ * callback the caller invokes on a wrong code to re-arm the counter under the
+ * original challenge expiry; a correct code leaves the row consumed so the
+ * challenge cannot be reused.
+ *
+ * TODO(totp-attempt-cap): superseded by the per-sign-in-attempt budget in the
+ * two-factor rewrite (RFC 0012 / PR #9278), which unifies all factors on the
+ * `signInAttempt` table. Remove this helper with the per-challenge counter.
+ */
+export async function beginTwoFactorAttempt(
+	ctx: GenericEndpointContext,
+	key: string,
+	allowedAttempts: number,
+) {
+	const identifier = `2fa-attempts-${key}`;
+	const consumed =
+		await ctx.context.internalAdapter.consumeVerificationValue(identifier);
+	const attempts = consumed ? Number.parseInt(consumed.value, 10) || 0 : 0;
+	if (!consumed || attempts >= allowedAttempts) {
+		// No counter row means the challenge is expired or the budget is already
+		// spent; either way the challenge is locked. Leaving a spent row consumed
+		// keeps it locked for every later submission.
+		throw APIError.from(
+			"BAD_REQUEST",
+			TWO_FACTOR_ERROR_CODES.TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE,
+		);
+	}
+	return {
+		recordFailure: async () => {
+			await ctx.context.internalAdapter.createVerificationValue({
+				value: `${attempts + 1}`,
+				identifier,
+				expiresAt: consumed.expiresAt,
+			});
+		},
+	};
+}

--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -165,18 +165,20 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 						TWO_FACTOR_ERROR_CODES.TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE,
 					);
 				}
+				const rearm = (count: number) =>
+					ctx.context.internalAdapter
+						.createVerificationValue({
+							value: `${count}`,
+							identifier,
+							expiresAt: verificationToken.expiresAt,
+						})
+						.catch(() => {});
 				return {
-					recordFailure: async () => {
-						// A write failure must not mask the wrong-code response; the
-						// rate limit backstops the un-incremented budget.
-						await ctx.context.internalAdapter
-							.createVerificationValue({
-								value: `${attempts + 1}`,
-								identifier,
-								expiresAt: verificationToken.expiresAt,
-							})
-							.catch(() => {});
-					},
+					// A wrong code spends a slot; a server error before the code is
+					// checked restores it so a transient failure does not forfeit the
+					// challenge. Both swallow write errors (fail closed).
+					recordFailure: () => rearm(attempts + 1),
+					restore: () => rearm(attempts),
 				};
 			},
 		};
@@ -194,6 +196,7 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 		// Re-verification is already authenticated, so it carries no attempt cap.
 		beginAttempt: async (_allowedAttempts: number) => ({
 			recordFailure: async () => {},
+			restore: async () => {},
 		}),
 	};
 }

--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -137,9 +137,8 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 			key: signedTwoFactorCookie,
 			beginAttempt: async (allowedAttempts: number) => {
 				const identifier = `2fa-attempts-${signedTwoFactorCookie}`;
-				// The counter is precreated with the challenge and consumed here as
-				// the atomic race gate. A missing row means this submission lost the
-				// race or the challenge expired: treat it as a stale challenge.
+				// Consume the precreated counter as the atomic race gate; a missing
+				// row means a lost race or an expired challenge.
 				const consumed = await ctx.context.internalAdapter
 					.consumeVerificationValue(identifier)
 					.catch(() => null);
@@ -174,9 +173,8 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 						})
 						.catch(() => {});
 				return {
-					// A wrong code spends a slot; a server error before the code is
-					// checked restores it so a transient failure does not forfeit the
-					// challenge. Both swallow write errors (fail closed).
+					// recordFailure spends a slot; restore returns it on a server
+					// error. Both swallow write errors (fail closed).
 					recordFailure: () => rearm(attempts + 1),
 					restore: () => rearm(attempts),
 				};

--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -137,16 +137,22 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 			key: signedTwoFactorCookie,
 			beginAttempt: async (allowedAttempts: number) => {
 				const identifier = `2fa-attempts-${signedTwoFactorCookie}`;
+				// The counter is precreated with the challenge and consumed here as
+				// the atomic race gate. A missing row means this submission lost the
+				// race or the challenge expired: treat it as a stale challenge.
 				const consumed = await ctx.context.internalAdapter
 					.consumeVerificationValue(identifier)
 					.catch(() => null);
-				let attempts = 0;
-				if (consumed) {
-					const parsed = Number(consumed.value);
-					// A corrupt counter fails closed (treated as spent).
-					attempts =
-						Number.isInteger(parsed) && parsed >= 0 ? parsed : allowedAttempts;
+				if (!consumed) {
+					throw APIError.from(
+						"UNAUTHORIZED",
+						TWO_FACTOR_ERROR_CODES.INVALID_TWO_FACTOR_COOKIE,
+					);
 				}
+				const parsed = Number(consumed.value);
+				// A corrupt counter fails closed (treated as spent).
+				const attempts =
+					Number.isInteger(parsed) && parsed >= 0 ? parsed : allowedAttempts;
 				if (attempts >= allowedAttempts) {
 					// Budget spent: cancel the whole challenge so every factor must
 					// start a new sign-in, and clear the now-dead cookie.


### PR DESCRIPTION
TOTP and backup-code two-factor verification accepted unlimited wrong guesses against a single sign-in challenge, which stayed valid for its full lifetime. Email OTP already caps attempts per challenge; TOTP and backup codes did not. The plugin's per-path rate limit already bounds this in a default deployment, so the cap is defense in depth.

A per-challenge counter is created with the challenge and consumed atomically on each verification, so a burst of concurrent guesses cannot race past the budget. After five wrong codes the challenge locks out and a new sign-in is required.

Scope for review: a correct first code is unaffected, and the gate applies only to the sign-in challenge, not already-authenticated re-verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap TOTP and backup-code 2FA attempts per sign-in challenge. After five wrong codes the challenge locks, the cookie is cleared, and a new sign-in is required; server errors don’t spend attempts.

- **Bug Fixes**
  - Added a shared per-challenge counter (`2fa-attempts-${key}`), created with the challenge and enforced via `beginAttempt` in `verifyTwoFactor` with `DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS = 5`.
  - Applied the gate to `verifyTOTP` and `verifyBackupCode` on sign-in only; already-authenticated re-verification is not gated.
  - Behavior: wrong codes return `401` until the limit; on lockout return `400` with `TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE`, cancel the challenge, and clear the cookie; concurrent attempts are serialized via the atomic counter and stale requests get `401` with `INVALID_TWO_FACTOR_COOKIE`.
  - Counter write failures no longer cause `500`; verification errors restore the attempt slot so only wrong codes consume it.

- **Migration**
  - During a rolling deploy, challenges from the previous version may force users to sign in again until the deploy completes.

<sup>Written for commit 4ed74f3b58d4374319a33e859f051b5d5b4a93e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

