### PR TITLE
chore!: move joins to advanced.database.joins

### DIFF
--- a/.changeset/joins-out-of-experimental.md
+++ b/.changeset/joins-out-of-experimental.md
@@ -4,8 +4,16 @@
 "@better-auth/drizzle-adapter": minor
 ---
 
-Database joins are now enabled by default. The `experimental.joins` option has been removed.
+Database joins have moved out of `experimental` into a stable option at `advanced.database.joins` (default: `false`).
 
-Adapters that support native joins use them automatically. If an adapter cannot return joined data for a query, Better Auth falls back to additional queries and combines the results.
+If you previously set `experimental: { joins: true }`, update your config to:
 
-If you previously set `experimental: { joins: true }`, you can remove that option. Drizzle and Prisma users should ensure their schema includes the required relations (`npx auth@latest generate`).
+```ts
+advanced: {
+  database: {
+    joins: true,
+  },
+}
+```
+
+Adapters that support native joins use them when enabled. If an adapter cannot return joined data for a query, Better Auth falls back to additional queries and combines the results. Drizzle and Prisma users should ensure their schema includes the required relations (`npx auth@latest generate`).

--- a/.changeset/joins-out-of-experimental.md
+++ b/.changeset/joins-out-of-experimental.md
@@ -1,0 +1,11 @@
+---
+"better-auth": minor
+"@better-auth/core": minor
+"@better-auth/drizzle-adapter": minor
+---
+
+Database joins are now enabled by default. The `experimental.joins` option has been removed.
+
+Adapters that support native joins use them automatically. If an adapter cannot return joined data for a query, Better Auth falls back to additional queries and combines the results.
+
+If you previously set `experimental: { joins: true }`, you can remove that option. Drizzle and Prisma users should ensure their schema includes the required relations (`npx auth@latest generate`).

--- a/docs/content/blogs/1-4.mdx
+++ b/docs/content/blogs/1-4.mdx
@@ -116,7 +116,7 @@ Better-Auth now supports database joins, improving over 50 endpoints by 2 to 3x 
 To enable, simply set the `joins` flag to `true` under `experimental` in your auth config.
 Then, re-run migrations or schema generation to get the updated schema which supports joins!
 
-[👉 Read more about database joins](/docs/concepts/database#experimental-joins)
+[👉 Read more about database joins](/docs/concepts/database#joins)
 
 ```ts
 import { betterAuth } from "better-auth";

--- a/docs/content/blogs/1-4.mdx
+++ b/docs/content/blogs/1-4.mdx
@@ -109,11 +109,11 @@ const auth = betterAuth({
 
 ***
 
-### Database Joins Improvements (experimental)
+### Database Joins Improvements
 
 Better-Auth now supports database joins, improving over 50 endpoints by 2 to 3x in latency. This is achieved by using database joins under the hood.
 
-To enable, simply set the `joins` flag to `true` under `experimental` in your auth config.
+To enable, set `advanced.database.joins` to `true` in your auth config.
 Then, re-run migrations or schema generation to get the updated schema which supports joins!
 
 [👉 Read more about database joins](/docs/concepts/database#joins)
@@ -122,14 +122,16 @@ Then, re-run migrations or schema generation to get the updated schema which sup
 import { betterAuth } from "better-auth";
 
 export const auth = betterAuth({
-    experimental: {
-        joins: true,
+    advanced: {
+        database: {
+            joins: true,
+        },
     },
 });
 ```
 
 <Callout type="info">
-  Although joins are experimental, they are supported by all adapters and will be enabled by default in the next release.
+  Joins are supported by all adapters. When disabled (the default), Better Auth falls back to separate queries.
 </Callout>
 
 ***

--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -65,7 +65,20 @@ Database joins is useful when Better-Auth needs to fetch related data from multi
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Drizzle adapter supports joins out of the box since version `1.4.0`. Joins are enabled by default.
+The Drizzle adapter supports joins out of the box since version `1.4.0`.
+To enable this feature, set `advanced.database.joins` to `true` in your auth configuration.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  advanced: {
+    database: {
+      joins: true,
+    },
+  },
+});
+```
 
 <Callout type="warn">
   Please make sure that your Drizzle schema has the necessary relations defined.

--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -59,22 +59,13 @@ To generate and apply the migration, run the following commands:
   </Tab>
 </Tabs>
 
-## Joins (Experimental)
+## Joins
 
 Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Drizzle adapter supports joins out of the box since version `1.4.0`.
-To enable this feature, you need to set the `experimental.joins` option to `true` in your auth configuration.
-
-```ts title="auth.ts"
-import { betterAuth } from "better-auth";
-
-export const auth = betterAuth({
-  experimental: { joins: true }
-});
-```
+The Drizzle adapter supports joins out of the box since version `1.4.0`. Joins are enabled by default.
 
 <Callout type="warn">
   Please make sure that your Drizzle schema has the necessary relations defined.

--- a/docs/content/docs/adapters/mongo.mdx
+++ b/docs/content/docs/adapters/mongo.mdx
@@ -45,7 +45,20 @@ Database joins is useful when Better-Auth needs to fetch related data from multi
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The MongoDB adapter supports joins out of the box since version `1.4.0`. Joins are enabled by default.
+The MongoDB adapter supports joins out of the box since version `1.4.0`.
+To enable this feature, set `advanced.database.joins` to `true` in your auth configuration.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  advanced: {
+    database: {
+      joins: true,
+    },
+  },
+});
+```
 
 ## Additional Information
 

--- a/docs/content/docs/adapters/mongo.mdx
+++ b/docs/content/docs/adapters/mongo.mdx
@@ -39,22 +39,13 @@ export const auth = betterAuth({
 
 For MongoDB, we don't need to generate or migrate the schema.
 
-## Joins (Experimental)
+## Joins
 
 Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The MongoDB adapter supports joins out of the box since version `1.4.0`.
-To enable this feature, you need to set the `experimental.joins` option to `true` in your auth configuration.
-
-```ts title="auth.ts"
-import { betterAuth } from "better-auth";
-
-export const auth = betterAuth({
-  experimental: { joins: true }
-});
-```
+The MongoDB adapter supports joins out of the box since version `1.4.0`. Joins are enabled by default.
 
 ## Additional Information
 

--- a/docs/content/docs/adapters/mssql.mdx
+++ b/docs/content/docs/adapters/mssql.mdx
@@ -103,26 +103,13 @@ your database schema based on your Better Auth configuration and plugins.
   </Tab>
 </Tabs>
 
-## Joins (Experimental)
+## Joins
 
 Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Kysely MS SQL dialect supports joins out of the box since version `1.4.0`.
-To enable this feature, you need to set the `experimental.joins` option to `true` in your auth configuration.
-
-```ts title="auth.ts"
-import { betterAuth } from "better-auth";
-
-export const auth = betterAuth({
-  experimental: { joins: true }
-});
-```
-
-<Callout type="warn">
-  It's possible that you may need to run migrations after enabling this feature.
-</Callout>
+The Kysely MS SQL dialect supports joins out of the box since version `1.4.0`. Joins are enabled by default.
 
 ## Additional Information
 

--- a/docs/content/docs/adapters/mssql.mdx
+++ b/docs/content/docs/adapters/mssql.mdx
@@ -109,7 +109,20 @@ Database joins is useful when Better-Auth needs to fetch related data from multi
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Kysely MS SQL dialect supports joins out of the box since version `1.4.0`. Joins are enabled by default.
+The Kysely MS SQL dialect supports joins out of the box since version `1.4.0`.
+To enable this feature, set `advanced.database.joins` to `true` in your auth configuration.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  advanced: {
+    database: {
+      joins: true,
+    },
+  },
+});
+```
 
 ## Additional Information
 

--- a/docs/content/docs/adapters/mysql.mdx
+++ b/docs/content/docs/adapters/mysql.mdx
@@ -87,7 +87,20 @@ Database joins is useful when Better-Auth needs to fetch related data from multi
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Kysely MySQL dialect supports joins out of the box since version `1.4.0`. Joins are enabled by default.
+The Kysely MySQL dialect supports joins out of the box since version `1.4.0`.
+To enable this feature, set `advanced.database.joins` to `true` in your auth configuration.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  advanced: {
+    database: {
+      joins: true,
+    },
+  },
+});
+```
 
 ## Additional Information
 

--- a/docs/content/docs/adapters/mysql.mdx
+++ b/docs/content/docs/adapters/mysql.mdx
@@ -81,27 +81,13 @@ your database schema based on your Better Auth configuration and plugins.
   </Tab>
 </Tabs>
 
-## Joins (Experimental)
+## Joins
 
 Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Kysely MySQL dialect supports joins out of the box since version `1.4.0`.
-
-To enable this feature, you need to set the `experimental.joins` option to `true` in your auth configuration.
-
-```ts title="auth.ts"
-import { betterAuth } from "better-auth";
-
-export const auth = betterAuth({
-  experimental: { joins: true }
-});
-```
-
-<Callout type="warn">
-  It's possible that you may need to run migrations after enabling this feature.
-</Callout>
+The Kysely MySQL dialect supports joins out of the box since version `1.4.0`. Joins are enabled by default.
 
 ## Additional Information
 

--- a/docs/content/docs/adapters/postgresql.mdx
+++ b/docs/content/docs/adapters/postgresql.mdx
@@ -73,7 +73,20 @@ Database joins is useful when Better-Auth needs to fetch related data from multi
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Kysely PostgreSQL dialect supports joins out of the box since version `1.4.0`. Joins are enabled by default.
+The Kysely PostgreSQL dialect supports joins out of the box since version `1.4.0`.
+To enable this feature, set `advanced.database.joins` to `true` in your auth configuration.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  advanced: {
+    database: {
+      joins: true,
+    },
+  },
+});
+```
 
 ## Use a non-default schema
 

--- a/docs/content/docs/adapters/postgresql.mdx
+++ b/docs/content/docs/adapters/postgresql.mdx
@@ -67,26 +67,13 @@ your database schema based on your Better Auth configuration and plugins.
   </Tab>
 </Tabs>
 
-## Joins (Experimental)
+## Joins
 
 Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Kysely PostgreSQL dialect supports joins out of the box since version `1.4.0`.
-To enable this feature, you need to set the `experimental.joins` option to `true` in your auth configuration.
-
-```ts title="auth.ts"
-import { betterAuth } from "better-auth";
-
-export const auth = betterAuth({
-  experimental: { joins: true }
-});
-```
-
-<Callout type="warn">
-  It's possible that you may need to run migrations after enabling this feature.
-</Callout>
+The Kysely PostgreSQL dialect supports joins out of the box since version `1.4.0`. Joins are enabled by default.
 
 ## Use a non-default schema
 

--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -73,7 +73,20 @@ Database joins is useful when Better-Auth needs to fetch related data from multi
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Prisma adapter supports joins out of the box since version `1.4.0`. Joins are enabled by default.
+The Prisma adapter supports joins out of the box since version `1.4.0`.
+To enable this feature, set `advanced.database.joins` to `true` in your auth configuration.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  advanced: {
+    database: {
+      joins: true,
+    },
+  },
+});
+```
 
 <Callout type="warn">
   Please make sure that your Prisma schema has the necessary relations defined.

--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -67,22 +67,13 @@ your database schema based on your Better Auth configuration and plugins.
 npx auth@latest generate
 ```
 
-## Joins (Experimental)
+## Joins
 
 Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Prisma adapter supports joins out of the box since version `1.4.0`.
-To enable this feature, you need to set the `experimental.joins` option to `true` in your auth configuration.
-
-```ts title="auth.ts"
-import { betterAuth } from "better-auth";
-
-export const auth = betterAuth({
-  experimental: { joins: true }
-});
-```
+The Prisma adapter supports joins out of the box since version `1.4.0`. Joins are enabled by default.
 
 <Callout type="warn">
   Please make sure that your Prisma schema has the necessary relations defined.

--- a/docs/content/docs/adapters/sqlite.mdx
+++ b/docs/content/docs/adapters/sqlite.mdx
@@ -114,7 +114,20 @@ Database joins is useful when Better-Auth needs to fetch related data from multi
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Kysely SQLite dialect supports joins out of the box since version `1.4.0`. Joins are enabled by default.
+The Kysely SQLite dialect supports joins out of the box since version `1.4.0`.
+To enable this feature, set `advanced.database.joins` to `true` in your auth configuration.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  advanced: {
+    database: {
+      joins: true,
+    },
+  },
+});
+```
 
 ## Additional Information
 

--- a/docs/content/docs/adapters/sqlite.mdx
+++ b/docs/content/docs/adapters/sqlite.mdx
@@ -108,24 +108,13 @@ your database schema based on your Better Auth configuration and plugins.
   </Tab>
 </Tabs>
 
-## Joins (Experimental)
+## Joins
 
 Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 
-The Kysely SQLite dialect supports joins out of the box since version `1.4.0`.
-To enable this feature, you need to set the `experimental.joins` option to `true` in your auth configuration.
-
-```ts title="auth.ts"
-export const auth = betterAuth({
-  experimental: { joins: true }
-});
-```
-
-<Callout type="warn">
-  It's possible that you may need to run migrations after enabling this feature.
-</Callout>
+The Kysely SQLite dialect supports joins out of the box since version `1.4.0`. Joins are enabled by default.
 
 ## Additional Information
 

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -1013,34 +1013,23 @@ To add new tables and columns to your database, you have two options:
 
 Both methods ensure your database schema stays up to date with your plugins' requirements.
 
-## Experimental Joins
+## Joins
 
-Since Better-Auth version `1.4` we've introduced experimental database joins support.
+Since Better-Auth version `1.4` we've introduced database joins support.
 This allows Better-Auth to perform multiple database queries in a single request, reducing the number of database roundtrips.
 Over 50 endpoints support joins, and we're constantly adding more.
 
-Under the hood, our adapter system supports joins natively, meaning even if you don't enable experimental joins,
-it will still fallback to making multiple database queries and combining the results.
+Joins are enabled by default. Under the hood, our adapter system supports joins natively.
+If an adapter cannot return joined data for a query, Better-Auth falls back to making multiple database queries and combining the results.
 
-To enable joins, update your auth config with the following:
+Be sure your DrizzleORM or PrismaORM schema includes the necessary relationships — run our migrate or generate CLI commands to stay up-to-date.
 
-```ts title="auth.ts"
-import { betterAuth } from "better-auth";
+Read the documentation regarding joins for your given adapter:
 
-export const auth = betterAuth({
-  experimental: { joins: true }
-});
-```
-
-The Better-Auth `1.4` CLI will generate DrizzleORM and PrismaORM relationships for you so if you do not have those already
-be sure to update your schema by running our migrate or generate CLI commands to be up-to-date with the latest required schema.
-
-It's very important to read the documentation regarding experimental joins for your given adapter:
-
-* [DrizzleORM](/docs/adapters/drizzle#joins-experimental)
-* [PrismaORM](/docs/adapters/prisma#joins-experimental)
-* [SQLite](/docs/adapters/sqlite#joins-experimental)
-* [MySQL](/docs/adapters/mysql#joins-experimental)
-* [PostgreSQL](/docs/adapters/postgresql#joins-experimental)
-* [MSSQL](/docs/adapters/mssql#joins-experimental)
-* [MongoDB](/docs/adapters/mongo#joins-experimental)
+* [DrizzleORM](/docs/adapters/drizzle#joins)
+* [PrismaORM](/docs/adapters/prisma#joins)
+* [SQLite](/docs/adapters/sqlite#joins)
+* [MySQL](/docs/adapters/mysql#joins)
+* [PostgreSQL](/docs/adapters/postgresql#joins)
+* [MSSQL](/docs/adapters/mssql#joins)
+* [MongoDB](/docs/adapters/mongo#joins)

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -1019,10 +1019,24 @@ Since Better-Auth version `1.4` we've introduced database joins support.
 This allows Better-Auth to perform multiple database queries in a single request, reducing the number of database roundtrips.
 Over 50 endpoints support joins, and we're constantly adding more.
 
-Joins are enabled by default. Under the hood, our adapter system supports joins natively.
-If an adapter cannot return joined data for a query, Better-Auth falls back to making multiple database queries and combining the results.
+Under the hood, our adapter system supports joins natively. When joins are disabled (the default),
+Better-Auth falls back to making multiple database queries and combining the results.
 
-Be sure your DrizzleORM or PrismaORM schema includes the necessary relationships — run our migrate or generate CLI commands to stay up-to-date.
+To enable joins, update your auth config with the following:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  advanced: {
+    database: {
+      joins: true,
+    },
+  },
+});
+```
+
+Make sure your DrizzleORM or PrismaORM schema includes the necessary relationships — run our migrate or generate CLI commands to stay up-to-date.
 
 Read the documentation regarding joins for your given adapter:
 

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -648,7 +648,6 @@ export const auth = betterAuth({
 				return "my-super-unique-id";
 			})) | false | "serial" | "uuid",
 			defaultFindManyLimit: 100,
-			experimentalJoins: false,
 		},
 		backgroundTasks: {
 			handler: (promise) => { /* e.g. waitUntil(promise) */ }

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -648,6 +648,7 @@ export const auth = betterAuth({
 				return "my-super-unique-id";
 			})) | false | "serial" | "uuid",
 			defaultFindManyLimit: 100,
+			joins: false,
 		},
 		backgroundTasks: {
 			handler: (promise) => { /* e.g. waitUntil(promise) */ }
@@ -675,10 +676,11 @@ export const auth = betterAuth({
 
 <h3 id="advanced-database"><code>database</code></h3>
 
-Set custom strategies for ID generation and findMany queries.
+Set custom strategies for ID generation, findMany queries, and database joins.
 
 * `generateId`: Controls how record IDs are generated. Accepts a custom function, `false`, `"serial"`, or `"uuid"` (default: [random base62 string](https://github.com/better-auth/better-auth/blob/main/packages/core/src/utils/id.ts)). See the [Database documentation](/docs/concepts/database#id-generation) for more info.
 * `defaultFindManyLimit`: The default maximum number of records returned by the `findMany` adapter method. (default: `100`)
+* `joins`: Enable database joins for adapters that support them. When disabled (default), related data is fetched via separate queries. See the [Database documentation](/docs/concepts/database#joins) for more info. (default: `false`)
 
 ```ts
 import { betterAuth } from "better-auth";
@@ -688,6 +690,7 @@ export const auth = betterAuth({
 		database: {
 			generateId: "uuid",
 			defaultFindManyLimit: 50,
+			joins: true,
 		},
 	},
 });

--- a/e2e/adapter/test/adapter-factory/adapter-factory.test.ts
+++ b/e2e/adapter/test/adapter-factory/adapter-factory.test.ts
@@ -1762,6 +1762,13 @@ describe("Fallback JoinOption System", async () => {
 				config: {
 					debugLogs: {},
 				},
+				options: {
+					advanced: {
+						database: {
+							joins: true,
+						},
+					},
+				},
 				adapter: () =>
 					({
 						async findOne({ model, where, join }: any) {
@@ -1820,6 +1827,13 @@ describe("Fallback JoinOption System", async () => {
 			const adapter = await createTestAdapter({
 				config: {
 					debugLogs: {},
+				},
+				options: {
+					advanced: {
+						database: {
+							joins: true,
+						},
+					},
 				},
 				adapter: () =>
 					({
@@ -1890,13 +1904,20 @@ describe("Fallback JoinOption System", async () => {
 		});
 	});
 
-	describe("native join support", () => {
+	describe("native join support (advanced.database.joins: true)", () => {
 		test("findOne: Should pass join to adapter and use nested data when present", async () => {
 			let joinPassedToAdapter = null;
 
 			const adapter = await createTestAdapter({
 				config: {
 					debugLogs: {},
+				},
+				options: {
+					advanced: {
+						database: {
+							joins: true,
+						},
+					},
 				},
 				adapter: () =>
 					({
@@ -1940,6 +1961,13 @@ describe("Fallback JoinOption System", async () => {
 				config: {
 					debugLogs: {},
 				},
+				options: {
+					advanced: {
+						database: {
+							joins: true,
+						},
+					},
+				},
 				adapter: () =>
 					({
 						async findMany({ model, join }: any) {
@@ -1979,8 +2007,8 @@ describe("Fallback JoinOption System", async () => {
 		});
 	});
 
-	describe("default behavior (joins always on)", () => {
-		test("Should pass join to adapter by default", async () => {
+	describe("default behavior (joins disabled)", () => {
+		test("Should not pass join to adapter by default", async () => {
 			let joinPassedToAdapter = null;
 
 			const adapter = await createTestAdapter({
@@ -1998,8 +2026,13 @@ describe("Fallback JoinOption System", async () => {
 								createdAt: new Date(),
 								updatedAt: new Date(),
 								name: "Test User",
-								session: [],
 							};
+						},
+						async findMany({ model }: any) {
+							if (model === "session") {
+								return [];
+							}
+							return [];
 						},
 					}) as any,
 			});
@@ -2010,8 +2043,7 @@ describe("Fallback JoinOption System", async () => {
 				join: { session: true },
 			});
 
-			expect(joinPassedToAdapter).not.toBeUndefined();
-			expect(joinPassedToAdapter).toHaveProperty("session");
+			expect(joinPassedToAdapter).toBeUndefined();
 		});
 	});
 });

--- a/e2e/adapter/test/adapter-factory/adapter-factory.test.ts
+++ b/e2e/adapter/test/adapter-factory/adapter-factory.test.ts
@@ -1754,19 +1754,13 @@ describe("Create Adapter Helper", async () => {
 });
 
 describe("Fallback JoinOption System", async () => {
-	describe("supportsJoin: false (Fallback mode)", () => {
+	describe("fallback when adapter returns flat rows (no join keys)", () => {
 		test("findOne: Should handle forward joins (joined model has FK to base model) by making separate queries", async () => {
 			let adapterCalls: Array<{ method: string; model: string }> = [];
 
 			const adapter = await createTestAdapter({
 				config: {
 					debugLogs: {},
-				},
-				options: {
-					experimental: {
-						// explicitally defining since in the future `join` will likely be default which would break this test
-						joins: false,
-					},
 				},
 				adapter: () =>
 					({
@@ -1826,12 +1820,6 @@ describe("Fallback JoinOption System", async () => {
 			const adapter = await createTestAdapter({
 				config: {
 					debugLogs: {},
-				},
-				options: {
-					experimental: {
-						// explicitally defining since in the future `join` will likely be default which would break this test
-						joins: false,
-					},
 				},
 				adapter: () =>
 					({
@@ -1900,19 +1888,15 @@ describe("Fallback JoinOption System", async () => {
 				expect(item).toHaveProperty("session");
 			});
 		});
+	});
 
-		test("findOne: Should not pass join to adapter when supportsJoin is false", async () => {
+	describe("native join support", () => {
+		test("findOne: Should pass join to adapter and use nested data when present", async () => {
 			let joinPassedToAdapter = null;
 
 			const adapter = await createTestAdapter({
 				config: {
 					debugLogs: {},
-				},
-				options: {
-					experimental: {
-						// explicitally defining since in the future `join` will likely be default which would break this test
-						joins: false,
-					},
 				},
 				adapter: () =>
 					({
@@ -1925,33 +1909,36 @@ describe("Fallback JoinOption System", async () => {
 								createdAt: new Date(),
 								updatedAt: new Date(),
 								name: "Test User",
+								session: [
+									{
+										id: "session-1",
+										userId: "user-123",
+										expiresAt: new Date(),
+										createdAt: new Date(),
+									},
+								],
 							};
 						},
 					}) as any,
 			});
 
-			await adapter.findOne({
+			const res = await adapter.findOne({
 				model: "user",
 				where: [{ field: "id", value: "user-123" }],
 				join: { session: true },
 			});
 
-			// JoinOption should NOT be passed to adapter when supportsJoin is false
-			expect(joinPassedToAdapter).toBeUndefined();
+			expect(joinPassedToAdapter).not.toBeUndefined();
+			expect(joinPassedToAdapter).toHaveProperty("session");
+			expect(res).toHaveProperty("session");
 		});
 
-		test("findMany: Should not pass join to adapter when supportsJoin is false", async () => {
+		test("findMany: Should pass join to adapter and use nested data when present", async () => {
 			let joinPassedToAdapter = null;
 
 			const adapter = await createTestAdapter({
 				config: {
 					debugLogs: {},
-				},
-				options: {
-					experimental: {
-						// explicitally defining since in the future `join` will likely be default which would break this test
-						joins: false,
-					},
 				},
 				adapter: () =>
 					({
@@ -1965,116 +1952,39 @@ describe("Fallback JoinOption System", async () => {
 									createdAt: new Date(),
 									updatedAt: new Date(),
 									name: "Test User",
+									session: [
+										{
+											id: "session-1",
+											userId: "user-123",
+											expiresAt: new Date(),
+											createdAt: new Date(),
+										},
+									],
 								},
 							];
 						},
 					}) as any,
 			});
 
-			await adapter.findMany({
+			const res = await adapter.findMany({
 				model: "user",
 				where: [],
 				join: { session: true },
 			});
 
-			// JoinOption should NOT be passed to adapter when supportsJoin is false
-			expect(joinPassedToAdapter).toBeUndefined();
+			expect(joinPassedToAdapter).not.toBeUndefined();
+			expect(joinPassedToAdapter).toHaveProperty("session");
+			expect(res).toBeInstanceOf(Array);
+			expect(res[0]).toHaveProperty("session");
 		});
 	});
 
-	describe("supportsJoin: true (Native join support)", () => {
-		test("findOne: Should pass join to adapter when supportsJoin is true", async () => {
+	describe("default behavior (joins always on)", () => {
+		test("Should pass join to adapter by default", async () => {
 			let joinPassedToAdapter = null;
 
 			const adapter = await createTestAdapter({
 				config: {
-					debugLogs: {},
-				},
-				options: {
-					experimental: {
-						joins: true,
-					},
-				},
-				adapter: () =>
-					({
-						async findOne({ model, join }: any) {
-							joinPassedToAdapter = join;
-							// When adapter supports joins, it returns data with joined structure
-							return {
-								id: "user-123",
-								email: "test@test.com",
-								emailVerified: false,
-								createdAt: new Date(),
-								updatedAt: new Date(),
-								name: "Test User",
-							};
-						},
-					}) as any,
-			});
-
-			await adapter.findOne({
-				model: "user",
-				where: [{ field: "id", value: "user-123" }],
-				join: { session: true },
-			});
-
-			// JoinOption SHOULD be passed to adapter when supportsJoin is true
-			// It's then the adapter's responsibility to handle the join
-			expect(joinPassedToAdapter).not.toBeUndefined();
-			expect(joinPassedToAdapter).toHaveProperty("session");
-		});
-
-		test("findMany: Should pass join to adapter when supportsJoin is true", async () => {
-			let joinPassedToAdapter = null;
-
-			const adapter = await createTestAdapter({
-				config: {
-					debugLogs: {},
-				},
-				options: {
-					experimental: {
-						joins: true,
-					},
-				},
-				adapter: () =>
-					({
-						async findMany({ model, join }: any) {
-							joinPassedToAdapter = join;
-							// When adapter supports joins, it returns data with joined structure
-							return [
-								{
-									id: "user-123",
-									email: "test@test.com",
-									emailVerified: false,
-									createdAt: new Date(),
-									updatedAt: new Date(),
-									name: "Test User",
-								},
-							];
-						},
-					}) as any,
-			});
-
-			await adapter.findMany({
-				model: "user",
-				where: [],
-				join: { session: true },
-			});
-
-			// JoinOption SHOULD be passed to adapter when supportsJoin is true
-			// It's then the adapter's responsibility to handle the join
-			expect(joinPassedToAdapter).not.toBeUndefined();
-			expect(joinPassedToAdapter).toHaveProperty("session");
-		});
-	});
-
-	describe("Default behavior (supportsJoin not specified)", () => {
-		test("Should default to supportsJoin: false and use fallback join system", async () => {
-			let joinPassedToAdapter = null;
-
-			const adapter = await createTestAdapter({
-				config: {
-					// supportsJoin not specified, should default to false
 					debugLogs: {},
 				},
 				adapter: () =>
@@ -2088,6 +1998,7 @@ describe("Fallback JoinOption System", async () => {
 								createdAt: new Date(),
 								updatedAt: new Date(),
 								name: "Test User",
+								session: [],
 							};
 						},
 					}) as any,
@@ -2099,8 +2010,8 @@ describe("Fallback JoinOption System", async () => {
 				join: { session: true },
 			});
 
-			// Since supportsJoin defaults to false, join should NOT be passed
-			expect(joinPassedToAdapter).toBeUndefined();
+			expect(joinPassedToAdapter).not.toBeUndefined();
+			expect(joinPassedToAdapter).toHaveProperty("session");
 		});
 	});
 });

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.mixed-where.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.mixed-where.test.ts
@@ -218,7 +218,9 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 			schema: adapterSchema,
 			provider: "sqlite",
 		});
-		const adapter = adapterFactory({});
+		const adapter = adapterFactory({
+			advanced: { database: { joins: true } },
+		});
 
 		const result = await adapter.findMany<User>({
 			model: "user",
@@ -231,6 +233,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 					connector: "OR",
 				},
 			],
+			join: { session: true },
 		});
 
 		expect(result).toHaveLength(1);
@@ -260,7 +263,9 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 			schema: adapterSchema,
 			provider: "sqlite",
 		});
-		const adapter = adapterFactory({});
+		const adapter = adapterFactory({
+			advanced: { database: { joins: true } },
+		});
 
 		const result = await adapter.findOne<User>({
 			model: "user",
@@ -273,6 +278,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 					connector: "OR",
 				},
 			],
+			join: { session: true },
 		});
 
 		expect(result).not.toBeNull();
@@ -296,7 +302,9 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 			schema: adapterSchema,
 			provider: "sqlite",
 		});
-		const adapter = adapterFactory({});
+		const adapter = adapterFactory({
+			advanced: { database: { joins: true } },
+		});
 
 		const result = await adapter.findMany<User>({
 			model: "user",
@@ -309,6 +317,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 					connector: "OR",
 				},
 			],
+			join: { session: true },
 		});
 
 		expect(result).toHaveLength(0);
@@ -330,7 +339,9 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 			schema: adapterSchema,
 			provider: "sqlite",
 		});
-		const adapter = adapterFactory({});
+		const adapter = adapterFactory({
+			advanced: { database: { joins: true } },
+		});
 
 		const result = await adapter.findMany<User>({
 			model: "user",
@@ -350,6 +361,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 					connector: "OR",
 				},
 			],
+			join: { session: true },
 		});
 
 		expect(result).toHaveLength(3);
@@ -374,7 +386,9 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 			schema: adapterSchema,
 			provider: "sqlite",
 		});
-		const adapter = adapterFactory({});
+		const adapter = adapterFactory({
+			advanced: { database: { joins: true } },
+		});
 
 		const result = await adapter.findOne<User>({
 			model: "user",
@@ -387,6 +401,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 					connector: "OR",
 				},
 			],
+			join: { session: true },
 		});
 
 		expect(result).toBeNull();

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.mixed-where.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.mixed-where.test.ts
@@ -208,7 +208,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/7271
 	 *
-	 * Same query on the experimental joins path.
+	 * Same query on the joins path.
 	 * The bug: `clause[0]` is used, dropping the OR group entirely.
 	 * Only the AND clause (email LIKE '%company.com%') is applied,
 	 * returning u1 AND u2 instead of just u1.
@@ -218,9 +218,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 			schema: adapterSchema,
 			provider: "sqlite",
 		});
-		const adapter = adapterFactory({
-			experimental: { joins: true },
-		});
+		const adapter = adapterFactory({});
 
 		const result = await adapter.findMany<User>({
 			model: "user",
@@ -262,9 +260,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 			schema: adapterSchema,
 			provider: "sqlite",
 		});
-		const adapter = adapterFactory({
-			experimental: { joins: true },
-		});
+		const adapter = adapterFactory({});
 
 		const result = await adapter.findOne<User>({
 			model: "user",
@@ -300,9 +296,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 			schema: adapterSchema,
 			provider: "sqlite",
 		});
-		const adapter = adapterFactory({
-			experimental: { joins: true },
-		});
+		const adapter = adapterFactory({});
 
 		const result = await adapter.findMany<User>({
 			model: "user",
@@ -336,9 +330,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 			schema: adapterSchema,
 			provider: "sqlite",
 		});
-		const adapter = adapterFactory({
-			experimental: { joins: true },
-		});
+		const adapter = adapterFactory({});
 
 		const result = await adapter.findMany<User>({
 			model: "user",
@@ -382,9 +374,7 @@ describe("drizzle adapter: mixed AND/OR connectors in where clauses", () => {
 			schema: adapterSchema,
 			provider: "sqlite",
 		});
-		const adapter = adapterFactory({
-			experimental: { joins: true },
-		});
+		const adapter = adapterFactory({});
 
 		const result = await adapter.findOne<User>({
 			model: "user",

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.plural-joins.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.plural-joins.test.ts
@@ -117,7 +117,7 @@ const adapterSchema = {
 
 // ── Tests ──
 
-describe("drizzle adapter: singular config.schema keys with plural db.query keys + experimental.joins", () => {
+describe("drizzle adapter: singular config.schema keys with plural db.query keys + joins", () => {
 	let sqliteDb: InstanceType<typeof Database>;
 	let db: ReturnType<typeof drizzle>;
 
@@ -183,9 +183,7 @@ describe("drizzle adapter: singular config.schema keys with plural db.query keys
 			// usePlural is NOT set (default: false) — this is the common config
 		});
 
-		const adapter = adapterFactory({
-			experimental: { joins: true },
-		});
+		const adapter = adapterFactory({});
 
 		const now = new Date();
 		const nowTs = now.getTime();
@@ -237,9 +235,7 @@ describe("drizzle adapter: singular config.schema keys with plural db.query keys
 			provider: "sqlite",
 		});
 
-		const adapter = adapterFactory({
-			experimental: { joins: true },
-		});
+		const adapter = adapterFactory({});
 
 		// findMany with join — exercises the findMany join path
 		const allUsers = await adapter.findMany<User & { session: Session[] }>({

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.plural-joins.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.plural-joins.test.ts
@@ -183,7 +183,9 @@ describe("drizzle adapter: singular config.schema keys with plural db.query keys
 			// usePlural is NOT set (default: false) — this is the common config
 		});
 
-		const adapter = adapterFactory({});
+		const adapter = adapterFactory({
+			advanced: { database: { joins: true } },
+		});
 
 		const now = new Date();
 		const nowTs = now.getTime();
@@ -235,7 +237,9 @@ describe("drizzle adapter: singular config.schema keys with plural db.query keys
 			provider: "sqlite",
 		});
 
-		const adapter = adapterFactory({});
+		const adapter = adapterFactory({
+			advanced: { database: { joins: true } },
+		});
 
 		// findMany with join — exercises the findMany join path
 		const allUsers = await adapter.findMany<User & { session: Session[] }>({

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.insensitive-join.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.insensitive-join.test.ts
@@ -1,7 +1,7 @@
 /**
  * The adapter skipped the relational query for case-insensitive where clauses,
- * falling back to the non-relational path. Under `experimental.joins` that
- * returned empty joins, so insensitive conditions are now routed through `RAW`.
+ * falling back to the non-relational path and returning empty joins.
+ * Insensitive conditions are now routed through `RAW`.
  */
 import { drizzleAdapter } from "@better-auth/drizzle-adapter/relations-v2";
 import Database from "better-sqlite3";
@@ -46,7 +46,7 @@ describe("drizzle relations-v2 adapter: case-insensitive where on the joins path
 	const adapter = drizzleAdapter(db, {
 		schema: { ...tables, relations },
 		provider: "sqlite",
-	})({ experimental: { joins: true } });
+	})({});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS session;");

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.insensitive-join.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.insensitive-join.test.ts
@@ -46,7 +46,9 @@ describe("drizzle relations-v2 adapter: case-insensitive where on the joins path
 	const adapter = drizzleAdapter(db, {
 		schema: { ...tables, relations },
 		provider: "sqlite",
-	})({});
+	})({
+		advanced: { database: { joins: true } },
+	});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS session;");

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.joins-where.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.joins-where.test.ts
@@ -31,7 +31,9 @@ describe("drizzle relations-v2 adapter: joins path honors insensitive mode", () 
 	const adapter = drizzleAdapter(db, {
 		schema,
 		provider: "sqlite",
-	})({});
+	})({
+		advanced: { database: { joins: true } },
+	});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS user;");

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.joins-where.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.joins-where.test.ts
@@ -1,5 +1,5 @@
 /**
- * Under `experimental.joins`, a `where` with `mode: "insensitive"` must fall back
+ * With joins, a `where` with `mode: "insensitive"` must fall back
  * to the SQL builder instead of silently degrading to a case-sensitive match.
  */
 import type { User } from "@better-auth/core/db";
@@ -31,7 +31,7 @@ describe("drizzle relations-v2 adapter: joins path honors insensitive mode", () 
 	const adapter = drizzleAdapter(db, {
 		schema,
 		provider: "sqlite",
-	})({ experimental: { joins: true } });
+	})({});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS user;");

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.like-escape-joins.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.like-escape-joins.test.ts
@@ -33,7 +33,9 @@ describe("drizzle relations-v2 adapter: LIKE escaping on the joins path", () => 
 	const adapter = drizzleAdapter(db, {
 		schema: { ...tables, relations },
 		provider: "sqlite",
-	})({});
+	})({
+		advanced: { database: { joins: true } },
+	});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS user;");

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.like-escape-joins.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.like-escape-joins.test.ts
@@ -1,5 +1,5 @@
 /**
- * With `experimental.joins`, `findMany` filters through Drizzle's relational
+ * With joins, `findMany` filters through Drizzle's relational
  * query object, whose `like` filter cannot carry `ESCAPE`. LIKE is routed
  * through `RAW`, so this checks `%` and `_` still match literally.
  *
@@ -33,7 +33,7 @@ describe("drizzle relations-v2 adapter: LIKE escaping on the joins path", () => 
 	const adapter = drizzleAdapter(db, {
 		schema: { ...tables, relations },
 		provider: "sqlite",
-	})({ experimental: { joins: true } });
+	})({});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS user;");

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-query-key.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-query-key.test.ts
@@ -2,7 +2,7 @@
  * Drizzle keys `db.query` by the schema export names, commonly plural ("users"),
  * while Better Auth passes singular model names. The adapter read
  * `db.query[model]` directly, so a plural-keyed schema fell back to the
- * non-relational query, returning empty joins under `experimental.joins`.
+ * non-relational query, returning empty joins.
  */
 import { drizzleAdapter } from "@better-auth/drizzle-adapter/relations-v2";
 import Database from "better-sqlite3";
@@ -49,7 +49,7 @@ describe("drizzle relations-v2 adapter: plural db.query keys", () => {
 	const adapter = drizzleAdapter(db, {
 		schema: { user: users, session: sessions, relations },
 		provider: "sqlite",
-	})({ experimental: { joins: true } });
+	})({});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS session;");
@@ -128,7 +128,7 @@ describe("drizzle relations-v2 adapter: missing relational query namespace", () 
 	const adapter = drizzleAdapter(db, {
 		schema: { user: users, session: sessions, relations },
 		provider: "sqlite",
-	})({ experimental: { joins: true } });
+	})({});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS user;");
@@ -174,7 +174,7 @@ describe("drizzle relations-v2 adapter: query key via relations internal", () =>
 	const adapter = drizzleAdapter(db, {
 		schema: { user: users, session: sessions, relations },
 		provider: "sqlite",
-	})({ experimental: { joins: true } });
+	})({});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS session;");

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-query-key.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-query-key.test.ts
@@ -49,7 +49,9 @@ describe("drizzle relations-v2 adapter: plural db.query keys", () => {
 	const adapter = drizzleAdapter(db, {
 		schema: { user: users, session: sessions, relations },
 		provider: "sqlite",
-	})({});
+	})({
+		advanced: { database: { joins: true } },
+	});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS session;");
@@ -128,7 +130,9 @@ describe("drizzle relations-v2 adapter: missing relational query namespace", () 
 	const adapter = drizzleAdapter(db, {
 		schema: { user: users, session: sessions, relations },
 		provider: "sqlite",
-	})({});
+	})({
+		advanced: { database: { joins: true } },
+	});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS user;");
@@ -174,7 +178,9 @@ describe("drizzle relations-v2 adapter: query key via relations internal", () =>
 	const adapter = drizzleAdapter(db, {
 		schema: { user: users, session: sessions, relations },
 		provider: "sqlite",
-	})({});
+	})({
+		advanced: { database: { joins: true } },
+	});
 
 	beforeEach(() => {
 		sqliteDb.exec("DROP TABLE IF EXISTS session;");

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-suffix-trailing-s.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-suffix-trailing-s.test.ts
@@ -53,7 +53,6 @@ describe("drizzle relations-v2 adapter: join model name ending in 's'", () => {
 		schema: { user: users, address, relations },
 		provider: "sqlite",
 	})({
-		experimental: { joins: true },
 		plugins: [
 			{
 				id: "test-address",

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-suffix-trailing-s.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-suffix-trailing-s.test.ts
@@ -53,6 +53,7 @@ describe("drizzle relations-v2 adapter: join model name ending in 's'", () => {
 		schema: { user: users, address, relations },
 		provider: "sqlite",
 	})({
+		advanced: { database: { joins: true } },
 		plugins: [
 			{
 				id: "test-address",

--- a/e2e/adapter/test/kysely-adapter/schema-reference-test-suite.ts
+++ b/e2e/adapter/test/kysely-adapter/schema-reference-test-suite.ts
@@ -37,17 +37,12 @@ export const schemaRefTestSuite = createTestSuite(
 );
 
 /**
- * Same as the normal standard notation test suite, but with joins enabled.
+ * Same as the normal standard notation test suite, exercising the joins path.
  */
 export const schemaRefJoinTestSuite = createTestSuite(
 	"schema-reference-join",
 	{
-		defaultBetterAuthOptions: {
-			...DEFAULT_BETTER_AUTH_OPTIONS,
-			experimental: {
-				joins: true,
-			},
-		},
+		defaultBetterAuthOptions: DEFAULT_BETTER_AUTH_OPTIONS,
 		alwaysMigrate: true,
 		prefixTests: "schema-reference-join",
 	},

--- a/e2e/adapter/test/kysely-adapter/schema-reference-test-suite.ts
+++ b/e2e/adapter/test/kysely-adapter/schema-reference-test-suite.ts
@@ -37,12 +37,19 @@ export const schemaRefTestSuite = createTestSuite(
 );
 
 /**
- * Same as the normal standard notation test suite, exercising the joins path.
+ * Same as the normal standard notation test suite, but with joins enabled.
  */
 export const schemaRefJoinTestSuite = createTestSuite(
 	"schema-reference-join",
 	{
-		defaultBetterAuthOptions: DEFAULT_BETTER_AUTH_OPTIONS,
+		defaultBetterAuthOptions: {
+			...DEFAULT_BETTER_AUTH_OPTIONS,
+			advanced: {
+				database: {
+					joins: true,
+				},
+			},
+		},
 		alwaysMigrate: true,
 		prefixTests: "schema-reference-join",
 	},

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -425,10 +425,12 @@ export const createAdapterFactory =
 				joinConfig,
 			} of requiredModels) {
 				let joinedData = await (async () => {
-					// Use native joined data when the adapter included the key;
-					// otherwise fall back to separate queries.
-					if (modelName in data) {
-						return data[modelName];
+					if (options.advanced?.database?.joins) {
+						// Use native joined data when the adapter included the key;
+						// otherwise fall back to separate queries.
+						if (modelName in data) {
+							return data[modelName];
+						}
 					}
 					return await handleFallbackJoin({
 						baseModel: unsafe_model,
@@ -1109,11 +1111,20 @@ export const createAdapterFactory =
 				});
 				unsafeModel = getDefaultModelName(unsafeModel);
 				let join: JoinConfig | undefined;
+				let passJoinToAdapter = true;
 				if (!config.disableTransformJoin) {
 					const result = transformJoinClause(unsafeModel, unsafeJoin, select);
 					if (result) {
 						join = result.join;
 						select = result.select;
+					}
+					// If joins are disabled and we have joins, don't pass them to the adapter
+					if (
+						!options.advanced?.database?.joins &&
+						join &&
+						Object.keys(join).length > 0
+					) {
+						passJoinToAdapter = false;
 					}
 				} else {
 					// assume it's already transformed if transformation is disabled
@@ -1137,7 +1148,7 @@ export const createAdapterFactory =
 							model,
 							where,
 							select,
-							join,
+							join: passJoinToAdapter ? join : undefined,
 						}),
 				);
 				debugLog(
@@ -1191,11 +1202,20 @@ export const createAdapterFactory =
 				});
 				unsafeModel = getDefaultModelName(unsafeModel);
 				let join: JoinConfig | undefined;
+				let passJoinToAdapter = true;
 				if (!config.disableTransformJoin) {
 					const result = transformJoinClause(unsafeModel, unsafeJoin, select);
 					if (result) {
 						join = result.join;
 						select = result.select;
+					}
+					// If joins are disabled and we have joins, don't pass them to the adapter
+					if (
+						!options.advanced?.database?.joins &&
+						join &&
+						Object.keys(join).length > 0
+					) {
+						passJoinToAdapter = false;
 					}
 				} else {
 					// assume it's already transformed if transformation is disabled
@@ -1221,7 +1241,7 @@ export const createAdapterFactory =
 							select,
 							sortBy,
 							offset,
-							join,
+							join: passJoinToAdapter ? join : undefined,
 						}),
 				);
 				debugLog(

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -425,19 +425,17 @@ export const createAdapterFactory =
 				joinConfig,
 			} of requiredModels) {
 				let joinedData = await (async () => {
-					if (options.experimental?.joins) {
-						const result = data[modelName];
-						return result;
-					} else {
-						// doesn't support joins, so fallback to handleFallbackJoin
-						const result = await handleFallbackJoin({
-							baseModel: unsafe_model,
-							baseData: transformedData,
-							joinModel: modelName,
-							specificJoinConfig: joinConfig,
-						});
-						return result;
+					// Use native joined data when the adapter included the key;
+					// otherwise fall back to separate queries.
+					if (modelName in data) {
+						return data[modelName];
 					}
+					return await handleFallbackJoin({
+						baseModel: unsafe_model,
+						baseData: transformedData,
+						joinModel: modelName,
+						specificJoinConfig: joinConfig,
+					});
 				})();
 
 				// If joinedData is undefined, initialize it based on relationship type
@@ -1111,17 +1109,11 @@ export const createAdapterFactory =
 				});
 				unsafeModel = getDefaultModelName(unsafeModel);
 				let join: JoinConfig | undefined;
-				let passJoinToAdapter = true;
 				if (!config.disableTransformJoin) {
 					const result = transformJoinClause(unsafeModel, unsafeJoin, select);
 					if (result) {
 						join = result.join;
 						select = result.select;
-					}
-					// If adapter doesn't support joins and we have joins, don't pass them to the adapter
-					const experimentalJoins = options.experimental?.joins;
-					if (!experimentalJoins && join && Object.keys(join).length > 0) {
-						passJoinToAdapter = false;
 					}
 				} else {
 					// assume it's already transformed if transformation is disabled
@@ -1145,7 +1137,7 @@ export const createAdapterFactory =
 							model,
 							where,
 							select,
-							join: passJoinToAdapter ? join : undefined,
+							join,
 						}),
 				);
 				debugLog(
@@ -1199,17 +1191,11 @@ export const createAdapterFactory =
 				});
 				unsafeModel = getDefaultModelName(unsafeModel);
 				let join: JoinConfig | undefined;
-				let passJoinToAdapter = true;
 				if (!config.disableTransformJoin) {
 					const result = transformJoinClause(unsafeModel, unsafeJoin, select);
 					if (result) {
 						join = result.join;
 						select = result.select;
-					}
-					// If adapter doesn't support joins and we have joins, don't pass them to the adapter
-					const experimentalJoins = options.experimental?.joins;
-					if (!experimentalJoins && join && Object.keys(join).length > 0) {
-						passJoinToAdapter = false;
 					}
 				} else {
 					// assume it's already transformed if transformation is disabled
@@ -1235,7 +1221,7 @@ export const createAdapterFactory =
 							select,
 							sortBy,
 							offset,
-							join: passJoinToAdapter ? join : undefined,
+							join,
 						}),
 				);
 				debugLog(

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -454,6 +454,21 @@ export type BetterAuthAdvancedOptions = {
 				 * function.
 				 */
 				generateId?: GenerateIdFn | false | "serial" | "uuid";
+				/**
+				 * Enable database joins for adapters that support them.
+				 *
+				 * When disabled (default), related data is fetched via
+				 * separate queries. When enabled, adapters that support
+				 * native joins use them; otherwise Better Auth falls back
+				 * to separate queries.
+				 *
+				 * Please read the adapter documentation for more
+				 * information regarding joins before enabling this.
+				 * Not all adapters support joins.
+				 *
+				 * @default false
+				 */
+				joins?: boolean;
 		  }
 		| undefined;
 	/**

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1783,18 +1783,4 @@ export type BetterAuthOptions = {
 				debug?: boolean;
 		  }
 		| undefined;
-	/**
-	 * Experimental features
-	 */
-	experimental?: {
-		/**
-		 * Enable experimental joins for your database adapter.
-		 *
-		 * 	Please read the adapter documentation for more information regarding joins before enabling this.
-		 * 	Not all adapters support joins.
-		 *
-		 * @default false
-		 */
-		joins?: boolean;
-	};
 };

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -758,7 +758,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					const schemaModel = getSchema(model);
 					const clause = convertWhereClause(where, model);
 
-					if (options.experimental?.joins) {
+					if (join) {
 						const queryModel = getQueryModel(model);
 						if (!db.query || !queryModel) {
 							logger.error(
@@ -771,22 +771,20 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const pluralJoinResults: string[] = [];
-							if (join) {
-								includes = {};
-								const joinEntries = Object.entries(join);
-								for (const [model, joinAttr] of joinEntries) {
-									const limit =
-										joinAttr.limit ??
-										options.advanced?.database?.defaultFindManyLimit ??
-										100;
-									const isUnique = joinAttr.relation === "one-to-one";
-									const pluralSuffix = isUnique || config.usePlural ? "" : "s";
-									includes[`${model}${pluralSuffix}`] = isUnique
-										? true
-										: { limit };
-									if (!isUnique) {
-										pluralJoinResults.push(`${model}${pluralSuffix}`);
-									}
+							includes = {};
+							const joinEntries = Object.entries(join);
+							for (const [model, joinAttr] of joinEntries) {
+								const limit =
+									joinAttr.limit ??
+									options.advanced?.database?.defaultFindManyLimit ??
+									100;
+								const isUnique = joinAttr.relation === "one-to-one";
+								const pluralSuffix = isUnique || config.usePlural ? "" : "s";
+								includes[`${model}${pluralSuffix}`] = isUnique
+									? true
+									: { limit };
+								if (!isUnique) {
+									pluralJoinResults.push(`${model}${pluralSuffix}`);
 								}
 							}
 							const query = db.query[queryModel].findFirst({
@@ -845,7 +843,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					const clause = where ? convertWhereClause(where, model) : [];
 					const sortFn = sortBy?.direction === "desc" ? desc : asc;
 
-					if (options.experimental?.joins) {
+					if (join) {
 						const queryModel = getQueryModel(model);
 						if (!queryModel) {
 							logger.error(
@@ -858,22 +856,20 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const pluralJoinResults: string[] = [];
-							if (join) {
-								includes = {};
-								const joinEntries = Object.entries(join);
-								for (const [model, joinAttr] of joinEntries) {
-									const isUnique = joinAttr.relation === "one-to-one";
-									const limit =
-										joinAttr.limit ??
-										options.advanced?.database?.defaultFindManyLimit ??
-										100;
-									const pluralSuffix = isUnique || config.usePlural ? "" : "s";
-									includes[`${model}${pluralSuffix}`] = isUnique
-										? true
-										: { limit };
-									if (!isUnique)
-										pluralJoinResults.push(`${model}${pluralSuffix}`);
-								}
+							includes = {};
+							const joinEntries = Object.entries(join);
+							for (const [model, joinAttr] of joinEntries) {
+								const isUnique = joinAttr.relation === "one-to-one";
+								const limit =
+									joinAttr.limit ??
+									options.advanced?.database?.defaultFindManyLimit ??
+									100;
+								const pluralSuffix = isUnique || config.usePlural ? "" : "s";
+								includes[`${model}${pluralSuffix}`] = isUnique
+									? true
+									: { limit };
+								if (!isUnique)
+									pluralJoinResults.push(`${model}${pluralSuffix}`);
 							}
 							let orderBy: SQL<unknown>[] | undefined = undefined;
 							if (sortBy?.field) {

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -722,6 +722,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 			 *    corresponds to the same table object
 			 */
 			function getQueryModel(model: string): string | null {
+				if (!db.query) return null;
 				if (db.query[model]) return model;
 
 				if (config.usePlural) {
@@ -845,7 +846,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 
 					if (join) {
 						const queryModel = getQueryModel(model);
-						if (!queryModel) {
+						if (!db.query || !queryModel) {
 							logger.error(
 								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx auth@latest generate".`,
 							);

--- a/packages/drizzle-adapter/src/relations-v2/index.ts
+++ b/packages/drizzle-adapter/src/relations-v2/index.ts
@@ -693,7 +693,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					const schemaModel = getSchema(model);
 					const clause = convertWhereClause(where, model);
 
-					if (options.experimental?.joins) {
+					if (join) {
 						const queryModel = getQueryModel(model);
 						if (!db.query || !queryModel) {
 							logger.error(
@@ -706,20 +706,18 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const pluralJoinResults: { key: string; target: string }[] = [];
-							if (join) {
-								includes = {};
-								const joinEntries = Object.entries(join);
-								for (const [model, joinAttr] of joinEntries) {
-									const limit =
-										joinAttr.limit ??
-										options.advanced?.database?.defaultFindManyLimit ??
-										100;
-									const isUnique = joinAttr.relation === "one-to-one";
-									const relationKey = getJoinRelationKey(model, isUnique);
-									includes[relationKey] = isUnique ? true : { limit };
-									if (!isUnique) {
-										pluralJoinResults.push({ key: relationKey, target: model });
-									}
+							includes = {};
+							const joinEntries = Object.entries(join);
+							for (const [model, joinAttr] of joinEntries) {
+								const limit =
+									joinAttr.limit ??
+									options.advanced?.database?.defaultFindManyLimit ??
+									100;
+								const isUnique = joinAttr.relation === "one-to-one";
+								const relationKey = getJoinRelationKey(model, isUnique);
+								includes[relationKey] = isUnique ? true : { limit };
+								if (!isUnique) {
+									pluralJoinResults.push({ key: relationKey, target: model });
 								}
 							}
 							const clause = convertNewWhereClause(where, model);
@@ -775,7 +773,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					const clause = where ? convertWhereClause(where, model) : [];
 					const sortFn = sortBy?.direction === "desc" ? desc : asc;
 
-					if (options.experimental?.joins) {
+					if (join) {
 						const queryModel = getQueryModel(model);
 						if (!db.query || !queryModel) {
 							logger.error(
@@ -788,20 +786,18 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const pluralJoinResults: { key: string; target: string }[] = [];
-							if (join) {
-								includes = {};
-								const joinEntries = Object.entries(join);
-								for (const [model, joinAttr] of joinEntries) {
-									const isUnique = joinAttr.relation === "one-to-one";
-									const limit =
-										joinAttr.limit ??
-										options.advanced?.database?.defaultFindManyLimit ??
-										100;
-									const relationKey = getJoinRelationKey(model, isUnique);
-									includes[relationKey] = isUnique ? true : { limit };
-									if (!isUnique)
-										pluralJoinResults.push({ key: relationKey, target: model });
-								}
+							includes = {};
+							const joinEntries = Object.entries(join);
+							for (const [model, joinAttr] of joinEntries) {
+								const isUnique = joinAttr.relation === "one-to-one";
+								const limit =
+									joinAttr.limit ??
+									options.advanced?.database?.defaultFindManyLimit ??
+									100;
+								const relationKey = getJoinRelationKey(model, isUnique);
+								includes[relationKey] = isUnique ? true : { limit };
+								if (!isUnique)
+									pluralJoinResults.push({ key: relationKey, target: model });
 							}
 							let orderBy: Record<string, "asc" | "desc"> | undefined =
 								undefined;

--- a/packages/test-utils/src/adapter/suites/joins.ts
+++ b/packages/test-utils/src/adapter/suites/joins.ts
@@ -1,15 +1,9 @@
-import { expect } from "vitest";
 import { createTestSuite } from "../create-test-suite";
 import { getNormalTestSuiteTests } from "./basic";
 
 export const joinsTestSuite = createTestSuite(
 	"joins",
 	{
-		defaultBetterAuthOptions: {
-			experimental: {
-				joins: true,
-			},
-		},
 		alwaysMigrate: true,
 		prefixTests: "joins",
 	},
@@ -18,10 +12,6 @@ export const joinsTestSuite = createTestSuite(
 			getNormalTestSuiteTests({ ...helpers });
 
 		return {
-			"init - tests": async () => {
-				const opts = helpers.getBetterAuthOptions();
-				expect(opts.experimental?.joins).toBe(true);
-			},
 			...normalTests,
 		};
 	},

--- a/packages/test-utils/src/adapter/suites/joins.ts
+++ b/packages/test-utils/src/adapter/suites/joins.ts
@@ -1,9 +1,17 @@
+import { expect } from "vitest";
 import { createTestSuite } from "../create-test-suite";
 import { getNormalTestSuiteTests } from "./basic";
 
 export const joinsTestSuite = createTestSuite(
 	"joins",
 	{
+		defaultBetterAuthOptions: {
+			advanced: {
+				database: {
+					joins: true,
+				},
+			},
+		},
 		alwaysMigrate: true,
 		prefixTests: "joins",
 	},
@@ -12,6 +20,10 @@ export const joinsTestSuite = createTestSuite(
 			getNormalTestSuiteTests({ ...helpers });
 
 		return {
+			"init - tests": async () => {
+				const opts = helpers.getBetterAuthOptions();
+				expect(opts.advanced?.database?.joins).toBe(true);
+			},
 			...normalTests,
 		};
 	},


### PR DESCRIPTION
## Summary
- Graduates `experimental.joins` to a stable opt-in at `advanced.database.joins` (default `false`)
- Removes the `experimental` options namespace (joins was its only member)
- When enabled, adapters that support native joins use them; otherwise the factory falls back to separate queries

## Migration
If you previously set `experimental: { joins: true }`, update to:

```ts
advanced: {
  database: {
    joins: true,
  },
}
```

## Test plan
- [x] Adapter-factory joins tests (default off / opt-in / fallback)
- [x] Drizzle / drizzle-v2 / kysely join e2e suites pass with `advanced.database.joins: true`
- [ ] CI green on this PR