### PR TITLE
fix(db): don't abort auth migrate when adding required or unique columns

### DIFF
--- a/.changeset/kysely-migrate-add-column-defaults.md
+++ b/.changeset/kysely-migrate-add-column-defaults.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+`npx auth migrate` no longer aborts when adding a column to an existing table. A required column with a default value, or a unique column, now migrates on SQLite and on populated Postgres and MySQL databases. Upgrading a database that already has organization teams previously failed on the new `team.memberCount` and `teamMember.membershipKey` columns.

--- a/packages/better-auth/src/db/get-migration.test.ts
+++ b/packages/better-auth/src/db/get-migration.test.ts
@@ -1,0 +1,76 @@
+import { DatabaseSync } from "node:sqlite";
+import type { BetterAuthOptions } from "@better-auth/core";
+import { describe, expect, it } from "vitest";
+import { organization } from "../plugins/organization";
+import { getMigrations } from "./get-migration";
+
+// A 1.6-shape team/teamMember schema: the 1.7 `memberCount` and `membershipKey`
+// columns are missing, so getMigrations must ADD them to a populated table.
+function createLegacyOrgDb() {
+	const db = new DatabaseSync(":memory:");
+	db.exec(
+		`CREATE TABLE "team" (
+			"id" text primary key not null,
+			"name" text not null,
+			"organizationId" text not null,
+			"createdAt" date not null,
+			"updatedAt" date
+		)`,
+	);
+	db.exec(
+		`CREATE TABLE "teamMember" (
+			"id" text primary key not null,
+			"teamId" text not null,
+			"userId" text not null,
+			"createdAt" date
+		)`,
+	);
+	db.exec(
+		`INSERT INTO "team" ("id", "name", "organizationId", "createdAt")
+		 VALUES ('t1', 'Engineering', 'org1', '2020-01-01')`,
+	);
+	db.exec(
+		`INSERT INTO "teamMember" ("id", "teamId", "userId", "createdAt")
+		 VALUES ('tm1', 't1', 'u1', '2020-01-01')`,
+	);
+	return db;
+}
+
+describe("get-migration: ALTER TABLE ADD COLUMN on SQLite", () => {
+	it("adds a required column with a static default and a unique column to a populated table", async () => {
+		const db = createLegacyOrgDb();
+		const config: BetterAuthOptions = {
+			database: db,
+			plugins: [organization({ teams: { enabled: true } })],
+		};
+
+		const { toBeAdded, runMigrations } = await getMigrations(config);
+
+		const teamAdditions = toBeAdded.find((t) => t.table === "team");
+		expect(teamAdditions?.fields).toHaveProperty("memberCount");
+		const teamMemberAdditions = toBeAdded.find((t) => t.table === "teamMember");
+		expect(teamMemberAdditions?.fields).toHaveProperty("membershipKey");
+
+		// SQLite rejects both `ADD COLUMN ... NOT NULL` without a default and
+		// `ADD COLUMN ... UNIQUE`, so an unhardened generator throws here.
+		await runMigrations();
+
+		// The required column is backfilled with its schema default on the existing row.
+		const team = db
+			.prepare(`SELECT "memberCount" FROM "team" WHERE "id" = 't1'`)
+			.get() as { memberCount: number };
+		expect(team.memberCount).toBe(0);
+
+		// The unique column is added and its uniqueness is enforced.
+		db.exec(
+			`INSERT INTO "teamMember" ("id", "teamId", "userId", "createdAt", "membershipKey")
+			 VALUES ('tm2', 't1', 'u2', '2020-01-01', 'org1:t1:u2')`,
+		);
+		expect(() =>
+			db.exec(
+				`INSERT INTO "teamMember" ("id", "teamId", "userId", "createdAt", "membershipKey")
+				 VALUES ('tm3', 't1', 'u3', '2020-01-01', 'org1:t1:u2')`,
+			),
+		).toThrow();
+	});
+});

--- a/packages/better-auth/src/db/get-migration.test.ts
+++ b/packages/better-auth/src/db/get-migration.test.ts
@@ -104,8 +104,15 @@ describe("get-migration: ALTER TABLE ADD COLUMN on SQLite", () => {
 			`INSERT INTO "user" ("id", "name", "email", "emailVerified", "createdAt", "updatedAt")
 			 VALUES ('u1', 'Ada', 'ada@example.com', 1, '2020-01-01', '2020-01-01')`,
 		);
+		const warnings: string[] = [];
 		const config: BetterAuthOptions = {
 			database: db,
+			logger: {
+				level: "warn",
+				log: (level, message) => {
+					if (level === "warn") warnings.push(message);
+				},
+			},
 			user: {
 				additionalFields: {
 					referralCode: {
@@ -119,6 +126,10 @@ describe("get-migration: ALTER TABLE ADD COLUMN on SQLite", () => {
 		};
 
 		const { runMigrations, compileMigrations } = await getMigrations(config);
+
+		// The shared backfill cannot be unique on a multi-row table, so the
+		// generator warns that a manual backfill may be needed.
+		expect(warnings.some((w) => w.includes('"referralCode"'))).toBe(true);
 
 		// A required unique column keeps its static default so the NOT NULL add
 		// succeeds; uniqueness is enforced through a separate index.

--- a/packages/better-auth/src/db/get-migration.test.ts
+++ b/packages/better-auth/src/db/get-migration.test.ts
@@ -44,12 +44,23 @@ describe("get-migration: ALTER TABLE ADD COLUMN on SQLite", () => {
 			plugins: [organization({ teams: { enabled: true } })],
 		};
 
-		const { toBeAdded, runMigrations } = await getMigrations(config);
+		const { toBeAdded, runMigrations, compileMigrations } =
+			await getMigrations(config);
 
 		const teamAdditions = toBeAdded.find((t) => t.table === "team");
 		expect(teamAdditions?.fields).toHaveProperty("memberCount");
 		const teamMemberAdditions = toBeAdded.find((t) => t.table === "teamMember");
 		expect(teamMemberAdditions?.fields).toHaveProperty("membershipKey");
+
+		// The generated SQL (also what `auth generate` emits) carries a literal
+		// default for the required column and a separate unique index for the
+		// unique column, never an inline `ADD COLUMN ... UNIQUE`.
+		const sql = (await compileMigrations()).toLowerCase();
+		expect(sql).toContain(
+			'add column "membercount" integer default 0 not null',
+		);
+		expect(sql).toContain("create unique index");
+		expect(sql).not.toMatch(/add column "membershipkey"[^;]*unique/);
 
 		// SQLite rejects both `ADD COLUMN ... NOT NULL` without a default and
 		// `ADD COLUMN ... UNIQUE`, so an unhardened generator throws here.

--- a/packages/better-auth/src/db/get-migration.test.ts
+++ b/packages/better-auth/src/db/get-migration.test.ts
@@ -61,6 +61,8 @@ describe("get-migration: ALTER TABLE ADD COLUMN on SQLite", () => {
 		);
 		expect(sql).toContain("create unique index");
 		expect(sql).not.toMatch(/add column "membershipkey"[^;]*unique/);
+		// The NULL-filtered unique index is MSSQL-only.
+		expect(sql).not.toMatch(/create unique index[^;]*where/);
 
 		// SQLite rejects both `ADD COLUMN ... NOT NULL` without a default and
 		// `ADD COLUMN ... UNIQUE`, so an unhardened generator throws here.
@@ -83,5 +85,54 @@ describe("get-migration: ALTER TABLE ADD COLUMN on SQLite", () => {
 				 VALUES ('tm3', 't1', 'u3', '2020-01-01', 'org1:t1:u2')`,
 			),
 		).toThrow();
+	});
+
+	it("adds a required unique column with a static default when the table has one row", async () => {
+		const db = new DatabaseSync(":memory:");
+		db.exec(
+			`CREATE TABLE "user" (
+				"id" text primary key not null,
+				"name" text not null,
+				"email" text not null unique,
+				"emailVerified" integer not null,
+				"image" text,
+				"createdAt" date not null,
+				"updatedAt" date not null
+			)`,
+		);
+		db.exec(
+			`INSERT INTO "user" ("id", "name", "email", "emailVerified", "createdAt", "updatedAt")
+			 VALUES ('u1', 'Ada', 'ada@example.com', 1, '2020-01-01', '2020-01-01')`,
+		);
+		const config: BetterAuthOptions = {
+			database: db,
+			user: {
+				additionalFields: {
+					referralCode: {
+						type: "string",
+						required: true,
+						unique: true,
+						defaultValue: "unset",
+					},
+				},
+			},
+		};
+
+		const { runMigrations, compileMigrations } = await getMigrations(config);
+
+		// A required unique column keeps its static default so the NOT NULL add
+		// succeeds; uniqueness is enforced through a separate index.
+		const sql = (await compileMigrations()).toLowerCase();
+		expect(sql).toContain(
+			`add column "referralcode" text default 'unset' not null`,
+		);
+		expect(sql).toContain('create unique index "user_referralcode_uidx"');
+
+		await runMigrations();
+
+		const user = db
+			.prepare(`SELECT "referralCode" FROM "user" WHERE "id" = 'u1'`)
+			.get() as { referralCode: string };
+		expect(user.referralCode).toBe("unset");
 	});
 });

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -435,15 +435,18 @@ export async function getMigrations(config: BetterAuthOptions) {
 				const type = getType(field, fieldName);
 				const builder = db.schema.alterTable(table.table);
 
-				if (field.index) {
+				// SQLite cannot add a column with an inline UNIQUE constraint, so a
+				// unique field is enforced with a separate index in the ALTER path.
+				if (field.index || field.unique) {
 					const indexName = `${table.table}_${fieldName}_${field.unique ? "uidx" : "idx"}`;
-					const indexBuilder = db.schema
+					let indexBuilder = db.schema
 						.createIndex(indexName)
 						.on(table.table)
 						.columns([fieldName]);
-					deferredIndexes.push(
-						field.unique ? indexBuilder.unique() : indexBuilder,
-					);
+					if (field.unique) {
+						indexBuilder = indexBuilder.unique();
+					}
+					deferredIndexes.push(indexBuilder);
 				}
 
 				const built = builder.addColumn(fieldName, type, (col) => {
@@ -458,9 +461,6 @@ export async function getMigrations(config: BetterAuthOptions) {
 							)
 							.onDelete(field.references.onDelete || "cascade");
 					}
-					if (field.unique) {
-						col = col.unique();
-					}
 					if (
 						field.type === "date" &&
 						typeof field.defaultValue === "function" &&
@@ -471,6 +471,25 @@ export async function getMigrations(config: BetterAuthOptions) {
 						} else {
 							col = col.defaultTo(sql`CURRENT_TIMESTAMP`);
 						}
+					} else if (
+						(field.type === "string" ||
+							field.type === "number" ||
+							field.type === "boolean") &&
+						field.defaultValue !== undefined &&
+						field.defaultValue !== null &&
+						typeof field.defaultValue !== "function"
+					) {
+						// A required column added to a populated table needs a SQL
+						// default, or the NOT NULL add fails. Booleans map to 1/0 on
+						// engines without a native boolean type.
+						col = col.defaultTo(
+							typeof field.defaultValue === "boolean" &&
+								(dbType === "sqlite" || dbType === "mssql")
+								? field.defaultValue
+									? 1
+									: 0
+								: field.defaultValue,
+						);
 					}
 					return col;
 				});

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -472,6 +472,7 @@ export async function getMigrations(config: BetterAuthOptions) {
 							col = col.defaultTo(sql`CURRENT_TIMESTAMP`);
 						}
 					} else if (
+						!field.unique &&
 						(field.type === "string" ||
 							field.type === "number" ||
 							field.type === "boolean") &&
@@ -480,8 +481,9 @@ export async function getMigrations(config: BetterAuthOptions) {
 						typeof field.defaultValue !== "function"
 					) {
 						// A required column added to a populated table needs a SQL
-						// default, or the NOT NULL add fails. Booleans map to 1/0 on
-						// engines without a native boolean type.
+						// default, or the NOT NULL add fails. Unique columns are
+						// excluded: a shared default would collide on the unique index.
+						// Booleans map to 1/0 on engines without a native boolean type.
 						col = col.defaultTo(
 							typeof field.defaultValue === "boolean" &&
 								(dbType === "sqlite" || dbType === "mssql")

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -451,6 +451,16 @@ export async function getMigrations(config: BetterAuthOptions) {
 							// build. Filtering NULLs matches the other dialects.
 							indexBuilder = indexBuilder.where(fieldName, "is not", null);
 						}
+						if (
+							field.required !== false &&
+							field.defaultValue !== undefined &&
+							field.defaultValue !== null &&
+							typeof field.defaultValue !== "function"
+						) {
+							logger.warn(
+								`Adding unique column "${fieldName}" to existing table "${table.table}" backfills every existing row with its default value. If the table has more than one row, creating the unique index "${indexName}" will fail; backfill distinct values manually, then re-run the migration or create the index yourself.`,
+							);
+						}
 					}
 					deferredIndexes.push(indexBuilder);
 				}

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -445,6 +445,12 @@ export async function getMigrations(config: BetterAuthOptions) {
 						.columns([fieldName]);
 					if (field.unique) {
 						indexBuilder = indexBuilder.unique();
+						if (field.required === false && dbType === "mssql") {
+							// MSSQL unique indexes treat NULLs as duplicates, so the
+							// NULL backfill on existing rows would abort the index
+							// build. Filtering NULLs matches the other dialects.
+							indexBuilder = indexBuilder.where(fieldName, "is not", null);
+						}
 					}
 					deferredIndexes.push(indexBuilder);
 				}
@@ -472,7 +478,7 @@ export async function getMigrations(config: BetterAuthOptions) {
 							col = col.defaultTo(sql`CURRENT_TIMESTAMP`);
 						}
 					} else if (
-						!field.unique &&
+						!(field.unique && field.required === false) &&
 						(field.type === "string" ||
 							field.type === "number" ||
 							field.type === "boolean") &&
@@ -481,8 +487,11 @@ export async function getMigrations(config: BetterAuthOptions) {
 						typeof field.defaultValue !== "function"
 					) {
 						// A required column added to a populated table needs a SQL
-						// default, or the NOT NULL add fails. Unique columns are
-						// excluded: a shared default would collide on the unique index.
+						// default, or the NOT NULL add fails. Nullable unique columns
+						// are excluded: NULL is their only unique-safe backfill. A
+						// required unique column keeps its default; on a table with
+						// more than one row the unique index then rejects the shared
+						// backfill, which no generated migration can avoid.
 						// Booleans map to 1/0 on engines without a native boolean type.
 						col = col.defaultTo(
 							typeof field.defaultValue === "boolean" &&


### PR DESCRIPTION
`npx auth migrate` aborts partway through when it adds a new column that is `NOT NULL` with a default, or `UNIQUE`, to an existing table. The Kysely migration generator emits these as a bare `ALTER TABLE ... ADD COLUMN`: it attaches a SQL `DEFAULT` only for date columns, and applies `UNIQUE` inline. SQLite rejects both forms outright, and a populated Postgres or MySQL table rejects the `NOT NULL` add. Upgrading a 1.6 database that uses organization teams hits this on the new `team.memberCount` and `teamMember.membershipKey` columns.

The generator now emits a SQL `DEFAULT` for a static scalar `defaultValue` (booleans map to `1`/`0` on SQLite and MSSQL), and enforces a unique column with a separate index instead of an inline constraint. This is the `ALTER TABLE` path only; `CREATE TABLE` already handles both, so schemas generated from scratch are unchanged. Drizzle and Prisma generators already emit defaults, so this brings the Kysely path in line.

A column that is both `NOT NULL` and `UNIQUE` with no default still needs a manual data step, since no value can be derived for existing rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `npx auth migrate` aborting when adding required or unique columns to existing tables, and warns when a required unique default would break the unique index. Upgrades (e.g., `team.memberCount`, `teamMember.membershipKey`) now run on SQLite and populated Postgres/MySQL.

- **Bug Fixes**
  - In the ALTER TABLE path, emit SQL DEFAULT for static string/number/boolean defaults (booleans map to 1/0 on SQLite/MSSQL); skip only for nullable unique columns.
  - Enforce UNIQUE with a separate index; on MSSQL, filter NULLs in the unique index; also log a warning when a required unique column has a static default that may fail on multi-row tables. CREATE TABLE behavior is unchanged.

- **Migration**
  - Required unique columns with a static default may still need a manual per-row backfill on multi-row tables; the generator now emits a warning with the column and index names.

<sup>Written for commit a7040e5e9020d750e1f2974166bf52a68e78965a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

