### PR TITLE
fix(cli): disambiguate Drizzle relations with relationName

### DIFF
--- a/.changeset/drizzle-relationname-disambiguation.md
+++ b/.changeset/drizzle-relationname-disambiguation.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+Disambiguate Drizzle relations with matching `relationName` values when a table has multiple foreign keys to the same model.

--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -87,7 +87,11 @@ export const auth = betterAuth({
 When a table has multiple foreign keys to the same table, each relation pair
 must use a matching [`relationName`](https://orm.drizzle.team/docs/relations#disambiguating-relations).
 The CLI generates these names automatically. If you generated your schema with
-an older CLI, regenerate it or add matching names to both sides:
+an older CLI, regenerate it or add matching names to both sides.
+
+The `relationName` prefix follows your table naming: with `usePlural: true` it
+is plural (`tests_userId`), otherwise singular (`test_userId`). Keep both sides
+identical.
 
 ```ts title="schema.ts"
 export const usersRelations = relations(users, ({ many }) => ({

--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -84,6 +84,35 @@ export const auth = betterAuth({
   Additionally, you're required to pass each [relation](https://orm.drizzle.team/docs/relations) through the drizzle adapter schema object.
 </Callout>
 
+When a table has multiple foreign keys to the same table, each relation pair
+must use a matching [`relationName`](https://orm.drizzle.team/docs/relations#disambiguating-relations).
+The CLI generates these names automatically. If you generated your schema with
+an older CLI, regenerate it or add matching names to both sides:
+
+```ts title="schema.ts"
+export const usersRelations = relations(users, ({ many }) => ({
+  testsByUserId: many(tests, { relationName: "tests_userId" }),
+  testsByManagerId: many(tests, { relationName: "tests_managerId" }),
+}));
+
+export const testsRelations = relations(tests, ({ one }) => ({
+  user: one(users, {
+    fields: [tests.userId],
+    references: [users.id],
+    relationName: "tests_userId",
+  }),
+  manager: one(users, {
+    fields: [tests.managerId],
+    references: [users.id],
+    relationName: "tests_managerId",
+  }),
+}));
+```
+
+Do not keep both singular and plural aliases for the same foreign key (for
+example, both `user` and `users`). Drizzle treats those as separate relations
+and cannot infer which reverse relation a join should use.
+
 ## Modifying Table Names
 
 The Drizzle adapter expects the schema you define to match the table names. For example, if your Drizzle schema maps the `user` table to `users`, you need to manually pass the schema and map it to the user table.

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.use-plural-joins-relationname.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.use-plural-joins-relationname.test.ts
@@ -1,0 +1,292 @@
+/**
+ * @see https://github.com/better-auth/better-auth/issues/8849
+ *
+ * Generated usePlural schemas must disambiguate multiple relations between the
+ * same tables while preserving the relation keys used by adapter joins.
+ */
+import type { Account, User } from "@better-auth/core/db";
+import { drizzleAdapter } from "@better-auth/drizzle-adapter";
+import Database from "better-sqlite3";
+import { relations } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const users = sqliteTable("users", {
+	id: text("id").primaryKey(),
+	name: text("name").notNull(),
+	email: text("email").notNull(),
+	emailVerified: integer("emailVerified", { mode: "boolean" }).notNull(),
+	image: text("image"),
+	createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+	updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+});
+
+const sessions = sqliteTable("sessions", {
+	id: text("id").primaryKey(),
+	userId: text("userId")
+		.notNull()
+		.references(() => users.id),
+	token: text("token").notNull(),
+	expiresAt: integer("expiresAt", { mode: "timestamp" }).notNull(),
+	ipAddress: text("ipAddress"),
+	userAgent: text("userAgent"),
+	createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+	updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+});
+
+const accounts = sqliteTable("accounts", {
+	id: text("id").primaryKey(),
+	accountId: text("accountId").notNull(),
+	providerId: text("providerId").notNull(),
+	userId: text("userId")
+		.notNull()
+		.references(() => users.id),
+	accessToken: text("accessToken"),
+	refreshToken: text("refreshToken"),
+	idToken: text("idToken"),
+	accessTokenExpiresAt: integer("accessTokenExpiresAt", {
+		mode: "timestamp",
+	}),
+	refreshTokenExpiresAt: integer("refreshTokenExpiresAt", {
+		mode: "timestamp",
+	}),
+	scope: text("scope"),
+	password: text("password"),
+	createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+	updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+});
+
+const verifications = sqliteTable("verifications", {
+	id: text("id").primaryKey(),
+	identifier: text("identifier").notNull(),
+	value: text("value").notNull(),
+	expiresAt: integer("expiresAt", { mode: "timestamp" }).notNull(),
+	createdAt: integer("createdAt", { mode: "timestamp" }),
+	updatedAt: integer("updatedAt", { mode: "timestamp" }),
+});
+
+/** Current main CLI usePlural output: plural many-to-one keys (`users`). */
+const usersRelationsCliMain = relations(users, ({ many }) => ({
+	sessions: many(sessions),
+	accounts: many(accounts),
+}));
+
+const accountsRelationsCliMain = relations(accounts, ({ one }) => ({
+	users: one(users, {
+		fields: [accounts.userId],
+		references: [users.id],
+	}),
+}));
+
+const sessionsRelationsCliMain = relations(sessions, ({ one }) => ({
+	users: one(users, {
+		fields: [sessions.userId],
+		references: [users.id],
+	}),
+}));
+
+/** Multi-FK relation shape emitted by the CLI. */
+const sessionsWithImpersonation = sqliteTable("sessions_imp", {
+	id: text("id").primaryKey(),
+	userId: text("userId")
+		.notNull()
+		.references(() => users.id),
+	impersonatedBy: text("impersonatedBy").references(() => users.id),
+	token: text("token").notNull(),
+	expiresAt: integer("expiresAt", { mode: "timestamp" }).notNull(),
+	createdAt: integer("createdAt", { mode: "timestamp" }).notNull(),
+	updatedAt: integer("updatedAt", { mode: "timestamp" }).notNull(),
+});
+
+const usersRelationsMultiFk = relations(users, ({ many }) => ({
+	sessions_impByUserId: many(sessionsWithImpersonation, {
+		relationName: "sessions_imp_userId",
+	}),
+	sessions_impByImpersonatedBy: many(sessionsWithImpersonation, {
+		relationName: "sessions_imp_impersonatedBy",
+	}),
+}));
+
+const sessionsMultiFkRelations = relations(
+	sessionsWithImpersonation,
+	({ one }) => ({
+		user: one(users, {
+			fields: [sessionsWithImpersonation.userId],
+			references: [users.id],
+			relationName: "sessions_imp_userId",
+		}),
+		impersonator: one(users, {
+			fields: [sessionsWithImpersonation.impersonatedBy],
+			references: [users.id],
+			relationName: "sessions_imp_impersonatedBy",
+		}),
+	}),
+);
+
+function createTables(sqliteDb: InstanceType<typeof Database>) {
+	sqliteDb.exec(`
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			email TEXT NOT NULL,
+			emailVerified INTEGER NOT NULL DEFAULT 0,
+			image TEXT,
+			createdAt INTEGER NOT NULL,
+			updatedAt INTEGER NOT NULL
+		);
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			userId TEXT NOT NULL REFERENCES users(id),
+			token TEXT NOT NULL,
+			expiresAt INTEGER NOT NULL,
+			ipAddress TEXT,
+			userAgent TEXT,
+			createdAt INTEGER NOT NULL,
+			updatedAt INTEGER NOT NULL
+		);
+		CREATE TABLE accounts (
+			id TEXT PRIMARY KEY,
+			accountId TEXT NOT NULL,
+			providerId TEXT NOT NULL,
+			userId TEXT NOT NULL REFERENCES users(id),
+			accessToken TEXT,
+			refreshToken TEXT,
+			idToken TEXT,
+			accessTokenExpiresAt INTEGER,
+			refreshTokenExpiresAt INTEGER,
+			scope TEXT,
+			password TEXT,
+			createdAt INTEGER NOT NULL,
+			updatedAt INTEGER NOT NULL
+		);
+		CREATE TABLE verifications (
+			id TEXT PRIMARY KEY,
+			identifier TEXT NOT NULL,
+			value TEXT NOT NULL,
+			expiresAt INTEGER NOT NULL,
+			createdAt INTEGER,
+			updatedAt INTEGER
+		);
+		CREATE TABLE sessions_imp (
+			id TEXT PRIMARY KEY,
+			userId TEXT NOT NULL REFERENCES users(id),
+			impersonatedBy TEXT REFERENCES users(id),
+			token TEXT NOT NULL,
+			expiresAt INTEGER NOT NULL,
+			createdAt INTEGER NOT NULL,
+			updatedAt INTEGER NOT NULL
+		);
+	`);
+}
+
+function seedAuthRows(sqliteDb: InstanceType<typeof Database>, nowTs: number) {
+	sqliteDb.exec(`
+		INSERT OR REPLACE INTO users (id, name, email, emailVerified, createdAt, updatedAt)
+		VALUES ('u1', 'Test User', 'test@example.com', 0, ${nowTs}, ${nowTs});
+
+		INSERT OR REPLACE INTO accounts (id, accountId, providerId, userId, password, createdAt, updatedAt)
+		VALUES ('a1', 'a1', 'credential', 'u1', 'hashed', ${nowTs}, ${nowTs});
+
+		INSERT OR REPLACE INTO sessions (id, userId, token, expiresAt, ipAddress, userAgent, createdAt, updatedAt)
+		VALUES ('s1', 'u1', 'test-token', ${nowTs + 86400000}, '127.0.0.1', 'vitest', ${nowTs}, ${nowTs});
+
+		INSERT OR REPLACE INTO sessions_imp (id, userId, impersonatedBy, token, expiresAt, createdAt, updatedAt)
+		VALUES ('si1', 'u1', null, 'imp-token', ${nowTs + 86400000}, ${nowTs}, ${nowTs});
+	`);
+}
+
+describe("drizzle adapter: usePlural + joins + ambiguous relations (#8849)", () => {
+	let sqliteDb: InstanceType<typeof Database>;
+
+	beforeAll(() => {
+		sqliteDb = new Database(":memory:");
+		createTables(sqliteDb);
+		seedAuthRows(sqliteDb, Date.now());
+	});
+
+	afterAll(() => {
+		sqliteDb.close();
+	});
+
+	it("queries both sides of multiple named relations without ambiguity", async () => {
+		const db = drizzle(sqliteDb, {
+			schema: {
+				users,
+				sessionsWithImpersonation,
+				usersRelationsMultiFk,
+				sessionsMultiFkRelations,
+			},
+		});
+
+		const user = await db.query.users.findFirst({
+			with: {
+				sessions_impByUserId: true,
+				sessions_impByImpersonatedBy: true,
+			},
+		});
+		expect(user?.sessions_impByUserId).toHaveLength(1);
+		expect(user?.sessions_impByImpersonatedBy).toHaveLength(0);
+
+		const session = await db.query.sessionsWithImpersonation.findFirst({
+			with: {
+				user: true,
+				impersonator: true,
+			},
+		});
+		expect(session?.user.id).toBe("u1");
+		expect(session?.impersonator).toBeNull();
+	});
+
+	it("clean CLI usePlural relations work with usePlural + joins (control)", async () => {
+		const db = drizzle(sqliteDb, {
+			schema: {
+				users,
+				sessions,
+				accounts,
+				verifications,
+				usersRelationsCliMain,
+				accountsRelationsCliMain,
+				sessionsRelationsCliMain,
+			},
+		});
+
+		const adapter = drizzleAdapter(db, {
+			schema: {
+				users,
+				sessions,
+				accounts,
+				verifications,
+			},
+			provider: "sqlite",
+			usePlural: true,
+		})({
+			experimental: { joins: true },
+		});
+
+		const userWithAccounts = await adapter.findOne<
+			User & { account: Account[] }
+		>({
+			model: "user",
+			where: [{ field: "id", value: "u1" }],
+			join: {
+				account: true,
+			},
+		});
+
+		expect(userWithAccounts).not.toBeNull();
+		expect(userWithAccounts?.account).toBeDefined();
+		expect(userWithAccounts?.account).toHaveLength(1);
+		expect(userWithAccounts?.account[0]?.id).toBe("a1");
+
+		const accountWithUser = await adapter.findOne<Account & { user: User }>({
+			model: "account",
+			where: [{ field: "id", value: "a1" }],
+			join: {
+				user: true,
+			},
+		});
+
+		expect(accountWithUser?.user?.id).toBe("u1");
+	});
+});

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -313,39 +313,53 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			 */
 			type: "one" | "many";
 			/**
+			 * Disambiguates multiple relations between the same two tables.
+			 */
+			relationName?: string;
+			/**
 			 * Foreign key field name and reference details (only for "one" relations).
 			 */
 			reference?: {
 				field: string;
 				references: string;
-				fieldName: string; // Original field name for generating unique relation export names
 			};
 		};
 
 		const oneRelations: Relation[] = [];
 		const manyRelations: Relation[] = [];
-		// Set to track "many" relations by key to prevent duplicates
-		const manyRelationsSet = new Set<string>();
 
 		// 1. Find all foreign keys in THIS table (creates "one" relations)
 		const fields = Object.entries(table.fields);
 		const foreignFields = fields.filter(([_, field]) => field.references);
+		const foreignFieldCounts = new Map<string, number>();
+		for (const [_, field] of foreignFields) {
+			const referencedModel = getModelName(field.references!.model);
+			foreignFieldCounts.set(
+				referencedModel,
+				(foreignFieldCounts.get(referencedModel) ?? 0) + 1,
+			);
+		}
 
 		for (const [fieldName, field] of foreignFields) {
 			const referencedModel = field.references!.model;
-			const relationKey = getModelName(referencedModel);
+			const hasMultipleRelations =
+				(foreignFieldCounts.get(getModelName(referencedModel)) ?? 0) > 1;
+			const relationKey = hasMultipleRelations
+				? fieldName.replace(/Id$/, "")
+				: getModelName(referencedModel);
 			const fieldRef = `${getModelName(tableKey)}.${getFieldName({ model: tableKey, field: fieldName })}`;
 			const referenceRef = `${getModelName(referencedModel)}.${getFieldName({ model: referencedModel, field: field.references!.field || "id" })}`;
 
-			// Create a separate relation for each foreign key
 			oneRelations.push({
 				key: relationKey,
 				model: getModelName(referencedModel),
 				type: "one",
+				relationName: hasMultipleRelations
+					? `${getModelName(tableKey)}_${fieldName}`
+					: undefined,
 				reference: {
 					field: fieldRef,
 					references: referenceRef,
-					fieldName: fieldName,
 				},
 			});
 		}
@@ -354,16 +368,6 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 		const otherModels = Object.entries(tables).filter(
 			([modelName]) => modelName !== tableKey,
 		);
-
-		// Map to track relations by model name to determine if unique or many
-		const modelRelationsMap = new Map<
-			string,
-			{
-				modelName: string;
-				hasUnique: boolean;
-				hasMany: boolean;
-			}
-		>();
 
 		for (const [modelName, otherTable] of otherModels) {
 			const foreignKeysPointingHere = Object.entries(otherTable.fields).filter(
@@ -374,95 +378,37 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 
 			if (foreignKeysPointingHere.length === 0) continue;
 
-			// Check if any foreign key is unique
-			const hasUnique = foreignKeysPointingHere.some(
-				([_, field]) => !!field.unique,
-			);
-			const hasMany = foreignKeysPointingHere.some(
-				([_, field]) => !field.unique,
-			);
+			for (const [fieldName, field] of foreignKeysPointingHere) {
+				const relationType = field.unique ? "one" : "many";
+				let relationKey = getModelName(modelName);
 
-			modelRelationsMap.set(modelName, {
-				modelName,
-				hasUnique,
-				hasMany,
-			});
-		}
+				// We have to apply this after checking if they have usePlural because otherwise they will end up seeing:
+				/* cspell:disable-next-line */
+				// "sesionss", or "accountss" - double s's.
+				if (
+					!adapter.options?.adapterConfig?.usePlural &&
+					relationType === "many"
+				) {
+					relationKey = `${relationKey}s`;
+				}
 
-		// Add relations, deduplicating by relationKey
-		for (const { modelName, hasMany } of modelRelationsMap.values()) {
-			// Determine relation type: if all are unique, it's "one", otherwise "many"
-			const relationType = hasMany ? "many" : "one";
-			let relationKey = getModelName(modelName);
+				const hasMultipleRelations = foreignKeysPointingHere.length > 1;
+				if (hasMultipleRelations) {
+					relationKey = `${relationKey}By${fieldName.charAt(0).toUpperCase()}${fieldName.slice(1)}`;
+				}
 
-			// We have to apply this after checking if they have usePlural because otherwise they will end up seeing:
-			/* cspell:disable-next-line */
-			// "sesionss", or "accountss" - double s's.
-			if (
-				!adapter.options?.adapterConfig?.usePlural &&
-				relationType === "many"
-			) {
-				relationKey = `${relationKey}s`;
-			}
-
-			// Only add if we haven't seen this key before
-			if (!manyRelationsSet.has(relationKey)) {
-				manyRelationsSet.add(relationKey);
 				manyRelations.push({
 					key: relationKey,
 					model: getModelName(modelName),
 					type: relationType,
+					relationName: hasMultipleRelations
+						? `${getModelName(modelName)}_${fieldName}`
+						: undefined,
 				});
 			}
 		}
 
-		// Group "one" relations by referenced model to detect duplicates
-		const relationsByModel = new Map<string, Relation[]>();
-		for (const relation of oneRelations) {
-			if (relation.reference) {
-				const modelKey = relation.key;
-				if (!relationsByModel.has(modelKey)) {
-					relationsByModel.set(modelKey, []);
-				}
-				relationsByModel.get(modelKey)!.push(relation);
-			}
-		}
-
-		// Separate relations with duplicates (same model) from those without
-		const duplicateRelations: Relation[] = [];
-		const singleRelations: Relation[] = [];
-
-		for (const [_modelKey, relations] of relationsByModel.entries()) {
-			if (relations.length > 1) {
-				// Multiple relations to the same model - these need field-specific naming
-				duplicateRelations.push(...relations);
-			} else {
-				// Single relation to this model - can be combined with others
-				singleRelations.push(relations[0]!);
-			}
-		}
-
-		// Generate field-specific exports for duplicate relations
-		for (const relation of duplicateRelations) {
-			if (relation.reference) {
-				const fieldName = relation.reference.fieldName;
-				const relationExportName = `${modelName}${fieldName.charAt(0).toUpperCase() + fieldName.slice(1)}Relations`;
-
-				const tableRelation = `export const ${relationExportName} = relations(${getModelName(
-					table.modelName,
-				)}, ({ one }) => ({
-				${relation.key}: one(${relation.model}, {
-					fields: [${relation.reference.field}],
-					references: [${relation.reference.references}],
-				})
-			}))`;
-
-				relationsString += `\n${tableRelation}\n`;
-			}
-		}
-
-		// Combine all single "one" relations and "many" relations into exports
-		const hasOne = singleRelations.length > 0;
+		const hasOne = oneRelations.length > 0;
 		const hasMany = manyRelations.length > 0;
 
 		if (hasOne && hasMany) {
@@ -470,21 +416,25 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			const tableRelation = `export const ${modelName}Relations = relations(${getModelName(
 				table.modelName,
 			)}, ({ one, many }) => ({
-				${singleRelations
+				${oneRelations
 					.map((relation) =>
 						relation.reference
 							? ` ${relation.key}: one(${relation.model}, {
 					fields: [${relation.reference.field}],
 					references: [${relation.reference.references}],
+					${relation.relationName ? `relationName: "${relation.relationName}",` : ""}
 				})`
 							: "",
 					)
 					.filter((x) => x !== "")
 					.join(",\n ")}${
-					singleRelations.length > 0 && manyRelations.length > 0 ? "," : ""
+					oneRelations.length > 0 && manyRelations.length > 0 ? "," : ""
 				}
 				${manyRelations
-					.map(({ key, model }) => ` ${key}: many(${model})`)
+					.map(
+						({ key, model, relationName }) =>
+							` ${key}: many(${model}${relationName ? `, { relationName: "${relationName}" }` : ""})`,
+					)
 					.join(",\n ")}
 			}))`;
 
@@ -494,12 +444,13 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			const tableRelation = `export const ${modelName}Relations = relations(${getModelName(
 				table.modelName,
 			)}, ({ one }) => ({
-				${singleRelations
+				${oneRelations
 					.map((relation) =>
 						relation.reference
 							? ` ${relation.key}: one(${relation.model}, {
 					fields: [${relation.reference.field}],
 					references: [${relation.reference.references}],
+					${relation.relationName ? `relationName: "${relation.relationName}",` : ""}
 				})`
 							: "",
 					)
@@ -514,7 +465,10 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				table.modelName,
 			)}, ({ many }) => ({
 				${manyRelations
-					.map(({ key, model }) => ` ${key}: many(${model})`)
+					.map(
+						({ key, model, relationName }) =>
+							` ${key}: many(${model}${relationName ? `, { relationName: "${relationName}" }` : ""})`,
+					)
 					.join(",\n ")}
 			}))`;
 

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -340,13 +340,20 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			);
 		}
 
+		const usedOneRelationKeys = new Set<string>();
 		for (const [fieldName, field] of foreignFields) {
 			const referencedModel = field.references!.model;
 			const hasMultipleRelations =
 				(foreignFieldCounts.get(getModelName(referencedModel)) ?? 0) > 1;
-			const relationKey = hasMultipleRelations
+			let relationKey = hasMultipleRelations
 				? fieldName.replace(/Id$/, "")
 				: getModelName(referencedModel);
+			// Avoid silent overwrites when stripping `Id` collides
+			// (e.g. `owner` and `ownerId` both become `owner`).
+			if (usedOneRelationKeys.has(relationKey)) {
+				relationKey = fieldName;
+			}
+			usedOneRelationKeys.add(relationKey);
 			const fieldRef = `${getModelName(tableKey)}.${getFieldName({ model: tableKey, field: fieldName })}`;
 			const referenceRef = `${getModelName(referencedModel)}.${getFieldName({ model: referencedModel, field: field.references!.field || "id" })}`;
 
@@ -408,68 +415,48 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			}
 		}
 
-		const hasOne = oneRelations.length > 0;
-		const hasMany = manyRelations.length > 0;
+		const hasForwardOne = oneRelations.length > 0;
+		const hasReverseOne = manyRelations.some(
+			(relation) => relation.type === "one",
+		);
+		const hasReverseMany = manyRelations.some(
+			(relation) => relation.type === "many",
+		);
+		const hasOne = hasForwardOne || hasReverseOne;
+		const hasMany = hasReverseMany;
 
-		if (hasOne && hasMany) {
-			// Both "one" and "many" relations exist - combine in one export
-			const tableRelation = `export const ${modelName}Relations = relations(${getModelName(
-				table.modelName,
-			)}, ({ one, many }) => ({
-				${oneRelations
-					.map((relation) =>
-						relation.reference
-							? ` ${relation.key}: one(${relation.model}, {
+		const renderOneRelation = (relation: Relation) =>
+			relation.reference
+				? ` ${relation.key}: one(${relation.model}, {
 					fields: [${relation.reference.field}],
 					references: [${relation.reference.references}],
 					${relation.relationName ? `relationName: "${relation.relationName}",` : ""}
 				})`
-							: "",
-					)
-					.filter((x) => x !== "")
-					.join(",\n ")}${
-					oneRelations.length > 0 && manyRelations.length > 0 ? "," : ""
-				}
-				${manyRelations
-					.map(
-						({ key, model, relationName }) =>
-							` ${key}: many(${model}${relationName ? `, { relationName: "${relationName}" }` : ""})`,
-					)
-					.join(",\n ")}
-			}))`;
+				: "";
 
-			relationsString += `\n${tableRelation}\n`;
-		} else if (hasOne) {
-			// Only "one" relations exist
+		const renderReverseRelation = ({
+			key,
+			model,
+			type,
+			relationName,
+		}: Relation) => {
+			const relationFn = type === "one" ? "one" : "many";
+			return ` ${key}: ${relationFn}(${model}${relationName ? `, { relationName: "${relationName}" }` : ""})`;
+		};
+
+		if (hasOne || hasMany) {
+			const helpers = [hasOne ? "one" : null, hasMany ? "many" : null]
+				.filter(Boolean)
+				.join(", ");
+			const relationEntries = [
+				...oneRelations.map(renderOneRelation).filter((x) => x !== ""),
+				...manyRelations.map(renderReverseRelation),
+			].join(",\n ");
+
 			const tableRelation = `export const ${modelName}Relations = relations(${getModelName(
 				table.modelName,
-			)}, ({ one }) => ({
-				${oneRelations
-					.map((relation) =>
-						relation.reference
-							? ` ${relation.key}: one(${relation.model}, {
-					fields: [${relation.reference.field}],
-					references: [${relation.reference.references}],
-					${relation.relationName ? `relationName: "${relation.relationName}",` : ""}
-				})`
-							: "",
-					)
-					.filter((x) => x !== "")
-					.join(",\n ")}
-			}))`;
-
-			relationsString += `\n${tableRelation}\n`;
-		} else if (hasMany) {
-			// Only "many" relations exist
-			const tableRelation = `export const ${modelName}Relations = relations(${getModelName(
-				table.modelName,
-			)}, ({ many }) => ({
-				${manyRelations
-					.map(
-						({ key, model, relationName }) =>
-							` ${key}: many(${model}${relationName ? `, { relationName: "${relationName}" }` : ""})`,
-					)
-					.join(",\n ")}
+			)}, ({ ${helpers} }) => ({
+				${relationEntries}
 			}))`;
 
 			relationsString += `\n${tableRelation}\n`;

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -349,9 +349,17 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				? fieldName.replace(/Id$/, "")
 				: getModelName(referencedModel);
 			// Avoid silent overwrites when stripping `Id` collides
-			// (e.g. `owner` and `ownerId` both become `owner`).
+			// (e.g. `owner` and `ownerId` both become `owner`), including
+			// when field insertion order is `ownerId` then `owner`.
 			if (usedOneRelationKeys.has(relationKey)) {
 				relationKey = fieldName;
+			}
+			if (usedOneRelationKeys.has(relationKey)) {
+				let suffix = 2;
+				while (usedOneRelationKeys.has(`${relationKey}_${suffix}`)) {
+					suffix++;
+				}
+				relationKey = `${relationKey}_${suffix}`;
 			}
 			usedOneRelationKeys.add(relationKey);
 			const fieldRef = `${getModelName(tableKey)}.${getFieldName({ model: tableKey, field: fieldName })}`;

--- a/packages/cli/test/__snapshots__/auth-schema-drizzle-use-plural-duplicate-relations.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-drizzle-use-plural-duplicate-relations.txt
@@ -1,7 +1,7 @@
 import { relations, sql } from "drizzle-orm";
 import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
 
-export const user = sqliteTable("user", {
+export const users = sqliteTable("users", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   email: text("email").notNull().unique(),
@@ -18,8 +18,8 @@ export const user = sqliteTable("user", {
     .notNull(),
 });
 
-export const session = sqliteTable(
-  "session",
+export const sessions = sqliteTable(
+  "sessions",
   {
     id: text("id").primaryKey(),
     expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
@@ -34,20 +34,20 @@ export const session = sqliteTable(
     userAgent: text("user_agent"),
     userId: text("user_id")
       .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
+      .references(() => users.id, { onDelete: "cascade" }),
   },
-  (table) => [index("session_userId_idx").on(table.userId)],
+  (table) => [index("sessions_userId_idx").on(table.userId)],
 );
 
-export const account = sqliteTable(
-  "account",
+export const accounts = sqliteTable(
+  "accounts",
   {
     id: text("id").primaryKey(),
     accountId: text("account_id").notNull(),
     providerId: text("provider_id").notNull(),
     userId: text("user_id")
       .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
+      .references(() => users.id, { onDelete: "cascade" }),
     accessToken: text("access_token"),
     refreshToken: text("refresh_token"),
     idToken: text("id_token"),
@@ -66,11 +66,11 @@ export const account = sqliteTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("account_userId_idx").on(table.userId)],
+  (table) => [index("accounts_userId_idx").on(table.userId)],
 );
 
-export const verification = sqliteTable(
-  "verification",
+export const verifications = sqliteTable(
+  "verifications",
   {
     id: text("id").primaryKey(),
     identifier: text("identifier").notNull(),
@@ -84,47 +84,47 @@ export const verification = sqliteTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("verification_identifier_idx").on(table.identifier)],
+  (table) => [index("verifications_identifier_idx").on(table.identifier)],
 );
 
-export const test = sqliteTable("test", {
+export const tests = sqliteTable("tests", {
   id: text("id").primaryKey(),
-  userId: text("user_id").references(() => user.id, { onDelete: "set null" }),
-  managerId: text("manager_id").references(() => user.id, {
+  userId: text("user_id").references(() => users.id, { onDelete: "set null" }),
+  managerId: text("manager_id").references(() => users.id, {
     onDelete: "set null",
   }),
 });
 
-export const userRelations = relations(user, ({ many }) => ({
-  sessions: many(session),
-  accounts: many(account),
-  testsByUserId: many(test, { relationName: "test_userId" }),
-  testsByManagerId: many(test, { relationName: "test_managerId" }),
+export const usersRelations = relations(users, ({ many }) => ({
+  sessions: many(sessions),
+  accounts: many(accounts),
+  testsByUserId: many(tests, { relationName: "tests_userId" }),
+  testsByManagerId: many(tests, { relationName: "tests_managerId" }),
 }));
 
-export const sessionRelations = relations(session, ({ one }) => ({
-  user: one(user, {
-    fields: [session.userId],
-    references: [user.id],
+export const sessionsRelations = relations(sessions, ({ one }) => ({
+  users: one(users, {
+    fields: [sessions.userId],
+    references: [users.id],
   }),
 }));
 
-export const accountRelations = relations(account, ({ one }) => ({
-  user: one(user, {
-    fields: [account.userId],
-    references: [user.id],
+export const accountsRelations = relations(accounts, ({ one }) => ({
+  users: one(users, {
+    fields: [accounts.userId],
+    references: [users.id],
   }),
 }));
 
-export const testRelations = relations(test, ({ one }) => ({
-  user: one(user, {
-    fields: [test.userId],
-    references: [user.id],
-    relationName: "test_userId",
+export const testsRelations = relations(tests, ({ one }) => ({
+  user: one(users, {
+    fields: [tests.userId],
+    references: [users.id],
+    relationName: "tests_userId",
   }),
-  manager: one(user, {
-    fields: [test.managerId],
-    references: [user.id],
-    relationName: "test_managerId",
+  manager: one(users, {
+    fields: [tests.managerId],
+    references: [users.id],
+    relationName: "tests_managerId",
   }),
 }));

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -687,57 +687,98 @@ describe("generate", async () => {
 	});
 
 	it("should avoid colliding one-side relation keys after Id stripping", async () => {
-		const collidingFkPlugin = (): BetterAuthPlugin => ({
+		const collidingFkPlugin = (
+			fieldOrder: "owner-first" | "ownerId-first",
+		): BetterAuthPlugin => ({
 			id: "colliding-fk",
 			schema: {
 				project: {
-					fields: {
-						owner: {
-							type: "string",
-							required: false,
-							references: {
-								model: "user",
-								field: "id",
-								onDelete: "set null",
-							},
-						},
-						ownerId: {
-							type: "string",
-							required: false,
-							references: {
-								model: "user",
-								field: "id",
-								onDelete: "set null",
-							},
-						},
-					},
+					fields:
+						fieldOrder === "owner-first"
+							? {
+									owner: {
+										type: "string",
+										required: false,
+										references: {
+											model: "user",
+											field: "id",
+											onDelete: "set null",
+										},
+									},
+									ownerId: {
+										type: "string",
+										required: false,
+										references: {
+											model: "user",
+											field: "id",
+											onDelete: "set null",
+										},
+									},
+								}
+							: {
+									ownerId: {
+										type: "string",
+										required: false,
+										references: {
+											model: "user",
+											field: "id",
+											onDelete: "set null",
+										},
+									},
+									owner: {
+										type: "string",
+										required: false,
+										references: {
+											model: "user",
+											field: "id",
+											onDelete: "set null",
+										},
+									},
+								},
 				},
 			},
 		});
-		const schema = await generateDrizzleSchema({
-			file: "test.drizzle",
-			adapter: drizzleAdapter(
-				{},
-				{
-					provider: "sqlite",
-					schema: {},
-				},
-			)({} as BetterAuthOptions),
-			options: {
-				database: drizzleAdapter(
+
+		for (const fieldOrder of ["owner-first", "ownerId-first"] as const) {
+			const schema = await generateDrizzleSchema({
+				file: "test.drizzle",
+				adapter: drizzleAdapter(
 					{},
 					{
 						provider: "sqlite",
 						schema: {},
 					},
-				),
-				plugins: [collidingFkPlugin()],
-			},
-		});
-		expect(schema.code).toContain("owner: one(user,");
-		expect(schema.code).toContain("ownerId: one(user,");
-		expect(schema.code).toContain('relationName: "project_owner"');
-		expect(schema.code).toContain('relationName: "project_ownerId"');
+				)({} as BetterAuthOptions),
+				options: {
+					database: drizzleAdapter(
+						{},
+						{
+							provider: "sqlite",
+							schema: {},
+						},
+					),
+					plugins: [collidingFkPlugin(fieldOrder)],
+				},
+			});
+			expect(schema.code).toContain('relationName: "project_owner"');
+			expect(schema.code).toContain('relationName: "project_ownerId"');
+			const projectRelations = schema.code.match(
+				/export const projectRelations = relations\([\s\S]*?\n\}\)\);/,
+			)?.[0];
+			expect(projectRelations).toBeTruthy();
+			const oneKeys = [
+				...projectRelations!.matchAll(/^\s+(\w+):\s+one\(user,/gm),
+			].map((match) => match[1]);
+			expect(oneKeys).toHaveLength(2);
+			expect(new Set(oneKeys).size).toBe(2);
+			if (fieldOrder === "owner-first") {
+				expect(oneKeys).toEqual(expect.arrayContaining(["owner", "ownerId"]));
+			} else {
+				// ownerId is stripped to `owner` first, so the later `owner`
+				// field needs a unique fallback key.
+				expect(oneKeys).toEqual(expect.arrayContaining(["owner", "owner_2"]));
+			}
+		}
 	});
 
 	// Plugin that tests multiple relations to different models (should be combined)

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -760,9 +760,10 @@ describe("generate", async () => {
 					plugins: [collidingFkPlugin(fieldOrder)],
 				},
 			});
+			expect(schema.code).toBeTruthy();
 			expect(schema.code).toContain('relationName: "project_owner"');
 			expect(schema.code).toContain('relationName: "project_ownerId"');
-			const projectRelations = schema.code.match(
+			const projectRelations = schema.code!.match(
 				/export const projectRelations = relations\([\s\S]*?\n\}\)\);/,
 			)?.[0];
 			expect(projectRelations).toBeTruthy();

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -617,6 +617,31 @@ describe("generate", async () => {
 		);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/8849
+	 */
+	it("should disambiguate duplicate relations when usePlural is enabled", async () => {
+		const database = drizzleAdapter(
+			{},
+			{
+				provider: "sqlite",
+				schema: {},
+				usePlural: true,
+			},
+		);
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: database({} as BetterAuthOptions),
+			options: {
+				database,
+				plugins: [testPlugin()],
+			},
+		});
+		await expect(schema.code).toMatchFileSnapshot(
+			"./__snapshots__/auth-schema-drizzle-use-plural-duplicate-relations.txt",
+		);
+	});
+
 	// Plugin that tests multiple relations to different models (should be combined)
 	const multiRelationPlugin = (): BetterAuthPlugin => {
 		return {

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -642,6 +642,104 @@ describe("generate", async () => {
 		);
 	});
 
+	it("should emit one() for unique reverse relations", async () => {
+		const uniqueProfilePlugin = (): BetterAuthPlugin => ({
+			id: "unique-profile",
+			schema: {
+				profile: {
+					fields: {
+						userId: {
+							type: "string",
+							required: true,
+							unique: true,
+							references: {
+								model: "user",
+								field: "id",
+								onDelete: "cascade",
+							},
+						},
+					},
+				},
+			},
+		});
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "sqlite",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "sqlite",
+						schema: {},
+					},
+				),
+				plugins: [uniqueProfilePlugin()],
+			},
+		});
+		expect(schema.code).toContain("profile: one(profile)");
+		expect(schema.code).not.toMatch(/profile:\s*many\(profile\)/);
+	});
+
+	it("should avoid colliding one-side relation keys after Id stripping", async () => {
+		const collidingFkPlugin = (): BetterAuthPlugin => ({
+			id: "colliding-fk",
+			schema: {
+				project: {
+					fields: {
+						owner: {
+							type: "string",
+							required: false,
+							references: {
+								model: "user",
+								field: "id",
+								onDelete: "set null",
+							},
+						},
+						ownerId: {
+							type: "string",
+							required: false,
+							references: {
+								model: "user",
+								field: "id",
+								onDelete: "set null",
+							},
+						},
+					},
+				},
+			},
+		});
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "sqlite",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "sqlite",
+						schema: {},
+					},
+				),
+				plugins: [collidingFkPlugin()],
+			},
+		});
+		expect(schema.code).toContain("owner: one(user,");
+		expect(schema.code).toContain("ownerId: one(user,");
+		expect(schema.code).toContain('relationName: "project_owner"');
+		expect(schema.code).toContain('relationName: "project_ownerId"');
+	});
+
 	// Plugin that tests multiple relations to different models (should be combined)
 	const multiRelationPlugin = (): BetterAuthPlugin => {
 		return {


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/8849

## Summary
- Generate matching `relationName` values and unique relation keys when a table has multiple foreign keys to the same model
- Document the required relation naming convention for Drizzle joins
- Add CLI snapshots and adapter regression coverage for