### PR TITLE
fix(auth): use case-insensitive email lookup for manually inserted users

### DIFF
--- a/.changeset/petite-lemons-stand.md
+++ b/.changeset/petite-lemons-stand.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Email lookup now uses case-insensitive comparison, fixing sign-in failures for users with mixed-case emails inserted directly into the database

--- a/packages/better-auth/src/api/routes/sign-in.test.ts
+++ b/packages/better-auth/src/api/routes/sign-in.test.ts
@@ -543,4 +543,54 @@ describe("email case insensitivity", async () => {
 			}),
 		).rejects.toThrow();
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10276
+	 */
+	it("should sign in when the stored email has mixed case from manual DB insertion", async () => {
+		const { auth, db } = await getTestInstance(undefined, {
+			disableTestUser: true,
+		});
+
+		const mixedCaseEmail = "Test@Example.COM";
+		const password = "password123";
+		const hash = await auth.$context.then((ctx) => ctx.password.hash(password));
+
+		// Directly insert user and account into the DB with mixed-case email,
+		// bypassing createUser which would normalize to lowercase.
+		const userId = "manual-user-id";
+		await db.create({
+			model: "user",
+			data: {
+				id: userId,
+				email: mixedCaseEmail, // Intentionally NOT lowercased
+				name: "Manual User",
+				emailVerified: false,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+			forceAllowId: true,
+		});
+		await db.create({
+			model: "account",
+			data: {
+				userId,
+				providerId: "credential",
+				accountId: userId,
+				password: hash,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+
+		// Sign in with lowercase email should find the mixed-case stored email
+		const result = await auth.api.signInEmail({
+			body: {
+				email: mixedCaseEmail.toLowerCase(),
+				password,
+			},
+		});
+		expect(result.user).toBeDefined();
+		expect(result.token).toBeDefined();
+	});
 });

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1015,6 +1015,7 @@ export const createInternalAdapter = (
 					{
 						field: "email",
 						value: email.toLowerCase(),
+						mode: "insensitive",
 					},
 				],
 				"user",

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -938,9 +938,7 @@ export const createInternalAdapter = (
 			options?: { includeAccounts: boolean } | undefined,
 		) => {
 			const currentAdapter = await getCurrentAdapter(adapter);
-			const users = await currentAdapter.findMany<
-				User & { account: Account[] | undefined }
-			>({
+			const users = await currentAdapter.findMany<User>({
 				model: "user",
 				where: [
 					{
@@ -949,18 +947,28 @@ export const createInternalAdapter = (
 						mode: "insensitive",
 					},
 				],
-				join: {
-					...(options?.includeAccounts ? { account: true } : {}),
-				},
 				limit: 2,
 			});
 			if (users.length > 1) return null;
-			const result = users[0] || null;
-			if (!result) return null;
-			const { account: accounts, ...user } = result;
+			const user = users[0] || null;
+			if (!user) return null;
+
+			let accounts: Account[] = [];
+			if (options?.includeAccounts) {
+				accounts = await currentAdapter.findMany<Account>({
+					model: "account",
+					where: [
+						{
+							field: "userId",
+							value: user.id,
+						},
+					],
+				});
+			}
+
 			return {
 				user,
-				accounts: accounts ?? [],
+				accounts,
 			};
 		},
 		findUserById: async (userId: string) => {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -879,6 +879,7 @@ export const createInternalAdapter = (
 							{
 								value: email.toLowerCase(),
 								field: "email",
+								mode: "insensitive",
 							},
 						],
 					});
@@ -898,6 +899,7 @@ export const createInternalAdapter = (
 						{
 							value: email.toLowerCase(),
 							field: "email",
+							mode: "insensitive",
 						},
 					],
 				});
@@ -936,6 +938,7 @@ export const createInternalAdapter = (
 					{
 						value: email.toLowerCase(),
 						field: "email",
+						mode: "insensitive",
 					},
 				],
 				join: {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1006,6 +1006,20 @@ export const createInternalAdapter = (
 			email: string,
 			data: Partial<User & Record<string, any>>,
 		) => {
+			const existingUser = await (
+				await getCurrentAdapter(adapter)
+			).findOne<User>({
+				model: "user",
+				where: [
+					{
+						field: "email",
+						value: email.toLowerCase(),
+						mode: "insensitive",
+					},
+				],
+			});
+			if (!existingUser) return null;
+
 			const user = await updateWithHooks<User>(
 				{
 					...data,
@@ -1013,9 +1027,8 @@ export const createInternalAdapter = (
 				},
 				[
 					{
-						field: "email",
-						value: email.toLowerCase(),
-						mode: "insensitive",
+						field: "id",
+						value: existingUser.id,
 					},
 				],
 				"user",

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -873,16 +873,21 @@ export const createInternalAdapter = (
 						accounts: [account],
 					};
 				} else {
-					const user = await (await getCurrentAdapter(adapter)).findOne<User>({
-						model: "user",
-						where: [
-							{
-								value: email.toLowerCase(),
-								field: "email",
-								mode: "insensitive",
-							},
-						],
-					});
+					const users = await (await getCurrentAdapter(adapter)).findMany<User>(
+						{
+							model: "user",
+							where: [
+								{
+									value: email.toLowerCase(),
+									field: "email",
+									mode: "insensitive",
+								},
+							],
+							limit: 2,
+						},
+					);
+					if (users.length > 1) return null;
+					const user = users[0] || null;
 					if (user) {
 						return {
 							user,
@@ -893,7 +898,7 @@ export const createInternalAdapter = (
 					return null;
 				}
 			} else {
-				const user = await (await getCurrentAdapter(adapter)).findOne<User>({
+				const users = await (await getCurrentAdapter(adapter)).findMany<User>({
 					model: "user",
 					where: [
 						{
@@ -902,7 +907,10 @@ export const createInternalAdapter = (
 							mode: "insensitive",
 						},
 					],
+					limit: 2,
 				});
+				if (users.length > 1) return null;
+				const user = users[0] || null;
 				if (user) {
 					const accounts = await (
 						await getCurrentAdapter(adapter)
@@ -930,7 +938,7 @@ export const createInternalAdapter = (
 			options?: { includeAccounts: boolean } | undefined,
 		) => {
 			const currentAdapter = await getCurrentAdapter(adapter);
-			const result = await currentAdapter.findOne<
+			const users = await currentAdapter.findMany<
 				User & { account: Account[] | undefined }
 			>({
 				model: "user",
@@ -944,7 +952,10 @@ export const createInternalAdapter = (
 				join: {
 					...(options?.includeAccounts ? { account: true } : {}),
 				},
+				limit: 2,
 			});
+			if (users.length > 1) return null;
+			const result = users[0] || null;
 			if (!result) return null;
 			const { account: accounts, ...user } = result;
 			return {
@@ -1006,9 +1017,9 @@ export const createInternalAdapter = (
 			email: string,
 			data: Partial<User & Record<string, any>>,
 		) => {
-			const existingUser = await (
+			const existingUsers = await (
 				await getCurrentAdapter(adapter)
-			).findOne<User>({
+			).findMany<User>({
 				model: "user",
 				where: [
 					{
@@ -1017,7 +1028,10 @@ export const createInternalAdapter = (
 						mode: "insensitive",
 					},
 				],
+				limit: 2,
 			});
+			if (existingUsers.length > 1) return null;
+			const existingUser = existingUsers[0] || null;
 			if (!existingUser) return null;
 
 			const user = await updateWithHooks<User>(


### PR DESCRIPTION
## Summary

Fixes #10276

Email sign-in fails when users are manually inserted into the database with mixed-case emails (e.g., `Test@Example.COM`). The `findUserByEmail` method lowercases the query input but relies on the database's default case-sensitive comparison, so it cannot match stored emails with different casing.

## Changes

### `packages/better-auth/src/db/internal-adapter.ts`
- Added `mode: "insensitive"` to the email `where` clause in `findUserByEmail` and both email fallback lookups in `findOAuthUser`
- The adapter's `Where` type already supported this option — it just wasn't being used for email lookups

### `packages/better-auth/src/api/routes/sign-in.test.ts`
- Added a regression test that directly inserts a user with mixed-case email via `db.create` (bypassing `createUser` normalization) and verifies sign-in with lowercase email succeeds

## Verification
- All 18 tests in `sign-in.test.ts` pass
- All 51 tests in `internal-adapter.test.ts` pass
- `pnpm typecheck` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make email lookups case-insensitive and handle ambiguous matches in `better-auth`, fixing sign-in and profile updates for users inserted with mixed‑case emails. We resolve a single user by case‑insensitive email, update by `id`, and load accounts separately when requested.

- **Bug Fixes**
  - Use case-insensitive search (`mode: "insensitive"`) with `findMany(limit: 2)` in `findUserByEmail` and both fallbacks in `findOAuthUser`; return `null` on duplicates. Add a regression test for mixed‑case manual insert sign‑in.
  - In `updateUserByEmail`, resolve by case-insensitive email; if exactly one match, update by `id`; otherwise return `null`.
  - Avoid `kysely` limit/join conflicts by fetching users without joins and loading accounts in a separate query when needed.

<sup>Written for commit 0b0c82a623dd2c8e34fbe5c6d3efdd65be794159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

