### PR TITLE
docs: remove "what's next" section from 1.7 rc blog

### DIFF
--- a/docs/content/blogs/1-7-rc.mdx
+++ b/docs/content/blogs/1-7-rc.mdx
@@ -266,12 +266,6 @@ Then run `npx auth@rc generate` for any schema changes; the unscoped `npx auth` 
 
 ***
 
-## What's next?
-
-We're planning Better Auth 1.7 as the last feature release on the v1 line. Once it is stable, v1 moves into maintenance, where security, bug, and compatibility fixes continue while our focus shifts to v2. v1 stays maintained and remains a solid base to build on. v2 is our chance to improve the foundation. We're making it more modular and focused. More soon.
-
-***
-
 ## Contributors
 
 Thanks to all the contributors for making this release possible!


### PR DESCRIPTION
It doesn't mean there's nothing next 😅

We're actively discussing v2, but we don't want to close the door on v1 work. We'll continue developing v1, so I'm removing this section.