### PR TITLE
feat(auth): re-hash outdated password hashes on verify

### DIFF
--- a/.changeset/password-rehash-on-verify.md
+++ b/.changeset/password-rehash-on-verify.md
@@ -1,0 +1,10 @@
+---
+"better-auth": minor
+"@better-auth/core": patch
+---
+
+A custom password `verify` function can now return `"success-rehash-needed"` to signal that a password is valid but its stored hash is outdated. When it does, Better Auth re-hashes the password with the configured `hash` function and persists it, allowing transparent migration to a new hashing algorithm or cost factor as users sign in. Re-hashing is opportunistic: a failure to persist the new hash is logged and never blocks an otherwise-valid authentication.
+
+The built-in scrypt verifier is unchanged, so runtime behavior is the same unless you opt in by returning the new value from your own `verify`.
+
+Note: the return type of `ctx.context.password.verify` has widened from `Promise<boolean>` to `Promise<boolean | "success-rehash-needed">`. Code that checks truthiness (`if (result)`) is unaffected. If you call `ctx.context.password.verify` directly, watch for two cases: assigning the result to a `boolean` now raises a type error, and a strict `result === true` comparison will no longer match when the outdated-hash sentinel is returned (this one is not caught by the compiler). Both only apply if you opt in by returning the new value from your own `verify`.

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -468,6 +468,25 @@ export const auth = betterAuth({
 });
 ```
 
+**Re-hashing on verify**: Your `verify` function can return `true`, `false`, or the string `"success-rehash-needed"`. Returning `"success-rehash-needed"` tells Better Auth that the password is valid but the stored hash is outdated (for example it was produced by a different algorithm or an older cost factor). When this is returned during a sign-in, Better Auth re-hashes the password with your `hash` function and persists the new hash automatically, letting you transparently migrate existing users to a new hashing scheme as they log in.
+
+```ts title="password.ts"
+export async function verifyPassword(data: { password: string; hash: string }) {
+  const { password, hash } = data;
+  if (isLegacyHash(hash)) {
+    // verify against your previous algorithm
+    return (await verifyLegacy(password, hash))
+      ? "success-rehash-needed"
+      : false;
+  }
+  return verify(hash, password, opts);
+}
+```
+
+<Callout>
+  Re-hashing is opportunistic: if persisting the new hash fails, the error is logged and the sign-in still succeeds, since the password itself was valid.
+</Callout>
+
 export const emailPasswordOptionsType = {
   enabled: {
     description: "Enable email and password authentication.",

--- a/docs/content/docs/concepts/hooks.mdx
+++ b/docs/content/docs/concepts/hooks.mdx
@@ -259,8 +259,8 @@ You can access the `secret` for your auth instance on `ctx.context.secret`
 
 The password object provider `hash` and `verify`
 
-* `ctx.context.password.hash`: let's you hash a given password.
-* `ctx.context.password.verify`: let's you verify given `password` and a `hash`.
+* `ctx.context.password.hash`: lets you hash a given password.
+* `ctx.context.password.verify`: lets you verify given `password` and a `hash`. It can return `true`, `false` or `"success-rehash-needed"` if the password is valid but the hash needs to be updated.
 
 #### Adapter
 

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -24,6 +24,7 @@ import {
 import { handleOAuthUserInfo } from "../../oauth2/link-account";
 import { getOAuthCallbackPath } from "../../oauth2/utils";
 import { generateIdTokenNonce, generateState } from "../../utils";
+import { rehashPasswordIfNeeded } from "../../utils/password";
 import { safeCloneRequest } from "../../utils/request";
 import { formCsrfMiddleware } from "../middlewares/origin-check";
 import { createEmailVerificationToken } from "./email-verification";
@@ -569,7 +570,6 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 					BASE_ERROR_CODES.INVALID_EMAIL_OR_PASSWORD,
 				);
 			}
-
 			if (
 				ctx.context.options?.emailAndPassword?.requireEmailVerification &&
 				!user.emailVerified
@@ -603,6 +603,14 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 
 				throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.EMAIL_NOT_VERIFIED);
 			}
+
+			// Only re-hash once the sign-in will actually produce a session, so we
+			// avoid a credential write on requests rejected by the checks above.
+			await rehashPasswordIfNeeded(ctx, {
+				accountId: credentialAccount.id,
+				password,
+				verifyResult: validPassword,
+			});
 
 			const session = await ctx.context.internalAdapter.createSession(
 				user.id,

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -609,6 +609,7 @@ export const signInEmail = <O extends BetterAuthOptions>() =>
 			await rehashPasswordIfNeeded(ctx, {
 				accountId: credentialAccount.id,
 				password,
+				currentHash: currentPassword,
 				verifyResult: validPassword,
 			});
 

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -282,6 +282,8 @@ export const changePassword = createAuthEndpoint(
 		if (!verify) {
 			throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_PASSWORD);
 		}
+		// No rehash-on-verify here: the account's password is replaced with the
+		// new hash immediately below, which supersedes any outdated hash.
 		await ctx.context.internalAdapter.updateAccount(account.id, {
 			password: passwordHash,
 		});

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -175,6 +175,7 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			await rehashPasswordIfNeeded(ctx, {
 				accountId: credentialAccount.id,
 				password,
+				currentHash: currentPassword,
 				verifyResult: validPassword,
 			});
 			const session = await ctx.context.internalAdapter.createSession(

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -10,6 +10,7 @@ import { parseUserInput } from "../../db";
 import { parseUserOutput } from "../../db/schema";
 import { HIDE_METADATA } from "../../utils";
 import { getDate } from "../../utils/date";
+import { rehashPasswordIfNeeded } from "../../utils/password";
 import { PHONE_NUMBER_ERROR_CODES } from "./error-codes";
 import type { PhoneNumberOptions, UserWithPhoneNumber } from "./types";
 
@@ -171,6 +172,11 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 					PHONE_NUMBER_ERROR_CODES.INVALID_PHONE_NUMBER_OR_PASSWORD,
 				);
 			}
+			await rehashPasswordIfNeeded(ctx, {
+				accountId: credentialAccount.id,
+				password,
+				verifyResult: validPassword,
+			});
 			const session = await ctx.context.internalAdapter.createSession(
 				user.id,
 				ctx.body.rememberMe === false,

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -529,6 +529,7 @@ export const username = (options?: UsernameOptions | undefined) => {
 					await rehashPasswordIfNeeded(ctx, {
 						accountId: account.id,
 						password: ctx.body.password,
+						currentHash: currentPassword,
 						verifyResult: validPassword,
 					});
 

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -11,6 +11,7 @@ import { getSessionFromCtx } from "../../api/routes/session";
 import { setSessionCookie } from "../../cookies";
 import { mergeSchema, parseUserOutput } from "../../db";
 import type { InferOptionSchema } from "../../types/plugins";
+import { rehashPasswordIfNeeded } from "../../utils/password";
 import { PACKAGE_VERSION } from "../../version";
 import { USERNAME_ERROR_CODES as ERROR_CODES } from "./error-codes";
 import type { UsernameSchema } from "./schema";
@@ -487,7 +488,6 @@ export const username = (options?: UsernameOptions | undefined) => {
 							ERROR_CODES.INVALID_USERNAME_OR_PASSWORD,
 						);
 					}
-
 					if (
 						ctx.context.options?.emailAndPassword?.requireEmailVerification &&
 						!user.emailVerified
@@ -522,6 +522,15 @@ export const username = (options?: UsernameOptions | undefined) => {
 
 						throw APIError.from("FORBIDDEN", ERROR_CODES.EMAIL_NOT_VERIFIED);
 					}
+
+					// Only re-hash once the sign-in will actually produce a session, so
+					// we avoid a credential write on requests rejected by the checks
+					// above.
+					await rehashPasswordIfNeeded(ctx, {
+						accountId: account.id,
+						password: ctx.body.password,
+						verifyResult: validPassword,
+					});
 
 					const session = await ctx.context.internalAdapter.createSession(
 						user.id,

--- a/packages/better-auth/src/utils/password-rehash.test.ts
+++ b/packages/better-auth/src/utils/password-rehash.test.ts
@@ -44,12 +44,21 @@ interface AdapterHolder {
  *   valid-but-outdated by returning `"success-rehash-needed"`.
  */
 function createPasswordConfig() {
-	const state = { hashCalls: 0, failNextHash: false };
+	const state = {
+		hashCalls: 0,
+		failNextHash: false,
+		// Fires inside `hash()` — used to simulate a concurrent write landing
+		// between verification and the re-hash guard's re-read.
+		onHash: undefined as (() => Promise<void>) | undefined,
+	};
 	const password: NonNullable<
 		NonNullable<BetterAuthOptions["emailAndPassword"]>["password"]
 	> = {
 		hash: async (plain) => {
 			state.hashCalls++;
+			if (state.onHash) {
+				await state.onHash();
+			}
 			if (state.failNextHash) {
 				throw new Error("simulated hash failure");
 			}
@@ -190,6 +199,37 @@ describe("password rehash on verify", () => {
 
 		const after = await getCredentialAccount(auth, user.id);
 		expect(after.password).toBe(`${LEGACY_PREFIX}${plain}`);
+	});
+
+	it("does not overwrite a concurrent password change while re-hashing", async () => {
+		const { password, state } = createPasswordConfig();
+		const { auth } = await getTestInstance({
+			emailAndPassword: { enabled: true, password },
+		});
+		const email = "concurrent-change@test.com";
+		const plain = "password1234";
+		const { user } = await auth.api.signUpEmail({
+			body: { email, password: plain, name: "concurrent" },
+		});
+		const account = await getCredentialAccount(auth, user.id);
+		await setStoredPassword(auth, account.id, `${LEGACY_PREFIX}${plain}`);
+
+		// Simulate a password change landing between verification and the guard's
+		// re-read: overwrite the stored hash during the re-hash's hash() call.
+		const concurrentHash = `${MODERN_PREFIX}concurrent-new-password`;
+		state.onHash = async () => {
+			state.onHash = undefined;
+			await setStoredPassword(auth, account.id, concurrentHash);
+		};
+
+		const res = await auth.api.signInEmail({
+			body: { email, password: plain },
+		});
+		expect(res.token).toBeTruthy();
+
+		// The re-hash of the old password must not clobber the concurrent change.
+		const after = await getCredentialAccount(auth, user.id);
+		expect(after.password).toBe(concurrentHash);
 	});
 
 	it("does not fail sign-in when persisting the new hash throws", async () => {

--- a/packages/better-auth/src/utils/password-rehash.test.ts
+++ b/packages/better-auth/src/utils/password-rehash.test.ts
@@ -1,0 +1,329 @@
+import type { BetterAuthOptions } from "@better-auth/core";
+import { describe, expect, it } from "vitest";
+import { username } from "../plugins/username";
+import { usernameClient } from "../plugins/username/client";
+import { getTestInstance } from "../test-utils/test-instance";
+
+/**
+ * A password `verify` function may return `"success-rehash-needed"` to signal
+ * that the password is valid but the stored hash is outdated and should be
+ * transparently re-hashed and persisted. These tests exercise the call sites
+ * that honor that sentinel.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10289
+ */
+
+const LEGACY_PREFIX = "legacy:";
+const MODERN_PREFIX = "modern:";
+
+/**
+ * Minimal structural view of the pieces of the auth context these helpers use.
+ * `Auth<Options>` is invariant in `Options`, so a concrete test instance is not
+ * assignable to a base-typed parameter — this narrows to only what we need.
+ */
+interface AdapterHolder {
+	$context: Promise<{
+		internalAdapter: {
+			findAccounts: (
+				userId: string,
+			) => Promise<
+				Array<{ id: string; providerId: string; password?: string | null }>
+			>;
+			updateAccount: (
+				accountId: string,
+				data: { password: string },
+			) => Promise<unknown>;
+		};
+	}>;
+}
+
+/**
+ * Deterministic hashing scheme for tests:
+ * - `hash` always produces a "modern" hash.
+ * - `verify` accepts modern hashes directly, and treats "legacy" hashes as
+ *   valid-but-outdated by returning `"success-rehash-needed"`.
+ */
+function createPasswordConfig() {
+	const state = { hashCalls: 0, failNextHash: false };
+	const password: NonNullable<
+		NonNullable<BetterAuthOptions["emailAndPassword"]>["password"]
+	> = {
+		hash: async (plain) => {
+			state.hashCalls++;
+			if (state.failNextHash) {
+				throw new Error("simulated hash failure");
+			}
+			return `${MODERN_PREFIX}${plain}`;
+		},
+		verify: async ({ hash, password }) => {
+			if (hash.startsWith(MODERN_PREFIX)) {
+				return hash === `${MODERN_PREFIX}${password}`;
+			}
+			if (hash.startsWith(LEGACY_PREFIX)) {
+				return hash === `${LEGACY_PREFIX}${password}`
+					? "success-rehash-needed"
+					: false;
+			}
+			return false;
+		},
+	};
+	return { state, password };
+}
+
+async function getCredentialAccount(auth: AdapterHolder, userId: string) {
+	const ctx = await auth.$context;
+	const accounts = await ctx.internalAdapter.findAccounts(userId);
+	const account = accounts.find((a) => a.providerId === "credential");
+	if (!account) {
+		throw new Error("credential account not found");
+	}
+	return account;
+}
+
+async function setStoredPassword(
+	auth: AdapterHolder,
+	accountId: string,
+	value: string,
+) {
+	const ctx = await auth.$context;
+	await ctx.internalAdapter.updateAccount(accountId, { password: value });
+}
+
+describe("password rehash on verify", () => {
+	it("re-hashes and persists an outdated hash on email sign-in", async () => {
+		const { password } = createPasswordConfig();
+		const { auth } = await getTestInstance({
+			emailAndPassword: { enabled: true, password },
+		});
+		const email = "rehash-signin@test.com";
+		const plain = "password1234";
+		const { user } = await auth.api.signUpEmail({
+			body: { email, password: plain, name: "rehash" },
+		});
+		const account = await getCredentialAccount(auth, user.id);
+		// Downgrade the stored hash to the legacy format.
+		await setStoredPassword(auth, account.id, `${LEGACY_PREFIX}${plain}`);
+
+		const res = await auth.api.signInEmail({
+			body: { email, password: plain },
+		});
+		expect(res.token).toBeTruthy();
+
+		const after = await getCredentialAccount(auth, user.id);
+		expect(after.password).toBe(`${MODERN_PREFIX}${plain}`);
+
+		// A subsequent sign-in verifies against the new hash and succeeds.
+		const res2 = await auth.api.signInEmail({
+			body: { email, password: plain },
+		});
+		expect(res2.token).toBeTruthy();
+	});
+
+	it("does not re-hash when the stored hash is already current", async () => {
+		const { password, state } = createPasswordConfig();
+		const { auth } = await getTestInstance({
+			emailAndPassword: { enabled: true, password },
+		});
+		const email = "no-rehash@test.com";
+		const plain = "password1234";
+		const { user } = await auth.api.signUpEmail({
+			body: { email, password: plain, name: "no rehash" },
+		});
+		const before = await getCredentialAccount(auth, user.id);
+		const hashCallsBefore = state.hashCalls;
+
+		await auth.api.signInEmail({ body: { email, password: plain } });
+
+		const after = await getCredentialAccount(auth, user.id);
+		expect(after.password).toBe(before.password);
+		// verify() returned `true`, so no additional hashing occurred.
+		expect(state.hashCalls).toBe(hashCallsBefore);
+	});
+
+	it("does not re-hash when the password is wrong", async () => {
+		const { password } = createPasswordConfig();
+		const { auth } = await getTestInstance({
+			emailAndPassword: { enabled: true, password },
+		});
+		const email = "wrong-password@test.com";
+		const plain = "password1234";
+		const { user } = await auth.api.signUpEmail({
+			body: { email, password: plain, name: "wrong" },
+		});
+		const account = await getCredentialAccount(auth, user.id);
+		await setStoredPassword(auth, account.id, `${LEGACY_PREFIX}${plain}`);
+
+		await expect(
+			auth.api.signInEmail({ body: { email, password: "not-the-password" } }),
+		).rejects.toThrow();
+
+		const after = await getCredentialAccount(auth, user.id);
+		expect(after.password).toBe(`${LEGACY_PREFIX}${plain}`);
+	});
+
+	it("does not re-hash when the sign-in is rejected by email verification", async () => {
+		const { password } = createPasswordConfig();
+		const { auth } = await getTestInstance({
+			emailAndPassword: {
+				enabled: true,
+				password,
+				requireEmailVerification: true,
+			},
+			emailVerification: {
+				sendVerificationEmail: async () => {},
+			},
+		});
+		const email = "unverified-rehash@test.com";
+		const plain = "password1234";
+		const { user } = await auth.api.signUpEmail({
+			body: { email, password: plain, name: "unverified" },
+		});
+		const account = await getCredentialAccount(auth, user.id);
+		await setStoredPassword(auth, account.id, `${LEGACY_PREFIX}${plain}`);
+
+		// Correct password, but the sign-in is rejected because the email is
+		// unverified — the hash upgrade must not be written for a request that
+		// cannot produce a session.
+		await expect(
+			auth.api.signInEmail({ body: { email, password: plain } }),
+		).rejects.toThrow();
+
+		const after = await getCredentialAccount(auth, user.id);
+		expect(after.password).toBe(`${LEGACY_PREFIX}${plain}`);
+	});
+
+	it("does not fail sign-in when persisting the new hash throws", async () => {
+		const { password, state } = createPasswordConfig();
+		const { auth } = await getTestInstance({
+			emailAndPassword: { enabled: true, password },
+		});
+		const email = "rehash-failure@test.com";
+		const plain = "password1234";
+		const { user } = await auth.api.signUpEmail({
+			body: { email, password: plain, name: "rehash failure" },
+		});
+		const account = await getCredentialAccount(auth, user.id);
+		await setStoredPassword(auth, account.id, `${LEGACY_PREFIX}${plain}`);
+
+		// Re-hashing will throw, but the credential itself is valid.
+		state.failNextHash = true;
+		const res = await auth.api.signInEmail({
+			body: { email, password: plain },
+		});
+		expect(res.token).toBeTruthy();
+
+		// The outdated hash is left untouched since the re-hash could not be saved.
+		const after = await getCredentialAccount(auth, user.id);
+		expect(after.password).toBe(`${LEGACY_PREFIX}${plain}`);
+
+		// Recovery: once hashing works again, the next sign-in migrates the hash.
+		state.failNextHash = false;
+		await auth.api.signInEmail({ body: { email, password: plain } });
+		const migrated = await getCredentialAccount(auth, user.id);
+		expect(migrated.password).toBe(`${MODERN_PREFIX}${plain}`);
+	});
+
+	it("re-hashes an outdated hash via validatePassword (verify-password endpoint)", async () => {
+		const { password } = createPasswordConfig();
+		const { auth, signInWithUser } = await getTestInstance({
+			emailAndPassword: { enabled: true, password },
+		});
+		const email = "validate-rehash@test.com";
+		const plain = "password1234";
+		const { user } = await auth.api.signUpEmail({
+			body: { email, password: plain, name: "validate" },
+		});
+		const { headers } = await signInWithUser(email, plain);
+		// Downgrade after signing in so the endpoint sees the legacy hash.
+		const account = await getCredentialAccount(auth, user.id);
+		await setStoredPassword(auth, account.id, `${LEGACY_PREFIX}${plain}`);
+
+		const res = await auth.api.verifyPassword({
+			body: { password: plain },
+			headers,
+		});
+		expect(res.status).toBe(true);
+
+		const after = await getCredentialAccount(auth, user.id);
+		expect(after.password).toBe(`${MODERN_PREFIX}${plain}`);
+	});
+
+	it("stores the new password (not an intermediate re-hash) on change-password with an outdated hash", async () => {
+		const { password } = createPasswordConfig();
+		const { auth, signInWithUser } = await getTestInstance({
+			emailAndPassword: { enabled: true, password },
+		});
+		const email = "change-password@test.com";
+		const oldPlain = "password1234";
+		const newPlain = "newpassword1234";
+		const { user } = await auth.api.signUpEmail({
+			body: { email, password: oldPlain, name: "change" },
+		});
+		const { headers } = await signInWithUser(email, oldPlain);
+		// Downgrade after signing in so change-password verifies the legacy hash.
+		const account = await getCredentialAccount(auth, user.id);
+		await setStoredPassword(auth, account.id, `${LEGACY_PREFIX}${oldPlain}`);
+
+		await auth.api.changePassword({
+			body: { currentPassword: oldPlain, newPassword: newPlain },
+			headers,
+		});
+
+		const after = await getCredentialAccount(auth, user.id);
+		expect(after.password).toBe(`${MODERN_PREFIX}${newPlain}`);
+
+		await expect(
+			auth.api.signInEmail({ body: { email, password: oldPlain } }),
+		).rejects.toThrow();
+		const res = await auth.api.signInEmail({
+			body: { email, password: newPlain },
+		});
+		expect(res.token).toBeTruthy();
+	});
+
+	it("re-hashes an outdated hash on username sign-in", async () => {
+		const { password } = createPasswordConfig();
+		const { auth, client } = await getTestInstance(
+			{
+				emailAndPassword: { enabled: true, password },
+				plugins: [username()],
+			},
+			{
+				clientOptions: {
+					plugins: [usernameClient()],
+				},
+			},
+		);
+		const email = "username-rehash@test.com";
+		const uname = "rehash_user";
+		const plain = "password1234";
+		await client.signUp.email({
+			email,
+			username: uname,
+			password: plain,
+			name: "uname",
+		});
+		// `auth` carries plugin generics here, so access the adapter directly
+		// rather than through the base-typed helpers.
+		const ctx = await auth.$context;
+		const found = await ctx.internalAdapter.findUserByEmail(email);
+		const userId = found!.user.id;
+		const account = (await ctx.internalAdapter.findAccounts(userId)).find(
+			(a) => a.providerId === "credential",
+		)!;
+		await ctx.internalAdapter.updateAccount(account.id, {
+			password: `${LEGACY_PREFIX}${plain}`,
+		});
+
+		const res = await client.signIn.username({
+			username: uname,
+			password: plain,
+		});
+		expect(res.data?.token).toBeTruthy();
+
+		const after = (await ctx.internalAdapter.findAccounts(userId)).find(
+			(a) => a.providerId === "credential",
+		)!;
+		expect(after.password).toBe(`${MODERN_PREFIX}${plain}`);
+	});
+});

--- a/packages/better-auth/src/utils/password.ts
+++ b/packages/better-auth/src/utils/password.ts
@@ -1,5 +1,43 @@
-import type { GenericEndpointContext } from "@better-auth/core";
+import type {
+	GenericEndpointContext,
+	PasswordVerifyResult,
+} from "@better-auth/core";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
+
+/**
+ * Sentinel returned by a password `verify` function to signal that the password
+ * is valid but the stored hash is outdated and should be re-hashed.
+ */
+const PASSWORD_REHASH_NEEDED = "success-rehash-needed" as const;
+
+/**
+ * Re-hash and persist a password when `verify` reported the stored hash is
+ * outdated. This is opportunistic: a failure to write the new hash must never
+ * block an otherwise-valid authentication, so errors are logged and swallowed.
+ */
+export async function rehashPasswordIfNeeded(
+	ctx: GenericEndpointContext,
+	data: {
+		accountId: string;
+		password: string;
+		verifyResult: PasswordVerifyResult;
+	},
+) {
+	if (data.verifyResult !== PASSWORD_REHASH_NEEDED) {
+		return;
+	}
+	try {
+		const newHash = await ctx.context.password.hash(data.password);
+		await ctx.context.internalAdapter.updateAccount(data.accountId, {
+			password: newHash,
+		});
+	} catch (error) {
+		ctx.context.logger.error(
+			"Failed to re-hash password after verification",
+			error,
+		);
+	}
+}
 
 export async function validatePassword(
 	ctx: GenericEndpointContext,
@@ -18,7 +56,12 @@ export async function validatePassword(
 		hash: currentPassword,
 		password: data.password,
 	});
-	return compare;
+	await rehashPasswordIfNeeded(ctx, {
+		accountId: credentialAccount.id,
+		password: data.password,
+		verifyResult: compare,
+	});
+	return Boolean(compare);
 }
 
 export async function checkPassword(userId: string, c: GenericEndpointContext) {
@@ -40,6 +83,11 @@ export async function checkPassword(userId: string, c: GenericEndpointContext) {
 	if (!compare) {
 		throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_PASSWORD);
 	}
+	await rehashPasswordIfNeeded(c, {
+		accountId: credentialAccount.id,
+		password,
+		verifyResult: compare,
+	});
 	return true;
 }
 

--- a/packages/better-auth/src/utils/password.ts
+++ b/packages/better-auth/src/utils/password.ts
@@ -14,12 +14,17 @@ const PASSWORD_REHASH_NEEDED = "success-rehash-needed" as const;
  * Re-hash and persist a password when `verify` reported the stored hash is
  * outdated. This is opportunistic: a failure to write the new hash must never
  * block an otherwise-valid authentication, so errors are logged and swallowed.
+ *
+ * `currentHash` is the hash that was just verified; the upgrade is only
+ * persisted if the stored hash still matches it, so a re-hash of the old
+ * password can never clobber a concurrent password change or reset.
  */
 export async function rehashPasswordIfNeeded(
 	ctx: GenericEndpointContext,
 	data: {
 		accountId: string;
 		password: string;
+		currentHash: string;
 		verifyResult: PasswordVerifyResult;
 	},
 ) {
@@ -28,6 +33,17 @@ export async function rehashPasswordIfNeeded(
 	}
 	try {
 		const newHash = await ctx.context.password.hash(data.password);
+		const account = await ctx.context.adapter.findOne<{
+			password?: string | null;
+		}>({
+			model: "account",
+			where: [{ field: "id", value: data.accountId }],
+		});
+		// The stored hash changed while we were re-hashing (e.g. a concurrent
+		// password change) — leave it alone rather than reverting it.
+		if (account?.password !== data.currentHash) {
+			return;
+		}
 		await ctx.context.internalAdapter.updateAccount(data.accountId, {
 			password: newHash,
 		});
@@ -59,6 +75,7 @@ export async function validatePassword(
 	await rehashPasswordIfNeeded(ctx, {
 		accountId: credentialAccount.id,
 		password: data.password,
+		currentHash: currentPassword,
 		verifyResult: compare,
 	});
 	return Boolean(compare);
@@ -86,6 +103,7 @@ export async function checkPassword(userId: string, c: GenericEndpointContext) {
 	await rehashPasswordIfNeeded(c, {
 		accountId: credentialAccount.id,
 		password,
+		currentHash: currentPassword,
 		verifyResult: compare,
 	});
 	return true;

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -286,6 +286,17 @@ type CheckPasswordFn<Options extends BetterAuthOptions = BetterAuthOptions> = (
 	ctx: GenericEndpointContext<Options>,
 ) => Promise<boolean>;
 
+/**
+ * The result of verifying a password.
+ *
+ * - `true`: the password is valid.
+ * - `false`: the password is invalid.
+ * - `"success-rehash-needed"`: the password is valid, but the stored hash is
+ *   outdated (e.g. produced by a different algorithm or cost factor) and should
+ *   be re-hashed and persisted. Better Auth will do this automatically.
+ */
+export type PasswordVerifyResult = boolean | "success-rehash-needed";
+
 export type PluginContext<Options extends BetterAuthOptions> = {
 	getPlugin: <
 		ID extends BetterAuthPluginRegistryIdentifier | LiteralString,
@@ -417,7 +428,10 @@ export type AuthContext<Options extends BetterAuthOptions = BetterAuthOptions> =
 			secondaryStorage: SecondaryStorage | undefined;
 			password: {
 				hash: (password: string) => Promise<string>;
-				verify: (data: { password: string; hash: string }) => Promise<boolean>;
+				verify: (data: {
+					password: string;
+					hash: string;
+				}) => Promise<PasswordVerifyResult>;
 				config: {
 					minPasswordLength: number;
 					maxPasswordLength: number;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -6,6 +6,7 @@ export type {
 	GenericEndpointContext,
 	InfoContext,
 	InternalAdapter,
+	PasswordVerifyResult,
 	PluginContext,
 } from "./context";
 export type {

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -27,7 +27,11 @@ import type { BaseUser } from "../db/schema/user";
 import type { BaseVerification } from "../db/schema/verification";
 import type { Logger } from "../env";
 import type { SocialProviderList, SocialProviders } from "../social-providers";
-import type { AuthContext, GenericEndpointContext } from "./context";
+import type {
+	AuthContext,
+	GenericEndpointContext,
+	PasswordVerifyResult,
+} from "./context";
 import type { Awaitable, LiteralString, LiteralUnion } from "./helper";
 import type { BetterAuthPlugin } from "./plugin";
 
@@ -829,10 +833,21 @@ export type BetterAuthOptions = {
 				 */
 				password?: {
 					hash?: (password: string) => Promise<string>;
+					/**
+					 * Verify a password against a stored hash.
+					 *
+					 * Return `true` if the password is valid, `false` if it is
+					 * invalid, or `"success-rehash-needed"` if the password is valid
+					 * but the stored hash is outdated and should be re-hashed. When
+					 * `"success-rehash-needed"` is returned, Better Auth re-hashes the
+					 * password with the `hash` function and persists it automatically. This is
+					 * useful when migrating from another hashing algorithm or changing
+					 * cost parameters.
+					 */
 					verify?: (data: {
 						hash: string;
 						password: string;
-					}) => Promise<boolean>;
+					}) => Promise<PasswordVerifyResult>;
 				};
 				/**
 				 * Automatically sign in the user after sign up


### PR DESCRIPTION
Closes #10289

Allow a custom password `verify` function to return `"success-rehash-needed"` to signal that a password is valid but its stored hash is outdated. Better Auth then re-hashes the password with the configured `hash` function and persists it, enabling transparent migration to a new hashing algorithm or cost factor as users sign in.

Re-hashing is opportunistic: a failure to persist the new hash is logged and never blocks an otherwise-valid authentication. The built-in scrypt verifier is unchanged, so this is fully opt-in.

### Breaking changes

I think this is a minor change based on what I see in other PRs but I'll leave it up to the reviewer's judgement if it should be or not since to me it's a bit edge casey. I decided to be safe and say it is breaking (and therefore minor instead of patch) since:

`ctx.context.password.verify` widens from `Promise<boolean>` to `Promise<boolean | "success-rehash-needed">`.  Truthiness checks (`if (result)`) and false & falsey checks (`if (!result)` or `if (result === false)`) are unaffected.

Two things can affect code that calls `ctx.context.password.verify` directly (either by the user or a 3rd-party plugin they use):
- Compile-time (any direct caller, whether or not you opt in): assigning the result to a `boolean` — via `const result: boolean = ...` or passing it where a `boolean` is expected - is now a type error. The compiler will catch this.
- Runtime (only if you opt in by returning the sentinel from your own `verify`): a strict `result === true` check will silently stop matching when the sentinel is returned. This is a legal comparison, so the compiler does *not* catch it.

There should be no runtime behaviour changes for anyone not opting in.

I did generate the majority of this with Claude Code but I've checked over what it has generated and it all makes sense to me.  
Know I've only just opened the feature request associated (#10289) so you might prefer the alternative solution I suggested but I wanted to see how possible my preferred solution was.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt‑in password rehash-on-verify to transparently migrate outdated hashes during sign-in and password checks. Updates happen only when a session will be created, are guarded against concurrent changes, and never block auth on failure.

- **New Features**
  - Added `rehashPasswordIfNeeded` and wired it into email, username, and phone sign-ins plus password validation endpoints; skipped for change‑password. Rehash runs only after sign-in prechecks; failures are logged without blocking.
  - Safe update: re‑reads the account and only writes if the stored hash still matches the verified hash to avoid overwriting concurrent changes. Built‑in scrypt verifier is unchanged (opt‑in via custom `verify` that returns `"success-rehash-needed"`).

- **Migration**
  - `ctx.context.password.verify` now returns `Promise<boolean | "success-rehash-needed">`.
  - Truthiness checks still work; direct callers that assign to `boolean` or compare with `=== true` may need updates if your custom verifier returns the new sentinel.

<sup>Written for commit cf30ed80167f980a9eab8a7d1409a01320d6bbd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



