### PR TITLE
docs: fix incorrect option name and reverse proxy example in cookies page

### DIFF
--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -23,7 +23,7 @@ export const auth = betterAuth({
 
 All cookies are `httpOnly` and `secure` when the server is running in production mode.
 
-If you want to set custom cookie names and attributes, you can do so by setting `cookieOptions` in the `advanced` object of the auth options.
+If you want to set custom cookie names and attributes, you can do so by setting `cookies` in the `advanced` object of the auth options.
 
 By default, Better Auth uses the following cookies:
 
@@ -138,7 +138,7 @@ https://domainA.com/api/auth/*
 you can call:
 
 ```
-https://app.domainA.com/api/auth/*
+https://app.domainB.com/api/auth/*
 ```
 
 Then configure your hosting provider to proxy the request to your actual API server.


### PR DESCRIPTION
## Summary

Fixes two errors in `docs/content/docs/concepts/cookies.mdx`.

### 1. `cookieOptions` → `cookies`

The text says to use `cookieOptions` in the `advanced` object, but this option no longer exists. The actual option is `advanced.cookies` — as shown in the code example right below the sentence and in the [Options reference](https://better-auth.com/docs/reference/options).

### 2. Wrong domain in the reverse proxy example

The scenario has the frontend on `app.domainB.com` and the API on `domainA.com`. The reverse proxy workaround requires calling the API through the **frontend's** domain, but the example uses `https://app.domainA.com/api/auth/*` (the API side). Changed it to `https://app.domainB.com/api/auth/*`, consistent with the Netlify/Vercel config examples below it.

Text-only changes, no behavior affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two mistakes in the cookies docs to align instructions with the current API and correct the reverse proxy example. Text-only changes; no behavior impact.

- **Bug Fixes**
  - Updated `advanced.cookieOptions` to `advanced.cookies` to match the example and options reference.
  - Corrected reverse proxy example URL from https://app.domainA.com/api/auth/* to https://app.domainB.com/api/auth/* to match the described setup.

<sup>Written for commit 6d1a98f226040d8cfcda96b681eec369b0461395. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

