### PR TITLE
fix(open-api): document form-encoded request bodies

### DIFF
--- a/.changeset/oauth-revoke-openapi-form.md
+++ b/.changeset/oauth-revoke-openapi-form.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Document form-only request bodies with their allowed media type in generated OpenAPI schemas.

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -75,10 +75,7 @@ type OpenAPIResponse = {
 
 type OpenAPIRequestBody = {
 	required?: boolean;
-	content: {
-		"application/json": OpenAPIRequestMediaTypeObject;
-		[contentType: string]: OpenAPIRequestMediaTypeObject | undefined;
-	};
+	content: Record<string, OpenAPIRequestMediaTypeObject | undefined>;
 };
 
 type OpenAPIOperation = {
@@ -400,25 +397,33 @@ function mergeObjectSchemas(
 function getRequestBody(
 	options: EndpointOptions,
 ): OpenAPIRequestBody | undefined {
-	const contentTypes = options.metadata?.allowedMediaTypes?.filter(
+	const allowedContentTypes = options.metadata?.allowedMediaTypes?.filter(
 		(type) => type.length > 0,
-	) || ["application/json"];
+	);
+	const contentTypes = allowedContentTypes?.length
+		? allowedContentTypes
+		: ["application/json"];
 	if (options.metadata?.openapi?.requestBody) {
 		const requestBody = options.metadata.openapi.requestBody;
-		const mediaType =
-			requestBody.content["application/json"] ||
-			Object.values(requestBody.content).find((value) => value !== undefined);
-		if (!mediaType) {
-			return requestBody;
-		}
+		const requestBodyContent =
+			requestBody.content as OpenAPIRequestBody["content"];
+		const fallbackMediaType =
+			requestBodyContent["application/json"] ??
+			Object.values(requestBodyContent).find((value) => value !== undefined);
+		const content = Object.fromEntries(
+			contentTypes
+				.map((contentType) => {
+					const mediaType =
+						requestBodyContent[contentType] ?? fallbackMediaType;
+					return mediaType
+						? ([contentType, cloneOpenAPIValue(mediaType)] as const)
+						: undefined;
+				})
+				.filter((entry) => entry !== undefined),
+		);
 		return {
 			...requestBody,
-			content: Object.fromEntries(
-				contentTypes.map((contentType) => [
-					contentType,
-					cloneOpenAPIValue(mediaType),
-				]),
-			) as OpenAPIRequestBody["content"],
+			content,
 		};
 	}
 	if (!options.body) return undefined;

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -57,6 +57,10 @@ type OpenAPIMediaTypeObject = {
 	schema?: OpenAPISchema;
 };
 
+type OpenAPIRequestMediaTypeObject = {
+	schema: OpenAPISchema;
+};
+
 type OpenAPIResponseContent = {
 	"application/json"?: OpenAPIMediaTypeObject;
 	"text/plain"?: OpenAPIMediaTypeObject;
@@ -72,9 +76,8 @@ type OpenAPIResponse = {
 type OpenAPIRequestBody = {
 	required?: boolean;
 	content: {
-		"application/json": {
-			schema: OpenAPISchema;
-		};
+		"application/json": OpenAPIRequestMediaTypeObject;
+		[contentType: string]: OpenAPIRequestMediaTypeObject | undefined;
 	};
 };
 
@@ -397,8 +400,26 @@ function mergeObjectSchemas(
 function getRequestBody(
 	options: EndpointOptions,
 ): OpenAPIRequestBody | undefined {
+	const contentTypes = options.metadata?.allowedMediaTypes?.filter(
+		(type) => type.length > 0,
+	) || ["application/json"];
 	if (options.metadata?.openapi?.requestBody) {
-		return options.metadata.openapi.requestBody;
+		const requestBody = options.metadata.openapi.requestBody;
+		const mediaType =
+			requestBody.content["application/json"] ||
+			Object.values(requestBody.content).find((value) => value !== undefined);
+		if (!mediaType) {
+			return requestBody;
+		}
+		return {
+			...requestBody,
+			content: Object.fromEntries(
+				contentTypes.map((contentType) => [
+					contentType,
+					cloneOpenAPIValue(mediaType),
+				]),
+			) as OpenAPIRequestBody["content"],
+		};
 	}
 	if (!options.body) return undefined;
 	const requestBodySchemaInfo = getRequestBodySchemaInfo(
@@ -407,11 +428,9 @@ function getRequestBody(
 	const schema = toOpenApiSchema(requestBodySchemaInfo.schema);
 	return {
 		required: requestBodySchemaInfo.required,
-		content: {
-			"application/json": {
-				schema,
-			},
-		},
+		content: Object.fromEntries(
+			contentTypes.map((contentType) => [contentType, { schema }]),
+		) as OpenAPIRequestBody["content"],
 	};
 }
 

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -8,6 +8,24 @@ import { openAPI } from ".";
 import type { OpenAPISchema, Path } from "./generator";
 
 type PostRequestBody = NonNullable<NonNullable<Path["post"]>["requestBody"]>;
+type TestRequestSchema = {
+	type?: "object";
+	properties?: Record<string, { type: "string" }>;
+	required?: string[];
+	$ref?: string;
+};
+
+type TestRequestMediaType = {
+	schema: TestRequestSchema;
+};
+
+type TestRequestBody = {
+	required: boolean;
+	content: {
+		"application/json": TestRequestMediaType;
+		[contentType: string]: TestRequestMediaType | undefined;
+	};
+};
 
 function getPostRequestBody(
 	paths: Record<string, Path>,
@@ -18,6 +36,17 @@ function getPostRequestBody(
 		throw new Error(`Expected ${path} to define a POST request body`);
 	}
 	return requestBody;
+}
+
+function getRequestBodySchema(
+	requestBody: PostRequestBody,
+	contentType = "application/json",
+) {
+	const mediaType = requestBody.content[contentType];
+	if (!mediaType) {
+		throw new Error(`Expected request body to define ${contentType}`);
+	}
+	return mediaType.schema;
 }
 
 function getSchemaProperty(schema: OpenAPISchema, propertyName: string) {
@@ -286,6 +315,73 @@ const formEncodedBodyPlugin = {
 	},
 } satisfies BetterAuthPlugin;
 
+const emptyAllowedMediaTypesPlugin = {
+	id: "empty-allowed-media-types-test",
+	endpoints: {
+		emptyAllowedMediaTypes: createAuthEndpoint(
+			"/test/empty-allowed-media-types",
+			{
+				method: "POST",
+				body: z.object({
+					token: z.string(),
+				}),
+				metadata: {
+					allowedMediaTypes: [""],
+				},
+			},
+			async () => ({ success: true }),
+		),
+	},
+} satisfies BetterAuthPlugin;
+
+const explicitRequestBodyContentPlugin = {
+	id: "explicit-request-body-content-test",
+	endpoints: {
+		explicitRequestBodyContent: createAuthEndpoint(
+			"/test/explicit-request-body-content",
+			{
+				method: "POST",
+				metadata: {
+					allowedMediaTypes: [
+						"application/json",
+						"application/x-www-form-urlencoded",
+					],
+					openapi: {
+						requestBody: {
+							required: true,
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											jsonToken: {
+												type: "string",
+											},
+										},
+										required: ["jsonToken"],
+									},
+								},
+								"application/x-www-form-urlencoded": {
+									schema: {
+										type: "object",
+										properties: {
+											formToken: {
+												type: "string",
+											},
+										},
+										required: ["formToken"],
+									},
+								},
+							},
+						} as TestRequestBody,
+					},
+				},
+			},
+			async () => ({ success: true }),
+		),
+	},
+} satisfies BetterAuthPlugin;
+
 describe("open-api", async () => {
 	const { auth } = await getTestInstance({
 		plugins: [openAPI()],
@@ -334,6 +430,12 @@ describe("open-api", async () => {
 	});
 	const { auth: authWithFormEncodedBody } = await getTestInstance({
 		plugins: [openAPI(), formEncodedBodyPlugin],
+	});
+	const { auth: authWithEmptyAllowedMediaTypes } = await getTestInstance({
+		plugins: [openAPI(), emptyAllowedMediaTypesPlugin],
+	});
+	const { auth: authWithExplicitRequestBodyContent } = await getTestInstance({
+		plugins: [openAPI(), explicitRequestBodyContentPlugin],
 	});
 
 	it("should generate OpenAPI schema", async () => {
@@ -742,10 +844,10 @@ describe("open-api", async () => {
 		const requestBody = paths["/test/nullable-intersection"].post.requestBody;
 		expect(requestBody.required).toBe(true);
 
-		const requestBodySchema = requestBody.content["application/json"].schema;
+		const requestBodySchema = getRequestBodySchema(requestBody);
 		expect(requestBodySchema.type).toEqual(["object", "null"]);
-		expect(requestBodySchema.properties.email.type).toBe("string");
-		expect(requestBodySchema.properties.otp.type).toBe("string");
+		expect(getSchemaProperty(requestBodySchema, "email").type).toBe("string");
+		expect(getSchemaProperty(requestBodySchema, "otp").type).toBe("string");
 		expect(requestBodySchema.required).toEqual(["email", "otp"]);
 	});
 
@@ -756,9 +858,11 @@ describe("open-api", async () => {
 		const requestBody = paths["/test/default-body"].post.requestBody;
 		expect(requestBody.required).toBe(false);
 
-		const requestBodySchema = requestBody.content["application/json"].schema;
+		const requestBodySchema = getRequestBodySchema(requestBody);
 		expect(requestBodySchema.type).toBe("object");
-		expect(requestBodySchema.properties.rememberMe.type).toBe("boolean");
+		expect(getSchemaProperty(requestBodySchema, "rememberMe").type).toBe(
+			"boolean",
+		);
 		expect(requestBodySchema.default).toBeUndefined();
 	});
 
@@ -769,7 +873,7 @@ describe("open-api", async () => {
 		const requestBody = getPostRequestBody(paths, "/test/choose-role");
 		expect(requestBody.required).toBe(true);
 
-		const requestBodySchema = requestBody.content["application/json"].schema;
+		const requestBodySchema = getRequestBodySchema(requestBody);
 		expect(requestBodySchema.allOf).toHaveLength(2);
 		expect(getComposedSchemaItem(requestBodySchema.allOf, 0)).toEqual({
 			type: "object",
@@ -808,7 +912,7 @@ describe("open-api", async () => {
 		const paths = schema.paths as Record<string, Path>;
 
 		const requestBody = getPostRequestBody(paths, "/test/update-fields");
-		const requestBodySchema = requestBody.content["application/json"].schema;
+		const requestBodySchema = getRequestBodySchema(requestBody);
 
 		expect(requestBodySchema.type).toBe("object");
 		expect(requestBodySchema.required).toEqual(["knownField"]);
@@ -859,7 +963,7 @@ describe("open-api", async () => {
 		expect(requestBody.required).toBe(false);
 		expect(defaultFactoryCallCount).toBe(0);
 
-		const requestBodySchema = requestBody.content["application/json"].schema;
+		const requestBodySchema = getRequestBodySchema(requestBody);
 		expect(requestBodySchema.default).toBeUndefined();
 		expect(getSchemaProperty(requestBodySchema, "nonce").type).toBe("string");
 	});
@@ -872,7 +976,7 @@ describe("open-api", async () => {
 		const requestBody = getPostRequestBody(paths, "/test/wrapper-semantics");
 		expect(requestBody.required).toBe(true);
 
-		const requestBodySchema = requestBody.content["application/json"].schema;
+		const requestBodySchema = getRequestBodySchema(requestBody);
 		expect(requestBodySchema.required).toEqual(["nonOptional"]);
 		expect(wrapperDefaultFactoryCallCount).toBe(0);
 
@@ -915,6 +1019,57 @@ describe("open-api", async () => {
 				},
 			},
 			required: ["token"],
+		});
+	});
+
+	it("should fall back to JSON when allowed media types are empty", async () => {
+		const schema =
+			await authWithEmptyAllowedMediaTypes.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, Path>;
+
+		const requestBody = getPostRequestBody(
+			paths,
+			"/test/empty-allowed-media-types",
+		);
+		expect(getRequestBodySchema(requestBody)).toEqual({
+			type: "object",
+			properties: {
+				token: {
+					type: "string",
+				},
+			},
+			required: ["token"],
+		});
+	});
+
+	it("should preserve explicit request body content schemas", async () => {
+		const schema =
+			await authWithExplicitRequestBodyContent.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, Path>;
+
+		const requestBody = getPostRequestBody(
+			paths,
+			"/test/explicit-request-body-content",
+		);
+		expect(getRequestBodySchema(requestBody)).toEqual({
+			type: "object",
+			properties: {
+				jsonToken: {
+					type: "string",
+				},
+			},
+			required: ["jsonToken"],
+		});
+		expect(
+			getRequestBodySchema(requestBody, "application/x-www-form-urlencoded"),
+		).toEqual({
+			type: "object",
+			properties: {
+				formToken: {
+					type: "string",
+				},
+			},
+			required: ["formToken"],
 		});
 	});
 });

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -267,6 +267,25 @@ const wrapperSemanticsPlugin = {
 	},
 } satisfies BetterAuthPlugin;
 
+const formEncodedBodyPlugin = {
+	id: "form-encoded-body-test",
+	endpoints: {
+		formEncodedBody: createAuthEndpoint(
+			"/test/form-encoded-body",
+			{
+				method: "POST",
+				body: z.object({
+					token: z.string(),
+				}),
+				metadata: {
+					allowedMediaTypes: ["application/x-www-form-urlencoded"],
+				},
+			},
+			async () => ({ success: true }),
+		),
+	},
+} satisfies BetterAuthPlugin;
+
 describe("open-api", async () => {
 	const { auth } = await getTestInstance({
 		plugins: [openAPI()],
@@ -312,6 +331,9 @@ describe("open-api", async () => {
 	});
 	const { auth: authWithWrapperSemantics } = await getTestInstance({
 		plugins: [openAPI(), wrapperSemanticsPlugin],
+	});
+	const { auth: authWithFormEncodedBody } = await getTestInstance({
+		plugins: [openAPI(), formEncodedBodyPlugin],
 	});
 
 	it("should generate OpenAPI schema", async () => {
@@ -875,5 +897,24 @@ describe("open-api", async () => {
 		expect(getSchemaProperty(requestBodySchema, "unionOptional").type).toBe(
 			"string",
 		);
+	});
+
+	it("should document generated request bodies with allowed media types", async () => {
+		const schema = await authWithFormEncodedBody.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, Path>;
+
+		const requestBody = getPostRequestBody(paths, "/test/form-encoded-body");
+		expect(requestBody.content["application/json"]).toBeUndefined();
+		expect(
+			requestBody.content["application/x-www-form-urlencoded"]?.schema,
+		).toEqual({
+			type: "object",
+			properties: {
+				token: {
+					type: "string",
+				},
+			},
+			required: ["token"],
+		});
 	});
 });

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -6,6 +6,7 @@ import {
 	organizationClient,
 } from "better-auth/client/plugins";
 import { toNodeHandler } from "better-auth/node";
+import { openAPI } from "better-auth/plugins";
 import type { GenericOAuthConfig } from "better-auth/plugins/generic-oauth";
 import { genericOAuth } from "better-auth/plugins/generic-oauth";
 import { jwt } from "better-auth/plugins/jwt";
@@ -44,6 +45,18 @@ function isRedirectResult(
 	);
 }
 
+type OpenAPIRequestBody = {
+	content: Record<string, unknown>;
+};
+
+type OpenAPIPostOperation = {
+	requestBody?: OpenAPIRequestBody;
+};
+
+type OpenAPIPath = {
+	post?: OpenAPIPostOperation;
+};
+
 describe("oauth - init", () => {
 	const createSecondaryStorage = () => ({
 		set(key: string, value: string, ttl?: number) {},
@@ -68,6 +81,36 @@ describe("oauth - init", () => {
 				],
 			}),
 		).rejects.toThrowError("jwt_config");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10346
+	 */
+	it("should document the revoke endpoint as form encoded", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [
+				openAPI(),
+				jwt(),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+				}),
+			],
+		});
+
+		const schema = await auth.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, OpenAPIPath>;
+		const requestBody = paths["/oauth2/revoke"]?.post?.requestBody;
+
+		expect(requestBody).toBeDefined();
+		expect(requestBody?.content["application/json"]).toBeUndefined();
+		expect(
+			requestBody?.content["application/x-www-form-urlencoded"],
+		).toBeDefined();
 	});
 
 	it("should pass without the jwt plugin and disableJwtPlugin set", async ({


### PR DESCRIPTION
## Summary

Fixes #10346.

Updates OpenAPI generation so request bodies respect endpoint `allowedMediaTypes` instead of always documenting JSON. This makes `/oauth2/revoke` show `application/x-www-form-urlencoded`, matching the runtime contract.

Also adds regression coverage for generated form-encoded request bodies and the OAuth provider revoke endpoint.

## Testing

- Passed: Biome check on changed files
- Passed: `packages/better-auth` TypeScript check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
OpenAPI now documents form-encoded request bodies based on each endpoint’s `allowedMediaTypes`, and preserves explicit per-media-type schemas. `/oauth2/revoke` is shown as `application/x-www-form-urlencoded`, matching the runtime.

- **Bug Fixes**
  - `better-auth` OpenAPI generator builds request body content from `metadata.allowedMediaTypes` (defaults to `application/json`), preserves explicit media schemas in custom `openapi.requestBody`, and falls back to an existing media schema when one is missing.
  - Added regression tests for form-encoded bodies, explicit multi-media request bodies, empty `allowedMediaTypes` fallback, and the revoke endpoint in `oauth-provider`.

<sup>Written for commit e918ed4d2e04717a25f90d43156958cb5532ccbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

