### PR TITLE
fix(core): resolve AsyncLocalStorage from globalThis synchronously on edge runtimes

### DIFF
--- a/packages/core/src/async_hooks/index.ts
+++ b/packages/core/src/async_hooks/index.ts
@@ -2,31 +2,39 @@ import type { AsyncLocalStorage } from "node:async_hooks";
 
 export type { AsyncLocalStorage };
 
+// On Cloudflare Workers (nodejs_compat) and some edge runtimes, AsyncLocalStorage
+// is available synchronously on globalThis. Resolve it without a dynamic import so
+// we never create a request-scoped promise: if the request that drives the lazy
+// import is aborted, workerd never settles the promise and every subsequent request
+// in the same isolate hangs forever. The synchronous path is immune to that.
+const _globalALS = (globalThis as any).AsyncLocalStorage as
+	| typeof AsyncLocalStorage
+	| undefined;
+
 const AsyncLocalStoragePromise: Promise<typeof AsyncLocalStorage | null> =
-	import(
-		/* @vite-ignore */
-		/* webpackIgnore: true */
-		"node:async_hooks"
-	)
-		.then((mod) => mod.AsyncLocalStorage)
-		.catch((err) => {
-			if ("AsyncLocalStorage" in globalThis) {
-				return (globalThis as any).AsyncLocalStorage;
-			}
-			if (typeof window !== "undefined") {
-				return null;
-			}
-			console.warn(
-				"[better-auth] Warning: AsyncLocalStorage is not available in this environment. Some features may not work as expected.",
-			);
-			console.warn(
-				"[better-auth] Please read more about this warning at https://better-auth.com/docs/installation#mount-handler",
-			);
-			console.warn(
-				"[better-auth] If you are using Cloudflare Workers, please see: https://developers.cloudflare.com/workers/configuration/compatibility-flags/#nodejs-compatibility-flag",
-			);
-			throw err;
-		});
+	_globalALS
+		? Promise.resolve(_globalALS)
+		: import(
+				/* @vite-ignore */
+				/* webpackIgnore: true */
+				"node:async_hooks"
+			)
+				.then((mod) => mod.AsyncLocalStorage)
+				.catch((err) => {
+					if (typeof window !== "undefined") {
+						return null;
+					}
+					console.warn(
+						"[better-auth] Warning: AsyncLocalStorage is not available in this environment. Some features may not work as expected.",
+					);
+					console.warn(
+						"[better-auth] Please read more about this warning at https://better-auth.com/docs/installation#mount-handler",
+					);
+					console.warn(
+						"[better-auth] If you are using Cloudflare Workers, please see: https://developers.cloudflare.com/workers/configuration/compatibility-flags/#nodejs-compatibility-flag",
+					);
+					throw err;
+				});
 
 export async function getAsyncLocalStorage(): Promise<
 	typeof AsyncLocalStorage


### PR DESCRIPTION
## Problem

`AsyncLocalStoragePromise` is a module-level singleton initialised by a dynamic `import("node:async_hooks")`. On Cloudflare Workers, dynamic imports are bound to the request's IoContext — if the request driving lazy first-touch initialisation is aborted by the client before the import settles, workerd never resolves the promise.

Because the promise is cached at module scope, every subsequent request in the same isolate awaits the same permanently-pending promise and hangs forever with no error and no timeout. The isolate must be recycled to recover, and a client whose connection sticks to that isolate sees a complete outage while other isolates are unaffected.

Reported with a production incident trace in #10315.

## Root cause

```ts
// module scope — created once, shared across all requests in the isolate
const AsyncLocalStoragePromise = import("node:async_hooks")  // request-bound on Workers
  .then(mod => mod.AsyncLocalStorage)
  .catch(...);
```

## Fix

Workers with `nodejs_compat` expose `AsyncLocalStorage` synchronously on `globalThis`. Check for it before launching the dynamic import and resolve immediately with `Promise.resolve()` — a microtask-settled promise with no IoContext attachment that cannot be poisoned by an abort.

```ts
const _globalALS = (globalThis as any).AsyncLocalStorage;

const AsyncLocalStoragePromise = _globalALS
  ? Promise.resolve(_globalALS)        // Workers: synchronous, abort-safe
  : import("node:async_hooks")...;     // Node.js / Bun: unchanged
```

Node.js and Bun do not set `globalThis.AsyncLocalStorage`, so they fall through to the existing dynamic import path with no behaviour change.

## What this doesn't fix

The `$context` caching hang (a second hang vector mentioned in #10315 — if the request driving `initFn(options)` is aborted before it resolves, the cached pending promise poisons the instance) is a separate issue and not addressed here.

Fixes #10315

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve `AsyncLocalStorage` from `globalThis` on edge runtimes to prevent dynamic import hangs on Cloudflare Workers. Fixes #10315 by making the module-level resolution abort-safe while keeping Node/Bun behavior unchanged.

- **Bug Fixes**
  - Use `globalThis.AsyncLocalStorage` when available and wrap with `Promise.resolve(...)` (abort-safe on Workers).
  - Fallback to `import('node:async_hooks')` on Node.js/Bun; browser environments return `null`, otherwise warnings are logged when unavailable.

<sup>Written for commit 4c4af01bb30426e8416d74fb8b57782afcd71365. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

