### PR TITLE
fix(cli): escape string default values in generated Prisma schema

### DIFF
--- a/.changeset/prisma-generate-escape-string-default.md
+++ b/.changeset/prisma-generate-escape-string-default.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+Fix `better-auth generate` emitting an invalid Prisma schema when a field's string default value contains a quote or backslash.

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -351,7 +351,11 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 						typeof attr.defaultValue === "string" &&
 						provider !== "mysql"
 					) {
-						fieldBuilder.attribute(`default("${attr.defaultValue}")`);
+						// Escape quotes and backslashes so the emitted Prisma default stays a
+						// valid string literal instead of a broken `@default("say "hi"")`.
+						fieldBuilder.attribute(
+							`default("${attr.defaultValue.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}")`,
+						);
 					} else if (
 						typeof attr.defaultValue === "boolean" ||
 						typeof attr.defaultValue === "number"

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -463,6 +463,42 @@ describe("generate", async () => {
 		expect(schema.code).toContain(String.raw`.default('say "hi"\\done')`);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/10259
+	 */
+	it("should escape string default values so the generated prisma schema stays valid", async () => {
+		const pluginWithQuotedDefault = (): BetterAuthPlugin => ({
+			id: "prisma-quoted-default-test",
+			schema: {
+				testTable: {
+					fields: {
+						greeting: {
+							type: "string",
+							defaultValue: 'say "hi"\\done',
+						},
+					},
+				},
+			},
+		});
+
+		const schema = await generatePrismaSchema({
+			file: "test.prisma",
+			adapter: prismaAdapter(
+				{},
+				{ provider: "postgresql" },
+			)({} as BetterAuthOptions),
+			options: {
+				database: prismaAdapter({}, { provider: "postgresql" }),
+				plugins: [pluginWithQuotedDefault()],
+			},
+		});
+
+		// Quotes and backslashes must be escaped so the default is a valid Prisma
+		// string literal. The raw interpolation would emit @default("say "hi"\done")
+		// and break the generated schema file.
+		expect(schema.code).toContain(String.raw`@default("say \"hi\"\\done")`);
+	});
+
 	it("should treat fields with omitted required as non-optional in prisma schema", async () => {
 		const originalCwd = process.cwd();
 		const tmpDir = fs.mkdtempSync(


### PR DESCRIPTION
#10259 fixed `better-auth generate` emitting an invalid Drizzle schema when a string default contained a quote or backslash. The Prisma generator has the same bug.

In `packages/cli/src/generators/prisma.ts` the string scalar branch interpolates the value straight into the attribute:

```ts
fieldBuilder.attribute(`default("${attr.defaultValue}")`);
```

So a field with `defaultValue: 'say "hi"'` emits `@default("say "hi"")`, which Prisma can't parse. The JSON object/array branches a few lines up already guard against this by running the value through `.replace(/\\/g, "\\\\").replace(/"/g, '\\"')`; the plain string branch just missed it. This applies the same escaping there.

Normal defaults are unchanged, since the replaces are no-ops unless the value contains `"` or `\`.

Added a regression test next to the Drizzle one from #10259 (it fails on the old code and passes with the fix), plus a changeset.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `better-auth generate` emitting an invalid Prisma schema when a field’s string default contains quotes or backslashes. The Prisma generator now escapes these characters so generated schemas parse correctly.

- **Bug Fixes**
  - Escape quotes and backslashes in string defaults when emitting `@default("...")` in the Prisma generator; other defaults are unchanged.
  - Added a regression test for quoted/backslashed defaults and a changeset.

<sup>Written for commit 406a9f9588d822fc76d2d0a95cda221bf0c57576. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

