### PR TITLE
fix(session): use authoritative session reads in token and delete-account routes

### DIFF
--- a/.changeset/authoritative-session-api-key-routes.md
+++ b/.changeset/authoritative-session-api-key-routes.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/api-key": patch
+---
+
+Fixes revoked sessions still being able to create or update API keys when the session cookie cache is enabled and a plugin or hook resolved the session earlier in the same request. Key creation and updates now perform an authoritative session read, so a session revoked server-side — including the revocation performed when a user is banned — can no longer mint a key that outlives it.

--- a/.changeset/authoritative-session-token-and-delete-routes.md
+++ b/.changeset/authoritative-session-token-and-delete-routes.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fixes revoked sessions still being accepted by `getAccessToken`, `refreshToken`, `accountInfo`, and the delete-account callback when the session cookie cache is enabled and a plugin or hook resolved the session earlier in the same request. These routes now perform an authoritative session read, so a session revoked server-side can no longer mint provider access tokens or complete an account deletion before the cached cookie expires.

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -1,5 +1,8 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
+import { createAuthMiddleware } from "@better-auth/core/api";
 import type { SecondaryStorage } from "@better-auth/core/db";
 import type { APIError } from "@better-auth/core/error";
+import { getSessionFromCtx } from "better-auth/api";
 import { getTestInstance } from "better-auth/test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { apiKey, API_KEY_ERROR_CODES as ERROR_CODES } from ".";
@@ -5322,6 +5325,59 @@ describe("api key creation uses a fresh session", async () => {
 
 		// Creation must re-check the authoritative store and reject, rather than
 		// minting a fresh key from the stale cookie-cache session.
+		const second = await client.apiKey.create({}, { headers });
+		expect(second.data).toBeNull();
+		expect(second.error?.status).toBe(401);
+	});
+
+	/**
+	 * Resolving the session from a `before` hook is a documented plugin pattern,
+	 * and it memoizes the cookie-cached session on `ctx.context.session`. The
+	 * authoritative re-read must not be satisfied by that memoized value, or a
+	 * revoked session can still mint a key that outlives it.
+	 *
+	 * @see https://github.com/better-auth/better-auth/pull/10187
+	 */
+	it("rejects creation with a revoked session when an earlier hook already resolved it", async () => {
+		const sessionReadingPlugin = {
+			id: "session-reading-hook",
+			hooks: {
+				before: [
+					{
+						matcher: (ctx) => ctx.path === "/api-key/create",
+						handler: createAuthMiddleware(async (ctx) => {
+							// Pins `ctx.context.session` to the cookie-cached session.
+							await getSessionFromCtx(ctx);
+						}),
+					},
+				],
+			},
+		} satisfies BetterAuthPlugin;
+
+		const { auth, client, testUser } = await getTestInstance(
+			{
+				session: { cookieCache: { enabled: true, maxAge: 60 * 5 } },
+				plugins: [apiKey(), sessionReadingPlugin],
+			},
+			{ clientOptions: { plugins: [apiKeyClient()] } },
+		);
+
+		const headers = new Headers();
+		const signIn = await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+			fetchOptions: { onSuccess: captureCookies(headers) },
+		});
+		const userId = signIn.data?.user.id;
+		expect(userId).toBeDefined();
+		expect(headers.get("cookie")).toContain("better-auth.session_data");
+
+		const first = await client.apiKey.create({}, { headers });
+		expect(first.data?.key).toBeDefined();
+
+		const ctx = await auth.$context;
+		await ctx.internalAdapter.deleteUserSessions(userId!);
+
 		const second = await client.apiKey.create({}, { headers });
 		expect(second.data).toBeNull();
 		expect(second.error?.status).toBe(401);

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -5382,4 +5382,58 @@ describe("api key creation uses a fresh session", async () => {
 		expect(second.data).toBeNull();
 		expect(second.error?.status).toBe(401);
 	});
+
+	/**
+	 * Same hook-memoization bypass as above, on the update surface: a revoked
+	 * session must not be able to mutate an existing key either.
+	 *
+	 * @see https://github.com/better-auth/better-auth/pull/10187
+	 */
+	it("rejects update with a revoked session when an earlier hook already resolved it", async () => {
+		const sessionReadingPlugin = {
+			id: "session-reading-hook",
+			hooks: {
+				before: [
+					{
+						matcher: (ctx) => ctx.path === "/api-key/update",
+						handler: createAuthMiddleware(async (ctx) => {
+							// Pins `ctx.context.session` to the cookie-cached session.
+							await getSessionFromCtx(ctx);
+						}),
+					},
+				],
+			},
+		} satisfies BetterAuthPlugin;
+
+		const { auth, client, testUser } = await getTestInstance(
+			{
+				session: { cookieCache: { enabled: true, maxAge: 60 * 5 } },
+				plugins: [apiKey(), sessionReadingPlugin],
+			},
+			{ clientOptions: { plugins: [apiKeyClient()] } },
+		);
+
+		const headers = new Headers();
+		const signIn = await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+			fetchOptions: { onSuccess: captureCookies(headers) },
+		});
+		const userId = signIn.data?.user.id;
+		expect(userId).toBeDefined();
+		expect(headers.get("cookie")).toContain("better-auth.session_data");
+
+		const created = await client.apiKey.create({}, { headers });
+		expect(created.data?.id).toBeDefined();
+
+		const ctx = await auth.$context;
+		await ctx.internalAdapter.deleteUserSessions(userId!);
+
+		const updated = await client.apiKey.update(
+			{ keyId: created.data!.id, name: "Renamed By Revoked Session" },
+			{ headers },
+		);
+		expect(updated.data).toBeNull();
+		expect(updated.error?.status).toBe(401);
+	});
 });

--- a/packages/api-key/src/routes/create-api-key.ts
+++ b/packages/api-key/src/routes/create-api-key.ts
@@ -3,7 +3,7 @@ import { createAuthEndpoint } from "@better-auth/core/api";
 import { APIError } from "@better-auth/core/error";
 import { generateId } from "@better-auth/core/utils/id";
 import { safeJSONParse } from "@better-auth/core/utils/json";
-import { getSessionFromCtx } from "better-auth/api";
+import { getAuthoritativeSessionFromCtx } from "better-auth/api";
 import * as z from "zod";
 import { API_KEY_TABLE_NAME, API_KEY_ERROR_CODES as ERROR_CODES } from "..";
 import { defaultKeyHasher } from "../";
@@ -294,9 +294,10 @@ export function createApiKey({
 			// session deletion performed when a user is banned — would
 			// otherwise still be accepted within the cookie-cache window,
 			// letting it mint a fresh key that outlives the revoked session.
-			const session = await getSessionFromCtx(ctx, {
-				disableCookieCache: true,
-			});
+			// `getAuthoritativeSessionFromCtx` also clears a session an earlier
+			// hook memoized on the context, which would otherwise satisfy this
+			// read from the cookie cache and defeat the bypass.
+			const session = await getAuthoritativeSessionFromCtx(ctx);
 			const isClientRequest = ctx.request || ctx.headers;
 
 			// if this endpoint was being called from the client,

--- a/packages/api-key/src/routes/update-api-key.ts
+++ b/packages/api-key/src/routes/update-api-key.ts
@@ -2,7 +2,7 @@ import type { AuthContext } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import { APIError } from "@better-auth/core/error";
 import { safeJSONParse } from "@better-auth/core/utils/json";
-import { getSessionFromCtx } from "better-auth/api";
+import { getAuthoritativeSessionFromCtx } from "better-auth/api";
 import * as z from "zod";
 import { API_KEY_TABLE_NAME, API_KEY_ERROR_CODES as ERROR_CODES } from "..";
 import {
@@ -278,10 +278,10 @@ export function updateApiKey({
 			// Updating an API key mutates a credential, so resolve the session from
 			// the authoritative store rather than the signed cookie-cache snapshot,
 			// matching create-api-key. A revoked session must not modify a key within
-			// the cookie-cache window.
-			const session = await getSessionFromCtx(ctx, {
-				disableCookieCache: true,
-			});
+			// the cookie-cache window. `getAuthoritativeSessionFromCtx` also clears a
+			// session an earlier hook memoized on the context, which would otherwise
+			// satisfy this read from the cookie cache and defeat the bypass.
+			const session = await getAuthoritativeSessionFromCtx(ctx);
 			const authRequired = ctx.request || ctx.headers;
 			const user =
 				authRequired && !session

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -1,3 +1,5 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
+import { createAuthMiddleware } from "@better-auth/core/api";
 import { BASE_ERROR_CODES } from "@better-auth/core/error";
 import type {
 	CognitoProfile,
@@ -24,6 +26,7 @@ import { genericOAuth } from "../../plugins/generic-oauth";
 import { getTestInstance } from "../../test-utils/test-instance";
 import type { Account } from "../../types";
 import { DEFAULT_SECRET } from "../../utils/constants";
+import { getSessionFromCtx } from "./session";
 
 let email = "";
 let handlers: ReturnType<typeof http.post>[];
@@ -2209,6 +2212,57 @@ describe("token routes cookie cache revocation", async () => {
 			},
 		);
 		expect(bypass.error?.status).toBe(401);
+	});
+
+	/**
+	 * Resolving the session from a `before` hook is a documented plugin pattern,
+	 * and it memoizes the cookie-cached session on `ctx.context.session`. The
+	 * authoritative re-read the token routes rely on must not be satisfied by
+	 * that memoized value, or a revoked session can still mint provider tokens.
+	 *
+	 * @see https://github.com/better-auth/better-auth/pull/10187
+	 */
+	it("get-access-token fails closed after revocation when an earlier hook already resolved the session", async () => {
+		const sessionReadingPlugin = {
+			id: "session-reading-hook",
+			hooks: {
+				before: [
+					{
+						matcher: (ctx) => ctx.path === "/get-access-token",
+						handler: createAuthMiddleware(async (ctx) => {
+							// Pins `ctx.context.session` to the cookie-cached session.
+							await getSessionFromCtx(ctx);
+						}),
+					},
+				],
+			},
+		} satisfies BetterAuthPlugin;
+
+		const { auth, client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: true, maxAge: 60 } },
+			plugins: [sessionReadingPlugin],
+		});
+
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+		const initial = await client.getSession({
+			fetchOptions: { headers, onSuccess: cookieSetter(headers) },
+		});
+		const sessionToken = initial.data!.session.token;
+		expect(headers.get("cookie")).toContain("session_data");
+
+		const ctx = await auth.$context;
+		await ctx.internalAdapter.deleteSession(sessionToken);
+
+		const res = await client.$fetch("/get-access-token", {
+			method: "POST",
+			body: { providerId: "google" },
+			headers,
+		});
+		expect(res.error?.status).toBe(401);
 	});
 });
 

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -19,8 +19,7 @@ import { generateState } from "../../oauth2/state";
 import { decryptOAuthToken, setTokenUtil } from "../../oauth2/utils";
 import {
 	freshSessionMiddleware,
-	getSessionFromCtx,
-	isStateful,
+	getAuthoritativeSessionFromCtx,
 	sessionMiddleware,
 } from "./session";
 
@@ -452,15 +451,15 @@ export const unlinkAccount = createAuthEndpoint(
  * routes mint or refresh provider access tokens, so a server-side session
  * revocation must take effect immediately rather than waiting for the cached
  * cookie to expire. DB-less deployments keep the session in the cookie itself,
- * so the cache is left in place for them.
+ * so the cache is left in place for them. `getAuthoritativeSessionFromCtx`
+ * clears any session an earlier hook memoized on the context first, so the
+ * bypass cannot be satisfied by a cookie-cached read that already happened.
  */
 async function resolveUserId(
 	ctx: GenericEndpointContext,
 	userId?: string,
 ): Promise<string> {
-	const session = await getSessionFromCtx(ctx, {
-		disableCookieCache: isStateful(ctx),
-	});
+	const session = await getAuthoritativeSessionFromCtx(ctx);
 	if (!session && (ctx.request || ctx.headers)) {
 		throw ctx.error("UNAUTHORIZED");
 	}

--- a/packages/better-auth/src/api/routes/update-user.test.ts
+++ b/packages/better-auth/src/api/routes/update-user.test.ts
@@ -1,8 +1,11 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
+import { createAuthMiddleware } from "@better-auth/core/api";
 import { describe, expect, it, vi } from "vitest";
 import { createAuthClient } from "../../client";
 import { inferAdditionalFields } from "../../client/plugins";
 import { getTestInstance } from "../../test-utils/test-instance";
 import type { Account, Session } from "../../types";
+import { getSessionFromCtx } from "./session";
 
 describe("updateUser", async () => {
 	const sendChangeEmail = vi.fn();
@@ -792,6 +795,96 @@ describe("delete user", async () => {
 			),
 		);
 		expect(response.status).toBe(404);
+	});
+
+	/**
+	 * Resolving the session from a `before` hook is a documented plugin pattern,
+	 * and it memoizes the cookie-cached session on `ctx.context.session`. The
+	 * authoritative re-read must not be satisfied by that memoized value, or a
+	 * revoked session paired with a valid token can still complete the deletion.
+	 *
+	 * @see https://github.com/better-auth/better-auth/pull/10187
+	 */
+	it("rejects /delete-user/callback with a revoked session when an earlier hook already resolved it", async () => {
+		let token = "";
+		const sessionReadingPlugin = {
+			id: "session-reading-hook",
+			hooks: {
+				before: [
+					{
+						matcher: (ctx) => ctx.path === "/delete-user/callback",
+						handler: createAuthMiddleware(async (ctx) => {
+							// Pins `ctx.context.session` to the cookie-cached session.
+							await getSessionFromCtx(ctx);
+						}),
+					},
+				],
+			},
+		} satisfies BetterAuthPlugin;
+
+		const { client, auth, db, cookieSetter } = await getTestInstance(
+			{
+				baseURL: "http://localhost:3000",
+				session: { cookieCache: { enabled: true, maxAge: 60 } },
+				plugins: [sessionReadingPlugin],
+				user: {
+					deleteUser: {
+						enabled: true,
+						async sendDeleteAccountVerification(data) {
+							token = data.token;
+						},
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const email = `delete-callback-hook-${Date.now()}@test.com`;
+		const password = "testPassword123";
+		await client.signUp.email({
+			email,
+			password,
+			name: "Delete Callback Hook",
+		});
+
+		const headers = new Headers();
+		await client.signIn.email({
+			email,
+			password,
+			fetchOptions: { onSuccess: cookieSetter(headers) },
+		});
+
+		// `cookieSetter` keeps the `session_data` cookie, so the cookie cache is
+		// what the earlier hook will resolve the session from.
+		const sessionRes = await client.getSession({
+			fetchOptions: { headers, onSuccess: cookieSetter(headers) },
+		});
+		const sessionToken = sessionRes.data?.session.token;
+		if (!sessionToken) throw new Error("expected an active session");
+		expect(headers.get("cookie")).toContain("session_data");
+
+		await client.deleteUser({ password, fetchOptions: { headers } });
+		expect(token.length).toBe(32);
+
+		await db.delete({
+			model: "session",
+			where: [{ field: "token", value: sessionToken }],
+		});
+
+		const response = await auth.handler(
+			new Request(
+				`http://localhost:3000/api/auth/delete-user/callback?token=${token}`,
+				{ method: "GET", headers: { cookie: headers.get("cookie") ?? "" } },
+			),
+		);
+		expect(response.status).toBe(404);
+
+		// The user must still exist: the revoked session cannot authorize deletion.
+		const stillThere = await db.findOne({
+			model: "user",
+			where: [{ field: "email", value: email }],
+		});
+		expect(stillThere).not.toBeNull();
 	});
 });
 

--- a/packages/better-auth/src/api/routes/update-user.ts
+++ b/packages/better-auth/src/api/routes/update-user.ts
@@ -9,8 +9,7 @@ import type { AdditionalUserFieldsInput } from "../../types";
 import { originCheck } from "../middlewares";
 import { createEmailVerificationToken } from "./email-verification";
 import {
-	getSessionFromCtx,
-	isStateful,
+	getAuthoritativeSessionFromCtx,
 	sensitiveSessionMiddleware,
 	sessionMiddleware,
 } from "./session";
@@ -622,10 +621,11 @@ export const deleteUserCallback = createAuthEndpoint(
 		}
 		// Account deletion is sensitive: bypass the cookie cache on stateful
 		// deployments so a revoked-but-cached session cannot complete the deletion
-		// even when paired with a valid delete-account token.
-		const session = await getSessionFromCtx(ctx, {
-			disableCookieCache: isStateful(ctx),
-		});
+		// even when paired with a valid delete-account token. Going through
+		// `getAuthoritativeSessionFromCtx` also clears a session an earlier hook
+		// memoized on the context, which would otherwise satisfy the read from
+		// the cookie cache and defeat the bypass.
+		const session = await getAuthoritativeSessionFromCtx(ctx);
 		if (!session) {
 			throw APIError.from(
 				"NOT_FOUND",


### PR DESCRIPTION
## What changed

`getAccessToken`, `refreshToken`, `accountInfo` (via `resolveUserId`) and the
delete-account callback all deliberately bypass the session cookie cache on
stateful deployments, so that a session revoked server-side stops working
immediately instead of surviving until the cached cookie expires. Their own
comments say so.

They did that by calling `getSessionFromCtx(ctx, { disableCookieCache: isStateful(ctx) })`.
But `getSessionFromCtx` short-circuits and returns `ctx.context.session` when it
is already set, so `disableCookieCache` is silently ignored if anything resolved
the session earlier in the same request. Reading the session from a `before`
hook is a documented plugin pattern ([plugins.mdx](https://github.com/better-auth/better-auth/blob/main/docs/content/docs/concepts/plugins.mdx#getsessionfromctx)),
and it pins `ctx.context.session` to the cookie-cached value. When that happens,
the authoritative re-read never runs and a revoked session is still honored.

`getAuthoritativeSessionFromCtx` (added in #10187) already handles this exactly:
it clears the memoized context session before re-reading the server-side store,
and keeps the signed cookie as the authority for stateless deployments. #10187
applied it to the admin plugin and `sensitiveSessionMiddleware`, but the two
call sites above kept the hand-rolled version. This routes them through the
same helper.

## Impact

With `session.cookieCache` enabled, a stateful deployment, and any plugin/hook
that resolves the session in a `before` hook, a session that was revoked
server-side could still:

- mint or refresh provider OAuth access tokens (`get-access-token`, `refresh-token`)
- read account info (`account-info`)
- complete an account deletion when paired with a valid delete-account token

until the cached cookie expired.

## Tests

Both regression tests fail on `main` and pass with this change:

- `account.test.ts` — `get-access-token` returned **400** (the revoked session
  was accepted and the request went on to the account lookup) instead of `401`.
  With a linked account it would have returned a provider token.
- `update-user.test.ts` — `/delete-user/callback` returned **200** and the user
  row was actually deleted, instead of `404`.

Existing suites stay green: `pnpm typecheck` clean, and all 386 tests under
`packages/better-auth/src/api/` pass.

Note: `src/plugins/oauth-proxy` > "should work with database mode + UUID" fails
on a clean checkout of `main` too — pre-existing and unrelated to this change.

## Stateless behavior

Unchanged. `getAuthoritativeSessionFromCtx` delegates to a plain
`getSessionFromCtx(ctx)` when there is no durable session store, which is what
`disableCookieCache: isStateful(ctx)` evaluated to before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened session checks for token, delete-account, and API key routes by using authoritative session reads so revoked sessions are rejected immediately on stateful deployments, even if a before hook resolved a cookie-cached session earlier. Stateless behavior is unchanged.

- **Bug Fixes**
  - `getAccessToken`, `refreshToken`, `accountInfo`, and `/delete-user/callback` now use `getAuthoritativeSessionFromCtx` to clear any memoized context session and bypass the cookie cache on stateful deployments.
  - `@better-auth/api-key`: `create` and `update` now use `getAuthoritativeSessionFromCtx` to prevent revoked sessions (including bans) from minting or modifying keys within the cookie-cache window.
  - Added regression tests that simulate a before-hook session read to confirm revoked sessions are rejected in token routes, the delete-account callback, and both API key paths (including update).

<sup>Written for commit ea0045ed97f24519889a14c39e0ed1c1ab9cbcf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

