### PR TITLE
fix: send Apple OAuth PKCE challenge

### DIFF
--- a/.changeset/fix-apple-oauth-pkce.md
+++ b/.changeset/fix-apple-oauth-pkce.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Send Apple OAuth PKCE code challenges during authorization so callback token exchanges include a matching code verifier.

--- a/packages/core/src/social-providers/apple.test.ts
+++ b/packages/core/src/social-providers/apple.test.ts
@@ -14,6 +14,8 @@ import { betterFetch } from "@better-fetch/fetch";
 import { apple } from "./apple";
 
 const mockedBetterFetch = vi.mocked(betterFetch);
+const CLIENT_ID = "service.example.app";
+const CLIENT_SECRET = "test-secret";
 
 async function createSignedAppleToken(payloadNonce: string) {
 	const { publicKey, privateKey } = await generateKeyPair("ES256", {
@@ -47,6 +49,48 @@ function mockAppleJwks(publicJWK: JWK) {
 	} as Awaited<ReturnType<typeof betterFetch>>);
 }
 
+function codeChallenge(codeVerifier: string) {
+	return createHash("sha256").update(codeVerifier).digest("base64url");
+}
+
+describe("apple.createAuthorizationURL", () => {
+	it("sends a PKCE code challenge when a code verifier is provided", async () => {
+		const verifier = "apple-code-verifier";
+		const provider = apple({
+			clientId: CLIENT_ID,
+			clientSecret: CLIENT_SECRET,
+		});
+
+		const url = await provider.createAuthorizationURL({
+			state: "state",
+			redirectURI: "https://example.com/api/auth/callback/apple",
+			codeVerifier: verifier,
+		});
+
+		expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+		expect(url.searchParams.get("code_challenge")).toBe(
+			codeChallenge(verifier),
+		);
+		expect(url.searchParams.has("code_verifier")).toBe(false);
+	});
+
+	it("omits PKCE parameters when no code verifier is provided", async () => {
+		const provider = apple({
+			clientId: CLIENT_ID,
+			clientSecret: CLIENT_SECRET,
+		});
+
+		const url = await provider.createAuthorizationURL({
+			state: "state",
+			redirectURI: "https://example.com/api/auth/callback/apple",
+			codeVerifier: "",
+		});
+
+		expect(url.searchParams.has("code_challenge_method")).toBe(false);
+		expect(url.searchParams.has("code_challenge")).toBe(false);
+	});
+});
+
 describe("apple.verifyIdToken", () => {
 	beforeEach(() => {
 		mockedBetterFetch.mockReset();
@@ -58,8 +102,8 @@ describe("apple.verifyIdToken", () => {
 		mockAppleJwks(publicJWK);
 
 		const provider = apple({
-			clientId: "service.example.app",
-			clientSecret: "test-secret",
+			clientId: CLIENT_ID,
+			clientSecret: CLIENT_SECRET,
 			appBundleIdentifier: "com.example.app",
 		});
 
@@ -73,8 +117,8 @@ describe("apple.verifyIdToken", () => {
 		mockAppleJwks(publicJWK);
 
 		const provider = apple({
-			clientId: "service.example.app",
-			clientSecret: "test-secret",
+			clientId: CLIENT_ID,
+			clientSecret: CLIENT_SECRET,
 			appBundleIdentifier: "com.example.app",
 		});
 
@@ -88,8 +132,8 @@ describe("apple.verifyIdToken", () => {
 		mockAppleJwks(publicJWK);
 
 		const provider = apple({
-			clientId: "service.example.app",
-			clientSecret: "test-secret",
+			clientId: CLIENT_ID,
+			clientSecret: CLIENT_SECRET,
 			appBundleIdentifier: "com.example.app",
 		});
 

--- a/packages/core/src/social-providers/apple.ts
+++ b/packages/core/src/social-providers/apple.ts
@@ -101,7 +101,7 @@ export const apple = (options: AppleOptions) => {
 	return {
 		id: "apple",
 		name: "Apple",
-		async createAuthorizationURL({ state, scopes, redirectURI }) {
+		async createAuthorizationURL({ state, scopes, redirectURI, codeVerifier }) {
 			if (!getPrimaryClientId(options.clientId) || !options.clientSecret) {
 				logger.error(
 					"Client ID and client secret are required for Apple. Make sure to provide them in the options.",
@@ -118,6 +118,7 @@ export const apple = (options: AppleOptions) => {
 				scopes: _scope,
 				state,
 				redirectURI,
+				codeVerifier,
 				responseMode: "form_post",
 				responseType: "code id_token",
 			});


### PR DESCRIPTION
## Summary

Apple social provider received the generated Better Auth `codeVerifier` during authorization but did not forward it to the shared OAuth authorization URL builder. The callback path then sent that verifier during token exchange, producing a token request with `code_verifier` but no matching authorization-time `code_challenge`.

This forwards `codeVerifier` when creating the Apple authorization URL so the Apple web OAuth flow uses PKCE consistently.

## Changes

- Pass `codeVerifier` into Apple `createAuthorizationURL`
- Add a regression test that Apple authorization URLs include an S256 `code_challenge` and do not leak `code_verifier`
- Add a patch changeset for `@better-auth/core`

## Validation

- `pnpm exec vitest run src/social-providers/apple.test.ts` from `packages/core`
- `pnpm --filter @better-auth/core typecheck`
- `pnpm exec biome check packages/core/src/social-providers/apple.ts packages/core/src/social-providers/apple.test.ts`

## Context

This is separate from #8870, which fixed native iOS nonce hash verification. This fixes the web OAuth redirect flow PKCE mismatch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Apple OAuth PKCE by sending an S256 code challenge during authorization when a `codeVerifier` is provided and omitting PKCE when it isn’t. Prevents token exchange mismatches caused by a `code_verifier` without a prior challenge.

- **Bug Fixes**
  - Pass `codeVerifier` to Apple `createAuthorizationURL` so `code_challenge_method=S256` and `code_challenge` are set (never `code_verifier` in the URL); omit PKCE params when no verifier.
  - Add targeted tests for both paths and a patch changeset for `@better-auth/core`.

<sup>Written for commit a8baec6f99eb49dc8b358ddda5f33c6b18d95871. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

