### PR TITLE
fix: three correctness bugs (organization, one-time-token, CLI) (#10252)

### DIFF
--- a/.changeset/fix-10252-correctness-bugs.md
+++ b/.changeset/fix-10252-correctness-bugs.md
@@ -1,0 +1,24 @@
+---
+"better-auth": patch
+"auth": patch
+---
+
+Fix three correctness bugs (#10252):
+
+- **organization**: `getAdditionalFields()` no longer mutates the shared
+  `options.schema.organizationRole.additionalFields` object when building
+  partial schemas for `updateOrgRole`. Previously, setting
+  `additionalFields[key].required = false` in-place permanently poisoned the
+  caller-supplied options, causing any subsequent `organization()` initialization
+  that shared the same `additionalFields` reference to build a `createOrgRole`
+  schema where all additional fields were treated as optional.
+
+- **one-time-token**: `verifyOneTimeToken` now checks `session.expiresAt` before
+  calling `setSessionCookie`. Previously the cookie was written to the response
+  context before the expiry guard ran, so callers received a stale session cookie
+  even when the endpoint correctly returned a 400 "Session expired" error.
+
+- **cli**: `installDependencies` now uses `bun add` and `yarn add` instead of
+  `bun install` and `yarn install`. The `install` sub-commands do not accept
+  package-name arguments and would silently ignore the dependencies passed to
+  the function.

--- a/packages/better-auth/src/plugins/one-time-token/index.ts
+++ b/packages/better-auth/src/plugins/one-time-token/index.ts
@@ -196,14 +196,14 @@ export const oneTimeToken = (options?: OneTimeTokenOptions | undefined) => {
 							message: "Session not found",
 						});
 					}
-					if (!opts?.disableSetSessionCookie) {
-						await setSessionCookie(c, session);
-					}
-
 					if (session.session.expiresAt < new Date()) {
 						throw c.error("BAD_REQUEST", {
 							message: "Session expired",
 						});
+					}
+
+					if (!opts?.disableSetSessionCookie) {
+						await setSessionCookie(c, session);
 					}
 
 					return c.json(session);

--- a/packages/better-auth/src/plugins/one-time-token/one-time-token.test.ts
+++ b/packages/better-auth/src/plugins/one-time-token/one-time-token.test.ts
@@ -391,3 +391,67 @@ describe("One-time token", async () => {
 		});
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10252
+ *
+ * verifyOneTimeToken must not write a session cookie for an expired session.
+ * The old code called setSessionCookie(c, session) before checking whether
+ * session.session.expiresAt < new Date(). That ordering meant the cookie was
+ * written into the response context even though the handler subsequently threw
+ * "Session expired", so the caller could end up with a stale session cookie.
+ */
+describe("verifyOneTimeToken expiry ordering", async () => {
+	const testInstance = await getTestInstance(
+		{
+			session: {
+				// Very short session lifetime so we can expire it with fake timers.
+				expiresIn: 60,
+				updateAge: 0,
+			},
+			plugins: [
+				oneTimeToken({
+					// OTT itself is valid for 10 min; only the underlying session expires.
+					expiresIn: 10,
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [oneTimeTokenClient()],
+			},
+		},
+	);
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("should not set a session cookie when the underlying session has expired", async () => {
+		const { headers } = await testInstance.signInWithTestUser();
+
+		const { token } = await testInstance.auth.api.generateOneTimeToken({
+			headers,
+		});
+		expect(token).toBeDefined();
+
+		// Advance time past the session's expiresIn (60 s) but before the OTT's
+		// expiresIn (10 min) so the token itself is still consumable.
+		vi.useFakeTimers();
+		await vi.advanceTimersByTimeAsync(2 * 60 * 1000); // 2 minutes
+
+		// The verify call must reject with "Session expired".
+		const response = await testInstance.auth.api
+			.verifyOneTimeToken({ body: { token }, asResponse: true })
+			.catch((e) => e.response as Response);
+
+		// Verify it did error (status 400).
+		expect(response.status).toBe(400);
+
+		// The key assertion: no session cookie should have been written even though
+		// the handler ran as far as calling setSessionCookie before (old code) or
+		// after (fix) the expiry guard.
+		const setCookie = response.headers.get("set-cookie");
+		expect(setCookie).toBeNull();
+	});
+});

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
@@ -1009,4 +1009,98 @@ describe("dynamic access control", async () => {
 			},
 		});
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10252
+	 *
+	 * getAdditionalFields() must not mutate the shared options object.
+	 * When shouldBePartial=true (used by updateOrgRole's initialization path),
+	 * the old code wrote `additionalFields[key].required = false` directly onto
+	 * the object that lives inside the caller-supplied options. Because JS objects
+	 * are passed by reference, that mutation is visible to any code that later
+	 * reads the same object — including a second `organization()` plugin instance
+	 * that was created with the identical `additionalFields` reference.
+	 *
+	 * Reproduction: create two auth instances that share the same `additionalFields`
+	 * object. Initializing the first instance runs `updateOrgRole(opts)` which calls
+	 * `getAdditionalFields(opts, true)` and permanently sets `required = false` on
+	 * every field. Initializing the second instance then runs `createOrgRole(opts)`
+	 * which calls `getAdditionalFields(opts, false)` but now reads the already-
+	 * mutated fields (required = false), so it builds a Zod schema where every
+	 * additionalField is `.nullish()`. As a result, the second instance silently
+	 * accepts a createOrgRole body that omits required fields.
+	 */
+	it("should not allow a second auth instance to bypass required additionalFields after sharing the same options object", async () => {
+		// Shared additionalFields object — both instances get the exact same reference.
+		const sharedAdditionalFields: Record<string, DBFieldAttribute> = {
+			color: {
+				type: "string",
+				defaultValue: "#ffffff",
+				required: true,
+			},
+		};
+
+		// First instance: initializing organization() calls updateOrgRole(opts)
+		// → getAdditionalFields(opts, true) → THE BUG mutates sharedAdditionalFields.
+		await getTestInstance({
+			plugins: [
+				organization({
+					ac,
+					roles: { admin, member, owner },
+					dynamicAccessControl: { enabled: true },
+					schema: {
+						organizationRole: {
+							additionalFields: sharedAdditionalFields,
+						},
+					},
+				}),
+			],
+		});
+
+		// After the first instance is created, sharedAdditionalFields.color.required
+		// is false (due to the bug). A second instance that now builds createOrgRole
+		// with the same reference sees color as .nullish().
+		const second = await getTestInstance({
+			plugins: [
+				organization({
+					ac,
+					roles: { admin, member, owner },
+					dynamicAccessControl: { enabled: true },
+					schema: {
+						organizationRole: {
+							additionalFields: sharedAdditionalFields,
+						},
+					},
+				}),
+			],
+		});
+
+		const { headers: h2 } = await second.signInWithTestUser();
+		// Set an active org so createOrgRole has an organizationId to work with.
+		const org2 = await second.auth.api.createOrganization({
+			body: { name: "org2", slug: `org2-${crypto.randomUUID()}` },
+			headers: h2,
+		});
+		await second.auth.api.setActiveOrganization({
+			body: { organizationId: org2.id },
+			headers: h2,
+		});
+		const h2Active = new Headers(h2);
+		h2Active.set("cookie", h2.get("cookie") ?? "");
+
+		// With the bug: color is .nullish() in the second instance's createOrgRole
+		// schema → passing additionalFields without color succeeds → no throw.
+		// With the fix: color is still z.string() (required) → Zod rejects the body.
+		await expect(
+			second.auth.api.createOrgRole({
+				body: {
+					role: `no-color-role-${crypto.randomUUID()}`,
+					permission: { project: ["read"] },
+					organizationId: org2.id,
+					additionalFields: {} as any, // omit required color
+				},
+				headers: h2Active,
+			}),
+		).rejects.toThrow();
+	});
 });

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.test.ts
@@ -1075,18 +1075,22 @@ describe("dynamic access control", async () => {
 			],
 		});
 
-		const { headers: h2 } = await second.signInWithTestUser();
+		const { headers: secondInstanceHeaders } =
+			await second.signInWithTestUser();
 		// Set an active org so createOrgRole has an organizationId to work with.
 		const org2 = await second.auth.api.createOrganization({
 			body: { name: "org2", slug: `org2-${crypto.randomUUID()}` },
-			headers: h2,
+			headers: secondInstanceHeaders,
 		});
 		await second.auth.api.setActiveOrganization({
 			body: { organizationId: org2.id },
-			headers: h2,
+			headers: secondInstanceHeaders,
 		});
-		const h2Active = new Headers(h2);
-		h2Active.set("cookie", h2.get("cookie") ?? "");
+		const secondInstanceActiveHeaders = new Headers(secondInstanceHeaders);
+		secondInstanceActiveHeaders.set(
+			"cookie",
+			secondInstanceHeaders.get("cookie") ?? "",
+		);
 
 		// With the bug: color is .nullish() in the second instance's createOrgRole
 		// schema → passing additionalFields without color succeeds → no throw.
@@ -1099,7 +1103,7 @@ describe("dynamic access control", async () => {
 					organizationId: org2.id,
 					additionalFields: {} as any, // omit required color
 				},
-				headers: h2Active,
+				headers: secondInstanceActiveHeaders,
 			}),
 		).rejects.toThrow();
 	});

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
@@ -31,13 +31,19 @@ const getAdditionalFields = <
 	options: O,
 	shouldBePartial: AllPartial = false as AllPartial,
 ) => {
-	const additionalFields =
+	const sourceFields =
 		options?.schema?.organizationRole?.additionalFields || {};
-	if (shouldBePartial) {
-		for (const key in additionalFields) {
-			additionalFields[key]!.required = false;
-		}
-	}
+	// Never mutate the shared options object. When shouldBePartial is true we need
+	// every field to be optional, so we build a shallow copy of the fields map with
+	// each field entry also shallow-copied (preserving all other attributes).
+	const additionalFields = shouldBePartial
+		? Object.fromEntries(
+				Object.entries(sourceFields).map(([k, v]) => [
+					k,
+					{ ...v, required: false as const },
+				]),
+			)
+		: sourceFields;
 	const additionalFieldsSchema = toZodSchema({
 		fields: additionalFields,
 		isClientSide: true,

--- a/packages/cli/src/utils/install-dependencies.ts
+++ b/packages/cli/src/utils/install-dependencies.ts
@@ -53,10 +53,10 @@ export function installDependencies({
 			installCommand = "pnpm add";
 			break;
 		case "bun":
-			installCommand = "bun install";
+			installCommand = "bun add";
 			break;
 		case "yarn":
-			installCommand = "yarn install";
+			installCommand = "yarn add";
 			break;
 		default:
 			throw new Error("Invalid package manager");

--- a/packages/cli/test/install-dependencies.test.ts
+++ b/packages/cli/test/install-dependencies.test.ts
@@ -182,8 +182,17 @@ describe("installDependencies", () => {
 		},
 	);
 
+	/*
+	 * @see https://github.com/better-auth/better-auth/issues/10252
+	 *
+	 * `bun install` and `yarn install` do not accept package-name arguments;
+	 * they only install from the lock file. The commands that accept package
+	 * names are `bun add` and `yarn add`. Using the wrong sub-command means
+	 * the dependency names passed to installDependencies() are silently
+	 * ignored.
+	 */
 	testWithTmpDir(
-		"should run bun install with single dependency",
+		"should run bun add with single dependency",
 		async ({ tmp }) => {
 			await installDependencies({
 				dependencies: "better-auth",
@@ -192,7 +201,7 @@ describe("installDependencies", () => {
 			});
 
 			expect(mockExec).toHaveBeenCalledWith(
-				"bun install better-auth",
+				"bun add better-auth",
 				{ cwd: tmp },
 				expect.any(Function),
 			);
@@ -200,7 +209,7 @@ describe("installDependencies", () => {
 	);
 
 	testWithTmpDir(
-		"should run bun install with --dev for dev dependencies",
+		"should run bun add with --dev for dev dependencies",
 		async ({ tmp }) => {
 			await installDependencies({
 				dependencies: "vitest",
@@ -210,7 +219,7 @@ describe("installDependencies", () => {
 			});
 
 			expect(mockExec).toHaveBeenCalledWith(
-				"bun install --dev vitest",
+				"bun add --dev vitest",
 				{ cwd: tmp },
 				expect.any(Function),
 			);
@@ -218,7 +227,7 @@ describe("installDependencies", () => {
 	);
 
 	testWithTmpDir(
-		"should run bun install with --peer for peer dependencies",
+		"should run bun add with --peer for peer dependencies",
 		async ({ tmp }) => {
 			await installDependencies({
 				dependencies: "react",
@@ -228,7 +237,7 @@ describe("installDependencies", () => {
 			});
 
 			expect(mockExec).toHaveBeenCalledWith(
-				"bun install --peer react",
+				"bun add --peer react",
 				{ cwd: tmp },
 				expect.any(Function),
 			);
@@ -236,7 +245,7 @@ describe("installDependencies", () => {
 	);
 
 	testWithTmpDir(
-		"should run bun install with --optional for optional dependencies",
+		"should run bun add with --optional for optional dependencies",
 		async ({ tmp }) => {
 			await installDependencies({
 				dependencies: "fsevents",
@@ -246,7 +255,7 @@ describe("installDependencies", () => {
 			});
 
 			expect(mockExec).toHaveBeenCalledWith(
-				"bun install --optional fsevents",
+				"bun add --optional fsevents",
 				{ cwd: tmp },
 				expect.any(Function),
 			);
@@ -254,7 +263,7 @@ describe("installDependencies", () => {
 	);
 
 	testWithTmpDir(
-		"should run yarn install with single dependency",
+		"should run yarn add with single dependency",
 		async ({ tmp }) => {
 			await installDependencies({
 				dependencies: "better-auth",
@@ -263,7 +272,7 @@ describe("installDependencies", () => {
 			});
 
 			expect(mockExec).toHaveBeenCalledWith(
-				"yarn install better-auth",
+				"yarn add better-auth",
 				{ cwd: tmp },
 				expect.any(Function),
 			);


### PR DESCRIPTION
## Summary

Fixes three independent correctness bugs reported in #10252. Each was reproduced from current `main` before writing any fix, with a RED regression test added first.

### Bug 1 - organization: `getAdditionalFields` mutates shared options object
`getAdditionalFields(opts, shouldBePartial=true)` (used by `updateOrgRole`) wrote `additionalFields[key].required = false` directly onto the caller-supplied config objects. Because objects are passed by reference, this permanently mutated the shared options: a second `organization()` instance reusing the same `additionalFields` reference then built a `createOrgRole` schema where every field was `.nullish()`, silently accepting bodies that omit required fields.
**Fix:** build a shallow copy of the fields map when `shouldBePartial=true`; never touch the original.
**Test:** `crud-access-control.test.ts` - 25 passed, incl. new regression asserting a second instance still enforces required additional fields.

### Bug 2 - one-time-token: session cookie written before expiry check
`verifyOneTimeToken` called `setSessionCookie(c, session)` before checking `session.session.expiresAt < new Date()`, so an expired session still wrote a `set-cookie` header on the error response.
**Fix:** move the `expiresAt` guard above `setSessionCookie`.
**Test:** `one-time-token.test.ts` - 15 passed, incl. new regression asserting no cookie is set when the session is expired.

### Bug 3 - CLI: `bun install` / `yarn install` ignore package-name args
`installDependencies()` used `bun install` / `yarn install`, neither of which accepts package-name arguments (they install from the lockfile only), so requested dependency names were silently discarded.
**Fix:** `bun install` → `bun add`, `yarn install` → `yarn add` (matching the already-correct `npm install` / `pnpm add`).
**Test:** `install-dependencies.test.ts` - 18 passed.

## Test plan
- [x] Reproduced each bug in current source before any fix
- [x] RED test first, confirmed failing for the right reason
- [x] Minimal fix, confirmed GREEN
- [x] Full suite for each affected file: 25 + 15 + 18 = 58 passed
- [x] Changeset added (patch bump)

Closes #10252

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #10252 by resolving three correctness bugs in organization roles, one-time-token session handling, and the CLI. Prevents mutated schemas, stale cookies on expired sessions, and ensures `bun`/`yarn` installs respect provided package names.

- **Bug Fixes**
  - Organization: stop mutating shared `additionalFields`; create a shallow copy for partial schemas so required fields stay enforced across instances.
  - One-time token: check `expiresAt` before `setSessionCookie`; no cookie is set for expired sessions.
  - CLI: switch to `bun add` and `yarn add` so passed dependency names are installed.

<sup>Written for commit 7fed227e944ec421162d7387d7e76e06713aa785. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


