### PR TITLE
feat(organization): add getOrganization for metadata-only fetches

### DIFF
--- a/.changeset/organization-get-organization.md
+++ b/.changeset/organization-get-organization.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Add `organization.getOrganization()` to fetch organization metadata without members or invitations.

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -731,6 +731,28 @@ To retrieve the active organization for the user, you can call the `useActiveOrg
   </Tab>
 </Tabs>
 
+### Get Organization
+
+To get organization metadata without members or invitations, use `getOrganization`.
+By default, if you don't pass any properties, it will use the active organization.
+
+Prefer this over `getFullOrganization` when you only need fields like `id`, `name`, `slug`, `logo`, and `metadata`.
+
+<APIMethod path="/organization/get-organization" method="GET" requireSession>
+  ```ts
+  type getOrganization = {
+      /**
+       * The organization ID to get. By default, it will use the active organization.  
+       */
+      organizationId?: string = "org-id"
+      /**
+       * The organization slug to get.  
+       */
+      organizationSlug?: string = "org-slug"
+  }
+  ```
+</APIMethod>
+
 ### Get Full Organization
 
 To get the full details of an organization, you can use the `getFullOrganization` function.

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -43,6 +43,7 @@ import {
 	createOrganization,
 	deleteOrganization,
 	getFullOrganization,
+	getOrganization,
 	listOrganizations,
 	setActiveOrganization,
 	updateOrganization,
@@ -142,6 +143,7 @@ export type OrganizationEndpoints<O extends OrganizationOptions> = {
 	updateOrganization: ReturnType<typeof updateOrganization<O>>;
 	deleteOrganization: ReturnType<typeof deleteOrganization<O>>;
 	setActiveOrganization: ReturnType<typeof setActiveOrganization<O>>;
+	getOrganization: ReturnType<typeof getOrganization<O>>;
 	getFullOrganization: ReturnType<typeof getFullOrganization<O>>;
 	listOrganizations: ReturnType<typeof listOrganizations<O>>;
 	createInvitation: ReturnType<typeof createInvitation<O>>;
@@ -508,6 +510,22 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 		 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/organization#api-method-organization-set-active)
 		 */
 		setActiveOrganization: setActiveOrganization(opts),
+		/**
+		 * ### Endpoint
+		 *
+		 * GET `/organization/get-organization`
+		 *
+		 * ### API Methods
+		 *
+		 * **server:**
+		 * `auth.api.getOrganization`
+		 *
+		 * **client:**
+		 * `authClient.organization.getOrganization`
+		 *
+		 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/organization#api-method-organization-get-organization)
+		 */
+		getOrganization: getOrganization(opts),
 		/**
 		 * ### Endpoint
 		 *

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
@@ -253,6 +253,197 @@ describe("get-full-organization", async () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10243
+ */
+describe("get-organization", async () => {
+	const { auth, signInWithTestUser, cookieSetter } = await getTestInstance({
+		plugins: [organization()],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [organizationClient()],
+		baseURL: "http://localhost:3000/api/auth",
+		fetchOptions: {
+			customFetchImpl: async (url, init) => {
+				return auth.handler(new Request(url, init));
+			},
+		},
+	});
+	const org = await client.organization.create({
+		name: "meta-org",
+		slug: "meta-org",
+		metadata: {
+			plan: "pro",
+		},
+		fetchOptions: {
+			headers,
+		},
+	});
+	const secondOrg = await client.organization.create({
+		name: "meta-org-second",
+		slug: "meta-org-second",
+		metadata: {
+			plan: "free",
+		},
+		fetchOptions: {
+			headers,
+		},
+	});
+
+	it("should get organization metadata by organizationId", async () => {
+		const { headers } = await signInWithTestUser();
+		await client.organization.setActive({
+			organizationId: secondOrg.data?.id as string,
+			fetchOptions: {
+				headers,
+			},
+		});
+		const result = await client.organization.getOrganization({
+			query: {
+				organizationId: org.data?.id as string,
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(result.data?.id).toBe(org.data?.id);
+		expect(result.data?.name).toBe("meta-org");
+		expect(result.data?.slug).toBe("meta-org");
+		expect(result.data).not.toHaveProperty("members");
+		expect(result.data).not.toHaveProperty("invitations");
+		expect(result.data).not.toHaveProperty("teams");
+	});
+
+	it("should get organization metadata by organizationSlug", async () => {
+		const { headers } = await signInWithTestUser();
+		const result = await client.organization.getOrganization({
+			query: {
+				organizationSlug: "meta-org",
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(result.data?.name).toBe("meta-org");
+		expect(result.data?.slug).toBe("meta-org");
+		expect(result.data).not.toHaveProperty("members");
+		expect(result.data).not.toHaveProperty("invitations");
+	});
+
+	it("should fall back to the active organization", async () => {
+		const { headers } = await signInWithTestUser();
+		await client.organization.setActive({
+			organizationId: secondOrg.data?.id as string,
+			fetchOptions: {
+				headers,
+			},
+		});
+		const result = await client.organization.getOrganization({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(result.data?.id).toBe(secondOrg.data?.id);
+		expect(result.data?.name).toBe("meta-org-second");
+		expect(result.data).not.toHaveProperty("members");
+	});
+
+	it("should return null when no active organization and no query params", async () => {
+		await client.organization.setActive({
+			organizationId: null,
+			fetchOptions: {
+				headers,
+			},
+		});
+		const result = await client.organization.getOrganization({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(result.data).toBeNull();
+		expect(result.error).toBeNull();
+	});
+
+	it("should throw FORBIDDEN when user is not a member of the organization", async () => {
+		const newHeaders = new Headers();
+		await client.signUp.email(
+			{
+				email: "get-org-outsider@test.com",
+				password: "password",
+				name: "outsider",
+			},
+			{
+				onSuccess: cookieSetter(newHeaders),
+			},
+		);
+		const result = await client.organization.getOrganization({
+			query: {
+				organizationId: org.data?.id as string,
+			},
+			fetchOptions: {
+				headers: newHeaders,
+			},
+		});
+		expect(result.error?.status).toBe(403);
+		expect(result.error?.code).toContain(
+			ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION.code,
+		);
+	});
+
+	it("should throw BAD_REQUEST when organization doesn't exist", async () => {
+		const result = await client.organization.getOrganization({
+			query: {
+				organizationId: "non-existent-org-id",
+			},
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(result.error?.status).toBe(400);
+		expect(result.error?.code).toContain(
+			ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND.code,
+		);
+	});
+
+	it("should not include members or invitations unlike getFullOrganization", async () => {
+		const { headers } = await signInWithTestUser();
+		await client.organization.setActive({
+			organizationId: org.data?.id as string,
+			fetchOptions: {
+				headers,
+			},
+		});
+		await client.organization.inviteMember({
+			email: "get-org-invited@test.com",
+			role: "member",
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		const metadataOnly = await client.organization.getOrganization({
+			fetchOptions: {
+				headers,
+			},
+		});
+		const fullOrg = await client.organization.getFullOrganization({
+			fetchOptions: {
+				headers,
+			},
+		});
+
+		expect(metadataOnly.data).not.toHaveProperty("members");
+		expect(metadataOnly.data).not.toHaveProperty("invitations");
+		expect(fullOrg.data?.members).toBeDefined();
+		expect(Array.isArray(fullOrg.data?.members)).toBe(true);
+		expect(fullOrg.data?.invitations).toBeDefined();
+		expect(Array.isArray(fullOrg.data?.invitations)).toBe(true);
+		expect(metadataOnly.data?.id).toBe(fullOrg.data?.id);
+		expect(metadataOnly.data?.name).toBe(fullOrg.data?.name);
+	});
+});
+
 describe("organization hooks", async () => {
 	it("should apply beforeCreateOrganization hook", async () => {
 		const beforeCreateOrganization = vi.fn();

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -622,6 +622,90 @@ export const deleteOrganization = <O extends OrganizationOptions>(
 	);
 };
 
+const getOrganizationQuerySchema = z.optional(
+	z.object({
+		organizationId: z
+			.string()
+			.meta({
+				description: "The organization id to get",
+			})
+			.optional(),
+		organizationSlug: z
+			.string()
+			.meta({
+				description: "The organization slug to get",
+			})
+			.optional(),
+	}),
+);
+
+export const getOrganization = <O extends OrganizationOptions>(options: O) =>
+	createAuthEndpoint(
+		"/organization/get-organization",
+		{
+			method: "GET",
+			query: getOrganizationQuerySchema,
+			requireHeaders: true,
+			use: [orgMiddleware, orgSessionMiddleware],
+			metadata: {
+				openapi: {
+					operationId: "getOrganization",
+					description: "Get the organization metadata",
+					responses: {
+						"200": {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										description: "The organization",
+										$ref: "#/components/schemas/Organization",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const session = ctx.context.session;
+			const organizationId =
+				ctx.query?.organizationSlug ||
+				ctx.query?.organizationId ||
+				session.session.activeOrganizationId;
+			// return null if no organization is found to avoid erroring since this is a usual scenario
+			if (!organizationId) {
+				return ctx.json(null, {
+					status: 200,
+				});
+			}
+			const adapter = getOrgAdapter<O>(ctx.context, options);
+			const organization = ctx.query?.organizationSlug
+				? await adapter.findOrganizationBySlug(organizationId)
+				: await adapter.findOrganizationById(organizationId);
+			if (!organization) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND,
+				);
+			}
+			const isMember = await adapter.checkMembership({
+				userId: session.user.id,
+				organizationId: organization.id,
+			});
+			if (!isMember) {
+				await adapter.setActiveOrganization(session.session.token, null, ctx);
+				throw APIError.from(
+					"FORBIDDEN",
+					ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
+				);
+			}
+
+			return ctx.json(organization as InferOrganization<O>);
+		},
+	);
+
 const getFullOrganizationQuerySchema = z.optional(
 	z.object({
 		organizationId: z
@@ -659,7 +743,7 @@ export const getFullOrganization = <O extends OrganizationOptions>(
 			use: [orgMiddleware, orgSessionMiddleware],
 			metadata: {
 				openapi: {
-					operationId: "getOrganization",
+					operationId: "getFullOrganization",
 					description: "Get the full organization",
 					responses: {
 						"200": {


### PR DESCRIPTION

Closes #10243


- Add `GET /organization/get-organization` (`auth.api.getOrganization` / `authClient.organization.getOrganization`) that returns organization metadata without members, invitations, or teams
- Keep the same lookup semantics as `getFullOrganization` (`organizationId`, `organizationSlug`, active-org fallback) and membership checks
- Document the new API and fix the OpenAPI `operationId` collision on `getFullOrganization`
