### PR TITLE
fix(sso): redirect idp initiated saml flows in split origin deployments

### DIFF
--- a/.changeset/saml-idp-initiated-split-origin.md
+++ b/.changeset/saml-idp-initiated-split-origin.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+Allow IdP-initiated SAML flows to redirect to the application when the authentication server and frontend use separate origins.

--- a/.changeset/saml-idp-initiated-split-origin.md
+++ b/.changeset/saml-idp-initiated-split-origin.md
@@ -2,4 +2,4 @@
 "@better-auth/sso": patch
 ---
 
-Allow IdP-initiated SAML flows to redirect to the application when the authentication server and frontend use separate origins.
+IdP-initiated SAML sign-ins in split-origin deployments can now return users to a configured application URL after authentication or a validation error, instead of falling back to the authentication server. Configure `idpInitiatedCallbackUrl` globally or per provider.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -1441,7 +1441,7 @@ await authClient.signIn.sso({
 });
 ```
 
-For unsolicited **IdP-initiated** flows where `signIn.sso()` is not used (and therefore no client-side `callbackURL` is set), the redirect uses `idpInitiatedCallbackURL` configured in `samlConfig` for the provider, or the global plugin option. If neither is configured, the existing redirect fallback behavior is preserved.
+For unsolicited **IdP-initiated** flows where `signIn.sso()` is not used (and therefore no client-side `callbackURL` is set), the redirect uses `idpInitiatedCallbackUrl` configured in `samlConfig` for the provider, or the global plugin option. If neither is configured, the existing redirect fallback behavior is preserved.
 
 The callback route supports both GET and POST methods automatically, so you don't need to create any additional route handlers in your framework.
 
@@ -1530,7 +1530,7 @@ Better Auth supports **IdP-initiated SSO flows**, where users access your applic
 **No additional configuration required** - the callback route automatically handles both GET and POST requests.
 
 <Callout type="warn">
-  IdP-initiated flows do not carry a Better Auth-generated RelayState containing a client-side callback URL, so the post-login redirect falls back to your application's base URL. In split-origin setups (where the app frontend is on a different origin than the Better Auth server), this redirect collapses to the auth server origin (resulting in a 404). To prevent this, you can configure `idpInitiatedCallbackURL` either globally under `saml` plugin options or per-provider under `samlConfig` (e.g., `https://app.example.com/dashboard`).
+  IdP-initiated flows do not carry a Better Auth-generated RelayState containing a client-side callback URL, so the post-login redirect falls back to your application's base URL. In split-origin setups (where the app frontend is on a different origin than the Better Auth server), this redirect collapses to the auth server origin (resulting in a 404). To prevent this, you can configure `idpInitiatedCallbackUrl` either globally under `saml` plugin options or per-provider under `samlConfig` (e.g., `https://app.example.com/dashboard`).
 </Callout>
 
 <Callout type="info">

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -1441,7 +1441,7 @@ await authClient.signIn.sso({
 });
 ```
 
-For unsolicited **IdP-initiated** flows where `signIn.sso()` is not used (and therefore no client-side `callbackURL` is set), the redirect uses `idpInitiatedCallbackUrl` configured in `samlConfig` for the provider, or the global plugin option. If neither is configured, the existing redirect fallback behavior is preserved.
+For unsolicited **IdP-initiated** flows where `signIn.sso()` is not used (and therefore no client-side `callbackURL` is set), configure `idpInitiatedCallbackUrl` in the provider's `samlConfig` or in the global `saml` plugin options. The provider setting takes precedence over the global setting, and the same fallback applies to validation error redirects. Better Auth-generated `RelayState` success and error callbacks retain higher priority. If neither fallback is configured, the existing redirect behavior is preserved.
 
 The callback route supports both GET and POST methods automatically, so you don't need to create any additional route handlers in your framework.
 
@@ -1527,10 +1527,10 @@ Better Auth supports **IdP-initiated SSO flows**, where users access your applic
 3. Better Auth processes the assertion, creates a session, and redirects to your application
 4. Browser follows the redirect with a GET request (handled automatically)
 
-**No additional configuration required** - the callback route automatically handles both GET and POST requests.
+No additional route handler is required. The callback route automatically handles both GET and POST requests.
 
 <Callout type="warn">
-  IdP-initiated flows do not carry a Better Auth-generated RelayState containing a client-side callback URL, so the post-login redirect falls back to your application's base URL. In split-origin setups (where the app frontend is on a different origin than the Better Auth server), this redirect collapses to the auth server origin (resulting in a 404). To prevent this, you can configure `idpInitiatedCallbackUrl` either globally under `saml` plugin options or per-provider under `samlConfig` (e.g., `https://app.example.com/dashboard`).
+  IdP-initiated flows do not carry a Better Auth-generated RelayState containing a client-side callback URL, so the redirect falls back to the Better Auth base URL. In split-origin setups (where the app frontend is on a different origin than the Better Auth server), this lands on the auth server origin and can result in a 404. Configure `idpInitiatedCallbackUrl` globally under the `saml` plugin options or per provider under `samlConfig` (e.g., `https://app.example.com/dashboard`) to return successful sign-ins and validation errors to the frontend.
 </Callout>
 
 <Callout type="info">

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -1441,6 +1441,8 @@ await authClient.signIn.sso({
 });
 ```
 
+For unsolicited **IdP-initiated** flows where `signIn.sso()` is not used (and therefore no client-side `callbackURL` is set), the redirect uses `idpInitiatedCallbackURL` configured in `samlConfig` for the provider, or the global plugin option. If neither is configured, the existing redirect fallback behavior is preserved.
+
 The callback route supports both GET and POST methods automatically, so you don't need to create any additional route handlers in your framework.
 
 ## Schema
@@ -1528,7 +1530,7 @@ Better Auth supports **IdP-initiated SSO flows**, where users access your applic
 **No additional configuration required** - the callback route automatically handles both GET and POST requests.
 
 <Callout type="warn">
-  IdP-initiated flows do not carry a RelayState, so the post-login redirect falls back to your application's base URL. To control where users land after SP-initiated SSO, pass the destination via `callbackURL` in the `signIn.sso()` call.
+  IdP-initiated flows do not carry a Better Auth-generated RelayState containing a client-side callback URL, so the post-login redirect falls back to your application's base URL. In split-origin setups (where the app frontend is on a different origin than the Better Auth server), this redirect collapses to the auth server origin (resulting in a 404). To prevent this, you can configure `idpInitiatedCallbackURL` either globally under `saml` plugin options or per-provider under `samlConfig` (e.g., `https://app.example.com/dashboard`).
 </Callout>
 
 <Callout type="info">

--- a/packages/sso/src/providers.test.ts
+++ b/packages/sso/src/providers.test.ts
@@ -854,6 +854,9 @@ describe("SSO provider read endpoints", () => {
 			expect(updated.domainVerified).toBe(false);
 		});
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
 		it("should perform partial update on SAML provider", async () => {
 			const { auth, getAuthHeaders, registerSAMLProvider } =
 				createTestAuth(false);
@@ -871,6 +874,7 @@ describe("SSO provider read endpoints", () => {
 					providerId: "my-saml-provider",
 					samlConfig: {
 						audience: "new-audience",
+						idpInitiatedCallbackUrl: "/dashboard",
 						wantAssertionsSigned: false,
 					},
 				},
@@ -878,6 +882,7 @@ describe("SSO provider read endpoints", () => {
 			});
 
 			expect(updated.samlConfig?.audience).toBe("new-audience");
+			expect(updated.samlConfig?.idpInitiatedCallbackUrl).toBe("/dashboard");
 			expect(updated.samlConfig?.wantAssertionsSigned).toBe(false);
 			expect(updated.samlConfig?.entryPoint).toBe(
 				"https://idp.example.com/sso",

--- a/packages/sso/src/providers.test.ts
+++ b/packages/sso/src/providers.test.ts
@@ -20,6 +20,8 @@ describe("SAML redirect URL schema", () => {
 		["https://frontend.example.com/dashboard", true],
 		["//evil.example.com", false],
 		["/\\evil.example.com", false],
+		["/%2fevil.example.com", false],
+		["/%5cevil.example.com", false],
 		["dashboard", false],
 	])("validates %s", (url, expected) => {
 		expect(samlRedirectUrlSchema.safeParse(url).success).toBe(expected);

--- a/packages/sso/src/providers.test.ts
+++ b/packages/sso/src/providers.test.ts
@@ -6,9 +6,25 @@ import { organization } from "better-auth/plugins";
 import { describe, expect, it } from "vitest";
 import { sso } from ".";
 import { ssoClient } from "./client";
+import { samlRedirectUrlSchema } from "./routes/schemas";
 
 const TEST_CERT = `MIIDXTCCAkWgAwIBAgIJAJC1HiIAZAiUMA0Gcm9markup
 temporary cert for testing`;
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10329
+ */
+describe("SAML redirect URL schema", () => {
+	it.each([
+		["/dashboard", true],
+		["https://frontend.example.com/dashboard", true],
+		["//evil.example.com", false],
+		["/\\evil.example.com", false],
+		["dashboard", false],
+	])("validates %s", (url, expected) => {
+		expect(samlRedirectUrlSchema.safeParse(url).success).toBe(expected);
+	});
+});
 
 describe("SSO provider read endpoints", () => {
 	type TestUser = { email: string; password: string; name: string };

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -437,8 +437,8 @@ function mergeSAMLConfig(
 		entryPoint: updates.entryPoint ?? current.entryPoint,
 		cert: updates.cert ?? current.cert,
 		callbackUrl: updates.callbackUrl ?? current.callbackUrl,
-		idpInitiatedCallbackURL:
-			updates.idpInitiatedCallbackURL ?? current.idpInitiatedCallbackURL,
+		idpInitiatedCallbackUrl:
+			updates.idpInitiatedCallbackUrl ?? current.idpInitiatedCallbackUrl,
 		spMetadata: updates.spMetadata ?? current.spMetadata,
 		idpMetadata: updates.idpMetadata ?? current.idpMetadata,
 		mapping: updates.mapping ?? current.mapping,

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -227,6 +227,7 @@ function sanitizeProvider(
 			? {
 					entryPoint: samlConfig.entryPoint,
 					callbackUrl: samlConfig.callbackUrl,
+					idpInitiatedCallbackUrl: samlConfig.idpInitiatedCallbackUrl,
 					audience: samlConfig.audience,
 					wantAssertionsSigned: samlConfig.wantAssertionsSigned,
 					authnRequestsSigned: samlConfig.authnRequestsSigned,

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -437,6 +437,8 @@ function mergeSAMLConfig(
 		entryPoint: updates.entryPoint ?? current.entryPoint,
 		cert: updates.cert ?? current.cert,
 		callbackUrl: updates.callbackUrl ?? current.callbackUrl,
+		idpInitiatedCallbackURL:
+			updates.idpInitiatedCallbackURL ?? current.idpInitiatedCallbackURL,
 		spMetadata: updates.spMetadata ?? current.spMetadata,
 		idpMetadata: updates.idpMetadata ?? current.idpMetadata,
 		mapping: updates.mapping ?? current.mapping,

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -548,7 +548,7 @@ export async function processSAMLResponse(
 		!!(provider as { domainVerified?: boolean }).domainVerified &&
 		validateEmailDomain(userInfo.email as string, provider.domain);
 
-	const callbackUrl = redirectCandidate || ctx.context.baseURL;
+	const callbackUrl = redirectCandidate ? samlRedirectUrl : ctx.context.baseURL;
 	const errorUrl = relayState?.errorURL || samlRedirectUrl;
 
 	let result: Awaited<ReturnType<typeof handleOAuthUserInfo>>;

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -29,6 +29,7 @@ import type {
 	SSOProvider,
 } from "../types";
 import {
+	isSafeSAMLRedirectPath,
 	parseProviderEmailVerified,
 	safeJsonParse,
 	validateEmailDomain,
@@ -50,7 +51,8 @@ function getSafeRedirectCandidate(
 ): string | undefined {
 	if (!url) return;
 
-	if (url.startsWith("/") && !url.startsWith("//")) {
+	if (url.startsWith("/")) {
+		if (!isSafeSAMLRedirectPath(url)) return;
 		try {
 			const absoluteUrl = new URL(url, appOrigin);
 			if (

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -37,67 +37,115 @@ import { createIdP, createSP, findSAMLProvider } from "./helpers";
 
 type RelayState = Awaited<ReturnType<typeof parseRelayState>>;
 
-/**
- * Validates and returns a safe redirect URL.
- * - Prevents open redirect attacks by validating against trusted origins
- * - Prevents redirect loops by checking if URL points to callback route
- * - Falls back to appOrigin if URL is invalid or unsafe
- */
-export function getSafeRedirectUrl(
+type IsTrustedOrigin = (
+	url: string,
+	settings?: { allowRelativePaths: boolean },
+) => boolean;
+
+function getSafeRedirectCandidate(
 	url: string | undefined,
-	callbackPath: string,
+	callbackPathname: string,
 	appOrigin: string,
-	isTrustedOrigin: (
-		url: string,
-		settings?: { allowRelativePaths: boolean },
-	) => boolean,
-): string {
-	if (!url) {
-		return appOrigin;
-	}
+	isTrustedOrigin: IsTrustedOrigin,
+): string | undefined {
+	if (!url) return;
 
 	if (url.startsWith("/") && !url.startsWith("//")) {
 		try {
 			const absoluteUrl = new URL(url, appOrigin);
-			if (absoluteUrl.origin !== appOrigin) {
-				return appOrigin;
+			if (
+				absoluteUrl.origin !== appOrigin ||
+				absoluteUrl.pathname === callbackPathname
+			) {
+				return;
 			}
-			const callbackPathname = new URL(callbackPath).pathname;
-			if (absoluteUrl.pathname === callbackPathname) {
-				return appOrigin;
-			}
+			return url;
 		} catch {
-			return appOrigin;
+			return;
 		}
-		return url;
 	}
 
-	if (!isTrustedOrigin(url, { allowRelativePaths: false })) {
-		return appOrigin;
-	}
-
+	let absoluteUrl: URL;
 	try {
-		const callbackPathname = new URL(callbackPath).pathname;
-		const urlPathname = new URL(url).pathname;
-		if (urlPathname === callbackPathname) {
-			return appOrigin;
-		}
+		absoluteUrl = new URL(url);
 	} catch {
-		if (url === callbackPath || url.startsWith(`${callbackPath}?`)) {
-			return appOrigin;
-		}
+		return;
 	}
+
+	if (
+		absoluteUrl.origin !== appOrigin &&
+		!isTrustedOrigin(url, { allowRelativePaths: false })
+	) {
+		return;
+	}
+
+	if (absoluteUrl.pathname === callbackPathname) return;
 
 	return url;
 }
 
-function buildSAMLRedirectUrl(
+/**
+ * Returns the first safe redirect URL from an ordered list of candidates.
+ * - Prevents open redirect attacks by validating against trusted origins
+ * - Prevents redirect loops by checking if URL points to callback route
+ * - Tries the next candidate when a URL is invalid or unsafe
+ * - Falls back to appOrigin when no candidate is safe
+ */
+export function getSafeRedirectUrl(
+	candidates: readonly (string | undefined)[],
+	callbackPath: string,
+	appOrigin: string,
+	isTrustedOrigin: IsTrustedOrigin,
+): string {
+	const callbackPathname = new URL(callbackPath).pathname;
+	for (const candidate of candidates) {
+		const safeCandidate = getSafeRedirectCandidate(
+			candidate,
+			callbackPathname,
+			appOrigin,
+			isTrustedOrigin,
+		);
+		if (safeCandidate) return safeCandidate;
+	}
+
+	return appOrigin;
+}
+
+export function buildSAMLRedirectUrl(
 	url: string,
 	params: Record<string, string>,
 ): string {
 	const searchParams = new URLSearchParams(params);
-	const separator = url.includes("?") ? "&" : "?";
-	return `${url}${separator}${searchParams.toString()}`;
+	try {
+		const isRelativePath = url.startsWith("/") && !url.startsWith("//");
+		const parsedUrl = new URL(url, "http://better-auth.local");
+		for (const [key, value] of searchParams) {
+			parsedUrl.searchParams.set(key, value);
+		}
+		if (isRelativePath) {
+			return `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`;
+		}
+		return parsedUrl.toString();
+	} catch {
+		const hashIndex = url.indexOf("#");
+		const urlWithoutFragment = hashIndex === -1 ? url : url.slice(0, hashIndex);
+		const fragment = hashIndex === -1 ? "" : url.slice(hashIndex);
+		const separator = urlWithoutFragment.includes("?") ? "&" : "?";
+		return `${urlWithoutFragment}${separator}${searchParams.toString()}${fragment}`;
+	}
+}
+
+export function getSAMLRedirectCandidates(
+	relayStateCallbackUrl: string | undefined,
+	samlConfig: SAMLConfig | undefined,
+	samlOptions: SSOOptions["saml"] | undefined,
+): readonly (string | undefined)[] {
+	return [
+		relayStateCallbackUrl,
+		samlConfig?.idpInitiatedCallbackUrl,
+		samlOptions?.idpInitiatedCallbackUrl,
+		samlConfig?.callbackUrl,
+	];
 }
 
 function toArray<T>(value: T | T[] | undefined): T[] {
@@ -254,17 +302,14 @@ export async function processSAMLResponse(
 	});
 	const idp = createIdP(parsedSamlConfig);
 
-	const idpInitiatedCallbackUrl =
-		parsedSamlConfig.idpInitiatedCallbackUrl ||
-		options?.saml?.idpInitiatedCallbackUrl;
-
-	const redirectCandidate =
-		relayState?.callbackURL ||
-		idpInitiatedCallbackUrl ||
-		parsedSamlConfig.callbackUrl;
+	const redirectCandidates = getSAMLRedirectCandidates(
+		relayState?.callbackURL,
+		parsedSamlConfig,
+		options?.saml,
+	);
 
 	const samlRedirectUrl = getSafeRedirectUrl(
-		redirectCandidate,
+		redirectCandidates,
 		currentCallbackPath,
 		appOrigin,
 		(url: string, settings?: { allowRelativePaths: boolean }) =>
@@ -548,7 +593,9 @@ export async function processSAMLResponse(
 		!!(provider as { domainVerified?: boolean }).domainVerified &&
 		validateEmailDomain(userInfo.email as string, provider.domain);
 
-	const callbackUrl = redirectCandidate ? samlRedirectUrl : ctx.context.baseURL;
+	const callbackUrl = redirectCandidates.some(Boolean)
+		? samlRedirectUrl
+		: ctx.context.baseURL;
 	const errorUrl = relayState?.errorURL || samlRedirectUrl;
 
 	let result: Awaited<ReturnType<typeof handleOAuthUserInfo>>;

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -658,12 +658,6 @@ export async function processSAMLResponse(
 			);
 	}
 
-	// 20. Compute safe redirect URL
-	return getSafeRedirectUrl(
-		redirectCandidate,
-		currentCallbackPath,
-		appOrigin,
-		(url: string, settings?: { allowRelativePaths: boolean }) =>
-			ctx.context.isTrustedOrigin(url, settings),
-	);
+	// 20. Return precomputed safe redirect URL
+	return samlRedirectUrl;
 }

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -254,13 +254,13 @@ export async function processSAMLResponse(
 	});
 	const idp = createIdP(parsedSamlConfig);
 
-	const idpInitiatedCallbackURL =
-		parsedSamlConfig.idpInitiatedCallbackURL ||
-		options?.saml?.idpInitiatedCallbackURL;
+	const idpInitiatedCallbackUrl =
+		parsedSamlConfig.idpInitiatedCallbackUrl ||
+		options?.saml?.idpInitiatedCallbackUrl;
 
 	const redirectCandidate =
 		relayState?.callbackURL ||
-		idpInitiatedCallbackURL ||
+		idpInitiatedCallbackUrl ||
 		parsedSamlConfig.callbackUrl;
 
 	const samlRedirectUrl = getSafeRedirectUrl(

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -254,9 +254,18 @@ export async function processSAMLResponse(
 	});
 	const idp = createIdP(parsedSamlConfig);
 
+	const idpInitiatedCallbackURL =
+		parsedSamlConfig.idpInitiatedCallbackURL ||
+		options?.saml?.idpInitiatedCallbackURL;
+
+	const redirectCandidate =
+		relayState?.callbackURL ||
+		idpInitiatedCallbackURL ||
+		parsedSamlConfig.callbackUrl;
+
 	const samlRedirectUrl = getSafeRedirectUrl(
-		relayState?.callbackURL || parsedSamlConfig.callbackUrl,
-		params.currentCallbackPath,
+		redirectCandidate,
+		currentCallbackPath,
 		appOrigin,
 		(url: string, settings?: { allowRelativePaths: boolean }) =>
 			ctx.context.isTrustedOrigin(url, settings),
@@ -539,14 +548,7 @@ export async function processSAMLResponse(
 		!!(provider as { domainVerified?: boolean }).domainVerified &&
 		validateEmailDomain(userInfo.email as string, provider.domain);
 
-	// TODO: split callbackUrl into separate ACS URL and post-auth redirect
-	// fields. Currently callbackUrl serves both purposes, which means
-	// IdP-initiated flows (no RelayState) fall back to either a URL that may be
-	// the ACS endpoint (blocked by loop protection) or baseURL.
-	const callbackUrl =
-		relayState?.callbackURL ||
-		parsedSamlConfig.callbackUrl ||
-		ctx.context.baseURL;
+	const callbackUrl = redirectCandidate || ctx.context.baseURL;
 	const errorUrl = relayState?.errorURL || samlRedirectUrl;
 
 	let result: Awaited<ReturnType<typeof handleOAuthUserInfo>>;
@@ -658,7 +660,7 @@ export async function processSAMLResponse(
 
 	// 20. Compute safe redirect URL
 	return getSafeRedirectUrl(
-		relayState?.callbackURL || parsedSamlConfig.callbackUrl,
+		redirectCandidate,
 		currentCallbackPath,
 		appOrigin,
 		(url: string, settings?: { allowRelativePaths: boolean }) =>

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -79,7 +79,15 @@ function getSafeRedirectCandidate(
 		return;
 	}
 
-	if (absoluteUrl.pathname === callbackPathname) return;
+	// TODO(next): retain this origin-qualified loop check when reconciling
+	// next's redirect helper. A trusted frontend can share the ACS pathname
+	// without routing back to this handler.
+	if (
+		absoluteUrl.origin === appOrigin &&
+		absoluteUrl.pathname === callbackPathname
+	) {
+		return;
+	}
 
 	return url;
 }
@@ -399,7 +407,7 @@ export async function processSAMLResponse(
 				expectedRecipients: expectedRecipients.filter(Boolean),
 			});
 			throw ctx.redirect(
-				buildSAMLRedirectUrl(samlRedirectUrl, {
+				buildSAMLRedirectUrl(samlErrorRedirectUrl, {
 					error: "invalid_saml_response",
 					error_description:
 						error.body?.message || error.message || "Invalid SAML response",
@@ -413,7 +421,7 @@ export async function processSAMLResponse(
 			expectedRecipients: expectedRecipients.filter(Boolean),
 		});
 		throw ctx.redirect(
-			buildSAMLRedirectUrl(samlRedirectUrl, {
+			buildSAMLRedirectUrl(samlErrorRedirectUrl, {
 				error: "invalid_saml_response",
 				error_description: "SAML response binding could not be validated",
 			}),
@@ -455,7 +463,7 @@ export async function processSAMLResponse(
 					{ inResponseTo, providerId },
 				);
 				throw ctx.redirect(
-					buildSAMLRedirectUrl(samlRedirectUrl, {
+					buildSAMLRedirectUrl(samlErrorRedirectUrl, {
 						error: "invalid_saml_response",
 						error_description: "Unknown or expired request ID",
 					}),
@@ -472,7 +480,7 @@ export async function processSAMLResponse(
 					},
 				);
 				throw ctx.redirect(
-					buildSAMLRedirectUrl(samlRedirectUrl, {
+					buildSAMLRedirectUrl(samlErrorRedirectUrl, {
 						error: "invalid_saml_response",
 						error_description: "Provider mismatch",
 					}),
@@ -484,7 +492,7 @@ export async function processSAMLResponse(
 				{ providerId },
 			);
 			throw ctx.redirect(
-				buildSAMLRedirectUrl(samlRedirectUrl, {
+				buildSAMLRedirectUrl(samlErrorRedirectUrl, {
 					error: "unsolicited_response",
 					error_description: "IdP-initiated SSO not allowed",
 				}),
@@ -530,7 +538,7 @@ export async function processSAMLResponse(
 				{ assertionId, issuer, providerId },
 			);
 			throw ctx.redirect(
-				buildSAMLRedirectUrl(samlRedirectUrl, {
+				buildSAMLRedirectUrl(samlErrorRedirectUrl, {
 					error: "replay_detected",
 					error_description: "SAML assertion has already been used",
 				}),

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -221,6 +221,8 @@ export interface SAMLResponseParams {
 	RelayState?: string;
 	providerId: string;
 	currentCallbackPath: string;
+	/** Receives the safe error destination after redirect context is resolved. */
+	onErrorRedirectResolved?: (url: string) => void;
 }
 
 /**
@@ -315,6 +317,14 @@ export async function processSAMLResponse(
 		(url: string, settings?: { allowRelativePaths: boolean }) =>
 			ctx.context.isTrustedOrigin(url, settings),
 	);
+	const samlErrorRedirectUrl = getSafeRedirectUrl(
+		[relayState?.errorURL, samlRedirectUrl],
+		currentCallbackPath,
+		appOrigin,
+		(url: string, settings?: { allowRelativePaths: boolean }) =>
+			ctx.context.isTrustedOrigin(url, settings),
+	);
+	params.onErrorRedirectResolved?.(samlErrorRedirectUrl);
 
 	// 8. Single assertion validation
 	// Throws APIError directly (not redirect) since this is a structural issue
@@ -596,7 +606,7 @@ export async function processSAMLResponse(
 	const callbackUrl = redirectCandidates.some(Boolean)
 		? samlRedirectUrl
 		: ctx.context.baseURL;
-	const errorUrl = relayState?.errorURL || samlRedirectUrl;
+	const errorUrl = samlErrorRedirectUrl;
 
 	let result: Awaited<ReturnType<typeof handleOAuthUserInfo>>;
 	try {

--- a/packages/sso/src/routes/schemas.ts
+++ b/packages/sso/src/routes/schemas.ts
@@ -6,7 +6,9 @@ export const samlRedirectUrlSchema = z
 	.string()
 	.refine(
 		(url) =>
-			(url.startsWith("/") && !url.startsWith("//")) ||
+			(url.startsWith("/") &&
+				!url.startsWith("//") &&
+				!url.startsWith("/\\")) ||
 			absoluteUrlSchema.safeParse(url).success,
 		{
 			message: "Expected an absolute URL or a relative path starting with /",

--- a/packages/sso/src/routes/schemas.ts
+++ b/packages/sso/src/routes/schemas.ts
@@ -44,7 +44,7 @@ const samlConfigSchema = z.object({
 	entryPoint: z.string().url().optional(),
 	cert: z.string().optional(),
 	callbackUrl: z.string().url().optional(),
-	idpInitiatedCallbackURL: z.string().url().optional(),
+	idpInitiatedCallbackUrl: z.string().url().optional(),
 	audience: z.string().optional(),
 	idpMetadata: z
 		.object({

--- a/packages/sso/src/routes/schemas.ts
+++ b/packages/sso/src/routes/schemas.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { isSafeSAMLRedirectPath } from "../utils";
 
 const absoluteUrlSchema = z.url();
 
@@ -6,10 +7,7 @@ export const samlRedirectUrlSchema = z
 	.string()
 	.refine(
 		(url) =>
-			(url.startsWith("/") &&
-				!url.startsWith("//") &&
-				!url.startsWith("/\\")) ||
-			absoluteUrlSchema.safeParse(url).success,
+			isSafeSAMLRedirectPath(url) || absoluteUrlSchema.safeParse(url).success,
 		{
 			message: "Expected an absolute URL or a relative path starting with /",
 		},

--- a/packages/sso/src/routes/schemas.ts
+++ b/packages/sso/src/routes/schemas.ts
@@ -1,5 +1,18 @@
 import * as z from "zod";
 
+const absoluteUrlSchema = z.url();
+
+export const samlRedirectUrlSchema = z
+	.string()
+	.refine(
+		(url) =>
+			(url.startsWith("/") && !url.startsWith("//")) ||
+			absoluteUrlSchema.safeParse(url).success,
+		{
+			message: "Expected an absolute URL or a relative path starting with /",
+		},
+	);
+
 const oidcMappingSchema = z
 	.object({
 		id: z.string().optional(),
@@ -44,7 +57,7 @@ const samlConfigSchema = z.object({
 	entryPoint: z.string().url().optional(),
 	cert: z.string().optional(),
 	callbackUrl: z.string().url().optional(),
-	idpInitiatedCallbackUrl: z.string().url().optional(),
+	idpInitiatedCallbackUrl: samlRedirectUrlSchema.optional(),
 	audience: z.string().optional(),
 	idpMetadata: z
 		.object({

--- a/packages/sso/src/routes/schemas.ts
+++ b/packages/sso/src/routes/schemas.ts
@@ -44,6 +44,7 @@ const samlConfigSchema = z.object({
 	entryPoint: z.string().url().optional(),
 	cert: z.string().optional(),
 	callbackUrl: z.string().url().optional(),
+	idpInitiatedCallbackURL: z.string().url().optional(),
 	audience: z.string().optional(),
 	idpMetadata: z
 		.object({

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -300,6 +300,7 @@ const ssoProviderBodySchema = z.object({
 			callbackUrl: z.string({}).meta({
 				description: "The callback URL of the provider",
 			}),
+			idpInitiatedCallbackURL: z.string().optional(),
 			audience: z.string().optional(),
 			idpMetadata: z
 				.object({
@@ -863,6 +864,8 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 								entryPoint: body.samlConfig.entryPoint,
 								cert: body.samlConfig.cert,
 								callbackUrl: body.samlConfig.callbackUrl,
+								idpInitiatedCallbackURL:
+									body.samlConfig.idpInitiatedCallbackURL,
 								audience: body.samlConfig.audience,
 								idpMetadata: body.samlConfig.idpMetadata,
 								spMetadata: body.samlConfig.spMetadata,
@@ -2048,8 +2051,25 @@ export const acsEndpoint = (options?: SSOOptions) => {
 							: internalCode === "SAML_NO_ASSERTION"
 								? "no_assertion"
 								: internalCode.toLowerCase() || "saml_error";
+					const provider = await findSAMLProvider(
+						providerId,
+						options,
+						ctx.context.adapter,
+					);
+					const parsedSamlConfig = provider?.samlConfig;
+					const idpInitiatedCallbackURL =
+						parsedSamlConfig?.idpInitiatedCallbackURL ||
+						options?.saml?.idpInitiatedCallbackURL;
+					const rawRelayState = ctx.body.RelayState;
+					const isTrustedRelayState =
+						rawRelayState &&
+						(rawRelayState.startsWith("/")
+							? !rawRelayState.startsWith("//")
+							: ctx.context.isTrustedOrigin(rawRelayState, {
+									allowRelativePaths: false,
+								}));
 					const redirectUrl = getSafeRedirectUrl(
-						ctx.body.RelayState || undefined,
+						isTrustedRelayState ? rawRelayState : idpInitiatedCallbackURL,
 						currentCallbackPath,
 						appOrigin,
 						(url, settings) => ctx.context.isTrustedOrigin(url, settings),

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -61,7 +61,12 @@ import {
 	findSAMLProvider,
 } from "./helpers";
 import { hasOrgAdminRole } from "./providers";
-import { getSafeRedirectUrl, processSAMLResponse } from "./saml-pipeline";
+import {
+	buildSAMLRedirectUrl,
+	getSAMLRedirectCandidates,
+	getSafeRedirectUrl,
+	processSAMLResponse,
+} from "./saml-pipeline";
 
 const BUILT_IN_ACCOUNT_PROVIDER_IDS = [
 	"credential",
@@ -1956,7 +1961,7 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 
 				const relayState = ctx.query?.RelayState as string | undefined;
 				const safeRedirectUrl = getSafeRedirectUrl(
-					relayState,
+					[relayState],
 					currentCallbackPath,
 					appOrigin,
 					(url, settings) => ctx.context.isTrustedOrigin(url, settings),
@@ -2064,25 +2069,21 @@ export const acsEndpoint = (options?: SSOOptions) => {
 						ctx.context.adapter,
 					);
 					const parsedSamlConfig = provider?.samlConfig;
-					const idpInitiatedCallbackUrl =
-						parsedSamlConfig?.idpInitiatedCallbackUrl ||
-						options?.saml?.idpInitiatedCallbackUrl;
-					const rawRelayState = ctx.body.RelayState;
-					const isTrustedRelayState =
-						rawRelayState &&
-						(rawRelayState.startsWith("/")
-							? !rawRelayState.startsWith("//")
-							: ctx.context.isTrustedOrigin(rawRelayState, {
-									allowRelativePaths: false,
-								}));
 					const redirectUrl = getSafeRedirectUrl(
-						isTrustedRelayState ? rawRelayState : idpInitiatedCallbackUrl,
+						getSAMLRedirectCandidates(
+							ctx.body.RelayState,
+							parsedSamlConfig,
+							options?.saml,
+						),
 						currentCallbackPath,
 						appOrigin,
 						(url, settings) => ctx.context.isTrustedOrigin(url, settings),
 					);
 					throw ctx.redirect(
-						`${redirectUrl}${redirectUrl.includes("?") ? "&" : "?"}error=${encodeURIComponent(errorCode)}&error_description=${encodeURIComponent(error.message)}`,
+						buildSAMLRedirectUrl(redirectUrl, {
+							error: errorCode,
+							error_description: error.message,
+						}),
 					);
 				}
 				throw error;
@@ -2129,7 +2130,7 @@ export const sloEndpoint = (options?: SSOOptions) => {
 			const relayState = ctx.body?.RelayState || ctx.query?.RelayState;
 			const appOrigin = new URL(ctx.context.baseURL).origin;
 			const safeErrorURL = getSafeRedirectUrl(
-				relayState,
+				[relayState],
 				`${appOrigin}/sso/saml2/sp/slo/${providerId}`,
 				appOrigin,
 				(url, settings) => ctx.context.isTrustedOrigin(url, settings),
@@ -2237,7 +2238,7 @@ async function handleLogoutResponse(
 
 	const appOrigin = new URL(ctx.context.baseURL).origin;
 	const safeRedirectUrl = getSafeRedirectUrl(
-		relayState,
+		[relayState],
 		`${appOrigin}/sso/saml2/sp/slo/${providerId}`,
 		appOrigin,
 		(url, settings) => ctx.context.isTrustedOrigin(url, settings),

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -2026,6 +2026,9 @@ export const acsEndpoint = (options?: SSOOptions) => {
 			const { providerId } = ctx.params;
 			const currentCallbackPath = `${ctx.context.baseURL}/sso/saml2/sp/acs/${providerId}`;
 			const appOrigin = new URL(ctx.context.baseURL).origin;
+			// TODO(next): preserve this ordered fallback and pipeline-resolved error
+			// redirect handoff when reconciling next's ACS handler. Signed RelayState
+			// is consumed during parsing and must not be parsed again or used as a URL.
 			let resolvedErrorRedirectUrl: string | undefined;
 
 			try {

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -300,7 +300,7 @@ const ssoProviderBodySchema = z.object({
 			callbackUrl: z.string({}).meta({
 				description: "The callback URL of the provider",
 			}),
-			idpInitiatedCallbackURL: z
+			idpInitiatedCallbackUrl: z
 				.string()
 				.url()
 				.meta({
@@ -871,8 +871,8 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 								entryPoint: body.samlConfig.entryPoint,
 								cert: body.samlConfig.cert,
 								callbackUrl: body.samlConfig.callbackUrl,
-								idpInitiatedCallbackURL:
-									body.samlConfig.idpInitiatedCallbackURL,
+								idpInitiatedCallbackUrl:
+									body.samlConfig.idpInitiatedCallbackUrl,
 								audience: body.samlConfig.audience,
 								idpMetadata: body.samlConfig.idpMetadata,
 								spMetadata: body.samlConfig.spMetadata,
@@ -2064,9 +2064,9 @@ export const acsEndpoint = (options?: SSOOptions) => {
 						ctx.context.adapter,
 					);
 					const parsedSamlConfig = provider?.samlConfig;
-					const idpInitiatedCallbackURL =
-						parsedSamlConfig?.idpInitiatedCallbackURL ||
-						options?.saml?.idpInitiatedCallbackURL;
+					const idpInitiatedCallbackUrl =
+						parsedSamlConfig?.idpInitiatedCallbackUrl ||
+						options?.saml?.idpInitiatedCallbackUrl;
 					const rawRelayState = ctx.body.RelayState;
 					const isTrustedRelayState =
 						rawRelayState &&
@@ -2076,7 +2076,7 @@ export const acsEndpoint = (options?: SSOOptions) => {
 									allowRelativePaths: false,
 								}));
 					const redirectUrl = getSafeRedirectUrl(
-						isTrustedRelayState ? rawRelayState : idpInitiatedCallbackURL,
+						isTrustedRelayState ? rawRelayState : idpInitiatedCallbackUrl,
 						currentCallbackPath,
 						appOrigin,
 						(url, settings) => ctx.context.isTrustedOrigin(url, settings),

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -2026,6 +2026,7 @@ export const acsEndpoint = (options?: SSOOptions) => {
 			const { providerId } = ctx.params;
 			const currentCallbackPath = `${ctx.context.baseURL}/sso/saml2/sp/acs/${providerId}`;
 			const appOrigin = new URL(ctx.context.baseURL).origin;
+			let resolvedErrorRedirectUrl: string | undefined;
 
 			try {
 				const safeRedirectUrl = await processSAMLResponse(
@@ -2035,6 +2036,9 @@ export const acsEndpoint = (options?: SSOOptions) => {
 						RelayState: ctx.body.RelayState,
 						providerId,
 						currentCallbackPath,
+						onErrorRedirectResolved: (url) => {
+							resolvedErrorRedirectUrl = url;
+						},
 					},
 					options,
 				);
@@ -2063,30 +2067,33 @@ export const acsEndpoint = (options?: SSOOptions) => {
 							: internalCode === "SAML_NO_ASSERTION"
 								? "no_assertion"
 								: internalCode.toLowerCase() || "saml_error";
-					let parsedSamlConfig: SAMLConfig | undefined;
-					try {
-						const provider = await findSAMLProvider(
-							providerId,
-							options,
-							ctx.context.adapter,
-						);
-						parsedSamlConfig = provider?.samlConfig;
-					} catch (providerLookupError) {
-						ctx.context.logger.warn(
-							"Failed to resolve SAML provider for error redirect",
-							{ providerId, error: providerLookupError },
+					let redirectUrl = resolvedErrorRedirectUrl;
+					if (!redirectUrl) {
+						let parsedSamlConfig: SAMLConfig | undefined;
+						try {
+							const provider = await findSAMLProvider(
+								providerId,
+								options,
+								ctx.context.adapter,
+							);
+							parsedSamlConfig = provider?.samlConfig;
+						} catch (providerLookupError) {
+							ctx.context.logger.warn(
+								"Failed to resolve SAML provider for error redirect",
+								{ providerId, error: providerLookupError },
+							);
+						}
+						redirectUrl = getSafeRedirectUrl(
+							getSAMLRedirectCandidates(
+								ctx.body.RelayState,
+								parsedSamlConfig,
+								options?.saml,
+							),
+							currentCallbackPath,
+							appOrigin,
+							(url, settings) => ctx.context.isTrustedOrigin(url, settings),
 						);
 					}
-					const redirectUrl = getSafeRedirectUrl(
-						getSAMLRedirectCandidates(
-							ctx.body.RelayState,
-							parsedSamlConfig,
-							options?.saml,
-						),
-						currentCallbackPath,
-						appOrigin,
-						(url, settings) => ctx.context.isTrustedOrigin(url, settings),
-					);
 					throw ctx.redirect(
 						buildSAMLRedirectUrl(redirectUrl, {
 							error: errorCode,

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -300,7 +300,14 @@ const ssoProviderBodySchema = z.object({
 			callbackUrl: z.string({}).meta({
 				description: "The callback URL of the provider",
 			}),
-			idpInitiatedCallbackURL: z.string().optional(),
+			idpInitiatedCallbackURL: z
+				.string()
+				.url()
+				.meta({
+					description:
+						"Callback URL to redirect to after successful IdP-initiated SAML login",
+				})
+				.optional(),
 			audience: z.string().optional(),
 			idpMetadata: z
 				.object({

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -67,6 +67,7 @@ import {
 	getSafeRedirectUrl,
 	processSAMLResponse,
 } from "./saml-pipeline";
+import { samlRedirectUrlSchema } from "./schemas";
 
 const BUILT_IN_ACCOUNT_PROVIDER_IDS = [
 	"credential",
@@ -305,12 +306,10 @@ const ssoProviderBodySchema = z.object({
 			callbackUrl: z.string({}).meta({
 				description: "The callback URL of the provider",
 			}),
-			idpInitiatedCallbackUrl: z
-				.string()
-				.url()
+			idpInitiatedCallbackUrl: samlRedirectUrlSchema
 				.meta({
 					description:
-						"Fallback URL for IdP-initiated SAML responses when RelayState does not contain a safe callback, including validation errors",
+						"Fallback absolute URL or same-origin relative path for IdP-initiated SAML responses when RelayState does not contain a safe callback, including validation errors",
 				})
 				.optional(),
 			audience: z.string().optional(),

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -310,7 +310,7 @@ const ssoProviderBodySchema = z.object({
 				.url()
 				.meta({
 					description:
-						"Callback URL to redirect to after successful IdP-initiated SAML login",
+						"Fallback URL for IdP-initiated SAML responses when RelayState does not contain a safe callback, including validation errors",
 				})
 				.optional(),
 			audience: z.string().optional(),
@@ -2063,12 +2063,20 @@ export const acsEndpoint = (options?: SSOOptions) => {
 							: internalCode === "SAML_NO_ASSERTION"
 								? "no_assertion"
 								: internalCode.toLowerCase() || "saml_error";
-					const provider = await findSAMLProvider(
-						providerId,
-						options,
-						ctx.context.adapter,
-					);
-					const parsedSamlConfig = provider?.samlConfig;
+					let parsedSamlConfig: SAMLConfig | undefined;
+					try {
+						const provider = await findSAMLProvider(
+							providerId,
+							options,
+							ctx.context.adapter,
+						);
+						parsedSamlConfig = provider?.samlConfig;
+					} catch (providerLookupError) {
+						ctx.context.logger.warn(
+							"Failed to resolve SAML provider for error redirect",
+							{ providerId, error: providerLookupError },
+						);
+					}
 					const redirectUrl = getSafeRedirectUrl(
 						getSAMLRedirectCandidates(
 							ctx.body.RelayState,

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -34,6 +34,7 @@ import {
 import { sso, validateSAMLTimestamp } from ".";
 import { ssoClient } from "./client";
 import { DEFAULT_CLOCK_SKEW_MS } from "./constants";
+import { getSafeRedirectUrl } from "./routes/saml-pipeline";
 import { saml } from "./samlify";
 import { normalizePem } from "./utils";
 
@@ -6487,6 +6488,24 @@ describe("SAML SSO Hardening", () => {
 	describe("IdP-initiated SAML login with split origin redirect", () => {
 		const frontendOrigin = "https://frontend.example.com";
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should allow a trusted cross-origin redirect with the ACS pathname", () => {
+			const appOrigin = "http://localhost:3000";
+			const callbackPath = `${appOrigin}/api/auth/sso/saml2/sp/acs/shared-path-provider`;
+			const frontendCallback = `${frontendOrigin}/api/auth/sso/saml2/sp/acs/shared-path-provider`;
+
+			expect(
+				getSafeRedirectUrl(
+					[frontendCallback],
+					callbackPath,
+					appOrigin,
+					() => true,
+				),
+			).toBe(frontendCallback);
+		});
+
 		async function getIdPInitiatedSAMLResponse(): Promise<string> {
 			let response: MockSAMLResponse | undefined;
 			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
@@ -6743,6 +6762,92 @@ describe("SAML SSO Hardening", () => {
 			expect(redirectUrl.pathname).toBe("/saml-error");
 			expect(redirectUrl.searchParams.get("error")).toBe(
 				"saml_invalid_encoding",
+			);
+			expect(redirectUrl.hash).toBe("#details");
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should preserve the signed error callback on binding validation errors", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				trustedOrigins: [frontendOrigin],
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackUrl: `${frontendOrigin}/global-idp-redirect`,
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "binding-error-relay-state-provider",
+					issuer: "http://localhost:8081",
+					domain: "binding-error.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/sp/acs/binding-error-relay-state-provider",
+						idpInitiatedCallbackUrl: `${frontendOrigin}/provider-idp-redirect`,
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			const signInResponse = await auth.api.signInSSO({
+				body: {
+					providerId: "binding-error-relay-state-provider",
+					callbackURL: `${frontendOrigin}/success`,
+					errorCallbackURL: `${frontendOrigin}/binding-error#details`,
+				},
+			});
+			const idpResponseUrl = new URL(signInResponse.url as string);
+			idpResponseUrl.searchParams.set(
+				"audience",
+				"https://unexpected.example.com/saml/metadata",
+			);
+
+			let samlResponse: MockSAMLResponse | undefined;
+			await betterFetch(idpResponseUrl.toString(), {
+				onSuccess: async (context) => {
+					samlResponse = (await context.data) as MockSAMLResponse;
+				},
+			});
+			if (!samlResponse)
+				throw new Error("Mock IdP did not return a SAML response");
+
+			const relayState = idpResponseUrl.searchParams.get("RelayState") ?? "";
+			const callbackResponse = await auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/sp/acs/binding-error-relay-state-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: samlResponse.samlResponse,
+							RelayState: relayState,
+						}),
+					},
+				),
+			);
+
+			expect(callbackResponse.status).toBe(302);
+			const redirectUrl = new URL(
+				callbackResponse.headers.get("location") || "",
+			);
+			expect(redirectUrl.origin).toBe(frontendOrigin);
+			expect(redirectUrl.pathname).toBe("/binding-error");
+			expect(redirectUrl.searchParams.get("error")).toBe(
+				"invalid_saml_response",
 			);
 			expect(redirectUrl.hash).toBe("#details");
 		});

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -6488,7 +6488,7 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should redirect to provider-level idpInitiatedCallbackURL when RelayState is missing (IdP-initiated)", async () => {
+		it("should redirect to provider-level idpInitiatedCallbackUrl when RelayState is missing (IdP-initiated)", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					sso({
@@ -6500,7 +6500,7 @@ describe("SAML SSO Hardening", () => {
 			});
 			const { headers } = await signInWithTestUser();
 
-			// Provider with provider-level idpInitiatedCallbackURL
+			// Provider with provider-level idpInitiatedCallbackUrl
 			await auth.api.registerSSOProvider({
 				body: {
 					providerId: "split-origin-provider",
@@ -6511,7 +6511,7 @@ describe("SAML SSO Hardening", () => {
 						cert: certificate,
 						callbackUrl:
 							"http://localhost:3000/api/auth/sso/saml2/callback/split-origin-provider",
-						idpInitiatedCallbackURL:
+						idpInitiatedCallbackUrl:
 							"http://localhost:3000/provider-idp-redirect",
 						idpMetadata: { metadata: idpMetadata },
 						spMetadata: { metadata: spMetadata },
@@ -6546,13 +6546,13 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should redirect to global idpInitiatedCallbackURL when RelayState is missing (IdP-initiated fallback)", async () => {
+		it("should redirect to global idpInitiatedCallbackUrl when RelayState is missing (IdP-initiated fallback)", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackURL:
+							idpInitiatedCallbackUrl:
 								"http://localhost:3000/global-idp-redirect",
 						},
 					}),
@@ -6560,7 +6560,7 @@ describe("SAML SSO Hardening", () => {
 			});
 			const { headers } = await signInWithTestUser();
 
-			// Provider without provider-level idpInitiatedCallbackURL (should fall back to global plugin option)
+			// Provider without provider-level idpInitiatedCallbackUrl (should fall back to global plugin option)
 			await auth.api.registerSSOProvider({
 				body: {
 					providerId: "global-fallback-provider",
@@ -6604,13 +6604,13 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should prioritize SP-initiated RelayState over idpInitiatedCallbackURL", async () => {
+		it("should prioritize SP-initiated RelayState over idpInitiatedCallbackUrl", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackURL:
+							idpInitiatedCallbackUrl:
 								"http://localhost:3000/global-idp-redirect",
 						},
 					}),
@@ -6628,7 +6628,7 @@ describe("SAML SSO Hardening", () => {
 						cert: certificate,
 						callbackUrl:
 							"http://localhost:3000/api/auth/sso/saml2/callback/priority-test-provider",
-						idpInitiatedCallbackURL:
+						idpInitiatedCallbackUrl:
 							"http://localhost:3000/provider-idp-redirect",
 						idpMetadata: { metadata: idpMetadata },
 						spMetadata: { metadata: spMetadata },
@@ -6675,13 +6675,13 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should prevent open redirect attacks on idpInitiatedCallbackURL", async () => {
+		it("should prevent open redirect attacks on idpInitiatedCallbackUrl", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackURL: "http://attacker.com/malicious",
+							idpInitiatedCallbackUrl: "http://attacker.com/malicious",
 						},
 					}),
 				],
@@ -6731,13 +6731,13 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should redirect to idpInitiatedCallbackURL on SAML validation error", async () => {
+		it("should redirect to idpInitiatedCallbackUrl on SAML validation error", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackURL:
+							idpInitiatedCallbackUrl:
 								"http://localhost:3000/global-idp-redirect",
 						},
 					}),
@@ -6755,7 +6755,7 @@ describe("SAML SSO Hardening", () => {
 						cert: certificate,
 						callbackUrl:
 							"http://localhost:3000/api/auth/sso/saml2/callback/error-provider",
-						idpInitiatedCallbackURL:
+						idpInitiatedCallbackUrl:
 							"http://localhost:3000/provider-idp-redirect",
 						idpMetadata: { metadata: idpMetadata },
 						spMetadata: { metadata: spMetadata },

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -6485,11 +6485,25 @@ describe("SAML SSO Hardening", () => {
 	 * @see https://github.com/better-auth/better-auth/issues/10329
 	 */
 	describe("IdP-initiated SAML login with split origin redirect", () => {
+		const frontendOrigin = "https://frontend.example.com";
+
+		async function getIdPInitiatedSAMLResponse(): Promise<string> {
+			let response: MockSAMLResponse | undefined;
+			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
+				onSuccess: async (context) => {
+					response = (await context.data) as MockSAMLResponse;
+				},
+			});
+			if (!response) throw new Error("Mock IdP did not return a SAML response");
+			return response.samlResponse;
+		}
+
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
 		it("should redirect to provider-level idpInitiatedCallbackUrl when RelayState is missing (IdP-initiated)", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
+				trustedOrigins: [frontendOrigin],
 				plugins: [
 					sso({
 						saml: {
@@ -6511,8 +6525,7 @@ describe("SAML SSO Hardening", () => {
 						cert: certificate,
 						callbackUrl:
 							"http://localhost:3000/api/auth/sso/saml2/callback/split-origin-provider",
-						idpInitiatedCallbackUrl:
-							"http://localhost:3000/provider-idp-redirect",
+						idpInitiatedCallbackUrl: `${frontendOrigin}/provider-idp-redirect`,
 						idpMetadata: { metadata: idpMetadata },
 						spMetadata: { metadata: spMetadata },
 					},
@@ -6520,18 +6533,12 @@ describe("SAML SSO Hardening", () => {
 				headers,
 			});
 
-			// Get unsolicited SAML response from mock IdP
-			let samlResponse: any;
-			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
-				onSuccess: async (context) => {
-					samlResponse = await context.data;
-				},
-			});
+			const samlResponse = await getIdPInitiatedSAMLResponse();
 
 			const callbackResponse = (await auth.api.callbackSSOSAML({
 				method: "POST",
 				body: {
-					SAMLResponse: samlResponse.samlResponse,
+					SAMLResponse: samlResponse,
 				},
 				params: { providerId: "split-origin-provider" },
 				asResponse: true,
@@ -6539,7 +6546,7 @@ describe("SAML SSO Hardening", () => {
 
 			expect(callbackResponse.status).toBe(302);
 			expect(callbackResponse.headers.get("location")).toBe(
-				"http://localhost:3000/provider-idp-redirect",
+				`${frontendOrigin}/provider-idp-redirect`,
 			);
 		});
 
@@ -6548,12 +6555,12 @@ describe("SAML SSO Hardening", () => {
 		 */
 		it("should redirect to global idpInitiatedCallbackUrl when RelayState is missing (IdP-initiated fallback)", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
+				trustedOrigins: [frontendOrigin],
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackUrl:
-								"http://localhost:3000/global-idp-redirect",
+							idpInitiatedCallbackUrl: `${frontendOrigin}/global-idp-redirect`,
 						},
 					}),
 				],
@@ -6578,18 +6585,12 @@ describe("SAML SSO Hardening", () => {
 				headers,
 			});
 
-			// Get unsolicited SAML response from mock IdP
-			let samlResponse: any;
-			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
-				onSuccess: async (context) => {
-					samlResponse = await context.data;
-				},
-			});
+			const samlResponse = await getIdPInitiatedSAMLResponse();
 
 			const fallbackResponse = (await auth.api.callbackSSOSAML({
 				method: "POST",
 				body: {
-					SAMLResponse: samlResponse.samlResponse,
+					SAMLResponse: samlResponse,
 				},
 				params: { providerId: "global-fallback-provider" },
 				asResponse: true,
@@ -6597,7 +6598,7 @@ describe("SAML SSO Hardening", () => {
 
 			expect(fallbackResponse.status).toBe(302);
 			expect(fallbackResponse.headers.get("location")).toBe(
-				"http://localhost:3000/global-idp-redirect",
+				`${frontendOrigin}/global-idp-redirect`,
 			);
 		});
 
@@ -6606,12 +6607,12 @@ describe("SAML SSO Hardening", () => {
 		 */
 		it("should prioritize SP-initiated RelayState over idpInitiatedCallbackUrl", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
+				trustedOrigins: [frontendOrigin],
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackUrl:
-								"http://localhost:3000/global-idp-redirect",
+							idpInitiatedCallbackUrl: `${frontendOrigin}/global-idp-redirect`,
 						},
 					}),
 				],
@@ -6628,8 +6629,7 @@ describe("SAML SSO Hardening", () => {
 						cert: certificate,
 						callbackUrl:
 							"http://localhost:3000/api/auth/sso/saml2/callback/priority-test-provider",
-						idpInitiatedCallbackUrl:
-							"http://localhost:3000/provider-idp-redirect",
+						idpInitiatedCallbackUrl: `${frontendOrigin}/provider-idp-redirect`,
 						idpMetadata: { metadata: idpMetadata },
 						spMetadata: { metadata: spMetadata },
 					},
@@ -6645,12 +6645,14 @@ describe("SAML SSO Hardening", () => {
 				},
 			});
 
-			let samlResponse: any;
+			let samlResponse: MockSAMLResponse | undefined;
 			await betterFetch(signInResponse.url as string, {
 				onSuccess: async (context) => {
-					samlResponse = await context.data;
+					samlResponse = (await context.data) as MockSAMLResponse;
 				},
 			});
+			if (!samlResponse)
+				throw new Error("Mock IdP did not return a SAML response");
 
 			const signInUrl = new URL(signInResponse.url as string);
 			const relayState = signInUrl.searchParams.get("RelayState") ?? "";
@@ -6705,17 +6707,12 @@ describe("SAML SSO Hardening", () => {
 				headers,
 			});
 
-			let samlResponse: any;
-			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
-				onSuccess: async (context) => {
-					samlResponse = await context.data;
-				},
-			});
+			const samlResponse = await getIdPInitiatedSAMLResponse();
 
 			const callbackResponse = (await auth.api.callbackSSOSAML({
 				method: "POST",
 				body: {
-					SAMLResponse: samlResponse.samlResponse,
+					SAMLResponse: samlResponse,
 				},
 				params: { providerId: "unsafe-provider" },
 				asResponse: true,
@@ -6733,12 +6730,12 @@ describe("SAML SSO Hardening", () => {
 		 */
 		it("should redirect to idpInitiatedCallbackUrl on SAML validation error", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
+				trustedOrigins: [frontendOrigin],
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackUrl:
-								"http://localhost:3000/global-idp-redirect",
+							idpInitiatedCallbackUrl: `${frontendOrigin}/global-idp-redirect`,
 						},
 					}),
 				],
@@ -6755,8 +6752,7 @@ describe("SAML SSO Hardening", () => {
 						cert: certificate,
 						callbackUrl:
 							"http://localhost:3000/api/auth/sso/saml2/callback/error-provider",
-						idpInitiatedCallbackUrl:
-							"http://localhost:3000/provider-idp-redirect",
+						idpInitiatedCallbackUrl: `${frontendOrigin}/provider-idp-redirect#saml`,
 						idpMetadata: { metadata: idpMetadata },
 						spMetadata: { metadata: spMetadata },
 					},
@@ -6774,7 +6770,8 @@ describe("SAML SSO Hardening", () => {
 						},
 						body: new URLSearchParams({
 							SAMLResponse: "invalid-saml-response-garbage",
-							RelayState: "id-12345",
+							RelayState:
+								"http://localhost:3000/api/auth/sso/saml2/sp/acs/error-provider",
 						}),
 					},
 				),
@@ -6782,11 +6779,13 @@ describe("SAML SSO Hardening", () => {
 
 			expect(callbackResponse.status).toBe(302);
 			const location = callbackResponse.headers.get("location") || "";
-			expect(location).toContain("http://localhost:3000/provider-idp-redirect");
-			expect(location).not.toContain(
-				"http://localhost:3000/global-idp-redirect",
+			const redirectUrl = new URL(location);
+			expect(redirectUrl.origin).toBe(frontendOrigin);
+			expect(redirectUrl.pathname).toBe("/provider-idp-redirect");
+			expect(redirectUrl.searchParams.get("error")).toBe(
+				"saml_invalid_encoding",
 			);
-			expect(location).toContain("error=");
+			expect(redirectUrl.hash).toBe("#saml");
 		});
 	});
 });

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -6787,5 +6787,92 @@ describe("SAML SSO Hardening", () => {
 			);
 			expect(redirectUrl.hash).toBe("#saml");
 		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should use the global fallback when the provider lookup for an error redirect fails", async () => {
+			const data = {
+				user: [],
+				session: [],
+				verification: [],
+				account: [],
+				ssoProvider: [],
+			};
+			const memory = memoryAdapter(data);
+			let failSecondProviderLookup = false;
+			let providerLookupCount = 0;
+			const database: typeof memory = (options) => {
+				const adapter = memory(options);
+				const findOne: typeof adapter.findOne = async (query) => {
+					if (failSecondProviderLookup && query.model === "ssoProvider") {
+						providerLookupCount++;
+						if (providerLookupCount === 2) {
+							throw new Error("provider lookup unavailable");
+						}
+					}
+					return adapter.findOne(query);
+				};
+				return { ...adapter, findOne };
+			};
+			const { auth, signInWithTestUser } = await getTestInstance({
+				database,
+				trustedOrigins: [frontendOrigin],
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackUrl: `${frontendOrigin}/global-idp-redirect`,
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "error-lookup-provider",
+					issuer: "http://localhost:8081",
+					domain: "error-lookup.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/error-lookup-provider",
+						idpInitiatedCallbackUrl: `${frontendOrigin}/provider-idp-redirect`,
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			failSecondProviderLookup = true;
+			providerLookupCount = 0;
+			const callbackResponse = await auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/sp/acs/error-lookup-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: "invalid-saml-response-garbage",
+						}),
+					},
+				),
+			);
+
+			expect(callbackResponse.status).toBe(302);
+			const redirectUrl = new URL(
+				callbackResponse.headers.get("location") || "",
+			);
+			expect(redirectUrl.origin).toBe(frontendOrigin);
+			expect(redirectUrl.pathname).toBe("/global-idp-redirect");
+			expect(redirectUrl.searchParams.get("error")).toBe(
+				"saml_invalid_encoding",
+			);
+		});
 	});
 });

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -6511,6 +6511,27 @@ describe("SAML SSO Hardening", () => {
 			).toBe(frontendCallback);
 		});
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it.each([
+			"/\\evil.example.com",
+			"/%2fevil.example.com",
+			"/%5cevil.example.com",
+		])("should skip unsafe relative redirect candidate %s", (candidate) => {
+			const appOrigin = "http://localhost:3000";
+			const callbackPath = `${appOrigin}/api/auth/sso/saml2/sp/acs/provider`;
+
+			expect(
+				getSafeRedirectUrl(
+					[candidate, "/dashboard"],
+					callbackPath,
+					appOrigin,
+					() => true,
+				),
+			).toBe("/dashboard");
+		});
+
 		async function getIdPInitiatedSAMLResponse(): Promise<string> {
 			let response: MockSAMLResponse | undefined;
 			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -6480,4 +6480,313 @@ describe("SAML SSO Hardening", () => {
 			expect(location).not.toContain("/from-config");
 		});
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10329
+	 */
+	describe("IdP-initiated SAML login with split origin redirect", () => {
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should redirect to provider-level idpInitiatedCallbackURL when RelayState is missing (IdP-initiated)", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			// Provider with provider-level idpInitiatedCallbackURL
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "split-origin-provider",
+					issuer: "http://localhost:8081",
+					domain: "split.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/split-origin-provider",
+						idpInitiatedCallbackURL:
+							"http://localhost:3000/provider-idp-redirect",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			// Get unsolicited SAML response from mock IdP
+			let samlResponse: any;
+			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
+				onSuccess: async (context) => {
+					samlResponse = await context.data;
+				},
+			});
+
+			const callbackResponse = (await auth.api.callbackSSOSAML({
+				method: "POST",
+				body: {
+					SAMLResponse: samlResponse.samlResponse,
+				},
+				params: { providerId: "split-origin-provider" },
+				asResponse: true,
+			})) as unknown as Response;
+
+			expect(callbackResponse.status).toBe(302);
+			expect(callbackResponse.headers.get("location")).toBe(
+				"http://localhost:3000/provider-idp-redirect",
+			);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should redirect to global idpInitiatedCallbackURL when RelayState is missing (IdP-initiated fallback)", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackURL:
+								"http://localhost:3000/global-idp-redirect",
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			// Provider without provider-level idpInitiatedCallbackURL (should fall back to global plugin option)
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "global-fallback-provider",
+					issuer: "http://localhost:8081",
+					domain: "fallback.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/global-fallback-provider",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			// Get unsolicited SAML response from mock IdP
+			let samlResponse: any;
+			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
+				onSuccess: async (context) => {
+					samlResponse = await context.data;
+				},
+			});
+
+			const fallbackResponse = (await auth.api.callbackSSOSAML({
+				method: "POST",
+				body: {
+					SAMLResponse: samlResponse.samlResponse,
+				},
+				params: { providerId: "global-fallback-provider" },
+				asResponse: true,
+			})) as unknown as Response;
+
+			expect(fallbackResponse.status).toBe(302);
+			expect(fallbackResponse.headers.get("location")).toBe(
+				"http://localhost:3000/global-idp-redirect",
+			);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should prioritize SP-initiated RelayState over idpInitiatedCallbackURL", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackURL:
+								"http://localhost:3000/global-idp-redirect",
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "priority-test-provider",
+					issuer: "http://localhost:8081",
+					domain: "priority.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/priority-test-provider",
+						idpInitiatedCallbackURL:
+							"http://localhost:3000/provider-idp-redirect",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			// Sign in with SP-initiated flow requesting a specific callbackURL
+			const signInResponse = await auth.api.signInSSO({
+				body: {
+					providerId: "priority-test-provider",
+					callbackURL: "/from-relay-state",
+				},
+			});
+
+			let samlResponse: any;
+			await betterFetch(signInResponse.url as string, {
+				onSuccess: async (context) => {
+					samlResponse = await context.data;
+				},
+			});
+
+			const signInUrl = new URL(signInResponse.url as string);
+			const relayState = signInUrl.searchParams.get("RelayState") ?? "";
+
+			const callbackResponse = (await auth.api.callbackSSOSAML({
+				method: "POST",
+				body: {
+					SAMLResponse: samlResponse.samlResponse,
+					RelayState: relayState,
+				},
+				params: { providerId: "priority-test-provider" },
+				asResponse: true,
+			})) as unknown as Response;
+
+			expect(callbackResponse.status).toBe(302);
+			const location = callbackResponse.headers.get("location") || "";
+			expect(location).toContain("/from-relay-state");
+			expect(location).not.toContain("/provider-idp-redirect");
+			expect(location).not.toContain("/global-idp-redirect");
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should prevent open redirect attacks on idpInitiatedCallbackURL", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackURL: "http://attacker.com/malicious",
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "unsafe-provider",
+					issuer: "http://localhost:8081",
+					domain: "unsafe.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/unsafe-provider",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			let samlResponse: any;
+			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
+				onSuccess: async (context) => {
+					samlResponse = await context.data;
+				},
+			});
+
+			const callbackResponse = (await auth.api.callbackSSOSAML({
+				method: "POST",
+				body: {
+					SAMLResponse: samlResponse.samlResponse,
+				},
+				params: { providerId: "unsafe-provider" },
+				asResponse: true,
+			})) as unknown as Response;
+
+			expect(callbackResponse.status).toBe(302);
+			const location = callbackResponse.headers.get("location") || "";
+			// Should fall back to appOrigin because http://attacker.com/malicious is not a trusted origin
+			expect(location).not.toContain("attacker.com");
+			expect(location).toBe("http://localhost:3000"); // appOrigin
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should redirect to idpInitiatedCallbackURL on SAML validation error", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackURL:
+								"http://localhost:3000/global-idp-redirect",
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "error-provider",
+					issuer: "http://localhost:8081",
+					domain: "error.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/error-provider",
+						idpInitiatedCallbackURL:
+							"http://localhost:3000/provider-idp-redirect",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			const callbackResponse = await auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/sp/acs/error-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: "invalid-saml-response-garbage",
+							RelayState: "id-12345",
+						}),
+					},
+				),
+			);
+
+			expect(callbackResponse.status).toBe(302);
+			const location = callbackResponse.headers.get("location") || "";
+			expect(location).toContain("http://localhost:3000/provider-idp-redirect");
+			expect(location).not.toContain(
+				"http://localhost:3000/global-idp-redirect",
+			);
+			expect(location).toContain("error=");
+		});
+	});
 });

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -6677,6 +6677,79 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
+		it("should preserve the signed RelayState error callback on validation errors", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				trustedOrigins: [frontendOrigin],
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackUrl: `${frontendOrigin}/global-idp-redirect`,
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "error-relay-state-provider",
+					issuer: "http://localhost:8081",
+					domain: "error-relay-state.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/error-relay-state-provider",
+						idpInitiatedCallbackUrl: `${frontendOrigin}/provider-idp-redirect`,
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			const signInResponse = await auth.api.signInSSO({
+				body: {
+					providerId: "error-relay-state-provider",
+					callbackURL: `${frontendOrigin}/success`,
+					errorCallbackURL: `${frontendOrigin}/saml-error#details`,
+				},
+			});
+			const signInUrl = new URL(signInResponse.url as string);
+			const relayState = signInUrl.searchParams.get("RelayState") ?? "";
+
+			const callbackResponse = await auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/sp/acs/error-relay-state-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: "invalid-saml-response-garbage",
+							RelayState: relayState,
+						}),
+					},
+				),
+			);
+
+			expect(callbackResponse.status).toBe(302);
+			const redirectUrl = new URL(
+				callbackResponse.headers.get("location") || "",
+			);
+			expect(redirectUrl.origin).toBe(frontendOrigin);
+			expect(redirectUrl.pathname).toBe("/saml-error");
+			expect(redirectUrl.searchParams.get("error")).toBe(
+				"saml_invalid_encoding",
+			);
+			expect(redirectUrl.hash).toBe("#details");
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
 		it("should prevent open redirect attacks on idpInitiatedCallbackUrl", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
@@ -6791,7 +6864,7 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should use the global fallback when the provider lookup for an error redirect fails", async () => {
+		it("should use the global fallback when provider lookup fails before error redirect resolution", async () => {
 			const data = {
 				user: [],
 				session: [],
@@ -6800,16 +6873,12 @@ describe("SAML SSO Hardening", () => {
 				ssoProvider: [],
 			};
 			const memory = memoryAdapter(data);
-			let failSecondProviderLookup = false;
-			let providerLookupCount = 0;
+			let failProviderLookup = false;
 			const database: typeof memory = (options) => {
 				const adapter = memory(options);
 				const findOne: typeof adapter.findOne = async (query) => {
-					if (failSecondProviderLookup && query.model === "ssoProvider") {
-						providerLookupCount++;
-						if (providerLookupCount === 2) {
-							throw new Error("provider lookup unavailable");
-						}
+					if (failProviderLookup && query.model === "ssoProvider") {
+						throw new Error("provider lookup unavailable");
 					}
 					return adapter.findOne(query);
 				};
@@ -6823,6 +6892,7 @@ describe("SAML SSO Hardening", () => {
 						saml: {
 							allowIdpInitiated: true,
 							idpInitiatedCallbackUrl: `${frontendOrigin}/global-idp-redirect`,
+							maxResponseSize: 16,
 						},
 					}),
 				],
@@ -6847,8 +6917,7 @@ describe("SAML SSO Hardening", () => {
 				headers,
 			});
 
-			failSecondProviderLookup = true;
-			providerLookupCount = 0;
+			failProviderLookup = true;
 			const callbackResponse = await auth.handler(
 				new Request(
 					"http://localhost:3000/api/auth/sso/saml2/sp/acs/error-lookup-provider",
@@ -6858,7 +6927,7 @@ describe("SAML SSO Hardening", () => {
 							"Content-Type": "application/x-www-form-urlencoded",
 						},
 						body: new URLSearchParams({
-							SAMLResponse: "invalid-saml-response-garbage",
+							SAMLResponse: "response-exceeds-size-limit",
 						}),
 					},
 				),
@@ -6870,9 +6939,7 @@ describe("SAML SSO Hardening", () => {
 			);
 			expect(redirectUrl.origin).toBe(frontendOrigin);
 			expect(redirectUrl.pathname).toBe("/global-idp-redirect");
-			expect(redirectUrl.searchParams.get("error")).toBe(
-				"saml_invalid_encoding",
-			);
+			expect(redirectUrl.searchParams.get("error")).toBe("saml_error");
 		});
 	});
 });

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -3067,6 +3067,9 @@ describe("safeJsonParse", () => {
 });
 
 describe("SSO Provider Config Parsing", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10329
+	 */
 	it("returns parsed SAML config and avoids [object Object] in response", async () => {
 		const data = {
 			user: [] as any[],
@@ -3114,6 +3117,7 @@ describe("SSO Provider Config Parsing", () => {
 					entryPoint: "http://localhost:8081/sso",
 					cert: "test-cert",
 					callbackUrl: "http://localhost:3000/callback",
+					idpInitiatedCallbackUrl: "/dashboard",
 					spMetadata: {
 						entityID: "test-entity",
 					},
@@ -3126,6 +3130,7 @@ describe("SSO Provider Config Parsing", () => {
 		expect(typeof provider.samlConfig).toBe("object");
 		expect(provider.samlConfig?.entryPoint).toBe("http://localhost:8081/sso");
 		expect(provider.samlConfig?.cert).toBe("test-cert");
+		expect(provider.samlConfig?.idpInitiatedCallbackUrl).toBe("/dashboard");
 
 		const serialized = JSON.stringify(provider.samlConfig);
 		expect(serialized).not.toContain("[object Object]");

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -43,7 +43,7 @@ export interface SAMLConfig {
 	entryPoint: string;
 	cert: string;
 	callbackUrl: string;
-	idpInitiatedCallbackURL?: string | undefined;
+	idpInitiatedCallbackUrl?: string | undefined;
 	audience?: string | undefined;
 	idpMetadata?:
 		| {
@@ -430,7 +430,7 @@ export interface SSOOptions {
 		/**
 		 * Callback URL to redirect to after successful IdP-initiated SAML login.
 		 */
-		idpInitiatedCallbackURL?: string | undefined;
+		idpInitiatedCallbackUrl?: string | undefined;
 	};
 }
 

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -44,8 +44,8 @@ export interface SAMLConfig {
 	cert: string;
 	callbackUrl: string;
 	/**
-	 * Callback URL used after an IdP-initiated SAML login when no valid
-	 * RelayState callback is available.
+	 * Fallback URL for IdP-initiated SAML responses when `RelayState` does not
+	 * contain a safe callback, including validation error redirects.
 	 */
 	idpInitiatedCallbackUrl?: string | undefined;
 	audience?: string | undefined;
@@ -432,7 +432,8 @@ export interface SSOOptions {
 		 */
 		wantLogoutResponseSigned?: boolean;
 		/**
-		 * Callback URL to redirect to after successful IdP-initiated SAML login.
+		 * Fallback URL for IdP-initiated SAML responses when `RelayState` does not
+		 * contain a safe callback, including validation error redirects.
 		 */
 		idpInitiatedCallbackUrl?: string | undefined;
 	};

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -43,6 +43,10 @@ export interface SAMLConfig {
 	entryPoint: string;
 	cert: string;
 	callbackUrl: string;
+	/**
+	 * Callback URL used after an IdP-initiated SAML login when no valid
+	 * RelayState callback is available.
+	 */
 	idpInitiatedCallbackUrl?: string | undefined;
 	audience?: string | undefined;
 	idpMetadata?:

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -44,8 +44,9 @@ export interface SAMLConfig {
 	cert: string;
 	callbackUrl: string;
 	/**
-	 * Fallback URL for IdP-initiated SAML responses when `RelayState` does not
-	 * contain a safe callback, including validation error redirects.
+	 * Fallback absolute URL or same-origin relative path for IdP-initiated SAML
+	 * responses when `RelayState` does not contain a safe callback, including
+	 * validation error redirects.
 	 */
 	idpInitiatedCallbackUrl?: string | undefined;
 	audience?: string | undefined;
@@ -432,8 +433,9 @@ export interface SSOOptions {
 		 */
 		wantLogoutResponseSigned?: boolean;
 		/**
-		 * Fallback URL for IdP-initiated SAML responses when `RelayState` does not
-		 * contain a safe callback, including validation error redirects.
+		 * Fallback absolute URL or same-origin relative path for IdP-initiated SAML
+		 * responses when `RelayState` does not contain a safe callback, including
+		 * validation error redirects.
 		 */
 		idpInitiatedCallbackUrl?: string | undefined;
 	};

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -43,6 +43,7 @@ export interface SAMLConfig {
 	entryPoint: string;
 	cert: string;
 	callbackUrl: string;
+	idpInitiatedCallbackURL?: string | undefined;
 	audience?: string | undefined;
 	idpMetadata?:
 		| {
@@ -426,6 +427,10 @@ export interface SSOOptions {
 		 * @default false
 		 */
 		wantLogoutResponseSigned?: boolean;
+		/**
+		 * Callback URL to redirect to after successful IdP-initiated SAML login.
+		 */
+		idpInitiatedCallbackURL?: string | undefined;
 	};
 }
 

--- a/packages/sso/src/utils.ts
+++ b/packages/sso/src/utils.ts
@@ -1,6 +1,11 @@
 import { X509Certificate } from "node:crypto";
 import { getHostname } from "tldts";
 
+const unsafeSAMLRedirectPathPrefix = /^\/(?:\/|\\|%2f|%5c)/i;
+
+export const isSafeSAMLRedirectPath = (url: string): boolean =>
+	url.startsWith("/") && !unsafeSAMLRedirectPathPrefix.test(url);
+
 /**
  * Safely parses a value that might be a JSON string or already a parsed object.
  * This handles cases where ORMs like Drizzle might return already parsed objects


### PR DESCRIPTION
IdP-initiated SAML flows can reach the Assertion Consumer Service without a Better Auth callback in `RelayState`. In split-origin deployments, the legacy fallback points back at the ACS route, where loop protection collapses the redirect to the authentication server origin. This change adds an explicit application redirect and applies one ordered safety policy to successful and failed SAML responses.

## What changes

- **Public redirect contract**: configure `idpInitiatedCallbackUrl` globally under `saml` or per provider under `samlConfig`; the provider setting takes precedence.
- **Stable precedence**: Better Auth tries the `RelayState` callback, the provider fallback, the global fallback, and the legacy provider callback in that order, then uses the first trusted candidate that does not point back at the ACS route.
- **Consistent failure handling**: SAML validation errors use the same redirect policy, and error parameters preserve existing query strings and URL fragments.
- **Contract coverage**: schemas, provider updates, documentation, and regression tests cover split-origin success, precedence, unsafe origins, and validation errors.

## Security and failure boundaries

Existing Better Auth-generated `RelayState` callbacks retain priority. Cross-origin fallbacks must match `trustedOrigins`; unsafe, malformed, protocol-relative, and ACS-loop candidates are skipped, with the authentication server origin as the final safe fallback.

The SAML pipeline resolves signed `RelayState` error callbacks once and retains that destination across validation failures, so the ACS handler does not reparse consumed state. If an error occurs before redirect context exists, provider lookup failures are logged and fall back to the global callback or authentication server origin.

Closes #10329
