### PR TITLE
docs: add better-inbox to community plugins

### DIFF
--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -38,3 +38,4 @@ Balázs
 Koomen
 Arnav
 Sahu
+stewartjarod

--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -291,4 +291,15 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/SulimanAbdulrazzaq.png",
 		},
 	},
+	{
+		name: "better-inbox",
+		url: "https://github.com/better-inbox/better-inbox",
+		description:
+			"In-app notifications for Better Auth apps. One plugin, one migration, one component — notifications live in your database, addressed to your users.",
+		author: {
+			name: "stewartjarod",
+			github: "stewartjarod",
+			avatar: "https://github.com/stewartjarod.png",
+		},
+	},
 ];


### PR DESCRIPTION
### What

Adds [better-inbox](https://github.com/better-inbox/better-inbox) to the community plugins list.

better-inbox is in-app notifications for Better Auth apps: one plugin, one migration, one component. Notifications live in your own database, addressed to your users — no third-party notification service.

- Repo: https://github.com/better-inbox/better-inbox
- npm: https://www.npmjs.com/package/better-inbox

### Changes

- Appends one entry to `docs/lib/community-plugins-data.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `better-inbox` to the community plugins list in docs to highlight in-app notifications for Better Auth apps. Updates `docs/lib/community-plugins-data.ts` with the new entry and adds `stewartjarod` to `.cspell/names.txt` to satisfy spell checks.

<sup>Written for commit 605843ad122a1f4c832b77db483abab912f9f600. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

