### PR TITLE
fix(cli): avoid duplicate unique indexes in drizzle schema

### DIFF
--- a/.changeset/hot-knives-yawn.md
+++ b/.changeset/hot-knives-yawn.md
@@ -1,0 +1,6 @@
+---
+"auth": patch
+"better-auth": patch
+---
+
+Fixes Drizzle schema generation for fields that are both unique: true and index: true.

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -222,12 +222,6 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 									name: `${modelName}_${fieldName}_idx`,
 									on: fieldName,
 								});
-							} else if (attr.index && attr.unique) {
-								indexes.push({
-									type: "uniqueIndex",
-									name: `${modelName}_${fieldName}_uidx`,
-									on: fieldName,
-								});
 							}
 
 							if (
@@ -662,14 +656,8 @@ function generateImport({
 	const hasIndexes = Object.values(tables).some((table) =>
 		Object.values(table.fields).some((field) => field.index && !field.unique),
 	);
-	const hasUniqueIndexes = Object.values(tables).some((table) =>
-		Object.values(table.fields).some((field) => field.unique && field.index),
-	);
 	if (hasIndexes) {
 		coreImports.push("index");
-	}
-	if (hasUniqueIndexes) {
-		coreImports.push("uniqueIndex");
 	}
 
 	return `${rootImports.length > 0 ? `import { ${rootImports.join(", ")} } from "drizzle-orm";\n` : ""}import { ${coreImports

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -463,6 +463,42 @@ describe("generate", async () => {
 		expect(schema.code).toContain(String.raw`.default('say "hi"\\done')`);
 	});
 
+	it("should not emit duplicate unique indexes for unique indexed fields", async () => {
+		const pluginWithUniqueIndexedField = (): BetterAuthPlugin => ({
+			id: "unique-index-test",
+			schema: {
+				testTable: {
+					fields: {
+						slug: {
+							type: "string",
+							index: true,
+							unique: true,
+						},
+					},
+				},
+			},
+		});
+
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: {
+				id: "drizzle",
+				options: {
+					provider: "pg",
+					schema: {},
+				},
+			} as any,
+			options: {
+				database: {} as any,
+				plugins: [pluginWithUniqueIndexedField()],
+			} as BetterAuthOptions,
+		});
+
+		expect(schema.code).toContain('slug: text("slug").notNull().unique()');
+		expect(schema.code).not.toContain("uniqueIndex");
+		expect(schema.code).not.toContain("slug_uidx");
+	});
+
 	it("should treat fields with omitted required as non-optional in prisma schema", async () => {
 		const originalCwd = process.cwd();
 		const tmpDir = fs.mkdtempSync(


### PR DESCRIPTION
Closes #10332

Fixes Drizzle schema generation for fields that are both `unique: true` and `index: true`. 

These fields already emit column-level `.unique()`, so the generator should not also emit a table-level `uniqueIndex(...)` for the same column. Added a regression test for this case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop generating duplicate unique indexes in Drizzle schemas. For fields with `unique: true` and `index: true`, the CLI now emits only column-level `.unique()` and skips table-level `uniqueIndex(...)` and its import.

- **Bug Fixes**
  - Removed `uniqueIndex` generation and its import for unique indexed fields.
  - Added a regression test to ensure only `.unique()` is emitted and no `uniqueIndex` appears.

- **Dependencies**
  - Added a changeset to publish patch updates for `auth` and `better-auth`.

<sup>Written for commit bd5e710fde4bc675163839b7b141b601f8ef47ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

