### PR TITLE
chore(release): prepare 1.7 RC channel

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,6 +17,7 @@
       "@better-auth/expo",
       "@better-auth/i18n",
       "@better-auth/kysely-adapter",
+      "@better-auth/mcp",
       "@better-auth/memory-adapter",
       "@better-auth/mongo-adapter",
       "@better-auth/oauth-provider",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,6 +1,6 @@
 {
   "mode": "pre",
-  "tag": "beta",
+  "tag": "rc",
   "initialVersions": {
     "docs": "0.1.0",
     "@better-auth/api-key": "1.6.0",


### PR DESCRIPTION
Switches the `next` prerelease channel from `beta` to `rc` and keeps MCP on the same fixed release train as the rest of the 1.7 packages.

The release metadata currently left `@better-auth/mcp` outside the fixed group, so it would not move with `better-auth`, `auth`, CIMD, SCIM, SSO, adapters, and test utilities when the next release PR is generated.

This PR does not version packages. It only prepares the release configuration. The generated release PR still needs its version output checked before merge, especially if the target tag must be `v1.7.0-rc.0` rather than the prerelease counter Changesets derives from the current beta line.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the 1.7 prerelease channel from `beta` to `rc`, and add `@better-auth/mcp` to the fixed release group so it ships with the rest of the 1.7 packages. Config-only Changesets update; no version bumps.

<sup>Written for commit d9e87292180577f7de92e2534527c35274d1f082. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

