### PR TITLE
feat(expo): support configurable origin and callback rewriting

### DIFF
--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -114,8 +114,6 @@ Expo is a popular framework for building cross-platform apps with React Native. 
                 scheme: "myapp",
                 storagePrefix: "myapp",
                 storage: SecureStore,
-                origin: "https://myapp.example.com",
-                rewriteCallbackToDeepLink: false,
             })
         ]
     });
@@ -126,6 +124,19 @@ Expo is a popular framework for building cross-platform apps with React Native. 
     you omit it, Expo continues to derive the origin from your app scheme by
     default. `rewriteCallbackToDeepLink` defaults to `true`, which preserves the
     current scheme-based deep-link callback behavior.
+
+    If you want to keep callback URLs as HTTPS App Links / Universal Links
+    instead of rewriting relative callback paths into deep links, configure the
+    options explicitly:
+
+    ```ts
+    expoClient({
+        storage: SecureStore,
+        storagePrefix: "myapp",
+        origin: "https://myapp.example.com",
+        rewriteCallbackToDeepLink: false,
+    });
+    ```
 
     <Callout>
       Be sure to include the full URL, including the path, if you've changed the default path from `/api/auth`.

--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -125,6 +125,10 @@ Expo is a popular framework for building cross-platform apps with React Native. 
     default. `rewriteCallbackToDeepLink` defaults to `true`, which preserves the
     current scheme-based deep-link callback behavior.
 
+    When you set `origin`, add that HTTPS origin to your server's
+    `trustedOrigins` list as well, or Better Auth will reject the request
+    during origin validation.
+
     If you want to keep callback URLs as HTTPS App Links / Universal Links
     instead of rewriting relative callback paths into deep links, configure the
     options explicitly:
@@ -163,11 +167,13 @@ Expo is a popular framework for building cross-platform apps with React Native. 
     }
     ```
 
-    Then, update your Better Auth config to include the scheme in the `trustedOrigins` list.
+    Then, update your Better Auth config to include the scheme in the
+    `trustedOrigins` list. If you use `expoClient({ origin: "https://..." })`,
+    include that HTTPS origin too.
 
     ```ts title="auth.ts"
     export const auth = betterAuth({
-        trustedOrigins: ["myapp://"]
+        trustedOrigins: ["myapp://", "https://myapp.example.com"]
     })
     ```
 

--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -138,6 +138,11 @@ Expo is a popular framework for building cross-platform apps with React Native. 
     });
     ```
 
+    When `rewriteCallbackToDeepLink` is `false`, pass an absolute callback URL
+    such as an HTTPS App Link / Universal Link. Relative callback paths like
+    `/dashboard` are only supported when the default deep-link rewriting stays
+    enabled.
+
     <Callout>
       Be sure to include the full URL, including the path, if you've changed the default path from `/api/auth`.
     </Callout>

--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -114,10 +114,18 @@ Expo is a popular framework for building cross-platform apps with React Native. 
                 scheme: "myapp",
                 storagePrefix: "myapp",
                 storage: SecureStore,
+                origin: "https://myapp.example.com",
+                rewriteCallbackToDeepLink: false,
             })
         ]
     });
     ```
+
+    Use `origin` when you want Expo requests to identify as an HTTPS App Link or
+    Universal Link origin, such as email verification or magic link flows. If
+    you omit it, Expo continues to derive the origin from your app scheme by
+    default. `rewriteCallbackToDeepLink` defaults to `true`, which preserves the
+    current scheme-based deep-link callback behavior.
 
     <Callout>
       Be sure to include the full URL, including the path, if you've changed the default path from `/api/auth`.

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -79,8 +79,6 @@ export const authClient = createAuthClient({
       scheme: 'myapp', // Your app's scheme (defined in app.json)
       storagePrefix: 'myapp', // A prefix for storage keys
       storage: SecureStore, // Pass SecureStore for token storage
-      origin: 'https://myapp.example.com',
-      rewriteCallbackToDeepLink: false,
     }),
   ],
 });
@@ -94,6 +92,18 @@ Use `origin` for HTTPS App Links / Universal Links and email-based flows. If you
 omit it, the client keeps using the scheme-based origin derived from
 `Linking.createURL`, and `rewriteCallbackToDeepLink` defaults to `true` to
 preserve the existing deep-link callback behavior.
+
+If you want to use HTTPS callback URLs instead of rewriting relative callbacks
+into deep links, configure the options explicitly:
+
+```typescript
+expoClient({
+  storage: SecureStore,
+  storagePrefix: 'myapp',
+  origin: 'https://myapp.example.com',
+  rewriteCallbackToDeepLink: false,
+});
+```
 
 ## Documentation
 

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -58,7 +58,7 @@ export const auth = betterAuth({
     enabled: true,
   },
   // Add other configurations like trustedOrigins
-  trustedOrigins: ['myapp://'], // Replace "myapp" with your app's scheme
+  trustedOrigins: ['myapp://'], // Replace "myapp" with your app's scheme. Also add your HTTPS origin here if you configure expoClient({ origin: "https://..." }).
 });
 ```
 
@@ -106,6 +106,12 @@ expoClient({
   origin: 'https://myapp.example.com',
   rewriteCallbackToDeepLink: false,
 });
+```
+
+On the backend, include that HTTPS origin in `trustedOrigins` as well:
+
+```typescript
+trustedOrigins: ['myapp://', 'https://myapp.example.com']
 ```
 
 When `rewriteCallbackToDeepLink` is `false`, pass an absolute callback URL

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -92,6 +92,9 @@ Use `origin` for HTTPS App Links / Universal Links and email-based flows. If you
 omit it, the client keeps using the scheme-based origin derived from
 `Linking.createURL`, and `rewriteCallbackToDeepLink` defaults to `true` to
 preserve the existing deep-link callback behavior.
+When you set `origin`, add that HTTPS origin to your server's
+`trustedOrigins` list too, or Better Auth will reject the request during
+origin validation.
 
 If you want to use HTTPS callback URLs instead of rewriting relative callbacks
 into deep links, configure the options explicitly:

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -79,6 +79,8 @@ export const authClient = createAuthClient({
       scheme: 'myapp', // Your app's scheme (defined in app.json)
       storagePrefix: 'myapp', // A prefix for storage keys
       storage: SecureStore, // Pass SecureStore for token storage
+      origin: 'https://myapp.example.com',
+      rewriteCallbackToDeepLink: false,
     }),
   ],
 });
@@ -88,6 +90,10 @@ export const authClient = createAuthClient({
 ```
 
 Make sure your app’s scheme (e.g., “myapp”) is defined in your `app.json`.
+Use `origin` for HTTPS App Links / Universal Links and email-based flows. If you
+omit it, the client keeps using the scheme-based origin derived from
+`Linking.createURL`, and `rewriteCallbackToDeepLink` defaults to `true` to
+preserve the existing deep-link callback behavior.
 
 ## Documentation
 

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -105,6 +105,10 @@ expoClient({
 });
 ```
 
+When `rewriteCallbackToDeepLink` is `false`, pass an absolute callback URL
+(for example an HTTPS App Link / Universal Link). Relative callback paths like
+`/dashboard` are only supported when the default deep-link rewriting is enabled.
+
 ## Documentation
 
 For more detailed information and advanced configurations, please refer to the

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -24,6 +24,8 @@ if (Platform.OS !== "web") {
 
 interface ExpoClientOptions {
 	scheme?: string | undefined;
+	origin?: string | undefined;
+	rewriteCallbackToDeepLink?: boolean | undefined;
 	storage: {
 		setItem: (key: string, value: string) => any;
 		getItem: (key: string) => string | null;
@@ -140,9 +142,8 @@ function getOAuthStateValue(
 	return null;
 }
 
-function getOrigin(scheme: string) {
-	const schemeURI = Linking.createURL("", { scheme });
-	return schemeURI;
+function getOrigin(scheme: string, origin?: string) {
+	return origin ?? Linking.createURL("", { scheme });
 }
 
 /**
@@ -548,25 +549,29 @@ export const expoClient = (opts: ExpoClientOptions) => {
 						options.headers = {
 							...options.headers,
 							...(cookie ? { cookie } : {}),
-							"expo-origin": getOrigin(scheme!),
+							"expo-origin": getOrigin(scheme!, opts?.origin),
 							"x-skip-oauth-proxy": "true",
 						};
-						if (options.body?.callbackURL) {
-							if (options.body.callbackURL.startsWith("/")) {
-								const url = Linking.createURL(options.body.callbackURL);
-								options.body.callbackURL = url;
+						if (opts?.rewriteCallbackToDeepLink !== false) {
+							if (options.body?.callbackURL) {
+								if (options.body.callbackURL.startsWith("/")) {
+									const url = Linking.createURL(options.body.callbackURL);
+									options.body.callbackURL = url;
+								}
 							}
-						}
-						if (options.body?.newUserCallbackURL) {
-							if (options.body.newUserCallbackURL.startsWith("/")) {
-								const url = Linking.createURL(options.body.newUserCallbackURL);
-								options.body.newUserCallbackURL = url;
+							if (options.body?.newUserCallbackURL) {
+								if (options.body.newUserCallbackURL.startsWith("/")) {
+									const url = Linking.createURL(
+										options.body.newUserCallbackURL,
+									);
+									options.body.newUserCallbackURL = url;
+								}
 							}
-						}
-						if (options.body?.errorCallbackURL) {
-							if (options.body.errorCallbackURL.startsWith("/")) {
-								const url = Linking.createURL(options.body.errorCallbackURL);
-								options.body.errorCallbackURL = url;
+							if (options.body?.errorCallbackURL) {
+								if (options.body.errorCallbackURL.startsWith("/")) {
+									const url = Linking.createURL(options.body.errorCallbackURL);
+									options.body.errorCallbackURL = url;
+								}
 							}
 						}
 						if (url.includes("/sign-out")) {

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -461,6 +461,14 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							!context.request?.body.includes("idToken") // id token is used for silent sign-in
 						) {
 							const callbackURL = JSON.parse(context.request.body)?.callbackURL;
+							if (
+								opts?.rewriteCallbackToDeepLink === false &&
+								callbackURL?.startsWith("/")
+							) {
+								throw new Error(
+									'Relative callbackURL values are not supported when "rewriteCallbackToDeepLink" is false. Pass an absolute callback URL or omit "rewriteCallbackToDeepLink" to preserve deep-link rewriting.',
+								);
+							}
 							const to = callbackURL;
 							const signInURL = context.data?.url;
 							let Browser: typeof import("expo-web-browser") | undefined =

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -178,7 +178,7 @@ describe("expo", async () => {
 		);
 	});
 
-	it("should not rewrite callback URLs when rewriteCallbackToDeepLink is false", async () => {
+	it("should not rewrite absolute callback URLs when rewriteCallbackToDeepLink is false", async () => {
 		const storage = new Map<string, string>();
 		const { auth, client } = await getTestInstance(
 			{
@@ -208,7 +208,7 @@ describe("expo", async () => {
 		fn.mockClear();
 		const { data: res } = await client.signIn.social({
 			provider: "google",
-			callbackURL: "/dashboard",
+			callbackURL: "https://myapp.example.com/dashboard",
 		});
 		const stateId = res?.url?.split("state=")[1]!.split("&")[0];
 		const ctx = await auth.$context;
@@ -217,12 +217,51 @@ describe("expo", async () => {
 		}
 		const state = await ctx.internalAdapter.findVerificationValue(stateId);
 		const callbackURL = JSON.parse(state?.value || "{}").callbackURL;
-		expect(callbackURL).toBe("/dashboard");
+		expect(callbackURL).toBe("https://myapp.example.com/dashboard");
 		expect(fn).toHaveBeenCalledWith(
 			expect.stringContaining("accounts.google"),
-			"/dashboard",
+			"https://myapp.example.com/dashboard",
 			undefined,
 		);
+	});
+
+	it("should reject relative callback URLs when rewriteCallbackToDeepLink is false", async () => {
+		const storage = new Map<string, string>();
+		const { client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+					},
+				},
+				plugins: [expo(), oAuthProxy()],
+				trustedOrigins: ["better-auth://"],
+			},
+			{
+				clientOptions: {
+					plugins: [
+						expoClient({
+							storage: {
+								getItem: (key) => storage.get(key) || null,
+								setItem: async (key, value) => storage.set(key, value),
+							},
+							rewriteCallbackToDeepLink: false,
+						}),
+					],
+				},
+			},
+		);
+		fn.mockClear();
+		await expect(
+			client.signIn.social({
+				provider: "google",
+				callbackURL: "/dashboard",
+			}),
+		).rejects.toThrow(
+			'Relative callbackURL values are not supported when "rewriteCallbackToDeepLink" is false.',
+		);
+		expect(fn).not.toHaveBeenCalled();
 	});
 
 	it("should pass webBrowserOptions to openAuthSessionAsync", async () => {

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -131,6 +131,100 @@ describe("expo", async () => {
 		);
 	});
 
+	it("should preserve deep-link rewriting when rewriteCallbackToDeepLink is true", async () => {
+		const storage = new Map<string, string>();
+		const { auth, client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+					},
+				},
+				plugins: [expo(), oAuthProxy()],
+				trustedOrigins: ["better-auth://"],
+			},
+			{
+				clientOptions: {
+					plugins: [
+						expoClient({
+							storage: {
+								getItem: (key) => storage.get(key) || null,
+								setItem: async (key, value) => storage.set(key, value),
+							},
+							rewriteCallbackToDeepLink: true,
+						}),
+					],
+				},
+			},
+		);
+		fn.mockClear();
+		const { data: res } = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/dashboard",
+		});
+		const stateId = res?.url?.split("state=")[1]!.split("&")[0];
+		const ctx = await auth.$context;
+		if (!stateId) {
+			throw new Error("State ID not found");
+		}
+		const state = await ctx.internalAdapter.findVerificationValue(stateId);
+		const callbackURL = JSON.parse(state?.value || "{}").callbackURL;
+		expect(callbackURL).toBe("better-auth:///dashboard");
+		expect(fn).toHaveBeenCalledWith(
+			expect.stringContaining("accounts.google"),
+			"better-auth:///dashboard",
+			undefined,
+		);
+	});
+
+	it("should not rewrite callback URLs when rewriteCallbackToDeepLink is false", async () => {
+		const storage = new Map<string, string>();
+		const { auth, client } = await getTestInstance(
+			{
+				socialProviders: {
+					google: {
+						clientId: "test",
+						clientSecret: "test",
+					},
+				},
+				plugins: [expo(), oAuthProxy()],
+				trustedOrigins: ["better-auth://"],
+			},
+			{
+				clientOptions: {
+					plugins: [
+						expoClient({
+							storage: {
+								getItem: (key) => storage.get(key) || null,
+								setItem: async (key, value) => storage.set(key, value),
+							},
+							rewriteCallbackToDeepLink: false,
+						}),
+					],
+				},
+			},
+		);
+		fn.mockClear();
+		const { data: res } = await client.signIn.social({
+			provider: "google",
+			callbackURL: "/dashboard",
+		});
+		const stateId = res?.url?.split("state=")[1]!.split("&")[0];
+		const ctx = await auth.$context;
+		if (!stateId) {
+			throw new Error("State ID not found");
+		}
+		const state = await ctx.internalAdapter.findVerificationValue(stateId);
+		const callbackURL = JSON.parse(state?.value || "{}").callbackURL;
+		expect(callbackURL).toBe("/dashboard");
+		expect(fn).toHaveBeenCalledWith(
+			expect.stringContaining("accounts.google"),
+			"/dashboard",
+			undefined,
+		);
+	});
+
 	it("should pass webBrowserOptions to openAuthSessionAsync", async () => {
 		const { client } = await getTestInstance(
 			{
@@ -367,6 +461,43 @@ describe("expo", async () => {
 		});
 		expect(origin).toBe("better-auth://");
 		expect(originalOrigin).toBeNull();
+	});
+
+	it("should use the provided origin for expo-origin header", async () => {
+		let expoOrigin = null;
+		let origin = null;
+		const storage = new Map<string, string>();
+		const { client, testUser } = await getTestInstance(
+			{
+				hooks: {
+					before: createAuthMiddleware(async (ctx) => {
+						expoOrigin = ctx.request?.headers.get("expo-origin");
+						origin = ctx.request?.headers.get("origin");
+					}),
+				},
+				plugins: [expo()],
+			},
+			{
+				clientOptions: {
+					plugins: [
+						expoClient({
+							origin: "https://myapp.example.com",
+							storage: {
+								getItem: (key) => storage.get(key) || null,
+								setItem: async (key, value) => storage.set(key, value),
+							},
+						}),
+					],
+				},
+			},
+		);
+		await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+			callbackURL: "http://localhost:3000/callback",
+		});
+		expect(expoOrigin).toBe("https://myapp.example.com");
+		expect(origin).toBe("https://myapp.example.com");
 	});
 
 	/**


### PR DESCRIPTION
## Summary
Adds two optional `expoClient` options to support HTTPS App Links / Universal Links for email-based authentication flows while preserving the existing scheme-based behavior by default.

* Adds `origin` to allow a custom `expo-origin` header instead of deriving it from `Linking.createURL()`
* Adds `rewriteCallbackToDeepLink` (default: `true`) to control whether relative callback URLs are rewritten into Expo deep links
* Keeps existing behavior unchanged when neither option is provided

Closes #10253.

## Changes

* Added `origin?: string` and `rewriteCallbackToDeepLink?: boolean` to `expoClient`
* Updated `expo-origin` generation to use `options.origin ?? Linking.createURL("", { scheme })`
* Made callback URL rewriting conditional on `rewriteCallbackToDeepLink`
* Added tests covering:

  * default behavior
  * custom `origin`
  * callback rewriting enabled/disabled
* Updated the Expo integration documentation

## Test Plan

* [x] `pnpm --filter @better-auth/expo test`
* [x] `pnpm lint`
* [x] Verified default behavior remains unchanged
* [x] Verified custom `origin` overrides the `expo-origin` header
* [x] Verified `rewriteCallbackToDeepLink: false` preserves callback URLs
* [x] Verified `rewriteCallbackToDeepLink: true` preserves existing deep-link rewriting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable `origin` and optional callback URL rewriting to the Expo client to support HTTPS App/Universal Links in email and magic link flows, while keeping the default scheme-based deep-link behavior. Adds a guard that rejects relative callbacks when rewriting is disabled and updates docs/README with `trustedOrigins` guidance.

- New Features
  - `origin`: sets custom `expo-origin` (mirrored to `Origin` server-side); falls back to `Linking.createURL("", { scheme })`.
  - `rewriteCallbackToDeepLink` (default: `true`): rewrites relative `callbackURL`, `newUserCallbackURL`, and `errorCallbackURL` to Expo deep links; when `false`, keeps HTTPS callbacks and rejects relative paths.
  - Docs: update Expo integration and `packages/expo/README.md` with examples and a `trustedOrigins` note to include the HTTPS origin when using `expoClient({ origin: "https://..." })`.

<sup>Written for commit 858d47d87f2f890ead1a807e078cc7ab2a158551. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

