### PR TITLE
fix(one-tap): stop calling FedCM-deprecated prompt moment APIs

### DIFF
--- a/.changeset/one-tap-fedcm-prompt-apis.md
+++ b/.changeset/one-tap-fedcm-prompt-apis.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix Google One Tap FedCM prompt handling to avoid calling deprecated moment APIs (`isNotDisplayed`, `getSkippedReason`) when FedCM is enabled, matching Google's FedCM migration guide.

--- a/docs/content/docs/plugins/one-tap.mdx
+++ b/docs/content/docs/plugins/one-tap.mdx
@@ -183,7 +183,7 @@ await authClient.oneTap({
 * `promptOptions`: Configuration for the prompt behavior and exponential backoff:
   * `baseDelay`: Base delay in milliseconds for retries. Default is 1000.
   * `maxAttempts`: Maximum number of prompt attempts before invoking the `onPromptNotification` callback. Default is 5.
-  * `fedCM`: When enabled, calls [`navigator.credentials.preventSilentAccess()`](https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/preventSilentAccess) on sign-out to clear the browser's FedCM credential state. FedCM itself is managed by the Google Identity Services library and cannot be disabled. Default is true.
+  * `fedCM`: Opt into Google Identity Services FedCM for the One Tap prompt (`use_fedcm_for_prompt`) and call [`navigator.credentials.preventSilentAccess()`](https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/preventSilentAccess) on sign-out. When enabled, display-moment APIs and `getSkippedReason` are not used. Default is true. Set to `false` only if you need non-FedCM prompt behavior (for example `cancelOnTapOutside`). Google's GSI library may still log a FedCM migration warning whenever a `prompt()` moment listener is registered; that warning is a known GSI false positive and does not mean FedCM is disabled.
 
 ### Button Mode Options
 

--- a/packages/better-auth/src/plugins/one-tap/client.ts
+++ b/packages/better-auth/src/plugins/one-tap/client.ts
@@ -134,9 +134,15 @@ export interface GoogleOneTapOptions {
 				 */
 				maxAttempts?: number;
 				/**
-				 * Whether to support FedCM (Federated Credential Management) support.
+				 * Whether to opt into FedCM for the One Tap prompt
+				 * (`use_fedcm_for_prompt`) and clear FedCM credential state on
+				 * sign-out via `navigator.credentials.preventSilentAccess()`.
+				 *
+				 * When enabled, display-moment APIs and `getSkippedReason` are
+				 * not called (Google FedCM migration guide).
 				 *
 				 * @see {@link https://developer.chrome.com/docs/identity/fedcm/overview}
+				 * @see {@link https://developers.google.com/identity/gsi/web/guides/fedcm-migration}
 				 * @default true
 				 */
 				fedCM?: boolean | undefined;
@@ -190,6 +196,72 @@ const noRetryReasons = {
 	dismissed: ["credential_returned", "cancel_called"],
 	skipped: ["user_cancel", "tap_outside"],
 } as const;
+
+/**
+ * Minimal prompt-moment surface used by {@link decidePromptNotification}.
+ * Kept narrow so FedCM paths never need to touch display-moment APIs.
+ */
+export interface OneTapPromptNotification {
+	isDismissedMoment?: (() => boolean) | undefined;
+	getDismissedReason?: (() => string) | undefined;
+	isSkippedMoment?: (() => boolean) | undefined;
+	getSkippedReason?: (() => string) | undefined;
+	isNotDisplayed?: (() => boolean) | undefined;
+}
+
+export type PromptNotificationDecision = "retry" | "stop" | null;
+
+/**
+ * Decide whether to retry or stop after a Google One Tap prompt notification.
+ *
+ * Under FedCM, Google's migration guide requires not calling display-moment
+ * APIs (`isNotDisplayed`, etc.) or `getSkippedReason`. Those are only used
+ * when FedCM is disabled.
+ *
+ * @see https://developers.google.com/identity/gsi/web/guides/fedcm-migration
+ * @see https://github.com/better-auth/better-auth/issues/10380
+ */
+export function decidePromptNotification(args: {
+	useFedCM: boolean;
+	attempt: number;
+	maxAttempts: number;
+	notification: OneTapPromptNotification;
+}): PromptNotificationDecision {
+	const { useFedCM, attempt, maxAttempts, notification } = args;
+
+	if (notification.isDismissedMoment?.()) {
+		const reason = notification.getDismissedReason?.();
+		if (
+			reason &&
+			(noRetryReasons.dismissed as readonly string[]).includes(reason)
+		) {
+			return "stop";
+		}
+		return attempt < maxAttempts ? "retry" : "stop";
+	}
+
+	if (notification.isSkippedMoment?.()) {
+		// Under FedCM, getSkippedReason() is deprecated — treat skip as terminal.
+		if (useFedCM) {
+			return "stop";
+		}
+		const reason = notification.getSkippedReason?.();
+		if (
+			!reason ||
+			(noRetryReasons.skipped as readonly string[]).includes(reason)
+		) {
+			return "stop";
+		}
+		return attempt < maxAttempts ? "retry" : "stop";
+	}
+
+	// Display-moment APIs are unsupported under FedCM — never call them there.
+	if (!useFedCM && notification.isNotDisplayed?.()) {
+		return "stop";
+	}
+
+	return null;
+}
 
 export const oneTapClient = (options: GoogleOneTapOptions) => {
 	return {
@@ -366,46 +438,29 @@ export const oneTapClient = (options: GoogleOneTapOptions) => {
 							const handlePrompt = (attempt: number) => {
 								if (isResolved) return;
 
-								window.google?.accounts.id.prompt((notification: any) => {
-									if (isResolved) return;
+								window.google?.accounts.id.prompt(
+									(notification: OneTapPromptNotification) => {
+										if (isResolved) return;
 
-									if (notification.isDismissedMoment?.()) {
-										const reason = notification.getDismissedReason?.();
-										if (noRetryReasons.dismissed.includes(reason)) {
-											opts?.onPromptNotification?.(notification);
-											resolve();
-											return;
-										}
-										if (attempt < maxAttempts) {
+										const decision = decidePromptNotification({
+											useFedCM,
+											attempt,
+											maxAttempts,
+											notification,
+										});
+
+										if (decision === "retry") {
 											const delay = Math.pow(2, attempt) * baseDelay;
 											setTimeout(() => handlePrompt(attempt + 1), delay);
-										} else {
-											opts?.onPromptNotification?.(notification);
-											resolve();
-										}
-									} else if (notification.isSkippedMoment?.()) {
-										// Under FedCM, getSkippedReason() is not available.
-										// Treat missing reason the same as a no-retry reason.
-										const reason = notification.getSkippedReason?.();
-										if (!reason || noRetryReasons.skipped.includes(reason)) {
-											opts?.onPromptNotification?.(notification);
-											resolve();
 											return;
 										}
-										if (attempt < maxAttempts) {
-											const delay = Math.pow(2, attempt) * baseDelay;
-											setTimeout(() => handlePrompt(attempt + 1), delay);
-										} else {
+
+										if (decision === "stop") {
 											opts?.onPromptNotification?.(notification);
 											resolve();
 										}
-									} else if (notification.isNotDisplayed?.()) {
-										// Under FedCM, isNotDisplayed() is deprecated.
-										// Still handle it for non-FedCM fallback.
-										opts?.onPromptNotification?.(notification);
-										resolve();
-									}
-								});
+									},
+								);
 							};
 
 							handlePrompt(0);

--- a/packages/better-auth/src/plugins/one-tap/client.ts
+++ b/packages/better-auth/src/plugins/one-tap/client.ts
@@ -362,8 +362,9 @@ export const oneTapClient = (options: GoogleOneTapOptions) => {
 							ux_mode: opts?.uxMode || "popup",
 							nonce: opts?.nonce,
 							itp_support: true,
-							use_fedcm_for_prompt: useFedCM,
 							...options.additionalOptions,
+							// Keep after additionalOptions so promptOptions.fedCM wins.
+							use_fedcm_for_prompt: useFedCM,
 						});
 
 						window.google?.accounts.id.renderButton(
@@ -431,8 +432,9 @@ export const oneTapClient = (options: GoogleOneTapOptions) => {
 								 * @see {@link https://developers.google.com/identity/gsi/web/guides/overview}
 								 */
 								itp_support: true,
-								use_fedcm_for_prompt: useFedCM,
 								...options.additionalOptions,
+								// Keep after additionalOptions so promptOptions.fedCM wins.
+								use_fedcm_for_prompt: useFedCM,
 							});
 
 							const handlePrompt = (attempt: number) => {

--- a/packages/better-auth/src/plugins/one-tap/prompt-notification.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/prompt-notification.test.ts
@@ -72,6 +72,54 @@ describe("decidePromptNotification", () => {
 		).toBe("retry");
 	});
 
+	it("without FedCM stops on terminal skip reasons", () => {
+		const notification: OneTapPromptNotification = {
+			isSkippedMoment: () => true,
+			getSkippedReason: () => "user_cancel",
+		};
+
+		expect(
+			decidePromptNotification({
+				useFedCM: false,
+				attempt: 0,
+				maxAttempts: 5,
+				notification,
+			}),
+		).toBe("stop");
+	});
+
+	it("stops retryable dismissals when maxAttempts is exhausted", () => {
+		const notification: OneTapPromptNotification = {
+			isDismissedMoment: () => true,
+			getDismissedReason: () => "flow_restarted",
+		};
+
+		expect(
+			decidePromptNotification({
+				useFedCM: true,
+				attempt: 5,
+				maxAttempts: 5,
+				notification,
+			}),
+		).toBe("stop");
+	});
+
+	it("without FedCM stops retryable skips when maxAttempts is exhausted", () => {
+		const notification: OneTapPromptNotification = {
+			isSkippedMoment: () => true,
+			getSkippedReason: () => "auto_cancel",
+		};
+
+		expect(
+			decidePromptNotification({
+				useFedCM: false,
+				attempt: 5,
+				maxAttempts: 5,
+				notification,
+			}),
+		).toBe("stop");
+	});
+
 	it("under FedCM never calls isNotDisplayed", () => {
 		const isNotDisplayed = vi.fn(() => true);
 		const notification: OneTapPromptNotification = {

--- a/packages/better-auth/src/plugins/one-tap/prompt-notification.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/prompt-notification.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OneTapPromptNotification } from "./client";
+import { decidePromptNotification } from "./client";
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10380
+ */
+describe("decidePromptNotification", () => {
+	it("stops on dismissed credential_returned without retrying", () => {
+		const notification: OneTapPromptNotification = {
+			isDismissedMoment: () => true,
+			getDismissedReason: () => "credential_returned",
+		};
+
+		expect(
+			decidePromptNotification({
+				useFedCM: true,
+				attempt: 0,
+				maxAttempts: 5,
+				notification,
+			}),
+		).toBe("stop");
+	});
+
+	it("retries dismissals that are not terminal when attempts remain", () => {
+		const notification: OneTapPromptNotification = {
+			isDismissedMoment: () => true,
+			getDismissedReason: () => "flow_restarted",
+		};
+
+		expect(
+			decidePromptNotification({
+				useFedCM: true,
+				attempt: 0,
+				maxAttempts: 5,
+				notification,
+			}),
+		).toBe("retry");
+	});
+
+	it("under FedCM stops on skip without calling getSkippedReason", () => {
+		const getSkippedReason = vi.fn(() => "auto_cancel");
+		const notification: OneTapPromptNotification = {
+			isSkippedMoment: () => true,
+			getSkippedReason,
+		};
+
+		expect(
+			decidePromptNotification({
+				useFedCM: true,
+				attempt: 0,
+				maxAttempts: 5,
+				notification,
+			}),
+		).toBe("stop");
+		expect(getSkippedReason).not.toHaveBeenCalled();
+	});
+
+	it("without FedCM can retry skip reasons that are not terminal", () => {
+		const notification: OneTapPromptNotification = {
+			isSkippedMoment: () => true,
+			getSkippedReason: () => "auto_cancel",
+		};
+
+		expect(
+			decidePromptNotification({
+				useFedCM: false,
+				attempt: 0,
+				maxAttempts: 5,
+				notification,
+			}),
+		).toBe("retry");
+	});
+
+	it("under FedCM never calls isNotDisplayed", () => {
+		const isNotDisplayed = vi.fn(() => true);
+		const notification: OneTapPromptNotification = {
+			isNotDisplayed,
+		};
+
+		expect(
+			decidePromptNotification({
+				useFedCM: true,
+				attempt: 0,
+				maxAttempts: 5,
+				notification,
+			}),
+		).toBeNull();
+		expect(isNotDisplayed).not.toHaveBeenCalled();
+	});
+
+	it("without FedCM stops when the prompt is not displayed", () => {
+		const notification: OneTapPromptNotification = {
+			isNotDisplayed: () => true,
+		};
+
+		expect(
+			decidePromptNotification({
+				useFedCM: false,
+				attempt: 0,
+				maxAttempts: 5,
+				notification,
+			}),
+		).toBe("stop");
+	});
+});


### PR DESCRIPTION

Closes #10380
- Under FedCM, stop calling Google-deprecated prompt moment APIs (`isNotDisplayed`, `getSkippedReason`) per the [FedCM migration guide](https://developers.google.com/identity/gsi/web/guides/fedcm-migration).
- Extract `decidePromptNotification` with unit tests covering FedCM vs non-FedCM paths.
- Clarify One Tap docs: FedCM remains opt-out via `promptOptions.fedCM: false`, and Google's GSI may still log a false-positive warning whenever any `prompt()` moment listener is registered.
