### PR TITLE
docs: add better-auth-referral to community plugin

### DIFF
--- a/.cspell/names.txt
+++ b/.cspell/names.txt
@@ -40,3 +40,4 @@ Arnav
 Sahu
 stewartjarod
 rajatsandeepsen
+shivamrun

--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -292,6 +292,16 @@ export const communityPlugins: CommunityPlugin[] = [
 		},
 	},
 	{
+		name: "@marinedotsh/better-auth-referral",
+		url: "https://github.com/marinedotsh/better-auth-referral",
+		description: "A Better Auth plugin for adding user referrals to your app.",
+		author: {
+			name: "Shivam Gupta",
+			github: "shivamrun",
+			avatar: "https://github.com/shivamrun.png",
+		},
+	},
+	{
 		name: "better-auth-instagram",
 		url: "https://github.com/rajatsandeepsen/better-auth-instagram",
 		description: "Instagram Provider for Better Auth",


### PR DESCRIPTION
Adds `@marinedotsh/better-auth-referral` to the community plugins list.

The plugin adds user-to-user referrals to Better Auth, including unique referral codes, referral tracking during signup, referral stats, paginated referred-user lists, optional email masking, and a callback for custom post-signup logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `@marinedotsh/better-auth-referral` to the community plugins list so developers can find a Better Auth referrals plugin. Also added `shivamrun` to the cspell names dictionary.

<sup>Written for commit 5989eb8a18cc3782aec82a68b6656f3c2947a576. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

