### PR TITLE
fix(oauth-provider): persist null revoked refresh tokens

### DIFF
--- a/.changeset/fix-oauth-provider-refresh-revoked-null.md
+++ b/.changeset/fix-oauth-provider-refresh-revoked-null.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Persist new OAuth refresh token rows with an explicit `revoked: null` value so rotation compare-and-swap guards work with adapters that distinguish missing fields from null.

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -663,6 +663,44 @@ describe("oauth token - refresh_token", async () => {
 		expect(tokens?.refresh_token).not.toEqual(newTokens.data?.refresh_token);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10309
+	 */
+	it("persists unrevoked refresh token rows with explicit null revoked value", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+
+		const context = await authorizationServer.$context;
+		const existingRefreshRows = await context.adapter.findMany<{
+			id: string;
+		}>({
+			model: "oauthRefreshToken",
+			where: [{ field: "clientId", value: oauthClient.client_id }],
+		});
+		const existingRefreshIds = new Set(
+			existingRefreshRows.map((row) => row.id),
+		);
+
+		const scopes = ["openid", "profile", "offline_access"];
+		const tokens = await authorizeForRefreshToken(scopes);
+		expect(tokens?.refresh_token).toBeDefined();
+
+		const refreshRows = await context.adapter.findMany<{
+			id: string;
+			revoked: Date | null;
+		}>({
+			model: "oauthRefreshToken",
+			where: [{ field: "clientId", value: oauthClient.client_id }],
+		});
+		const newRefreshRows = refreshRows.filter(
+			(row) => !existingRefreshIds.has(row.id),
+		);
+
+		expect(newRefreshRows).toHaveLength(1);
+		expect(newRefreshRows[0]?.revoked).toBeNull();
+	});
+
 	it("should preserve auth_time in id_token after refresh (OIDC Core 1.0 Section 12.2)", async ({
 		expect,
 	}) => {

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -350,6 +350,7 @@ async function createRefreshToken(
 		scopes,
 		createdAt: new Date(iat * 1000),
 		expiresAt: new Date(exp * 1000),
+		revoked: null,
 	};
 
 	// Initial issuance (no rotation): single insert.

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1048,9 +1048,9 @@ export interface OAuthRefreshToken<
 	expiresAt: Date;
 	createdAt: Date;
 	/**
-	 * When token was revoked. If set, token is considered a replay attack.
+	 * When token was revoked. If set to a date, token is considered a replay attack.
 	 */
-	revoked?: Date;
+	revoked?: Date | null;
 	/**
 	 * The time the user originally authenticated.
 	 * Persisted so refreshed ID tokens can include a correct `auth_time` claim.


### PR DESCRIPTION
## Summary
- Persist newly issued OAuth refresh token rows with an explicit `revoked: null` value.
- Add a regression test covering adapters that distinguish missing fields from null during refresh token rotation.
- Add a patch changeset for `@better-auth/oauth-provider`.

Fixes #10309

## Tests
- `pnpm exec vitest --config vitest.config.ts packages/oauth-provider/src/token.test.ts -t "persists unrevoked refresh token rows with explicit null revoked value"`
- `pnpm exec vitest --config vitest.config.ts packages/oauth-provider/src/token.test.ts -t "oauth token - refresh_token"`
- `pnpm typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist `revoked: null` for newly issued OAuth refresh tokens to make rotation compare-and-swap checks consistent across adapters. Fixes #10309.

- **Bug Fixes**
  - Set `revoked: null` on insert and update `OAuthRefreshToken` to `revoked?: Date | null` to align behavior across adapters.
  - Add a regression test and a patch changeset for `@better-auth/oauth-provider`.

<sup>Written for commit dc781f2fc20aa47facea581b65b959bac25513ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

