### PR TITLE
fix(cli): escape string default values in generated Drizzle schema

### DIFF
--- a/.changeset/drizzle-generate-escape-string-default.md
+++ b/.changeset/drizzle-generate-escape-string-default.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+Fix `better-auth generate` emitting an invalid Drizzle schema when a field's string default value contains a quote or backslash.

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -250,7 +250,9 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 										// custom logic within that function that might not work in drizzle's context.
 									}
 								} else if (typeof attr.defaultValue === "string") {
-									type += `.default("${attr.defaultValue}")`;
+									// Serialize through JSON.stringify so a value with quotes or
+									// backslashes emits valid TypeScript instead of a broken literal.
+									type += `.default(${JSON.stringify(attr.defaultValue)})`;
 								} else if (Array.isArray(attr.defaultValue)) {
 									// Stringify each element so a `["customer"]` default emits
 									// `.default(["customer"])` rather than `.default(customer)`

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -427,6 +427,42 @@ describe("generate", async () => {
 		expect(schema.code).not.toMatch(/explicitOptional:.*\.notNull\(\)/);
 	});
 
+	it("should escape string default values so the generated schema stays valid TypeScript", async () => {
+		const pluginWithQuotedDefault = (): BetterAuthPlugin => ({
+			id: "quoted-default-test",
+			schema: {
+				testTable: {
+					fields: {
+						greeting: {
+							type: "string",
+							defaultValue: 'say "hi"\\done',
+						},
+					},
+				},
+			},
+		});
+
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: {
+				id: "drizzle",
+				options: {
+					provider: "pg",
+					schema: {},
+				},
+			} as any,
+			options: {
+				database: {} as any,
+				plugins: [pluginWithQuotedDefault()],
+			} as BetterAuthOptions,
+		});
+
+		// Quotes and backslashes must be escaped so the default is a valid
+		// literal. The raw interpolation would emit `.default("say "hi"\done")`
+		// and break the generated schema file.
+		expect(schema.code).toContain(String.raw`.default('say "hi"\\done')`);
+	});
+
 	it("should treat fields with omitted required as non-optional in prisma schema", async () => {
 		const originalCwd = process.cwd();
 		const tmpDir = fs.mkdtempSync(


### PR DESCRIPTION
Related to https://github.com/better-auth/better-auth/pull/9489#issuecomment-4808841926