### PR TITLE
feat(oauth-provider): remove silenceWarnings config and well-known endpoint warnings

### DIFF
--- a/demo/nextjs/lib/auth.ts
+++ b/demo/nextjs/lib/auth.ts
@@ -430,10 +430,6 @@ const authOptions = {
 					}
 				},
 			},
-			silenceWarnings: {
-				openidConfig: true,
-				oauthAuthServerConfig: true,
-			},
 		}),
 		electron(),
 	],

--- a/e2e/integration/vanilla-node/e2e/app.ts
+++ b/e2e/integration/vanilla-node/e2e/app.ts
@@ -51,10 +51,6 @@ export async function createAuthServer(
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 					jwt(),
 				]

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -210,10 +210,6 @@ describe("oauth authorize - unauthenticated", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],
@@ -394,10 +390,6 @@ describe("oauth authorize - request_uri resolution", async () => {
 
 					return null;
 				},
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],
@@ -514,10 +506,6 @@ describe("oauth authorize - authenticated", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],

--- a/packages/oauth-provider/src/client-resource.ts
+++ b/packages/oauth-provider/src/client-resource.ts
@@ -1,4 +1,3 @@
-import { logger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
 import { verifyAccessToken } from "better-auth/oauth2";
 import type {
@@ -153,9 +152,6 @@ export const oauthProviderResourceClient = <
 					overrides: Partial<ResourceServerMetadata> | undefined,
 					opts:
 						| {
-								silenceWarnings?: {
-									oidcScopes?: boolean;
-								};
 								externalScopes?: string[];
 						  }
 						| undefined,
@@ -186,13 +182,6 @@ export const oauthProviderResourceClient = <
 								throw new BetterAuthError(
 									"Only the Auth Server should utilize the openid scope",
 								);
-							}
-							if (["profile", "email", "phone", "address"].includes(sc)) {
-								if (!opts?.silenceWarnings?.oidcScopes) {
-									logger.warn(
-										`"${sc}" is typically restricted for the authorization server, a resource server typically shouldn't handle this scope`,
-									);
-								}
 							}
 							if (!allValidScopes.has(sc)) {
 								throw new BetterAuthError(
@@ -288,18 +277,12 @@ type ProtectedResourceMetadataOutput<T> = T extends undefined
 	? (
 			overrides: ResourceServerMetadata,
 			opts?: {
-				silenceWarnings?: {
-					oidcScopes?: boolean;
-				};
 				externalScopes?: string[];
 			},
 		) => Promise<ResourceServerMetadata>
 	: (
 			overrides?: Partial<ResourceServerMetadata>,
 			opts?: {
-				silenceWarnings?: {
-					oidcScopes?: boolean;
-				};
 				externalScopes?: string[];
 			},
 		) => Promise<ResourceServerMetadata>;

--- a/packages/oauth-provider/src/introspect.test.ts
+++ b/packages/oauth-provider/src/introspect.test.ts
@@ -30,10 +30,6 @@ describe("oauth introspect", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				validAudiences: [validAudience],
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});
@@ -557,10 +553,6 @@ describe("oauth introspect - config", async () => {
 						consentPage: "/consent",
 						validAudiences: [validAudience],
 						scopes,
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 						...opts?.oauthProviderConfig,
 					}),
 					...(opts?.oauthProviderConfig?.disableJwtPlugin
@@ -781,10 +773,6 @@ describe("oauth introspect - rejects non-OAuth same-issuer JWTs", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				validAudiences: [authServerBaseUrl],
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});

--- a/packages/oauth-provider/src/logout.test.ts
+++ b/packages/oauth-provider/src/logout.test.ts
@@ -31,10 +31,6 @@ describe("oauth logout", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				allowDynamicClientRegistration: true,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 				scopes,
 			}),
 			jwt(),
@@ -394,10 +390,6 @@ describe("oauth logout - disableJwtPlugin", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				allowDynamicClientRegistration: true,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 				scopes,
 			}),
 			jwt(),

--- a/packages/oauth-provider/src/mcp.test.ts
+++ b/packages/oauth-provider/src/mcp.test.ts
@@ -113,10 +113,6 @@ describe("mcp - server-client flows", async () => {
 					allowDynamicClientRegistration: true,
 					allowUnauthenticatedClientRegistration: true,
 					scopes,
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});

--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -49,10 +49,6 @@ describe("oauth metadata", async () => {
 				oauthProvider({
 					loginPage: "/login",
 					consentPage: "/consent",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 					allowDynamicClientRegistration: true,
 					...opts?.oauthProviderConfig,
 				}),
@@ -339,10 +335,6 @@ describe("oauth metadata", async () => {
 						advertisedMetadata: {
 							scopes_supported: advertisedScopes,
 						},
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 					jwt(),
 				],
@@ -425,10 +417,6 @@ describe("dynamic baseURL metadata wrappers", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],
@@ -478,10 +466,6 @@ describe("oauth resource metadata", async () => {
 				consentPage: "/consent",
 				validAudiences: [validAudience],
 				scopes: supportedScopes,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -60,10 +60,6 @@ describe("oauth - init", () => {
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 				],
 			}),
@@ -80,10 +76,6 @@ describe("oauth - init", () => {
 						loginPage: "/login",
 						consentPage: "/consent",
 						disableJwtPlugin: true,
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 				],
 			}),
@@ -98,10 +90,6 @@ describe("oauth - init", () => {
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 				],
 			}),
@@ -117,10 +105,6 @@ describe("oauth - init", () => {
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 				],
 			}),
@@ -141,10 +125,6 @@ describe("oauth - init", () => {
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 				],
 			}),
@@ -165,10 +145,6 @@ describe("oauth - init", () => {
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 				],
 			}),
@@ -187,10 +163,6 @@ describe("oauth - init", () => {
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 				],
 			}),
@@ -209,10 +181,6 @@ describe("oauth - init", () => {
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 				],
 			}),
@@ -237,10 +205,6 @@ describe("oauth", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});
@@ -1045,10 +1009,6 @@ describe("oauth - prompt", async () => {
 					shouldRedirect() {
 						return isUserRegistered ? false : "/setup";
 					},
-				},
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
 				},
 				scopes,
 				selectAccount: {
@@ -2934,10 +2894,6 @@ describe("oauth - config", () => {
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 					}),
 				],
 			});
@@ -3021,10 +2977,6 @@ describe("oauth - config", () => {
 					loginPage: "/login",
 					consentPage: "/consent",
 					storeClientSecret,
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 				jwt(),
 			],
@@ -3129,10 +3081,6 @@ describe("oauth - config", () => {
 					consentPage: "/consent",
 					storeClientSecret,
 					disableJwtPlugin: true,
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});
@@ -3245,10 +3193,6 @@ describe("oauth - config", () => {
 					consentPage: "/consent",
 					disableJwtPlugin: disableJwtPlugin,
 					validAudiences: resource ? [validAudience] : undefined,
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 				...(disableJwtPlugin ? [] : [jwt()]),
 			],
@@ -3437,10 +3381,6 @@ describe("oauth - rate limiting", () => {
 				oauthProvider({
 					loginPage: "/login",
 					consentPage: "/consent",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});
@@ -3499,10 +3439,6 @@ describe("oauth - rate limiting", () => {
 				oauthProvider({
 					loginPage: "/login",
 					consentPage: "/consent",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 					rateLimit: {
 						token: { window: 1, max: 4 },
 						introspect: { window: 1, max: 50 },
@@ -3542,10 +3478,6 @@ describe("oauth - rate limiting", () => {
 				oauthProvider({
 					loginPage: "/login",
 					consentPage: "/consent",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 					rateLimit: {
 						token: false,
 						introspect: false,
@@ -3587,10 +3519,6 @@ describe("oauth - rate limiting", () => {
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 						rateLimit: {
 							token: { window: 60, max: 3 },
 						},
@@ -3652,10 +3580,6 @@ describe("oauth - rate limiting", () => {
 					oauthProvider({
 						loginPage: "/login",
 						consentPage: "/consent",
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 						rateLimit: {
 							token: false, // Disable rate limiting for token endpoint
 						},

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1,6 +1,5 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { defineRequestState } from "@better-auth/core/context";
-import { logger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
 import type { DispatchContext } from "better-auth/api";
 import {
@@ -437,43 +436,23 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 			// Check for jwt plugin registration
 			if (!opts.disableJwtPlugin) {
 				const jwtPlugin = getJwtPlugin(ctx);
-				const jwtPluginOptions = jwtPlugin?.options;
+				const jwtIssuer = jwtPlugin?.options?.jwt?.issuer;
 
-				// Issuer and well-known endpoint checks
-				const issuer = jwtPluginOptions?.jwt?.issuer ?? ctx.baseURL;
+				// Fail fast on an invalid configured issuer
+				const issuer = jwtIssuer ?? ctx.baseURL;
 				const isDynamicBaseURLInit =
-					jwtPluginOptions?.jwt?.issuer == null &&
+					jwtIssuer == null &&
 					typeof ctx.options.baseURL === "object" &&
 					ctx.options.baseURL !== null &&
 					"allowedHosts" in ctx.options.baseURL;
-				let issuerPath: string;
 				try {
-					issuerPath = new URL(issuer).pathname;
+					new URL(issuer);
 				} catch (error) {
 					// baseURL may not be available during init when using dynamic baseURL config
 					if (isDynamicBaseURLInit && issuer === "") {
 						return;
 					}
 					throw error;
-				}
-				// oAuth Server Config
-				if (
-					!opts.silenceWarnings?.oauthAuthServerConfig &&
-					!(ctx.options.basePath === "/" && issuerPath === "/")
-				) {
-					logger.warn(
-						`Please ensure '/.well-known/oauth-authorization-server${issuerPath === "/" ? "" : issuerPath}' exists. Upon completion, clear with silenceWarnings.oauthAuthServerConfig.`,
-					);
-				}
-				// OpenId Config
-				if (
-					!opts.silenceWarnings?.openidConfig &&
-					ctx.options.basePath !== issuerPath &&
-					opts.scopes?.includes("openid")
-				) {
-					logger.warn(
-						`Please ensure '${issuerPath}${issuerPath.endsWith("/") ? "" : "/"}.well-known/openid-configuration' exists. Upon completion, clear with silenceWarnings.openidConfig.`,
-					);
 				}
 			}
 		},

--- a/packages/oauth-provider/src/oauthClient/endpoints-privileges.test.ts
+++ b/packages/oauth-provider/src/oauthClient/endpoints-privileges.test.ts
@@ -34,10 +34,6 @@ describe("oauthClient", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 				clientReference() {
 					return "oauth-client-test";
 				},
@@ -409,10 +405,6 @@ describe("oauthClient dynamic registration privileges", async () => {
 				allowDynamicClientRegistration: true,
 				allowUnauthenticatedClientRegistration: true,
 				clientPrivileges,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],

--- a/packages/oauth-provider/src/oauthClient/endpoints.test.ts
+++ b/packages/oauth-provider/src/oauthClient/endpoints.test.ts
@@ -18,10 +18,6 @@ describe("oauthClient", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 				allowPublicClientPrelogin: true,
 			}),
 			jwt(),

--- a/packages/oauth-provider/src/oauthConsent/endpoints.test.ts
+++ b/packages/oauth-provider/src/oauthConsent/endpoints.test.ts
@@ -22,10 +22,6 @@ describe("oauthConsent", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 			{

--- a/packages/oauth-provider/src/pairwise.test.ts
+++ b/packages/oauth-provider/src/pairwise.test.ts
@@ -33,10 +33,6 @@ describe("pairwise subject identifiers", async () => {
 				pairwiseSecret: "test-pairwise-secret-key-32chars!!",
 				validAudiences: [validAudience],
 				allowDynamicClientRegistration: true,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});
@@ -313,10 +309,6 @@ describe("pairwise DCR validation", async () => {
 				oauthProvider({
 					loginPage: "/login",
 					consentPage: "/consent",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});
@@ -342,10 +334,6 @@ describe("pairwise DCR validation", async () => {
 					loginPage: "/login",
 					consentPage: "/consent",
 					pairwiseSecret: "test-secret-for-dcr-test-32chars!",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});
@@ -373,10 +361,6 @@ describe("pairwise DCR validation", async () => {
 					loginPage: "/login",
 					consentPage: "/consent",
 					pairwiseSecret: "test-secret-for-dcr-test-32chars!",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});
@@ -403,10 +387,6 @@ describe("pairwise DCR validation", async () => {
 					loginPage: "/login",
 					consentPage: "/consent",
 					pairwiseSecret: "test-secret-for-dcr-test-32chars!",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});
@@ -435,10 +415,6 @@ describe("pairwise DCR validation", async () => {
 					loginPage: "/login",
 					consentPage: "/consent",
 					pairwiseSecret: "test-secret-for-dcr-test-32chars!",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});
@@ -470,10 +446,6 @@ describe("pairwise DCR validation", async () => {
 					consentPage: "/consent",
 					pairwiseSecret: "test-secret-for-dcr-test-32chars!",
 					allowDynamicClientRegistration: true,
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});
@@ -535,10 +507,6 @@ describe("pairwise metadata", async () => {
 					loginPage: "/login",
 					consentPage: "/consent",
 					pairwiseSecret: "test-pairwise-metadata-secret!!!",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});
@@ -555,10 +523,6 @@ describe("pairwise metadata", async () => {
 				oauthProvider({
 					loginPage: "/login",
 					consentPage: "/consent",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});

--- a/packages/oauth-provider/src/pkce-optional.test.ts
+++ b/packages/oauth-provider/src/pkce-optional.test.ts
@@ -33,10 +33,6 @@ describe("PKCE optional - default behavior", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],
@@ -160,10 +156,6 @@ describe("PKCE optional - per-client opt-out", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],
@@ -288,10 +280,6 @@ describe("PKCE optional - offline_access scope", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],
@@ -411,10 +399,6 @@ describe("PKCE optional - consistency checks", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],
@@ -618,10 +602,6 @@ describe("PKCE optional - registration restrictions", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				allowDynamicClientRegistration: true,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -24,10 +24,6 @@ describe("oauth register", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				allowDynamicClientRegistration: true,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 				scopes: [
 					"openid",
 					"profile",
@@ -279,10 +275,6 @@ describe("oauth register - unauthenticated", async () => {
 				consentPage: "/consent",
 				allowDynamicClientRegistration: true,
 				allowUnauthenticatedClientRegistration: true,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});
@@ -406,10 +398,6 @@ describe("oauth register - unauthenticated DCR full flow", async () => {
 				consentPage: "/consent",
 				allowDynamicClientRegistration: true,
 				allowUnauthenticatedClientRegistration: true,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});
@@ -531,10 +519,6 @@ describe("oauth register - organization", async () => {
 						(session?.activeOrganizationId as string | undefined) ?? undefined
 					);
 				},
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],
@@ -591,10 +575,6 @@ describe("oauth register - skip_consent blocked", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				allowDynamicClientRegistration: true,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 			jwt(),
 		],

--- a/packages/oauth-provider/src/revoke.test.ts
+++ b/packages/oauth-provider/src/revoke.test.ts
@@ -30,10 +30,6 @@ describe("oauth revoke", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				validAudiences: [validAudience],
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});
@@ -355,10 +351,6 @@ describe("oauth revoke - config", async () => {
 						consentPage: "/consent",
 						validAudiences: [validAudience],
 						scopes,
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 						...opts?.oauthProviderConfig,
 					}),
 					...(opts?.oauthProviderConfig?.disableJwtPlugin

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -37,10 +37,6 @@ describe("oauth token - authorization_code", async () => {
 					loginPage: "/login",
 					consentPage: "/consent",
 					validAudiences: [validAudience],
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 				}),
 			],
 		});
@@ -463,10 +459,6 @@ describe("oauth token - refresh_token", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				validAudiences: [validAudience],
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});
@@ -1307,10 +1299,6 @@ describe("oauth token - client_credentials", async () => {
 				validAudiences: [validAudience],
 				allowDynamicClientRegistration: true,
 				scopes: allScopes,
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});
@@ -1494,10 +1482,6 @@ describe("oauth token - customIdTokenClaims precedence", async () => {
 				oauthProvider({
 					loginPage: "/login",
 					consentPage: "/consent",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 					customIdTokenClaims: () => ({
 						given_name: "CustomFirst",
 						family_name: "CustomLast",
@@ -1654,10 +1638,6 @@ describe("oauth token - config", async () => {
 						consentPage: "/consent",
 						validAudiences: [validAudience],
 						scopes,
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 						...opts?.oauthProviderConfig,
 					}),
 					...(opts?.oauthProviderConfig?.disableJwtPlugin
@@ -2041,10 +2021,6 @@ describe("oauth token - client secret validation", async () => {
 						consentPage: "/consent",
 						validAudiences: [validAudience],
 						scopes,
-						silenceWarnings: {
-							oauthAuthServerConfig: true,
-							openidConfig: true,
-						},
 						...opts?.oauthProviderConfig,
 					}),
 					...(opts?.oauthProviderConfig?.disableJwtPlugin
@@ -2180,10 +2156,6 @@ describe("id token claim override security", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 				customIdTokenClaims: () => ({
 					acr: "silver",
 					auth_time: 0,
@@ -2326,10 +2298,6 @@ describe("loopback redirect URI matching", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});
@@ -2527,10 +2495,6 @@ describe("scope preservation through authorization code flow", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});
@@ -2613,10 +2577,6 @@ describe("customTokenResponseFields", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 				customTokenResponseFields: ({ grantType, verificationValue }) => {
 					if (
 						grantType === "authorization_code" &&
@@ -2729,10 +2689,6 @@ describe("customTokenResponseFields", async () => {
 				oauthProvider({
 					loginPage: "/login",
 					consentPage: "/consent",
-					silenceWarnings: {
-						oauthAuthServerConfig: true,
-						openidConfig: true,
-					},
 					customTokenResponseFields: () => ({
 						access_token: "should-be-ignored",
 						token_type: "should-be-ignored",
@@ -2937,10 +2893,6 @@ describe("oauth token - per-client grant_type enforcement", async () => {
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -623,27 +623,6 @@ export interface OAuthOptions<
 	 */
 	generateRefreshToken?: () => Awaitable<string>;
 	/**
-	 * Confirmations that individually silences specific well-known endpoint
-	 * configuration warnings.
-	 *
-	 * Only set these specific values if you see the error as they
-	 * are configuration specific.
-	 */
-	silenceWarnings?: {
-		/**
-		 * Config warning for `/.well-known/oauth-authorization-server/[issuer-path]`
-		 *
-		 * @default false
-		 */
-		oauthAuthServerConfig?: boolean;
-		/**
-		 * Config warning for `[issuer-path]/.well-known/openid-configuration`
-		 *
-		 * @default false
-		 */
-		openidConfig?: boolean;
-	};
-	/**
 	 * By default, access and id tokens can be issued and verified
 	 * through the JWT plugin.
 	 *

--- a/packages/oauth-provider/src/userinfo.test.ts
+++ b/packages/oauth-provider/src/userinfo.test.ts
@@ -30,10 +30,6 @@ describe("oauth userinfo", async () => {
 				loginPage: "/login",
 				consentPage: "/consent",
 				validAudiences: [validAudience],
-				silenceWarnings: {
-					oauthAuthServerConfig: true,
-					openidConfig: true,
-				},
 			}),
 		],
 	});


### PR DESCRIPTION
## Summary

Removes the `silenceWarnings` option from the oauth-provider plugin and stops logging the well-known endpoint configuration warnings entirely.

The plugin logged two warnings on init ("Please ensure '/.well-known/oauth-authorization-server...' exists" and the openid-configuration equivalent) and required setting `silenceWarnings.oauthAuthServerConfig` / `silenceWarnings.openidConfig` to quiet them. Since the plugin already serves both issuer metadata endpoints itself through its `onRequest` handler, the warnings were noise for correctly configured setups — and every consumer (including our own tests, demo, and e2e apps) ended up carrying the config flag just to silence them.

## Changes

- Remove `silenceWarnings` from `OAuthOptions` and drop both init warnings
- Remove `silenceWarnings.oidcScopes` from the resource client's `getProtectedResourceMetadata` opts and drop the OIDC scope warning
- Keep the fail-fast init checks that matter: jwt plugin registration and issuer URL validation still throw (`Invalid URL`), and invalid resource scopes still throw
- Clean up all `silenceWarnings` usages across tests, demo, and e2e apps

## Testing

- `pnpm vitest run` in `packages/oauth-provider`: 22 files / 337 tests pass
- Package typecheck produces an error set identical to `main` (pre-existing, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)