### PR TITLE
fix(sso): validate SAML response binding against the Service Provider

### DIFF
--- a/.changeset/sso-saml-audience-validation.md
+++ b/.changeset/sso-saml-audience-validation.md
@@ -2,4 +2,4 @@
 "@better-auth/sso": patch
 ---
 
-SAML SSO now validates the assertion's `Audience` against this Service Provider's entity id before creating a session, rejecting an assertion that was issued for a different relying party.
+SAML SSO now rejects responses whose audience, bearer recipient, or response destination does not match the configured Service Provider before creating a session.

--- a/.changeset/sso-saml-audience-validation.md
+++ b/.changeset/sso-saml-audience-validation.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+SAML SSO now validates the assertion's `Audience` against this Service Provider's entity id before creating a session, rejecting an assertion that was issued for a different relying party.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -1428,6 +1428,8 @@ The SAML callback endpoint (`/api/auth/sso/saml2/callback/{providerId}`) handles
 
 **Important**: `callbackUrl` in your SAML configuration is used as the Assertion Consumer Service (ACS) URL. Set it to the SAML callback route for your provider (e.g., `https://yourapp.com/api/auth/sso/saml2/sp/acs/my-provider`). If omitted, Better Auth derives it automatically from your `baseURL` and `providerId`.
 
+Your IdP must include an `AudienceRestriction` for this SP. The accepted audience is the SP entity ID, or the explicit `audience` value in `samlConfig` when you need to match an IdP-specific SP identifier. Better Auth also checks bearer `Recipient` and response `Destination` values against this provider's ACS endpoints.
+
 The post-login redirect destination is controlled by the `callbackURL` parameter in the client-side `signIn.sso()` call:
 
 ```ts

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -10,6 +10,7 @@ import * as constants from "../constants";
 import { assignOrganizationFromProvider } from "../linking";
 import {
 	getSAMLPostAssertionConsumerServiceUrls,
+	hasSAMLEncryptedAssertion,
 	SAML_HTTP_POST_BINDING,
 	validateSAMLAlgorithms,
 	validateSAMLResponseBinding,
@@ -18,6 +19,7 @@ import {
 import type { SAMLConditions } from "../saml/timestamp";
 import { validateSAMLTimestamp } from "../saml/timestamp";
 import { parseRelayState } from "../saml-state";
+import { saml } from "../samlify";
 import type {
 	AuthnRequestRecord,
 	SAMLAssertionExtract,
@@ -121,6 +123,21 @@ function getExpectedSAMLRecipients(
 		...configuredPostAssertionConsumerServiceUrls,
 		...toArray(assertionConsumerServiceUrl),
 	];
+}
+
+async function getSAMLResponseBindingContent(
+	sp: ReturnType<typeof createSP>,
+	samlContent: string,
+): Promise<string> {
+	if (!hasSAMLEncryptedAssertion(samlContent)) {
+		return samlContent;
+	}
+
+	const [decryptedContent] = await saml.SamlLib.decryptAssertion(
+		sp,
+		samlContent,
+	);
+	return decryptedContent;
 }
 
 /**
@@ -302,8 +319,10 @@ export async function processSAMLResponse(
 		currentCallbackPath,
 		assertionConsumerServiceUrl,
 	);
+	let samlBindingContent = samlContent;
 	try {
-		validateSAMLResponseBinding(samlContent, {
+		samlBindingContent = await getSAMLResponseBindingContent(sp, samlContent);
+		validateSAMLResponseBinding(samlBindingContent, {
 			expectedAudiences,
 			expectedRecipients,
 		});
@@ -323,7 +342,18 @@ export async function processSAMLResponse(
 				}),
 			);
 		}
-		throw error;
+		ctx.context.logger.error("SAML response binding validation failed", {
+			providerId,
+			error,
+			expectedAudiences: expectedAudiences.filter(Boolean),
+			expectedRecipients: expectedRecipients.filter(Boolean),
+		});
+		throw ctx.redirect(
+			buildSAMLRedirectUrl(samlRedirectUrl, {
+				error: "invalid_saml_response",
+				error_description: "SAML response binding could not be validated",
+			}),
+		);
 	}
 
 	// 12. InResponseTo validation
@@ -403,7 +433,9 @@ export async function processSAMLResponse(
 	// and proceeds, every later caller (including a concurrent submission) finds
 	// the row already present and is rejected. The deterministic primary key is
 	// the gate, so no separate find/expiry check is needed.
-	const assertionId = samlContent ? extractAssertionId(samlContent) : null;
+	const assertionId = samlBindingContent
+		? extractAssertionId(samlBindingContent)
+		: null;
 
 	if (assertionId) {
 		const issuer = idp.entityMeta.getEntityID();

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -8,7 +8,13 @@ import type { FlowResult } from "samlify/types/src/flow";
 
 import * as constants from "../constants";
 import { assignOrganizationFromProvider } from "../linking";
-import { validateSAMLAlgorithms, validateSingleAssertion } from "../saml";
+import {
+	getSAMLPostAssertionConsumerServiceUrls,
+	SAML_HTTP_POST_BINDING,
+	validateSAMLAlgorithms,
+	validateSAMLResponseBinding,
+	validateSingleAssertion,
+} from "../saml";
 import type { SAMLConditions } from "../saml/timestamp";
 import { validateSAMLTimestamp } from "../saml/timestamp";
 import { parseRelayState } from "../saml-state";
@@ -81,6 +87,40 @@ export function getSafeRedirectUrl(
 	}
 
 	return url;
+}
+
+function buildSAMLRedirectUrl(
+	url: string,
+	params: Record<string, string>,
+): string {
+	const searchParams = new URLSearchParams(params);
+	const separator = url.includes("?") ? "&" : "?";
+	return `${url}${separator}${searchParams.toString()}`;
+}
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+	if (Array.isArray(value)) {
+		return value;
+	}
+	return value ? [value] : [];
+}
+
+function getExpectedSAMLRecipients(
+	config: SAMLConfig,
+	baseURL: string,
+	providerId: string,
+	currentCallbackPath: string,
+	assertionConsumerServiceUrl: string | string[] | undefined,
+): string[] {
+	const configuredPostAssertionConsumerServiceUrls =
+		getSAMLPostAssertionConsumerServiceUrls(config.spMetadata?.metadata);
+
+	return [
+		currentCallbackPath,
+		`${baseURL}/sso/saml2/sp/acs/${providerId}`,
+		...configuredPostAssertionConsumerServiceUrls,
+		...toArray(assertionConsumerServiceUrl),
+	];
 }
 
 /**
@@ -235,6 +275,7 @@ export async function processSAMLResponse(
 	}
 
 	const { extract } = parsedResponse!;
+	const samlContent = parsedResponse.samlContent;
 
 	// 10. Algorithm validation
 	validateSAMLAlgorithms(parsedResponse, options?.saml?.algorithms);
@@ -246,33 +287,43 @@ export async function processSAMLResponse(
 		logger: ctx.context.logger,
 	});
 
-	// 11b. Audience validation — the assertion's <Audience> must match this SP's
-	// entity id, or an explicitly configured `audience`.
-	const expectedAudiences = new Set(
-		[sp.entityMeta.getEntityID(), parsedSamlConfig.audience].filter(
-			Boolean,
-		) as string[],
+	// 11b. Response binding validation
+	const expectedAudiences = [
+		sp.entityMeta.getEntityID(),
+		parsedSamlConfig.audience,
+	];
+	const assertionConsumerServiceUrl = sp.entityMeta.getAssertionConsumerService(
+		SAML_HTTP_POST_BINDING,
 	);
-	const assertionAudienceRaw = (extract as SAMLAssertionExtract).audience;
-	const assertionAudiences = (
-		Array.isArray(assertionAudienceRaw)
-			? assertionAudienceRaw
-			: assertionAudienceRaw
-				? [assertionAudienceRaw]
-				: []
-	).filter(Boolean);
-	if (
-		assertionAudiences.length === 0 ||
-		!assertionAudiences.some((audience) => expectedAudiences.has(audience))
-	) {
-		ctx.context.logger.error("SAML audience validation failed", {
-			providerId,
-			expected: [...expectedAudiences],
-			received: assertionAudiences,
+	const expectedRecipients = getExpectedSAMLRecipients(
+		parsedSamlConfig,
+		ctx.context.baseURL,
+		providerId,
+		currentCallbackPath,
+		assertionConsumerServiceUrl,
+	);
+	try {
+		validateSAMLResponseBinding(samlContent, {
+			expectedAudiences,
+			expectedRecipients,
 		});
-		throw ctx.redirect(
-			`${samlRedirectUrl}?error=invalid_saml_response&error_description=Audience+mismatch`,
-		);
+	} catch (error) {
+		if (isAPIError(error)) {
+			ctx.context.logger.error("SAML response binding validation failed", {
+				providerId,
+				code: error.body?.code,
+				expectedAudiences: expectedAudiences.filter(Boolean),
+				expectedRecipients: expectedRecipients.filter(Boolean),
+			});
+			throw ctx.redirect(
+				buildSAMLRedirectUrl(samlRedirectUrl, {
+					error: "invalid_saml_response",
+					error_description:
+						error.body?.message || error.message || "Invalid SAML response",
+				}),
+			);
+		}
+		throw error;
 	}
 
 	// 12. InResponseTo validation
@@ -310,7 +361,10 @@ export async function processSAMLResponse(
 					{ inResponseTo, providerId },
 				);
 				throw ctx.redirect(
-					`${samlRedirectUrl}?error=invalid_saml_response&error_description=Unknown+or+expired+request+ID`,
+					buildSAMLRedirectUrl(samlRedirectUrl, {
+						error: "invalid_saml_response",
+						error_description: "Unknown or expired request ID",
+					}),
 				);
 			}
 
@@ -324,7 +378,10 @@ export async function processSAMLResponse(
 					},
 				);
 				throw ctx.redirect(
-					`${samlRedirectUrl}?error=invalid_saml_response&error_description=Provider+mismatch`,
+					buildSAMLRedirectUrl(samlRedirectUrl, {
+						error: "invalid_saml_response",
+						error_description: "Provider mismatch",
+					}),
 				);
 			}
 		} else if (!allowIdpInitiated) {
@@ -333,7 +390,10 @@ export async function processSAMLResponse(
 				{ providerId },
 			);
 			throw ctx.redirect(
-				`${samlRedirectUrl}?error=unsolicited_response&error_description=IdP-initiated+SSO+not+allowed`,
+				buildSAMLRedirectUrl(samlRedirectUrl, {
+					error: "unsolicited_response",
+					error_description: "IdP-initiated SSO not allowed",
+				}),
 			);
 		}
 	}
@@ -343,7 +403,6 @@ export async function processSAMLResponse(
 	// and proceeds, every later caller (including a concurrent submission) finds
 	// the row already present and is rejected. The deterministic primary key is
 	// the gate, so no separate find/expiry check is needed.
-	const samlContent = (parsedResponse as any).samlContent as string | undefined;
 	const assertionId = samlContent ? extractAssertionId(samlContent) : null;
 
 	if (assertionId) {
@@ -377,7 +436,10 @@ export async function processSAMLResponse(
 				{ assertionId, issuer, providerId },
 			);
 			throw ctx.redirect(
-				`${samlRedirectUrl}?error=replay_detected&error_description=SAML+assertion+has+already+been+used`,
+				buildSAMLRedirectUrl(samlRedirectUrl, {
+					error: "replay_detected",
+					error_description: "SAML assertion has already been used",
+				}),
 			);
 		}
 	} else {
@@ -479,17 +541,21 @@ export async function processSAMLResponse(
 		});
 	} catch (e) {
 		if (isAPIError(e) && e.body?.code) {
-			const params = new URLSearchParams({ error: e.body.code });
-			if (e.body.message) params.set("error_description", e.body.message);
-			const sep = errorUrl.includes("?") ? "&" : "?";
-			throw ctx.redirect(`${errorUrl}${sep}${params.toString()}`);
+			throw ctx.redirect(
+				buildSAMLRedirectUrl(errorUrl, {
+					error: e.body.code,
+					...(e.body.message ? { error_description: e.body.message } : {}),
+				}),
+			);
 		}
 		throw e;
 	}
 
 	if (result.error) {
 		throw ctx.redirect(
-			`${callbackUrl}?error=${result.error.split(" ").join("_")}`,
+			buildSAMLRedirectUrl(callbackUrl, {
+				error: result.error.split(" ").join("_"),
+			}),
 		);
 	}
 

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -319,7 +319,7 @@ export async function processSAMLResponse(
 		currentCallbackPath,
 		assertionConsumerServiceUrl,
 	);
-	let samlBindingContent = samlContent;
+	let samlBindingContent: string;
 	try {
 		samlBindingContent = await getSAMLResponseBindingContent(sp, samlContent);
 		validateSAMLResponseBinding(samlBindingContent, {
@@ -433,9 +433,7 @@ export async function processSAMLResponse(
 	// and proceeds, every later caller (including a concurrent submission) finds
 	// the row already present and is rejected. The deterministic primary key is
 	// the gate, so no separate find/expiry check is needed.
-	const assertionId = samlBindingContent
-		? extractAssertionId(samlBindingContent)
-		: null;
+	const assertionId = extractAssertionId(samlBindingContent);
 
 	if (assertionId) {
 		const issuer = idp.entityMeta.getEntityID();

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -246,6 +246,35 @@ export async function processSAMLResponse(
 		logger: ctx.context.logger,
 	});
 
+	// 11b. Audience validation — the assertion's <Audience> must match this SP's
+	// entity id, or an explicitly configured `audience`.
+	const expectedAudiences = new Set(
+		[sp.entityMeta.getEntityID(), parsedSamlConfig.audience].filter(
+			Boolean,
+		) as string[],
+	);
+	const assertionAudienceRaw = (extract as SAMLAssertionExtract).audience;
+	const assertionAudiences = (
+		Array.isArray(assertionAudienceRaw)
+			? assertionAudienceRaw
+			: assertionAudienceRaw
+				? [assertionAudienceRaw]
+				: []
+	).filter(Boolean);
+	if (
+		assertionAudiences.length === 0 ||
+		!assertionAudiences.some((audience) => expectedAudiences.has(audience))
+	) {
+		ctx.context.logger.error("SAML audience validation failed", {
+			providerId,
+			expected: [...expectedAudiences],
+			received: assertionAudiences,
+		});
+		throw ctx.redirect(
+			`${samlRedirectUrl}?error=invalid_saml_response&error_description=Audience+mismatch`,
+		);
+	}
+
 	// 12. InResponseTo validation
 	const inResponseTo = (extract as SAMLAssertionExtract).inResponseTo as
 		| string

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -330,8 +330,21 @@ const spEncryptionKey = dedentPem`
 const generateRequestID = () => {
 	return "_" + randomUUID();
 };
+
+interface MockSAMLTemplateOverrides {
+	audience?: string;
+	destination?: string;
+	subjectRecipient?: string;
+}
+
 const createTemplateCallback =
-	(idp: any, sp: any, email: string) => (template: any) => {
+	(
+		idp: any,
+		sp: any,
+		email: string,
+		overrides: MockSAMLTemplateOverrides = {},
+	) =>
+	(template: any) => {
 		const assertionConsumerServiceUrl =
 			sp.entityMeta.getAssertionConsumerService(
 				saml.Constants.wording.binding.post,
@@ -348,10 +361,11 @@ const createTemplateCallback =
 		const tagValues = {
 			ID: id,
 			AssertionID: generateRequestID(),
-			Destination: assertionConsumerServiceUrl,
-			Audience: sp.entityMeta.getEntityID(),
+			Destination: overrides.destination ?? assertionConsumerServiceUrl,
+			Audience: overrides.audience ?? sp.entityMeta.getEntityID(),
 			EntityID: sp.entityMeta.getEntityID(),
-			SubjectRecipient: assertionConsumerServiceUrl,
+			SubjectRecipient:
+				overrides.subjectRecipient ?? assertionConsumerServiceUrl,
 			Issuer: idp.entityMeta.getEntityID(),
 			IssueInstant: now.toISOString(),
 			AssertionConsumerServiceURL: assertionConsumerServiceUrl,
@@ -417,6 +431,11 @@ interface MockIdPOptions {
 	wantAuthnRequestsSigned?: boolean;
 	spSigningKey?: string;
 	spSigningKeyPass?: string;
+}
+
+interface MockSAMLResponse {
+	samlResponse: string;
+	entityEndpoint?: string;
 }
 
 const createMockSAMLIdP = (port: number, options: MockIdPOptions = {}) => {
@@ -506,12 +525,19 @@ const createMockSAMLIdP = (port: number, options: MockIdPOptions = {}) => {
 				emailAddress: emailValue,
 				famName: "hello world",
 			};
+			const queryValue = (value: unknown) =>
+				typeof value === "string" ? value : undefined;
+			const templateOverrides: MockSAMLTemplateOverrides = {
+				audience: queryValue(req.query.audience),
+				destination: queryValue(req.query.destination),
+				subjectRecipient: queryValue(req.query.recipient),
+			};
 			const { context, entityEndpoint } = (await idp.createLoginResponse(
 				sp,
 				{} as any,
 				saml.Constants.wording.binding.post,
 				user,
-				createTemplateCallback(idp, sp, user.emailAddress),
+				createTemplateCallback(idp, sp, user.emailAddress, templateOverrides),
 			)) as { context: string; entityEndpoint?: string };
 			res.status(200).json({ samlResponse: context, entityEndpoint });
 		} catch (error) {
@@ -1899,6 +1925,8 @@ describe("SAML SSO", async () => {
 		});
 
 		const { headers } = await signInWithTestUser();
+		const acsUrl =
+			"http://localhost:3000/api/auth/sso/saml2/sp/acs/saml-audience-provider";
 
 		await authAudience.api.registerSSOProvider({
 			body: {
@@ -1908,17 +1936,16 @@ describe("SAML SSO", async () => {
 				samlConfig: {
 					entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
 					cert: certificate,
-					callbackUrl: "http://localhost:3000/dashboard",
+					callbackUrl: "http://localhost:3000/dashboard?source=saml",
 					wantAssertionsSigned: false,
 					signatureAlgorithm: "sha256",
 					digestAlgorithm: "sha256",
 					idpMetadata: {
 						metadata: idpMetadata,
 					},
-					// Empty spMetadata: this SP's entity id falls back to its issuer
-					// (http://localhost:8081), which differs from the assertion's
-					// <Audience> (the IdP's spMetadata entity id).
-					spMetadata: {},
+					spMetadata: {
+						metadata: spMetadata,
+					},
 					identifierFormat:
 						"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
 				},
@@ -1926,32 +1953,45 @@ describe("SAML SSO", async () => {
 			headers,
 		});
 
-		let samlResponse: any;
-		await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
+		const idpResponseUrl = new URL(
+			"http://localhost:8081/api/sso/saml2/idp/post",
+		);
+		idpResponseUrl.searchParams.set(
+			"audience",
+			"http://other.example.com/saml/metadata",
+		);
+		idpResponseUrl.searchParams.set("destination", acsUrl);
+		idpResponseUrl.searchParams.set("recipient", acsUrl);
+
+		let samlResponse: MockSAMLResponse | undefined;
+		await betterFetch(idpResponseUrl.toString(), {
 			onSuccess: async (context) => {
-				samlResponse = await context.data;
+				samlResponse = (await context.data) as MockSAMLResponse;
 			},
 		});
+		expect(samlResponse).toBeDefined();
 
 		const response = await authAudience.handler(
-			new Request(
-				"http://localhost:3000/api/auth/sso/saml2/sp/acs/saml-audience-provider",
-				{
-					method: "POST",
-					headers: {
-						"Content-Type": "application/x-www-form-urlencoded",
-					},
-					body: new URLSearchParams({
-						SAMLResponse: samlResponse.samlResponse,
-					}),
+			new Request(acsUrl, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
 				},
-			),
+				body: new URLSearchParams({
+					SAMLResponse: samlResponse!.samlResponse,
+				}),
+			}),
 		);
 
 		expect(response.status).toBe(302);
 		const redirectLocation = response.headers.get("location") || "";
+		const redirectUrl = new URL(redirectLocation);
 		expect(redirectLocation).toContain("error=invalid_saml_response");
-		expect(redirectLocation).toContain("Audience");
+		expect(redirectLocation).toContain("source=saml");
+		expect(redirectLocation).toContain("error_description=");
+		expect(redirectUrl.searchParams.get("error_description")).toContain(
+			"audience does not match",
+		);
 	});
 
 	it("should deny account linking when provider is not trusted and domain is not verified", async () => {

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -1893,6 +1893,67 @@ describe("SAML SSO", async () => {
 		expect(redirectLocation).toContain("error=signup_disabled");
 	});
 
+	it("rejects a SAML assertion whose audience does not match this SP", async () => {
+		const { auth: authAudience, signInWithTestUser } = await getTestInstance({
+			plugins: [sso()],
+		});
+
+		const { headers } = await signInWithTestUser();
+
+		await authAudience.api.registerSSOProvider({
+			body: {
+				providerId: "saml-audience-provider",
+				issuer: "http://localhost:8081",
+				domain: "http://localhost:8081",
+				samlConfig: {
+					entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+					cert: certificate,
+					callbackUrl: "http://localhost:3000/dashboard",
+					wantAssertionsSigned: false,
+					signatureAlgorithm: "sha256",
+					digestAlgorithm: "sha256",
+					idpMetadata: {
+						metadata: idpMetadata,
+					},
+					// Empty spMetadata: this SP's entity id falls back to its issuer
+					// (http://localhost:8081), which differs from the assertion's
+					// <Audience> (the IdP's spMetadata entity id).
+					spMetadata: {},
+					identifierFormat:
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+				},
+			},
+			headers,
+		});
+
+		let samlResponse: any;
+		await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
+			onSuccess: async (context) => {
+				samlResponse = await context.data;
+			},
+		});
+
+		const response = await authAudience.handler(
+			new Request(
+				"http://localhost:3000/api/auth/sso/saml2/sp/acs/saml-audience-provider",
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded",
+					},
+					body: new URLSearchParams({
+						SAMLResponse: samlResponse.samlResponse,
+					}),
+				},
+			),
+		);
+
+		expect(response.status).toBe(302);
+		const redirectLocation = response.headers.get("location") || "";
+		expect(redirectLocation).toContain("error=invalid_saml_response");
+		expect(redirectLocation).toContain("Audience");
+	});
+
 	it("should deny account linking when provider is not trusted and domain is not verified", async () => {
 		const { auth: authUntrusted, signInWithTestUser } = await getTestInstance({
 			account: {

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -428,6 +428,8 @@ function verifyRedirectSignature(
 
 interface MockIdPOptions {
 	idpMetadataXml?: string;
+	spMetadataXml?: string;
+	isAssertionEncrypted?: boolean;
 	wantAuthnRequestsSigned?: boolean;
 	spSigningKey?: string;
 	spSigningKeyPass?: string;
@@ -450,7 +452,7 @@ const createMockSAMLIdP = (port: number, options: MockIdPOptions = {}) => {
 	const idp = saml.IdentityProvider({
 		metadata: idpMetadataXml,
 		privateKey: idPk,
-		isAssertionEncrypted: false,
+		isAssertionEncrypted: options.isAssertionEncrypted ?? false,
 		privateKeyPass: "jXmKf9By6ruLnUdRo90G",
 		loginResponseTemplate: {
 			context:
@@ -478,7 +480,7 @@ const createMockSAMLIdP = (port: number, options: MockIdPOptions = {}) => {
 		},
 	});
 	const sp = saml.ServiceProvider({
-		metadata: spMetadata,
+		metadata: options.spMetadataXml ?? spMetadata,
 	});
 
 	const handleIdPRequest = async (
@@ -1382,6 +1384,123 @@ describe("SAML SSO", async () => {
 			},
 		);
 		expect(redirectLocation).toBe("http://localhost:3000/dashboard");
+	});
+
+	it("should validate response binding after decrypting an encrypted assertion", async () => {
+		const encryptedIdpMetadata = idpMetadata.replaceAll(
+			"localhost:8081",
+			"localhost:8084",
+		);
+		const encryptionCertificate = certificate
+			.replace(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----/g, "")
+			.replace(/\s+/g, "");
+		const encryptedSpMetadata = spMetadata.replace(
+			/<ds:X509Certificate>[^<]+<\/ds:X509Certificate>/g,
+			`<ds:X509Certificate>${encryptionCertificate}</ds:X509Certificate>`,
+		);
+		const encryptedMockIdP = createMockSAMLIdP(8084, {
+			idpMetadataXml: encryptedIdpMetadata,
+			spMetadataXml: encryptedSpMetadata,
+			isAssertionEncrypted: true,
+		});
+
+		await encryptedMockIdP.start();
+		try {
+			const encryptedAuth = betterAuth({
+				database: memoryAdapter({
+					user: [],
+					session: [],
+					verification: [],
+					account: [],
+					ssoProvider: [],
+				}),
+				baseURL: "http://localhost:3000",
+				emailAndPassword: {
+					enabled: true,
+				},
+				plugins: [
+					sso({
+						defaultSSO: [
+							{
+								domain: "localhost:8084",
+								providerId: "encrypted-saml-provider",
+								samlConfig: {
+									issuer: "http://localhost:8084",
+									entryPoint: "http://localhost:8084/api/sso/saml2/idp/post",
+									cert: certificate,
+									callbackUrl: "http://localhost:8084/dashboard",
+									wantAssertionsSigned: false,
+									signatureAlgorithm: "sha256",
+									digestAlgorithm: "sha256",
+									idpMetadata: {
+										metadata: encryptedIdpMetadata,
+										privateKey: idpPrivateKey,
+										privateKeyPass: "q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW",
+										isAssertionEncrypted: true,
+										encPrivateKey: idpEncryptionKey,
+										encPrivateKeyPass: "g7hGcRmp8PxT5QeP2q9Ehf1bWe9zTALN",
+									},
+									spMetadata: {
+										metadata: encryptedSpMetadata,
+										binding: "post",
+										privateKey: idpPrivateKey,
+										privateKeyPass: "q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW",
+										isAssertionEncrypted: true,
+										encPrivateKey: idpPrivateKey,
+										encPrivateKeyPass: "q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW",
+									},
+									identifierFormat:
+										"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+								},
+							},
+						],
+					}),
+				],
+			});
+
+			const signInResponse = await encryptedAuth.api.signInSSO({
+				body: {
+					providerId: "encrypted-saml-provider",
+					callbackURL: "http://localhost:3000/dashboard",
+				},
+			});
+			const relayState =
+				new URL(signInResponse?.url as string).searchParams.get("RelayState") ??
+				"";
+			let samlResponse: MockSAMLResponse | undefined;
+			await betterFetch(signInResponse?.url as string, {
+				onSuccess: async (context) => {
+					samlResponse = (await context.data) as MockSAMLResponse;
+				},
+			});
+			expect(samlResponse).toBeDefined();
+			const samlResponseXml = Buffer.from(
+				samlResponse!.samlResponse,
+				"base64",
+			).toString("utf8");
+			expect(samlResponseXml).toContain("EncryptedAssertion");
+
+			const response = await encryptedAuth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/callback/encrypted-saml-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: samlResponse!.samlResponse,
+							RelayState: relayState,
+						}),
+					},
+				),
+			);
+			expect(response.status).toBe(302);
+			const redirectLocation = response.headers.get("location") || "";
+			expect(redirectLocation).toBe("http://localhost:3000/dashboard");
+		} finally {
+			await encryptedMockIdP.stop();
+		}
 	});
 
 	it("should not allow creating a provider if limit is set to 0", async () => {

--- a/packages/sso/src/saml/index.ts
+++ b/packages/sso/src/saml/index.ts
@@ -9,5 +9,9 @@ export {
 	validateConfigAlgorithms,
 	validateSAMLAlgorithms,
 } from "./algorithms";
-
 export { validateSingleAssertion } from "./assertions";
+export {
+	getSAMLPostAssertionConsumerServiceUrls,
+	SAML_HTTP_POST_BINDING,
+	validateSAMLResponseBinding,
+} from "./response-binding";

--- a/packages/sso/src/saml/index.ts
+++ b/packages/sso/src/saml/index.ts
@@ -12,6 +12,7 @@ export {
 export { validateSingleAssertion } from "./assertions";
 export {
 	getSAMLPostAssertionConsumerServiceUrls,
+	hasSAMLEncryptedAssertion,
 	SAML_HTTP_POST_BINDING,
 	validateSAMLResponseBinding,
 } from "./response-binding";

--- a/packages/sso/src/saml/response-binding.test.ts
+++ b/packages/sso/src/saml/response-binding.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+	getSAMLPostAssertionConsumerServiceUrls,
+	validateSAMLResponseBinding,
+} from "./response-binding";
+
+const serviceProviderEntityId = "https://sp.example.com/metadata";
+const serviceProviderAcsUrl = "https://sp.example.com/sso/acs";
+const otherServiceProvider = "https://other.example.com/metadata";
+
+function buildAudienceRestrictions(audienceGroups: string[][]): string {
+	return audienceGroups
+		.map(
+			(audiences) => `
+				<saml:AudienceRestriction>
+					${audiences
+						.map((audience) => `<saml:Audience>${audience}</saml:Audience>`)
+						.join("")}
+				</saml:AudienceRestriction>
+			`,
+		)
+		.join("");
+}
+
+function buildSAMLResponse({
+	audienceGroups = [[serviceProviderEntityId]],
+	destination = serviceProviderAcsUrl,
+	recipient = serviceProviderAcsUrl,
+}: {
+	audienceGroups?: string[][];
+	destination?: string | null;
+	recipient?: string | null;
+} = {}): string {
+	const destinationAttribute = destination
+		? ` Destination="${destination}"`
+		: "";
+	const recipientAttribute = recipient ? ` Recipient="${recipient}"` : "";
+
+	return `
+		<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"${destinationAttribute}>
+			<saml:Assertion>
+				<saml:Subject>
+					<saml:NameID>user@example.com</saml:NameID>
+					<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+						<saml:SubjectConfirmationData${recipientAttribute} NotOnOrAfter="2030-01-01T00:00:00.000Z" />
+					</saml:SubjectConfirmation>
+				</saml:Subject>
+				<saml:Conditions>
+					${buildAudienceRestrictions(audienceGroups)}
+				</saml:Conditions>
+			</saml:Assertion>
+		</samlp:Response>
+	`;
+}
+
+function validate(xml: string, expectedAudiences = [serviceProviderEntityId]) {
+	return validateSAMLResponseBinding(xml, {
+		expectedAudiences,
+		expectedRecipients: [serviceProviderAcsUrl],
+	});
+}
+
+describe("validateSAMLResponseBinding", () => {
+	it("accepts an assertion addressed to this Service Provider", () => {
+		expect(() => validate(buildSAMLResponse())).not.toThrow();
+	});
+
+	it("accepts an explicitly configured audience alias", () => {
+		const audienceAlias = "https://app.example.com/saml";
+
+		expect(() =>
+			validate(buildSAMLResponse({ audienceGroups: [[audienceAlias]] }), [
+				serviceProviderEntityId,
+				audienceAlias,
+			]),
+		).not.toThrow();
+	});
+
+	it("accepts multiple audiences in one AudienceRestriction when one matches", () => {
+		expect(() =>
+			validate(
+				buildSAMLResponse({
+					audienceGroups: [[otherServiceProvider, serviceProviderEntityId]],
+				}),
+			),
+		).not.toThrow();
+	});
+
+	it("rejects an assertion with no AudienceRestriction", () => {
+		expect(() => validate(buildSAMLResponse({ audienceGroups: [] }))).toThrow(
+			/missing an AudienceRestriction/,
+		);
+	});
+
+	it("rejects an assertion whose AudienceRestriction does not include this Service Provider", () => {
+		expect(() =>
+			validate(buildSAMLResponse({ audienceGroups: [[otherServiceProvider]] })),
+		).toThrow(/audience does not match/);
+	});
+
+	it("rejects multiple AudienceRestriction conditions unless every condition matches", () => {
+		expect(() =>
+			validate(
+				buildSAMLResponse({
+					audienceGroups: [[serviceProviderEntityId], [otherServiceProvider]],
+				}),
+			),
+		).toThrow(/audience does not match/);
+	});
+
+	it("rejects a bearer confirmation without Recipient", () => {
+		expect(() => validate(buildSAMLResponse({ recipient: null }))).toThrow(
+			/missing a Recipient/,
+		);
+	});
+
+	it("rejects a bearer Recipient for another Service Provider", () => {
+		expect(() =>
+			validate(
+				buildSAMLResponse({ recipient: "https://other.example.com/sso/acs" }),
+			),
+		).toThrow(/Recipient does not match/);
+	});
+
+	it("rejects a response Destination for another Service Provider", () => {
+		expect(() =>
+			validate(
+				buildSAMLResponse({
+					destination: "https://other.example.com/sso/acs",
+				}),
+			),
+		).toThrow(/Destination does not match/);
+	});
+
+	it("accepts a response without Destination", () => {
+		expect(() =>
+			validate(buildSAMLResponse({ destination: null })),
+		).not.toThrow();
+	});
+});
+
+describe("getSAMLPostAssertionConsumerServiceUrls", () => {
+	it("extracts only POST AssertionConsumerService locations from SP metadata", () => {
+		const metadata = `
+			<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">
+				<md:SPSSODescriptor>
+					<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.example.com/saml/post" />
+					<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sp.example.com/saml/redirect" />
+					<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.example.com/saml/post" />
+				</md:SPSSODescriptor>
+			</md:EntityDescriptor>
+		`;
+
+		expect(getSAMLPostAssertionConsumerServiceUrls(metadata)).toEqual([
+			"https://sp.example.com/saml/post",
+		]);
+	});
+
+	it("returns no locations for empty or invalid metadata", () => {
+		expect(getSAMLPostAssertionConsumerServiceUrls(undefined)).toEqual([]);
+		expect(getSAMLPostAssertionConsumerServiceUrls("<")).toEqual([]);
+	});
+});

--- a/packages/sso/src/saml/response-binding.test.ts
+++ b/packages/sso/src/saml/response-binding.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	getSAMLPostAssertionConsumerServiceUrls,
+	hasSAMLEncryptedAssertion,
 	validateSAMLResponseBinding,
 } from "./response-binding";
 
@@ -159,5 +160,18 @@ describe("getSAMLPostAssertionConsumerServiceUrls", () => {
 	it("returns no locations for empty or invalid metadata", () => {
 		expect(getSAMLPostAssertionConsumerServiceUrls(undefined)).toEqual([]);
 		expect(getSAMLPostAssertionConsumerServiceUrls("<")).toEqual([]);
+	});
+});
+
+describe("hasSAMLEncryptedAssertion", () => {
+	it("detects encrypted assertions without treating plain assertions as encrypted", () => {
+		const encryptedResponse = `
+			<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+				<saml:EncryptedAssertion />
+			</samlp:Response>
+		`;
+
+		expect(hasSAMLEncryptedAssertion(encryptedResponse)).toBe(true);
+		expect(hasSAMLEncryptedAssertion(buildSAMLResponse())).toBe(false);
 	});
 });

--- a/packages/sso/src/saml/response-binding.ts
+++ b/packages/sso/src/saml/response-binding.ts
@@ -1,0 +1,218 @@
+import { APIError } from "better-auth/api";
+import { findNode, xmlParser } from "./parser";
+
+export const SAML_HTTP_POST_BINDING =
+	"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
+
+const SAML_BEARER_CONFIRMATION_METHOD = "urn:oasis:names:tc:SAML:2.0:cm:bearer";
+
+type XmlNode = Record<string, unknown>;
+
+export interface SAMLResponseBindingValidationOptions {
+	expectedAudiences: Array<string | undefined>;
+	expectedRecipients: Array<string | undefined>;
+}
+
+function toNode(value: unknown): XmlNode | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return null;
+	}
+	return value as XmlNode;
+}
+
+function toNodeArray(value: unknown): XmlNode[] {
+	if (Array.isArray(value)) {
+		return value.map(toNode).filter((node): node is XmlNode => !!node);
+	}
+	const node = toNode(value);
+	return node ? [node] : [];
+}
+
+function firstNode(value: unknown): XmlNode | null {
+	return toNodeArray(value)[0] ?? null;
+}
+
+function toStringArray(value: unknown): string[] {
+	if (typeof value === "string") {
+		return [value];
+	}
+	if (Array.isArray(value)) {
+		return value.flatMap(toStringArray);
+	}
+	const node = toNode(value);
+	const text = node?.["#text"];
+	return typeof text === "string" ? [text] : [];
+}
+
+function toStringSet(values: Array<string | undefined>): Set<string> {
+	return new Set(values.filter((value): value is string => !!value));
+}
+
+function parseSAMLContent(samlContent: string): XmlNode {
+	try {
+		const parsed = toNode(xmlParser.parse(samlContent));
+		if (parsed) {
+			return parsed;
+		}
+	} catch {
+		// Fall through to the APIError below so callers receive a stable code.
+	}
+	throw new APIError("BAD_REQUEST", {
+		message: "SAML response XML could not be parsed",
+		code: "SAML_RESPONSE_INVALID_XML",
+	});
+}
+
+export function getSAMLPostAssertionConsumerServiceUrls(
+	metadata: string | undefined,
+): string[] {
+	if (!metadata) {
+		return [];
+	}
+
+	try {
+		const parsed = toNode(xmlParser.parse(metadata));
+		const spDescriptors = toNodeArray(findNode(parsed, "SPSSODescriptor"));
+		const locations = spDescriptors.flatMap((descriptor) =>
+			toNodeArray(descriptor.AssertionConsumerService)
+				.filter((service) => service["@_Binding"] === SAML_HTTP_POST_BINDING)
+				.map((service) => service["@_Location"])
+				.filter(
+					(location): location is string =>
+						typeof location === "string" && !!location,
+				),
+		);
+		return [...new Set(locations)];
+	} catch {
+		return [];
+	}
+}
+
+function getResponseNode(parsed: XmlNode): XmlNode | null {
+	return firstNode(parsed.Response);
+}
+
+function getAssertionNode(parsed: XmlNode, response: XmlNode | null): XmlNode {
+	const assertion =
+		firstNode(response?.Assertion) ?? firstNode(parsed.Assertion);
+	if (assertion) {
+		return assertion;
+	}
+	throw new APIError("BAD_REQUEST", {
+		message: "SAML response is missing an assertion",
+		code: "SAML_ASSERTION_MISSING",
+	});
+}
+
+function getAudienceRestrictionGroups(assertion: XmlNode): string[][] {
+	const conditions = firstNode(assertion.Conditions);
+	const restrictions = toNodeArray(conditions?.AudienceRestriction);
+	return restrictions.map((restriction) =>
+		toStringArray(restriction.Audience).filter(Boolean),
+	);
+}
+
+function validateAudienceRestrictions(
+	assertion: XmlNode,
+	expectedAudiences: Set<string>,
+): void {
+	const audienceGroups = getAudienceRestrictionGroups(assertion);
+
+	if (
+		audienceGroups.length === 0 ||
+		audienceGroups.every((group) => !group.length)
+	) {
+		throw new APIError("BAD_REQUEST", {
+			message: "SAML assertion is missing an AudienceRestriction",
+			code: "SAML_AUDIENCE_MISSING",
+		});
+	}
+
+	const hasRejectedAudienceRestriction = audienceGroups.some(
+		(group) => !group.some((audience) => expectedAudiences.has(audience)),
+	);
+
+	if (hasRejectedAudienceRestriction) {
+		throw new APIError("BAD_REQUEST", {
+			message: "SAML assertion audience does not match this Service Provider",
+			code: "SAML_AUDIENCE_MISMATCH",
+		});
+	}
+}
+
+function getBearerSubjectConfirmationData(assertion: XmlNode): XmlNode[] {
+	const subject = firstNode(assertion.Subject);
+	const confirmations = toNodeArray(subject?.SubjectConfirmation);
+	return confirmations
+		.filter(
+			(confirmation) =>
+				confirmation["@_Method"] === SAML_BEARER_CONFIRMATION_METHOD,
+		)
+		.map((confirmation) => firstNode(confirmation.SubjectConfirmationData))
+		.filter((data): data is XmlNode => !!data);
+}
+
+function validateBearerRecipient(
+	assertion: XmlNode,
+	expectedRecipients: Set<string>,
+): void {
+	const confirmationData = getBearerSubjectConfirmationData(assertion);
+
+	if (!confirmationData.length) {
+		throw new APIError("BAD_REQUEST", {
+			message: "SAML assertion is missing bearer SubjectConfirmationData",
+			code: "SAML_BEARER_CONFIRMATION_MISSING",
+		});
+	}
+
+	const recipients = confirmationData
+		.map((data) => data["@_Recipient"])
+		.filter((recipient): recipient is string => typeof recipient === "string");
+
+	if (!recipients.length) {
+		throw new APIError("BAD_REQUEST", {
+			message: "SAML bearer SubjectConfirmationData is missing a Recipient",
+			code: "SAML_RECIPIENT_MISSING",
+		});
+	}
+
+	if (!recipients.some((recipient) => expectedRecipients.has(recipient))) {
+		throw new APIError("BAD_REQUEST", {
+			message:
+				"SAML bearer SubjectConfirmationData Recipient does not match this Service Provider",
+			code: "SAML_RECIPIENT_MISMATCH",
+		});
+	}
+}
+
+function validateResponseDestination(
+	response: XmlNode | null,
+	expectedRecipients: Set<string>,
+): void {
+	const destination = response?.["@_Destination"];
+	if (typeof destination !== "string" || !destination) {
+		return;
+	}
+
+	if (!expectedRecipients.has(destination)) {
+		throw new APIError("BAD_REQUEST", {
+			message: "SAML response Destination does not match this Service Provider",
+			code: "SAML_DESTINATION_MISMATCH",
+		});
+	}
+}
+
+export function validateSAMLResponseBinding(
+	samlContent: string,
+	options: SAMLResponseBindingValidationOptions,
+): void {
+	const expectedAudiences = toStringSet(options.expectedAudiences);
+	const expectedRecipients = toStringSet(options.expectedRecipients);
+	const parsed = parseSAMLContent(samlContent);
+	const response = getResponseNode(parsed);
+	const assertion = getAssertionNode(parsed, response);
+
+	validateAudienceRestrictions(assertion, expectedAudiences);
+	validateBearerRecipient(assertion, expectedRecipients);
+	validateResponseDestination(response, expectedRecipients);
+}

--- a/packages/sso/src/saml/response-binding.ts
+++ b/packages/sso/src/saml/response-binding.ts
@@ -1,5 +1,5 @@
 import { APIError } from "better-auth/api";
-import { findNode, xmlParser } from "./parser";
+import { countAllNodes, findNode, xmlParser } from "./parser";
 
 export const SAML_HTTP_POST_BINDING =
 	"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
@@ -85,6 +85,15 @@ export function getSAMLPostAssertionConsumerServiceUrls(
 		return [...new Set(locations)];
 	} catch {
 		return [];
+	}
+}
+
+export function hasSAMLEncryptedAssertion(samlContent: string): boolean {
+	try {
+		const parsed = xmlParser.parse(samlContent);
+		return countAllNodes(parsed, "EncryptedAssertion") > 0;
+	} catch {
+		return false;
 	}
 }
 

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -111,7 +111,6 @@ export interface SAMLAssertionExtract {
 	nameID?: string;
 	sessionIndex?: string;
 	inResponseTo?: string;
-	audience?: string | string[];
 	conditions?: {
 		notBefore?: string;
 		notOnOrAfter?: string;

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -111,6 +111,7 @@ export interface SAMLAssertionExtract {
 	nameID?: string;
 	sessionIndex?: string;
 	inResponseTo?: string;
+	audience?: string | string[];
 	conditions?: {
 		notBefore?: string;
 		notOnOrAfter?: string;


### PR DESCRIPTION
SAML SSO accepted signed SAML responses without proving the assertion was issued for, and delivered to, this Service Provider.

This moves the check into Better Auth's SAML response pipeline instead of relying on samlify's flattened assertion extract. The response binding now validates `AudienceRestriction` using SAML condition semantics, rejects bearer confirmations whose `Recipient` is outside this provider's ACS endpoints, and rejects mismatched response `Destination` values when present.

Encrypted assertions are decrypted before this binding validation and before replay-protection assertion ID extraction, so encrypted SAML deployments use the same relying-party boundary.

The accepted audience is this SP entity ID or an explicit `samlConfig.audience` alias. Error redirects now preserve existing callback query params while returning distinct SAML validation messages.