### PR TITLE
docs: migrate AI chat from OpenRouter to Vercel AI Gateway

### DIFF
--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,8 +1,8 @@
 # GitHub API - community stats
 GITHUB_TOKEN=
 
-# Openrouter API - docs AI chat
-OPENROUTER_API_KEY=
+# Vercel AI Gateway - docs AI chat (not needed when deployed on Vercel with OIDC)
+AI_GATEWAY_API_KEY=
 
 # Upstash Redis - AI chat rate limiting
 UPSTASH_REDIS_REST_URL=

--- a/docs/lib/ai-chat/route.ts
+++ b/docs/lib/ai-chat/route.ts
@@ -1,14 +1,11 @@
-import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { convertToModelMessages, stepCountIs, streamText, tool } from "ai";
 import * as z from "zod";
 import { getLLMText } from "@/lib/llm-text";
 import { source } from "@/lib/source";
 import { checkRateLimit, getClientIP } from "./rate-limit";
 
-const openrouter = createOpenRouter({
-	apiKey: process.env.OPENROUTER_API_KEY,
-});
-const chatModel = openrouter.chat("moonshotai/kimi-k2.5");
+// Resolved through the Vercel AI Gateway (AI_GATEWAY_API_KEY, or OIDC when deployed on Vercel)
+const chatModel = "moonshotai/kimi-k2.5";
 
 function buildDocsIndex(): string {
 	const pages = source.getPages();

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,6 @@
     "@better-auth/utils": "catalog:",
     "@better-fetch/fetch": "catalog:",
     "@hookform/resolvers": "^5.2.1",
-    "@openrouter/ai-sdk-provider": "^2.2.5",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,9 +184,6 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.1
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
-      '@openrouter/ai-sdk-provider':
-        specifier: ^2.2.5
-        version: 2.2.5(ai@6.0.116(zod@4.3.6))(zod@4.3.6)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2843,11 +2840,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -3789,13 +3786,6 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
-
-  '@openrouter/ai-sdk-provider@2.2.5':
-    resolution: {integrity: sha512-IgM96gPvpxMZYYJQSIuXqvHX0mUXHEvsa/AtIlfb1VK4ek584ydAzc/wf3IuKxNof15o38WZMpCwfsOFHv96Jg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      ai: ^6.0.0
-      zod: ^3.25.0 || ^4.0.0
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -16521,11 +16511,6 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
-
-  '@openrouter/ai-sdk-provider@2.2.5(ai@6.0.116(zod@4.3.6))(zod@4.3.6)':
-    dependencies:
-      ai: 6.0.116(zod@4.3.6)
-      zod: 4.3.6
 
   '@opentelemetry/api@1.9.0': {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -31,7 +31,7 @@
         "RESEND_API_KEY",
         "TYPESENSE_ADMIN_API_KEY",
         "GITHUB_TOKEN",
-        "OPENROUTER_API_KEY",
+        "AI_GATEWAY_API_KEY",
         "UPSTASH_REDIS_REST_URL",
         "UPSTASH_REDIS_REST_TOKEN"
       ]


### PR DESCRIPTION
## Summary

Moves the docs AI chat (`docs/lib/ai-chat/route.ts`) off OpenRouter and onto the Vercel AI Gateway.

- Drops the `@openrouter/ai-sdk-provider` dependency — with AI SDK v6 the gateway is the built-in default provider, so the model is now referenced as a plain `moonshotai/kimi-k2.5` string (same model, same ID on the gateway)
- Replaces `OPENROUTER_API_KEY` with `AI_GATEWAY_API_KEY` in `.env.example` and in `turbo.json`'s `docs#build.passThroughEnv`; no key is needed when deployed on Vercel with OIDC

## Deployment note

The docs deployment needs `AI_GATEWAY_API_KEY` set (or Vercel OIDC available) and `OPENROUTER_API_KEY` can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)