### PR TITLE
feat(phone-number): opt-in masked phone numbers in API responses

### DIFF
--- a/.changeset/mask-phone-number.md
+++ b/.changeset/mask-phone-number.md
@@ -1,6 +1,6 @@
 ---
-"better-auth": minor
-"@better-auth/core": minor
+"better-auth": patch
+"@better-auth/core": patch
 ---
 
 Add opt-in `maskPhoneNumber` option to the phone-number plugin to mask phone numbers in client-facing responses and session cookie cache

--- a/.changeset/mask-phone-number.md
+++ b/.changeset/mask-phone-number.md
@@ -1,0 +1,6 @@
+---
+"better-auth": minor
+"@better-auth/core": minor
+---
+
+Add opt-in `maskPhoneNumber` option to the phone-number plugin to mask phone numbers in client-facing responses and session cookie cache

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -354,6 +354,38 @@ An object with the following properties:
 
 When enabled, users cannot sign in with their phone number until it has been verified. If an unverified user attempts to sign in, the server will respond with a 401 error (PHONE\_NUMBER\_NOT\_VERIFIED) and automatically trigger an OTP send to start the verification process.
 
+### `maskPhoneNumber`
+
+When enabled, `phoneNumber` is masked in client-facing user payloads (including `/get-session` and the session cookie cache). The default mask keeps a leading `+` (when present) and the last 4 digits (for example, `+15551234567` becomes `+*******4567`).
+
+The full number is still returned on:
+
+* Admin plugin routes under `/admin/*`
+* `POST /sign-in/phone-number`
+* `POST /phone-number/verify`
+
+Server-internal session loads keep the full value. If your server needs the unmasked number outside those reveal routes, read it from the database or an admin endpoint.
+
+```ts
+import { betterAuth } from "better-auth";
+import { phoneNumber } from "better-auth/plugins"
+
+export const auth = betterAuth({
+    plugins: [
+        phoneNumber({
+            sendOTP: ({ phoneNumber, code }, ctx) => {
+                // Implement sending OTP code via SMS
+            },
+            maskPhoneNumber: true, // [!code highlight]
+            // Or with a custom mask:
+            // maskPhoneNumber: {
+            //     mask: (phoneNumber) => phoneNumber.slice(0, 3) + "****"
+            // }
+        })
+    ]
+})
+```
+
 ## Schema
 
 The plugin requires 2 fields to be added to the user table

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -166,7 +166,9 @@ export async function setCookieCache(
 		ctx.context.options.session?.additionalFields,
 	);
 
-	const filteredUser = parseUserOutput(ctx.context.options, session.user);
+	const filteredUser = parseUserOutput(ctx.context.options, session.user, {
+		forCookie: true,
+	});
 
 	const versionConfig = ctx.context.options.session?.cookieCache?.version;
 	let version = "1";

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -471,11 +471,15 @@ export const createInternalAdapter = (
 						createdAt: new Date(s.session.createdAt),
 						updatedAt: new Date(s.session.updatedAt),
 					});
-					const parsedUser = parseUserOutput(ctx.options, {
-						...s.user,
-						createdAt: new Date(s.user.createdAt),
-						updatedAt: new Date(s.user.updatedAt),
-					});
+					const parsedUser = parseUserOutput(
+						ctx.options,
+						{
+							...s.user,
+							createdAt: new Date(s.user.createdAt),
+							updatedAt: new Date(s.user.updatedAt),
+						},
+						{ skipMask: true },
+					);
 					return {
 						session: parsedSession,
 						user: parsedUser,
@@ -503,7 +507,9 @@ export const createInternalAdapter = (
 			const { user, ...session } = result;
 			if (!user) return null;
 			const parsedSession = parseSessionOutput(ctx.options, session);
-			const parsedUser = parseUserOutput(ctx.options, user);
+			const parsedUser = parseUserOutput(ctx.options, user, {
+				skipMask: true,
+			});
 			return {
 				session: parsedSession,
 				user: parsedUser,

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -84,10 +84,9 @@ export function parseUserOutput<T extends User>(
 	}
 	for (const plugin of options.plugins || []) {
 		if (typeof plugin.$maskUserOutput === "function") {
-			output = plugin.$maskUserOutput(
-				output as Record<string, unknown>,
-				meta,
-			) as T;
+			output = plugin.$maskUserOutput(output as Record<string, unknown>, {
+				...meta,
+			}) as T;
 		}
 	}
 	return output;

--- a/packages/better-auth/src/db/schema.ts
+++ b/packages/better-auth/src/db/schema.ts
@@ -57,12 +57,40 @@ function getFields(
 	return schema;
 }
 
+export type ParseUserOutputMeta = {
+	/**
+	 * Skip all plugin output masks (server-internal session loads).
+	 */
+	skipMask?: boolean | undefined;
+	/**
+	 * Always apply masks (session cookie cache).
+	 */
+	forCookie?: boolean | undefined;
+	/**
+	 * Request path used for reveal allowlisting.
+	 */
+	path?: string | undefined;
+};
+
 export function parseUserOutput<T extends User>(
 	options: BetterAuthOptions,
 	user: T,
+	meta?: ParseUserOutputMeta | undefined,
 ) {
 	const schema = getFields(options, "user", "output");
-	return filterOutputFields(user, schema);
+	let output = filterOutputFields(user, schema) as T;
+	if (meta?.skipMask) {
+		return output;
+	}
+	for (const plugin of options.plugins || []) {
+		if (typeof plugin.$maskUserOutput === "function") {
+			output = plugin.$maskUserOutput(
+				output as Record<string, unknown>,
+				meta,
+			) as T;
+		}
+	}
+	return output;
 }
 
 /**

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -168,7 +168,9 @@ export const setRole = <O extends AdminOptions>(opts: O) =>
 				},
 			);
 			return ctx.json({
-				user: parseUserOutput(ctx.context.options, updatedUser) as UserWithRole,
+				user: parseUserOutput(ctx.context.options, updatedUser, {
+					path: ctx.path,
+				}) as UserWithRole,
 			});
 		},
 	);
@@ -236,7 +238,9 @@ export const getUser = (opts: AdminOptions) =>
 				throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.USER_NOT_FOUND);
 			}
 
-			return parseUserOutput(ctx.context.options, user) as UserWithRole;
+			return parseUserOutput(ctx.context.options, user, {
+				path: ctx.path,
+			}) as UserWithRole;
 		},
 	);
 
@@ -463,7 +467,9 @@ export const createUser = <O extends AdminOptions>(opts: O) =>
 				});
 			}
 			return ctx.json({
-				user: parseUserOutput(ctx.context.options, user) as UserWithRole,
+				user: parseUserOutput(ctx.context.options, user, {
+					path: ctx.path,
+				}) as UserWithRole,
 			});
 		},
 	);
@@ -674,7 +680,9 @@ export const adminUpdateUser = (opts: AdminOptions) =>
 			}
 
 			return ctx.json(
-				parseUserOutput(ctx.context.options, updatedUser) as UserWithRole,
+				parseUserOutput(ctx.context.options, updatedUser, {
+					path: ctx.path,
+				}) as UserWithRole,
 			);
 		},
 	);
@@ -844,7 +852,9 @@ export const listUsers = (opts: AdminOptions) =>
 				);
 				return ctx.json({
 					users: users.map((user) =>
-						parseUserOutput(ctx.context.options, user),
+						parseUserOutput(ctx.context.options, user, {
+							path: ctx.path,
+						}),
 					) as UserWithRole[],
 					total: total,
 					limit: Number(ctx.query?.limit) || undefined,
@@ -1029,7 +1039,9 @@ export const unbanUser = (opts: AdminOptions) =>
 				},
 			);
 			return ctx.json({
-				user: parseUserOutput(ctx.context.options, user) as UserWithRole,
+				user: parseUserOutput(ctx.context.options, user, {
+					path: ctx.path,
+				}) as UserWithRole,
 			});
 		},
 	);
@@ -1153,7 +1165,9 @@ export const banUser = (opts: AdminOptions) =>
 			//revoke all sessions
 			await ctx.context.internalAdapter.deleteUserSessions(ctx.body.userId);
 			return ctx.json({
-				user: parseUserOutput(ctx.context.options, user) as UserWithRole,
+				user: parseUserOutput(ctx.context.options, user, {
+					path: ctx.path,
+				}) as UserWithRole,
 			});
 		},
 	);
@@ -1309,7 +1323,9 @@ export const impersonateUser = (opts: AdminOptions) =>
 			);
 			return ctx.json({
 				session: session,
-				user: parseUserOutput(ctx.context.options, targetUser) as UserWithRole,
+				user: parseUserOutput(ctx.context.options, targetUser, {
+					path: ctx.path,
+				}) as UserWithRole,
 			});
 		},
 	);
@@ -1385,7 +1401,9 @@ export const stopImpersonating = () =>
 			expireCookie(ctx, adminSessionCookie);
 			return ctx.json({
 				session: parseSessionOutput(ctx.context.options, adminSession.session),
-				user: parseUserOutput(ctx.context.options, adminSession.user),
+				user: parseUserOutput(ctx.context.options, adminSession.user, {
+					path: ctx.path,
+				}),
 			});
 		},
 	);

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -4,6 +4,7 @@ import { APIError } from "@better-auth/core/error";
 import { mergeSchema } from "../../db/schema";
 import { PACKAGE_VERSION } from "../../version";
 import { PHONE_NUMBER_ERROR_CODES } from "./error-codes";
+import { resolveMaskPhoneNumberOption, shouldRevealPhoneNumber } from "./mask";
 import type { RequiredPhoneNumberOptions } from "./routes";
 import {
 	requestPasswordResetPhoneNumber,
@@ -16,6 +17,10 @@ import { schema } from "./schema";
 import type { PhoneNumberOptions, UserWithPhoneNumber } from "./types";
 
 export type { PhoneNumberOptions, UserWithPhoneNumber };
+export {
+	defaultMaskPhoneNumber,
+	PHONE_NUMBER_REVEAL_PATHS,
+} from "./mask";
 
 declare module "@better-auth/core" {
 	interface BetterAuthPluginRegistry<AuthOptions, Options> {
@@ -35,10 +40,27 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 		code: "code",
 		createdAt: "createdAt",
 	};
+	const phoneMask = resolveMaskPhoneNumberOption(options?.maskPhoneNumber);
 
 	return {
 		id: "phone-number",
 		version: PACKAGE_VERSION,
+		$maskUserOutput(user, meta) {
+			if (!phoneMask.enabled) {
+				return user;
+			}
+			if (shouldRevealPhoneNumber(meta)) {
+				return user;
+			}
+			const phoneNumber = user.phoneNumber;
+			if (typeof phoneNumber !== "string" || phoneNumber.length === 0) {
+				return user;
+			}
+			return {
+				...user,
+				phoneNumber: phoneMask.mask(phoneNumber),
+			};
+		},
 		init() {
 			return {
 				options: {

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -52,13 +52,13 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 			if (shouldRevealPhoneNumber(meta)) {
 				return user;
 			}
-			const phoneNumber = user.phoneNumber;
-			if (typeof phoneNumber !== "string" || phoneNumber.length === 0) {
+			const value = user.phoneNumber;
+			if (typeof value !== "string" || value.length === 0) {
 				return user;
 			}
 			return {
 				...user,
-				phoneNumber: phoneMask.mask(phoneNumber),
+				phoneNumber: phoneMask.mask(value),
 			};
 		},
 		init() {

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -16,11 +16,11 @@ import {
 import { schema } from "./schema";
 import type { PhoneNumberOptions, UserWithPhoneNumber } from "./types";
 
-export type { PhoneNumberOptions, UserWithPhoneNumber };
 export {
 	defaultMaskPhoneNumber,
 	PHONE_NUMBER_REVEAL_PATHS,
 } from "./mask";
+export type { PhoneNumberOptions, UserWithPhoneNumber };
 
 declare module "@better-auth/core" {
 	interface BetterAuthPluginRegistry<AuthOptions, Options> {

--- a/packages/better-auth/src/plugins/phone-number/mask.ts
+++ b/packages/better-auth/src/plugins/phone-number/mask.ts
@@ -1,0 +1,70 @@
+/**
+ * Paths that may return the full phone number when masking is enabled.
+ * Cookie cache always masks regardless of path.
+ */
+export const PHONE_NUMBER_REVEAL_PATHS = [
+	"/sign-in/phone-number",
+	"/phone-number/verify",
+] as const;
+
+/**
+ * Default phone mask: preserve leading `+`, replace digits with `*`, keep last 4.
+ *
+ * @example defaultMaskPhoneNumber("+15551234567") // "+*******4567"
+ */
+export function defaultMaskPhoneNumber(phoneNumber: string): string {
+	if (phoneNumber.includes("*")) {
+		return phoneNumber;
+	}
+	const digits = phoneNumber.replace(/\D/g, "");
+	if (digits.length === 0) {
+		return phoneNumber;
+	}
+	if (digits.length <= 4) {
+		return phoneNumber.startsWith("+")
+			? `+${"*".repeat(digits.length)}`
+			: "*".repeat(digits.length);
+	}
+	const last4 = digits.slice(-4);
+	const masked = "*".repeat(digits.length - 4) + last4;
+	return phoneNumber.startsWith("+") ? `+${masked}` : masked;
+}
+
+export function shouldRevealPhoneNumber(
+	meta?:
+		| {
+				forCookie?: boolean | undefined;
+				path?: string | undefined;
+		  }
+		| undefined,
+): boolean {
+	if (meta?.forCookie) {
+		return false;
+	}
+	const path = meta?.path;
+	if (!path) {
+		return false;
+	}
+	if (path.startsWith("/admin/")) {
+		return true;
+	}
+	return (PHONE_NUMBER_REVEAL_PATHS as readonly string[]).includes(path);
+}
+
+export function resolveMaskPhoneNumberOption(
+	maskPhoneNumber:
+		| boolean
+		| { mask?: (phoneNumber: string) => string }
+		| undefined,
+): { enabled: boolean; mask: (phoneNumber: string) => string } {
+	if (!maskPhoneNumber) {
+		return { enabled: false, mask: defaultMaskPhoneNumber };
+	}
+	if (maskPhoneNumber === true) {
+		return { enabled: true, mask: defaultMaskPhoneNumber };
+	}
+	return {
+		enabled: true,
+		mask: maskPhoneNumber.mask ?? defaultMaskPhoneNumber,
+	};
+}

--- a/packages/better-auth/src/plugins/phone-number/mask.ts
+++ b/packages/better-auth/src/plugins/phone-number/mask.ts
@@ -8,12 +8,36 @@ export const PHONE_NUMBER_REVEAL_PATHS = [
 ] as const;
 
 /**
+ * True when the value already matches the default mask format
+ * (`+` optional, then one or more `*`, then up to 4 trailing digits).
+ */
+export function isDefaultMaskedPhoneNumber(phoneNumber: string): boolean {
+	return /^\+?\*+\d{0,4}$/.test(phoneNumber);
+}
+
+/**
+ * True when the value still looks like a raw phone number worth masking.
+ * Used so cookie-cached / already-masked values are not transformed again.
+ */
+export function looksLikeRawPhoneNumber(phoneNumber: string): boolean {
+	if (isDefaultMaskedPhoneNumber(phoneNumber)) {
+		return false;
+	}
+	const digits = phoneNumber.replace(/\D/g, "");
+	if (digits.length === 0) {
+		return false;
+	}
+	const starCount = (phoneNumber.match(/\*/g) ?? []).length;
+	return starCount < Math.max(digits.length - 4, 1);
+}
+
+/**
  * Default phone mask: preserve leading `+`, replace digits with `*`, keep last 4.
  *
  * @example defaultMaskPhoneNumber("+15551234567") // "+*******4567"
  */
 export function defaultMaskPhoneNumber(phoneNumber: string): string {
-	if (phoneNumber.includes("*")) {
+	if (isDefaultMaskedPhoneNumber(phoneNumber)) {
 		return phoneNumber;
 	}
 	const digits = phoneNumber.replace(/\D/g, "");
@@ -63,8 +87,17 @@ export function resolveMaskPhoneNumberOption(
 	if (maskPhoneNumber === true) {
 		return { enabled: true, mask: defaultMaskPhoneNumber };
 	}
+	const customMask = maskPhoneNumber.mask;
+	if (!customMask) {
+		return { enabled: true, mask: defaultMaskPhoneNumber };
+	}
 	return {
 		enabled: true,
-		mask: maskPhoneNumber.mask ?? defaultMaskPhoneNumber,
+		mask: (phoneNumber) => {
+			if (!looksLikeRawPhoneNumber(phoneNumber)) {
+				return phoneNumber;
+			}
+			return customMask(phoneNumber);
+		},
 	};
 }

--- a/packages/better-auth/src/plugins/phone-number/mask.ts
+++ b/packages/better-auth/src/plugins/phone-number/mask.ts
@@ -11,7 +11,7 @@ export const PHONE_NUMBER_REVEAL_PATHS = [
  * True when the value already matches the default mask format
  * (`+` optional, then one or more `*`, then up to 4 trailing digits).
  */
-export function isDefaultMaskedPhoneNumber(phoneNumber: string): boolean {
+function isDefaultMaskedPhoneNumber(phoneNumber: string): boolean {
 	return /^\+?\*+\d{0,4}$/.test(phoneNumber);
 }
 
@@ -19,7 +19,7 @@ export function isDefaultMaskedPhoneNumber(phoneNumber: string): boolean {
  * True when the value still looks like a raw phone number worth masking.
  * Used so cookie-cached / already-masked values are not transformed again.
  */
-export function looksLikeRawPhoneNumber(phoneNumber: string): boolean {
+function looksLikeRawPhoneNumber(phoneNumber: string): boolean {
 	if (isDefaultMaskedPhoneNumber(phoneNumber)) {
 		return false;
 	}

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1299,7 +1299,8 @@ describe("defaultMaskPhoneNumber", () => {
 	});
 
 	it("still masks numbers that contain a literal asterisk", () => {
-		expect(defaultMaskPhoneNumber("+1*5551234567")).toBe("+********4567");
+		// Digits are extracted ignoring `*`, so this masks like +15551234567.
+		expect(defaultMaskPhoneNumber("+1*5551234567")).toBe("+*******4567");
 	});
 });
 

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
+import { admin } from "../admin";
+import { adminClient } from "../admin/client";
 import { bearer } from "../bearer";
 import { phoneNumber } from ".";
 import { phoneNumberClient } from "./client";
+import { defaultMaskPhoneNumber } from "./mask";
 
 describe("phone-number", async () => {
 	let otp = "";
@@ -1281,5 +1284,217 @@ describe("custom verifyOTP", async () => {
 		});
 		expect(user.data?.user.phoneNumber).toBe(updatedPhoneNumber);
 		expect(user.data?.user.phoneNumberVerified).toBe(true);
+	});
+});
+
+describe("defaultMaskPhoneNumber", () => {
+	it("masks digits and keeps last 4 with + prefix", () => {
+		expect(defaultMaskPhoneNumber("+15551234567")).toBe("+*******4567");
+		expect(defaultMaskPhoneNumber("+251911121314")).toBe("+********1314");
+	});
+
+	it("is idempotent", () => {
+		const masked = defaultMaskPhoneNumber("+15551234567");
+		expect(defaultMaskPhoneNumber(masked)).toBe(masked);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/5305
+ */
+describe("phone-number maskPhoneNumber", async () => {
+	let otp = "";
+	const testPhone = "+15551234567";
+	const maskedPhone = "+*******4567";
+
+	const { client, sessionSetter, signInWithTestUser, auth } =
+		await getTestInstance(
+			{
+				session: {
+					cookieCache: {
+						enabled: true,
+					},
+				},
+				plugins: [
+					phoneNumber({
+						maskPhoneNumber: true,
+						async sendOTP({ code }) {
+							otp = code;
+						},
+						signUpOnVerification: {
+							getTempEmail(phoneNumber) {
+								return `temp-${phoneNumber}@example.com`;
+							},
+						},
+					}),
+					admin(),
+				],
+				databaseHooks: {
+					user: {
+						create: {
+							before: async (user) => ({
+								data: {
+									...user,
+									emailVerified: true,
+									...(user.name === "Admin" ? { role: "admin" } : {}),
+								},
+							}),
+						},
+					},
+				},
+			},
+			{
+				testUser: {
+					name: "Admin",
+				},
+				clientOptions: {
+					plugins: [phoneNumberClient(), adminClient()],
+				},
+			},
+		);
+
+	const headers = new Headers();
+
+	it("should return full phone number on verify", async () => {
+		await client.phoneNumber.sendOtp({
+			phoneNumber: testPhone,
+		});
+		const res = await client.phoneNumber.verify(
+			{
+				phoneNumber: testPhone,
+				code: otp,
+			},
+			{
+				onSuccess: sessionSetter(headers),
+			},
+		);
+		expect(res.error).toBe(null);
+		expect(res.data?.user.phoneNumber).toBe(testPhone);
+	});
+
+	it("should mask phone number on get-session", async () => {
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(session.data?.user.phoneNumber).toBe(maskedPhone);
+	});
+
+	it("should return full phone number on sign-in/phone-number", async () => {
+		await auth.api.setPassword({
+			body: {
+				newPassword: "password",
+			},
+			headers,
+		});
+		const res = await client.signIn.phoneNumber({
+			phoneNumber: testPhone,
+			password: "password",
+		});
+		expect(res.error).toBe(null);
+		expect(res.data?.user.phoneNumber).toBe(testPhone);
+	});
+
+	it("should mask phone number on email sign-in", async () => {
+		const res = await client.signIn.email({
+			email: `temp-${testPhone}@example.com`,
+			password: "password",
+		});
+		expect(res.error).toBe(null);
+		expect(res.data?.user.phoneNumber).toBe(maskedPhone);
+	});
+
+	it("should return full phone number on admin get-user", async () => {
+		const { headers: adminHeaders } = await signInWithTestUser();
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		const userId = session.data?.user.id;
+		expect(userId).toBeDefined();
+
+		const res = await client.admin.getUser(
+			{
+				query: {
+					id: userId!,
+				},
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.error).toBe(null);
+		expect(
+			(res.data as { phoneNumber?: string } | null | undefined)?.phoneNumber,
+		).toBe(testPhone);
+	});
+
+	it("should keep cookie cache masked across get-session", async () => {
+		const first = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(first.data?.user.phoneNumber).toBe(maskedPhone);
+		const second = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(second.data?.user.phoneNumber).toBe(maskedPhone);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/5305
+ */
+describe("phone-number maskPhoneNumber disabled by default", async () => {
+	let otp = "";
+	const testPhone = "+15559876543";
+
+	const { client, sessionSetter } = await getTestInstance(
+		{
+			plugins: [
+				phoneNumber({
+					async sendOTP({ code }) {
+						otp = code;
+					},
+					signUpOnVerification: {
+						getTempEmail(phoneNumber) {
+							return `temp-${phoneNumber}@example.com`;
+						},
+					},
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [phoneNumberClient()],
+			},
+		},
+	);
+
+	it("should return full phone number on get-session when masking is off", async () => {
+		const headers = new Headers();
+		await client.phoneNumber.sendOtp({
+			phoneNumber: testPhone,
+		});
+		await client.phoneNumber.verify(
+			{
+				phoneNumber: testPhone,
+				code: otp,
+			},
+			{
+				onSuccess: sessionSetter(headers),
+			},
+		);
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(session.data?.user.phoneNumber).toBe(testPhone);
 	});
 });

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1293,9 +1293,13 @@ describe("defaultMaskPhoneNumber", () => {
 		expect(defaultMaskPhoneNumber("+251911121314")).toBe("+********1314");
 	});
 
-	it("is idempotent", () => {
+	it("is idempotent for the default mask format", () => {
 		const masked = defaultMaskPhoneNumber("+15551234567");
 		expect(defaultMaskPhoneNumber(masked)).toBe(masked);
+	});
+
+	it("still masks numbers that contain a literal asterisk", () => {
+		expect(defaultMaskPhoneNumber("+1*5551234567")).toBe("+********4567");
 	});
 });
 

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -196,7 +196,9 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			);
 			return ctx.json({
 				token: session.token,
-				user: parseUserOutput(ctx.context.options, user),
+				user: parseUserOutput(ctx.context.options, user, {
+					path: ctx.path,
+				}),
 			});
 		},
 	);
@@ -544,7 +546,9 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				return ctx.json({
 					status: true,
 					token: session.session.token,
-					user: parseUserOutput(ctx.context.options, user),
+					user: parseUserOutput(ctx.context.options, user, {
+						path: ctx.path,
+					}),
 				});
 			}
 
@@ -631,14 +635,18 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				return ctx.json({
 					status: true,
 					token: session.token,
-					user: parseUserOutput(ctx.context.options, user),
+					user: parseUserOutput(ctx.context.options, user, {
+						path: ctx.path,
+					}),
 				});
 			}
 
 			return ctx.json({
 				status: true,
 				token: null,
-				user: parseUserOutput(ctx.context.options, user),
+				user: parseUserOutput(ctx.context.options, user, {
+					path: ctx.path,
+				}),
 			});
 		},
 	);

--- a/packages/better-auth/src/plugins/phone-number/types.ts
+++ b/packages/better-auth/src/plugins/phone-number/types.ts
@@ -127,4 +127,24 @@ export interface PhoneNumberOptions {
 	 * @default 3
 	 */
 	allowedAttempts?: number | undefined;
+	/**
+	 * Mask `phoneNumber` in client-facing user payloads and the session cookie cache.
+	 *
+	 * When enabled, the full number is still returned on admin routes and on
+	 * `/sign-in/phone-number` / `/phone-number/verify`. Server-internal session
+	 * loads keep the full value.
+	 *
+	 * @default false
+	 */
+	maskPhoneNumber?:
+		| boolean
+		| {
+				/**
+				 * Custom mask function.
+				 *
+				 * @default keep `+` prefix and last 4 digits
+				 */
+				mask?: (phoneNumber: string) => string;
+		  }
+		| undefined;
 }

--- a/packages/better-auth/src/plugins/phone-number/types.ts
+++ b/packages/better-auth/src/plugins/phone-number/types.ts
@@ -142,6 +142,10 @@ export interface PhoneNumberOptions {
 				/**
 				 * Custom mask function.
 				 *
+				 * Must be idempotent: cookie cache and `/get-session` may apply it
+				 * more than once to the same value. Prefer returning the input
+				 * unchanged when it is already masked.
+				 *
 				 * @default keep `+` prefix and last 4 digits
 				 */
 				mask?: (phoneNumber: string) => string;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -141,15 +141,15 @@ export type BetterAuthPlugin = BetterAuthPluginErrorCodePart & {
 	/**
 	 * Mask sensitive fields on user objects returned via `parseUserOutput`.
 	 *
-	 * Called after `returned: false` filtering. Skip with `{ skipMask: true }`
-	 * for server-internal loads; force with `{ forCookie: true }` for cookie cache.
+	 * Called after `returned: false` filtering when masking is not skipped by
+	 * the caller. Use `{ forCookie: true }` for cookie-cache writes and
+	 * `{ path }` for reveal allowlisting.
 	 */
 	$maskUserOutput?:
 		| ((
 				user: Record<string, unknown>,
 				meta?:
 					| {
-							skipMask?: boolean | undefined;
 							forCookie?: boolean | undefined;
 							path?: string | undefined;
 					  }

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -139,6 +139,24 @@ export type BetterAuthPlugin = BetterAuthPluginErrorCodePart & {
 	 */
 	options?: Record<string, any> | undefined;
 	/**
+	 * Mask sensitive fields on user objects returned via `parseUserOutput`.
+	 *
+	 * Called after `returned: false` filtering. Skip with `{ skipMask: true }`
+	 * for server-internal loads; force with `{ forCookie: true }` for cookie cache.
+	 */
+	$maskUserOutput?:
+		| ((
+				user: Record<string, unknown>,
+				meta?:
+					| {
+							skipMask?: boolean | undefined;
+							forCookie?: boolean | undefined;
+							path?: string | undefined;
+					  }
+					| undefined,
+		  ) => Record<string, unknown>)
+		| undefined;
+	/**
 	 * types to be inferred
 	 */
 	$Infer?: Record<string, any> | undefined;


### PR DESCRIPTION
- Add opt-in `maskPhoneNumber` to the phone-number plugin so client-facing user payloads and the session cookie cache return a masked number by default when enabled
- Keep the full number on admin routes and phone sign-in/verify; server-internal session loads remain unmasked
- Document the option and cover reveal vs mask paths with regression tests for #5305

Closes #5305