### PR TITLE
fix(oauth2): use standard Base64 for client_credentials Basic auth (RFC 7617)

### DIFF
--- a/.changeset/client-credentials-basic-auth-base64.md
+++ b/.changeset/client-credentials-basic-auth-base64.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Fix the `client_credentials` grant encoding the HTTP Basic auth header with Base64URL instead of standard Base64 when `authentication: "basic"`. A client secret whose Base64 contains `+`, `/`, or `=` padding was mangled and rejected by a standards-compliant token endpoint (RFC 7617). It now uses standard Base64, matching the authorization-code and refresh-token requests.

--- a/packages/core/src/oauth2/client-credentials-token.test.ts
+++ b/packages/core/src/oauth2/client-credentials-token.test.ts
@@ -1,0 +1,18 @@
+import { base64 } from "@better-auth/utils/base64";
+import { describe, expect, it } from "vitest";
+import { createClientCredentialsTokenRequest } from "./client-credentials-token";
+
+describe("createClientCredentialsTokenRequest basic auth header", () => {
+	it("encodes the Basic credentials with standard Base64 (RFC 7617), not Base64URL", () => {
+		// "a:~" is "YTp+" in standard Base64 but "YTp-" in Base64URL. A secret whose
+		// Base64 contains +, /, or = padding is mangled by Base64URL and rejected by
+		// a standards-compliant token endpoint, breaking the client_credentials grant.
+		const { headers } = createClientCredentialsTokenRequest({
+			options: { clientId: "a", clientSecret: "~" } as any,
+			authentication: "basic",
+		});
+
+		expect(headers["authorization"]).toBe(`Basic ${base64.encode("a:~")}`);
+		expect(headers["authorization"]).toBe("Basic YTp+");
+	});
+});

--- a/packages/core/src/oauth2/client-credentials-token.ts
+++ b/packages/core/src/oauth2/client-credentials-token.ts
@@ -1,4 +1,4 @@
-import { base64Url } from "@better-auth/utils/base64";
+import { base64 } from "@better-auth/utils/base64";
 import type { AwaitableFunction } from "../types";
 import type { OAuth2Tokens, ProviderOptions } from "./oauth-provider";
 import { fetchRefusingRedirects } from "./reject-redirects";
@@ -58,7 +58,9 @@ export function createClientCredentialsTokenRequest({
 		const primaryClientId = Array.isArray(options.clientId)
 			? options.clientId[0]
 			: options.clientId;
-		const encodedCredentials = base64Url.encode(
+		// Use standard Base64 encoding for HTTP Basic Auth (OAuth2 spec, RFC 7617),
+		// matching validate-authorization-code.ts and refresh-access-token.ts.
+		const encodedCredentials = base64.encode(
 			`${primaryClientId}:${options.clientSecret}`,
 		);
 		headers["authorization"] = `Basic ${encodedCredentials}`;


### PR DESCRIPTION
## Description

In the `client_credentials` grant with `authentication: "basic"`, the HTTP Basic auth header is built with `base64Url.encode(...)` instead of standard `base64.encode(...)`. Base64URL uses `-` and `_` in place of `+` and `/` and drops `=` padding, so for any `clientId:clientSecret` whose standard Base64 contains `+`, `/`, or padding (common for high-entropy secrets), the credential is malformed. A standards-compliant token endpoint decodes it to the wrong bytes and rejects the request, so the grant fails.

RFC 7617 (HTTP Basic auth) requires standard Base64. The two sibling request builders, `validate-authorization-code.ts` and `refresh-access-token.ts`, already use standard `base64.encode` with the comment "Use standard Base64 encoding for HTTP Basic Auth (OAuth2 spec, RFC 7617)". This path was missed when those were fixed.

## Fix

Import `base64` instead of `base64Url` and use `base64.encode` for the credentials, matching the sibling builders.

## Tests

Added `client-credentials-token.test.ts`. `"a:~"` encodes to `"YTp+"` in standard Base64 but `"YTp-"` in Base64URL, so the test asserts the `authorization` header is `Basic YTp+`. It fails on `main` (produces `Basic YTp-`) and passes with the fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use standard Base64 for Basic auth in the OAuth2 `client_credentials` flow (RFC 7617). This prevents token requests from failing when credentials encode to `+`, `/`, or `=` against compliant servers in `@better-auth/core`.

- **Bug Fixes**
  - Replace `base64Url.encode` with `base64.encode` in the `client_credentials` request builder, matching the authorization-code and refresh flows.
  - Add `client-credentials-token.test.ts` to assert the header is `Basic YTp+` for `a:~`.

<sup>Written for commit 25f8eac68dfc84a06210094d76d90896ffa779d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

