### PR TITLE
feat(generic-oauth): add ThunderID login support

### DIFF
--- a/.cspell/company-names.txt
+++ b/.cspell/company-names.txt
@@ -29,4 +29,6 @@ payu
 PayU
 Mikro
 anthropics
+thunderid
+THUNDERID
 Zitadel

--- a/.cspell/company-names.txt
+++ b/.cspell/company-names.txt
@@ -31,4 +31,6 @@ contoso
 Contoso
 Mikro
 anthropics
+thunderid
+THUNDERID
 Zitadel

--- a/docs/content/docs/authentication/other-social-providers.mdx
+++ b/docs/content/docs/authentication/other-social-providers.mdx
@@ -95,6 +95,7 @@ Better Auth includes helpers for these providers:
 * **Okta** - `okta(options)`
 * **Patreon** - `patreon(options)`
 * **Slack** - `slack(options)`
+* **ThunderID** - `thunderid(options)`
 * **Yandex** - `yandex(options)`
 
 Here's an example using Slack:
@@ -132,6 +133,7 @@ Each helper accepts common OAuth options through `BaseOAuthProviderOptions`, plu
 * **LINE**: Accepts an optional `providerId`. Call `line()` with different provider IDs and credentials to support multiple country-specific channels
 * **Microsoft Entra ID**: Requires a concrete tenant GUID. Use the built-in [Microsoft social provider](/docs/authentication/microsoft) for the multi-tenant `"common"`, `"organizations"`, or `"consumers"` authorities
 * **Okta**: Requires `issuer` (for example, `https://dev-xxxxx.okta.com/oauth2/default`)
+* **ThunderID**: Requires `issuer` (for example, `https://thunderid.example.com`)
 
 All helpers accept these common options:
 

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -137,6 +137,7 @@ Better Auth provides pre-configured helper functions for popular OAuth providers
 * **Okta** - `okta(options)`
 * **Slack** - `slack(options)`
 * **Patreon** - `patreon(options)`
+* **ThunderID** - `thunderid(options)`
 * **Yandex** - `yandex(options)`
 
 ### Example: Using Pre-configured Providers
@@ -156,6 +157,7 @@ import {
 	okta,
 	slack,
 	patreon,
+	thunderid,
 	yandex,
 } from 'better-auth/plugins';
 
@@ -211,6 +213,11 @@ export const auth = betterAuth({
 					clientId: process.env.PATREON_CLIENT_ID,
 					clientSecret: process.env.PATREON_CLIENT_SECRET,
 				}),
+				thunderid({
+					clientId: process.env.THUNDERID_CLIENT_ID,
+					clientSecret: process.env.THUNDERID_CLIENT_SECRET,
+					issuer: process.env.THUNDERID_ISSUER,
+				}),
 				yandex({
 					clientId: process.env.YANDEX_CLIENT_ID,
 					clientSecret: process.env.YANDEX_CLIENT_SECRET,
@@ -231,6 +238,7 @@ Each provider helper accepts common OAuth options (extending `BaseOAuthProviderO
 * **Okta**: Requires `issuer` (e.g., `https://dev-xxxxx.okta.com/oauth2/default`)
 * **Slack**: No additional required fields
 * **Patreon**: No additional required fields
+* **ThunderID**: Requires `issuer` (e.g., `https://thunderid.example.com`)
 * **Yandex**: No additional required fields
 
 All providers support the same optional fields:

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -16,6 +16,7 @@ import { keycloak } from "./providers/keycloak";
 import { microsoftEntraId } from "./providers/microsoft-entra-id";
 import { okta } from "./providers/okta";
 import { slack } from "./providers/slack";
+import { thunderid } from "./providers/thunderid";
 
 describe("oauth2", async () => {
 	const providerId = "test";
@@ -2585,6 +2586,79 @@ describe("oauth2", async () => {
 							clientId: "keycloak-client-id",
 							clientSecret: "keycloak-client-secret",
 							issuer: "https://my-domain.com/realms/MyRealm",
+						}),
+					],
+				}),
+			],
+		});
+
+		expect(testAuth).toBeDefined();
+	});
+
+	describe("ThunderID Provider Helper", () => {
+		it("should return correct GenericOAuthConfig", () => {
+			const thunderidConfig = thunderid({
+				clientId: "thunderid-client-id",
+				clientSecret: "thunderid-client-secret",
+				issuer: "https://thunderid.example.com",
+			});
+
+			expect(thunderidConfig.providerId).toBe("thunderid");
+			expect(thunderidConfig.discoveryUrl).toBe(
+				"https://thunderid.example.com/.well-known/openid-configuration",
+			);
+			expect(thunderidConfig.scopes).toEqual(["openid", "profile", "email"]);
+			expect(thunderidConfig.clientId).toBe("thunderid-client-id");
+			expect(thunderidConfig.clientSecret).toBe("thunderid-client-secret");
+			expect(thunderidConfig.getUserInfo).toBeUndefined();
+		});
+
+		it("should handle issuer with trailing slash", () => {
+			const thunderidConfig = thunderid({
+				clientId: "thunderid-client-id",
+				clientSecret: "thunderid-client-secret",
+				issuer: "https://thunderid.example.com/",
+			});
+
+			expect(thunderidConfig.discoveryUrl).toBe(
+				"https://thunderid.example.com/.well-known/openid-configuration",
+			);
+		});
+
+		it("should allow overriding scopes", () => {
+			const thunderidConfig = thunderid({
+				clientId: "thunderid-client-id",
+				clientSecret: "thunderid-client-secret",
+				issuer: "https://thunderid.example.com",
+				scopes: ["openid", "profile"],
+			});
+
+			expect(thunderidConfig.scopes).toEqual(["openid", "profile"]);
+		});
+
+		it("should allow overriding other options", () => {
+			const thunderidConfig = thunderid({
+				clientId: "thunderid-client-id",
+				clientSecret: "thunderid-client-secret",
+				issuer: "https://thunderid.example.com",
+				pkce: true,
+				disableImplicitSignUp: true,
+			});
+
+			expect(thunderidConfig.pkce).toBe(true);
+			expect(thunderidConfig.disableImplicitSignUp).toBe(true);
+		});
+	});
+
+	it("should integrate thunderid provider helper with genericOAuth", async () => {
+		const { auth: testAuth } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						thunderid({
+							clientId: "thunderid-client-id",
+							clientSecret: "thunderid-client-secret",
+							issuer: "https://thunderid.example.com",
 						}),
 					],
 				}),

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -33,6 +33,7 @@ import { keycloak } from "./providers/keycloak";
 import { microsoftEntraId } from "./providers/microsoft-entra-id";
 import { okta } from "./providers/okta";
 import { slack } from "./providers/slack";
+import { thunderid } from "./providers/thunderid";
 import { yandex } from "./providers/yandex";
 
 describe("oauth2", async () => {
@@ -3571,6 +3572,108 @@ describe("oauth2", async () => {
 							clientId: "keycloak-client-id",
 							clientSecret: "keycloak-client-secret",
 							issuer: "https://my-domain.com/realms/MyRealm",
+						}),
+					],
+				}),
+			],
+		});
+
+		expect(testAuth).toBeDefined();
+	});
+
+	describe("ThunderID Provider Helper", () => {
+		it("should return correct GenericOAuthConfig", () => {
+			const thunderidConfig = thunderid({
+				clientId: "thunderid-client-id",
+				clientSecret: "thunderid-client-secret",
+				issuer: "https://thunderid.example.com",
+			});
+
+			expect(thunderidConfig.providerId).toBe("thunderid");
+			expect(thunderidConfig.accountIssuer).toBe(
+				"https://thunderid.example.com",
+			);
+			expect(thunderidConfig.discoveryUrl).toBe(
+				"https://thunderid.example.com/.well-known/openid-configuration",
+			);
+			expect(thunderidConfig.scopes).toEqual(["openid", "profile", "email"]);
+			expect(thunderidConfig.clientId).toBe("thunderid-client-id");
+			expect(thunderidConfig.clientSecret).toBe("thunderid-client-secret");
+			expect(thunderidConfig.getUserInfo).toBeUndefined();
+		});
+
+		it("should handle issuer with trailing slash", () => {
+			const thunderidConfig = thunderid({
+				clientId: "thunderid-client-id",
+				clientSecret: "thunderid-client-secret",
+				issuer: "https://thunderid.example.com/",
+			});
+
+			expect(thunderidConfig.accountIssuer).toBe(
+				"https://thunderid.example.com",
+			);
+			expect(thunderidConfig.discoveryUrl).toBe(
+				"https://thunderid.example.com/.well-known/openid-configuration",
+			);
+		});
+
+		it("should allow overriding scopes", () => {
+			const thunderidConfig = thunderid({
+				clientId: "thunderid-client-id",
+				clientSecret: "thunderid-client-secret",
+				issuer: "https://thunderid.example.com",
+				scopes: ["openid", "profile"],
+			});
+
+			expect(thunderidConfig.scopes).toEqual(["openid", "profile"]);
+		});
+
+		it("should allow overriding other options", () => {
+			const thunderidConfig = thunderid({
+				clientId: "thunderid-client-id",
+				clientSecret: "thunderid-client-secret",
+				issuer: "https://thunderid.example.com",
+				pkce: true,
+				disableImplicitSignUp: true,
+			});
+
+			expect(thunderidConfig.pkce).toBe(true);
+			expect(thunderidConfig.disableImplicitSignUp).toBe(true);
+		});
+
+		it("should forward token endpoint auth and logout options", () => {
+			const thunderidConfig = thunderid({
+				clientId: "thunderid-client-id",
+				clientSecret: "thunderid-client-secret",
+				issuer: "https://thunderid.example.com",
+				tokenEndpointAuth: { method: "client_secret_post" },
+				endSessionEndpoint: "https://thunderid.example.com/logout",
+				postLogoutRedirectURI: "https://app.example.com/logged-out",
+				disableProviderLogout: true,
+			});
+
+			expect(thunderidConfig.tokenEndpointAuth).toEqual({
+				method: "client_secret_post",
+			});
+			expect(thunderidConfig.endSessionEndpoint).toBe(
+				"https://thunderid.example.com/logout",
+			);
+			expect(thunderidConfig.postLogoutRedirectURI).toBe(
+				"https://app.example.com/logged-out",
+			);
+			expect(thunderidConfig.disableProviderLogout).toBe(true);
+		});
+	});
+
+	it("should integrate thunderid provider helper with genericOAuth", async () => {
+		const { auth: testAuth } = await getTestInstance({
+			plugins: [
+				genericOAuth({
+					config: [
+						thunderid({
+							clientId: "thunderid-client-id",
+							clientSecret: "thunderid-client-secret",
+							issuer: "https://thunderid.example.com",
 						}),
 					],
 				}),

--- a/packages/better-auth/src/plugins/generic-oauth/providers/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/index.ts
@@ -17,6 +17,7 @@
  *  okta,
  *  slack,
  *  patreon,
+ *  thunderid,
  *  yandex,
  * } from 'better-auth/plugins';
  *
@@ -49,4 +50,5 @@ export {
 export { type OktaOptions, okta } from "./okta";
 export { type PatreonOptions, patreon } from "./patreon";
 export { type SlackOptions, slack } from "./slack";
+export { type ThunderIDOptions, thunderid } from "./thunderid";
 export { type YandexOptions, yandex } from "./yandex";

--- a/packages/better-auth/src/plugins/generic-oauth/providers/thunderid.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/thunderid.ts
@@ -1,0 +1,52 @@
+import type { BaseOAuthProviderOptions, GenericOAuthConfig } from "../index";
+
+export interface ThunderIDOptions extends BaseOAuthProviderOptions {
+	/**
+	 * ThunderID issuer URL (e.g., https://thunderid.example.com)
+	 * This will be used to construct the discovery URL.
+	 */
+	issuer: string;
+}
+
+/**
+ * ThunderID OAuth provider helper
+ *
+ * @example
+ * ```ts
+ * import { genericOAuth, thunderid } from "better-auth/plugins/generic-oauth";
+ *
+ * export const auth = betterAuth({
+ *   plugins: [
+ *     genericOAuth({
+ *       config: [
+ *         thunderid({
+ *           clientId: process.env.THUNDERID_CLIENT_ID,
+ *           clientSecret: process.env.THUNDERID_CLIENT_SECRET,
+ *           issuer: process.env.THUNDERID_ISSUER,
+ *         }),
+ *       ],
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function thunderid(options: ThunderIDOptions): GenericOAuthConfig {
+	const defaultScopes = ["openid", "profile", "email"];
+
+	// Ensure issuer ends without trailing slash for proper discovery URL construction
+	const issuer = options.issuer.replace(/\/$/, "");
+	const discoveryUrl = `${issuer}/.well-known/openid-configuration`;
+
+	return {
+		providerId: "thunderid",
+		discoveryUrl,
+		clientId: options.clientId,
+		clientSecret: options.clientSecret,
+		scopes: options.scopes ?? defaultScopes,
+		redirectURI: options.redirectURI,
+		pkce: options.pkce,
+		disableImplicitSignUp: options.disableImplicitSignUp,
+		disableSignUp: options.disableSignUp,
+		overrideUserInfo: options.overrideUserInfo,
+	};
+}

--- a/packages/better-auth/src/plugins/generic-oauth/providers/thunderid.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/thunderid.ts
@@ -1,0 +1,59 @@
+import type { BaseOAuthProviderOptions, GenericOAuthConfig } from "../index";
+
+export interface ThunderIDOptions extends BaseOAuthProviderOptions {
+	/**
+	 * ThunderID issuer URL (e.g., https://thunderid.example.com)
+	 * This will be used to construct the discovery URL.
+	 */
+	issuer: string;
+}
+
+/**
+ * ThunderID OAuth provider helper
+ *
+ * @example
+ * ```ts
+ * import { genericOAuth, thunderid } from "better-auth/plugins/generic-oauth";
+ *
+ * export const auth = betterAuth({
+ *   plugins: [
+ *     genericOAuth({
+ *       config: [
+ *         thunderid({
+ *           clientId: process.env.THUNDERID_CLIENT_ID,
+ *           clientSecret: process.env.THUNDERID_CLIENT_SECRET,
+ *           issuer: process.env.THUNDERID_ISSUER,
+ *         }),
+ *       ],
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function thunderid(
+	options: ThunderIDOptions,
+): GenericOAuthConfig<"thunderid"> {
+	const defaultScopes = ["openid", "profile", "email"];
+
+	// Ensure issuer ends without trailing slash for proper discovery URL construction
+	const issuer = options.issuer.replace(/\/$/, "");
+	const discoveryUrl = `${issuer}/.well-known/openid-configuration`;
+
+	return {
+		providerId: "thunderid",
+		accountIssuer: issuer,
+		discoveryUrl,
+		clientId: options.clientId,
+		clientSecret: options.clientSecret,
+		tokenEndpointAuth: options.tokenEndpointAuth,
+		scopes: options.scopes ?? defaultScopes,
+		redirectURI: options.redirectURI,
+		endSessionEndpoint: options.endSessionEndpoint,
+		postLogoutRedirectURI: options.postLogoutRedirectURI,
+		disableProviderLogout: options.disableProviderLogout,
+		pkce: options.pkce,
+		disableImplicitSignUp: options.disableImplicitSignUp,
+		disableSignUp: options.disableSignUp,
+		overrideUserInfo: options.overrideUserInfo,
+	};
+}


### PR DESCRIPTION
[ThunderID](https://thunderid.dev/) is a fully open source, OIDC-compliant identity platform initiated by [WSO2](https://wso2.com/) (the team behind [WSO2 Identity Server](https://wso2.com/identity-platform/identity-server/) and [Asgardeo](https://wso2.com/identity-platform/developer/)), which are widely used in enterprise IAM.

WSO2's managed identity platform, Asgardeo, already has a first-class provider in [Auth.js](https://authjs.dev/getting-started/providers/asgardeo). ThunderID is the next step in that ecosystem, bringing the same IAM expertise to a fully self-hostable, community-driven platform.

Resolves https://github.com/better-auth/better-auth/issues/10238


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ThunderID login to the `generic-oauth` plugin via a new `thunderid` provider, enabling OIDC login against any ThunderID issuer. No breaking changes.

**New Features**
- Builds discovery URL from the required `issuer`, trimming any trailing slash.
- Defaults to `["openid", "profile", "email"]` scopes with support for `scopes` overrides.
- Forwards token endpoint auth, logout options, `pkce`, `redirectURI`, `disableImplicitSignUp`, `disableSignUp`, and `overrideUserInfo`.
- Exports `thunderid` and `ThunderIDOptions` from `better-auth/plugins`, with docs and tests covering config, overrides, and `genericOAuth` integration.

<sup>Written for commit 791784bdc06337c05edbf6d956419c3291429f43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



