### PR TITLE
fix: check added for subscription = null for stripe

### DIFF
--- a/packages/stripe/src/hooks.test.ts
+++ b/packages/stripe/src/hooks.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { onCheckoutSessionCompleted } from "./hooks"; // Adjust path
+
+describe("onCheckoutSessionCompleted", () => {
+	it("should return early for 'payment' mode sessions without calling subscription retrieve", async () => {
+		// 1. Mock the client
+		const mockRetrieve = vi.fn();
+		const mockOptions = {
+			stripeClient: {
+				subscriptions: { retrieve: mockRetrieve },
+			},
+			subscription: {
+				enabled: true,
+			},
+		} as any;
+
+		// 2. Mock the context
+		const mockCtx = {
+			context: { logger: { error: vi.fn(), warn: vi.fn() } },
+		} as any;
+
+		// 3. Mock the event (The core of the problem)
+		const mockEvent = {
+			type: "checkout.session.completed",
+			data: {
+				object: {
+					mode: "payment",
+					subscription: null,
+				},
+			},
+		} as any;
+
+		// 4. Execute
+		await onCheckoutSessionCompleted(mockCtx, mockOptions, mockEvent);
+
+		// 5. Assertions
+		// If the bug is fixed, retrieve should NEVER be called
+		expect(mockRetrieve).not.toHaveBeenCalled();
+
+		// Ensure no errors were logged (meaning it didn't crash)
+		expect(mockCtx.context.logger.error).not.toHaveBeenCalled();
+	});
+});

--- a/packages/stripe/src/hooks.ts
+++ b/packages/stripe/src/hooks.ts
@@ -49,6 +49,13 @@ export async function onCheckoutSessionCompleted(
 		if (checkoutSession.mode === "setup" || !options.subscription?.enabled) {
 			return;
 		}
+
+		// check for those who use stripe as a subscription as well as one-time-payment
+		// plugin. stripe sets the subscription = null when it is a one time payment.
+		if (!checkoutSession.subscription) {
+			return;
+		}
+
 		const subscription = await client.subscriptions.retrieve(
 			checkoutSession.subscription as string,
 		);


### PR DESCRIPTION
Fixes #10244

### Description
This PR addresses a bug in the `onCheckoutSessionCompleted` webhook handler where the Stripe plugin forces all `checkout.session.completed` events through subscription-specific logic, even when no subscription is present.

### The Problem
When using Stripe Checkout for one-time payments (`mode: "payment"`), the `subscription` field is `null`. The current implementation attempts to call `client.subscriptions.retrieve(null)`, which results in a runtime error. This causes the webhook to return a `500` status code, triggering Stripe's webhook retry loop and flooding logs with `No such subscription: 'null'` errors.

### The Fix
I have added a guard clause to verify the existence of `checkoutSession.subscription` before attempting to retrieve it. 

### Benefits
* **Prevents Crashes:** Stops the runtime error and subsequent 500 responses for one-time payment sessions.
* **Unblocks `onEvent`:** By allowing the function to exit gracefully for one-time payments, the execution flow is now able to proceed to the `options.onEvent?.(event)` callback, allowing developers to handle PAYG/one-time payments as intended.
* **Safe for Subscriptions:** This change does not affect existing subscription flows; it simply ensures the library handles the reality of mixed-mode Stripe integrations correctly.

### Testing
Added a unit test case that mocks a `mode: "payment"` event with `subscription: null` to verify that the retrieval logic is correctly skipped and no errors are thrown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip subscription retrieval in the Stripe `checkout.session.completed` webhook when `subscription` is null to prevent 500s on one-time payments and let `onEvent` run as expected.

- **Bug Fixes**
  - Added a guard in `onCheckoutSessionCompleted` to return early for `mode: "payment"` sessions with `subscription: null`.
  - Added a unit test to ensure `subscriptions.retrieve` isn’t called and no errors are logged for one-time payments.

<sup>Written for commit 4b128b1eab402be0299b28b690cf5f0103f6814d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

