### PR TITLE
fix(auth): cache handler router

### DIFF
--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -4,6 +4,7 @@ import type {
 	BetterAuthOptions,
 	BetterAuthPlugin,
 } from "@better-auth/core";
+import { getAsyncLocalStorage } from "@better-auth/core/async_hooks";
 import type { InternalLogger } from "@better-auth/core/env";
 import { logger } from "@better-auth/core/env";
 import {
@@ -171,9 +172,10 @@ To resolve this, you can:
 }
 
 export function getEndpoints<Option extends BetterAuthOptions>(
-	ctx: Awaitable<AuthContext>,
+	ctx: Awaitable<AuthContext> | (() => Awaitable<AuthContext>),
 	options: Option,
 ) {
+	const resolveContext = () => (typeof ctx === "function" ? ctx() : ctx);
 	const pluginEndpoints =
 		options.plugins?.reduce<Record<string, Endpoint>>((acc, plugin) => {
 			return {
@@ -199,7 +201,7 @@ export function getEndpoints<Option extends BetterAuthOptions>(
 			?.map((plugin) =>
 				plugin.middlewares?.map((m) => {
 					const middleware = (async (context: any) => {
-						const authContext = await ctx;
+						const authContext = await resolveContext();
 						return withSpan(
 							`middleware ${m.path} ${plugin.id}`,
 							{
@@ -264,21 +266,24 @@ export function getEndpoints<Option extends BetterAuthOptions>(
 		ok,
 		error,
 	} as const;
-	const api = toAuthEndpoints(endpoints, ctx);
+	const api = toAuthEndpoints(endpoints, resolveContext);
 	return {
 		api: api as unknown as OverrideMerge<typeof endpoints, PluginEndpoint>,
 		middlewares,
 	};
 }
 export const router = <Option extends BetterAuthOptions>(
-	ctx: AuthContext,
+	routerCtx: AuthContext | (() => Awaitable<AuthContext>),
 	options: Option,
 ) => {
-	const { api, middlewares } = getEndpoints(ctx, options);
-	const basePath = new URL(ctx.baseURL).pathname;
+	const { api, middlewares } = getEndpoints(routerCtx, options);
+	const basePath =
+		typeof routerCtx === "function"
+			? options.basePath || "/api/auth"
+			: new URL(routerCtx.baseURL).pathname;
 
 	return createRouter(api, {
-		routerContext: ctx,
+		routerContext: typeof routerCtx === "function" ? {} : routerCtx,
 		openapi: {
 			disabled: true,
 		},
@@ -293,6 +298,8 @@ export const router = <Option extends BetterAuthOptions>(
 		allowedMediaTypes: ["application/json"],
 		skipTrailingSlashes: options.advanced?.skipTrailingSlashes ?? false,
 		async onRequest(req) {
+			const ctx =
+				typeof routerCtx === "function" ? await routerCtx() : routerCtx;
 			//handle disabled paths
 			const disabledPaths = ctx.options.disabledPaths || [];
 			const normalizedPath = normalizePathname(req.url, basePath);
@@ -329,6 +336,8 @@ export const router = <Option extends BetterAuthOptions>(
 			return currentRequest;
 		},
 		async onResponse(res, req) {
+			const ctx =
+				typeof routerCtx === "function" ? await routerCtx() : routerCtx;
 			for (const plugin of ctx.options.plugins || []) {
 				if (plugin.onResponse) {
 					const response = await withSpan(
@@ -347,7 +356,9 @@ export const router = <Option extends BetterAuthOptions>(
 			}
 			return res;
 		},
-		onError(e) {
+		async onError(e) {
+			const ctx =
+				typeof routerCtx === "function" ? await routerCtx() : routerCtx;
 			if (isAPIError(e) && e.status === "FOUND") {
 				return;
 			}
@@ -400,6 +411,25 @@ export const router = <Option extends BetterAuthOptions>(
 		},
 	});
 };
+
+export async function createRouterHandler<Option extends BetterAuthOptions>(
+	ctx: AuthContext,
+	options: Option,
+) {
+	const AsyncLocalStorage = await getAsyncLocalStorage();
+	const requestContext = new AsyncLocalStorage<AuthContext>();
+	const getContext = () => requestContext.getStore() || ctx;
+	const { handler } = router(getContext, {
+		...options,
+		basePath: ctx.baseURL
+			? new URL(ctx.baseURL).pathname
+			: ctx.options.basePath || "/api/auth",
+	});
+
+	return (handlerCtx: AuthContext, request: Request) => {
+		return requestContext.run(handlerCtx, () => handler(request));
+	};
+}
 
 export {
 	type AuthEndpoint,

--- a/packages/better-auth/src/api/to-auth-endpoints.ts
+++ b/packages/better-auth/src/api/to-auth-endpoints.ts
@@ -72,7 +72,10 @@ async function resolveDynamicContext(
  */
 export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 	endpoints: E,
-	ctx: AuthContext | Promise<AuthContext>,
+	ctx:
+		| AuthContext
+		| Promise<AuthContext>
+		| (() => AuthContext | Promise<AuthContext>),
 ): E {
 	const api: Record<
 		string,
@@ -89,7 +92,7 @@ export function toAuthEndpoints<const E extends Record<string, Endpoint>>(
 			const operationId = getOperationId(endpoint, key);
 
 			const run = async () => {
-				const rawContext = await ctx;
+				const rawContext = await (typeof ctx === "function" ? ctx() : ctx);
 				const authContext = isDynamicBaseURLConfig(rawContext.options.baseURL)
 					? await resolveDynamicContext(rawContext, context)
 					: rawContext;

--- a/packages/better-auth/src/auth/base.ts
+++ b/packages/better-auth/src/auth/base.ts
@@ -1,7 +1,7 @@
 import type { AuthContext, BetterAuthOptions } from "@better-auth/core";
 import { runWithAdapter } from "@better-auth/core/context";
 import { BASE_ERROR_CODES, BetterAuthError } from "@better-auth/core/error";
-import { getEndpoints, router } from "../api";
+import { createRouterHandler, getEndpoints } from "../api";
 import {
 	getTrustedOrigins,
 	getTrustedProviders,
@@ -17,6 +17,9 @@ export const createBetterAuth = <Options extends BetterAuthOptions>(
 ): Auth<Options> => {
 	const authContext = initFn(options);
 	const { api } = getEndpoints(authContext, options);
+	let routerHandler:
+		| ReturnType<typeof createRouterHandler<Options>>
+		| undefined;
 	const errorCodes = options.plugins?.reduce((acc, plugin) => {
 		if (plugin.$ERROR_CODES) {
 			return {
@@ -85,8 +88,13 @@ export const createBetterAuth = <Options extends BetterAuthOptions>(
 				);
 			}
 
-			const { handler } = router(handlerCtx, options);
-			return runWithAdapter(handlerCtx.adapter, () => handler(request));
+			const handler = await (routerHandler ||= createRouterHandler(
+				ctx,
+				options,
+			));
+			return runWithAdapter(handlerCtx.adapter, () =>
+				handler(handlerCtx, request),
+			);
 		},
 		api,
 		options: options,

--- a/packages/better-auth/src/auth/full.test.ts
+++ b/packages/better-auth/src/auth/full.test.ts
@@ -129,6 +129,80 @@ describe("auth with trusted proxy headers", () => {
 });
 
 /**
+ * @see https://github.com/better-auth/better-auth/issues/10188
+ */
+describe("auth handler router caching", () => {
+	test("should not rebuild plugin middleware wrappers for every handler request", async () => {
+		let endpointReads = 0;
+		let middlewareReads = 0;
+		const endpoints = {
+			cacheProbe: createAuthEndpoint(
+				"/cache-probe",
+				{ method: "GET" },
+				async () => ({ ok: true }),
+			),
+		};
+		const plugin = {
+			id: "middleware-read-counter",
+			get endpoints() {
+				endpointReads++;
+				return endpoints;
+			},
+			get middlewares() {
+				middlewareReads++;
+				return [];
+			},
+		};
+		const { auth } = await getTestInstance({
+			plugins: [plugin],
+		});
+
+		await auth.handler(new Request("http://localhost:3000/api/auth/ok"));
+		const initialEndpointReads = endpointReads;
+		const initialReads = middlewareReads;
+		await auth.handler(new Request("http://localhost:3000/api/auth/ok"));
+		await auth.handler(new Request("http://localhost:3000/api/auth/ok"));
+		await auth.handler(new Request("http://localhost:3000/api/auth/ok"));
+
+		expect(endpointReads).toBe(initialEndpointReads);
+		expect(middlewareReads).toBe(initialReads);
+	});
+
+	test("should keep request-derived context isolated across parallel handler requests", async () => {
+		const seenBaseURLs: string[] = [];
+		const { auth } = await getTestInstance({
+			baseURL: undefined,
+			hooks: {
+				before: createAuthMiddleware(async (ctx) => {
+					await new Promise((resolve) => setTimeout(resolve, 0));
+					seenBaseURLs.push(ctx.context.baseURL);
+				}),
+			},
+		});
+
+		await Promise.all([
+			auth.handler(
+				new Request("https://tenant-a.example.com/api/auth/ok", {
+					headers: { host: "tenant-a.example.com" },
+				}),
+			),
+			auth.handler(
+				new Request("https://tenant-b.example.com/api/auth/ok", {
+					headers: { host: "tenant-b.example.com" },
+				}),
+			),
+		]);
+
+		expect(seenBaseURLs).toEqual(
+			expect.arrayContaining([
+				"https://tenant-a.example.com/api/auth",
+				"https://tenant-b.example.com/api/auth",
+			]),
+		);
+	});
+});
+
+/**
  * @see https://github.com/better-auth/better-auth/issues/4151
  */
 describe("auth with dynamic baseURL (allowedHosts)", () => {


### PR DESCRIPTION
## Summary

Caches the `auth.handler` router per auth instance instead of rebuilding the endpoint map and `better-call` router on every request.

The router still receives request-specific auth context through request-local storage, so dynamic/no-baseURL resolution, trusted origins/providers, plugin `onRequest`/`onResponse`, middleware, and endpoint dispatch continue to use the per-request `handlerCtx`.

## Root Cause

`auth.handler` resolved a per-request `handlerCtx`, then called `router(handlerCtx, options)` for every incoming request. `router()` calls `getEndpoints()` and `createRouter(...)`, so concurrent handler calls rebuilt endpoint wrappers and route tables once per request. That work is synchronous, so parallel requests queue on the JS thread before endpoint dispatch.

## Changes

- Adds `createRouterHandler()` to build the router once and dispatch with the current request context.
- Allows endpoint and middleware wrappers to resolve context from a provider function.
- Updates `auth.handler` to lazily create and reuse the router handler.
- Adds regression coverage for issue #10188:
  - verifies endpoint/middleware wrappers are not rebuilt after the cached handler is warm
  - verifies parallel requests keep isolated request-derived `baseURL` values

## Validation

```bash
corepack pnpm --filter better-auth typecheck
corepack pnpm exec vitest packages/better-auth/src/auth/full.test.ts packages/better-auth/src/api/index.test.ts packages/better-auth/src/api/to-auth-endpoints.test.ts --run
corepack pnpm --filter better-auth... build
git diff --check
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache the auth handler router per auth instance to stop rebuilding endpoints and route tables on every request. This improves throughput under load while keeping per-request context isolated.

- **Bug Fixes**
  - Removed per-request router rebuild that blocked the JS thread.
  - Preserved request-specific context (dynamic baseURL, trusted origins/providers, plugin hooks) via request-local storage.
  - Added tests to ensure middleware wrappers aren’t rebuilt after warm-up and parallel requests keep isolated baseURL values.

- **Refactors**
  - Added `createRouterHandler()` to build the router once and dispatch with the current request context.
  - Updated `getEndpoints`/`toAuthEndpoints` to accept a context provider function.
  - Made `auth.handler` lazily create and reuse the cached router handler.

<sup>Written for commit 690629d0181b3f347a27ea32278e4d3f09ee221d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

