### PR TITLE
fix(oauth-provider): reject jwt tokens for expired sessions

### DIFF
--- a/.changeset/honest-queens-vanish.md
+++ b/.changeset/honest-queens-vanish.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+fix(oauth provider): reject jwt tokens for expired sessions

--- a/packages/oauth-provider/src/introspect.test.ts
+++ b/packages/oauth-provider/src/introspect.test.ts
@@ -453,7 +453,7 @@ describe("oauth introspect", async () => {
 		expect(introspection.data?.sid).toBeUndefined();
 	});
 
-	it("should pass jwt access_token introspection with logged out user", async () => {
+	it("should reject jwt access_token introspection with logged out user", async () => {
 		const { headers: testHeaders } = await signInWithTestUser();
 		const tokens = await getTokens(
 			undefined,
@@ -481,16 +481,54 @@ describe("oauth introspect", async () => {
 				},
 			},
 		);
-		expect(introspection.data).toMatchObject({
-			active: true,
-			client_id: oauthClient?.client_id,
-			scope: "openid profile email offline_access",
-			sub: expect.any(String),
-			iss: authServerBaseUrl,
-			exp: expect.any(Number),
-			iat: expect.any(Number),
+		expect(introspection.data?.active).toBe(false);
+	});
+
+	it("should reject jwt access_token introspection with expired session", async () => {
+		const { headers: testHeaders } = await signInWithTestUser();
+		const tokens = await getTokens(
+			undefined,
+			{
+				resource: validAudience,
+			},
+			testHeaders,
+		);
+		const currentSession = await auth.api.getSession({
+			headers: testHeaders,
 		});
-		expect(introspection.data?.sid).toBeUndefined();
+		const sessionId = currentSession?.session.id;
+		if (!sessionId) {
+			throw new Error("Expected signed-in user to have a session");
+		}
+		const ctx = await auth.$context;
+		await ctx.adapter.update({
+			model: "session",
+			where: [
+				{
+					field: "id",
+					value: sessionId,
+				},
+			],
+			update: {
+				expiresAt: new Date(Date.now() - 1000),
+			},
+		});
+
+		const introspection = await client.oauth2.introspect(
+			{
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				token: tokens.data?.access_token!,
+				token_type_hint: "access_token",
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		expect(introspection.data?.active).toBe(false);
 	});
 
 	it("should pass refresh_token introspection with logged out user", async () => {

--- a/packages/oauth-provider/src/introspect.ts
+++ b/packages/oauth-provider/src/introspect.ts
@@ -128,7 +128,9 @@ async function validateJwtAccessToken(
 			],
 		});
 		if (!session || session.expiresAt < new Date()) {
-			jwtPayload.sid = undefined;
+			return {
+				active: false,
+			};
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes JWT access token introspection so tokens bound to a missing or expired session are reported as inactive.

When a JWT access token includes `sid`, introspection now treats that session as part of the token validity check instead of silently removing `sid` and returning `active: true`.

Fixes #10267.

## What changed

- Return `active: false` for JWT access tokens whose `sid` no longer resolves to a valid session
- Updated the logged-out JWT introspection regression test
- Added coverage for JWT introspection with an expired session

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JWT access token introspection in `oauth-provider` to mark tokens with a missing or expired `sid` session as inactive, preventing logged-out or expired sessions from being treated as valid. Fixes #10267.

- **Bug Fixes**
  - Return `active: false` for JWT access tokens when the `sid` session is missing or expired (previously removed `sid` and returned active).
  - Updated tests for logged-out and expired sessions; added a changeset to publish a patch for `@better-auth/oauth-provider`.

<sup>Written for commit fe03963f58e8a6fde6d32b197883d5491bd081c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

