### PR TITLE
ci(release): skip pre-commit hooks for the release bot commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    env:
+      # The release bot's auto-commit must not be gated by the local pre-commit hooks.
+      LEFTHOOK: "0"
     steps:
       - name: Generate App Token
         id: app-token


### PR DESCRIPTION
The release workflow fails intermittently when the Changesets action commits the version bump. That commit runs the repository's developer `pre-commit` hooks (Biome, cspell, formatting, lockfile) against machine-generated `package.json` and `CHANGELOG.md` files. The cspell hook treats short commit SHAs as words, and any SHA that lands all hex letters (no digits) is flagged as an unknown word, which fails the commit and aborts the whole release.

Those hooks exist to gate human commits, not the release bot's `chore: release` commit. This sets `LEFTHOOK=0` on the release job so the bot's auto-commit bypasses them. The real lint, spell, and type gates still run on contributor PRs.

Scoped to the `release` job: the `snapshot` and `preview-notes` jobs never commit, so they have no hooks to skip.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent intermittent release failures by skipping local pre-commit hooks for the Changesets auto-commit. Sets `LEFTHOOK=0` in the `release` job so `cspell` doesn’t block hex-only SHAs in generated files.

- **Bug Fixes**
  - Set `LEFTHOOK: "0"` for the `release` job only.
  - Stops `cspell` false positives on short SHAs in `CHANGELOG.md` and `package.json`; contributor PR checks remain unchanged.

<sup>Written for commit f1d9af8856c6156d8975e7da55d8253ca03bbd0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

