### PR TITLE
docs: add nuxt module and remove NuxSaaS 404

### DIFF
--- a/docs/content/docs/integrations/nuxt.mdx
+++ b/docs/content/docs/integrations/nuxt.mdx
@@ -152,10 +152,9 @@ export default defineNuxtConfig({
 ## Resources & examples
 
 {/* cspell:disable */}
-
+* [`nuxt-modules/better-auth`](https://github.com/nuxt-modules/better-auth)
 * [`atinux/nuxthub-better-auth`](https://github.com/atinux/nuxthub-better-auth)
 * [`leamsigc/nuxt-better-auth-drizzle`](https://github.com/leamsigc/nuxt-better-auth-drizzle)
-* [`NuxSaaS/NuxSaaS`](https://github.com/NuxSaaS/NuxSaaS)
 * [`nuxtone/nuxt-one`](https://github.com/nuxtone/nuxt-one)
 
 {/* cspell:enable */}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Nuxt integration docs to add the official `nuxt-modules/better-auth` resource and remove the dead `NuxSaaS/NuxSaaS` link. Prevents a 404 and makes it easier to find the recommended module.

<sup>Written for commit a44bcf116b7946637753e0ddbbeb7824911baf3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

