### PR TITLE
fix(oauth-provider): resolve exactOptionalPropertyTypes incompatibility

### DIFF
--- a/.changeset/oauth-provider-exact-optional-property-types.md
+++ b/.changeset/oauth-provider-exact-optional-property-types.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Fix TypeScript error when using `oauthProvider()` with `exactOptionalPropertyTypes: true`. The `oauth2Authorize` endpoint's OpenAPI parameters array now carries an explicit `OpenAPIParameter[]` annotation, preventing TypeScript from synthesizing `format?: undefined` on scalar schemas and causing a TS2322 assignability failure.

--- a/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "better-auth": "workspace:*",
     "@better-auth/sso": "workspace:*",
-    "@better-auth/passkey": "workspace:*"
+    "@better-auth/passkey": "workspace:*",
+    "@better-auth/oauth-provider": "workspace:*"
   }
 }

--- a/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/oauth-provider.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/src/oauth-provider.ts
@@ -1,0 +1,14 @@
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10213
+ */
+import { oauthProvider } from "@better-auth/oauth-provider";
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+	plugins: [
+		oauthProvider({
+			loginPage: "/login",
+			consentPage: "/consent",
+		}),
+	],
+});

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -14,6 +14,7 @@ import {
 import { parseSetCookieHeader } from "better-auth/cookies";
 import { mergeSchema } from "better-auth/db";
 import type { BetterAuthPlugin } from "better-auth/types";
+import type { OpenAPIParameter } from "better-call";
 import * as z from "zod";
 import type { AuthorizeEndpointSettings } from "./authorize";
 import { authorizeEndpoint } from "./authorize";
@@ -366,7 +367,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							schema: { type: "string" },
 							description: "OAuth2 prompt parameter",
 						},
-					],
+					] as OpenAPIParameter[],
 					responses: {
 						"302": {
 							description: "Redirect to client with code or error",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -814,6 +814,9 @@ importers:
 
   e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types:
     dependencies:
+      '@better-auth/oauth-provider':
+        specifier: workspace:*
+        version: link:../../../../../packages/oauth-provider
       '@better-auth/passkey':
         specifier: workspace:*
         version: link:../../../../../packages/passkey


### PR DESCRIPTION
## Summary

Fixes #10213 — `oauthProvider()` fails TS2322 under `exactOptionalPropertyTypes: true` on the 1.7.0-beta line.

The `oauth2Authorize` endpoint's OpenAPI `parameters` array mixes `{schema: {type: "string"}}` entries with `{schema: {type: "string", format: "uri"}}` for `redirect_uri`. Without an explicit type annotation, TypeScript infers a union whose scalar members get `format?: undefined` synthesized. Under `exactOptionalPropertyTypes: true`, this causes a TS2344 `EndpointOptions` constraint failure, which cascades to `oauthProvider()` not being assignable to `BetterAuthPlugin` (TS2322).

Fix: annotate the array `as OpenAPIParameter[]`, the same approach used in #6502 (oidc-provider) and #9270 (passkey) for identical issues.

## Changes

- `packages/oauth-provider/src/oauth.ts` — import `OpenAPIParameter` from `better-call` and annotate the `oauth2Authorize` parameters array
- `e2e/smoke/test/fixtures/tsconfig-exact-optional-property-types/` — extend the existing smoke fixture to cover `@better-auth/oauth-provider`, preventing regression

## Test plan

- [ ] `pnpm --filter "@better-auth-test/fixtures-tsconfig-exact-optional-property-types" typecheck` passes with the new `oauth-provider.ts` fixture
- [ ] `pnpm --filter "@better-auth/oauth-provider" typecheck` — no new errors introduced in source files
- [ ] Manual repro from #10213 passes: `tsc --noEmit` with `exactOptionalPropertyTypes: true` + `skipLibCheck: true`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TypeScript errors with `oauthProvider()` under `exactOptionalPropertyTypes: true` by annotating the `oauth2Authorize` OpenAPI parameters array. Prevents TS2322/TS2344 and restores compatibility. Fixes #10213.

- **Bug Fixes**
  - Annotated the `oauth2Authorize` parameters as `OpenAPIParameter[]` in `packages/oauth-provider/src/oauth.ts` (with an explicit `OpenAPIParameter` type import) to avoid `format?: undefined` inference.
  - Added an e2e smoke fixture for `@better-auth/oauth-provider` in the `exactOptionalPropertyTypes` setup to prevent regressions.

- **Dependencies**
  - Included `@better-auth/oauth-provider` in the `tsconfig-exact-optional-property-types` fixture dependencies.

<sup>Written for commit 1d0e360b1be6af928168546ccb546ee249eebaf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

