### PR TITLE
fix(core): propagate resolved method to hooks in programmatic dispatch

### DIFF
--- a/packages/better-auth/src/api/dispatch.ts
+++ b/packages/better-auth/src/api/dispatch.ts
@@ -39,6 +39,7 @@ export type DispatchContext = Partial<
 type InternalContext = DispatchContext & {
 	path?: string | undefined;
 	asResponse?: boolean | undefined;
+	method?: string | undefined;
 };
 
 const defuReplaceArrays = createDefu((obj, key, value) => {
@@ -343,6 +344,7 @@ export async function dispatchAuthEndpoint(
 			session: input.context.session ?? null,
 		},
 		path: endpoint.path,
+		method: methodName,
 		headers: input.headers ? new Headers(input.headers) : undefined,
 	};
 


### PR DESCRIPTION
Set the resolved methodName on internalContext so hooks receive the HTTP method during programmatic calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes the resolved HTTP method to hooks during programmatic dispatch. Sets `method` on the internal context in `dispatchAuthEndpoint` so hooks receive the correct method.

<sup>Written for commit 7084284e5be9a5bd19601e64a1e993645157724f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

