### PR TITLE
feat(device-authorization): support RFC 8707 resource indicators and RFC 9068 JWT access tokens

### DIFF
--- a/.changeset/device-authorization-resource-indicators.md
+++ b/.changeset/device-authorization-resource-indicators.md
@@ -2,4 +2,4 @@
 "better-auth": minor
 ---
 
-Add RFC 8707 resource indicator support to the device authorization plugin. Passing a `resource` to `/device/code` and/or `/device/token` now returns an RFC 9068 JWT access token audience-restricted to that resource, validated against a new `allowedResources` option, with an optional `customAccessTokenClaims` hook. Without a `resource`, behavior is unchanged (opaque token).
+Add RFC 8707 resource indicator support to the device authorization plugin. Bind one or more allowed resources at `/device/code`, then omit `resource` at `/device/token` to use the full grant or request a subset. The token endpoint returns an RFC 9068 JWT access token restricted to the resolved audience, and `GET /device` exposes the bound client, scope, and resource to the authenticated user for approval. The existing opaque-token behavior remains unchanged when the device request omits `resource`.

--- a/.changeset/device-authorization-resource-indicators.md
+++ b/.changeset/device-authorization-resource-indicators.md
@@ -2,4 +2,4 @@
 "better-auth": minor
 ---
 
-Add RFC 8707 resource indicator support to the device authorization plugin. Bind one or more allowed resources at `/device/code`, then omit `resource` at `/device/token` to use the full grant or request a subset. The token endpoint returns an RFC 9068 JWT access token restricted to the resolved audience, and `GET /device` exposes the bound client, scope, and resource to the authenticated user for approval. The existing opaque-token behavior remains unchanged when the device request omits `resource`.
+Device authorization can now bind one or more RFC 8707 `resource` values at `/device/code` and issue an RFC 9068 JWT access token for the approved audience, or a requested subset, at `/device/token`. Enable this path with the JWT plugin and `allowedResources`; requests without `resource` continue returning opaque tokens. Authenticated approval pages can read the requested `client_id`, `scope`, and `resource` from `GET /device`, and `customAccessTokenClaims` can add non-reserved claims to issued JWTs. Re-run Better Auth schema migration or generation to add the nullable `deviceCode.resource` field.

--- a/.changeset/device-authorization-resource-indicators.md
+++ b/.changeset/device-authorization-resource-indicators.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Add RFC 8707 resource indicator support to the device authorization plugin. Passing a `resource` to `/device/code` and/or `/device/token` now returns an RFC 9068 JWT access token audience-restricted to that resource, validated against a new `allowedResources` option, with an optional `customAccessTokenClaims` hook. Without a `resource`, behavior is unchanged (opaque token).

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -247,8 +247,10 @@ The user authorization flow requires two steps:
 1. **Code Verification**: Validate the user code via `GET /device`. The verification request claims the pending device code for the calling session.
 2. **Authorization**: The session that claimed the code can approve or deny it.
 
+The verification response includes the requesting `client_id`, `scope`, and `resource` for the authenticated user who owns the code. Display these values before offering approval so the user can review which client is requesting which permissions and audiences.
+
 <Callout type="warn">
-  Users must be authenticated when calling `GET /device`, because the verification step binds the pending device code to that session. Only the same session can later approve or deny. If the user is not authenticated when entering the code, redirect them to the login page with a return URL and re-call `GET /device` after sign-in.
+  Authenticate the user before using `GET /device` for approval. An unauthenticated request can validate the code status, but it does not claim the request or receive its client, scope, and resource details. After sign-in, call `GET /device` again so the request is bound to that session; only the same session can later approve or deny it.
 </Callout>
 
 Create a page where users can enter their code:
@@ -410,9 +412,10 @@ deviceAuthorization({
     return client && client.allowDeviceFlow;
   },
   
-  onDeviceAuthRequest: async (clientId, scope) => {
-    // Log device authorization requests
-    await logDeviceAuthRequest(clientId, scope);
+  onDeviceAuthRequest: async (clientId, scope, resource) => {
+    // Enforce the client-to-resource and scope policy for this deployment.
+    await authorizeDeviceRequest({ clientId, scope, resource });
+    await logDeviceAuthRequest(clientId, scope, resource);
   },
 })
 ```
@@ -594,8 +597,10 @@ authenticateCLI().catch((err) => {
 3. **Client Validation**: Always validate client IDs in production to prevent unauthorized access
 4. **HTTPS Only**: Always use HTTPS in production for device authorization
 5. **User Code Format**: User codes use a limited character set (excluding similar-looking characters like 0/O, 1/I) to reduce typing errors
-6. **Authentication Required**: Users must be authenticated when calling `GET /device`. The verification step claims the pending device code for the calling session, and only that session can later approve or deny it
+6. **Authentication Required**: Users must be authenticated for `GET /device` to claim the pending code and return its approval details. Only the same session can later approve or deny it
 7. **Pre-binding**: Device codes issued with `user_id` skip the claiming step and can only be approved or denied by that user. Pass `user_id` from trusted server-side code only
+8. **Informed Approval**: Display the `client_id`, `scope`, and `resource` returned by `GET /device` before the user approves the request
+9. **Resource Policy**: `allowedResources` is a global allow-list. Use `onDeviceAuthRequest` to enforce which resources and scopes each client may request. If you permit multiple resources, ensure every requested scope has the same meaning for every resource in the resulting `aud` claim
 
 ## Options
 
@@ -637,7 +642,7 @@ No client-specific configuration options. The plugin adds the following methods:
 
 By default the device flow returns an **opaque** access token. To obtain a JWT-formatted access token ([RFC 9068](https://datatracker.ietf.org/doc/html/rfc9068)) that a resource server can validate locally, request an [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) `resource` indicator and configure the allow-list.
 
-This requires the [JWT plugin](/docs/plugins/jwt) to be enabled: its signing key signs the token, and its `/jwks` endpoint is what resource servers call to verify it. If a `resource` is requested while the JWT plugin isn't registered, the token exchange (`POST /device/token`) fails with a `server_error`.
+This requires the [JWT plugin](/docs/plugins/jwt) to be enabled: its signing key signs the token, and its configured JWKS endpoint publishes the verification keys. If a `resource` is requested while the JWT plugin isn't registered, the token exchange (`POST /device/token`) fails with a `server_error`.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
@@ -659,11 +664,15 @@ Pass `resource` when **requesting the device code** — this binds the audience 
 
 ```http
 POST /device/code
+Content-Type: application/x-www-form-urlencoded
+
 client_id=my-client&scope=read&resource=https://api.example.com
 ```
 
 ```http
 POST /device/token
+Content-Type: application/x-www-form-urlencoded
+
 grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code=...&client_id=my-client
 ```
 
@@ -671,7 +680,9 @@ When a valid `resource` is present, `access_token` in the `/device/token` respon
 
 ### Options
 
-**allowedResources**: Allow-list of absolute-URI resource indicators (RFC 8707). A requested resource outside this list — or one that isn't an absolute URI, or contains a fragment — is rejected with `invalid_target`. When unset or empty, any `resource` request is rejected.
+**allowedResources**: Allow-list of absolute-URI resource indicators (RFC 8707). A requested resource outside this list, one that is not an absolute URI, or one that contains a fragment is rejected with `invalid_target`. When unset or empty, any `resource` request is rejected.
+
+`allowedResources` does not assign resources to individual clients. Use `onDeviceAuthRequest` to reject client, resource, or scope combinations that your deployment does not authorize. RFC 9068 requires every scope in a multi-audience token to apply unambiguously to every audience, so reject a multi-resource request when that condition does not hold.
 
 **customAccessTokenClaims**: Adds custom claims to the issued JWT access token. Receives `{ user, scopes, resource, clientId }` and returns a claims object, or a `Promise` of one.
 

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -655,7 +655,7 @@ export const auth = betterAuth({
 });
 ```
 
-You may pass `resource` when requesting the device code (recommended, since it binds the audience to the user's consent) and/or when exchanging the device code for a token. When it's supplied at both steps, the resource requested at token time must equal or be a subset of the resource bound at code-request time, or the exchange fails with `invalid_target`.
+Pass `resource` when **requesting the device code** — this binds the audience to what the user approves. At the **token exchange** the `resource` is optional: when supplied it must equal or be a subset of the resource bound at code-request time. A `resource` sent at the token exchange that was never bound at the device-code request is rejected with `invalid_target`, so the issued token's audience always reflects what was authorized.
 
 ```http
 POST /device/code

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -121,6 +121,12 @@ To initiate device authorization, call `device.code` with the client ID:
        * Pass this from trusted server-side code only. (optional)
        */
       user_id?: string;
+      /**
+       * RFC 8707 resource indicator(s) the issued access token should be
+       * scoped to. Requesting a valid resource yields a JWT access token
+       * whose audience is that resource, instead of an opaque token. (optional)
+       */
+      resource?: string | string[];
   }
   ```
 </APIMethod>
@@ -181,6 +187,12 @@ After displaying the user code, poll for the access token:
        * The OAuth client identifier
        */
       client_id: string;
+      /**
+       * RFC 8707 resource indicator(s). Must equal or be a subset of the
+       * resource bound at /device/code. A valid resource yields a JWT
+       * access token. (optional)
+       */
+      resource?: string | string[];
   }
   ```
 </APIMethod>
@@ -434,13 +446,14 @@ deviceAuthorization({
 
 The device flow defines specific error codes:
 
-| Error Code              | Description                                 |
-| ----------------------- | ------------------------------------------- |
-| `authorization_pending` | User hasn't approved yet (continue polling) |
-| `slow_down`             | Polling too frequently (increase interval)  |
-| `expired_token`         | Device code has expired                     |
-| `access_denied`         | User denied the authorization               |
-| `invalid_grant`         | Invalid device code or client ID            |
+| Error Code              | Description                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| `authorization_pending` | User hasn't approved yet (continue polling)                                  |
+| `slow_down`             | Polling too frequently (increase interval)                                   |
+| `expired_token`         | Device code has expired                                                      |
+| `access_denied`         | User denied the authorization                                                |
+| `invalid_grant`         | Invalid device code or client ID                                             |
+| `invalid_target`        | Requested `resource` is unknown, disallowed, malformed, or exceeds the grant |
 
 ## Example: CLI Application
 
@@ -604,7 +617,11 @@ authenticateCLI().catch((err) => {
 
 **validateClient**: Function to validate client IDs. Takes a clientId and returns boolean or `Promise<boolean>`.
 
-**onDeviceAuthRequest**: Hook called when device authorization is requested. Takes clientId and optional scope.
+**onDeviceAuthRequest**: Hook called when device authorization is requested. Takes clientId, optional scope, and the optional requested `resource`.
+
+**allowedResources**: Allow-list of RFC 8707 resource indicator URIs clients may request via `resource`. See [Requesting a JWT Access Token](#requesting-a-jwt-access-token-resource-indicators) below.
+
+**customAccessTokenClaims**: Hook to add custom claims to the JWT access token issued when a `resource` is requested. See [Requesting a JWT Access Token](#requesting-a-jwt-access-token-resource-indicators) below.
 
 ### Client
 
@@ -615,6 +632,56 @@ No client-specific configuration options. The plugin adds the following methods:
 * **device.token()**: Poll for access token
 * **device.approve()**: Approve device (requires authentication)
 * **device.deny()**: Deny device (requires authentication)
+
+## Requesting a JWT Access Token (Resource Indicators)
+
+By default the device flow returns an **opaque** access token. To obtain a JWT-formatted access token ([RFC 9068](https://datatracker.ietf.org/doc/html/rfc9068)) that a resource server can validate locally, request an [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) `resource` indicator and configure the allow-list.
+
+This requires the [JWT plugin](/docs/plugins/jwt) to be enabled: its signing key signs the token, and its `/jwks` endpoint is what resource servers call to verify it. If a `resource` is requested while the JWT plugin isn't registered, the token exchange (`POST /device/token`) fails with a `server_error`.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { jwt, deviceAuthorization } from "better-auth/plugins";
+
+export const auth = betterAuth({
+  plugins: [
+    jwt(),
+    deviceAuthorization({
+      // Only these resource URIs may be requested; anything else is
+      // rejected with `invalid_target`.
+      allowedResources: ["https://api.example.com"],
+    }),
+  ],
+});
+```
+
+You may pass `resource` when requesting the device code (recommended, since it binds the audience to the user's consent) and/or when exchanging the device code for a token. When it's supplied at both steps, the resource requested at token time must equal or be a subset of the resource bound at code-request time, or the exchange fails with `invalid_target`.
+
+```http
+POST /device/code
+client_id=my-client&scope=read&resource=https://api.example.com
+```
+
+```http
+POST /device/token
+grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code=...&client_id=my-client
+```
+
+When a valid `resource` is present, `access_token` in the `/device/token` response is a signed JWT whose `aud` claim is the requested resource (an array if multiple were requested). With no `resource` at all, behavior is unchanged: `access_token` is the existing opaque session token.
+
+### Options
+
+**allowedResources**: Allow-list of absolute-URI resource indicators (RFC 8707). A requested resource outside this list — or one that isn't an absolute URI, or contains a fragment — is rejected with `invalid_target`. When unset or empty, any `resource` request is rejected.
+
+**customAccessTokenClaims**: Adds custom claims to the issued JWT access token. Receives `{ user, scopes, resource, clientId }` and returns a claims object, or a `Promise` of one.
+
+<Callout type="info">
+  The JWT access token is stateless: it isn't stored, and it can't be revoked before it expires. Keep the JWT plugin's `expirationTime` short. Requesting a `resource` does not create a Better Auth session.
+</Callout>
+
+<Callout type="warn">
+  After upgrading, re-run the schema migration or generation (`npx auth migrate` or `npx auth generate`) so the `deviceCode` table gains the new, nullable `resource` column.
+</Callout>
 
 ## Schema
 
@@ -677,6 +744,12 @@ export const deviceCodeTableFields = [
 		name: "pollingInterval",
 		type: "number",
 		description: "Minimum seconds between polls",
+		isOptional: true,
+	},
+	{
+		name: "resource",
+		type: "string",
+		description: "RFC 8707 resource indicator(s) bound to this device code (JSON-encoded when there are multiple)",
 		isOptional: true,
 	},
 ];

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -62,6 +62,12 @@ describe("device authorization plugin input validation", () => {
 				allowedResources: ["https://api.example.com#frag"],
 			}),
 		).toThrow();
+		// A bare trailing `#` (empty fragment) is still a fragment component.
+		expect(() =>
+			deviceAuthorizationOptionsSchema.parse({
+				allowedResources: ["https://api.example.com/#"],
+			}),
+		).toThrow();
 		expect(
 			deviceAuthorizationOptionsSchema.parse({
 				allowedResources: ["https://api.example.com"],
@@ -1633,12 +1639,15 @@ describe("device authorization resource indicators", async () => {
 			expect(payload.iss).not.toBe("https://evil.example.com");
 		});
 
-		it("errors when a resource is requested without the jwt plugin", async () => {
-			const { auth: authNoJwt, signInWithTestUser: signIn } =
-				await getTestInstance(
-					{ plugins: [deviceAuthorization({ allowedResources })] },
-					{ clientOptions: { plugins: [deviceAuthorizationClient()] } },
-				);
+		it("errors without consuming the code when a resource is requested but the jwt plugin is missing", async () => {
+			const {
+				auth: authNoJwt,
+				signInWithTestUser: signIn,
+				db: dbNoJwt,
+			} = await getTestInstance(
+				{ plugins: [deviceAuthorization({ allowedResources })] },
+				{ clientOptions: { plugins: [deviceAuthorizationClient()] } },
+			);
 			const { device_code, user_code } = await authNoJwt.api.deviceCode({
 				body: { client_id: "test-client", resource: "https://api.example.com" },
 			});
@@ -1657,6 +1666,14 @@ describe("device authorization resource indicators", async () => {
 					},
 				}),
 			).rejects.toMatchObject({ body: { error: "server_error" } });
+
+			// The misconfiguration is caught before the code is consumed, so the
+			// approval survives once the jwt plugin is registered.
+			const record = await dbNoJwt.findOne<{ status?: string }>({
+				model: "deviceCode",
+				where: [{ field: "deviceCode", value: device_code }],
+			});
+			expect(record?.status).toBe("approved");
 		});
 
 		it("returns an opaque session token when no resource is requested (regression)", async () => {

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -50,6 +50,24 @@ describe("device authorization plugin input validation", () => {
 		expect(options.allowedResources).toEqual(["https://api.example.com"]);
 		expect(options.customAccessTokenClaims).toBe(claims);
 	});
+
+	it("rejects invalid allowedResources entries at parse time", () => {
+		expect(() =>
+			deviceAuthorizationOptionsSchema.parse({
+				allowedResources: ["not-a-uri"],
+			}),
+		).toThrow();
+		expect(() =>
+			deviceAuthorizationOptionsSchema.parse({
+				allowedResources: ["https://api.example.com#frag"],
+			}),
+		).toThrow();
+		expect(
+			deviceAuthorizationOptionsSchema.parse({
+				allowedResources: ["https://api.example.com"],
+			}).allowedResources,
+		).toEqual(["https://api.example.com"]);
+	});
 });
 
 describe("client validation", async () => {
@@ -1491,6 +1509,32 @@ describe("device authorization resource indicators", async () => {
 			).rejects.toMatchObject({ body: { error: "invalid_target" } });
 		});
 
+		it("does not consume the approved code when the token-time resource is invalid", async () => {
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: { client_id: "test-client" },
+			});
+			await approve(user_code);
+
+			// A disallowed resource is rejected WITHOUT burning the approved code.
+			await expect(
+				auth.api.deviceToken({
+					body: {
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						device_code,
+						client_id: "test-client",
+						resource: "https://evil.example.com",
+					},
+				}),
+			).rejects.toMatchObject({ body: { error: "invalid_target" } });
+
+			// The approved code survives in the database (was not consumed).
+			const record = await db.findOne<{ status?: string }>({
+				model: "deviceCode",
+				where: [{ field: "deviceCode", value: device_code }],
+			});
+			expect(record?.status).toBe("approved");
+		});
+
 		it("issues an array aud for multiple resources", async () => {
 			const { device_code, user_code } = await auth.api.deviceCode({
 				body: {
@@ -1523,7 +1567,13 @@ describe("device authorization resource indicators", async () => {
 							jwt(),
 							deviceAuthorization({
 								allowedResources,
-								customAccessTokenClaims: () => ({ tenant: "acme" }),
+								customAccessTokenClaims: () => ({
+									tenant: "acme",
+									// Attempts to override reserved claims must be ignored.
+									iss: "https://evil.example.com",
+									sub: "evil-user",
+									aud: "https://evil.example.com",
+								}),
 							}),
 						],
 					},
@@ -1555,6 +1605,10 @@ describe("device authorization resource indicators", async () => {
 				createLocalJWKSet(jwks),
 			);
 			expect(payload.tenant).toBe("acme");
+			// Reserved claims returned by the hook are stripped, not honored.
+			expect(payload.sub).not.toBe("evil-user");
+			expect(payload.aud).toBe("https://api.example.com");
+			expect(payload.iss).not.toBe("https://evil.example.com");
 		});
 
 		it("errors when a resource is requested without the jwt plugin", async () => {

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -9,6 +9,7 @@ import { getTestInstance } from "../../test-utils/test-instance";
 import { jwt } from "../jwt";
 import { deviceAuthorization, deviceAuthorizationOptionsSchema } from ".";
 import { deviceAuthorizationClient } from "./client";
+import { deviceToken } from "./routes";
 import type { DeviceCode } from "./schema";
 
 describe("device authorization plugin input validation", () => {
@@ -73,6 +74,35 @@ describe("device authorization plugin input validation", () => {
 				allowedResources: ["https://api.example.com"],
 			}).allowedResources,
 		).toEqual(["https://api.example.com"]);
+	});
+
+	it("declares server_error as a device token failure", () => {
+		const endpoint = deviceToken(deviceAuthorizationOptionsSchema.parse({}));
+		const errorSchema = endpoint.options.error;
+		expect(
+			errorSchema.safeParse({
+				error: "server_error",
+				error_description: "Token issuance failed",
+			}).success,
+		).toBe(true);
+
+		const responses = endpoint.options.metadata.openapi.responses as Record<
+			number,
+			{
+				content?: Record<
+					string,
+					{
+						schema?: {
+							properties?: { error?: { enum?: string[] } };
+						};
+					}
+				>;
+			}
+		>;
+		expect(
+			responses[500]?.content?.["application/json"]?.schema?.properties?.error
+				?.enum,
+		).toContain("server_error");
 	});
 });
 
@@ -1728,6 +1758,58 @@ describe("device authorization resource indicators", async () => {
 			expect(payload.auth_time).toBeUndefined();
 			expect(payload.acr).toBeUndefined();
 			expect(payload.amr).toBeUndefined();
+		});
+
+		it.each([
+			["null", null],
+			["an array", []],
+			["a primitive", "claims"],
+		] as const)("rejects customAccessTokenClaims that returns %s", async (_label, invalidClaims) => {
+			const { auth: authWithInvalidClaims, signInWithTestUser: signIn } =
+				await getTestInstance(
+					{
+						plugins: [
+							jwt(),
+							deviceAuthorization({
+								allowedResources,
+								customAccessTokenClaims: () =>
+									invalidClaims as unknown as Record<string, unknown>,
+							}),
+						],
+					},
+					{ clientOptions: { plugins: [deviceAuthorizationClient()] } },
+				);
+			const { device_code, user_code } =
+				await authWithInvalidClaims.api.deviceCode({
+					body: {
+						client_id: "test-client",
+						resource: "https://api.example.com",
+					},
+				});
+			const { headers } = await signIn();
+			await authWithInvalidClaims.api.deviceVerify({
+				query: { user_code },
+				headers,
+			});
+			await authWithInvalidClaims.api.deviceApprove({
+				body: { userCode: user_code },
+				headers,
+			});
+
+			await expect(
+				authWithInvalidClaims.api.deviceToken({
+					body: {
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						device_code,
+						client_id: "test-client",
+					},
+				}),
+			).rejects.toMatchObject({
+				body: {
+					error: "server_error",
+					error_description: "customAccessTokenClaims must return an object",
+				},
+			});
 		});
 
 		it("errors without consuming the code when a resource is requested but the jwt plugin is missing", async () => {

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -1472,9 +1472,30 @@ describe("device authorization resource indicators", async () => {
 			expect(session).toBeFalsy();
 		});
 
-		it("issues a JWT when the resource is requested at /device/token", async () => {
+		it("rejects a token-time resource that was not authorized at /device/code", async () => {
 			const { device_code, user_code } = await auth.api.deviceCode({
 				body: { client_id: "test-client" },
+			});
+			await approve(user_code);
+
+			await expect(
+				auth.api.deviceToken({
+					body: {
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						device_code,
+						client_id: "test-client",
+						resource: "https://api.example.com",
+					},
+				}),
+			).rejects.toMatchObject({ body: { error: "invalid_target" } });
+		});
+
+		it("honors a token-time resource that matches the code-time binding", async () => {
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: {
+					client_id: "test-client",
+					resource: "https://api.example.com",
+				},
 			});
 			await approve(user_code);
 
@@ -1515,7 +1536,8 @@ describe("device authorization resource indicators", async () => {
 			});
 			await approve(user_code);
 
-			// A disallowed resource is rejected WITHOUT burning the approved code.
+			// An invalid token-time resource is rejected WITHOUT burning the
+			// approved code (validation runs before the code is consumed).
 			await expect(
 				auth.api.deviceToken({
 					body: {

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -1420,6 +1420,58 @@ describe("device authorization resource indicators", async () => {
 			expect(record?.resource).toBe("https://api.example.com");
 		});
 
+		it("preserves repeated resource parameters from a form-encoded request", async () => {
+			const body = new URLSearchParams({ client_id: "test-client" });
+			body.append("resource", "https://api.example.com");
+			body.append("resource", "https://api.other.com");
+
+			const response = await auth.handler(
+				new Request("http://localhost:3000/api/auth/device/code", {
+					method: "POST",
+					headers: { "content-type": "application/x-www-form-urlencoded" },
+					body,
+				}),
+			);
+			expect(response.status).toBe(200);
+			const result = (await response.json()) as { device_code: string };
+			const record = await db.findOne<{ resource?: string }>({
+				model: "deviceCode",
+				where: [{ field: "deviceCode", value: result.device_code }],
+			});
+			expect(record?.resource).toBe(
+				JSON.stringify(["https://api.example.com", "https://api.other.com"]),
+			);
+		});
+
+		it("returns request details needed for informed approval", async () => {
+			const { user_code } = await auth.api.deviceCode({
+				body: {
+					client_id: "test-client",
+					scope: "read write",
+					resource: ["https://api.example.com", "https://api.other.com"],
+				},
+			});
+			const unauthenticatedResponse = await auth.api.deviceVerify({
+				query: { user_code },
+			});
+			expect(unauthenticatedResponse).not.toHaveProperty("client_id");
+			expect(unauthenticatedResponse).not.toHaveProperty("scope");
+			expect(unauthenticatedResponse).not.toHaveProperty("resource");
+
+			const { headers } = await signInWithTestUser();
+
+			const response = await auth.api.deviceVerify({
+				query: { user_code },
+				headers,
+			});
+
+			expect(response).toMatchObject({
+				client_id: "test-client",
+				scope: "read write",
+				resource: ["https://api.example.com", "https://api.other.com"],
+			});
+		});
+
 		it("rejects a resource not in allowedResources", async () => {
 			await expect(
 				auth.api.deviceCode({
@@ -1587,6 +1639,39 @@ describe("device authorization resource indicators", async () => {
 			]);
 		});
 
+		it("preserves repeated resource parameters at the form-encoded token endpoint", async () => {
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: {
+					client_id: "test-client",
+					resource: ["https://api.example.com", "https://api.other.com"],
+				},
+			});
+			await approve(user_code);
+
+			const body = new URLSearchParams({
+				grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+				device_code,
+				client_id: "test-client",
+			});
+			body.append("resource", "https://api.example.com");
+			body.append("resource", "https://api.other.com");
+
+			const response = await auth.handler(
+				new Request("http://localhost:3000/api/auth/device/token", {
+					method: "POST",
+					headers: { "content-type": "application/x-www-form-urlencoded" },
+					body,
+				}),
+			);
+			expect(response.status).toBe(200);
+			const result = (await response.json()) as { access_token: string };
+			const { payload } = await decode(result.access_token);
+			expect(payload.aud).toEqual([
+				"https://api.example.com",
+				"https://api.other.com",
+			]);
+		});
+
 		it("reflects customAccessTokenClaims in the JWT", async () => {
 			const { auth: authWithClaims, signInWithTestUser: signIn } =
 				await getTestInstance(
@@ -1601,6 +1686,9 @@ describe("device authorization resource indicators", async () => {
 									iss: "https://evil.example.com",
 									sub: "evil-user",
 									aud: "https://evil.example.com",
+									auth_time: 0,
+									acr: "evil-acr",
+									amr: ["evil-amr"],
 								}),
 							}),
 						],
@@ -1637,6 +1725,9 @@ describe("device authorization resource indicators", async () => {
 			expect(payload.sub).not.toBe("evil-user");
 			expect(payload.aud).toBe("https://api.example.com");
 			expect(payload.iss).not.toBe("https://evil.example.com");
+			expect(payload.auth_time).toBeUndefined();
+			expect(payload.acr).toBeUndefined();
+			expect(payload.amr).toBeUndefined();
 		});
 
 		it("errors without consuming the code when a resource is requested but the jwt plugin is missing", async () => {

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -1370,13 +1370,11 @@ describe("device authorization resource indicators", async () => {
 		{ clientOptions: { plugins: [deviceAuthorizationClient()] } },
 	);
 
-	// biome-ignore lint/correctness/noUnusedVariables: shared scaffolding consumed by the /device/token tests added in a follow-up task
 	const decode = async (token: string) => {
 		const jwks = await auth.api.getJwks();
 		return jwtVerify(token, createLocalJWKSet(jwks));
 	};
 
-	// biome-ignore lint/correctness/noUnusedVariables: shared scaffolding consumed by the /device/token tests added in a follow-up task
 	const approve = async (userCode: string) => {
 		const { headers } = await signInWithTestUser();
 		await auth.api.deviceVerify({ query: { user_code: userCode }, headers });
@@ -1415,6 +1413,195 @@ describe("device authorization resource indicators", async () => {
 					body: { client_id: "test-client", resource: "not-a-uri" },
 				}),
 			).rejects.toMatchObject({ body: { error: "invalid_target" } });
+		});
+	});
+
+	describe("/device/token JWT issuance", () => {
+		it("issues a JWT access token when a resource is bound at /device/code", async () => {
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: {
+					client_id: "test-client",
+					scope: "read",
+					resource: "https://api.example.com",
+				},
+			});
+			await approve(user_code);
+
+			const res = await auth.api.deviceToken({
+				body: {
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					device_code,
+					client_id: "test-client",
+				},
+			});
+			if (!("access_token" in res)) throw new Error("expected access_token");
+			expect(res.token_type).toBe("Bearer");
+
+			const { payload, protectedHeader } = await decode(res.access_token);
+			expect(protectedHeader.typ).toBe("at+jwt");
+			expect(payload.aud).toBe("https://api.example.com");
+			expect(payload.client_id).toBe("test-client");
+			expect(payload.azp).toBe("test-client");
+			expect(payload.scope).toBe("read");
+			expect(payload.sub).toBeDefined();
+			expect(payload.jti).toBeDefined();
+
+			// JWT path is stateless: the token is NOT a session token
+			const session = await db.findOne({
+				model: "session",
+				where: [{ field: "token", value: res.access_token }],
+			});
+			expect(session).toBeFalsy();
+		});
+
+		it("issues a JWT when the resource is requested at /device/token", async () => {
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: { client_id: "test-client" },
+			});
+			await approve(user_code);
+
+			const res = await auth.api.deviceToken({
+				body: {
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					device_code,
+					client_id: "test-client",
+					resource: "https://api.example.com",
+				},
+			});
+			if (!("access_token" in res)) throw new Error("expected access_token");
+			const { payload } = await decode(res.access_token);
+			expect(payload.aud).toBe("https://api.example.com");
+		});
+
+		it("enforces the subset rule at the token endpoint", async () => {
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: { client_id: "test-client", resource: "https://api.example.com" },
+			});
+			await approve(user_code);
+
+			await expect(
+				auth.api.deviceToken({
+					body: {
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						device_code,
+						client_id: "test-client",
+						resource: "https://api.other.com",
+					},
+				}),
+			).rejects.toMatchObject({ body: { error: "invalid_target" } });
+		});
+
+		it("issues an array aud for multiple resources", async () => {
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: {
+					client_id: "test-client",
+					resource: ["https://api.example.com", "https://api.other.com"],
+				},
+			});
+			await approve(user_code);
+
+			const res = await auth.api.deviceToken({
+				body: {
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					device_code,
+					client_id: "test-client",
+				},
+			});
+			if (!("access_token" in res)) throw new Error("expected access_token");
+			const { payload } = await decode(res.access_token);
+			expect(payload.aud).toEqual([
+				"https://api.example.com",
+				"https://api.other.com",
+			]);
+		});
+
+		it("reflects customAccessTokenClaims in the JWT", async () => {
+			const { auth: authWithClaims, signInWithTestUser: signIn } =
+				await getTestInstance(
+					{
+						plugins: [
+							jwt(),
+							deviceAuthorization({
+								allowedResources,
+								customAccessTokenClaims: () => ({ tenant: "acme" }),
+							}),
+						],
+					},
+					{ clientOptions: { plugins: [deviceAuthorizationClient()] } },
+				);
+			const { device_code, user_code } = await authWithClaims.api.deviceCode({
+				body: { client_id: "test-client", resource: "https://api.example.com" },
+			});
+			const { headers } = await signIn();
+			await authWithClaims.api.deviceVerify({
+				query: { user_code },
+				headers,
+			});
+			await authWithClaims.api.deviceApprove({
+				body: { userCode: user_code },
+				headers,
+			});
+			const res = await authWithClaims.api.deviceToken({
+				body: {
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					device_code,
+					client_id: "test-client",
+				},
+			});
+			if (!("access_token" in res)) throw new Error("expected access_token");
+			const jwks = await authWithClaims.api.getJwks();
+			const { payload } = await jwtVerify(
+				res.access_token,
+				createLocalJWKSet(jwks),
+			);
+			expect(payload.tenant).toBe("acme");
+		});
+
+		it("errors when a resource is requested without the jwt plugin", async () => {
+			const { auth: authNoJwt, signInWithTestUser: signIn } =
+				await getTestInstance(
+					{ plugins: [deviceAuthorization({ allowedResources })] },
+					{ clientOptions: { plugins: [deviceAuthorizationClient()] } },
+				);
+			const { device_code, user_code } = await authNoJwt.api.deviceCode({
+				body: { client_id: "test-client", resource: "https://api.example.com" },
+			});
+			const { headers } = await signIn();
+			await authNoJwt.api.deviceVerify({ query: { user_code }, headers });
+			await authNoJwt.api.deviceApprove({
+				body: { userCode: user_code },
+				headers,
+			});
+			await expect(
+				authNoJwt.api.deviceToken({
+					body: {
+						grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+						device_code,
+						client_id: "test-client",
+					},
+				}),
+			).rejects.toMatchObject({ body: { error: "server_error" } });
+		});
+
+		it("returns an opaque session token when no resource is requested (regression)", async () => {
+			const { device_code, user_code } = await auth.api.deviceCode({
+				body: { client_id: "test-client" },
+			});
+			await approve(user_code);
+			const res = await auth.api.deviceToken({
+				body: {
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+					device_code,
+					client_id: "test-client",
+				},
+			});
+			if (!("access_token" in res)) throw new Error("expected access_token");
+			// The opaque path DOES create a session keyed by the returned token
+			const session = await db.findOne({
+				model: "session",
+				where: [{ field: "token", value: res.access_token }],
+			});
+			expect(session).toBeTruthy();
 		});
 	});
 });

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -3,8 +3,10 @@ import { getAuthTables } from "@better-auth/core/db";
 import type { DBAdapter } from "@better-auth/core/db/adapter";
 import type { MemoryDB } from "@better-auth/memory-adapter";
 import { memoryAdapter } from "@better-auth/memory-adapter";
+import { createLocalJWKSet, jwtVerify } from "jose";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
+import { jwt } from "../jwt";
 import { deviceAuthorization, deviceAuthorizationOptionsSchema } from ".";
 import { deviceAuthorizationClient } from "./client";
 import type { DeviceCode } from "./schema";
@@ -1355,5 +1357,64 @@ describe("verificationUri option", async () => {
 		expect(response.verification_uri_complete).toContain(
 			`user_code=${response.user_code}`,
 		);
+	});
+});
+
+/** @see https://github.com/better-auth/better-auth/issues/10345 */
+describe("device authorization resource indicators", async () => {
+	const allowedResources = ["https://api.example.com", "https://api.other.com"];
+	const { auth, signInWithTestUser, db } = await getTestInstance(
+		{
+			plugins: [jwt(), deviceAuthorization({ allowedResources })],
+		},
+		{ clientOptions: { plugins: [deviceAuthorizationClient()] } },
+	);
+
+	// biome-ignore lint/correctness/noUnusedVariables: shared scaffolding consumed by the /device/token tests added in a follow-up task
+	const decode = async (token: string) => {
+		const jwks = await auth.api.getJwks();
+		return jwtVerify(token, createLocalJWKSet(jwks));
+	};
+
+	// biome-ignore lint/correctness/noUnusedVariables: shared scaffolding consumed by the /device/token tests added in a follow-up task
+	const approve = async (userCode: string) => {
+		const { headers } = await signInWithTestUser();
+		await auth.api.deviceVerify({ query: { user_code: userCode }, headers });
+		await auth.api.deviceApprove({ body: { userCode }, headers });
+	};
+
+	describe("/device/code resource binding", () => {
+		it("stores a valid resource on the device code", async () => {
+			const { device_code } = await auth.api.deviceCode({
+				body: {
+					client_id: "test-client",
+					resource: "https://api.example.com",
+				},
+			});
+			const record = await db.findOne<{ resource?: string }>({
+				model: "deviceCode",
+				where: [{ field: "deviceCode", value: device_code }],
+			});
+			expect(record?.resource).toBe("https://api.example.com");
+		});
+
+		it("rejects a resource not in allowedResources", async () => {
+			await expect(
+				auth.api.deviceCode({
+					body: {
+						client_id: "test-client",
+						resource: "https://evil.example.com",
+					},
+				}),
+			).rejects.toMatchObject({ body: { error: "invalid_target" } });
+		});
+
+		it("rejects a non-absolute-URI resource", async () => {
+			await expect(
+				auth.api.deviceCode({
+					body: { client_id: "test-client", resource: "not-a-uri" },
+				}),
+			).rejects.toMatchObject({ body: { error: "invalid_target" } });
+		});
 	});
 });

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -1807,7 +1807,8 @@ describe("device authorization resource indicators", async () => {
 			).rejects.toMatchObject({
 				body: {
 					error: "server_error",
-					error_description: "customAccessTokenClaims must return an object",
+					error_description:
+						"The customAccessTokenClaims option must return an object",
 				},
 			});
 		});

--- a/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts
@@ -38,6 +38,16 @@ describe("device authorization plugin input validation", () => {
 			}
 		`);
 	});
+
+	it("preserves resource options through the schema", () => {
+		const claims = () => ({ tenant: "acme" });
+		const options = deviceAuthorizationOptionsSchema.parse({
+			allowedResources: ["https://api.example.com"],
+			customAccessTokenClaims: claims,
+		});
+		expect(options.allowedResources).toEqual(["https://api.example.com"]);
+		expect(options.customAccessTokenClaims).toBe(claims);
+	});
 });
 
 describe("client validation", async () => {

--- a/packages/better-auth/src/plugins/device-authorization/error-codes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/error-codes.ts
@@ -27,5 +27,5 @@ export const DEVICE_AUTHORIZATION_ERROR_CODES = defineErrorCodes({
 	JWT_PLUGIN_REQUIRED:
 		"The jwt plugin is required to issue JWT access tokens for a requested resource",
 	INVALID_CUSTOM_ACCESS_TOKEN_CLAIMS:
-		"customAccessTokenClaims must return an object",
+		"The customAccessTokenClaims option must return an object",
 });

--- a/packages/better-auth/src/plugins/device-authorization/error-codes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/error-codes.ts
@@ -15,4 +15,13 @@ export const DEVICE_AUTHORIZATION_ERROR_CODES = defineErrorCodes({
 	FAILED_TO_CREATE_SESSION: "Failed to create session",
 	INVALID_DEVICE_CODE_STATUS: "Invalid device code status",
 	AUTHENTICATION_REQUIRED: "Authentication required",
+	RESOURCE_NOT_ALLOWED:
+		"The requested resource is not in the list of allowed resources",
+	RESOURCE_NOT_ABSOLUTE_URI: "The resource parameter must be an absolute URI",
+	RESOURCE_HAS_FRAGMENT:
+		"The resource parameter must not contain a fragment component",
+	RESOURCE_EXCEEDS_GRANT:
+		"The requested resource exceeds the resource authorized for this device code",
+	JWT_PLUGIN_REQUIRED:
+		"The jwt plugin is required to issue JWT access tokens for a requested resource",
 });

--- a/packages/better-auth/src/plugins/device-authorization/error-codes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/error-codes.ts
@@ -26,4 +26,6 @@ export const DEVICE_AUTHORIZATION_ERROR_CODES = defineErrorCodes({
 		"The requested resource exceeds the resource authorized for this device code",
 	JWT_PLUGIN_REQUIRED:
 		"The jwt plugin is required to issue JWT access tokens for a requested resource",
+	INVALID_CUSTOM_ACCESS_TOKEN_CLAIMS:
+		"customAccessTokenClaims must return an object",
 });

--- a/packages/better-auth/src/plugins/device-authorization/error-codes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/error-codes.ts
@@ -20,6 +20,8 @@ export const DEVICE_AUTHORIZATION_ERROR_CODES = defineErrorCodes({
 	RESOURCE_NOT_ABSOLUTE_URI: "The resource parameter must be an absolute URI",
 	RESOURCE_HAS_FRAGMENT:
 		"The resource parameter must not contain a fragment component",
+	RESOURCE_NOT_AUTHORIZED:
+		"A resource was requested at the token endpoint but none was authorized at the device authorization request",
 	RESOURCE_EXCEEDS_GRANT:
 		"The requested resource exceeds the resource authorized for this device code",
 	JWT_PLUGIN_REQUIRED:

--- a/packages/better-auth/src/plugins/device-authorization/index.ts
+++ b/packages/better-auth/src/plugins/device-authorization/index.ts
@@ -1,6 +1,7 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import * as z from "zod";
 import { mergeSchema } from "../../db";
+import type { User } from "../../types";
 import type { InferOptionSchema } from "../../types/plugins";
 import type { TimeString } from "../../utils/time";
 import { ms } from "../../utils/time";
@@ -104,7 +105,11 @@ export const deviceAuthorizationOptionsSchema = z.object({
 		),
 	onDeviceAuthRequest: z
 		.custom<
-			(clientId: string, scope: string | undefined) => void | Promise<void>
+			(
+				clientId: string,
+				scope: string | undefined,
+				resource?: string | string[] | undefined,
+			) => void | Promise<void>
 		>((val) => typeof val === "function", {
 			message:
 				"onDeviceAuthRequest must be a function that returns void or a promise that resolves to void.",
@@ -113,6 +118,25 @@ export const deviceAuthorizationOptionsSchema = z.object({
 		.describe(
 			"Function to handle device authorization requests. If not provided, no additional actions will be taken.",
 		),
+	allowedResources: z
+		.array(z.string())
+		.optional()
+		.describe(
+			"Allow-list of RFC 8707 resource indicator URIs clients may request. A resource outside this list is rejected with `invalid_target`. When unset/empty, any `resource` request is rejected. Each entry must be an absolute URI without a fragment.",
+		),
+	customAccessTokenClaims: z
+		.custom<
+			(params: {
+				user: User;
+				scopes: string[];
+				resource: string | string[];
+				clientId: string;
+			}) => Record<string, unknown> | Promise<Record<string, unknown>>
+		>((val) => typeof val === "function", {
+			message: "customAccessTokenClaims must be a function.",
+		})
+		.optional()
+		.describe("Hook to add custom claims to the issued JWT access token."),
 	verificationUri: z
 		.string()
 		.optional()

--- a/packages/better-auth/src/plugins/device-authorization/index.ts
+++ b/packages/better-auth/src/plugins/device-authorization/index.ts
@@ -131,7 +131,9 @@ export const deviceAuthorizationOptionsSchema = z.object({
 					} catch {
 						return false;
 					}
-					return url.hash === "";
+					// A bare trailing `#` yields url.hash === "" but is still a
+					// fragment component (RFC 3986), so also check the raw string.
+					return url.hash === "" && !value.includes("#");
 				},
 				{
 					message:

--- a/packages/better-auth/src/plugins/device-authorization/index.ts
+++ b/packages/better-auth/src/plugins/device-authorization/index.ts
@@ -119,7 +119,26 @@ export const deviceAuthorizationOptionsSchema = z.object({
 			"Function to handle device authorization requests. If not provided, no additional actions will be taken.",
 		),
 	allowedResources: z
-		.array(z.string())
+		.array(
+			z.string().refine(
+				(value) => {
+					// RFC 8707 §2: an absolute URI with no fragment. Validated at
+					// config-parse time so a misconfigured allow-list fails fast at
+					// `betterAuth()` init rather than silently at request time.
+					let url: URL;
+					try {
+						url = new URL(value);
+					} catch {
+						return false;
+					}
+					return url.hash === "";
+				},
+				{
+					message:
+						"allowedResources entries must be absolute URIs without a fragment (RFC 8707 §2).",
+				},
+			),
+		)
 		.optional()
 		.describe(
 			"Allow-list of RFC 8707 resource indicator URIs clients may request. A resource outside this list is rejected with `invalid_target`. When unset/empty, any `resource` request is rejected. Each entry must be an absolute URI without a fragment.",

--- a/packages/better-auth/src/plugins/device-authorization/resource.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import type { DeviceAuthorizationOptions } from ".";
+import {
+	normalizeResource,
+	parseStoredResource,
+	resolveResourceAudience,
+	serializeResource,
+} from "./resource";
+
+const opts = (allowedResources?: string[]): DeviceAuthorizationOptions =>
+	({ allowedResources }) as unknown as DeviceAuthorizationOptions;
+
+const errorOf = (fn: () => unknown): string | undefined => {
+	try {
+		fn();
+	} catch (e) {
+		return (e as { body?: { error?: string } }).body?.error;
+	}
+	return undefined;
+};
+
+describe("normalizeResource", () => {
+	it("wraps a string, passes arrays, drops empty", () => {
+		expect(normalizeResource("https://a")).toEqual(["https://a"]);
+		expect(normalizeResource(["https://a", "https://b"])).toEqual([
+			"https://a",
+			"https://b",
+		]);
+		expect(normalizeResource(undefined)).toBeUndefined();
+		expect(normalizeResource([])).toBeUndefined();
+		expect(normalizeResource(["https://a", "https://a"])).toEqual([
+			"https://a",
+		]);
+	});
+});
+
+describe("resolveResourceAudience", () => {
+	const allowed = ["https://api.example.com", "https://other.example.com"];
+
+	it("returns undefined when no resource is present", () => {
+		expect(
+			resolveResourceAudience({
+				opts: opts(allowed),
+				boundResource: undefined,
+				requestedResource: undefined,
+			}),
+		).toBeUndefined();
+	});
+
+	it("collapses duplicate requested resources to a single string audience", () => {
+		expect(
+			resolveResourceAudience({
+				opts: opts(allowed),
+				boundResource: undefined,
+				requestedResource: [
+					"https://api.example.com",
+					"https://api.example.com",
+				],
+			}),
+		).toBe("https://api.example.com");
+	});
+
+	it("returns a single string audience for one allowed resource", () => {
+		expect(
+			resolveResourceAudience({
+				opts: opts(allowed),
+				boundResource: undefined,
+				requestedResource: "https://api.example.com",
+			}),
+		).toBe("https://api.example.com");
+	});
+
+	it("rejects a resource that is not in the allow-list", () => {
+		expect(
+			errorOf(() =>
+				resolveResourceAudience({
+					opts: opts(allowed),
+					boundResource: undefined,
+					requestedResource: "https://evil.example.com",
+				}),
+			),
+		).toBe("invalid_target");
+	});
+
+	it("rejects a non-absolute-URI resource", () => {
+		expect(
+			errorOf(() =>
+				resolveResourceAudience({
+					opts: opts(["/relative"]),
+					boundResource: undefined,
+					requestedResource: "/relative",
+				}),
+			),
+		).toBe("invalid_target");
+	});
+
+	it("rejects a resource with a fragment", () => {
+		expect(
+			errorOf(() =>
+				resolveResourceAudience({
+					opts: opts(["https://api.example.com#x"]),
+					boundResource: undefined,
+					requestedResource: "https://api.example.com#x",
+				}),
+			),
+		).toBe("invalid_target");
+	});
+
+	it("enforces the subset rule when bound and requested both present", () => {
+		expect(
+			resolveResourceAudience({
+				opts: opts(allowed),
+				boundResource: ["https://api.example.com", "https://other.example.com"],
+				requestedResource: "https://api.example.com",
+			}),
+		).toBe("https://api.example.com");
+
+		expect(
+			errorOf(() =>
+				resolveResourceAudience({
+					opts: opts(allowed),
+					boundResource: ["https://api.example.com"],
+					requestedResource: "https://other.example.com",
+				}),
+			),
+		).toBe("invalid_target");
+	});
+
+	it("inherits the bound resource when none requested at token time", () => {
+		expect(
+			resolveResourceAudience({
+				opts: opts(allowed),
+				boundResource: "https://api.example.com",
+				requestedResource: undefined,
+			}),
+		).toBe("https://api.example.com");
+	});
+});
+
+describe("serializeResource / parseStoredResource round-trip", () => {
+	it("round-trips a single resource", () => {
+		expect(parseStoredResource(serializeResource("https://a"))).toBe(
+			"https://a",
+		);
+	});
+	it("round-trips multiple resources", () => {
+		expect(
+			parseStoredResource(serializeResource(["https://a", "https://b"])),
+		).toEqual(["https://a", "https://b"]);
+	});
+	it("returns undefined for empty stored values", () => {
+		expect(parseStoredResource(null)).toBeUndefined();
+		expect(parseStoredResource(undefined)).toBeUndefined();
+	});
+});

--- a/packages/better-auth/src/plugins/device-authorization/resource.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { DeviceAuthorizationOptions } from ".";
 import {
-	normalizeResource,
 	parseStoredResource,
 	resolveResourceAudience,
 	serializeResource,
@@ -19,21 +18,6 @@ const errorOf = (fn: () => unknown): string | undefined => {
 	return undefined;
 };
 
-describe("normalizeResource", () => {
-	it("wraps a string, passes arrays, drops empty", () => {
-		expect(normalizeResource("https://a")).toEqual(["https://a"]);
-		expect(normalizeResource(["https://a", "https://b"])).toEqual([
-			"https://a",
-			"https://b",
-		]);
-		expect(normalizeResource(undefined)).toBeUndefined();
-		expect(normalizeResource([])).toBeUndefined();
-		expect(normalizeResource(["https://a", "https://a"])).toEqual([
-			"https://a",
-		]);
-	});
-});
-
 describe("resolveResourceAudience", () => {
 	const allowed = ["https://api.example.com", "https://other.example.com"];
 
@@ -43,6 +27,14 @@ describe("resolveResourceAudience", () => {
 				opts: opts(allowed),
 				boundResource: undefined,
 				requestedResource: undefined,
+			}),
+		).toBeUndefined();
+		// An empty array normalizes to "no resource" (opaque-token path).
+		expect(
+			resolveResourceAudience({
+				opts: opts(allowed),
+				boundResource: undefined,
+				requestedResource: [],
 			}),
 		).toBeUndefined();
 	});

--- a/packages/better-auth/src/plugins/device-authorization/resource.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.test.ts
@@ -104,6 +104,16 @@ describe("resolveResourceAudience", () => {
 				}),
 			),
 		).toBe("invalid_target");
+		// A bare trailing `#` (empty fragment) is also rejected.
+		expect(
+			errorOf(() =>
+				resolveResourceAudience({
+					opts: opts(["https://api.example.com/#"]),
+					boundResource: undefined,
+					requestedResource: "https://api.example.com/#",
+				}),
+			),
+		).toBe("invalid_target");
 	});
 
 	it("enforces the subset rule when bound and requested both present", () => {

--- a/packages/better-auth/src/plugins/device-authorization/resource.test.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.test.ts
@@ -135,6 +135,19 @@ describe("resolveResourceAudience", () => {
 			}),
 		).toBe("https://api.example.com");
 	});
+
+	it("rejects a requested resource with no binding when requireBinding is set", () => {
+		expect(
+			errorOf(() =>
+				resolveResourceAudience({
+					opts: opts(allowed),
+					boundResource: undefined,
+					requestedResource: "https://api.example.com",
+					requireBinding: true,
+				}),
+			),
+		).toBe("invalid_target");
+	});
 });
 
 describe("serializeResource / parseStoredResource round-trip", () => {

--- a/packages/better-auth/src/plugins/device-authorization/resource.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.ts
@@ -67,7 +67,9 @@ export function assertValidResources(
 				DEVICE_AUTHORIZATION_ERROR_CODES.RESOURCE_NOT_ABSOLUTE_URI.message,
 			);
 		}
-		if (url.hash) {
+		// `url.hash` is "" for a bare trailing `#`, but RFC 8707 forbids any
+		// fragment component (empty or not), so also check the raw string.
+		if (url.hash || resource.includes("#")) {
 			throw invalidTarget(
 				DEVICE_AUTHORIZATION_ERROR_CODES.RESOURCE_HAS_FRAGMENT.message,
 			);
@@ -157,6 +159,29 @@ export function parseStoredResource(
 }
 
 /**
+ * Resolve the `jwt` plugin's options, throwing `server_error` if the plugin is
+ * not registered (it is required to sign JWT access tokens and to expose the
+ * `/jwks` verification endpoint). Call this before consuming the device code so
+ * a misconfigured server does not burn the user's approval.
+ */
+export function requireJwtOptions(
+	ctx: GenericEndpointContext,
+): JwtOptions | undefined {
+	const jwtPlugin = ctx.context.getPlugin("jwt");
+	if (!jwtPlugin) {
+		ctx.context.logger.error(
+			"device-authorization: a `resource` was requested but the jwt plugin is not registered. Add the jwt() plugin to issue JWT access tokens.",
+		);
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error: "server_error",
+			error_description:
+				DEVICE_AUTHORIZATION_ERROR_CODES.JWT_PLUGIN_REQUIRED.message,
+		});
+	}
+	return jwtPlugin.options as JwtOptions | undefined;
+}
+
+/**
  * Mint an RFC 9068 JWT access token audience-restricted to `audience`.
  * Requires the `jwt` plugin (for JWKS signing + the /jwks verification
  * endpoint). Returns the compact JWT and its lifetime in seconds.
@@ -171,18 +196,7 @@ export async function createDeviceJwtAccessToken(params: {
 }): Promise<{ token: string; expiresIn: number }> {
 	const { ctx, opts, user, clientId, scope, audience } = params;
 
-	const jwtPlugin = ctx.context.getPlugin("jwt");
-	if (!jwtPlugin) {
-		ctx.context.logger.error(
-			"device-authorization: a `resource` was requested but the jwt plugin is not registered. Add the jwt() plugin to issue JWT access tokens.",
-		);
-		throw new APIError("INTERNAL_SERVER_ERROR", {
-			error: "server_error",
-			error_description:
-				DEVICE_AUTHORIZATION_ERROR_CODES.JWT_PLUGIN_REQUIRED.message,
-		});
-	}
-	const jwtOptions = jwtPlugin.options as JwtOptions | undefined;
+	const jwtOptions = requireJwtOptions(ctx);
 
 	const iat = Math.floor(Date.now() / 1000);
 	const exp = toExpJWT(jwtOptions?.jwt?.expirationTime ?? "15m", iat);

--- a/packages/better-auth/src/plugins/device-authorization/resource.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.ts
@@ -1,4 +1,9 @@
+import type { GenericEndpointContext } from "@better-auth/core";
 import { APIError } from "@better-auth/core/error";
+import { generateRandomString } from "../../crypto";
+import type { User } from "../../types";
+import { signJWT, toExpJWT } from "../jwt";
+import type { JwtOptions } from "../jwt/types";
 import type { DeviceAuthorizationOptions } from ".";
 import { DEVICE_AUTHORIZATION_ERROR_CODES } from "./error-codes";
 
@@ -110,4 +115,64 @@ export function parseStoredResource(
 		}
 	}
 	return stored;
+}
+
+/**
+ * Mint an RFC 9068 JWT access token audience-restricted to `audience`.
+ * Requires the `jwt` plugin (for JWKS signing + the /jwks verification
+ * endpoint). Returns the compact JWT and its lifetime in seconds.
+ */
+export async function createDeviceJwtAccessToken(params: {
+	ctx: GenericEndpointContext;
+	opts: DeviceAuthorizationOptions;
+	user: User;
+	clientId: string;
+	scope: string;
+	audience: string | string[];
+}): Promise<{ token: string; expiresIn: number }> {
+	const { ctx, opts, user, clientId, scope, audience } = params;
+
+	const jwtPlugin = ctx.context.getPlugin("jwt");
+	if (!jwtPlugin) {
+		ctx.context.logger.error(
+			"device-authorization: a `resource` was requested but the jwt plugin is not registered. Add the jwt() plugin to issue JWT access tokens.",
+		);
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error: "server_error",
+			error_description:
+				DEVICE_AUTHORIZATION_ERROR_CODES.JWT_PLUGIN_REQUIRED.message,
+		});
+	}
+	const jwtOptions = jwtPlugin.options as JwtOptions | undefined;
+
+	const iat = Math.floor(Date.now() / 1000);
+	const exp = toExpJWT(jwtOptions?.jwt?.expirationTime ?? "15m", iat);
+	const scopes = scope ? scope.split(" ") : [];
+	const customClaims = opts.customAccessTokenClaims
+		? await opts.customAccessTokenClaims({
+				user,
+				scopes,
+				resource: audience,
+				clientId,
+			})
+		: {};
+
+	const token = await signJWT(ctx, {
+		options: jwtOptions,
+		type: "at+jwt",
+		payload: {
+			...customClaims,
+			iss: jwtOptions?.jwt?.issuer ?? (ctx.context.options.baseURL as string),
+			sub: user.id,
+			aud: audience,
+			client_id: clientId,
+			azp: clientId,
+			scope: scopes.length ? scopes.join(" ") : undefined,
+			iat,
+			exp,
+			jti: generateRandomString(32, "a-z", "A-Z", "0-9"),
+		},
+	});
+
+	return { token, expiresIn: exp - iat };
 }

--- a/packages/better-auth/src/plugins/device-authorization/resource.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.ts
@@ -8,6 +8,27 @@ import type { DeviceAuthorizationOptions } from ".";
 import { DEVICE_AUTHORIZATION_ERROR_CODES } from "./error-codes";
 
 /**
+ * Registered / protocol claims a `customAccessTokenClaims` hook must not be
+ * able to override: they are set authoritatively when minting the access token
+ * (or, for `iss`, derived by `signJWT`). Filtering these keeps the issued token
+ * RFC 9068-conformant regardless of what the hook returns.
+ */
+const RESERVED_CLAIMS = new Set([
+	"iss",
+	"sub",
+	"aud",
+	"exp",
+	"nbf",
+	"iat",
+	"jti",
+	"client_id",
+	"azp",
+	"scope",
+	"typ",
+	"cnf",
+]);
+
+/**
  * Normalize an RFC 8707 `resource` value (string or repeated string) into a
  * de-duplicated, non-empty array, or `undefined` when absent/empty. Duplicate
  * entries are collapsed so a repeated single resource resolves to one audience.
@@ -148,7 +169,7 @@ export async function createDeviceJwtAccessToken(params: {
 	const iat = Math.floor(Date.now() / 1000);
 	const exp = toExpJWT(jwtOptions?.jwt?.expirationTime ?? "15m", iat);
 	const scopes = scope ? scope.split(" ") : [];
-	const customClaims = opts.customAccessTokenClaims
+	const rawCustomClaims = opts.customAccessTokenClaims
 		? await opts.customAccessTokenClaims({
 				user,
 				scopes,
@@ -156,10 +177,20 @@ export async function createDeviceJwtAccessToken(params: {
 				clientId,
 			})
 		: {};
+	// Strip reserved/registered claims so the hook can never forge protocol
+	// claims (e.g. `iss`, `sub`, `aud`); those are set authoritatively below.
+	const customClaims = Object.fromEntries(
+		Object.entries(rawCustomClaims).filter(
+			([claim]) => !RESERVED_CLAIMS.has(claim),
+		),
+	);
 
 	const token = await signJWT(ctx, {
 		options: jwtOptions,
-		type: "at+jwt",
+		// RFC 9068 §2.1: access tokens use the `at+jwt` media type. `signJWT`
+		// merges this into the JWS protected header and forwards it to custom
+		// remote signers.
+		header: { typ: "at+jwt" },
 		payload: {
 			...customClaims,
 			// `iss` is derived by signJWT (options.jwt.issuer ?? baseURL origin).

--- a/packages/better-auth/src/plugins/device-authorization/resource.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.ts
@@ -1,0 +1,113 @@
+import { APIError } from "@better-auth/core/error";
+import type { DeviceAuthorizationOptions } from ".";
+import { DEVICE_AUTHORIZATION_ERROR_CODES } from "./error-codes";
+
+/**
+ * Normalize an RFC 8707 `resource` value (string or repeated string) into a
+ * de-duplicated, non-empty array, or `undefined` when absent/empty. Duplicate
+ * entries are collapsed so a repeated single resource resolves to one audience.
+ */
+export function normalizeResource(
+	resource: string | string[] | undefined,
+): string[] | undefined {
+	if (resource === undefined) return undefined;
+	const arr = [...new Set(Array.isArray(resource) ? resource : [resource])];
+	return arr.length ? arr : undefined;
+}
+
+function invalidTarget(message: string): APIError {
+	return new APIError("BAD_REQUEST", {
+		error: "invalid_target",
+		error_description: message,
+	});
+}
+
+/**
+ * Validate every resource: must be an absolute URI without a fragment
+ * (RFC 8707 §2) and a member of `opts.allowedResources`. Throws `invalid_target`
+ * otherwise. An unset/empty allow-list rejects all resources.
+ */
+export function assertValidResources(
+	opts: DeviceAuthorizationOptions,
+	resources: string[],
+): void {
+	const allowed = new Set(opts.allowedResources ?? []);
+	for (const resource of resources) {
+		let url: URL;
+		try {
+			url = new URL(resource);
+		} catch {
+			throw invalidTarget(
+				DEVICE_AUTHORIZATION_ERROR_CODES.RESOURCE_NOT_ABSOLUTE_URI.message,
+			);
+		}
+		if (url.hash) {
+			throw invalidTarget(
+				DEVICE_AUTHORIZATION_ERROR_CODES.RESOURCE_HAS_FRAGMENT.message,
+			);
+		}
+		if (!allowed.has(resource)) {
+			throw invalidTarget(
+				DEVICE_AUTHORIZATION_ERROR_CODES.RESOURCE_NOT_ALLOWED.message,
+			);
+		}
+	}
+}
+
+/**
+ * Resolve the effective audience from the resource bound at `/device/code` and
+ * the resource requested at `/device/token`, applying the RFC 8707 §2.2 subset
+ * rule. Returns a single string for one resource, an array for many, or
+ * `undefined` when no resource is involved (opaque-token path).
+ */
+export function resolveResourceAudience(params: {
+	opts: DeviceAuthorizationOptions;
+	boundResource: string | string[] | undefined;
+	requestedResource: string | string[] | undefined;
+}): string | string[] | undefined {
+	const { opts, boundResource, requestedResource } = params;
+	const bound = normalizeResource(boundResource);
+	const requested = normalizeResource(requestedResource);
+
+	if (!bound && !requested) return undefined;
+
+	let effective: string[];
+	if (bound && requested) {
+		const boundSet = new Set(bound);
+		for (const resource of requested) {
+			if (!boundSet.has(resource)) {
+				throw invalidTarget(
+					DEVICE_AUTHORIZATION_ERROR_CODES.RESOURCE_EXCEEDS_GRANT.message,
+				);
+			}
+		}
+		effective = requested;
+	} else {
+		// exactly one of bound/requested is defined here
+		effective = (requested ?? bound) as string[];
+	}
+
+	assertValidResources(opts, effective);
+	return effective.length === 1 ? effective[0] : effective;
+}
+
+/** Serialize a resolved audience for storage on the deviceCode row. */
+export function serializeResource(audience: string | string[]): string {
+	return Array.isArray(audience) ? JSON.stringify(audience) : audience;
+}
+
+/** Parse a stored resource value back into a string or string[]. */
+export function parseStoredResource(
+	stored: string | null | undefined,
+): string | string[] | undefined {
+	if (!stored) return undefined;
+	if (stored.startsWith("[")) {
+		try {
+			const parsed = JSON.parse(stored);
+			if (Array.isArray(parsed)) return parsed as string[];
+		} catch {
+			// fall through to treat as a single opaque string
+		}
+	}
+	return stored;
+}

--- a/packages/better-auth/src/plugins/device-authorization/resource.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.ts
@@ -31,10 +31,19 @@ const RESERVED_CLAIMS = new Set([
 	"cnf",
 ]);
 
-function stripReservedClaims(
+function sanitizeCustomClaims(
 	ctx: GenericEndpointContext,
-	claims: Record<string, unknown>,
+	claims: unknown,
 ): Record<string, unknown> {
+	if (typeof claims !== "object" || claims === null || Array.isArray(claims)) {
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error: "server_error",
+			error_description:
+				DEVICE_AUTHORIZATION_ERROR_CODES.INVALID_CUSTOM_ACCESS_TOKEN_CLAIMS
+					.message,
+		});
+	}
+
 	const stripped: string[] = [];
 	const safe: Record<string, unknown> = {};
 	for (const [claim, value] of Object.entries(claims)) {
@@ -185,7 +194,7 @@ export function parseStoredResource(
 }
 
 /**
- * Recover repeated RFC 8707 `resource` values from a form body. Better Call's
+ * Recover repeated RFC 8707 `resource` values from a form body. `better-call`'s
  * parsed body keeps only the final value for repeated form keys, so both device
  * endpoints clone and re-read the request before resolving the audience.
  */
@@ -254,7 +263,7 @@ export async function createDeviceJwtAccessToken(params: {
 	const iat = Math.floor(Date.now() / 1000);
 	const exp = toExpJWT(jwtOptions?.jwt?.expirationTime ?? "15m", iat);
 	const scopes = scope ? scope.split(" ") : [];
-	const rawCustomClaims = opts.customAccessTokenClaims
+	const rawCustomClaims: unknown = opts.customAccessTokenClaims
 		? await opts.customAccessTokenClaims({
 				user,
 				scopes,
@@ -264,7 +273,7 @@ export async function createDeviceJwtAccessToken(params: {
 		: {};
 	// Strip reserved/registered claims so the hook can never forge protocol
 	// claims (e.g. `iss`, `sub`, `aud`); those are set authoritatively below.
-	const customClaims = stripReservedClaims(ctx, rawCustomClaims);
+	const customClaims = sanitizeCustomClaims(ctx, rawCustomClaims);
 
 	const token = await signJWT(ctx, {
 		options: jwtOptions,

--- a/packages/better-auth/src/plugins/device-authorization/resource.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.ts
@@ -162,7 +162,7 @@ export async function createDeviceJwtAccessToken(params: {
 		type: "at+jwt",
 		payload: {
 			...customClaims,
-			iss: jwtOptions?.jwt?.issuer ?? (ctx.context.options.baseURL as string),
+			// `iss` is derived by signJWT (options.jwt.issuer ?? baseURL origin).
 			sub: user.id,
 			aud: audience,
 			client_id: clientId,

--- a/packages/better-auth/src/plugins/device-authorization/resource.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.ts
@@ -24,9 +24,35 @@ const RESERVED_CLAIMS = new Set([
 	"client_id",
 	"azp",
 	"scope",
+	"auth_time",
+	"acr",
+	"amr",
 	"typ",
 	"cnf",
 ]);
+
+function stripReservedClaims(
+	ctx: GenericEndpointContext,
+	claims: Record<string, unknown>,
+): Record<string, unknown> {
+	const stripped: string[] = [];
+	const safe: Record<string, unknown> = {};
+	for (const [claim, value] of Object.entries(claims)) {
+		if (RESERVED_CLAIMS.has(claim)) {
+			stripped.push(claim);
+			continue;
+		}
+		safe[claim] = value;
+	}
+	if (stripped.length > 0) {
+		ctx.context.logger.warn(
+			`device-authorization: stripped reserved access-token claim name(s): ${stripped.join(
+				", ",
+			)}. The authorization server owns these claim values.`,
+		);
+	}
+	return safe;
+}
 
 /**
  * Normalize an RFC 8707 `resource` value (string or repeated string) into a
@@ -159,10 +185,37 @@ export function parseStoredResource(
 }
 
 /**
+ * Recover repeated RFC 8707 `resource` values from a form body. Better Call's
+ * parsed body keeps only the final value for repeated form keys, so both device
+ * endpoints clone and re-read the request before resolving the audience.
+ */
+export async function extractRepeatedResourceFromForm(
+	request: Request,
+): Promise<string[] | undefined> {
+	const contentType = request.headers.get("content-type")?.toLowerCase() ?? "";
+	if (!contentType.includes("application/x-www-form-urlencoded")) {
+		return undefined;
+	}
+
+	let text: string;
+	try {
+		text = await request.text();
+	} catch {
+		return undefined;
+	}
+	if (!text) return undefined;
+
+	const params = new URLSearchParams(text);
+	if (!params.has("resource")) return undefined;
+	return params.getAll("resource").filter((resource) => resource.length > 0);
+}
+
+/**
  * Resolve the `jwt` plugin's options, throwing `server_error` if the plugin is
- * not registered (it is required to sign JWT access tokens and to expose the
- * `/jwks` verification endpoint). Call this before consuming the device code so
- * a misconfigured server does not burn the user's approval.
+ * not registered. The plugin supplies the signer and publishes verification
+ * keys through its local or remote JWKS configuration. Call this before
+ * consuming the device code so a misconfigured server does not burn the user's
+ * approval.
  */
 export function requireJwtOptions(
 	ctx: GenericEndpointContext,
@@ -183,8 +236,8 @@ export function requireJwtOptions(
 
 /**
  * Mint an RFC 9068 JWT access token audience-restricted to `audience`.
- * Requires the `jwt` plugin (for JWKS signing + the /jwks verification
- * endpoint). Returns the compact JWT and its lifetime in seconds.
+ * Requires the `jwt` plugin for signing and JWKS publication. Returns the
+ * compact JWT and its lifetime in seconds.
  */
 export async function createDeviceJwtAccessToken(params: {
 	ctx: GenericEndpointContext;
@@ -211,11 +264,7 @@ export async function createDeviceJwtAccessToken(params: {
 		: {};
 	// Strip reserved/registered claims so the hook can never forge protocol
 	// claims (e.g. `iss`, `sub`, `aud`); those are set authoritatively below.
-	const customClaims = Object.fromEntries(
-		Object.entries(rawCustomClaims).filter(
-			([claim]) => !RESERVED_CLAIMS.has(claim),
-		),
-	);
+	const customClaims = stripReservedClaims(ctx, rawCustomClaims);
 
 	const token = await signJWT(ctx, {
 		options: jwtOptions,

--- a/packages/better-auth/src/plugins/device-authorization/resource.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.ts
@@ -33,7 +33,7 @@ const RESERVED_CLAIMS = new Set([
  * de-duplicated, non-empty array, or `undefined` when absent/empty. Duplicate
  * entries are collapsed so a repeated single resource resolves to one audience.
  */
-export function normalizeResource(
+function normalizeResource(
 	resource: string | string[] | undefined,
 ): string[] | undefined {
 	if (resource === undefined) return undefined;
@@ -53,7 +53,7 @@ function invalidTarget(message: string): APIError {
  * (RFC 8707 §2) and a member of `opts.allowedResources`. Throws `invalid_target`
  * otherwise. An unset/empty allow-list rejects all resources.
  */
-export function assertValidResources(
+function assertValidResources(
 	opts: DeviceAuthorizationOptions,
 	resources: string[],
 ): void {

--- a/packages/better-auth/src/plugins/device-authorization/resource.ts
+++ b/packages/better-auth/src/plugins/device-authorization/resource.ts
@@ -81,17 +81,25 @@ export function assertValidResources(
 }
 
 /**
- * Resolve the effective audience from the resource bound at `/device/code` and
- * the resource requested at `/device/token`, applying the RFC 8707 §2.2 subset
- * rule. Returns a single string for one resource, an array for many, or
- * `undefined` when no resource is involved (opaque-token path).
+ * Resolve the effective audience from the resource bound at `/device/code`
+ * (`boundResource`) and the resource requested at `/device/token`
+ * (`requestedResource`), applying the RFC 8707 §2.2 subset rule. Returns a
+ * single string for one resource, an array for many, or `undefined` when no
+ * resource is involved (opaque-token path).
+ *
+ * `requireBinding` (set at the token endpoint) rejects a `requestedResource`
+ * that was never authorized at the device-authorization request, so the issued
+ * token's audience is always tied to what the user's approval covered. RFC 8707
+ * §2.2 permits this stricter policy. It is left unset at the authorization
+ * request itself, since that is where a resource is first declared.
  */
 export function resolveResourceAudience(params: {
 	opts: DeviceAuthorizationOptions;
 	boundResource: string | string[] | undefined;
 	requestedResource: string | string[] | undefined;
+	requireBinding?: boolean;
 }): string | string[] | undefined {
-	const { opts, boundResource, requestedResource } = params;
+	const { opts, boundResource, requestedResource, requireBinding } = params;
 	const bound = normalizeResource(boundResource);
 	const requested = normalizeResource(requestedResource);
 
@@ -99,6 +107,7 @@ export function resolveResourceAudience(params: {
 
 	let effective: string[];
 	if (bound && requested) {
+		// Token-time resource(s) must equal or be a subset of the bound set.
 		const boundSet = new Set(bound);
 		for (const resource of requested) {
 			if (!boundSet.has(resource)) {
@@ -108,9 +117,18 @@ export function resolveResourceAudience(params: {
 			}
 		}
 		effective = requested;
+	} else if (bound) {
+		effective = bound;
 	} else {
-		// exactly one of bound/requested is defined here
-		effective = (requested ?? bound) as string[];
+		// A resource requested with nothing bound at the authorization request:
+		// rejected at the token endpoint (`requireBinding`); the normal
+		// first-declaration path at `/device/code`.
+		if (requireBinding) {
+			throw invalidTarget(
+				DEVICE_AUTHORIZATION_ERROR_CODES.RESOURCE_NOT_AUTHORIZED.message,
+			);
+		}
+		effective = requested as string[];
 	}
 
 	assertValidResources(opts, effective);

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -6,6 +6,7 @@ import { generateRandomString } from "../../crypto";
 import { ms } from "../../utils/time";
 import type { DeviceAuthorizationOptions } from ".";
 import { DEVICE_AUTHORIZATION_ERROR_CODES } from "./error-codes";
+import { resolveResourceAudience, serializeResource } from "./resource";
 import type { DeviceCode } from "./schema";
 
 /* cspell:disable-next-line */
@@ -27,10 +28,17 @@ const deviceCodeBodySchema = z.object({
 			description: "Space-separated list of scopes",
 		})
 		.optional(),
+	resource: z
+		.union([z.string(), z.array(z.string())])
+		.meta({
+			description:
+				"RFC 8707 resource indicator(s) the issued access token is intended for. Requesting a valid resource yields a JWT access token audienced at it.",
+		})
+		.optional(),
 });
 
 const deviceCodeErrorSchema = z.object({
-	error: z.enum(["invalid_request", "invalid_client"]).meta({
+	error: z.enum(["invalid_request", "invalid_client", "invalid_target"]).meta({
 		description: "Error code",
 	}),
 	error_description: z.string().meta({
@@ -114,7 +122,11 @@ Follow [rfc8628#section-3.2](https://datatracker.ietf.org/doc/html/rfc8628#secti
 										properties: {
 											error: {
 												type: "string",
-												enum: ["invalid_request", "invalid_client"],
+												enum: [
+													"invalid_request",
+													"invalid_client",
+													"invalid_target",
+												],
 											},
 											error_description: {
 												type: "string",
@@ -139,8 +151,22 @@ Follow [rfc8628#section-3.2](https://datatracker.ietf.org/doc/html/rfc8628#secti
 				}
 			}
 
+			let resourceToStore: string | null = null;
+			if (ctx.body.resource !== undefined) {
+				const audience = resolveResourceAudience({
+					opts,
+					boundResource: undefined,
+					requestedResource: ctx.body.resource,
+				});
+				resourceToStore = audience ? serializeResource(audience) : null;
+			}
+
 			if (opts.onDeviceAuthRequest) {
-				await opts.onDeviceAuthRequest(ctx.body.client_id, ctx.body.scope);
+				await opts.onDeviceAuthRequest(
+					ctx.body.client_id,
+					ctx.body.scope,
+					ctx.body.resource,
+				);
 			}
 
 			const deviceCode = await generateDeviceCode();
@@ -159,6 +185,7 @@ Follow [rfc8628#section-3.2](https://datatracker.ietf.org/doc/html/rfc8628#secti
 					pollingInterval: ms(opts.interval),
 					clientId: ctx.body.client_id,
 					scope: ctx.body.scope,
+					resource: resourceToStore,
 				},
 			});
 

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -9,6 +9,7 @@ import { DEVICE_AUTHORIZATION_ERROR_CODES } from "./error-codes";
 import {
 	createDeviceJwtAccessToken,
 	parseStoredResource,
+	requireJwtOptions,
 	resolveResourceAudience,
 	serializeResource,
 } from "./resource";
@@ -456,6 +457,13 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 					// `/device/code`; reject a token-time-only resource.
 					requireBinding: true,
 				});
+
+				// If a JWT will be minted, confirm the jwt plugin is available
+				// BEFORE consuming the code, so a misconfigured server (resource
+				// allowed but jwt() not registered) doesn't burn the approval.
+				if (audience) {
+					requireJwtOptions(ctx);
+				}
 
 				// Atomically claim the approved code as the single race gate:
 				// concurrent polls contend on this delete-and-return, and only the

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -8,6 +8,7 @@ import type { DeviceAuthorizationOptions } from ".";
 import { DEVICE_AUTHORIZATION_ERROR_CODES } from "./error-codes";
 import {
 	createDeviceJwtAccessToken,
+	extractRepeatedResourceFromForm,
 	parseStoredResource,
 	requireJwtOptions,
 	resolveResourceAudience,
@@ -70,10 +71,15 @@ export const deviceCode = (opts: DeviceAuthorizationOptions) => {
 		"/device/code",
 		{
 			method: "POST",
+			cloneRequest: true,
 			body: deviceCodeBodySchema,
 			error: deviceCodeErrorSchema,
 			metadata: {
 				noStore: true,
+				allowedMediaTypes: [
+					"application/json",
+					"application/x-www-form-urlencoded",
+				],
 				openapi: {
 					description: `Request a device and user code
 
@@ -147,6 +153,13 @@ Follow [rfc8628#section-3.2](https://datatracker.ietf.org/doc/html/rfc8628#secti
 			},
 		},
 		async (ctx) => {
+			if (ctx.request) {
+				const resources = await extractRepeatedResourceFromForm(ctx.request);
+				if (resources) {
+					ctx.body.resource = resources.length > 1 ? resources : resources[0];
+				}
+			}
+
 			if (opts.validateClient) {
 				const isValid = await opts.validateClient(ctx.body.client_id);
 				if (!isValid) {
@@ -259,10 +272,15 @@ export const deviceToken = (opts: DeviceAuthorizationOptions) =>
 		"/device/token",
 		{
 			method: "POST",
+			cloneRequest: true,
 			body: deviceTokenBodySchema,
 			error: deviceTokenErrorSchema,
 			metadata: {
 				noStore: true,
+				allowedMediaTypes: [
+					"application/json",
+					"application/x-www-form-urlencoded",
+				],
 				openapi: {
 					description: `Exchange device code for access token
 
@@ -320,6 +338,13 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 			},
 		},
 		async (ctx) => {
+			if (ctx.request) {
+				const resources = await extractRepeatedResourceFromForm(ctx.request);
+				if (resources) {
+					ctx.body.resource = resources.length > 1 ? resources : resources[0];
+				}
+			}
+
 			const { device_code, client_id } = ctx.body;
 
 			if (opts.validateClient) {
@@ -615,6 +640,22 @@ export const deviceVerify = createAuthEndpoint(
 											enum: ["pending", "approved", "denied"],
 											description: "Current status of the device authorization",
 										},
+										client_id: {
+											type: "string",
+											description: "The client requesting authorization",
+										},
+										scope: {
+											type: "string",
+											description: "The requested OAuth scopes",
+										},
+										resource: {
+											oneOf: [
+												{ type: "string" },
+												{ type: "array", items: { type: "string" } },
+											],
+											description:
+												"The RFC 8707 resource indicator(s) bound to this request",
+										},
 									},
 								},
 							},
@@ -676,9 +717,19 @@ export const deviceVerify = createAuthEndpoint(
 			}
 		}
 
+		const canReviewRequest =
+			session?.user.id !== undefined &&
+			deviceCodeRecord.userId === session.user.id;
 		return ctx.json({
 			user_code: user_code,
 			status: deviceCodeRecord.status,
+			...(canReviewRequest
+				? {
+						client_id: deviceCodeRecord.clientId,
+						scope: deviceCodeRecord.scope,
+						resource: parseStoredResource(deviceCodeRecord.resource),
+					}
+				: {}),
 		});
 	},
 );

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -258,6 +258,7 @@ const deviceTokenErrorSchema = z.object({
 			"invalid_request",
 			"invalid_grant",
 			"invalid_target",
+			"server_error",
 		])
 		.meta({
 			description: "Error code",
@@ -324,6 +325,25 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 													"invalid_grant",
 													"invalid_target",
 												],
+											},
+											error_description: {
+												type: "string",
+											},
+										},
+									},
+								},
+							},
+						},
+						500: {
+							description: "Token issuance failed",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											error: {
+												type: "string",
+												enum: ["server_error"],
 											},
 											error_description: {
 												type: "string",

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -342,6 +342,7 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 				pollingInterval?: number | undefined;
 				clientId?: string | undefined;
 				scope?: string | undefined;
+				resource?: string | undefined;
 			}>({
 				model: "deviceCode",
 				where: [
@@ -442,15 +443,25 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 			}
 
 			if (deviceCodeRecord.status === "approved" && deviceCodeRecord.userId) {
+				// Resolve/validate the requested resource BEFORE consuming the code.
+				// Validation is read-only and idempotent, so a malformed or
+				// disallowed `resource` (or an `allowedResources` change after the
+				// code was issued) returns `invalid_target` without burning the
+				// approved code and forcing a full device-flow restart (RFC 8707 §2.2).
+				const audience = resolveResourceAudience({
+					opts,
+					boundResource: parseStoredResource(deviceCodeRecord.resource),
+					requestedResource: ctx.body.resource,
+				});
+
 				// Atomically claim the approved code as the single race gate:
 				// concurrent polls contend on this delete-and-return, and only the
-				// caller that removes the row may issue a session. Losers receive
+				// caller that removes the row may issue a token. Losers receive
 				// null and are rejected, so the code is redeemed at most once.
 				const claimedDeviceCode = await ctx.context.adapter.consumeOne<{
 					id: string;
 					userId?: string | undefined;
 					scope?: string | undefined;
-					resource?: string | undefined;
 				}>({
 					model: "deviceCode",
 					where: [
@@ -480,13 +491,8 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 					});
 				}
 
-				// RFC 8707 / RFC 9068: when a resource resolves, issue a stateless
+				// RFC 8707 / RFC 9068: when a resource resolved, issue a stateless
 				// JWT access token scoped to that audience instead of an opaque session.
-				const audience = resolveResourceAudience({
-					opts,
-					boundResource: parseStoredResource(claimedDeviceCode.resource),
-					requestedResource: ctx.body.resource,
-				});
 				if (audience) {
 					const { token, expiresIn } = await createDeviceJwtAccessToken({
 						ctx,
@@ -496,20 +502,14 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 						scope: claimedDeviceCode.scope || "",
 						audience,
 					});
-					return ctx.json(
-						{
-							access_token: token,
-							token_type: "Bearer",
-							expires_in: expiresIn,
-							scope: claimedDeviceCode.scope || "",
-						},
-						{
-							headers: {
-								"Cache-Control": "no-store",
-								Pragma: "no-cache",
-							},
-						},
-					);
+					ctx.setHeader("Cache-Control", "no-store");
+					ctx.setHeader("Pragma", "no-cache");
+					return ctx.json({
+						access_token: token,
+						token_type: "Bearer",
+						expires_in: expiresIn,
+						scope: claimedDeviceCode.scope || "",
+					});
 				}
 
 				const session = await ctx.context.internalAdapter.createSession(

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -452,6 +452,9 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 					opts,
 					boundResource: parseStoredResource(deviceCodeRecord.resource),
 					requestedResource: ctx.body.resource,
+					// Token-endpoint policy: a resource must have been authorized at
+					// `/device/code`; reject a token-time-only resource.
+					requireBinding: true,
 				});
 
 				// Atomically claim the approved code as the single race gate:

--- a/packages/better-auth/src/plugins/device-authorization/routes.ts
+++ b/packages/better-auth/src/plugins/device-authorization/routes.ts
@@ -6,7 +6,12 @@ import { generateRandomString } from "../../crypto";
 import { ms } from "../../utils/time";
 import type { DeviceAuthorizationOptions } from ".";
 import { DEVICE_AUTHORIZATION_ERROR_CODES } from "./error-codes";
-import { resolveResourceAudience, serializeResource } from "./resource";
+import {
+	createDeviceJwtAccessToken,
+	parseStoredResource,
+	resolveResourceAudience,
+	serializeResource,
+} from "./resource";
 import type { DeviceCode } from "./schema";
 
 /* cspell:disable-next-line */
@@ -220,6 +225,13 @@ const deviceTokenBodySchema = z.object({
 	client_id: z.string().meta({
 		description: "The client ID of the application",
 	}),
+	resource: z
+		.union([z.string(), z.array(z.string())])
+		.meta({
+			description:
+				"RFC 8707 resource indicator(s). Must equal or be a subset of the resource bound at /device/code. A valid resource yields a JWT access token.",
+		})
+		.optional(),
 });
 
 const deviceTokenErrorSchema = z.object({
@@ -231,6 +243,7 @@ const deviceTokenErrorSchema = z.object({
 			"access_denied",
 			"invalid_request",
 			"invalid_grant",
+			"invalid_target",
 		])
 		.meta({
 			description: "Error code",
@@ -261,12 +274,14 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 									schema: {
 										type: "object",
 										properties: {
-											session: {
-												$ref: "#/components/schemas/Session",
+											access_token: {
+												type: "string",
+												description:
+													"The access token. An opaque session token by default, or an RFC 9068 JWT when a valid `resource` was requested.",
 											},
-											user: {
-												$ref: "#/components/schemas/User",
-											},
+											token_type: { type: "string", enum: ["Bearer"] },
+											expires_in: { type: "number" },
+											scope: { type: "string" },
 										},
 									},
 								},
@@ -288,6 +303,7 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 													"access_denied",
 													"invalid_request",
 													"invalid_grant",
+													"invalid_target",
 												],
 											},
 											error_description: {
@@ -434,6 +450,7 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 					id: string;
 					userId?: string | undefined;
 					scope?: string | undefined;
+					resource?: string | undefined;
 				}>({
 					model: "deviceCode",
 					where: [
@@ -461,6 +478,38 @@ Follow [rfc8628#section-3.4](https://datatracker.ietf.org/doc/html/rfc8628#secti
 						error_description:
 							DEVICE_AUTHORIZATION_ERROR_CODES.USER_NOT_FOUND.message,
 					});
+				}
+
+				// RFC 8707 / RFC 9068: when a resource resolves, issue a stateless
+				// JWT access token scoped to that audience instead of an opaque session.
+				const audience = resolveResourceAudience({
+					opts,
+					boundResource: parseStoredResource(claimedDeviceCode.resource),
+					requestedResource: ctx.body.resource,
+				});
+				if (audience) {
+					const { token, expiresIn } = await createDeviceJwtAccessToken({
+						ctx,
+						opts,
+						user,
+						clientId: client_id,
+						scope: claimedDeviceCode.scope || "",
+						audience,
+					});
+					return ctx.json(
+						{
+							access_token: token,
+							token_type: "Bearer",
+							expires_in: expiresIn,
+							scope: claimedDeviceCode.scope || "",
+						},
+						{
+							headers: {
+								"Cache-Control": "no-store",
+								Pragma: "no-cache",
+							},
+						},
+					);
 				}
 
 				const session = await ctx.context.internalAdapter.createSession(

--- a/packages/better-auth/src/plugins/device-authorization/schema.ts
+++ b/packages/better-auth/src/plugins/device-authorization/schema.ts
@@ -40,6 +40,10 @@ export const schema = {
 				type: "string",
 				required: false,
 			},
+			resource: {
+				type: "string",
+				required: false,
+			},
 		},
 	},
 } satisfies BetterAuthPluginDBSchema;
@@ -55,6 +59,7 @@ const deviceCode = z.object({
 	pollingInterval: z.number().optional(),
 	clientId: z.string().optional(),
 	scope: z.string().optional(),
+	resource: z.string().optional(),
 });
 
 export type DeviceCode = z.infer<typeof deviceCode>;


### PR DESCRIPTION
The device authorization plugin could only issue opaque session tokens, which prevented device clients from requesting access tokens scoped to downstream APIs. This adds an RFC 8707 resource boundary and an RFC 9068 JWT path while preserving the existing opaque-token behavior for requests without `resource`.

## What changes

- **Authorization request**: `/device/code` accepts one or more `resource` values in JSON or form-encoded requests, preserves repeated form parameters, and binds the resolved audience to the device grant.
- **User approval**: `GET /device` returns the requesting `client_id`, `scope`, and `resource` only to the authenticated user who owns the request, so approval pages can present the complete grant before accepting it.
- **Token issuance**: `/device/token` can use the full bound resource set or request a subset. A valid resource produces an RFC 9068 JWT whose verification keys come from the JWT plugin's configured JWKS setup; the no-resource path continues creating a Better Auth session and returning its opaque token.
- **Policy controls**: `allowedResources` defines the global resource allow-list, while `onDeviceAuthRequest` can enforce client-specific resource and scope policy. Invalid targets fail before consuming an approved code, and `customAccessTokenClaims` cannot override authorization-server-owned claims.
- **Storage**: device grants persist their approved audience in the nullable `deviceCode.resource` field.

> [!IMPORTANT]
> After upgrading, run the Better Auth schema migration or generation workflow so the `deviceCode` table includes the nullable `resource` field.

## Review focus

- **Grant boundary**: the token endpoint rejects resources that were not approved at `/device/code`, and a token-time resource must be a subset of the bound grant.
- **Issuance failure**: the JWT plugin requirement and resource policy are checked before the approved code is consumed, so a configuration or request error does not force the user through another device flow.
- **Multi-audience tokens**: deployments must ensure that every requested scope has the same meaning for every resource in a multi-resource audience.

Closes #10345.
