### PR TITLE
fix(sso): delete linked account rows when an SSO provider is deleted

### DIFF
--- a/.changeset/sso-delete-provider-accounts.md
+++ b/.changeset/sso-delete-provider-accounts.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+Deleting an SSO provider now also removes its linked account rows, so a re-registered `providerId` cannot inherit accounts from a previously deleted provider.

--- a/.changeset/sso-delete-provider-accounts.md
+++ b/.changeset/sso-delete-provider-accounts.md
@@ -1,5 +1,8 @@
 ---
 "@better-auth/sso": patch
+"@better-auth/scim": patch
 ---
 
-Deleting an SSO provider now also removes its linked account rows, so a re-registered `providerId` cannot inherit accounts from a previously deleted provider.
+Deleting an SSO provider no longer leaves linked accounts that a later provider with the same provider ID can reuse.
+
+SSO and SCIM provider setup now rejects provider IDs already used by another account provider.

--- a/.changeset/sso-delete-provider-accounts.md
+++ b/.changeset/sso-delete-provider-accounts.md
@@ -6,3 +6,5 @@
 Deleting an SSO provider no longer leaves linked accounts that a later provider with the same provider ID can reuse.
 
 SSO and SCIM provider setup now rejects provider IDs already used by another account provider.
+
+SSO provider updates now reject identity-defining changes, such as issuer, login endpoints, client ID, SAML metadata, or user ID mappings, after accounts are linked. Secret rotation and same-value updates still work.

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -57,6 +57,31 @@ const deleteSCIMProviderConnectionBodySchema = z.object({
 	providerId: z.string(),
 });
 
+function getDefaultSSOProviderIds(pluginOptions: unknown): string[] {
+	if (
+		!pluginOptions ||
+		typeof pluginOptions !== "object" ||
+		!("defaultSSO" in pluginOptions) ||
+		!Array.isArray(pluginOptions.defaultSSO)
+	) {
+		return [];
+	}
+
+	return pluginOptions.defaultSSO
+		.map((provider) => {
+			if (
+				provider &&
+				typeof provider === "object" &&
+				"providerId" in provider &&
+				typeof provider.providerId === "string"
+			) {
+				return provider.providerId;
+			}
+			return null;
+		})
+		.filter((providerId): providerId is string => providerId !== null);
+}
+
 function parseMemberRoles(role: string): string[] {
 	return role
 		.split(",")
@@ -297,19 +322,18 @@ export const generateSCIMToken = (opts: SCIMOptions) =>
 			}
 
 			// A SCIM token authenticates as the row whose providerId matches the
-			// claim in the bearer token. If a caller mints a token whose
-			// providerId collides with a built-in account.providerId
-			// (`credential`, `email-otp`, `magic-link`, `phone-number`,
-			// `anonymous`, `siwe`, or any configured social provider key), the
-			// resulting token can be used to act against accounts that were
-			// never SCIM-provisioned, which would be a privilege escalation.
-			// Reject the collision at issuance.
+			// claim in the bearer token. Reject ids that collide with other
+			// account-producing providers so a token cannot act against accounts
+			// that were never SCIM-provisioned.
 			//
 			// We read social provider keys from `options.socialProviders` (raw
 			// config) rather than `context.socialProviders` (resolved list) so
 			// that providers configured with `enabled: false` are still
 			// rejected: their account rows can persist in the DB from a prior
 			// enabled state.
+			const defaultSSOProviderIds = getDefaultSSOProviderIds(
+				ctx.context.getPlugin("sso")?.options,
+			);
 			const reservedProviderIds = new Set<string>([
 				"credential",
 				"email-otp",
@@ -318,12 +342,29 @@ export const generateSCIMToken = (opts: SCIMOptions) =>
 				"anonymous",
 				"siwe",
 				...Object.keys(ctx.context.options.socialProviders ?? {}),
+				...ctx.context.socialProviders.map((p) => p.id),
+				...defaultSSOProviderIds,
 			]);
 			if (reservedProviderIds.has(providerId)) {
 				throw new APIError("BAD_REQUEST", {
 					message:
-						"Provider id collides with a built-in account provider and cannot be used for SCIM",
+						"Provider id collides with another account provider and cannot be used for SCIM",
 				});
+			}
+
+			if (ctx.context.hasPlugin("sso")) {
+				const existingSSOProvider = await ctx.context.adapter.findOne<{
+					id: string;
+				}>({
+					model: "ssoProvider",
+					where: [{ field: "providerId", value: providerId }],
+				});
+				if (existingSSOProvider) {
+					throw new APIError("BAD_REQUEST", {
+						message:
+							"Provider id collides with another account provider and cannot be used for SCIM",
+					});
+				}
 			}
 
 			if (organizationId && !ctx.context.hasPlugin("organization")) {

--- a/packages/scim/src/scim.management.test.ts
+++ b/packages/scim/src/scim.management.test.ts
@@ -4,7 +4,7 @@ import { memoryAdapter } from "better-auth/adapters/memory";
 import { createAuthClient } from "better-auth/client";
 import { setCookieToHeader } from "better-auth/cookies";
 import type { OrganizationOptions } from "better-auth/plugins";
-import { bearer, organization } from "better-auth/plugins";
+import { bearer, genericOAuth, organization } from "better-auth/plugins";
 import { describe, expect, it } from "vitest";
 import { scim } from ".";
 import { scimClient } from "./client";
@@ -229,7 +229,7 @@ describe("SCIM provider management", () => {
 				await expect(generateSCIMToken(reserved)).rejects.toThrowError(
 					expect.objectContaining({
 						message:
-							"Provider id collides with a built-in account provider and cannot be used for SCIM",
+							"Provider id collides with another account provider and cannot be used for SCIM",
 					}),
 				);
 			}
@@ -302,10 +302,202 @@ describe("SCIM provider management", () => {
 				).rejects.toThrowError(
 					expect.objectContaining({
 						message:
-							"Provider id collides with a built-in account provider and cannot be used for SCIM",
+							"Provider id collides with another account provider and cannot be used for SCIM",
 					}),
 				);
 			}
+		});
+
+		it("rejects providerId values that collide with configured generic OAuth providers", async () => {
+			const data = {
+				user: [],
+				session: [],
+				verification: [],
+				account: [],
+				ssoProvider: [],
+				scimProvider: [],
+				organization: [],
+				member: [],
+			};
+			const memory = memoryAdapter(data);
+			const auth = betterAuth({
+				database: memory,
+				baseURL: "http://localhost:3000",
+				emailAndPassword: { enabled: true },
+				plugins: [
+					scim(),
+					genericOAuth({
+						config: [
+							{
+								providerId: "generic-provider",
+								clientId: "generic-client-id",
+								clientSecret: "generic-client-secret",
+								authorizationUrl: "https://idp.example.com/auth",
+								tokenUrl: "https://idp.example.com/token",
+								userInfoUrl: "https://idp.example.com/userinfo",
+							},
+						],
+					}),
+				],
+			});
+			const authClient = createAuthClient({
+				baseURL: "http://localhost:3000",
+				plugins: [bearer(), scimClient()],
+				fetchOptions: {
+					customFetchImpl: async (url, init) =>
+						auth.handler(new Request(url, init)),
+				},
+			});
+			const headers = new Headers();
+			await authClient.signUp.email({
+				email: "generic@email.com",
+				password: "password",
+				name: "Generic User",
+			});
+			await authClient.signIn.email(
+				{ email: "generic@email.com", password: "password" },
+				{ throw: true, onSuccess: setCookieToHeader(headers) },
+			);
+
+			await expect(
+				auth.api.generateSCIMToken({
+					body: { providerId: "generic-provider" },
+					headers,
+				}),
+			).rejects.toThrowError(
+				expect.objectContaining({
+					message:
+						"Provider id collides with another account provider and cannot be used for SCIM",
+				}),
+			);
+		});
+
+		it("rejects providerId values that collide with SSO providers", async () => {
+			const { auth, getAuthCookieHeaders } = createTestInstance();
+			const headers = await getAuthCookieHeaders();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "sso-provider",
+					issuer: "https://idp.example.com",
+					domain: "example.com",
+					samlConfig: {
+						entryPoint: "https://idp.example.com/sso",
+						cert: "test-cert",
+						callbackUrl: "http://localhost:3000/api/sso/callback",
+						spMetadata: {},
+					},
+				},
+				headers,
+			});
+
+			await expect(
+				auth.api.generateSCIMToken({
+					body: { providerId: "sso-provider" },
+					headers,
+				}),
+			).rejects.toThrowError(
+				expect.objectContaining({
+					message:
+						"Provider id collides with another account provider and cannot be used for SCIM",
+				}),
+			);
+		});
+
+		it("prevents SSO provider registration with an existing SCIM providerId", async () => {
+			const { auth, getAuthCookieHeaders } = createTestInstance();
+			const headers = await getAuthCookieHeaders();
+
+			await auth.api.generateSCIMToken({
+				body: { providerId: "scim-provider" },
+				headers,
+			});
+
+			const response = await auth.api.registerSSOProvider({
+				body: {
+					providerId: "scim-provider",
+					issuer: "https://idp.example.com",
+					domain: "example.com",
+					samlConfig: {
+						entryPoint: "https://idp.example.com/sso",
+						cert: "test-cert",
+						callbackUrl: "http://localhost:3000/api/sso/callback",
+						spMetadata: {},
+					},
+				},
+				headers,
+				asResponse: true,
+			});
+
+			expect(response.status).toBe(422);
+		});
+
+		it("rejects providerId values that collide with default SSO providers", async () => {
+			const data = {
+				user: [],
+				session: [],
+				verification: [],
+				account: [],
+				ssoProvider: [],
+				scimProvider: [],
+				organization: [],
+				member: [],
+			};
+			const memory = memoryAdapter(data);
+			const auth = betterAuth({
+				database: memory,
+				baseURL: "http://localhost:3000",
+				emailAndPassword: { enabled: true },
+				plugins: [
+					sso({
+						defaultSSO: [
+							{
+								domain: "example.com",
+								providerId: "default-sso-provider",
+								samlConfig: {
+									issuer: "https://idp.example.com",
+									entryPoint: "https://idp.example.com/sso",
+									cert: "test-cert",
+									callbackUrl: "http://localhost:3000/api/sso/callback",
+									spMetadata: {},
+								},
+							},
+						],
+					}),
+					scim(),
+					organization(),
+				],
+			});
+			const authClient = createAuthClient({
+				baseURL: "http://localhost:3000",
+				plugins: [bearer(), scimClient()],
+				fetchOptions: {
+					customFetchImpl: async (url, init) =>
+						auth.handler(new Request(url, init)),
+				},
+			});
+			const headers = new Headers();
+			await authClient.signUp.email({
+				email: "default-sso@email.com",
+				password: "password",
+				name: "Default SSO User",
+			});
+			await authClient.signIn.email(
+				{ email: "default-sso@email.com", password: "password" },
+				{ throw: true, onSuccess: setCookieToHeader(headers) },
+			);
+
+			await expect(
+				auth.api.generateSCIMToken({
+					body: { providerId: "default-sso-provider" },
+					headers,
+				}),
+			).rejects.toThrowError(
+				expect.objectContaining({
+					message:
+						"Provider id collides with another account provider and cannot be used for SCIM",
+				}),
+			);
 		});
 
 		it("should generate a new scim token (client)", async () => {
@@ -481,6 +673,9 @@ describe("SCIM provider management", () => {
 			const [secret, ...rest] = Buffer.from(response.scimToken, "base64url")
 				.toString()
 				.split(":");
+			if (!secret) {
+				throw new Error("Expected SCIM token to include a secret");
+			}
 			// Tamper the secret while preserving its length, so verification cannot
 			// short-circuit on a length mismatch and must reject the value itself
 			// through the constant-time comparison.

--- a/packages/sso/src/providers.test.ts
+++ b/packages/sso/src/providers.test.ts
@@ -976,6 +976,39 @@ describe("SSO provider read endpoints", () => {
 			expect(response.status).toBe(409);
 		});
 
+		it("allows same-value issuer updates when linked account rows exist", async () => {
+			const { auth, getAuthHeaders, registerSAMLProvider, data } =
+				createTestAuth(false);
+
+			const headers = await getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+			await registerSAMLProvider(headers, "my-saml-provider");
+
+			const user = (data.user as { id: string; email: string }[]).find(
+				(u) => u.email === "owner@example.com",
+			);
+			data.account.push({
+				id: "linked-saml-account",
+				userId: user!.id,
+				providerId: "my-saml-provider",
+				accountId: "saml-account-id",
+			});
+
+			const updated = await auth.api.updateSSOProvider({
+				body: {
+					providerId: "my-saml-provider",
+					issuer: "https://idp.example.com",
+				},
+				headers,
+			});
+
+			expect(updated.issuer).toBe("https://idp.example.com");
+		});
+
 		it("rejects OIDC client id updates when linked account rows exist", async () => {
 			const { auth, getAuthHeaders, createOIDCProviderData, data } =
 				createTestAuth(false);
@@ -1007,6 +1040,42 @@ describe("SSO provider read endpoints", () => {
 			});
 
 			expect(response.status).toBe(409);
+		});
+
+		it("allows OIDC secret rotation with same identity fields when linked account rows exist", async () => {
+			const { auth, getAuthHeaders, createOIDCProviderData, data } =
+				createTestAuth(false);
+
+			const headers = await getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+			const user = (data.user as { id: string; email: string }[]).find(
+				(u) => u.email === "owner@example.com",
+			);
+			createOIDCProviderData(user!.id, "my-oidc-provider", "client123");
+			data.account.push({
+				id: "linked-oidc-account",
+				userId: user!.id,
+				providerId: "my-oidc-provider",
+				accountId: "oidc-account-id",
+			});
+
+			const updated = await auth.api.updateSSOProvider({
+				body: {
+					providerId: "my-oidc-provider",
+					oidcConfig: {
+						clientId: "client123",
+						clientSecret: "rotated-secret-value",
+						discoveryEndpoint: "https://idp.example.com/.well-known",
+					},
+				},
+				headers,
+			});
+
+			expect(updated.oidcConfig?.clientIdLastFour).toBe("****t123");
 		});
 
 		it("allows OIDC client secret updates when linked account rows exist", async () => {

--- a/packages/sso/src/providers.test.ts
+++ b/packages/sso/src/providers.test.ts
@@ -942,6 +942,105 @@ describe("SSO provider read endpoints", () => {
 			expect(updated.issuer).toBe("https://new-issuer.example.com");
 		});
 
+		it("rejects issuer updates when linked account rows exist", async () => {
+			const { auth, getAuthHeaders, registerSAMLProvider, data } =
+				createTestAuth(false);
+
+			const headers = await getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+			await registerSAMLProvider(headers, "my-saml-provider");
+
+			const user = (data.user as { id: string; email: string }[]).find(
+				(u) => u.email === "owner@example.com",
+			);
+			data.account.push({
+				id: "linked-saml-account",
+				userId: user!.id,
+				providerId: "my-saml-provider",
+				accountId: "saml-account-id",
+			});
+
+			const response = await auth.api.updateSSOProvider({
+				body: {
+					providerId: "my-saml-provider",
+					issuer: "https://new-issuer.example.com",
+				},
+				headers,
+				asResponse: true,
+			});
+
+			expect(response.status).toBe(409);
+		});
+
+		it("rejects OIDC client id updates when linked account rows exist", async () => {
+			const { auth, getAuthHeaders, createOIDCProviderData, data } =
+				createTestAuth(false);
+
+			const headers = await getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+			const user = (data.user as { id: string; email: string }[]).find(
+				(u) => u.email === "owner@example.com",
+			);
+			createOIDCProviderData(user!.id, "my-oidc-provider", "client123");
+			data.account.push({
+				id: "linked-oidc-account",
+				userId: user!.id,
+				providerId: "my-oidc-provider",
+				accountId: "oidc-account-id",
+			});
+
+			const response = await auth.api.updateSSOProvider({
+				body: {
+					providerId: "my-oidc-provider",
+					oidcConfig: { clientId: "new-client-id" },
+				},
+				headers,
+				asResponse: true,
+			});
+
+			expect(response.status).toBe(409);
+		});
+
+		it("allows OIDC client secret updates when linked account rows exist", async () => {
+			const { auth, getAuthHeaders, createOIDCProviderData, data } =
+				createTestAuth(false);
+
+			const headers = await getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+			const user = (data.user as { id: string; email: string }[]).find(
+				(u) => u.email === "owner@example.com",
+			);
+			createOIDCProviderData(user!.id, "my-oidc-provider", "client123");
+			data.account.push({
+				id: "linked-oidc-account",
+				userId: user!.id,
+				providerId: "my-oidc-provider",
+				accountId: "oidc-account-id",
+			});
+
+			const updated = await auth.api.updateSSOProvider({
+				body: {
+					providerId: "my-oidc-provider",
+					oidcConfig: { clientSecret: "new-secret" },
+				},
+				headers,
+			});
+
+			expect(updated.oidcConfig?.clientIdLastFour).toBe("****t123");
+		});
+
 		it("should return 400 when issuer is invalid URL", async () => {
 			const { auth, getAuthHeaders, registerSAMLProvider } =
 				createTestAuth(false);
@@ -1471,7 +1570,7 @@ describe("SSO provider read endpoints", () => {
  * Registration must reject such colliding ids.
  */
 describe("SSO providerId namespace collisions", () => {
-	const setup = () => {
+	const setup = (ssoOptions?: Parameters<typeof sso>[0]) => {
 		const data: Record<string, any[]> = {
 			user: [],
 			session: [],
@@ -1492,7 +1591,7 @@ describe("SSO providerId namespace collisions", () => {
 					trustedProviders: ["github"],
 				},
 			},
-			plugins: [sso()],
+			plugins: [sso(ssoOptions)],
 		});
 		const authClient = createAuthClient({
 			baseURL: "http://localhost:3000",
@@ -1559,6 +1658,31 @@ describe("SSO providerId namespace collisions", () => {
 		const headers = await signIn();
 		const response = await auth.api.registerSSOProvider({
 			body: registerBody("credential"),
+			headers,
+			asResponse: true,
+		});
+		expect(response.status).toBe(422);
+	});
+
+	it("rejects a providerId that collides with a default SSO provider", async () => {
+		const { auth, signIn } = setup({
+			defaultSSO: [
+				{
+					domain: "example.com",
+					providerId: "default-sso",
+					samlConfig: {
+						issuer: "https://idp.example.com",
+						entryPoint: "https://idp.example.com/sso",
+						cert: TEST_CERT,
+						callbackUrl: "http://localhost:3000/api/sso/callback",
+						spMetadata: {},
+					},
+				},
+			],
+		});
+		const headers = await signIn();
+		const response = await auth.api.registerSSOProvider({
+			body: registerBody("default-sso"),
 			headers,
 			asResponse: true,
 		});

--- a/packages/sso/src/providers.test.ts
+++ b/packages/sso/src/providers.test.ts
@@ -1282,7 +1282,7 @@ describe("SSO provider read endpoints", () => {
 			expect(response.status).toBe(403);
 		});
 
-		it("should not delete linked accounts when provider is deleted", async () => {
+		it("deletes linked account rows when the provider is deleted", async () => {
 			const { auth, getAuthHeaders, registerSAMLProvider, data } =
 				createTestAuth(false);
 
@@ -1307,14 +1307,16 @@ describe("SSO provider read endpoints", () => {
 				refreshToken: "refresh",
 			});
 
-			const accountCountBefore = data.account.length;
-
 			await auth.api.deleteSSOProvider({
 				body: { providerId: "my-saml-provider" },
 				headers,
 			});
 
-			expect(data.account.length).toBe(accountCountBefore);
+			const accounts = data.account as { providerId: string }[];
+			expect(accounts.some((a) => a.providerId === "my-saml-provider")).toBe(
+				false,
+			);
+			expect(accounts.some((a) => a.providerId === "credential")).toBe(true);
 		});
 	});
 

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -1,3 +1,7 @@
+import {
+	getCurrentAdapter,
+	runWithTransaction,
+} from "@better-auth/core/context";
 import type { AuthContext } from "better-auth";
 import {
 	APIError,
@@ -29,6 +33,63 @@ interface SSOProviderRecord {
 }
 
 const ADMIN_ROLES = ["owner", "admin"];
+const OIDC_IDENTITY_BOUNDARY_FIELDS = [
+	"authorizationEndpoint",
+	"clientId",
+	"discoveryEndpoint",
+	"jwksEndpoint",
+	"tokenEndpoint",
+	"userInfoEndpoint",
+] as const;
+const SAML_IDENTITY_BOUNDARY_FIELDS = [
+	"audience",
+	"callbackUrl",
+	"entryPoint",
+	"identifierFormat",
+] as const;
+const SAML_IDP_BOUNDARY_FIELDS = [
+	"metadata",
+	"entityID",
+	"singleSignOnService",
+] as const;
+const SAML_SP_BOUNDARY_FIELDS = ["metadata", "entityID"] as const;
+
+function hasDefinedField<T extends Record<string, unknown>>(
+	value: T | null | undefined,
+	fields: readonly (keyof T)[],
+): boolean {
+	return fields.some((field) => value?.[field] !== undefined);
+}
+
+function changesProviderIdentityBoundary(
+	body: Pick<
+		z.infer<typeof updateSSOProviderBodySchema>,
+		"issuer" | "oidcConfig" | "samlConfig"
+	>,
+): boolean {
+	if (body.issuer !== undefined) {
+		return true;
+	}
+
+	if (
+		body.oidcConfig &&
+		(hasDefinedField(body.oidcConfig, OIDC_IDENTITY_BOUNDARY_FIELDS) ||
+			body.oidcConfig.mapping?.id !== undefined)
+	) {
+		return true;
+	}
+
+	if (!body.samlConfig) {
+		return false;
+	}
+
+	return (
+		hasDefinedField(body.samlConfig, SAML_IDENTITY_BOUNDARY_FIELDS) ||
+		body.samlConfig.mapping?.id !== undefined ||
+		hasDefinedField(body.samlConfig.idpMetadata, SAML_IDP_BOUNDARY_FIELDS) ||
+		hasDefinedField(body.samlConfig.spMetadata, SAML_SP_BOUNDARY_FIELDS)
+	);
+}
 
 export function hasOrgAdminRole(member: Pick<Member, "role">): boolean {
 	return member.role.split(",").some((r) => ADMIN_ROLES.includes(r.trim()));
@@ -431,6 +492,22 @@ export const updateSSOProvider = (options: SSOOptions) => {
 			}
 
 			const existingProvider = await checkProviderAccess(ctx, providerId);
+			if (changesProviderIdentityBoundary({ issuer, samlConfig, oidcConfig })) {
+				const linkedAccount = await ctx.context.adapter.findOne<{ id: string }>(
+					{
+						model: "account",
+						where: [{ field: "providerId", value: providerId }],
+					},
+				);
+				if (linkedAccount) {
+					// TODO(next): move SSO account links to immutable provider instance
+					// ids, then expose explicit relinking for identity-boundary changes.
+					throw new APIError("CONFLICT", {
+						message:
+							"Cannot change SSO provider identity fields while linked accounts exist",
+					});
+				}
+			}
 
 			const updateData: Partial<SSOProviderRecord> = {};
 
@@ -573,14 +650,16 @@ export const deleteSSOProvider = () => {
 
 			await checkProviderAccess(ctx, providerId);
 
-			await ctx.context.adapter.delete({
-				model: "ssoProvider",
-				where: [{ field: "providerId", value: providerId }],
-			});
-
-			await ctx.context.adapter.deleteMany({
-				model: "account",
-				where: [{ field: "providerId", value: providerId }],
+			await runWithTransaction(ctx.context.adapter, async () => {
+				const trx = await getCurrentAdapter(ctx.context.adapter);
+				await trx.deleteMany({
+					model: "account",
+					where: [{ field: "providerId", value: providerId }],
+				});
+				await trx.delete({
+					model: "ssoProvider",
+					where: [{ field: "providerId", value: providerId }],
+				});
 			});
 
 			return ctx.json({ success: true });

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -54,40 +54,66 @@ const SAML_IDP_BOUNDARY_FIELDS = [
 ] as const;
 const SAML_SP_BOUNDARY_FIELDS = ["metadata", "entityID"] as const;
 
-function hasDefinedField<T extends Record<string, unknown>>(
-	value: T | null | undefined,
-	fields: readonly (keyof T)[],
-): boolean {
-	return fields.some((field) => value?.[field] !== undefined);
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function changesProviderIdentityBoundary(
-	body: Pick<
-		z.infer<typeof updateSSOProviderBodySchema>,
-		"issuer" | "oidcConfig" | "samlConfig"
-	>,
+function stableStringify(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map(stableStringify).join(",")}]`;
+	}
+
+	if (isRecord(value)) {
+		return `{${Object.keys(value)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+			.join(",")}}`;
+	}
+
+	return JSON.stringify(value) ?? String(value);
+}
+
+function identityValueChanged(current: unknown, updated: unknown): boolean {
+	return stableStringify(current) !== stableStringify(updated);
+}
+
+function hasChangedField<T extends object>(
+	current: T | null | undefined,
+	updated: T | null | undefined,
+	fields: readonly (keyof T)[],
 ): boolean {
-	if (body.issuer !== undefined) {
-		return true;
-	}
+	return fields.some((field) =>
+		identityValueChanged(current?.[field], updated?.[field]),
+	);
+}
 
-	if (
-		body.oidcConfig &&
-		(hasDefinedField(body.oidcConfig, OIDC_IDENTITY_BOUNDARY_FIELDS) ||
-			body.oidcConfig.mapping?.id !== undefined)
-	) {
-		return true;
-	}
-
-	if (!body.samlConfig) {
-		return false;
-	}
-
+function oidcIdentityBoundaryChanged(
+	current: OIDCConfig,
+	updated: OIDCConfig,
+): boolean {
 	return (
-		hasDefinedField(body.samlConfig, SAML_IDENTITY_BOUNDARY_FIELDS) ||
-		body.samlConfig.mapping?.id !== undefined ||
-		hasDefinedField(body.samlConfig.idpMetadata, SAML_IDP_BOUNDARY_FIELDS) ||
-		hasDefinedField(body.samlConfig.spMetadata, SAML_SP_BOUNDARY_FIELDS)
+		hasChangedField(current, updated, OIDC_IDENTITY_BOUNDARY_FIELDS) ||
+		identityValueChanged(current.mapping?.id, updated.mapping?.id)
+	);
+}
+
+function samlIdentityBoundaryChanged(
+	current: SAMLConfig,
+	updated: SAMLConfig,
+): boolean {
+	return (
+		hasChangedField(current, updated, SAML_IDENTITY_BOUNDARY_FIELDS) ||
+		identityValueChanged(current.mapping?.id, updated.mapping?.id) ||
+		hasChangedField(
+			current.idpMetadata,
+			updated.idpMetadata,
+			SAML_IDP_BOUNDARY_FIELDS,
+		) ||
+		hasChangedField(
+			current.spMetadata,
+			updated.spMetadata,
+			SAML_SP_BOUNDARY_FIELDS,
+		)
 	);
 }
 
@@ -492,24 +518,10 @@ export const updateSSOProvider = (options: SSOOptions) => {
 			}
 
 			const existingProvider = await checkProviderAccess(ctx, providerId);
-			if (changesProviderIdentityBoundary({ issuer, samlConfig, oidcConfig })) {
-				const linkedAccount = await ctx.context.adapter.findOne<{ id: string }>(
-					{
-						model: "account",
-						where: [{ field: "providerId", value: providerId }],
-					},
-				);
-				if (linkedAccount) {
-					// TODO(next): move SSO account links to immutable provider instance
-					// ids, then expose explicit relinking for identity-boundary changes.
-					throw new APIError("CONFLICT", {
-						message:
-							"Cannot change SSO provider identity fields while linked accounts exist",
-					});
-				}
-			}
 
 			const updateData: Partial<SSOProviderRecord> = {};
+			let providerIdentityBoundaryChanged =
+				body.issuer !== undefined && body.issuer !== existingProvider.issuer;
 
 			if (body.issuer !== undefined) {
 				updateData.issuer = body.issuer;
@@ -562,6 +574,10 @@ export const updateSSOProvider = (options: SSOOptions) => {
 						existingProvider.issuer,
 				);
 
+				if (samlIdentityBoundaryChanged(currentSamlConfig, updatedSamlConfig)) {
+					providerIdentityBoundaryChanged = true;
+				}
+
 				updateData.samlConfig = JSON.stringify(updatedSamlConfig);
 			}
 
@@ -590,7 +606,29 @@ export const updateSSOProvider = (options: SSOOptions) => {
 						existingProvider.issuer,
 				);
 
+				if (oidcIdentityBoundaryChanged(currentOidcConfig, updatedOidcConfig)) {
+					providerIdentityBoundaryChanged = true;
+				}
+
 				updateData.oidcConfig = JSON.stringify(updatedOidcConfig);
+			}
+
+			if (providerIdentityBoundaryChanged) {
+				const linkedAccount = await ctx.context.adapter.findOne<{ id: string }>(
+					{
+						model: "account",
+						where: [{ field: "providerId", value: providerId }],
+					},
+				);
+				if (linkedAccount) {
+					// TODO(next): move SSO account links to immutable provider instance
+					// ids, then expose explicit relinking for race-proof
+					// identity-boundary changes.
+					throw new APIError("CONFLICT", {
+						message:
+							"Cannot change SSO provider identity fields while linked accounts exist",
+					});
+				}
 			}
 
 			await ctx.context.adapter.update({

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -578,6 +578,11 @@ export const deleteSSOProvider = () => {
 				where: [{ field: "providerId", value: providerId }],
 			});
 
+			await ctx.context.adapter.deleteMany({
+				model: "account",
+				where: [{ field: "providerId", value: providerId }],
+			});
+
 			return ctx.json({ success: true });
 		},
 	);

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -63,6 +63,15 @@ import {
 import { hasOrgAdminRole } from "./providers";
 import { getSafeRedirectUrl, processSAMLResponse } from "./saml-pipeline";
 
+const BUILT_IN_ACCOUNT_PROVIDER_IDS = [
+	"credential",
+	"email-otp",
+	"magic-link",
+	"phone-number",
+	"anonymous",
+	"siwe",
+] as const;
+
 /**
  * Builds the OIDC redirect URI. Uses the shared `redirectURI` option
  * when set, otherwise falls back to `/sso/callback/:providerId`.
@@ -659,16 +668,19 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 				}
 			}
 
-			// SSO provider ids share the account-linking provider namespace with
-			// social/OAuth providers. Reject ids that collide with a configured
-			// social provider, a trusted provider, or a reserved built-in id so a
-			// user-registered SSO provider can't be confused with one of them.
+			// SSO provider ids currently share the account-linking provider namespace.
+			// Reject collisions so a user-registered SSO provider cannot be confused
+			// with another account-producing provider.
+			// TODO(next): replace providerId account-link ownership with immutable
+			// SSO provider instance ids, then remove this cross-plugin slug coupling.
 			// Trust for SSO providers is established separately via
 			// verified domain ownership, never by this shared namespace.
 			const reservedProviderIds = new Set<string>([
-				"credential",
+				...BUILT_IN_ACCOUNT_PROVIDER_IDS,
+				...Object.keys(ctx.context.options.socialProviders ?? {}),
 				...ctx.context.socialProviders.map((p) => p.id),
 				...ctx.context.trustedProviders,
+				...(options?.defaultSSO?.map((p) => p.providerId) ?? []),
 			]);
 			if (reservedProviderIds.has(body.providerId)) {
 				ctx.context.logger.warn(
@@ -678,6 +690,24 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 					message:
 						"This providerId is reserved and cannot be used for an SSO provider",
 				});
+			}
+
+			if (ctx.context.hasPlugin("scim")) {
+				const existingSCIMProvider = await ctx.context.adapter.findOne<{
+					id: string;
+				}>({
+					model: "scimProvider",
+					where: [{ field: "providerId", value: body.providerId }],
+				});
+				if (existingSCIMProvider) {
+					ctx.context.logger.warn(
+						`SSO provider registration rejected for SCIM providerId: ${body.providerId}`,
+					);
+					throw new APIError("UNPROCESSABLE_ENTITY", {
+						message:
+							"This providerId is already used by a SCIM provider and cannot be used for an SSO provider",
+					});
+				}
 			}
 
 			const existingProvider = await ctx.context.adapter.findOne({


### PR DESCRIPTION
Deleting SSO provider config left account links live under a reusable providerId.

This keeps provider deletion and account-link cleanup in one transaction, rejects providerId collisions across account-producing provider surfaces, and rejects SSO identity-boundary changes when linked accounts already exist. Same-boundary updates, including secret rotation, still work.

providerId is currently the account-link namespace. Reusing it or retargeting it to another upstream identity source can let existing (providerId, accountId) links resolve for the wrong provider.