### PR TITLE
fix(scim): paginate list users and report accurate totalResults

### DIFF
--- a/.changeset/fix-scim-list-users-pagination.md
+++ b/.changeset/fix-scim-list-users-pagination.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix SCIM `GET /scim/v2/Users` silently truncating at 100 results and reporting the wrong `totalResults`. Accept RFC 7644 `startIndex` and `count` query parameters for pagination.

--- a/docs/content/docs/plugins/scim.mdx
+++ b/docs/content/docs/plugins/scim.mdx
@@ -294,13 +294,21 @@ The following subset of the specification is currently supported:
 
 Get a list of available users in the database. This is restricted to list only users associated to the same provider and organization than your SCIM token.
 
-<APIMethod path="/scim/v2/Users" method="GET" requireBearerToken isExternalOnly note="Returns the provisioned SCIM user details. See https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.1">
+<APIMethod path="/scim/v2/Users" method="GET" requireBearerToken isExternalOnly note="Returns the provisioned SCIM user details. See https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2">
   ```ts
   type listSCIMUsers = {
       /**
        * SCIM compliant filter expression
-      */
+       */
       filter?: string = 'userName eq "user-a"'
+      /**
+       * 1-based index of the first result. Defaults to 1.
+       */
+      startIndex?: number = 1
+      /**
+       * Maximum number of results to return. When omitted, all matching results are returned. When 0, returns no resources but still reports totalResults.
+       */
+      count?: number = 100
   }
   ```
 </APIMethod>

--- a/docs/content/docs/plugins/scim.mdx
+++ b/docs/content/docs/plugins/scim.mdx
@@ -308,7 +308,7 @@ Get a list of available users in the database. This is restricted to list only u
       /**
        * Maximum number of results to return. When omitted, all matching results are returned. When 0, returns no resources but still reports totalResults.
        */
-      count?: number = 100
+      count?: number
   }
   ```
 </APIMethod>

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -992,6 +992,14 @@ export const updateSCIMUser = (authMiddleware: AuthMiddleware) =>
 const listSCIMUsersQuerySchema = z
 	.object({
 		filter: z.string().optional(),
+		startIndex: z.coerce.number().int().min(1).optional().meta({
+			description:
+				"1-based index of the first result (RFC 7644 §3.4.2.4). Defaults to 1.",
+		}),
+		count: z.coerce.number().int().min(0).optional().meta({
+			description:
+				"Maximum number of results to return (RFC 7644 §3.4.2.4). When omitted, all matching results are returned. When 0, returns no resources but still reports totalResults.",
+		}),
 	})
 	.optional();
 
@@ -1007,7 +1015,7 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 				openapi: {
 					summary: "List SCIM users",
 					description:
-						"Returns all users provisioned via SCIM for the linked organization. See https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2",
+						"Returns users provisioned via SCIM for the linked organization, with RFC 7644 pagination via startIndex and count. See https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2",
 					responses: {
 						"200": {
 							description: "SCIM user list",
@@ -1035,10 +1043,13 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 			use: [authMiddleware],
 		},
 		async (ctx) => {
+			const startIndex = ctx.query?.startIndex ?? 1;
+			const count = ctx.query?.count;
+
 			const emptyListResponse = {
 				schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
 				totalResults: 0,
-				startIndex: 1,
+				startIndex,
 				itemsPerPage: 0,
 				Resources: [],
 			} as const;
@@ -1046,18 +1057,25 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 			const apiFilters: DBFilter[] = parseSCIMAPIUserFilter(ctx.query?.filter);
 
 			const providerId = ctx.context.scimProvider.providerId;
+			const accountWhere = [{ field: "providerId", value: providerId }];
+			// Count first, then fetch with an explicit limit so the adapter
+			// factory default (100) does not silently truncate the ID set.
+			const accountCount = await ctx.context.adapter.count({
+				model: "account",
+				where: accountWhere,
+			});
+
+			if (accountCount === 0) {
+				return ctx.json(emptyListResponse);
+			}
+
 			const accounts = await ctx.context.adapter.findMany<Account>({
 				model: "account",
-				where: [{ field: "providerId", value: providerId }],
+				where: accountWhere,
+				limit: accountCount,
 			});
 
 			const accountUserIds = accounts.map((account) => account.userId);
-
-			// No accounts exist for this provider
-
-			if (accountUserIds.length === 0) {
-				return ctx.json(emptyListResponse);
-			}
 
 			let userFilters: DBFilter[] = [
 				{ field: "id", value: accountUserIds, operator: "in" },
@@ -1065,34 +1083,65 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 
 			const organizationId = ctx.context.scimProvider.organizationId;
 			if (organizationId) {
-				const members = await ctx.context.adapter.findMany<Member>({
+				const memberWhere: DBFilter[] = [
+					{ field: "organizationId", value: organizationId },
+					{ field: "userId", value: accountUserIds, operator: "in" },
+				];
+				const memberCount = await ctx.context.adapter.count({
 					model: "member",
-					where: [
-						{ field: "organizationId", value: organizationId },
-						{ field: "userId", value: accountUserIds, operator: "in" },
-					],
+					where: memberWhere,
 				});
 
-				const memberUserIds = members.map((member) => member.userId);
-
-				// No members exist for this organization
-
-				if (memberUserIds.length === 0) {
+				if (memberCount === 0) {
 					return ctx.json(emptyListResponse);
 				}
 
+				const members = await ctx.context.adapter.findMany<Member>({
+					model: "member",
+					where: memberWhere,
+					limit: memberCount,
+				});
+
+				const memberUserIds = members.map((member) => member.userId);
 				userFilters = [{ field: "id", value: memberUserIds, operator: "in" }];
+			}
+
+			const where = [...userFilters, ...apiFilters];
+			const totalResults = await ctx.context.adapter.count({
+				model: "user",
+				where,
+			});
+
+			if (totalResults === 0) {
+				return ctx.json(emptyListResponse);
+			}
+
+			// When count is omitted, return the full matching set. When count is
+			// 0, return no resources but still report totalResults (RFC 7644).
+			const pageSize = count ?? totalResults;
+			const offset = startIndex - 1;
+
+			if (pageSize === 0 || offset >= totalResults) {
+				return ctx.json({
+					schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+					totalResults,
+					startIndex,
+					itemsPerPage: 0,
+					Resources: [],
+				});
 			}
 
 			const users = await ctx.context.adapter.findMany<User>({
 				model: "user",
-				where: [...userFilters, ...apiFilters],
+				where,
+				limit: pageSize,
+				offset,
 			});
 
 			return ctx.json({
 				schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-				totalResults: users.length,
-				startIndex: 1,
+				totalResults,
+				startIndex,
 				itemsPerPage: users.length,
 				Resources: users.map((user) => {
 					const account = accounts.find((a) => a.userId === user.id);

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -1136,6 +1136,8 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 				where,
 				limit: pageSize,
 				offset,
+				// Stable order is required for RFC 7644 startIndex/count pagination.
+				sortBy: { field: "id", direction: "asc" },
 			});
 
 			return ctx.json({

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -1140,13 +1140,17 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 				sortBy: { field: "id", direction: "asc" },
 			});
 
+			const accountsByUserId = new Map(
+				accounts.map((account) => [account.userId, account]),
+			);
+
 			return ctx.json({
 				schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
 				totalResults,
 				startIndex,
 				itemsPerPage: users.length,
 				Resources: users.map((user) => {
-					const account = accounts.find((a) => a.userId === user.id);
+					const account = accountsByUserId.get(user.id);
 					return createUserResource(ctx.context.baseURL, user, account);
 				}),
 			});

--- a/packages/scim/src/scim-users.test.ts
+++ b/packages/scim/src/scim-users.test.ts
@@ -369,6 +369,127 @@ describe("SCIM", () => {
 				}),
 			);
 		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10398
+		 */
+		it("should report the real totalResults when more than 100 users are provisioned", async () => {
+			const { auth, getSCIMToken } = createTestInstance();
+			const scimToken = await getSCIMToken();
+			const totalUsers = 101;
+
+			await Promise.all(
+				Array.from({ length: totalUsers }, (_, index) =>
+					auth.api.createSCIMUser({
+						body: {
+							userName: `user-${index}`,
+						},
+						headers: {
+							authorization: `Bearer ${scimToken}`,
+						},
+					}),
+				),
+			);
+
+			const users = await auth.api.listSCIMUsers({
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+
+			expect(users.totalResults).toBe(totalUsers);
+			expect(users.Resources.length).toBe(totalUsers);
+			expect(users.itemsPerPage).toBe(totalUsers);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10398
+		 */
+		it("should accept startIndex and count query parameters for pagination", async () => {
+			const { auth, getSCIMToken } = createTestInstance();
+			const scimToken = await getSCIMToken();
+			const totalUsers = 15;
+
+			await Promise.all(
+				Array.from({ length: totalUsers }, (_, index) =>
+					auth.api.createSCIMUser({
+						body: {
+							userName: `page-user-${index}`,
+						},
+						headers: {
+							authorization: `Bearer ${scimToken}`,
+						},
+					}),
+				),
+			);
+
+			const page = await auth.api.listSCIMUsers({
+				query: {
+					startIndex: 6,
+					count: 5,
+				},
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+
+			expect(page.totalResults).toBe(totalUsers);
+			expect(page.startIndex).toBe(6);
+			expect(page.itemsPerPage).toBe(5);
+			expect(page.Resources).toHaveLength(5);
+
+			const emptyPage = await auth.api.listSCIMUsers({
+				query: {
+					startIndex: 1,
+					count: 0,
+				},
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+
+			expect(emptyPage.totalResults).toBe(totalUsers);
+			expect(emptyPage.startIndex).toBe(1);
+			expect(emptyPage.itemsPerPage).toBe(0);
+			expect(emptyPage.Resources).toHaveLength(0);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10398
+		 */
+		it("should paginate beyond the adapter default findMany limit of 100", async () => {
+			const { auth, getSCIMToken } = createTestInstance();
+			const scimToken = await getSCIMToken();
+			const totalUsers = 105;
+
+			await Promise.all(
+				Array.from({ length: totalUsers }, (_, index) =>
+					auth.api.createSCIMUser({
+						body: {
+							userName: `overflow-user-${index}`,
+						},
+						headers: {
+							authorization: `Bearer ${scimToken}`,
+						},
+					}),
+				),
+			);
+
+			const page = await auth.api.listSCIMUsers({
+				query: {
+					startIndex: 101,
+					count: 10,
+				},
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+
+			expect(page.totalResults).toBe(totalUsers);
+			expect(page.startIndex).toBe(101);
+			expect(page.itemsPerPage).toBe(5);
+			expect(page.Resources).toHaveLength(5);
+		});
 	});
 
 	describe("GET /scim/v2/Users/:userId", () => {

--- a/packages/scim/src/scim-users.test.ts
+++ b/packages/scim/src/scim-users.test.ts
@@ -140,8 +140,9 @@ describe("SCIM", () => {
 				schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
 				startIndex: 1,
 				totalResults: 2,
-				Resources: [userA, userB],
 			});
+			expect(users.Resources).toEqual(expect.arrayContaining([userA, userB]));
+			expect(users.Resources).toHaveLength(2);
 		});
 
 		it("should return an empty list when no users have been provisioned or belong to the organization", async () => {
@@ -249,8 +250,11 @@ describe("SCIM", () => {
 				schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
 				startIndex: 1,
 				totalResults: 2,
-				Resources: [userA, userC],
 			});
+			expect(usersProviderB.Resources).toEqual(
+				expect.arrayContaining([userA, userC]),
+			);
+			expect(usersProviderB.Resources).toHaveLength(2);
 		});
 
 		it("should only allow access to users that belong to the same provider and organization", async () => {
@@ -308,8 +312,11 @@ describe("SCIM", () => {
 				schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
 				startIndex: 1,
 				totalResults: 2,
-				Resources: [userA, userC],
 			});
+			expect(usersProviderB.Resources).toEqual(
+				expect.arrayContaining([userA, userC]),
+			);
+			expect(usersProviderB.Resources).toHaveLength(2);
 		});
 
 		it("should filter the list of users", async () => {
@@ -437,6 +444,21 @@ describe("SCIM", () => {
 			expect(page.startIndex).toBe(6);
 			expect(page.itemsPerPage).toBe(5);
 			expect(page.Resources).toHaveLength(5);
+
+			const allUsers = await auth.api.listSCIMUsers({
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+			const expectedPage = allUsers.Resources.slice(5, 10);
+			expect(page.Resources.map((user) => user.id)).toEqual(
+				expectedPage.map((user) => user.id),
+			);
+			expect(allUsers.Resources.map((user) => user.id)).toEqual(
+				[...allUsers.Resources]
+					.map((user) => user.id)
+					.sort((a, b) => a.localeCompare(b)),
+			);
 
 			const emptyPage = await auth.api.listSCIMUsers({
 				query: {


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/10398
- Fix `GET /scim/v2/Users` silently truncating results at the adapter `findMany` default of 100 and reporting that truncated length as `totalResults`.
- Accept RFC 7644 `startIndex` and `count` query parameters so clients can paginate the full matching set.
- Count matching rows first and pass explicit limits for account/member/user lookups so discovery queries are not capped at 100.
