### PR TITLE
docs: correct filename for svelte client snippet

### DIFF
--- a/docs/content/docs/integrations/svelte-kit.mdx
+++ b/docs/content/docs/integrations/svelte-kit.mdx
@@ -70,7 +70,7 @@ export const auth = betterAuth({
 
 Create a client instance. You can name the file anything you want. Here we are creating `client.ts` file inside the `lib/` directory.
 
-```ts title="auth-client.ts"
+```ts title="lib/client.ts"
 import { createAuthClient } from "better-auth/svelte"; // make sure to import from better-auth/svelte
 
 export const authClient = createAuthClient({


### PR DESCRIPTION
This PR just fixes the naming that is displayed in the documentation for the SvelteKit integration.

Before:
<img width="888" height="240" alt="image" src="https://github.com/user-attachments/assets/a1310869-3f9b-4211-bccb-5a671fb2c166" />

After:
<img width="848" height="232" alt="image" src="https://github.com/user-attachments/assets/8f8df1de-0fed-45bc-a3b6-4ed679d40e7f" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the code snippet filename in the SvelteKit integration docs from "auth-client.ts" to "lib/client.ts" to match the instructions and avoid setup confusion.

<sup>Written for commit 6916380f917f297d7b8e266bfee074cecdffdb85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

