### PR TITLE
fix(memory-adapter): guard starts_with and ends_with against null fields

### DIFF
--- a/.changeset/memory-adapter-startswith-null-guard.md
+++ b/.changeset/memory-adapter-startswith-null-guard.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/memory-adapter": patch
+---
+
+Fix `starts_with` and `ends_with` filters throwing a `TypeError` when a queried field is `null` or absent. They now exclude such rows (matching the `contains` operator and the SQL/Prisma/Mongo adapters) instead of crashing the whole query.

--- a/packages/memory-adapter/src/memory-adapter.test.ts
+++ b/packages/memory-adapter/src/memory-adapter.test.ts
@@ -460,3 +460,37 @@ describe("memory adapter transaction isolation", () => {
 		expect(db.widget?.map((r) => r.id)).toEqual(["committed"]);
 	});
 });
+
+describe("memory adapter starts_with/ends_with with a null or absent field", () => {
+	it("starts_with excludes a row whose field is absent instead of throwing", async () => {
+		const { adapter } = setup();
+		await seedWidget(adapter, "1", "alice"); // no tag field
+		await adapter.create({
+			model: "widget",
+			data: { id: "2", name: "bob", tag: "hello" },
+			forceAllowId: true,
+		});
+
+		const rows = await adapter.findMany<{ id: string }>({
+			model: "widget",
+			where: [{ field: "tag", value: "hel", operator: "starts_with" }],
+		});
+		expect(rows.map((r) => r.id)).toEqual(["2"]);
+	});
+
+	it("ends_with excludes a row whose field is absent instead of throwing", async () => {
+		const { adapter } = setup();
+		await seedWidget(adapter, "1", "alice"); // no tag field
+		await adapter.create({
+			model: "widget",
+			data: { id: "2", name: "bob", tag: "hello" },
+			forceAllowId: true,
+		});
+
+		const rows = await adapter.findMany<{ id: string }>({
+			model: "widget",
+			where: [{ field: "tag", value: "llo", operator: "ends_with" }],
+		});
+		expect(rows.map((r) => r.id)).toEqual(["2"]);
+	});
+});

--- a/packages/memory-adapter/src/memory-adapter.ts
+++ b/packages/memory-adapter/src/memory-adapter.ts
@@ -279,12 +279,12 @@ export const memoryAdapter = (
 									if (isInsensitive) {
 										return insensitiveStartsWith(record[field], value);
 									}
-									return record[field].startsWith(value);
+									return record[field]?.startsWith(value);
 								case "ends_with":
 									if (isInsensitive) {
 										return insensitiveEndsWith(record[field], value);
 									}
-									return record[field].endsWith(value);
+									return record[field]?.endsWith(value);
 								case "ne":
 									return isInsensitive
 										? !insensitiveCompare(record[field], value)


### PR DESCRIPTION
## Description

The in-memory adapter's `starts_with` and `ends_with` operators (sensitive mode) call `record[field].startsWith(value)` / `.endsWith(value)` with no null guard. When the queried field is `null` or absent in a row, `findOne`, `findMany`, `count`, `update`, and `delete` throw `TypeError: Cannot read properties of undefined (reading 'startsWith')` and the whole operation fails, because `convertWhereClause` evaluates the predicate against every row.

This looks like an oversight rather than intended behavior: the adjacent `contains` branch already guards with `record[field]?.includes(value)`, and the insensitive `startsWith` / `endsWith` helpers in `query-builders.ts` guard via a `typeof recordVal !== "string"` check. Only the sensitive inline path was missed. A row gets an absent field whenever a nullable column has no value (the factory's `transformInput` drops `undefined`).

## Fix

Add optional chaining to the two operators so a missing field yields `undefined` (falsy, so the row is simply excluded). This makes the memory adapter consistent with itself and with the other adapters: SQL `LIKE` against `NULL`, Prisma `startsWith`, and Mongo `$regex` all exclude null or missing-field rows rather than erroring.

## Tests

Added two cases to `memory-adapter.test.ts` using the existing `widget` model (whose `tag` field is optional): seed one row with no `tag` and one with `tag: "hello"`, then query `starts_with: "hel"` and `ends_with: "llo"` and assert only the matching row is returned. Both cases throw on `main` and pass with the fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `starts_with` and `ends_with` in `@better-auth/memory-adapter` so queries don’t crash when the field is null or missing. Such rows are now ignored, matching `contains` and other adapters.

- **Bug Fixes**
  - Guard sensitive operators with `record[field]?.startsWith/endsWith`.
  - Prevents `TypeError` in `findOne`/`findMany`/`count`/`update`/`delete`; rows without the field are excluded.
  - Added tests for both operators and a patch changeset for `@better-auth/memory-adapter`.

<sup>Written for commit 61a4530cf2350026ed570883bb6b9f6ce004134e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

