### PR TITLE
fix(adapter): coerce numeric-string and number timestamps to Date on read (#9963)

### DIFF
--- a/.changeset/adapter-date-coercion-9963.md
+++ b/.changeset/adapter-date-coercion-9963.md
@@ -1,0 +1,6 @@
+---
+"@better-auth/core": patch
+"@better-auth/drizzle-adapter": patch
+---
+
+Fix date fields coming back as `Invalid Date` when a driver returns them as a raw epoch-millisecond string or number (e.g. a Drizzle + libSQL text column). The adapter factory's `supportsDates: false` output transform and the Drizzle adapter's `customTransformOutput` now parse numeric-millisecond strings and raw numbers into `Date` in addition to ISO strings.

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -231,3 +231,94 @@ describe("createAdapterFactory consumeOne fallback", () => {
 		).rejects.toThrowError(/non-numeric value from deleteMany/);
 	});
 });
+
+describe("createAdapterFactory date field output coercion", () => {
+	function createDateTestAdapter({
+		findOne,
+		supportsDates,
+	}: {
+		findOne: CustomAdapter["findOne"];
+		supportsDates?: boolean;
+	}) {
+		return createAdapterFactory<BetterAuthOptions>({
+			config: {
+				adapterId: "date-test-adapter",
+				adapterName: "Date Test Adapter",
+				supportsDates,
+			},
+			adapter: () => createCustomAdapter({ findOne }),
+		})({});
+	}
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9963
+	 */
+	it("coerces a numeric-millisecond-string date value into a valid Date when supportsDates is false", async () => {
+		const adapter = createDateTestAdapter({
+			supportsDates: false,
+			findOne: async <T>() =>
+				({
+					id: "verification-id",
+					identifier: "token",
+					value: "value",
+					expiresAt: "1774295570569",
+				}) as T,
+		});
+
+		const result = await adapter.findOne<{ expiresAt: unknown }>({
+			model: "verification",
+			where: [{ field: "id", value: "verification-id" }],
+		});
+
+		expect(result?.expiresAt).toBeInstanceOf(Date);
+		expect(Number.isNaN((result?.expiresAt as Date).getTime())).toBe(false);
+		expect((result?.expiresAt as Date).getTime()).toBe(1774295570569);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9963
+	 */
+	it("coerces a numeric date value into a valid Date when supportsDates is false", async () => {
+		const adapter = createDateTestAdapter({
+			supportsDates: false,
+			findOne: async <T>() =>
+				({
+					id: "verification-id",
+					identifier: "token",
+					value: "value",
+					expiresAt: 1774295570569,
+				}) as T,
+		});
+
+		const result = await adapter.findOne<{ expiresAt: unknown }>({
+			model: "verification",
+			where: [{ field: "id", value: "verification-id" }],
+		});
+
+		expect(result?.expiresAt).toBeInstanceOf(Date);
+		expect(Number.isNaN((result?.expiresAt as Date).getTime())).toBe(false);
+		expect((result?.expiresAt as Date).getTime()).toBe(1774295570569);
+	});
+
+	it("still coerces a plain ISO date string into a valid Date when supportsDates is false", async () => {
+		const iso = "2026-01-01T00:00:00.000Z";
+		const adapter = createDateTestAdapter({
+			supportsDates: false,
+			findOne: async <T>() =>
+				({
+					id: "verification-id",
+					identifier: "token",
+					value: "value",
+					expiresAt: iso,
+				}) as T,
+		});
+
+		const result = await adapter.findOne<{ expiresAt: unknown }>({
+			model: "verification",
+			where: [{ field: "id", value: "verification-id" }],
+		});
+
+		expect(result?.expiresAt).toBeInstanceOf(Date);
+		expect((result?.expiresAt as Date).toISOString()).toBe(iso);
+	});
+});

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -31,7 +31,7 @@ import type {
 	AdapterFactoryOptions,
 	AdapterTestDebugLogs,
 } from "./types";
-import { withApplyDefault } from "./utils";
+import { parseDateValue, withApplyDefault } from "./utils";
 
 export {
 	initGetDefaultModelName,
@@ -368,10 +368,17 @@ export const createAdapterFactory =
 							newValue = safeJSONParse(newValue);
 						} else if (
 							config.supportsDates === false &&
-							typeof newValue === "string" &&
+							(typeof newValue === "string" || typeof newValue === "number") &&
 							field.type === "date"
 						) {
-							newValue = new Date(newValue);
+							// `supportsDates: false` means the adapter/driver doesn't
+							// guarantee a `Date` instance back for a `date` field — it may
+							// return an ISO string, epoch milliseconds as a number, or a
+							// numeric-millisecond string. `parseDateValue` handles all
+							// three; a bare `new Date(...)` mis-parses the numeric-string
+							// case into `Invalid Date`.
+							// @see https://github.com/better-auth/better-auth/issues/9963
+							newValue = parseDateValue(newValue);
 						} else if (
 							config.supportsBooleans === false &&
 							typeof newValue === "number" &&

--- a/packages/core/src/db/adapter/utils.test.ts
+++ b/packages/core/src/db/adapter/utils.test.ts
@@ -44,4 +44,31 @@ describe("parseDateValue", () => {
 		expect(parseDateValue(null)).toBeNull();
 		expect(parseDateValue(undefined)).toBeUndefined();
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9963
+	 */
+	it("parses a short numeric string like a year, not epoch milliseconds", () => {
+		const result = parseDateValue("2026");
+		expect(result).toBeInstanceOf(Date);
+		expect((result as Date).getUTCFullYear()).toBe(2026);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9963
+	 */
+	it('parses "0" as the string date "0", not epoch millisecond 0', () => {
+		const result = parseDateValue("0");
+		expect(result).toBeInstanceOf(Date);
+		expect((result as Date).getTime()).toBe(new Date("0").getTime());
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9963
+	 */
+	it("still parses a real 13-digit epoch-millisecond string as epoch milliseconds", () => {
+		const result = parseDateValue("1774295570569");
+		expect(result).toBeInstanceOf(Date);
+		expect((result as Date).getTime()).toBe(1774295570569);
+	});
 });

--- a/packages/core/src/db/adapter/utils.test.ts
+++ b/packages/core/src/db/adapter/utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseDateValue } from "./utils";
+
+describe("parseDateValue", () => {
+	it("returns a Date instance unchanged", () => {
+		const date = new Date("2026-01-01T00:00:00.000Z");
+		expect(parseDateValue(date)).toBe(date);
+	});
+
+	it("parses a number as epoch milliseconds", () => {
+		const result = parseDateValue(1774295570569);
+		expect(result).toBeInstanceOf(Date);
+		expect((result as Date).getTime()).toBe(1774295570569);
+	});
+
+	it("parses an ISO date string", () => {
+		const iso = "2026-01-01T00:00:00.000Z";
+		const result = parseDateValue(iso);
+		expect(result).toBeInstanceOf(Date);
+		expect((result as Date).toISOString()).toBe(iso);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9963
+	 */
+	it("parses a numeric-millisecond string as epoch milliseconds instead of Invalid Date", () => {
+		const result = parseDateValue("1774295570569");
+		expect(result).toBeInstanceOf(Date);
+		expect(Number.isNaN((result as Date).getTime())).toBe(false);
+		expect((result as Date).getTime()).toBe(1774295570569);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/9963
+	 */
+	it("parses a numeric-millisecond string with a trailing fractional part", () => {
+		const result = parseDateValue("1774295570569.0");
+		expect(result).toBeInstanceOf(Date);
+		expect(Number.isNaN((result as Date).getTime())).toBe(false);
+		expect((result as Date).getTime()).toBe(1774295570569);
+	});
+
+	it("passes null and undefined through unchanged", () => {
+		expect(parseDateValue(null)).toBeNull();
+		expect(parseDateValue(undefined)).toBeUndefined();
+	});
+});

--- a/packages/core/src/db/adapter/utils.ts
+++ b/packages/core/src/db/adapter/utils.ts
@@ -29,6 +29,42 @@ export function withApplyDefault(
 	return value;
 }
 
+/**
+ * Parses a value read back from an adapter into a `Date`.
+ *
+ * Adapters that don't natively return `Date` instances for `date`-typed
+ * fields (or drivers/columns that hand back epoch milliseconds instead of an
+ * ISO string) can return a `number`, or a `string` that is either an ISO
+ * date or a numeric-millisecond value such as `"1774295570569"` or
+ * `"1774295570569.0"`.
+ *
+ * A bare `new Date(value)` mis-parses the numeric-string case: the `Date`
+ * constructor only recognizes ISO 8601 date strings, so a purely numeric
+ * string is treated as an invalid ISO date and yields `Invalid Date` instead
+ * of the intended timestamp.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/9963
+ */
+export function parseDateValue(value: unknown): unknown {
+	if (value instanceof Date) {
+		return value;
+	}
+	if (typeof value === "number") {
+		return new Date(value);
+	}
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		// A purely numeric string (optionally with a trailing fractional part,
+		// e.g. "1774295570569" or "1774295570569.0") represents epoch
+		// milliseconds, not an ISO date string.
+		if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+			return new Date(Number(trimmed));
+		}
+		return new Date(value);
+	}
+	return value;
+}
+
 function isObject(item: unknown): item is Record<string, unknown> {
 	return item !== null && typeof item === "object" && !Array.isArray(item);
 }

--- a/packages/core/src/db/adapter/utils.ts
+++ b/packages/core/src/db/adapter/utils.ts
@@ -54,10 +54,13 @@ export function parseDateValue(value: unknown): unknown {
 	}
 	if (typeof value === "string") {
 		const trimmed = value.trim();
-		// A purely numeric string (optionally with a trailing fractional part,
-		// e.g. "1774295570569" or "1774295570569.0") represents epoch
-		// milliseconds, not an ISO date string.
-		if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+		// A purely numeric string of at least 9 digits (optionally with a
+		// trailing fractional part, e.g. "1774295570569" or
+		// "1774295570569.0") represents epoch milliseconds, not an ISO date
+		// string. Shorter numeric strings (e.g. "2026" or "0") are valid
+		// inputs to `new Date()` with a different meaning and must not be
+		// reinterpreted as epoch milliseconds.
+		if (/^-?\d{9,}(\.\d+)?$/.test(trimmed)) {
 			return new Date(Number(trimmed));
 		}
 		return new Date(value);

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -16,6 +16,97 @@ describe("drizzle-adapter", () => {
 		expect(adapter).toBeDefined();
 	});
 
+	describe("customTransformOutput date coercion", () => {
+		function getCustomTransformOutput(provider: "sqlite" | "pg" | "mysql") {
+			const db = { _: { fullSchema: {} } } as any;
+			const adapter = drizzleAdapter(db, { provider })({
+				secret: "test-secret-that-is-at-least-32-chars-long!!",
+			});
+			const customTransformOutput = (adapter.options as any).adapterConfig
+				.customTransformOutput;
+			expect(customTransformOutput).toBeTypeOf("function");
+			return customTransformOutput as (props: {
+				data: any;
+				fieldAttributes: { type: string };
+			}) => any;
+		}
+
+		/**
+		 * A libSQL/sqlite `text` column storing a `Date` as epoch milliseconds
+		 * (e.g. from a hand-written schema, per the CLI-emitted
+		 * `integer({ mode: "timestamp_ms" })` guidance) returns a
+		 * numeric-millisecond string, not an ISO date string.
+		 *
+		 * @see https://github.com/better-auth/better-auth/issues/9963
+		 */
+		it("coerces a numeric-millisecond-string date value into a valid Date", () => {
+			const customTransformOutput = getCustomTransformOutput("sqlite");
+
+			const result = customTransformOutput({
+				data: "1774295570569",
+				fieldAttributes: { type: "date" },
+			});
+
+			expect(result).toBeInstanceOf(Date);
+			expect(Number.isNaN((result as Date).getTime())).toBe(false);
+			expect((result as Date).getTime()).toBe(1774295570569);
+		});
+
+		it("coerces a numeric date value into a valid Date", () => {
+			const customTransformOutput = getCustomTransformOutput("sqlite");
+
+			const result = customTransformOutput({
+				data: 1774295570569,
+				fieldAttributes: { type: "date" },
+			});
+
+			expect(result).toBeInstanceOf(Date);
+			expect((result as Date).getTime()).toBe(1774295570569);
+		});
+
+		it("still coerces a plain ISO date string into a valid Date", () => {
+			const customTransformOutput = getCustomTransformOutput("sqlite");
+			const iso = "2026-01-01T00:00:00.000Z";
+
+			const result = customTransformOutput({
+				data: iso,
+				fieldAttributes: { type: "date" },
+			});
+
+			expect(result).toBeInstanceOf(Date);
+			expect((result as Date).toISOString()).toBe(iso);
+		});
+
+		it("returns null/undefined unchanged", () => {
+			const customTransformOutput = getCustomTransformOutput("sqlite");
+
+			expect(
+				customTransformOutput({
+					data: null,
+					fieldAttributes: { type: "date" },
+				}),
+			).toBeNull();
+			expect(
+				customTransformOutput({
+					data: undefined,
+					fieldAttributes: { type: "date" },
+				}),
+			).toBeUndefined();
+		});
+
+		it("leaves a real Date instance unchanged", () => {
+			const customTransformOutput = getCustomTransformOutput("pg");
+			const date = new Date("2026-01-01T00:00:00.000Z");
+
+			const result = customTransformOutput({
+				data: date,
+				fieldAttributes: { type: "date" },
+			});
+
+			expect(result).toBe(date);
+		});
+	});
+
 	it("should use unique column fallback for MySQL creates without an id", async () => {
 		const userRow = {
 			id: 42,

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -6,7 +6,10 @@ import type {
 	DBAdapterDebugLogOption,
 	Where,
 } from "@better-auth/core/db/adapter";
-import { createAdapterFactory } from "@better-auth/core/db/adapter";
+import {
+	createAdapterFactory,
+	parseDateValue,
+} from "@better-auth/core/db/adapter";
 import { logger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
 import type { SQL } from "drizzle-orm";
@@ -1135,7 +1138,14 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					if (data === null || data === undefined) {
 						return data;
 					}
-					return new Date(data);
+					// A raw `new Date(data)` mis-parses a numeric-millisecond string
+					// (e.g. a sqlite/libSQL `text` column storing a `Date` as
+					// "1774295570569") into `Invalid Date`, since the `Date`
+					// constructor only recognizes ISO 8601 date strings for string
+					// input. `parseDateValue` also handles a raw `number` driver
+					// return (e.g. an `integer` column).
+					// @see https://github.com/better-auth/better-auth/issues/9963
+					return parseDateValue(data);
 				}
 				return data;
 			},


### PR DESCRIPTION
## Summary

Fixes #9963 (scoped). On read, better-auth coerces `date`-typed fields back into `Date` objects, but two coercion sites used a bare `new Date(value)`, which returns `Invalid Date` for a raw epoch-millisecond **string** like `"1774295570569"` (the `Date` string constructor only parses ISO 8601, not numeric strings) and skipped raw `number` values entirely. This silently produced `Invalid Date` at call sites (e.g. the OIDC `max_age` check loops on a session whose `createdAt` came back as a numeric string from a Drizzle + libSQL text column).

Closes #9963

## Root cause

Two sites already attempt date coercion on read, both with `new Date(value)`:
1. `packages/core/src/db/adapter/factory.ts` `transformOutput`, gated on `supportsDates === false`, and only checked `typeof === "string"`, so raw `number` was never coerced.
2. `packages/drizzle-adapter/src/drizzle-adapter.ts` `customTransformOutput`, runs unconditionally and is the exact site of the reporter's repro.

`new Date("1774295570569")` → `Invalid Date`.

## Fix

Add `parseDateValue()` in `packages/core/src/db/adapter/utils.ts` (exported via `@better-auth/core/db/adapter`) that correctly parses ISO strings, numeric-millisecond strings, and raw numbers into a `Date`. Wire it into both existing coercion sites.

**Deliberately scoped.** This does NOT change gating logic, adapter contracts, or defaults, it only fixes the two spots that already attempted coercion. The issue's full proposal (coerce every adapter regardless of `supportsDates`, re-hydrate secondary-storage/cookie-cache reads, retire `oauth-provider`'s private timestamp helpers) is an admitted breaking adapter-contract change targeting `next`; that's a maintainer scope decision and is intentionally left out. Every adapter that currently trusts its driver to return `Date` (Prisma, Mongo, Kysely pg/mysql, Memory) is provably untouched.

## Test evidence

- RED confirmed pre-fix in `factory.test.ts` (numeric-string → `Invalid Date`; number → not coerced) and in `drizzle-adapter.test.ts` (reproduces the reported symptom).
- New `parseDateValue` unit tests in core.
- GREEN: `packages/core` 372/372, `packages/drizzle-adapter` 25/25, `packages/kysely-adapter` 21/21 (exercises the `supportsDates:false` branch), `packages/memory-adapter` 16/16, no regressions.
- `tsc` clean for both touched packages; Biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coerces numeric-string and number timestamps into real Date objects when reading date fields in `@better-auth/core`’s adapter factory and `@better-auth/drizzle-adapter`. Fixes #9963 and stops OIDC `max_age` loops caused by `Invalid Date`.

- Bug Fixes
  - Added `parseDateValue` in `@better-auth/core/db/adapter` to handle `Date`, number, ISO string, and epoch-millisecond numeric-string inputs; only 9+ digit numeric strings are treated as epoch ms.
  - Applied in core `transformOutput` when `supportsDates: false` and in `@better-auth/drizzle-adapter` `customTransformOutput`; `Date`, `null`, and `undefined` pass through unchanged; no adapter contract changes.

<sup>Written for commit 070cf8b343ec85900f46e885a4747defcbc2d701. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

