### PR TITLE
docs: update ZenStack plugin url to the update-to-date ZenStack repo

### DIFF
--- a/docs/lib/community-adapters-data.ts
+++ b/docs/lib/community-adapters-data.ts
@@ -134,7 +134,7 @@ export const communityAdapters: CommunityAdapter[] = [
 	},
 	{
 		name: "@zenstackhq/better-auth",
-		url: "https://github.com/zenstackhq/zenstack-v3/tree/main/packages/auth-adapters/better-auth",
+		url: "https://github.com/zenstackhq/zenstack/tree/main/packages/auth-adapters/better-auth",
 		database: "ZenStack",
 		databaseUrl: "https://zenstack.dev",
 		author: {


### PR DESCRIPTION
ZenStack V3 repo has been merged to the main repo and was archived.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the `@zenstackhq/better-auth` adapter link to point to the main ZenStack repository, replacing the archived `zenstack-v3` URL. Fixes the Community Adapters docs link so users land on the correct source.

<sup>Written for commit 334a257858eda00b5b19f50017c2619c133ec4eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

