### PR TITLE
fix(siwe): issue addressless nonces

### DIFF
--- a/.changeset/siwe-addressless-nonces.md
+++ b/.changeset/siwe-addressless-nonces.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+The SIWE plugin now issues nonces before the wallet address or Chain ID is known. `authClient.siwe.nonce()` and `authClient.siwe.getNonce()` no longer accept wallet fields, `getNonce` must return an ERC-4361 nonce (8-250 alphanumeric characters), and SIWE verification now reads the wallet address and Chain ID from the signed ERC-4361 message.

--- a/docs/content/docs/plugins/siwe.mdx
+++ b/docs/content/docs/plugins/siwe.mdx
@@ -24,8 +24,8 @@ The Sign in with Ethereum (SIWE) plugin allows users to authenticate using their
                 emailDomainName: "example.com", // optional
                 anonymous: false, // optional, default is true
                 getNonce: async () => {
-                    // Implement your nonce generation logic here
-                    return "your-secure-random-nonce";
+                    // Return an ERC-4361 nonce: 8-250 alphanumeric characters
+                    return "A1b2C3d4E5f6G7h8J";
                 },
                 verifyMessage: async (args) => {
                     // Implement your SIWE message verification logic here
@@ -87,15 +87,12 @@ The Sign in with Ethereum (SIWE) plugin allows users to authenticate using their
 
 ### Generate a Nonce
 
-Before signing a SIWE message, you need to generate a nonce for the wallet address:
+Before asking the wallet to sign, issue a nonce for the sign-in attempt. The nonce is not bound to a wallet address or Chain ID because one-step wallet flows may not know either value until the wallet signs the SIWE message.
 
 ```ts
 import { authClient } from "@/lib/auth-client";
 
-const { data, error } = await authClient.siwe.nonce({
-  walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
-  chainId: 1, // optional for Ethereum mainnet, required for other chains. Defaults to 1
-});
+const { data, error } = await authClient.siwe.nonce();
 
 if (data) {
   console.log("Nonce:", data.nonce);
@@ -110,10 +107,8 @@ After generating a nonce and creating a SIWE message, verify the signature to au
 import { authClient } from "@/lib/auth-client";
 
 const { data, error } = await authClient.siwe.verify({
-  message: "Your SIWE message string",
+  message: "Your ERC-4361 SIWE message string",
   signature: "0x...", // The signature from the user's wallet
-  walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
-  chainId: 1, // optional for Ethereum mainnet, required for other chains. Must match Chain ID in SIWE message
   email: "user@example.com", // optional, required if anonymous is false
 });
 
@@ -123,67 +118,32 @@ if (data) {
 ```
 
 <Callout type="warning">
-  `message` must be a valid [ERC-4361](https://eips.ethereum.org/EIPS/eip-4361) message (which every standard SIWE client produces). Before accepting the signature, the plugin parses the message and requires its **nonce**, **domain**, **address**, and **Chain ID** to match the server-issued nonce and your configured `domain`, and it honors the message's `Expiration Time` / `Not Before` bounds. Signature recovery alone is **not** sufficient — this binding ensures a signature is only accepted together with the message it was produced for, bound to the current server-issued nonce. Verification fails with a 401 (`UNAUTHORIZED_SIWE_MESSAGE_MISMATCH`) if any field doesn't match.
+  `message` must be a valid [ERC-4361](https://eips.ethereum.org/EIPS/eip-4361) message (which every standard SIWE client produces). Before accepting the signature, the plugin parses the message, consumes the matching server-issued **nonce**, derives the **address** and **Chain ID** from the signed message, requires the signed **domain** to match your configured `domain`, and honors the message's `Expiration Time` / `Not Before` bounds. Signature recovery alone is **not** sufficient — this binding ensures a signature is only accepted together with the message it was produced for, bound to the current server-issued nonce. Verification fails with a 401 (`UNAUTHORIZED_SIWE_MESSAGE_MISMATCH`) if any signed field is invalid.
 </Callout>
 
 <Callout type="warning">
   A SIWE signature proves control of the wallet, not ownership of the `email` you pass. The plugin stores that email unverified and only binds it to the new account when it is not already in use. When `anonymous` is `false` and the supplied email already belongs to another account, the new wallet account is created with a wallet-derived address instead, so a sign-in cannot attach an email another account owns.
 </Callout>
 
-### Chain-Specific Examples
+### Chain-Specific Messages
 
-Here are examples for different blockchain networks:
-
-```ts
-// Ethereum Mainnet (chainId can be omitted, defaults to 1)
-import { authClient } from "@/lib/auth-client";
-
-const { data, error } = await authClient.siwe.verify({
-  message,
-  signature,
-  walletAddress,
-  // chainId: 1 (default)
-});
-```
+Chain selection belongs in the ERC-4361 message, not in the verification request body. Generate a nonce, build the SIWE message with the wallet address and target Chain ID, ask the wallet to sign that exact message, and then verify the signed message:
 
 ```ts
-// Polygon (chainId REQUIRED)
 import { authClient } from "@/lib/auth-client";
 
-const { data, error } = await authClient.siwe.verify({
-  message,
-  signature,
-  walletAddress,
-  chainId: 137, // Required for Polygon
-});
-```
-
-```ts
-// Arbitrum (chainId REQUIRED)
-import { authClient } from "@/lib/auth-client";
+const nonce = await authClient.siwe.nonce();
 
 const { data, error } = await authClient.siwe.verify({
+  // The signed ERC-4361 message contains the wallet address,
+  // Chain ID: 137, and Nonce: nonce.data?.nonce.
   message,
   signature,
-  walletAddress,
-  chainId: 42161, // Required for Arbitrum
-});
-```
-
-```ts
-// Base (chainId REQUIRED)
-import { authClient } from "@/lib/auth-client";
-
-const { data, error } = await authClient.siwe.verify({
-  message,
-  signature,
-  walletAddress,
-  chainId: 8453, // Required for Base
 });
 ```
 
 <Callout type="warning">
-  The `chainId` must match the Chain ID specified in your SIWE message. Verification will fail with a 401 error if there's a mismatch between the message's Chain ID and the `chainId` parameter.
+  The signed SIWE message must include a positive Chain ID. Verification derives the wallet identity from that signed Chain ID and fails with a 401 error if the message is missing a valid Chain ID.
 </Callout>
 
 ## Configuration Options
@@ -195,13 +155,13 @@ The SIWE plugin accepts the following configuration options:
 * **domain**: The domain name of your application (required for SIWE message generation)
 * **emailDomainName**: The email domain name for creating user accounts when not using anonymous mode. Defaults to the domain from your base URL
 * **anonymous**: Whether to allow anonymous sign-ins without requiring an email. Default is `true`
-* **getNonce**: Function to generate a unique nonce for each sign-in attempt. You must implement this function to return a cryptographically secure random string. Must return a `Promise<string>`
+* **getNonce**: Function to generate a globally unique nonce for each sign-in attempt. You must implement this function to return a cryptographically secure ERC-4361 nonce: 8-250 alphanumeric characters. Must return a `Promise<string>`
 * **verifyMessage**: Function to verify the signature over the SIWE message. It only needs to perform signature recovery for the supplied address (e.g. viem's `verifyMessage`) and return `Promise<boolean>` — the plugin independently validates the message's nonce, domain, address, Chain ID, and time bounds before creating a session
 * **ensLookup**: Optional function to lookup ENS names and avatars for Ethereum addresses
 
 ### Client Options
 
-The SIWE client plugin doesn't require any configuration options, but you can pass them if needed for future extensibility:
+The SIWE client plugin doesn't require any configuration options:
 
 ```ts title="auth-client.ts"
 import { createAuthClient } from "better-auth/client";
@@ -209,9 +169,7 @@ import { siweClient } from "better-auth/client/plugins";
 
 export const authClient = createAuthClient({
   plugins: [
-    siweClient({
-      // Optional client configuration can go here
-    }),
+    siweClient(),
   ],
 });
 ```

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -131,15 +131,11 @@ describe("lastLoginMethod", async () => {
 
 	it("should set the last login method cookie for siwe", async () => {
 		const headers = new Headers();
-		const walletAddress = SIWE_WALLET;
-		const chainId = SIWE_CHAIN_ID;
-		await client.siwe.nonce({ walletAddress, chainId });
+		await client.siwe.nonce();
 		await client.siwe.verify(
 			{
 				message: siweMessage(),
 				signature: "valid_signature",
-				walletAddress,
-				chainId,
 				email: "user@example.com",
 			},
 			{
@@ -274,8 +270,6 @@ describe("lastLoginMethod", async () => {
 	});
 
 	it("should set the last login method for siwe in the database", async () => {
-		const walletAddress = SIWE_WALLET;
-		const chainId = SIWE_CHAIN_ID;
 		const { client, auth } = await getTestInstance(
 			{
 				plugins: [
@@ -297,12 +291,10 @@ describe("lastLoginMethod", async () => {
 				},
 			},
 		);
-		await client.siwe.nonce({ walletAddress, chainId });
+		await client.siwe.nonce();
 		const { data } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 			email: "user@example.com",
 		});
 		const session = await auth.api.getSession({

--- a/packages/better-auth/src/plugins/siwe/index.ts
+++ b/packages/better-auth/src/plugins/siwe/index.ts
@@ -37,21 +37,26 @@ export interface SIWEPluginOptions {
 	schema?: InferOptionSchema<typeof schema> | undefined;
 }
 
-const walletAddressInputSchema = z
+const signedWalletAddressSchema = z
 	.string()
-	.regex(/^0[xX][a-fA-F0-9]{40}$/i)
+	.regex(/^0x[a-fA-F0-9]{40}$/)
 	.length(42);
 
-const getSiweNonceBodySchema = z
-	.object({
-		walletAddress: walletAddressInputSchema.optional(),
-		address: walletAddressInputSchema.optional(),
-		chainId: z.number().int().positive().optional().default(1),
-	})
-	.refine((body) => body.walletAddress || body.address, {
-		message: "walletAddress or address is required",
-		path: ["walletAddress"],
-	});
+const SIWE_VERIFICATION_IDENTIFIER_PREFIX = "siwe:";
+// MySQL adapter schemas cap verification.identifier at 255 characters.
+const VERIFICATION_IDENTIFIER_MAX_LENGTH = 255;
+const SIWE_NONCE_MAX_LENGTH =
+	VERIFICATION_IDENTIFIER_MAX_LENGTH -
+	SIWE_VERIFICATION_IDENTIFIER_PREFIX.length;
+const SIWE_NONCE_ALPHANUMERIC_REGEX = /^[a-zA-Z0-9]+$/;
+
+const isValidSiweNonce = (nonce: string | undefined): nonce is string =>
+	typeof nonce === "string" &&
+	nonce.length >= 8 &&
+	nonce.length <= SIWE_NONCE_MAX_LENGTH &&
+	SIWE_NONCE_ALPHANUMERIC_REGEX.test(nonce);
+
+const getSiweNonceBodySchema = z.object({}).strict().optional();
 
 export const siwe = (options: SIWEPluginOptions) => {
 	const createSiweNonceEndpoint = (path: "/siwe/nonce" | "/siwe/get-nonce") =>
@@ -62,20 +67,17 @@ export const siwe = (options: SIWEPluginOptions) => {
 				body: getSiweNonceBodySchema,
 			},
 			async (ctx) => {
-				const rawWalletAddress = ctx.body.walletAddress ?? ctx.body.address;
-				if (!rawWalletAddress) {
-					throw APIError.fromStatus("BAD_REQUEST", {
-						message: "walletAddress or address is required",
-						status: 400,
+				const nonce = await options.getNonce();
+				if (!isValidSiweNonce(nonce)) {
+					throw APIError.fromStatus("INTERNAL_SERVER_ERROR", {
+						message: `SIWE getNonce must return an ERC-4361 nonce: 8-${SIWE_NONCE_MAX_LENGTH} alphanumeric characters.`,
+						status: 500,
+						code: "SIWE_INVALID_NONCE",
 					});
 				}
-				const { chainId } = ctx.body;
-				const walletAddress = toChecksumAddress(rawWalletAddress);
-				const nonce = await options.getNonce();
 
-				// Store nonce with wallet address and chain ID context
 				await ctx.context.internalAdapter.createVerificationValue({
-					identifier: `siwe:${walletAddress}:${chainId}`,
+					identifier: `${SIWE_VERIFICATION_IDENTIFIER_PREFIX}${nonce}`,
 					value: nonce,
 					expiresAt: new Date(Date.now() + 15 * 60 * 1000),
 				});
@@ -99,13 +101,9 @@ export const siwe = (options: SIWEPluginOptions) => {
 						.object({
 							message: z.string().min(1),
 							signature: z.string().min(1),
-							walletAddress: z
-								.string()
-								.regex(/^0[xX][a-fA-F0-9]{40}$/i)
-								.length(42),
-							chainId: z.number().int().positive().optional().default(1),
 							email: z.email().optional(),
 						})
+						.strict()
 						.refine((data) => options.anonymous !== false || !!data.email, {
 							message:
 								"Email is required when the anonymous plugin option is disabled.",
@@ -114,14 +112,7 @@ export const siwe = (options: SIWEPluginOptions) => {
 					requireRequest: true,
 				},
 				async (ctx) => {
-					const {
-						message,
-						signature,
-						walletAddress: rawWalletAddress,
-						chainId,
-						email,
-					} = ctx.body;
-					const walletAddress = toChecksumAddress(rawWalletAddress);
+					const { message, signature, email } = ctx.body;
 					const isAnon = options.anonymous ?? true;
 
 					if (!isAnon && !email) {
@@ -132,6 +123,20 @@ export const siwe = (options: SIWEPluginOptions) => {
 					}
 
 					try {
+						// The signed ERC-4361 message is the source of truth for wallet
+						// identity. Nonce issuance happens before the wallet connection is
+						// known, so address and chain ID are verified from the signed
+						// message instead of being pre-bound at the nonce endpoint.
+						const parsedMessage = parseSiweMessage(message);
+						if (!isValidSiweNonce(parsedMessage.nonce)) {
+							throw APIError.fromStatus("UNAUTHORIZED", {
+								message:
+									"Unauthorized: SIWE message does not match the expected nonce, domain, address, or chain ID",
+								status: 401,
+								code: "UNAUTHORIZED_SIWE_MESSAGE_MISMATCH",
+							});
+						}
+
 						// Atomically consume the single-use nonce before any signature
 						// work or state mutation. The first concurrent request wins; every
 						// racer gets null, so the same nonce can never replay a login.
@@ -139,7 +144,7 @@ export const siwe = (options: SIWEPluginOptions) => {
 						// a failed attempt and applies the built-in expiry gate.
 						const verification =
 							await ctx.context.internalAdapter.consumeVerificationValue(
-								`siwe:${walletAddress}:${chainId}`,
+								`${SIWE_VERIFICATION_IDENTIFIER_PREFIX}${parsedMessage.nonce}`,
 							);
 
 						if (!verification) {
@@ -151,7 +156,7 @@ export const siwe = (options: SIWEPluginOptions) => {
 						}
 
 						// Verify SIWE message with enhanced parameters
-						const { value: nonce } = verification;
+						const nonce = parsedMessage.nonce;
 
 						// Bind the *signed* message to server state before accepting the
 						// signature. Signature recovery alone (the documented `verifyMessage`
@@ -159,24 +164,24 @@ export const siwe = (options: SIWEPluginOptions) => {
 						// produced signature (stale, for another domain, or over an
 						// arbitrary string) could otherwise be presented alongside a freshly
 						// minted nonce. Parse the ERC-4361 message ourselves and require the
-						// nonce, address, chain id, and domain to match the server-issued
-						// values, plus honor the signed time bounds.
-						const parsedMessage = parseSiweMessage(message);
-						const nonceMatches = parsedMessage.nonce === nonce;
-						const addressMatches =
-							!!parsedMessage.address &&
-							parsedMessage.address.toLowerCase() ===
-								walletAddress.toLowerCase();
-						const chainMatches = parsedMessage.chainId === chainId;
+						// signed nonce, address, chain ID, and domain to satisfy the plugin
+						// contract, plus honor the signed time bounds.
+						const parsedWalletAddress = signedWalletAddressSchema.safeParse(
+							parsedMessage.address,
+						);
+						const walletAddress = parsedWalletAddress.success
+							? toChecksumAddress(parsedWalletAddress.data)
+							: null;
+						const chainId = parsedMessage.chainId;
 						const domainMatches =
 							!!parsedMessage.domain &&
 							normalizeSiweDomain(parsedMessage.domain) ===
 								normalizeSiweDomain(options.domain);
 
 						if (
-							!nonceMatches ||
-							!addressMatches ||
-							!chainMatches ||
+							!walletAddress ||
+							typeof chainId !== "number" ||
+							chainId <= 0 ||
 							!domainMatches
 						) {
 							throw APIError.fromStatus("UNAUTHORIZED", {

--- a/packages/better-auth/src/plugins/siwe/siwe.test.ts
+++ b/packages/better-auth/src/plugins/siwe/siwe.test.ts
@@ -39,7 +39,10 @@ describe("siwe", async () => {
 		return msg;
 	};
 
-	it("should generate a valid nonce for a valid public key", async () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8116
+	 */
+	it("should generate a valid nonce before the wallet address and chain are known", async () => {
 		const { client } = await getTestInstance(
 			{
 				plugins: [
@@ -61,14 +64,14 @@ describe("siwe", async () => {
 				},
 			},
 		);
-		const { data } = await client.siwe.nonce({ walletAddress, chainId });
+		const { data } = await client.siwe.nonce();
 		// to be of type string
 		expect(typeof data?.nonce).toBe("string");
 		// to be 17 alphanumeric characters (96 bits of entropy)
 		expect(data?.nonce).toMatch(/^[a-zA-Z0-9]{17}$/);
 	});
 
-	it("should generate a valid nonce with default chainId", async () => {
+	it("should allow an empty body when generating a nonce", async () => {
 		const { client } = await getTestInstance(
 			{
 				plugins: [
@@ -90,16 +93,47 @@ describe("siwe", async () => {
 				},
 			},
 		);
-		// Test without chainId (should default to 1)
-		const { data } = await client.siwe.nonce({ walletAddress });
+		const { data } = await client.siwe.nonce();
 		expect(typeof data?.nonce).toBe("string");
 		expect(data?.nonce).toMatch(/^[a-zA-Z0-9]{17}$/);
+	});
+
+	it("should reject obsolete wallet-bound nonce inputs", async () => {
+		const { client } = await getTestInstance(
+			{
+				plugins: [
+					siwe({
+						domain,
+						async getNonce() {
+							return "A1b2C3d4E5f6G7h8J";
+						},
+						async verifyMessage({ signature }) {
+							// Mirrors the documented viem pattern: signature recovery only.
+							return signature === "valid_signature";
+						},
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [siweClient()],
+				},
+			},
+		);
+
+		const { error } = await client.$fetch("/siwe/nonce", {
+			method: "POST",
+			body: { walletAddress, chainId },
+		});
+
+		expect(error).toBeDefined();
+		expect(error?.status).toBe(400);
 	});
 
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/8631
 	 */
-	it("should support getNonce alias with address input", async () => {
+	it("should support getNonce alias", async () => {
 		const { client } = await getTestInstance(
 			{
 				plugins: [
@@ -122,13 +156,40 @@ describe("siwe", async () => {
 			},
 		);
 
-		const { data, error } = await client.siwe.getNonce({
-			address: walletAddress,
-			chainId,
-		});
+		const { data, error } = await client.siwe.getNonce();
 
 		expect(error).toBeNull();
 		expect(data?.nonce).toBe("A1b2C3d4E5f6G7h8J");
+	});
+
+	it("should reject server nonce generation that does not follow ERC-4361", async () => {
+		const { client } = await getTestInstance(
+			{
+				plugins: [
+					siwe({
+						domain,
+						async getNonce() {
+							return "your-secure-random-nonce";
+						},
+						async verifyMessage({ signature }) {
+							// Mirrors the documented viem pattern: signature recovery only.
+							return signature === "valid_signature";
+						},
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [siweClient()],
+				},
+			},
+		);
+
+		const { error } = await client.siwe.nonce();
+
+		expect(error).toBeDefined();
+		expect(error?.status).toBe(500);
+		expect(error?.code).toBe("SIWE_INVALID_NONCE");
 	});
 
 	it("should reject verification if nonce is missing", async () => {
@@ -156,8 +217,6 @@ describe("siwe", async () => {
 		const { error } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 		});
 
 		expect(error).toBeDefined();
@@ -166,7 +225,60 @@ describe("siwe", async () => {
 		expect(error?.message).toMatch(/nonce/i);
 	});
 
-	it("should reject invalid public key", async () => {
+	it.each([
+		{ name: "short", nonce: "abc1234" },
+		{ name: "non-alphanumeric", nonce: "some-other-nonce" },
+		{ name: "oversized", nonce: "A".repeat(251) },
+	])("should reject a signed SIWE message with a $name nonce before lookup", async ({
+		nonce,
+	}) => {
+		const { client, auth } = await getTestInstance(
+			{
+				plugins: [
+					siwe({
+						domain,
+						async getNonce() {
+							return "A1b2C3d4E5f6G7h8J";
+						},
+						async verifyMessage({ signature }) {
+							// Mirrors the documented viem pattern: signature recovery only.
+							return signature === "valid_signature";
+						},
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [siweClient()],
+				},
+			},
+		);
+		const context = await auth.$context;
+		const consumeVerificationValue =
+			context.internalAdapter.consumeVerificationValue;
+		let consumedVerificationValue = false;
+		context.internalAdapter.consumeVerificationValue = async (identifier) => {
+			consumedVerificationValue = true;
+			return consumeVerificationValue(identifier);
+		};
+
+		try {
+			const { error } = await client.siwe.verify({
+				message: siweMessage({ nonce }),
+				signature: "valid_signature",
+			});
+
+			expect(error).toBeDefined();
+			expect(error?.status).toBe(401);
+			expect(error?.code).toBe("UNAUTHORIZED_SIWE_MESSAGE_MISMATCH");
+			expect(consumedVerificationValue).toBe(false);
+		} finally {
+			context.internalAdapter.consumeVerificationValue =
+				consumeVerificationValue;
+		}
+	});
+
+	it("should reject a signed SIWE message without a valid address", async () => {
 		const { client } = await getTestInstance(
 			{
 				plugins: [
@@ -188,12 +300,14 @@ describe("siwe", async () => {
 				},
 			},
 		);
-		const { error } = await client.siwe.nonce({ walletAddress: "invalid" });
+		await client.siwe.nonce();
+		const { error } = await client.siwe.verify({
+			message: siweMessage({ address: "invalid" }),
+			signature: "valid_signature",
+		});
 		expect(error).toBeDefined();
-		expect(error?.status).toBe(400);
-		expect(error?.message).toBe(
-			"[body.walletAddress] Invalid string: must match pattern /^0[xX][a-fA-F0-9]{40}$/i; [body.walletAddress] Too small: expected string to have >=42 characters",
-		);
+		expect(error?.status).toBe(401);
+		expect(error?.code).toBe("UNAUTHORIZED_SIWE_MESSAGE_MISMATCH");
 	});
 
 	it("should reject verification with invalid signature", async () => {
@@ -218,16 +332,16 @@ describe("siwe", async () => {
 				},
 			},
 		);
+		await client.siwe.nonce();
 		const { error } = await client.siwe.verify({
-			message: "Sign in with Ethereum.",
+			message: siweMessage(),
 			signature: "invalid_signature",
-			walletAddress,
 		});
 		expect(error).toBeDefined();
 		expect(error?.status).toBe(401);
 	});
 
-	it("should reject invalid walletAddress format", async () => {
+	it("should reject a signed SIWE message without a positive chain ID", async () => {
 		const { client } = await getTestInstance(
 			{
 				plugins: [
@@ -249,9 +363,50 @@ describe("siwe", async () => {
 				},
 			},
 		);
-		const { error } = await client.siwe.nonce({
-			walletAddress: "not_a_valid_key",
+		await client.siwe.nonce();
+		const { error } = await client.siwe.verify({
+			message: siweMessage().replace("Chain ID: 1", "Chain ID: 0"),
+			signature: "valid_signature",
 		});
+		expect(error).toBeDefined();
+		expect(error?.status).toBe(401);
+		expect(error?.code).toBe("UNAUTHORIZED_SIWE_MESSAGE_MISMATCH");
+	});
+
+	it("should reject obsolete wallet-bound verification inputs", async () => {
+		const { client } = await getTestInstance(
+			{
+				plugins: [
+					siwe({
+						domain,
+						async getNonce() {
+							return "A1b2C3d4E5f6G7h8J";
+						},
+						async verifyMessage({ signature }) {
+							// Mirrors the documented viem pattern: signature recovery only.
+							return signature === "valid_signature";
+						},
+					}),
+				],
+			},
+			{
+				clientOptions: {
+					plugins: [siweClient()],
+				},
+			},
+		);
+		await client.siwe.nonce();
+
+		const { error } = await client.$fetch("/siwe/verify", {
+			method: "POST",
+			body: {
+				message: siweMessage(),
+				signature: "valid_signature",
+				walletAddress,
+				chainId,
+			},
+		});
+
 		expect(error).toBeDefined();
 		expect(error?.status).toBe(400);
 	});
@@ -281,7 +436,6 @@ describe("siwe", async () => {
 		const { error } = await client.siwe.verify({
 			message: "invalid_message",
 			signature: "valid_signature",
-			walletAddress,
 		});
 		expect(error).toBeDefined();
 		expect(error?.status).toBe(401);
@@ -314,7 +468,6 @@ describe("siwe", async () => {
 		const { error } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
 			email: undefined,
 		});
 		expect(error).toBeDefined();
@@ -348,13 +501,11 @@ describe("siwe", async () => {
 			},
 		);
 
-		await client.siwe.nonce({ walletAddress, chainId });
+		await client.siwe.nonce();
 
 		const { data, error } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 			email: "user@example.com",
 		});
 		expect(error).toBeNull();
@@ -397,12 +548,10 @@ describe("siwe", async () => {
 		const headers = new Headers();
 
 		try {
-			await client.siwe.nonce({ walletAddress, chainId });
+			await client.siwe.nonce();
 			const { data, error } = await client.siwe.verify({
 				message: siweMessage(),
 				signature: "valid_signature",
-				walletAddress,
-				chainId,
 				email: "user@example.com",
 				fetchOptions: { onSuccess: sessionSetter(headers) },
 			});
@@ -454,12 +603,10 @@ describe("siwe", async () => {
 			},
 		);
 
-		await client.siwe.nonce({ walletAddress, chainId });
+		await client.siwe.nonce();
 		const { error } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 			email: "siwe@example.com",
 		});
 
@@ -491,13 +638,11 @@ describe("siwe", async () => {
 		);
 
 		const headers = new Headers();
-		await client.siwe.nonce({ walletAddress, chainId });
+		await client.siwe.nonce();
 
 		const { data, error } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 			email: testUser.email,
 			fetchOptions: { onSuccess: sessionSetter(headers) },
 		});
@@ -544,12 +689,10 @@ describe("siwe", async () => {
 
 		// First wallet claims a mixed-case email; it is stored normalized.
 		const firstHeaders = new Headers();
-		await client.siwe.nonce({ walletAddress, chainId });
+		await client.siwe.nonce();
 		const first = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 			email: "Mixed@Case.com",
 			fetchOptions: { onSuccess: sessionSetter(firstHeaders) },
 		});
@@ -561,12 +704,10 @@ describe("siwe", async () => {
 
 		// A different wallet presenting the lowercase variant must not claim it.
 		const secondHeaders = new Headers();
-		await client.siwe.nonce({ walletAddress: otherWallet, chainId });
+		await client.siwe.nonce();
 		const second = await client.siwe.verify({
 			message: siweMessage({ address: otherWallet }),
 			signature: "valid_signature",
-			walletAddress: otherWallet,
-			chainId,
 			email: "mixed@case.com",
 			fetchOptions: { onSuccess: sessionSetter(secondHeaders) },
 		});
@@ -604,7 +745,6 @@ describe("siwe", async () => {
 		const { error } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
 			email: "not-an-email",
 		});
 		expect(error).toBeDefined();
@@ -636,12 +776,10 @@ describe("siwe", async () => {
 			},
 		);
 
-		await client.siwe.nonce({ walletAddress, chainId });
+		await client.siwe.nonce();
 		const { data, error } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 		});
 		expect(error).toBeNull();
 		expect(data?.success).toBe(true);
@@ -676,7 +814,7 @@ describe("siwe", async () => {
 			{ clientOptions: { plugins: [siweClient()] } },
 		);
 
-		await client.siwe.nonce({ walletAddress, chainId });
+		await client.siwe.nonce();
 
 		const ctx = await auth.$context;
 		const sessionsBefore = await ctx.adapter.findMany({ model: "session" });
@@ -685,8 +823,6 @@ describe("siwe", async () => {
 			client.siwe.verify({
 				message: siweMessage(),
 				signature: "valid_signature",
-				walletAddress,
-				chainId,
 			});
 
 		const [first, second] = await Promise.all([verifyOnce(), verifyOnce()]);
@@ -728,7 +864,7 @@ describe("siwe", async () => {
 		);
 
 		const ctx = await auth.$context;
-		const identifier = `siwe:${walletAddress}:${chainId}`;
+		const identifier = `siwe:${NONCE}`;
 		await ctx.internalAdapter.createVerificationValue({
 			identifier,
 			value: NONCE,
@@ -738,8 +874,6 @@ describe("siwe", async () => {
 		const { error } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 		});
 		expect(error?.status).toBe(401);
 		expect(error?.code).toBe("UNAUTHORIZED_INVALID_OR_EXPIRED_NONCE");
@@ -771,12 +905,10 @@ describe("siwe", async () => {
 			},
 		);
 
-		await client.siwe.nonce({ walletAddress, chainId });
+		await client.siwe.nonce();
 		const first = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 		});
 		expect(first.error).toBeNull();
 		expect(first.data?.success).toBe(true);
@@ -785,8 +917,6 @@ describe("siwe", async () => {
 		const second = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 		});
 		expect(second.error).toBeDefined();
 		expect(second.error?.status).toBe(401);
@@ -815,12 +945,10 @@ describe("siwe", async () => {
 			},
 		);
 
-		await client.siwe.nonce({ walletAddress, chainId });
+		await client.siwe.nonce();
 		const { error } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress,
-			chainId,
 			email: "",
 		});
 		expect(error).toBeDefined();
@@ -852,15 +980,10 @@ describe("siwe", async () => {
 		);
 
 		// Use lowercase address
-		await client.siwe.nonce({
-			walletAddress: walletAddress.toLowerCase(),
-			chainId,
-		});
+		await client.siwe.nonce();
 		const { data } = await client.siwe.verify({
-			message: siweMessage(),
+			message: siweMessage({ address: walletAddress.toLowerCase() }),
 			signature: "valid_signature",
-			walletAddress: walletAddress.toLowerCase(),
-			chainId,
 		});
 		expect(data?.success).toBe(true);
 
@@ -875,15 +998,11 @@ describe("siwe", async () => {
 		expect(walletAddresses[0]?.address).toBe(walletAddress); // checksummed
 
 		// Try with uppercase address, should not create a new wallet address entry
-		await client.siwe.nonce({
-			walletAddress: walletAddress.toUpperCase(),
-			chainId,
-		});
+		const uppercaseWalletAddress = `0x${walletAddress.slice(2).toUpperCase()}`;
+		await client.siwe.nonce();
 		const { data: data2 } = await client.siwe.verify({
-			message: siweMessage(),
+			message: siweMessage({ address: uppercaseWalletAddress }),
 			signature: "valid_signature",
-			walletAddress: walletAddress.toUpperCase(),
-			chainId,
 		});
 		expect(data2?.success).toBe(true); // Should succeed with existing address
 
@@ -917,15 +1036,10 @@ describe("siwe", async () => {
 		const testChainId = 1;
 
 		// First user successfully creates account with wallet address
-		await client.siwe.nonce({
-			walletAddress: testAddress,
-			chainId: testChainId,
-		});
+		await client.siwe.nonce();
 		const firstUser = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress: testAddress,
-			chainId: testChainId,
 		});
 		expect(firstUser.error).toBeNull();
 		expect(firstUser.data?.success).toBe(true);
@@ -946,15 +1060,10 @@ describe("siwe", async () => {
 		expect(walletAddresses[0]?.isPrimary).toBe(true);
 
 		// Second attempt with same address + chainId should use existing user
-		await client.siwe.nonce({
-			walletAddress: testAddress,
-			chainId: testChainId,
-		});
+		await client.siwe.nonce();
 		const secondUser = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress: testAddress,
-			chainId: testChainId,
 		});
 		expect(secondUser.error).toBeNull();
 		expect(secondUser.data?.success).toBe(true);
@@ -1020,15 +1129,10 @@ describe("siwe", async () => {
 		const testChainId = 1;
 
 		// Create account with custom schema
-		await client.siwe.nonce({
-			walletAddress: testAddress,
-			chainId: testChainId,
-		});
+		await client.siwe.nonce();
 		const result = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress: testAddress,
-			chainId: testChainId,
 		});
 		expect(result.error).toBeNull();
 		expect(result.data?.success).toBe(true);
@@ -1073,23 +1177,19 @@ describe("siwe", async () => {
 		const chainId2 = 137; // Polygon
 
 		// First authentication on Ethereum
-		await client.siwe.nonce({ walletAddress: testAddress, chainId: chainId1 });
+		await client.siwe.nonce();
 		const ethereumAuth = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
-			walletAddress: testAddress,
-			chainId: chainId1,
 		});
 		expect(ethereumAuth.error).toBeNull();
 		expect(ethereumAuth.data?.success).toBe(true);
 
 		// Second authentication on Polygon with same address
-		await client.siwe.nonce({ walletAddress: testAddress, chainId: chainId2 });
+		await client.siwe.nonce();
 		const polygonAuth = await client.siwe.verify({
 			message: siweMessage({ chainId: chainId2 }),
 			signature: "valid_signature",
-			walletAddress: testAddress,
-			chainId: chainId2,
 		});
 		expect(polygonAuth.error).toBeNull();
 		expect(polygonAuth.data?.success).toBe(true);
@@ -1149,40 +1249,34 @@ describe("siwe", async () => {
 			return { client, auth };
 		};
 
-		it("rejects a valid signature over a message with a non-matching nonce", async () => {
+		it("rejects a valid signature over a message with an unknown nonce", async () => {
 			const { client } = await setup();
-			await client.siwe.nonce({ walletAddress, chainId });
+			await client.siwe.nonce();
 			const { error } = await client.siwe.verify({
-				message: siweMessage({ nonce: "some-other-nonce" }),
+				message: siweMessage({ nonce: "SomeOtherNonce123" }),
 				signature: "valid_signature",
-				walletAddress,
-				chainId,
 			});
 			expect(error?.status).toBe(401);
-			expect(error?.code).toBe("UNAUTHORIZED_SIWE_MESSAGE_MISMATCH");
+			expect(error?.code).toBe("UNAUTHORIZED_INVALID_OR_EXPIRED_NONCE");
 		});
 
 		it("rejects a message bound to a different domain", async () => {
 			const { client } = await setup();
-			await client.siwe.nonce({ walletAddress, chainId });
+			await client.siwe.nonce();
 			const { error } = await client.siwe.verify({
 				message: siweMessage({ domain: "other.example.com" }),
 				signature: "valid_signature",
-				walletAddress,
-				chainId,
 			});
 			expect(error?.status).toBe(401);
 			expect(error?.code).toBe("UNAUTHORIZED_SIWE_MESSAGE_MISMATCH");
 		});
 
-		it("rejects a message whose chain id does not match", async () => {
+		it("rejects a message with an invalid chain id", async () => {
 			const { client } = await setup();
-			await client.siwe.nonce({ walletAddress, chainId });
+			await client.siwe.nonce();
 			const { error } = await client.siwe.verify({
-				message: siweMessage({ chainId: 137 }),
+				message: siweMessage().replace("Chain ID: 1", "Chain ID: 0"),
 				signature: "valid_signature",
-				walletAddress,
-				chainId,
 			});
 			expect(error?.status).toBe(401);
 			expect(error?.code).toBe("UNAUTHORIZED_SIWE_MESSAGE_MISMATCH");
@@ -1190,12 +1284,10 @@ describe("siwe", async () => {
 
 		it("rejects an arbitrary (non-SIWE) message even with a valid signature", async () => {
 			const { client } = await setup();
-			await client.siwe.nonce({ walletAddress, chainId });
+			await client.siwe.nonce();
 			const { error } = await client.siwe.verify({
 				message: "gm, please sign this to continue",
 				signature: "valid_signature",
-				walletAddress,
-				chainId,
 			});
 			expect(error?.status).toBe(401);
 			expect(error?.code).toBe("UNAUTHORIZED_SIWE_MESSAGE_MISMATCH");
@@ -1203,14 +1295,12 @@ describe("siwe", async () => {
 
 		it("rejects an expired SIWE message", async () => {
 			const { client } = await setup();
-			await client.siwe.nonce({ walletAddress, chainId });
+			await client.siwe.nonce();
 			const { error } = await client.siwe.verify({
 				message: siweMessage({
 					expirationTime: "2020-01-01T00:00:00.000Z",
 				}),
 				signature: "valid_signature",
-				walletAddress,
-				chainId,
 			});
 			expect(error?.status).toBe(401);
 			expect(error?.code).toBe("UNAUTHORIZED_SIWE_MESSAGE_EXPIRED");
@@ -1220,12 +1310,10 @@ describe("siwe", async () => {
 			const { client, auth } = await setup();
 
 			// The wallet user signs in normally, creating the wallet user.
-			await client.siwe.nonce({ walletAddress, chainId });
+			await client.siwe.nonce();
 			const legit = await client.siwe.verify({
 				message: siweMessage(),
 				signature: "valid_signature",
-				walletAddress,
-				chainId,
 			});
 			expect(legit.data?.success).toBe(true);
 
@@ -1236,12 +1324,10 @@ describe("siwe", async () => {
 
 			// A second request mints a fresh nonce and reuses a previously
 			// produced signature over an unrelated message for the same wallet.
-			await client.siwe.nonce({ walletAddress, chainId });
+			await client.siwe.nonce();
 			const secondAttempt = await client.siwe.verify({
 				message: "Approve transfer of 1 ETH",
 				signature: "valid_signature",
-				walletAddress,
-				chainId,
 			});
 			expect(secondAttempt.error?.status).toBe(401);
 			expect(secondAttempt.data).toBeNull();


### PR DESCRIPTION
SIWE nonce generation required wallet identity before issuing a nonce, which blocked one-step wallet auth flows where address and chain are only known after signing.

This makes the signed ERC-4361 message the source of truth for wallet identity. Nonce endpoints now issue a single-use challenge without wallet fields, and verification consumes the matching nonce before validating the signed domain, address, Chain ID, and time bounds.

The request schemas reject the old wallet fields instead of stripping them, so client types and runtime behavior agree. Docs and the last-login SIWE integration tests now follow the nonce-first flow.

Fixes #8116.