### PR TITLE
feat(email-otp): inform email taken option for change email flow

### DIFF
--- a/docs/content/docs/plugins/email-otp.mdx
+++ b/docs/content/docs/plugins/email-otp.mdx
@@ -341,6 +341,29 @@ Before requesting the email change, use the `sendVerificationOtp()` method with 
 
 Then, the user can provide the OTP when calling `requestEmailChange()`. The system will first verify the OTP sent to the current email before sending an OTP to the new email.
 
+#### Informing on Taken Email
+
+The `changeEmail.informEmailTaken` option controls what happens when the requested new email is already registered to another account. It accepts three values:
+
+* `"never"` **(default)** — The OTP is discarded and `requestEmailChange()` silently returns `{ success: true }`. This does not inform that the email is already in use, preventing email enumeration.
+* `"immediate"` — The OTP is discarded and `requestEmailChange()` immediately returns a `400` error with message `"Email is already taken"`. This may pose an email enumeration risk if exposed to the client.
+* `"deferred"` — The OTP is still sent to the new email address and `requestEmailChange()` returns `{ success: true }`. The conflict is surfaced after the user successfully submits the OTP via `changeEmail()`, returning a `400` error with message `"Email is already taken"`. This prevents email enumeration at the cost of an additional email being sent to the new address.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+    plugins: [
+        emailOTP({
+            changeEmail: {
+                enabled: true,
+                informEmailTaken: "deferred", // [!code highlight]
+            }
+        })
+    ]
+})
+```
+
 ### Override Default Email Verification
 
 To override the default email verification, pass `overrideDefaultEmailVerification: true` in the options. This will make the system use an email OTP instead of the default verification link whenever email verification is triggered. In other words, the user will verify their email using an OTP rather than clicking a link.

--- a/docs/content/docs/plugins/email-otp.mdx
+++ b/docs/content/docs/plugins/email-otp.mdx
@@ -350,7 +350,8 @@ The `changeEmail.informEmailTaken` option controls what happens when the request
 * `"deferred"` — The OTP is still sent to the new email address and `requestEmailChange()` returns `{ success: true }`. The conflict is surfaced after the user successfully submits the OTP via `changeEmail()`, returning a `400` error with message `"Email is already taken"`. This prevents email enumeration at the cost of an additional email being sent to the new address.
 
 ```ts title="auth.ts"
-import { betterAuth } from "better-auth";
+import { betterAuth } from "better-auth";  
+import { emailOTP } from "better-auth/plugins";
 
 export const auth = betterAuth({
     plugins: [

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -607,7 +607,8 @@ describe("change email", async () => {
 			);
 		});
 
-		describe('when informEmailTaken is "immediate"', async () => {
+		describe("when informEmailTaken is immediate", async () => {
+			const immediateOtpFn = vi.fn(async () => {});
 			const {
 				client: immediateClient,
 				testUser: immediateTestUser,
@@ -617,7 +618,7 @@ describe("change email", async () => {
 					plugins: [
 						bearer(),
 						emailOTP({
-							async sendVerificationOTP() {},
+							sendVerificationOTP: immediateOtpFn,
 							sendVerificationOnSignUp: true,
 							changeEmail: { enabled: true, informEmailTaken: "immediate" },
 						}),
@@ -648,12 +649,17 @@ describe("change email", async () => {
 						});
 					},
 				);
+				expect(immediateOtpFn).not.toHaveBeenCalledWith(
+					takenEmail,
+					expect.any(String),
+					"change-email",
+				);
 				expect(res!.error?.status).toBe(400);
 				expect(res!.error?.message).toContain("Email is already taken");
 			});
 		});
 
-		describe('when informEmailTaken is "deferred"', async () => {
+		describe("when informEmailTaken is deferred", async () => {
 			const deferredOtpFn = vi.fn();
 			let deferredOtp = "";
 			const {

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -607,6 +607,117 @@ describe("change email", async () => {
 			);
 		});
 
+		describe('when informEmailTaken is "immediate"', async () => {
+			const {
+				client: immediateClient,
+				testUser: immediateTestUser,
+				runWithUser: immediateRunWithUser,
+			} = await getTestInstance(
+				{
+					plugins: [
+						bearer(),
+						emailOTP({
+							async sendVerificationOTP() {},
+							sendVerificationOnSignUp: true,
+							changeEmail: { enabled: true, informEmailTaken: "immediate" },
+						}),
+					],
+				},
+				{
+					clientOptions: { plugins: [emailOTPClient()] },
+				},
+			);
+
+			it("should return an error immediately without sending otp", async () => {
+				const takenEmail = "taken-immediate@test.com";
+				await immediateClient.signUp.email({
+					email: takenEmail,
+					password: "password123",
+					name: "Other User",
+				});
+
+				let res: Awaited<
+					ReturnType<typeof immediateClient.emailOtp.requestEmailChange>
+				>;
+				await immediateRunWithUser(
+					immediateTestUser.email,
+					immediateTestUser.password,
+					async () => {
+						res = await immediateClient.emailOtp.requestEmailChange({
+							newEmail: takenEmail,
+						});
+					},
+				);
+				expect(res!.error?.status).toBe(400);
+				expect(res!.error?.message).toContain("Email is already taken");
+			});
+		});
+
+		describe('when informEmailTaken is "deferred"', async () => {
+			const deferredOtpFn = vi.fn();
+			let deferredOtp = "";
+			const {
+				client: deferredClient,
+				testUser: deferredTestUser,
+				runWithUser: deferredRunWithUser,
+			} = await getTestInstance(
+				{
+					plugins: [
+						bearer(),
+						emailOTP({
+							async sendVerificationOTP({ email, otp: _otp, type }) {
+								deferredOtp = _otp;
+								deferredOtpFn(email, _otp, type);
+							},
+							sendVerificationOnSignUp: true,
+							changeEmail: { enabled: true, informEmailTaken: "deferred" },
+						}),
+					],
+				},
+				{
+					clientOptions: { plugins: [emailOTPClient()] },
+				},
+			);
+
+			it("should send otp to taken email and error on changeEmail", async () => {
+				const takenEmail = "taken-deferred@test.com";
+				await deferredClient.signUp.email({
+					email: takenEmail,
+					password: "password123",
+					name: "Other User",
+				});
+
+				deferredOtpFn.mockClear();
+				await deferredRunWithUser(
+					deferredTestUser.email,
+					deferredTestUser.password,
+					async () => {
+						const requestRes = await deferredClient.emailOtp.requestEmailChange(
+							{
+								newEmail: takenEmail,
+							},
+						);
+						expect(requestRes.data?.success).toBe(true);
+						expect(requestRes.error).toBeFalsy();
+						expect(deferredOtpFn).toHaveBeenCalledWith(
+							takenEmail,
+							expect.any(String),
+							"change-email",
+						);
+
+						const changeRes = await deferredClient.emailOtp.changeEmail({
+							newEmail: takenEmail,
+							otp: deferredOtp,
+						});
+						expect(changeRes.error?.status).toBe(400);
+						expect(changeRes.error?.message).toContain(
+							"Email is already taken",
+						);
+					},
+				);
+			});
+		});
+
 		describe("when verifyCurrentEmail is enabled", async () => {
 			const verifyCurrentOtpFn = vi.fn();
 			let currentEmailOtp = "";

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -1109,12 +1109,18 @@ export const requestEmailChangeEmailOTP = (opts: RequiredEmailOTPOptions) =>
 
 			const user = await ctx.context.internalAdapter.findUserByEmail(newEmail);
 			if (user) {
-				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-					toOTPIdentifier("change-email", `${email}-${newEmail}`),
-				);
-				return ctx.json({
-					success: true,
-				});
+				const strategy = opts.changeEmail?.informEmailTaken ?? "never";
+				if (strategy !== "deferred") {
+					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+						toOTPIdentifier("change-email", `${email}-${newEmail}`),
+					);
+					if (strategy === "immediate") {
+						throw APIError.fromStatus("BAD_REQUEST", {
+							message: "Email is already taken",
+						});
+					}
+					return ctx.json({ success: true });
+				}
 			}
 
 			await ctx.context.runInBackgroundOrAwait(
@@ -1235,7 +1241,7 @@ export const changeEmailEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				 * safe to leak the existence of a user as a valid OTP has been provided
 				 */
 				throw APIError.fromStatus("BAD_REQUEST", {
-					message: "Email already in use",
+					message: "Email is already taken",
 				});
 			}
 

--- a/packages/better-auth/src/plugins/email-otp/types.ts
+++ b/packages/better-auth/src/plugins/email-otp/types.ts
@@ -106,11 +106,27 @@ export interface EmailOTPOptions {
 	 * @default {
 	 *  enabled: false,
 	 *  verifyCurrentEmail: false,
+	 *  informEmailTaken: "never"
 	 * }
 	 */
 	changeEmail?: {
 		enabled?: boolean;
 		verifyCurrentEmail?: boolean;
+		/**
+		 * Controls how `requestEmailChange` behaves when the requested new email
+		 * is already registered to another account.
+		 *
+		 * - `"never"` (default) — The OTP is discarded and `requestEmailChange()` silently returns `{ success: true }`.
+		 *    This does not inform that the email is already in use, preventing email enumeration.
+		 * - `"immediate"` — The OTP is discarded and `requestEmailChange()` immediately returns a `400` error with message `"Email is already taken"`.
+		 *    This may pose an email enumeration risk if exposed to the client.
+		 * - `"deferred"` — The OTP is still sent to the new email address and `requestEmailChange()` returns `{ success: true }`.
+		 *    The conflict is surfaced after the user successfully submits the OTP via `changeEmail()`, returning a `400` error with message `"Email is already taken"`.
+		 *    This prevents email enumeration at the cost of an additional email being sent to the new address.
+		 *
+		 * @default "never"
+		 */
+		informEmailTaken?: "never" | "immediate" | "deferred";
 	};
 	/**
 	 * Override the default email verification to use email otp instead


### PR DESCRIPTION
# Summary

The change email flow via email OTP provides no way to indicate that an email address is taken, silently returning a success response and discarding the OTP. This prevents email enumeration, but at the cost of UX and DX, where it is difficult to communicate to a user if the email is taken or if there is an issue with the flow. The change implements 3 strategies a developer can choose between, defaulting to the current behaviour.

# Changes

- Added optional `changeEmail.informEmailTaken` option to `emailOTP` config with 3 values:
    - `"never"` (default) - Current behaviour, discards OTP during `requestEmailChange()` and silently returns success response. Prevents email enumeration.
    - `"immediate"` - Discards OTP during `requestEmailChange()` and returns a `400` error with message `"Email is already taken"`. Poses email enumeration risk.
    - `"deferred"` - OTP is still sent to the taken email during `requestEmailChange()` and returns a success response. The conflict is raised after the user successfully provides the OTP of the new email, where `changeEmail()` returns a `400` error with message `"Email is already taken"`. Prevents email enumeration at the cost of still sending the OTP to the new email.
- Updated the change email section of the email otp docs with a subsection covering these strategies
- Added tests for the `"immediate"` and `"deferred"` strategies

There are no breaking changes as the default value `"never"` coincides with the current behaviour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `changeEmail.informEmailTaken` to `emailOTP` to control how we surface “email already in use” during the change-email via OTP flow. Keeps the current silent default and adds immediate or deferred options; docs example fixed and tests updated.

- New Features
  - `changeEmail.informEmailTaken`: "never" (default, silent), "immediate" (no OTP sent; 400 on `requestEmailChange()`), "deferred" (OTP sent; 400 on `changeEmail()`).
  - Standardized error to "Email is already taken".
  - Docs updated with a corrected example; tests added for "immediate" (asserts no OTP is sent) and "deferred".

<sup>Written for commit 0b63c59b053e2421ebc21db71c44c41a980f2cd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

