### PR TITLE
fix(sso): require DNS proof for every domain listed on a provider

### DIFF
--- a/.changeset/sso-verify-every-listed-domain.md
+++ b/.changeset/sso-verify-every-listed-domain.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+SSO domain verification now proves ownership of every domain a provider lists. When a provider's `domain` holds several comma-separated domains, each one must have its own verifying DNS TXT record before the provider is marked verified — matching the set of domains accepted at sign-in and used for provider and organization routing. Previously the value was reduced to a single host for the DNS check.

--- a/.changeset/sso-verify-every-listed-domain.md
+++ b/.changeset/sso-verify-every-listed-domain.md
@@ -2,4 +2,4 @@
 "@better-auth/sso": patch
 ---
 
-SSO domain verification now proves ownership of every domain a provider lists. When a provider's `domain` holds several comma-separated domains, each one must have its own verifying DNS TXT record before the provider is marked verified — matching the set of domains accepted at sign-in and used for provider and organization routing. Previously the value was reduced to a single host for the DNS check.
+SSO domain verification now requires proof for every domain a provider lists. When a provider's `domain` has multiple comma-separated domains, each listed domain must publish the verification TXT record before the provider is marked verified. The verifier also accepts TXT records containing the raw verification token, matching the documented setup flow.

--- a/.changeset/sso-verify-every-listed-domain.md
+++ b/.changeset/sso-verify-every-listed-domain.md
@@ -2,4 +2,4 @@
 "@better-auth/sso": patch
 ---
 
-SSO domain verification now requires proof for every domain a provider lists. When a provider's `domain` has multiple comma-separated domains, each listed domain must publish the verification TXT record before the provider is marked verified. The verifier also accepts TXT records containing the raw verification token, matching the documented setup flow.
+SSO domain verification now requires proof for every domain a provider lists. When a provider's `domain` has multiple comma-separated domains, each listed domain must publish the verification TXT record before the provider is marked verified. The verifier accepts TXT records that exactly match the raw verification token, matching the documented setup flow, or the existing `identifier=value` format.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -192,7 +192,7 @@ This allows most endpoint-related fields in `oidcConfig` to be **optional** — 
        */
       issuer: string = "https://your-org.okta.com"
       /**
-       * Email domain for this provider
+       * Bare email domain, or comma-separated bare email domains, for this provider
        */
       domain: string = "yourcompany.com"
       /**
@@ -1346,7 +1346,7 @@ See the [Schema](#if-you-have-enabled-domain-verification) section to add the fi
 ### Verify your domain
 
 When domain verification is enabled, every new SSO provider will be untrusted at first.
-This means that new sign-ups or sign-ins will be allowed until the domain ownership has been verified.
+This means that new sign-ups or sign-ins will not be allowed until domain ownership has been verified.
 
 To verify your ownership over a domain, follow these steps:
 
@@ -1365,6 +1365,8 @@ To verify your ownership over a domain, follow these steps:
 
     * **Host:** `_better-auth-token-{your-provider-id}` (**Note:** An underscore is automatically prepended to follow DNS infrastructure subdomain conventions. The `better-auth-token` part can be customized through the `domainVerification.tokenPrefix` option)
     * **Value:** The verification token you were given.
+
+    If the SSO provider lists multiple comma-separated domains, add this `TXT` record under every listed domain. For example, a provider with `domain: "company.com,subsidiary.com"` must publish the record for both `company.com` and `subsidiary.com`.
 
     **Save the record and wait for it to propagate.** This can take up to 48 hours, but it's usually much faster.
   </Step>
@@ -1628,7 +1630,7 @@ export const ssoOptionsType = {
 			type: "object",
 			properties: {
 				domain: {
-					description: "The domain to match for this default provider.",
+					description: "The bare email domain, or comma-separated bare email domains, to match for this default provider.",
 					type: "string",
 					required: true,
 				},

--- a/packages/sso/src/domain-verification.test.ts
+++ b/packages/sso/src/domain-verification.test.ts
@@ -442,6 +442,34 @@ describe("Domain verification", async () => {
 			});
 		});
 
+		it("should return bad gateway when the TXT record only contains the verification token as a substring", async () => {
+			const { auth, getAuthHeaders, registerSSOProvider } = createTestAuth();
+			const headers = await getAuthHeaders(testUser);
+			const provider = await registerSSOProvider(headers);
+
+			dnsMock.resolveTxt.mockResolvedValue([
+				[`prefix-${provider.domainVerificationToken}-suffix`],
+				[
+					`_better-auth-token-saml-provider-1=${provider.domainVerificationToken}-suffix`,
+				],
+			]);
+
+			const response = await auth.api.verifyDomain({
+				body: {
+					providerId: provider.providerId,
+				},
+				headers,
+				asResponse: true,
+			});
+
+			expect(response.status).toBe(502);
+			expect(await response.json()).toEqual({
+				message:
+					"Unable to verify domain ownership for hello.com. Try again later",
+				code: "DOMAIN_VERIFICATION_FAILED",
+			});
+		});
+
 		it("should return forbidden if user does not own the provider", async () => {
 			const { auth, getAuthHeaders, registerSSOProvider } = createTestAuth();
 			const headers = await getAuthHeaders(testUser);
@@ -512,7 +540,8 @@ describe("Domain verification", async () => {
 					"v=spf1 ip4:50.242.118.232/29 include:_spf.google.com include:mail.zendesk.com ~all",
 				],
 				[
-					`_better-auth-token-saml-provider-1=${provider.domainVerificationToken}`,
+					"_better-auth-token-saml-provider-1=",
+					provider.domainVerificationToken,
 				],
 			]);
 

--- a/packages/sso/src/domain-verification.test.ts
+++ b/packages/sso/src/domain-verification.test.ts
@@ -151,6 +151,7 @@ describe("Domain verification", async () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+		dnsMock.resolveTxt.mockReset();
 	});
 
 	describe("POST /sso/request-domain-verification", () => {
@@ -674,6 +675,105 @@ describe("Domain verification", async () => {
 				message: "Domain has already been verified",
 				code: "DOMAIN_VERIFIED",
 			});
+		});
+
+		it("does not verify a multi-domain provider when only one listed domain is owned", async () => {
+			const { auth, getAuthHeaders } = createTestAuth();
+			const headers = await getAuthHeaders(testUser);
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "multi-domain-provider",
+					issuer: "https://idp.example.com",
+					// The "/x" makes URL parsing collapse the first entry to
+					// "first.example"; "second.example" stays a co-listed domain.
+					domain: "first.example/x,second.example",
+					samlConfig: {
+						entryPoint: "http://idp.com:",
+						cert: "the-cert",
+						callbackUrl: "http://hello.com:8081/api/sso/saml2/callback",
+						spMetadata: {},
+					},
+				},
+				headers,
+			});
+
+			const requestResponse = await auth.api.requestDomainVerification({
+				body: { providerId: "multi-domain-provider" },
+				headers,
+				asResponse: true,
+			});
+			const { domainVerificationToken } = await requestResponse.json();
+
+			// Only first.example publishes the verifying record; second.example does not.
+			dnsMock.resolveTxt.mockImplementation(async (name: string) => {
+				if (name === "_better-auth-token-multi-domain-provider.first.example") {
+					return [
+						[
+							`_better-auth-token-multi-domain-provider=${domainVerificationToken}`,
+						],
+					];
+				}
+				return [];
+			});
+
+			const verifyResponse = await auth.api.verifyDomain({
+				body: { providerId: "multi-domain-provider" },
+				headers,
+				asResponse: true,
+			});
+
+			// second.example ownership was never proven, so the provider must not verify.
+			expect(verifyResponse.status).toBe(502);
+			expect(dnsMock.resolveTxt).toHaveBeenCalledWith(
+				"_better-auth-token-multi-domain-provider.second.example",
+			);
+		});
+
+		it("verifies a multi-domain provider when every listed domain is owned", async () => {
+			const { auth, getAuthHeaders } = createTestAuth();
+			const headers = await getAuthHeaders(testUser);
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "owned-multi-domain",
+					issuer: "https://idp.company.example",
+					domain: "company.com,subsidiary.com",
+					samlConfig: {
+						entryPoint: "http://idp.com:",
+						cert: "the-cert",
+						callbackUrl: "http://hello.com:8081/api/sso/saml2/callback",
+						spMetadata: {},
+					},
+				},
+				headers,
+			});
+
+			const requestResponse = await auth.api.requestDomainVerification({
+				body: { providerId: "owned-multi-domain" },
+				headers,
+				asResponse: true,
+			});
+			const { domainVerificationToken } = await requestResponse.json();
+
+			// Both listed domains publish the verifying record.
+			dnsMock.resolveTxt.mockResolvedValue([
+				[`_better-auth-token-owned-multi-domain=${domainVerificationToken}`],
+			]);
+
+			const verifyResponse = await auth.api.verifyDomain({
+				body: { providerId: "owned-multi-domain" },
+				headers,
+				asResponse: true,
+			});
+
+			expect(verifyResponse.status).toBe(204);
+			expect(dnsMock.resolveTxt).toHaveBeenCalledWith(
+				"_better-auth-token-owned-multi-domain.company.com",
+			);
+			expect(dnsMock.resolveTxt).toHaveBeenCalledWith(
+				"_better-auth-token-owned-multi-domain.subsidiary.com",
+			);
 		});
 	});
 

--- a/packages/sso/src/domain-verification.test.ts
+++ b/packages/sso/src/domain-verification.test.ts
@@ -436,7 +436,8 @@ describe("Domain verification", async () => {
 
 			expect(response.status).toBe(502);
 			expect(await response.json()).toEqual({
-				message: "Unable to verify domain ownership. Try again later",
+				message:
+					"Unable to verify domain ownership for hello.com. Try again later",
 				code: "DOMAIN_VERIFICATION_FAILED",
 			});
 		});
@@ -677,7 +678,7 @@ describe("Domain verification", async () => {
 			});
 		});
 
-		it("does not verify a multi-domain provider when only one listed domain is owned", async () => {
+		it("does not verify a URL-like multi-domain provider unless every later-accepted domain is owned", async () => {
 			const { auth, getAuthHeaders } = createTestAuth();
 			const headers = await getAuthHeaders(testUser);
 
@@ -685,9 +686,9 @@ describe("Domain verification", async () => {
 				body: {
 					providerId: "multi-domain-provider",
 					issuer: "https://idp.example.com",
-					// The "/x" makes URL parsing collapse the first entry to
-					// "first.example"; "second.example" stays a co-listed domain.
-					domain: "first.example/x,second.example",
+					// The URL-like first entry exercises the shared normalization used
+					// by both verification and later domain matching.
+					domain: "https://attacker.com/path,victim.com",
 					samlConfig: {
 						entryPoint: "http://idp.com:",
 						cert: "the-cert",
@@ -705,9 +706,9 @@ describe("Domain verification", async () => {
 			});
 			const { domainVerificationToken } = await requestResponse.json();
 
-			// Only first.example publishes the verifying record; second.example does not.
+			// Only attacker.com publishes the verifying record; victim.com does not.
 			dnsMock.resolveTxt.mockImplementation(async (name: string) => {
-				if (name === "_better-auth-token-multi-domain-provider.first.example") {
+				if (name === "_better-auth-token-multi-domain-provider.attacker.com") {
 					return [
 						[
 							`_better-auth-token-multi-domain-provider=${domainVerificationToken}`,
@@ -723,10 +724,15 @@ describe("Domain verification", async () => {
 				asResponse: true,
 			});
 
-			// second.example ownership was never proven, so the provider must not verify.
+			// victim.com ownership was never proven, so the provider must not verify.
 			expect(verifyResponse.status).toBe(502);
+			expect(await verifyResponse.json()).toEqual({
+				message:
+					"Unable to verify domain ownership for victim.com. Try again later",
+				code: "DOMAIN_VERIFICATION_FAILED",
+			});
 			expect(dnsMock.resolveTxt).toHaveBeenCalledWith(
-				"_better-auth-token-multi-domain-provider.second.example",
+				"_better-auth-token-multi-domain-provider.victim.com",
 			);
 		});
 
@@ -757,9 +763,7 @@ describe("Domain verification", async () => {
 			const { domainVerificationToken } = await requestResponse.json();
 
 			// Both listed domains publish the verifying record.
-			dnsMock.resolveTxt.mockResolvedValue([
-				[`_better-auth-token-owned-multi-domain=${domainVerificationToken}`],
-			]);
+			dnsMock.resolveTxt.mockResolvedValue([[domainVerificationToken]]);
 
 			const verifyResponse = await auth.api.verifyDomain({
 				body: { providerId: "owned-multi-domain" },

--- a/packages/sso/src/linking/org-assignment.test.ts
+++ b/packages/sso/src/linking/org-assignment.test.ts
@@ -146,6 +146,59 @@ describe("assignOrganizationByDomain", () => {
 		expect(members[0]?.role).toBe("member");
 	});
 
+	it("should assign user when a verified provider's normalized domain set includes the email domain", async () => {
+		const { data, createContext } = createTestContext();
+
+		const org = createOrg();
+		data.organization.push(org);
+		data.ssoProvider.push(
+			createProvider({
+				domain: "https://attacker.com/path,victim.com",
+				domainVerified: true,
+				organizationId: org.id,
+			}),
+		);
+
+		const user = createUser({ email: "alice@victim.com" });
+		data.user.push(user);
+
+		const ctx = (await createContext()) as GenericEndpointContext;
+		await assignOrganizationByDomain(ctx, {
+			user,
+			domainVerification: { enabled: true },
+		});
+
+		const members = data.member.filter((m) => m.userId === user.id);
+		expect(members).toHaveLength(1);
+		expect(members[0]?.organizationId).toBe(org.id);
+	});
+
+	it("should NOT assign user when the email domain is malformed", async () => {
+		const { data, createContext } = createTestContext();
+
+		const org = createOrg();
+		data.organization.push(org);
+		data.ssoProvider.push(
+			createProvider({
+				domain: "victim.com",
+				domainVerified: true,
+				organizationId: org.id,
+			}),
+		);
+
+		const user = createUser({ email: "alice@https://victim.com/path" });
+		data.user.push(user);
+
+		const ctx = (await createContext()) as GenericEndpointContext;
+		await assignOrganizationByDomain(ctx, {
+			user,
+			domainVerification: { enabled: true },
+		});
+
+		const members = data.member.filter((m) => m.userId === user.id);
+		expect(members).toHaveLength(0);
+	});
+
 	it("should NOT assign user when email domain does not match any provider", async () => {
 		const { data, createContext } = createTestContext();
 

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -1245,6 +1245,22 @@ describe("OIDC SSO with defaultSSO array", async () => {
 								"http://localhost:8080/.well-known/openid-configuration",
 						},
 					},
+					{
+						domain:
+							"https://default-oidc-normalized.com/path,default-oidc-secondary.com",
+						providerId: "default-oidc-provider-normalized",
+						oidcConfig: {
+							issuer: "http://localhost:8080",
+							clientId: "normalized-client",
+							clientSecret: "normalized-secret",
+							pkce: false,
+							authorizationEndpoint: "http://localhost:8080/authorize",
+							tokenEndpoint: "http://localhost:8080/token",
+							jwksEndpoint: "http://localhost:8080/jwks",
+							discoveryEndpoint:
+								"http://localhost:8080/.well-known/openid-configuration",
+						},
+					},
 				],
 			}),
 			organization(),
@@ -1274,10 +1290,17 @@ describe("OIDC SSO with defaultSSO array", async () => {
 
 	const tokenHandler = (token: any) => {
 		const isExplicit = token.payload.aud === "explicit-client";
-		currentEmail = isExplicit
-			? "default-sso-user@default-oidc-explicit.com"
-			: "default-sso-user@default-oidc.com";
-		currentSub = isExplicit ? "explicit-sso-sub" : "default-sso-sub";
+		const isNormalized = token.payload.aud === "normalized-client";
+		currentEmail = isNormalized
+			? "default-sso-user@default-oidc-secondary.com"
+			: isExplicit
+				? "default-sso-user@default-oidc-explicit.com"
+				: "default-sso-user@default-oidc.com";
+		currentSub = isNormalized
+			? "normalized-sso-sub"
+			: isExplicit
+				? "explicit-sso-sub"
+				: "default-sso-sub";
 		token.payload.email = currentEmail;
 		token.payload.email_verified = true;
 		token.payload.name = "Default SSO User";
@@ -1370,6 +1393,36 @@ describe("OIDC SSO with defaultSSO array", async () => {
 
 		const { callbackURL } = await simulateOAuthFlow(res.url, headers);
 		expect(callbackURL).toContain("/dashboard");
+	});
+
+	it("should sign in via defaultSSO OIDC using normalized domain matching", async () => {
+		const headers = new Headers();
+		const res = await authClient.signIn.sso({
+			email: "someone@default-oidc-secondary.com",
+			callbackURL: "/dashboard",
+			fetchOptions: {
+				throw: true,
+				onSuccess: cookieSetter(headers),
+			},
+		});
+
+		expect(res.url).toContain("http://localhost:8080/authorize");
+		expect(res.url).toContain(
+			"redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fauth%2Fsso%2Fcallback%2Fdefault-oidc-provider-normalized",
+		);
+
+		const { callbackURL, headers: sessionHeaders } = await simulateOAuthFlow(
+			res.url,
+			headers,
+		);
+		expect(callbackURL).toContain("/dashboard");
+
+		const session = await authClient.getSession({
+			fetchOptions: { headers: sessionHeaders },
+		});
+		expect(session.data?.user.email).toBe(
+			"default-sso-user@default-oidc-secondary.com",
+		);
 	});
 
 	it("should sign in via defaultSSO OIDC with all endpoints explicit (no discovery needed)", async () => {

--- a/packages/sso/src/routes/domain-verification.ts
+++ b/packages/sso/src/routes/domain-verification.ts
@@ -6,7 +6,7 @@ import {
 import { generateRandomString } from "better-auth/crypto";
 import * as z from "zod";
 import type { SSOOptions, SSOProvider } from "../types";
-import { parseDomainHostnames } from "../utils";
+import { parseProviderDomains } from "../utils";
 import { checkProviderAccess } from "./providers";
 
 const DNS_LABEL_MAX_LENGTH = 63;
@@ -174,39 +174,44 @@ export const verifyDomain = (options: SSOOptions) => {
 				});
 			}
 
-			const hostnames = parseDomainHostnames(provider.domain);
-			if (!hostnames) {
+			const domains = parseProviderDomains(provider.domain);
+			if (!domains) {
 				throw new APIError("BAD_REQUEST", {
 					message: "Invalid domain",
 					code: "INVALID_DOMAIN",
 				});
 			}
 
-			for (const hostname of hostnames) {
+			for (const domain of domains) {
 				let records: string[] = [];
 				try {
-					const dnsRecords = await dns.resolveTxt(`${identifier}.${hostname}`);
+					const dnsRecords = await dns.resolveTxt(`${identifier}.${domain}`);
 					records = dnsRecords.flat();
 				} catch (error) {
 					ctx.context.logger.warn(
-						"DNS resolution failure while validating domain ownership",
+						`DNS resolution failure while validating domain ownership for ${domain}`,
 						error,
 					);
 				}
 
-				const record = records.find((record) =>
-					record.includes(
-						`${activeVerification.identifier}=${activeVerification.value}`,
-					),
+				const verificationValue = activeVerification.value;
+				const verificationRecord = `${activeVerification.identifier}=${verificationValue}`;
+				const record = records.find(
+					(record) =>
+						record.includes(verificationRecord) ||
+						record.includes(verificationValue),
 				);
 				if (!record) {
 					throw new APIError("BAD_GATEWAY", {
-						message: "Unable to verify domain ownership. Try again later",
+						message: `Unable to verify domain ownership for ${domain}. Try again later`,
 						code: "DOMAIN_VERIFICATION_FAILED",
 					});
 				}
 			}
 
+			// FIXME(next): this remains a provider-level proof bit. When the next
+			// schema can change, store verification per normalized domain or force
+			// previously verified multi-domain providers through re-verification.
 			await ctx.context.adapter.update<SSOProvider<SSOOptions>>({
 				model: "ssoProvider",
 				where: [{ field: "providerId", value: provider.providerId }],

--- a/packages/sso/src/routes/domain-verification.ts
+++ b/packages/sso/src/routes/domain-verification.ts
@@ -186,7 +186,7 @@ export const verifyDomain = (options: SSOOptions) => {
 				let records: string[] = [];
 				try {
 					const dnsRecords = await dns.resolveTxt(`${identifier}.${domain}`);
-					records = dnsRecords.flat();
+					records = dnsRecords.map((record) => record.join(""));
 				} catch (error) {
 					ctx.context.logger.warn(
 						`DNS resolution failure while validating domain ownership for ${domain}`,
@@ -196,11 +196,13 @@ export const verifyDomain = (options: SSOOptions) => {
 
 				const verificationValue = activeVerification.value;
 				const verificationRecord = `${activeVerification.identifier}=${verificationValue}`;
-				const record = records.find(
-					(record) =>
-						record.includes(verificationRecord) ||
-						record.includes(verificationValue),
-				);
+				const record = records.find((record) => {
+					const normalizedRecord = record.trim();
+					return (
+						normalizedRecord === verificationRecord ||
+						normalizedRecord === verificationValue
+					);
+				});
 				if (!record) {
 					throw new APIError("BAD_GATEWAY", {
 						message: `Unable to verify domain ownership for ${domain}. Try again later`,

--- a/packages/sso/src/routes/domain-verification.ts
+++ b/packages/sso/src/routes/domain-verification.ts
@@ -6,7 +6,7 @@ import {
 import { generateRandomString } from "better-auth/crypto";
 import * as z from "zod";
 import type { SSOOptions, SSOProvider } from "../types";
-import { getHostnameFromDomain } from "../utils";
+import { parseDomainHostnames } from "../utils";
 import { checkProviderAccess } from "./providers";
 
 const DNS_LABEL_MAX_LENGTH = 63;
@@ -159,7 +159,6 @@ export const verifyDomain = (options: SSOOptions) => {
 				});
 			}
 
-			let records: string[] = [];
 			let dns: typeof import("node:dns/promises");
 
 			try {
@@ -175,34 +174,37 @@ export const verifyDomain = (options: SSOOptions) => {
 				});
 			}
 
-			const hostname = getHostnameFromDomain(provider.domain);
-			if (!hostname) {
+			const hostnames = parseDomainHostnames(provider.domain);
+			if (!hostnames) {
 				throw new APIError("BAD_REQUEST", {
 					message: "Invalid domain",
 					code: "INVALID_DOMAIN",
 				});
 			}
 
-			try {
-				const dnsRecords = await dns.resolveTxt(`${identifier}.${hostname}`);
-				records = dnsRecords.flat();
-			} catch (error) {
-				ctx.context.logger.warn(
-					"DNS resolution failure while validating domain ownership",
-					error,
-				);
-			}
+			for (const hostname of hostnames) {
+				let records: string[] = [];
+				try {
+					const dnsRecords = await dns.resolveTxt(`${identifier}.${hostname}`);
+					records = dnsRecords.flat();
+				} catch (error) {
+					ctx.context.logger.warn(
+						"DNS resolution failure while validating domain ownership",
+						error,
+					);
+				}
 
-			const record = records.find((record) =>
-				record.includes(
-					`${activeVerification.identifier}=${activeVerification.value}`,
-				),
-			);
-			if (!record) {
-				throw new APIError("BAD_GATEWAY", {
-					message: "Unable to verify domain ownership. Try again later",
-					code: "DOMAIN_VERIFICATION_FAILED",
-				});
+				const record = records.find((record) =>
+					record.includes(
+						`${activeVerification.identifier}=${activeVerification.value}`,
+					),
+				);
+				if (!record) {
+					throw new APIError("BAD_GATEWAY", {
+						message: "Unable to verify domain ownership. Try again later",
+						code: "DOMAIN_VERIFICATION_FAILED",
+					});
+				}
 			}
 
 			await ctx.context.adapter.update<SSOProvider<SSOOptions>>({

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1099,7 +1099,8 @@ export const signInSSO = (options?: SSOOptions) => {
 							(defaultProvider) => defaultProvider.providerId === providerId,
 						)
 					: options.defaultSSO.find(
-							(defaultProvider) => defaultProvider.domain === domain,
+							(defaultProvider) =>
+								domain && domainMatches(domain, defaultProvider.domain),
 						);
 
 				if (matchingDefault) {

--- a/packages/sso/src/utils.test.ts
+++ b/packages/sso/src/utils.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+	domainMatches,
 	getHostnameFromDomain,
+	parseProviderDomains,
 	parseProviderEmailVerified,
 	validateEmailDomain,
 } from "./utils";
@@ -34,6 +36,21 @@ describe("parseProviderEmailVerified", () => {
 		]) {
 			expect(parseProviderEmailVerified(value)).toBe(false);
 		}
+	});
+});
+
+describe("parseProviderDomains", () => {
+	it("normalizes comma-separated provider domains", () => {
+		expect(
+			parseProviderDomains(
+				"https://company.com/path, subsidiary.com, COMPANY.com",
+			),
+		).toEqual(["company.com", "subsidiary.com"]);
+	});
+
+	it("returns null when no domain can be parsed", () => {
+		expect(parseProviderDomains(", ,")).toBeNull();
+		expect(parseProviderDomains("")).toBeNull();
 	});
 });
 
@@ -119,6 +136,19 @@ describe("validateEmailDomain", () => {
 			const domains = "Company.COM,SUBSIDIARY.com";
 			expect(validateEmailDomain("user@company.com", domains)).toBe(true);
 			expect(validateEmailDomain("USER@SUBSIDIARY.COM", domains)).toBe(true);
+		});
+
+		it("should use the same normalized domains as ownership verification", () => {
+			const domains = "https://attacker.com/path,victim.com";
+			expect(domainMatches("attacker.com", domains)).toBe(true);
+			expect(validateEmailDomain("user@attacker.com", domains)).toBe(true);
+			expect(validateEmailDomain("user@victim.com", domains)).toBe(true);
+		});
+
+		it("should not normalize malformed email domains", () => {
+			expect(
+				validateEmailDomain("user@https://victim.com/path", "victim.com"),
+			).toBe(false);
 		});
 	});
 

--- a/packages/sso/src/utils.test.ts
+++ b/packages/sso/src/utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
 	domainMatches,
-	getHostnameFromDomain,
 	parseProviderDomains,
 	parseProviderEmailVerified,
 	validateEmailDomain,
@@ -174,30 +173,34 @@ describe("validateEmailDomain", () => {
 /**
  * @see https://github.com/better-auth/better-auth/issues/8361
  */
-describe("getHostnameFromDomain", () => {
+describe("parseProviderDomains hostname normalization", () => {
 	it("should extract hostname from a bare domain", () => {
-		expect(getHostnameFromDomain("github.com")).toBe("github.com");
+		expect(parseProviderDomains("github.com")).toEqual(["github.com"]);
 	});
 
 	it("should extract hostname from a full URL", () => {
-		expect(getHostnameFromDomain("https://github.com")).toBe("github.com");
+		expect(parseProviderDomains("https://github.com")).toEqual(["github.com"]);
 	});
 
 	it("should extract hostname from a URL with port", () => {
-		expect(getHostnameFromDomain("https://github.com:8081")).toBe("github.com");
+		expect(parseProviderDomains("https://github.com:8081")).toEqual([
+			"github.com",
+		]);
 	});
 
 	it("should extract hostname from a subdomain", () => {
-		expect(getHostnameFromDomain("auth.github.com")).toBe("auth.github.com");
+		expect(parseProviderDomains("auth.github.com")).toEqual([
+			"auth.github.com",
+		]);
 	});
 
 	it("should extract hostname from a URL with path", () => {
-		expect(getHostnameFromDomain("https://github.com/path/to/resource")).toBe(
-			"github.com",
+		expect(parseProviderDomains("https://github.com/path/to/resource")).toEqual(
+			["github.com"],
 		);
 	});
 
 	it("should return null for an empty string", () => {
-		expect(getHostnameFromDomain("")).toBeNull();
+		expect(parseProviderDomains("")).toBeNull();
 	});
 });

--- a/packages/sso/src/utils.ts
+++ b/packages/sso/src/utils.ts
@@ -107,6 +107,32 @@ export function getHostnameFromDomain(domain: string): string | null {
 	return getHostname(domain) || null;
 }
 
+/**
+ * Reduce a provider `domain` value (single host, URL, or comma-separated list)
+ * to the set of hostnames it authorizes. Returns `null` if any entry cannot be
+ * reduced to a hostname.
+ */
+export function parseDomainHostnames(domain: string): string[] | null {
+	const entries = domain
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+	if (entries.length === 0) {
+		return null;
+	}
+	const hostnames: string[] = [];
+	for (const entry of entries) {
+		const hostname = getHostnameFromDomain(entry)?.toLowerCase();
+		if (!hostname) {
+			return null;
+		}
+		if (!hostnames.includes(hostname)) {
+			hostnames.push(hostname);
+		}
+	}
+	return hostnames;
+}
+
 export function maskClientId(clientId: string): string {
 	if (clientId.length <= 4) {
 		return "****";

--- a/packages/sso/src/utils.ts
+++ b/packages/sso/src/utils.ts
@@ -105,7 +105,7 @@ export function normalizePem(key: string | undefined): string | undefined {
 		.trim()}\n`;
 }
 
-export function getHostnameFromDomain(domain: string): string | null {
+function getHostnameFromDomain(domain: string): string | null {
 	return getHostname(domain) || null;
 }
 

--- a/packages/sso/src/utils.ts
+++ b/packages/sso/src/utils.ts
@@ -36,12 +36,14 @@ export function safeJsonParse<T>(
  * Checks if a domain matches any domain in a comma-separated list.
  */
 export const domainMatches = (searchDomain: string, domainList: string) => {
-	const search = searchDomain.toLowerCase();
-	const domains = domainList
-		.split(",")
-		.map((d) => d.trim().toLowerCase())
-		.filter(Boolean);
-	return domains.some((d) => search === d || search.endsWith(`.${d}`));
+	const search = searchDomain.trim().toLowerCase();
+	const domains = parseProviderDomains(domainList);
+	if (!search || !domains) {
+		return false;
+	}
+	return domains.some(
+		(domain) => search === domain || search.endsWith(`.${domain}`),
+	);
 };
 
 /**
@@ -108,11 +110,13 @@ export function getHostnameFromDomain(domain: string): string | null {
 }
 
 /**
- * Reduce a provider `domain` value (single host, URL, or comma-separated list)
- * to the set of hostnames it authorizes. Returns `null` if any entry cannot be
- * reduced to a hostname.
+ * Normalize a provider `domain` value to the email domains it authorizes.
+ *
+ * TODO(next): replace the serialized provider.domain string with a canonical
+ * domains array and reject URL/path-shaped values at register/update once main
+ * and next provider schemas are reconciled.
  */
-export function parseDomainHostnames(domain: string): string[] | null {
+export function parseProviderDomains(domain: string): string[] | null {
 	const entries = domain
 		.split(",")
 		.map((entry) => entry.trim())
@@ -120,17 +124,15 @@ export function parseDomainHostnames(domain: string): string[] | null {
 	if (entries.length === 0) {
 		return null;
 	}
-	const hostnames: string[] = [];
+	const domains = new Set<string>();
 	for (const entry of entries) {
-		const hostname = getHostnameFromDomain(entry)?.toLowerCase();
-		if (!hostname) {
+		const parsedDomain = getHostnameFromDomain(entry)?.toLowerCase();
+		if (!parsedDomain) {
 			return null;
 		}
-		if (!hostnames.includes(hostname)) {
-			hostnames.push(hostname);
-		}
+		domains.add(parsedDomain);
 	}
-	return hostnames;
+	return [...domains];
 }
 
 export function maskClientId(clientId: string): string {


### PR DESCRIPTION
SSO domain verification could mark a multi-domain provider as trusted after proving ownership of only one normalized domain.

This aligns the SSO domain contract so DNS verification, database/default provider routing, organization assignment, and OIDC/SAML email-domain trust all use the same provider-domain normalization. `verify-domain` now checks every normalized domain listed on the provider before setting `domainVerified`, and failure responses identify the specific domain that could not be verified. The verifier accepts exact TXT records in either the documented raw-token format or the existing `identifier=value` format.

Existing verified provider rows are not migrated by this patch; deployments with previously verified multi-domain providers should request verification again if they need to invalidate old proofs.