### PR TITLE
feat(db): add compound table indexes

### DIFF
--- a/.changeset/compound-database-indexes.md
+++ b/.changeset/compound-database-indexes.md
@@ -1,0 +1,9 @@
+---
+"@better-auth/core": minor
+"@better-auth/drizzle-adapter": minor
+"@better-auth/mongo-adapter": minor
+"auth": minor
+"better-auth": minor
+---
+
+Plugin database schemas can now define named or generated table-level indexes across multiple fields. SQL migrations and generated Drizzle or Prisma schemas resolve configured table and column names consistently, while the MongoDB adapter creates the same indexes before the first index-enforcing write.

--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -179,6 +179,38 @@ The key is the column name and the value is the column definition. The column de
 
 `unique`: if the field should be unique. (default: `false`)
 
+For indexes that span multiple fields, add an `indexes` array to the table. Index fields use the logical field keys from `fields`, even when a field has a custom database column name.
+
+```ts title="plugin.ts"
+import type { BetterAuthPlugin } from "better-auth";
+
+const directoryPlugin = {
+  id: "directory",
+  schema: {
+    directoryUser: {
+      fields: {
+        connectionId: {
+          type: "string",
+          fieldName: "connection_id",
+        },
+        externalId: {
+          type: "string",
+          fieldName: "external_id",
+        },
+      },
+      indexes: [
+        {
+          fields: ["connectionId", "externalId"],
+          unique: true,
+        },
+      ],
+    },
+  },
+} satisfies BetterAuthPlugin;
+```
+
+Each index can include up to 16 fields. Set `unique: true` when each field tuple must identify at most one row. Every field in a unique table-level index must be required so that null handling remains consistent across databases. You can also provide a schema-wide `name` of up to 63 UTF-8 bytes to control the database index name. Names must start with a letter or underscore and contain only letters, numbers, and underscores. Names are compared case-insensitively and cannot conflict with a table or another index. The CLI includes table-level indexes in SQL migrations and generated Drizzle or Prisma schemas. The MongoDB adapter creates them before the first indexed write to the collection.
+
 `references`: if the field is a reference to another table. (optional) It takes an object with the following properties:
 
 * `model`: The table name to reference.

--- a/e2e/adapter/test/adapter-factory/compound-index-test-suite.ts
+++ b/e2e/adapter/test/adapter-factory/compound-index-test-suite.ts
@@ -1,0 +1,108 @@
+import type { BetterAuthOptions, BetterAuthPlugin } from "@better-auth/core";
+import { createTestSuite } from "@better-auth/test-utils/adapter";
+import { expect } from "vitest";
+
+const compoundIndexName = "compound_identity_uidx";
+const compoundIndexTableName = "compound_index_subject";
+
+const compoundIndexBetterAuthOptions = {
+	plugins: [
+		{
+			id: "compound-index-workflow",
+			schema: {
+				compoundIndexSubject: {
+					modelName: compoundIndexTableName,
+					fields: {
+						issuer: {
+							type: "string",
+							fieldName: "issuer_url",
+						},
+						providerSubject: {
+							type: "string",
+							fieldName: "provider_subject",
+						},
+						displayName: {
+							type: "string",
+							fieldName: "display_name",
+						},
+					},
+					indexes: [
+						{
+							fields: ["issuer", "providerSubject"],
+							name: compoundIndexName,
+							unique: true,
+						},
+					],
+				},
+			},
+		} satisfies BetterAuthPlugin,
+	],
+} satisfies BetterAuthOptions;
+
+interface CompoundIndexTestSuiteOptions {
+	rerunMigrations?:
+		| ((options: BetterAuthOptions) => Promise<string>)
+		| undefined;
+	mismatchError?: RegExp | string | undefined;
+	verifyIndexState?: (() => Promise<void>) | undefined;
+	verifyMismatchedIndexRejected?:
+		| ((options: BetterAuthOptions) => Promise<void>)
+		| undefined;
+}
+
+interface CompoundIndexSubject {
+	displayName: string;
+	id: string;
+	issuer: string;
+	providerSubject: string;
+}
+
+export function compoundIndexTestSuite(
+	options: CompoundIndexTestSuiteOptions = {},
+) {
+	return createTestSuite("compound-index", {}, ({ adapter }) => ({
+		"enforces the configured tuple through the real database": {
+			migrateBetterAuth: compoundIndexBetterAuthOptions,
+			async test() {
+				const createSubject = (
+					issuer: string,
+					providerSubject: string,
+					displayName: string,
+				) =>
+					adapter.create<CompoundIndexSubject>({
+						model: "compoundIndexSubject",
+						data: { issuer, providerSubject, displayName },
+					});
+
+				await expect(
+					Promise.all([
+						createSubject("https://idp.example", "employee-1", "Ada"),
+						createSubject("https://idp.example", "employee-2", "Lin"),
+						createSubject("https://partner.example", "employee-1", "Kai"),
+					]),
+				).resolves.toHaveLength(3);
+
+				await expect(
+					createSubject("https://idp.example", "employee-1", "Duplicate"),
+				).rejects.toThrow();
+
+				if (options.rerunMigrations) {
+					const pendingMigration = await options.rerunMigrations(
+						compoundIndexBetterAuthOptions,
+					);
+					expect(pendingMigration.trim()).toBe(";");
+				}
+
+				await options.verifyIndexState?.();
+
+				if (options.verifyMismatchedIndexRejected) {
+					await expect(
+						options.verifyMismatchedIndexRejected(
+							compoundIndexBetterAuthOptions,
+						),
+					).rejects.toThrow(options.mismatchError);
+				}
+			},
+		},
+	}))();
+}

--- a/e2e/adapter/test/kysely-adapter/adapter.kysely.mssql.test.ts
+++ b/e2e/adapter/test/kysely-adapter/adapter.kysely.mssql.test.ts
@@ -363,7 +363,7 @@ const { execute } = await testAdapter({
 							[id] varchar(36) NOT NULL,
 							[issuer_url] varchar(max) NOT NULL,
 							[provider_subject] varchar(max) NOT NULL,
-							[display_name] varchar(max) NOT NULL
+							[display_name] varchar(255) NOT NULL
 						);
 						CREATE INDEX [compound_identity_uidx]
 							ON [better_auth_shadow].[compound_index_subject] ([display_name]);

--- a/e2e/adapter/test/kysely-adapter/adapter.kysely.mssql.test.ts
+++ b/e2e/adapter/test/kysely-adapter/adapter.kysely.mssql.test.ts
@@ -348,13 +348,46 @@ const { execute } = await testAdapter({
 		uuidTestSuite(),
 		compoundIndexTestSuite({
 			async rerunMigrations(options) {
-				const migrations = await getMigrations({
-					...options,
-					database: { db: kyselyDB, type: "mssql" },
-				});
-				const pendingMigration = await migrations.compileMigrations();
-				await migrations.runMigrations();
-				return pendingMigration;
+				try {
+					await query(`
+						IF NOT EXISTS (
+							SELECT 1 FROM sys.schemas WHERE name = N'better_auth_shadow'
+						)
+							EXEC(N'CREATE SCHEMA [better_auth_shadow]');
+						IF OBJECT_ID(
+							N'[better_auth_shadow].[compound_index_subject]',
+							N'U'
+						) IS NOT NULL
+							DROP TABLE [better_auth_shadow].[compound_index_subject];
+						CREATE TABLE [better_auth_shadow].[compound_index_subject] (
+							[id] varchar(36) NOT NULL,
+							[issuer_url] varchar(max) NOT NULL,
+							[provider_subject] varchar(max) NOT NULL,
+							[display_name] varchar(max) NOT NULL
+						);
+						CREATE INDEX [compound_identity_uidx]
+							ON [better_auth_shadow].[compound_index_subject] ([display_name]);
+					`);
+					const migrations = await getMigrations({
+						...options,
+						database: { db: kyselyDB, type: "mssql" },
+					});
+					const pendingMigration = await migrations.compileMigrations();
+					await migrations.runMigrations();
+					return pendingMigration;
+				} finally {
+					await query(`
+						IF OBJECT_ID(
+							N'[better_auth_shadow].[compound_index_subject]',
+							N'U'
+						) IS NOT NULL
+							DROP TABLE [better_auth_shadow].[compound_index_subject];
+						IF EXISTS (
+							SELECT 1 FROM sys.schemas WHERE name = N'better_auth_shadow'
+						)
+							EXEC(N'DROP SCHEMA [better_auth_shadow]');
+					`);
+				}
 			},
 			mismatchError:
 				'Database index "compound_identity_uidx" on table "compound_index_subject" does not match the configured fields and uniqueness.',

--- a/e2e/adapter/test/kysely-adapter/adapter.kysely.mssql.test.ts
+++ b/e2e/adapter/test/kysely-adapter/adapter.kysely.mssql.test.ts
@@ -13,6 +13,7 @@ import {
 	transactionsTestSuite,
 	uuidTestSuite,
 } from "../adapter-factory";
+import { compoundIndexTestSuite } from "../adapter-factory/compound-index-test-suite";
 
 // We are not allowed to handle the mssql connection
 // we must let kysely handle it. This is because if kysely is already
@@ -345,6 +346,40 @@ const { execute } = await testAdapter({
 		numberIdTestSuite(),
 		joinsTestSuite(),
 		uuidTestSuite(),
+		compoundIndexTestSuite({
+			async rerunMigrations(options) {
+				const migrations = await getMigrations({
+					...options,
+					database: { db: kyselyDB, type: "mssql" },
+				});
+				const pendingMigration = await migrations.compileMigrations();
+				await migrations.runMigrations();
+				return pendingMigration;
+			},
+			mismatchError:
+				'Database index "compound_identity_uidx" on table "compound_index_subject" does not match the configured fields and uniqueness.',
+			async verifyMismatchedIndexRejected(options) {
+				await query(`
+					DROP INDEX [compound_identity_uidx]
+						ON [dbo].[compound_index_subject];
+					CREATE INDEX [compound_identity_uidx]
+						ON [dbo].[compound_index_subject] ([provider_subject]);
+				`);
+				try {
+					await getMigrations({
+						...options,
+						database: { db: kyselyDB, type: "mssql" },
+					});
+				} finally {
+					await query(`
+						DROP INDEX [compound_identity_uidx]
+							ON [dbo].[compound_index_subject];
+						CREATE UNIQUE INDEX [compound_identity_uidx]
+							ON [dbo].[compound_index_subject] ([issuer_url], [provider_subject]);
+					`);
+				}
+			},
+		}),
 	],
 	async onFinish() {
 		kyselyDB.destroy();

--- a/e2e/adapter/test/kysely-adapter/adapter.kysely.mysql.test.ts
+++ b/e2e/adapter/test/kysely-adapter/adapter.kysely.mysql.test.ts
@@ -13,6 +13,7 @@ import {
 	transactionsTestSuite,
 	uuidTestSuite,
 } from "../adapter-factory";
+import { compoundIndexTestSuite } from "../adapter-factory/compound-index-test-suite";
 
 const mysqlDB = createPool({
 	uri: "mysql://user:password@localhost:3307/better_auth",
@@ -55,6 +56,37 @@ const { execute } = await testAdapter({
 		caseInsensitiveTestSuite({
 			disableTests: {
 				"findOne - eq with mode sensitive (default) should not match different case": true,
+			},
+		}),
+		compoundIndexTestSuite({
+			async rerunMigrations(options) {
+				const migrations = await getMigrations({
+					...options,
+					database: mysqlDB,
+				});
+				const pendingMigration = await migrations.compileMigrations();
+				await migrations.runMigrations();
+				return pendingMigration;
+			},
+			mismatchError:
+				'Database index "compound_identity_uidx" on table "compound_index_subject" does not match the configured fields and uniqueness.',
+			async verifyMismatchedIndexRejected(options) {
+				await mysqlDB.query(
+					"ALTER TABLE `compound_index_subject` DROP INDEX `compound_identity_uidx`",
+				);
+				await mysqlDB.query(
+					"CREATE INDEX `compound_identity_uidx` ON `compound_index_subject` (`provider_subject`)",
+				);
+				try {
+					await getMigrations({ ...options, database: mysqlDB });
+				} finally {
+					await mysqlDB.query(
+						"ALTER TABLE `compound_index_subject` DROP INDEX `compound_identity_uidx`",
+					);
+					await mysqlDB.query(
+						"CREATE UNIQUE INDEX `compound_identity_uidx` ON `compound_index_subject` (`issuer_url`, `provider_subject`)",
+					);
+				}
 			},
 		}),
 	],

--- a/e2e/adapter/test/kysely-adapter/adapter.kysely.pg.test.ts
+++ b/e2e/adapter/test/kysely-adapter/adapter.kysely.pg.test.ts
@@ -13,6 +13,7 @@ import {
 	transactionsTestSuite,
 	uuidTestSuite,
 } from "../adapter-factory";
+import { compoundIndexTestSuite } from "../adapter-factory/compound-index-test-suite";
 import { scimHttpTestSuite } from "../adapter-factory/scim-http-test-suite";
 import {
 	DEFAULT_SCHEMA_REFERENCE,
@@ -65,6 +66,32 @@ const { execute } = await testAdapter({
 			connectionId: "kysely-postgres-workforce",
 			token: "kysely-postgres-scim-token",
 			testId: "kysely-postgres",
+		}),
+		compoundIndexTestSuite({
+			async rerunMigrations(options) {
+				const migrations = await getMigrations({ ...options, database: pgDB });
+				const pendingMigration = await migrations.compileMigrations();
+				await migrations.runMigrations();
+				return pendingMigration;
+			},
+			mismatchError:
+				'Database index "compound_identity_uidx" on table "compound_index_subject" does not match the configured fields and uniqueness.',
+			async verifyMismatchedIndexRejected(options) {
+				await pgDB.query(`
+					DROP INDEX "compound_identity_uidx";
+					CREATE INDEX "compound_identity_uidx"
+						ON "compound_index_subject" ("provider_subject");
+				`);
+				try {
+					await getMigrations({ ...options, database: pgDB });
+				} finally {
+					await pgDB.query(`
+						DROP INDEX IF EXISTS "compound_identity_uidx";
+						CREATE UNIQUE INDEX "compound_identity_uidx"
+							ON "compound_index_subject" ("issuer_url", "provider_subject");
+					`);
+				}
+			},
 		}),
 	],
 	async onFinish() {

--- a/e2e/adapter/test/kysely-adapter/adapter.kysely.sqlite.test.ts
+++ b/e2e/adapter/test/kysely-adapter/adapter.kysely.sqlite.test.ts
@@ -14,6 +14,7 @@ import {
 	transactionsTestSuite,
 	uuidTestSuite,
 } from "../adapter-factory";
+import { compoundIndexTestSuite } from "../adapter-factory/compound-index-test-suite";
 
 const dbPath = path.join(__dirname, "test.db");
 let database = new Database(dbPath);
@@ -51,6 +52,32 @@ const { execute } = await testAdapter({
 		joinsTestSuite(),
 		uuidTestSuite(),
 		caseInsensitiveTestSuite(),
+		compoundIndexTestSuite({
+			async rerunMigrations(options) {
+				const migrations = await getMigrations({ ...options, database });
+				const pendingMigration = await migrations.compileMigrations();
+				await migrations.runMigrations();
+				return pendingMigration;
+			},
+			mismatchError:
+				'Database index "compound_identity_uidx" on table "compound_index_subject" does not match the configured fields and uniqueness.',
+			async verifyMismatchedIndexRejected(options) {
+				database.exec(`
+					DROP INDEX "compound_identity_uidx";
+					CREATE INDEX "compound_identity_uidx"
+						ON "compound_index_subject" ("provider_subject");
+				`);
+				try {
+					await getMigrations({ ...options, database });
+				} finally {
+					database.exec(`
+						DROP INDEX IF EXISTS "compound_identity_uidx";
+						CREATE UNIQUE INDEX "compound_identity_uidx"
+							ON "compound_index_subject" ("issuer_url", "provider_subject");
+					`);
+				}
+			},
+		}),
 	],
 	async onFinish() {
 		database.close();

--- a/e2e/adapter/test/kysely-adapter/package.json
+++ b/e2e/adapter/test/kysely-adapter/package.json
@@ -6,6 +6,7 @@
     "e2e:integration": "vitest run"
   },
   "devDependencies": {
+    "@better-auth/core": "workspace:*",
     "@better-auth/kysely-adapter": "workspace:*",
     "@better-auth/scim": "workspace:*",
     "@better-auth/test-utils": "workspace:*",

--- a/e2e/adapter/test/mongo-adapter/adapter.mongo-db.test.ts
+++ b/e2e/adapter/test/mongo-adapter/adapter.mongo-db.test.ts
@@ -11,6 +11,7 @@ import {
 	transactionsTestSuite,
 	uuidTestSuite,
 } from "../adapter-factory";
+import { compoundIndexTestSuite } from "../adapter-factory/compound-index-test-suite";
 
 const dbClient = async (connectionString: string, dbName: string) => {
 	const client = new MongoClient(connectionString);
@@ -90,6 +91,51 @@ const { execute } = await testAdapter({
 		caseInsensitiveTestSuite(),
 		updateObjectIdTestSuite(),
 		uuidTestSuite(),
+		compoundIndexTestSuite({
+			mismatchError: /existing index has the same name/i,
+			async verifyIndexState() {
+				const indexes = await db
+					.collection("compound_index_subject")
+					.listIndexes()
+					.toArray();
+				expect(indexes).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({
+							key: { issuer_url: 1, provider_subject: 1 },
+							name: "compound_identity_uidx",
+							unique: true,
+						}),
+					]),
+				);
+			},
+			async verifyMismatchedIndexRejected(options) {
+				const collection = db.collection("compound_index_subject");
+				await collection.dropIndex("compound_identity_uidx");
+				await collection.createIndex(
+					{ provider_subject: 1 },
+					{ name: "compound_identity_uidx" },
+				);
+				try {
+					const freshAdapter = mongodbAdapter(db, { transaction: false })(
+						options,
+					);
+					await freshAdapter.create({
+						model: "compoundIndexSubject",
+						data: {
+							displayName: "Mismatch probe",
+							issuer: "https://mismatch.example",
+							providerSubject: "employee-mismatch",
+						},
+					});
+				} finally {
+					await collection.dropIndex("compound_identity_uidx");
+					await collection.createIndex(
+						{ issuer_url: 1, provider_subject: 1 },
+						{ name: "compound_identity_uidx", unique: true },
+					);
+				}
+			},
+		}),
 		// numberIdTestSuite(), // no support
 	],
 	customIdGenerator: () => new ObjectId().toHexString(),

--- a/packages/better-auth/src/db/get-migration.test.ts
+++ b/packages/better-auth/src/db/get-migration.test.ts
@@ -147,3 +147,266 @@ describe("get-migration: ALTER TABLE ADD COLUMN on SQLite", () => {
 		expect(user.referralCode).toBe("unset");
 	});
 });
+
+describe("get-migration: compound indexes on SQLite", () => {
+	it("rejects duplicate field-level and table-level indexes before creating a table", async () => {
+		await expect(
+			getMigrations({
+				database: new DatabaseSync(":memory:"),
+				plugins: [
+					{
+						id: "directory",
+						schema: {
+							directoryUser: {
+								fields: {
+									subject: { type: "string", index: true },
+								},
+								indexes: [{ fields: ["subject"] }],
+							},
+						},
+					},
+				],
+			}),
+		).rejects.toThrow(
+			'Database index name "directoryUser_subject_idx" is already reserved by field-level index metadata on table "directoryUser".',
+		);
+	});
+
+	it("enforces a compound unique index with configured table and field names", async () => {
+		const db = new DatabaseSync(":memory:");
+		const config: BetterAuthOptions = {
+			database: db,
+			plugins: [
+				{
+					id: "directory",
+					schema: {
+						directoryUser: {
+							modelName: "directory_user",
+							fields: {
+								connectionId: {
+									type: "string",
+									fieldName: "connection_id",
+								},
+								externalId: {
+									type: "string",
+									fieldName: "external_id",
+								},
+							},
+							indexes: [
+								{
+									fields: ["connectionId", "externalId"],
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		};
+
+		const migrations = await getMigrations(config);
+		const sql = (await migrations.compileMigrations()).toLowerCase();
+
+		expect(sql).toContain(
+			'create unique index "directory_user_connection_id_external_id_uidx" on "directory_user" ("connection_id", "external_id")',
+		);
+
+		await migrations.runMigrations();
+		db.exec(`
+			INSERT INTO "directory_user" ("id", "connection_id", "external_id")
+			VALUES
+				('du1', 'okta', 'employee-1'),
+				('du2', 'entra', 'employee-1');
+		`);
+
+		expect(() =>
+			db.exec(`
+				INSERT INTO "directory_user" ("id", "connection_id", "external_id")
+				VALUES ('du3', 'okta', 'employee-1');
+			`),
+		).toThrow();
+
+		const nextMigration = await getMigrations(config);
+		expect(await nextMigration.compileMigrations()).not.toContain(
+			"directory_user_connection_id_external_id_uidx",
+		);
+	});
+
+	it("rejects an existing index with the requested name but different semantics", async () => {
+		const db = new DatabaseSync(":memory:");
+		db.exec(`
+			CREATE TABLE "directory_user" (
+				"id" text primary key not null,
+				"connection_id" text not null,
+				"external_id" text not null
+			);
+			CREATE INDEX "directory_identity_uidx"
+				ON "directory_user" ("external_id");
+		`);
+		const config: BetterAuthOptions = {
+			database: db,
+			plugins: [
+				{
+					id: "directory",
+					schema: {
+						directoryUser: {
+							modelName: "directory_user",
+							fields: {
+								connectionId: {
+									type: "string",
+									fieldName: "connection_id",
+								},
+								externalId: {
+									type: "string",
+									fieldName: "external_id",
+								},
+							},
+							indexes: [
+								{
+									fields: ["connectionId", "externalId"],
+									name: "directory_identity_uidx",
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		};
+
+		await expect(getMigrations(config)).rejects.toThrow(
+			'Database index "directory_identity_uidx" on table "directory_user" does not match the configured fields and uniqueness.',
+		);
+	});
+
+	it("recognizes existing index names case-insensitively", async () => {
+		const db = new DatabaseSync(":memory:");
+		db.exec(`
+			CREATE TABLE "directory_user" (
+				"id" text primary key not null,
+				"connection_id" text not null,
+				"external_id" text not null
+			);
+			CREATE UNIQUE INDEX "Directory_Identity_UIDX"
+				ON "directory_user" ("connection_id", "external_id");
+		`);
+		const migrations = await getMigrations({
+			database: db,
+			plugins: [
+				{
+					id: "directory",
+					schema: {
+						directoryUser: {
+							modelName: "directory_user",
+							fields: {
+								connectionId: {
+									type: "string",
+									fieldName: "connection_id",
+								},
+								externalId: {
+									type: "string",
+									fieldName: "external_id",
+								},
+							},
+							indexes: [
+								{
+									fields: ["connectionId", "externalId"],
+									name: "directory_identity_uidx",
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		});
+
+		expect(await migrations.compileMigrations()).not.toContain(
+			"directory_identity_uidx",
+		);
+	});
+
+	it("rejects a case-insensitive existing index name on another table", async () => {
+		const db = new DatabaseSync(":memory:");
+		db.exec(`
+			CREATE TABLE "reserved_index_owner" (
+				"id" text primary key not null,
+				"subject" text not null
+			);
+			CREATE INDEX "Directory_Identity_UIDX"
+				ON "reserved_index_owner" ("subject");
+		`);
+
+		await expect(
+			getMigrations({
+				database: db,
+				plugins: [
+					{
+						id: "directory",
+						schema: {
+							directoryUser: {
+								fields: { subject: { type: "string" } },
+								indexes: [
+									{
+										fields: ["subject"],
+										name: "directory_identity_uidx",
+									},
+								],
+							},
+						},
+					},
+				],
+			}),
+		).rejects.toThrow(
+			'Database index name "directory_identity_uidx" is already used by table "reserved_index_owner".',
+		);
+	});
+
+	it("does not accept a partial unique index as a full uniqueness guarantee", async () => {
+		const db = new DatabaseSync(":memory:");
+		db.exec(`
+			CREATE TABLE "directory_user" (
+				"id" text primary key not null,
+				"connection_id" text not null,
+				"external_id" text not null
+			);
+			CREATE UNIQUE INDEX "directory_identity_uidx"
+				ON "directory_user" ("connection_id", "external_id")
+				WHERE "external_id" IS NOT NULL;
+		`);
+		const config: BetterAuthOptions = {
+			database: db,
+			plugins: [
+				{
+					id: "directory",
+					schema: {
+						directoryUser: {
+							modelName: "directory_user",
+							fields: {
+								connectionId: {
+									type: "string",
+									fieldName: "connection_id",
+								},
+								externalId: {
+									type: "string",
+									fieldName: "external_id",
+								},
+							},
+							indexes: [
+								{
+									fields: ["connectionId", "externalId"],
+									name: "directory_identity_uidx",
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		};
+
+		await expect(getMigrations(config)).rejects.toThrow(
+			'Database index "directory_identity_uidx" on table "directory_user" does not match the configured fields and uniqueness.',
+		);
+	});
+});

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -5,7 +5,14 @@ import {
 	initGetFieldName,
 	initGetModelName,
 } from "@better-auth/core/db/adapter";
+import type { ResolvedDBTableIndex } from "@better-auth/core/db/internal";
+import {
+	getDatabaseFieldIndexName,
+	getDatabaseIndexStringLength,
+	getPortableDatabaseIdentifierKey,
+} from "@better-auth/core/db/internal";
 import { createLogger } from "@better-auth/core/env";
+import { BetterAuthError } from "@better-auth/core/error";
 import type { KyselyDatabaseType } from "@better-auth/kysely-adapter";
 import { createKyselyAdapter } from "@better-auth/kysely-adapter";
 import type {
@@ -18,6 +25,8 @@ import type {
 } from "kysely";
 import { sql } from "kysely";
 import { getSchema } from "./get-schema";
+
+// cspell:ignore attnum attrelid indisunique indisvalid indexrelid indnkeyatts ordinality seqno
 
 const postgresMap = {
 	string: ["character varying", "varchar", "text", "uuid"],
@@ -72,6 +81,381 @@ const map = {
 	sqlite: sqliteMap,
 	mssql: mssqlMap,
 };
+
+interface DatabaseIndexRow {
+	columnName?: string;
+	column_name?: string;
+	COLUMN_NAME?: string | null;
+	columnPosition?: number | string;
+	column_position?: number | string;
+	isDisabled?: boolean | number | string;
+	isHypothetical?: boolean | number | string;
+	isPartial?: boolean | number | string;
+	indexName?: string;
+	index_name?: string;
+	INDEX_NAME?: string;
+	isUnique?: boolean | number | string;
+	is_unique?: boolean | number | string;
+	isValid?: boolean | number | string;
+	keyOrdinal?: number | string;
+	key_ordinal?: number | string;
+	name?: string;
+	nonUnique?: boolean | number | string;
+	non_unique?: boolean | number | string;
+	NON_UNIQUE?: boolean | number | string;
+	ordinality?: number | string;
+	prefixLength?: number | string | null;
+	seqInIndex?: number | string;
+	seq_in_index?: number | string;
+	SEQ_IN_INDEX?: number | string;
+	seqno?: number | string;
+	tableName?: string;
+	table_name?: string;
+	TABLE_NAME?: string;
+	tablename?: string;
+	tbl_name?: string;
+}
+
+interface DatabaseIndexDefinition {
+	columns: readonly string[];
+	name: string;
+	table: string;
+	unique: boolean;
+	validFullColumns: boolean;
+}
+
+interface DatabaseColumnRow {
+	characterMaximumLength?: number | string | null;
+	CHARACTER_MAXIMUM_LENGTH?: number | string | null;
+	columnName?: string;
+	COLUMN_NAME?: string;
+	dataType?: string;
+	DATA_TYPE?: string;
+	maxLength?: number | string;
+	tableName?: string;
+	TABLE_NAME?: string;
+}
+
+interface DatabaseColumnBound {
+	maxIndexBytes: number | null;
+}
+
+function createDatabaseIndexKey(tableName: string, indexName: string) {
+	return `${getPortableDatabaseIdentifierKey(tableName)}\u0000${getPortableDatabaseIdentifierKey(indexName)}`;
+}
+
+function createDatabaseColumnKey(tableName: string, columnName: string) {
+	return `${tableName}\u0000${columnName}`;
+}
+
+function databaseIndexMatches(
+	existing: DatabaseIndexDefinition,
+	configured: ResolvedDBTableIndex,
+) {
+	return (
+		existing.unique === (configured.unique ?? false) &&
+		existing.validFullColumns &&
+		existing.columns.length === configured.columns.length &&
+		existing.columns.every(
+			(column, position) => column === configured.columns[position],
+		)
+	);
+}
+
+function databaseValueIsTrue(value: boolean | number | string | undefined) {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "number") return value !== 0;
+	return value === "1" || value?.toLowerCase() === "true" || value === "t";
+}
+
+async function getDatabaseIndexes(
+	db: Kysely<unknown>,
+	dbType: KyselyDatabaseType,
+	postgresSchema: string,
+) {
+	let rows: readonly DatabaseIndexRow[];
+	if (dbType === "sqlite") {
+		rows = (
+			await sql<DatabaseIndexRow>`
+				SELECT
+					tables.name AS "tableName",
+					index_list.name AS "indexName",
+					index_info.name AS "columnName",
+					index_list."unique" AS "isUnique",
+					index_list.partial AS "isPartial",
+					index_info.seqno AS "columnPosition"
+				FROM sqlite_master AS tables
+				INNER JOIN pragma_index_list(tables.name) AS index_list
+				INNER JOIN pragma_index_info(index_list.name) AS index_info
+				WHERE tables.type = 'table'
+			`.execute(db)
+		).rows;
+	} else if (dbType === "postgres") {
+		rows = (
+			await sql<DatabaseIndexRow>`
+				SELECT
+					table_class.relname AS "tableName",
+					index_class.relname AS "indexName",
+					index_attribute.attname AS "columnName",
+					index_data.indisunique AS "isUnique",
+					index_data.indisvalid AS "isValid",
+					(index_data.indpred IS NOT NULL) AS "isPartial",
+					index_column.ordinality AS "columnPosition"
+				FROM pg_class AS table_class
+				INNER JOIN pg_namespace AS table_namespace
+					ON table_namespace.oid = table_class.relnamespace
+				INNER JOIN pg_index AS index_data
+					ON index_data.indrelid = table_class.oid
+				INNER JOIN pg_class AS index_class
+					ON index_class.oid = index_data.indexrelid
+				INNER JOIN LATERAL unnest(index_data.indkey)
+					WITH ORDINALITY AS index_column(attribute_number, ordinality)
+					ON TRUE
+				LEFT JOIN pg_attribute AS index_attribute
+					ON index_attribute.attrelid = table_class.oid
+					AND index_attribute.attnum = index_column.attribute_number
+				WHERE table_namespace.nspname = ${postgresSchema}
+					AND table_class.relkind = 'r'
+					AND index_column.ordinality <= index_data.indnkeyatts
+			`.execute(db)
+		).rows;
+	} else if (dbType === "mysql") {
+		rows = (
+			await sql<DatabaseIndexRow>`
+				SELECT
+					table_name AS tableName,
+					index_name AS indexName,
+					column_name AS columnName,
+					non_unique AS nonUnique,
+					seq_in_index AS columnPosition,
+					sub_part AS prefixLength
+				FROM information_schema.statistics
+				WHERE table_schema = DATABASE()
+			`.execute(db)
+		).rows;
+	} else {
+		rows = (
+			await sql<DatabaseIndexRow>`
+				SELECT
+					tables.name AS "tableName",
+					indexes.name AS "indexName",
+					columns.name AS "columnName",
+					indexes.is_unique AS "isUnique",
+					indexes.is_disabled AS "isDisabled",
+					indexes.is_hypothetical AS "isHypothetical",
+					indexes.has_filter AS "isPartial",
+					index_columns.key_ordinal AS "columnPosition"
+				FROM sys.indexes AS indexes
+				INNER JOIN sys.tables AS tables
+					ON indexes.object_id = tables.object_id
+				INNER JOIN sys.index_columns AS index_columns
+					ON index_columns.object_id = indexes.object_id
+					AND index_columns.index_id = indexes.index_id
+				INNER JOIN sys.columns AS columns
+					ON columns.object_id = index_columns.object_id
+					AND columns.column_id = index_columns.column_id
+				WHERE indexes.name IS NOT NULL
+					AND index_columns.key_ordinal > 0
+			`.execute(db)
+		).rows;
+	}
+
+	const indexRows = new Map<
+		string,
+		{
+			columns: { name: string; position: number }[];
+			name: string;
+			table: string;
+			unique: boolean;
+			validFullColumns: boolean;
+		}
+	>();
+	for (const row of rows) {
+		const table =
+			row.tableName ??
+			row.table_name ??
+			row.TABLE_NAME ??
+			row.tablename ??
+			row.tbl_name;
+		const name = row.indexName ?? row.index_name ?? row.INDEX_NAME ?? row.name;
+		const column = row.columnName ?? row.column_name ?? row.COLUMN_NAME;
+		if (!table || !name) continue;
+		const key = createDatabaseIndexKey(table, name);
+		const nonUnique = row.nonUnique ?? row.non_unique ?? row.NON_UNIQUE;
+		const unique =
+			nonUnique === undefined
+				? databaseValueIsTrue(row.isUnique ?? row.is_unique)
+				: !databaseValueIsTrue(nonUnique);
+		const position = Number(
+			row.columnPosition ??
+				row.column_position ??
+				row.keyOrdinal ??
+				row.key_ordinal ??
+				row.ordinality ??
+				row.seqInIndex ??
+				row.seq_in_index ??
+				row.SEQ_IN_INDEX ??
+				row.seqno ??
+				0,
+		);
+		const index = indexRows.get(key) ?? {
+			columns: [],
+			name,
+			table,
+			unique,
+			validFullColumns: true,
+		};
+		if (column) {
+			index.columns.push({ name: column, position });
+		} else {
+			index.validFullColumns = false;
+		}
+		if (
+			databaseValueIsTrue(row.isPartial) ||
+			databaseValueIsTrue(row.isDisabled) ||
+			databaseValueIsTrue(row.isHypothetical) ||
+			(row.isValid !== undefined && !databaseValueIsTrue(row.isValid)) ||
+			(row.prefixLength !== undefined && row.prefixLength !== null)
+		) {
+			index.validFullColumns = false;
+		}
+		indexRows.set(key, index);
+	}
+
+	return new Map<string, DatabaseIndexDefinition>(
+		[...indexRows].map(([key, index]) => [
+			key,
+			{
+				columns: index.columns
+					.sort((left, right) => left.position - right.position)
+					.map((column) => column.name),
+				name: index.name,
+				table: index.table,
+				unique: index.unique,
+				validFullColumns: index.validFullColumns,
+			},
+		]),
+	);
+}
+
+async function getDatabaseColumnBounds(
+	db: Kysely<unknown>,
+	dbType: KyselyDatabaseType,
+) {
+	if (dbType !== "mysql" && dbType !== "mssql") {
+		return new Map<string, DatabaseColumnBound>();
+	}
+
+	let rows: readonly DatabaseColumnRow[];
+	if (dbType === "mysql") {
+		rows = (
+			await sql<DatabaseColumnRow>`
+				SELECT
+					table_name AS tableName,
+					column_name AS columnName,
+					data_type AS dataType,
+					character_maximum_length AS characterMaximumLength
+				FROM information_schema.columns
+				WHERE table_schema = DATABASE()
+			`.execute(db)
+		).rows;
+	} else {
+		rows = (
+			await sql<DatabaseColumnRow>`
+				SELECT
+					tables.name AS "tableName",
+					columns.name AS "columnName",
+					types.name AS "dataType",
+					columns.max_length AS "maxLength"
+				FROM sys.columns AS columns
+				INNER JOIN sys.tables AS tables
+					ON tables.object_id = columns.object_id
+				INNER JOIN sys.types AS types
+					ON types.user_type_id = columns.user_type_id
+			`.execute(db)
+		).rows;
+	}
+
+	return new Map(
+		rows.flatMap((row) => {
+			const table = row.tableName ?? row.TABLE_NAME;
+			const column = row.columnName ?? row.COLUMN_NAME;
+			const dataType = (row.dataType ?? row.DATA_TYPE)?.toLowerCase();
+			if (!table || !column || !dataType) return [];
+
+			if (dbType === "mysql") {
+				const characterLength =
+					row.characterMaximumLength ?? row.CHARACTER_MAXIMUM_LENGTH;
+				const maxIndexBytes =
+					characterLength === null || characterLength === undefined
+						? null
+						: Number(characterLength) * 4;
+				return [
+					[createDatabaseColumnKey(table, column), { maxIndexBytes }] as const,
+				];
+			}
+
+			const maxLength = Number(row.maxLength ?? -1);
+			return [
+				[
+					createDatabaseColumnKey(table, column),
+					{ maxIndexBytes: maxLength < 0 ? null : maxLength },
+				] as const,
+			];
+		}),
+	);
+}
+
+function assertExistingTableIndexFits({
+	columnBounds,
+	dbType,
+	existingColumns,
+	fields,
+	indexes,
+	index,
+	table,
+}: {
+	columnBounds: ReadonlyMap<string, DatabaseColumnBound>;
+	dbType: "mssql" | "mysql";
+	existingColumns: ReadonlySet<string>;
+	fields: Readonly<Record<string, DBFieldAttribute>>;
+	indexes: readonly ResolvedDBTableIndex[];
+	index: ResolvedDBTableIndex;
+	table: string;
+}) {
+	const byteBudget = dbType === "mysql" ? 3072 : 1700;
+	let requiredBytes = 0;
+	for (const column of index.columns) {
+		const field = fields[column];
+		if (!field) continue;
+		if (field.type === "string" || Array.isArray(field.type)) {
+			if (!existingColumns.has(column)) {
+				const generatedLength = getDatabaseIndexStringLength({
+					columnName: column,
+					dialect: dbType,
+					fields,
+					indexes,
+				});
+				requiredBytes += (generatedLength ?? 0) * (dbType === "mysql" ? 4 : 1);
+				continue;
+			}
+			const bound = columnBounds.get(createDatabaseColumnKey(table, column));
+			if (!bound?.maxIndexBytes) {
+				throw new BetterAuthError(
+					`Cannot create database index "${index.name}" on existing table "${table}" because column "${column}" is not bounded for ${dbType === "mysql" ? "MySQL" : "SQL Server"}. Change it to a bounded string column, resolve oversized values, then run the migration again.`,
+				);
+			}
+			requiredBytes += bound.maxIndexBytes;
+		} else {
+			requiredBytes += 16;
+		}
+	}
+	if (requiredBytes > byteBudget) {
+		throw new BetterAuthError(
+			`Cannot create database index "${index.name}" on existing table "${table}" because its columns can exceed ${dbType === "mysql" ? "MySQL" : "SQL Server"}'s ${byteBudget}-byte index-key limit. Bound the indexed string columns to the generated schema lengths, resolve oversized values, then run the migration again.`,
+		);
+	}
+}
 
 export function matchType(
 	columnDataType: string,
@@ -176,6 +560,8 @@ export async function getMigrations(config: BetterAuthOptions) {
 	}
 
 	const allTableMetadata = await db.introspection.getTables();
+	const databaseIndexes = await getDatabaseIndexes(db, dbType, currentSchema);
+	const databaseColumnBounds = await getDatabaseColumnBounds(db, dbType);
 
 	// For PostgreSQL, filter tables to only those in the target schema
 	let tableMetadata = allTableMetadata;
@@ -222,12 +608,74 @@ export async function getMigrations(config: BetterAuthOptions) {
 		fields: Record<string, DBFieldAttribute>;
 		order: number;
 	}[] = [];
+	const toBeAddedIndexes: {
+		table: string;
+		index: ResolvedDBTableIndex;
+		name: string;
+	}[] = [];
+	const plannedIndexes = new Map<string, ResolvedDBTableIndex>();
 
 	for (const [key, value] of Object.entries(betterAuthSchema)) {
 		if (value.disableMigrations) {
 			continue;
 		}
-		const table = tableMetadata.find((t) => t.name === key);
+		const table = tableMetadata.find((table) => table.name === key);
+		for (const index of value.indexes ?? []) {
+			const name = index.name;
+			const indexKey = createDatabaseIndexKey(key, name);
+			const existingIndex = databaseIndexes.get(indexKey);
+			if (existingIndex) {
+				if (!databaseIndexMatches(existingIndex, index)) {
+					throw new BetterAuthError(
+						`Database index "${name}" on table "${key}" does not match the configured fields and uniqueness. Rename or replace the existing index, then run the migration again.`,
+					);
+				}
+				continue;
+			}
+			if (dbType === "sqlite" || dbType === "postgres") {
+				const indexOnAnotherTable = [...databaseIndexes.values()].find(
+					(databaseIndex) =>
+						getPortableDatabaseIdentifierKey(databaseIndex.name) ===
+							getPortableDatabaseIdentifierKey(name) &&
+						getPortableDatabaseIdentifierKey(databaseIndex.table) !==
+							getPortableDatabaseIdentifierKey(key),
+				);
+				if (indexOnAnotherTable) {
+					throw new BetterAuthError(
+						`Database index name "${name}" is already used by table "${indexOnAnotherTable.table}". Index names must be unique across the schema.`,
+					);
+				}
+			}
+			const plannedIndex = plannedIndexes.get(indexKey);
+			if (plannedIndex) {
+				const plannedDefinition: DatabaseIndexDefinition = {
+					columns: plannedIndex.columns,
+					name: plannedIndex.name,
+					table: key,
+					unique: plannedIndex.unique ?? false,
+					validFullColumns: true,
+				};
+				if (!databaseIndexMatches(plannedDefinition, index)) {
+					throw new BetterAuthError(
+						`Database index name "${name}" identifies more than one index on table "${key}".`,
+					);
+				}
+				continue;
+			}
+			if (table && (dbType === "mysql" || dbType === "mssql")) {
+				assertExistingTableIndexFits({
+					columnBounds: databaseColumnBounds,
+					dbType,
+					existingColumns: new Set(table.columns.map((column) => column.name)),
+					fields: value.fields,
+					index,
+					indexes: value.indexes ?? [],
+					table: key,
+				});
+			}
+			plannedIndexes.set(indexKey, index);
+			toBeAddedIndexes.push({ table: key, index, name });
+		}
 		if (!table) {
 			const tIndex = toBeCreated.findIndex((t) => t.table === key);
 			const tableData = {
@@ -288,7 +736,11 @@ export async function getMigrations(config: BetterAuthOptions) {
 	const useUUIDs = config.advanced?.database?.generateId === "uuid";
 	const useNumberId = config.advanced?.database?.generateId === "serial";
 
-	function getType(field: DBFieldAttribute, fieldName: string) {
+	function getType(
+		field: DBFieldAttribute,
+		fieldName: string,
+		tableIndexStringLength?: number | undefined,
+	) {
 		const type = field.type;
 		const provider = dbType || "sqlite";
 		type StringOnlyUnion<T> = T extends string ? T : never;
@@ -299,17 +751,20 @@ export async function getMigrations(config: BetterAuthOptions) {
 			string: {
 				sqlite: "text",
 				postgres: "text",
-				mysql: field.unique
-					? "varchar(255)"
-					: field.references
-						? "varchar(36)"
-						: field.sortable
-							? "varchar(255)"
-							: field.index
+				mysql: tableIndexStringLength
+					? `varchar(${tableIndexStringLength})`
+					: field.unique
+						? "varchar(255)"
+						: field.references
+							? "varchar(36)"
+							: field.sortable
 								? "varchar(255)"
-								: "text",
-				mssql:
-					field.unique || field.sortable
+								: field.index
+									? "varchar(255)"
+									: "text",
+				mssql: tableIndexStringLength
+					? `varchar(${tableIndexStringLength})`
+					: field.unique || field.sortable
 						? "varchar(255)"
 						: field.references
 							? "varchar(36)"
@@ -428,17 +883,36 @@ export async function getMigrations(config: BetterAuthOptions) {
 	// Indexes are collected separately and appended last to ensure all
 	// referenced columns/tables exist before any CREATE INDEX executes.
 	const deferredIndexes: CreateIndexBuilder[] = [];
+	const getTableIndexStringLength = (tableName: string, fieldName: string) => {
+		if (dbType !== "mysql" && dbType !== "mssql") return undefined;
+		const table = betterAuthSchema[tableName];
+		if (!table) return undefined;
+		return getDatabaseIndexStringLength({
+			columnName: fieldName,
+			dialect: dbType,
+			fields: table.fields,
+			indexes: table.indexes ?? [],
+		});
+	};
 
 	if (toBeAdded.length) {
 		for (const table of toBeAdded) {
 			for (const [fieldName, field] of Object.entries(table.fields)) {
-				const type = getType(field, fieldName);
+				const type = getType(
+					field,
+					fieldName,
+					getTableIndexStringLength(table.table, fieldName),
+				);
 				const builder = db.schema.alterTable(table.table);
 
 				// SQLite cannot add a column with an inline UNIQUE constraint, so a
 				// unique field is enforced with a separate index in the ALTER path.
 				if (field.index || field.unique) {
-					const indexName = `${table.table}_${fieldName}_${field.unique ? "uidx" : "idx"}`;
+					const indexName = getDatabaseFieldIndexName(
+						table.table,
+						fieldName,
+						field.unique ?? false,
+					);
 					let indexBuilder = db.schema
 						.createIndex(indexName)
 						.on(table.table)
@@ -549,7 +1023,11 @@ export async function getMigrations(config: BetterAuthOptions) {
 				});
 
 			for (const [fieldName, field] of Object.entries(table.fields)) {
-				const type = getType(field, fieldName);
+				const type = getType(
+					field,
+					fieldName,
+					getTableIndexStringLength(table.table, fieldName),
+				);
 				dbT = dbT.addColumn(fieldName, type, (col) => {
 					col = field.required !== false ? col.notNull() : col;
 					if (field.references) {
@@ -583,7 +1061,11 @@ export async function getMigrations(config: BetterAuthOptions) {
 				if (field.index) {
 					const builder = db.schema
 						.createIndex(
-							`${table.table}_${fieldName}_${field.unique ? "uidx" : "idx"}`,
+							getDatabaseFieldIndexName(
+								table.table,
+								fieldName,
+								field.unique ?? false,
+							),
 						)
 						.on(table.table)
 						.columns([fieldName]);
@@ -592,6 +1074,17 @@ export async function getMigrations(config: BetterAuthOptions) {
 			}
 			migrations.push(dbT);
 		}
+	}
+
+	for (const { table, index, name } of toBeAddedIndexes) {
+		let builder = db.schema
+			.createIndex(name)
+			.on(table)
+			.columns([...index.columns]);
+		if (index.unique) {
+			builder = builder.unique();
+		}
+		deferredIndexes.push(builder);
 	}
 
 	for (const index of deferredIndexes) {
@@ -607,5 +1100,11 @@ export async function getMigrations(config: BetterAuthOptions) {
 		const compiled = migrations.map((m) => m.compile().sql);
 		return compiled.join(";\n\n") + ";";
 	}
-	return { toBeCreated, toBeAdded, runMigrations, compileMigrations };
+	return {
+		toBeCreated,
+		toBeAdded,
+		toBeAddedIndexes,
+		runMigrations,
+		compileMigrations,
+	};
 }

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -171,7 +171,7 @@ function databaseValueIsTrue(value: boolean | number | string | undefined) {
 async function getDatabaseIndexes(
 	db: Kysely<unknown>,
 	dbType: KyselyDatabaseType,
-	postgresSchema: string,
+	schemaName: string,
 ) {
 	let rows: readonly DatabaseIndexRow[];
 	if (dbType === "sqlite") {
@@ -214,7 +214,7 @@ async function getDatabaseIndexes(
 				LEFT JOIN pg_attribute AS index_attribute
 					ON index_attribute.attrelid = table_class.oid
 					AND index_attribute.attnum = index_column.attribute_number
-				WHERE table_namespace.nspname = ${postgresSchema}
+				WHERE table_namespace.nspname = ${schemaName}
 					AND table_class.relkind = 'r'
 					AND index_column.ordinality <= index_data.indnkeyatts
 			`.execute(db)
@@ -248,13 +248,16 @@ async function getDatabaseIndexes(
 				FROM sys.indexes AS indexes
 				INNER JOIN sys.tables AS tables
 					ON indexes.object_id = tables.object_id
+				INNER JOIN sys.schemas AS table_schemas
+					ON table_schemas.schema_id = tables.schema_id
 				INNER JOIN sys.index_columns AS index_columns
 					ON index_columns.object_id = indexes.object_id
 					AND index_columns.index_id = indexes.index_id
 				INNER JOIN sys.columns AS columns
 					ON columns.object_id = index_columns.object_id
 					AND columns.column_id = index_columns.column_id
-				WHERE indexes.name IS NOT NULL
+				WHERE table_schemas.name = ${schemaName}
+					AND indexes.name IS NOT NULL
 					AND index_columns.key_ordinal > 0
 			`.execute(db)
 		).rows;
@@ -341,6 +344,7 @@ async function getDatabaseIndexes(
 async function getDatabaseColumnBounds(
 	db: Kysely<unknown>,
 	dbType: KyselyDatabaseType,
+	schemaName: string,
 ) {
 	if (dbType !== "mysql" && dbType !== "mssql") {
 		return new Map<string, DatabaseColumnBound>();
@@ -370,8 +374,11 @@ async function getDatabaseColumnBounds(
 				FROM sys.columns AS columns
 				INNER JOIN sys.tables AS tables
 					ON tables.object_id = columns.object_id
+				INNER JOIN sys.schemas AS table_schemas
+					ON table_schemas.schema_id = tables.schema_id
 				INNER JOIN sys.types AS types
 					ON types.user_type_id = columns.user_type_id
+				WHERE table_schemas.name = ${schemaName}
 			`.execute(db)
 		).rows;
 	}
@@ -506,6 +513,17 @@ async function getPostgresSchema(db: Kysely<unknown>): Promise<string> {
 	return "public";
 }
 
+async function getMssqlSchema(db: Kysely<unknown>): Promise<string> {
+	try {
+		const result = await sql<{ schemaName?: string }>`
+			SELECT SCHEMA_NAME() AS "schemaName"
+		`.execute(db);
+		return result.rows[0]?.schemaName || "dbo";
+	} catch {
+		return "dbo";
+	}
+}
+
 export async function getMigrations(config: BetterAuthOptions) {
 	const betterAuthSchema = getSchema(config);
 	const logger = createLogger(config.logger);
@@ -526,8 +544,7 @@ export async function getMigrations(config: BetterAuthOptions) {
 		process.exit(1);
 	}
 
-	// For PostgreSQL, detect and log the current schema being used
-	let currentSchema = "public";
+	let currentSchema = dbType === "mssql" ? await getMssqlSchema(db) : "public";
 	if (dbType === "postgres") {
 		currentSchema = await getPostgresSchema(db);
 		logger.debug(
@@ -557,13 +574,21 @@ export async function getMigrations(config: BetterAuthOptions) {
 				`Could not verify schema existence: ${error instanceof Error ? error.message : String(error)}`,
 			);
 		}
+	} else if (dbType === "mssql") {
+		logger.debug(
+			`SQL Server migration: Using schema '${currentSchema}' (from the current user's default schema)`,
+		);
 	}
 
 	const allTableMetadata = await db.introspection.getTables();
 	const databaseIndexes = await getDatabaseIndexes(db, dbType, currentSchema);
-	const databaseColumnBounds = await getDatabaseColumnBounds(db, dbType);
+	const databaseColumnBounds = await getDatabaseColumnBounds(
+		db,
+		dbType,
+		currentSchema,
+	);
 
-	// For PostgreSQL, filter tables to only those in the target schema
+	// Filter introspected tables to the schema used by unqualified migrations.
 	let tableMetadata = allTableMetadata;
 	if (dbType === "postgres") {
 		// Get tables with their schema information
@@ -597,6 +622,10 @@ export async function getMigrations(config: BetterAuthOptions) {
 			);
 			// Fall back to using all tables if schema filtering fails
 		}
+	} else if (dbType === "mssql") {
+		tableMetadata = allTableMetadata.filter(
+			(table) => table.schema === currentSchema,
+		);
 	}
 	const toBeCreated: {
 		table: string;

--- a/packages/better-auth/src/db/get-schema.ts
+++ b/packages/better-auth/src/db/get-schema.ts
@@ -1,11 +1,10 @@
 import type { BetterAuthOptions } from "@better-auth/core";
 import type { DBFieldAttribute } from "@better-auth/core/db";
-import { getAuthTables } from "@better-auth/core/db";
 import type { ResolvedDBTableIndex } from "@better-auth/core/db/internal";
-import { resolveDatabaseSchemaIndexes } from "@better-auth/core/db/internal";
+import { getAuthTablesWithResolvedIndexes } from "@better-auth/core/db/internal";
 
 export function getSchema(config: BetterAuthOptions) {
-	const tables = getAuthTables(config);
+	const { indexesByTable, tables } = getAuthTablesWithResolvedIndexes(config);
 	const schema: Record<
 		string,
 		{
@@ -15,15 +14,6 @@ export function getSchema(config: BetterAuthOptions) {
 			disableMigrations?: boolean | undefined;
 		}
 	> = {};
-	const resolvedIndexesByTable = resolveDatabaseSchemaIndexes(
-		Object.values(tables)
-			.filter((table) => !table.disableMigrations)
-			.map((table) => ({
-				fields: table.fields,
-				indexes: table.indexes,
-				tableName: table.modelName,
-			})),
-	);
 	for (const key in tables) {
 		const table = tables[key]!;
 		const fields = table.fields;
@@ -57,7 +47,7 @@ export function getSchema(config: BetterAuthOptions) {
 			disableMigrations: table.disableMigrations,
 		};
 	}
-	for (const [tableName, indexes] of resolvedIndexesByTable) {
+	for (const [tableName, indexes] of indexesByTable) {
 		if (schema[tableName]) {
 			schema[tableName].indexes = indexes;
 		}

--- a/packages/better-auth/src/db/get-schema.ts
+++ b/packages/better-auth/src/db/get-schema.ts
@@ -1,6 +1,8 @@
 import type { BetterAuthOptions } from "@better-auth/core";
 import type { DBFieldAttribute } from "@better-auth/core/db";
 import { getAuthTables } from "@better-auth/core/db";
+import type { ResolvedDBTableIndex } from "@better-auth/core/db/internal";
+import { resolveDatabaseSchemaIndexes } from "@better-auth/core/db/internal";
 
 export function getSchema(config: BetterAuthOptions) {
 	const tables = getAuthTables(config);
@@ -8,10 +10,20 @@ export function getSchema(config: BetterAuthOptions) {
 		string,
 		{
 			fields: Record<string, DBFieldAttribute>;
+			indexes?: readonly ResolvedDBTableIndex[] | undefined;
 			order: number;
 			disableMigrations?: boolean | undefined;
 		}
 	> = {};
+	const resolvedIndexesByTable = resolveDatabaseSchemaIndexes(
+		Object.values(tables)
+			.filter((table) => !table.disableMigrations)
+			.map((table) => ({
+				fields: table.fields,
+				indexes: table.indexes,
+				tableName: table.modelName,
+			})),
+	);
 	for (const key in tables) {
 		const table = tables[key]!;
 		const fields = table.fields;
@@ -44,6 +56,11 @@ export function getSchema(config: BetterAuthOptions) {
 			order: table.order || Infinity,
 			disableMigrations: table.disableMigrations,
 		};
+	}
+	for (const [tableName, indexes] of resolvedIndexesByTable) {
+		if (schema[tableName]) {
+			schema[tableName].indexes = indexes;
+		}
 	}
 	return schema;
 }

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -102,9 +102,10 @@ export async function migrateAction(opts: any) {
 
 	const spinner = yoctoSpinner({ text: "preparing migration..." }).start();
 
-	const { toBeAdded, toBeCreated, runMigrations } = await getMigrations(config);
+	const { toBeAdded, toBeAddedIndexes, toBeCreated, runMigrations } =
+		await getMigrations(config);
 
-	if (!toBeAdded.length && !toBeCreated.length) {
+	if (!toBeAdded.length && !toBeAddedIndexes.length && !toBeCreated.length) {
 		spinner.stop();
 		console.log("🚀 No migrations needed.");
 		try {
@@ -129,6 +130,17 @@ export async function migrateAction(opts: any) {
 			chalk.magenta(Object.keys(table.fields).join(", ")),
 			chalk.white("fields on"),
 			chalk.yellow(`${table.table}`),
+			chalk.white("table."),
+		);
+	}
+	for (const { index, table } of toBeAddedIndexes) {
+		console.log(
+			"->",
+			chalk.magenta(index.columns.join(", ")),
+			chalk.white(
+				index.unique ? "fields in a unique index on" : "fields indexed on",
+			),
+			chalk.yellow(table),
 			chalk.white("table."),
 		);
 	}

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -1,4 +1,9 @@
 import { existsSync } from "node:fs";
+import {
+	getDatabaseFieldIndexName,
+	getDatabaseIndexStringLength,
+	resolveDatabaseSchemaIndexes,
+} from "@better-auth/core/db/internal";
 import { toSnakeCase } from "@better-auth/core/utils/string";
 import { initGetFieldName, initGetModelName } from "better-auth/adapters";
 import type { BetterAuthDBSchema, DBFieldAttribute } from "better-auth/db";
@@ -91,6 +96,15 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				model === getModelName(customModelName)
 			);
 		});
+	const resolvedIndexesByTable = resolveDatabaseSchemaIndexes(
+		Object.keys(tables)
+			.filter((tableKey) => !isMigrationDisabled(tableKey))
+			.map((tableKey) => ({
+				fields: tables[tableKey]!.fields,
+				indexes: tables[tableKey]!.indexes,
+				tableName: getModelName(tableKey),
+			})),
+	);
 
 	for (const tableKey in tables) {
 		const table = tables[tableKey]!;
@@ -99,8 +113,13 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 		}
 		const modelName = getModelName(tableKey);
 		const fields = table.fields;
+		const resolvedTableIndexes = resolvedIndexesByTable.get(modelName) ?? [];
 
-		function getType(name: string, field: DBFieldAttribute) {
+		function getType(
+			name: string,
+			field: DBFieldAttribute,
+			tableIndexStringLength?: number | undefined,
+		) {
 			// Not possible to reach, it's here to make typescript happy
 			if (!databaseType) {
 				throw new Error(
@@ -152,15 +171,17 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				string: {
 					sqlite: `text('${name}')`,
 					pg: `text('${name}')`,
-					mysql: field.unique
-						? `varchar('${name}', { length: 255 })`
-						: field.references
-							? `varchar('${name}', { length: 36 })`
-							: field.sortable
-								? `varchar('${name}', { length: 255 })`
-								: field.index
+					mysql: tableIndexStringLength
+						? `varchar('${name}', { length: ${tableIndexStringLength} })`
+						: field.unique
+							? `varchar('${name}', { length: 255 })`
+							: field.references
+								? `varchar('${name}', { length: 36 })`
+								: field.sortable
 									? `varchar('${name}', { length: 255 })`
-									: `text('${name}')`,
+									: field.index
+										? `varchar('${name}', { length: 255 })`
+										: `text('${name}')`,
 				},
 				boolean: {
 					sqlite: `integer('${name}', { mode: 'boolean' })`,
@@ -235,7 +256,11 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			}
 		}
 
-		type Index = { type: "uniqueIndex" | "index"; name: string; on: string };
+		type Index = {
+			type: "uniqueIndex" | "index";
+			name: string;
+			on: readonly string[];
+		};
 
 		const indexes: Index[] = [];
 
@@ -245,13 +270,23 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			const code: string[] = [`, (table) => [`];
 
 			for (const index of indexes) {
-				code.push(`  ${index.type}("${index.name}").on(table.${index.on}),`);
+				code.push(
+					`  ${index.type}(${JSON.stringify(index.name)}).on(${index.on.map((fieldName) => `table.${fieldName}`).join(", ")}),`,
+				);
 			}
 
 			code.push(`]`);
 
 			return code.join("\n");
 		};
+
+		for (const tableIndex of resolvedTableIndexes) {
+			indexes.push({
+				type: tableIndex.unique ? "uniqueIndex" : "index",
+				name: tableIndex.name,
+				on: tableIndex.columns,
+			});
+		}
 
 		// Determine table function to use based on schema support
 		const tableFunction =
@@ -268,19 +303,30 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 						.map((field) => {
 							const attr = fields[field]!;
 							const fieldName = attr.fieldName || field;
-							let type = getType(fieldName, attr);
+							let type = getType(
+								fieldName,
+								attr,
+								databaseType === "mysql"
+									? getDatabaseIndexStringLength({
+											columnName: fieldName,
+											dialect: "mysql",
+											fields,
+											indexes: resolvedTableIndexes,
+										})
+									: undefined,
+							);
 
 							if (attr.index && !attr.unique) {
 								indexes.push({
 									type: "index",
-									name: `${modelName}_${fieldName}_idx`,
-									on: fieldName,
+									name: getDatabaseFieldIndexName(modelName, fieldName, false),
+									on: [fieldName],
 								});
 							} else if (attr.index && attr.unique) {
 								indexes.push({
 									type: "uniqueIndex",
-									name: `${modelName}_${fieldName}_uidx`,
-									on: fieldName,
+									name: getDatabaseFieldIndexName(modelName, fieldName, true),
+									on: [fieldName],
 								});
 							}
 
@@ -729,11 +775,19 @@ function generateImport({
 	}
 
 	//handle indexes
-	const hasIndexes = Object.values(tables).some((table) =>
-		Object.values(table.fields).some((field) => field.index && !field.unique),
+	const hasIndexes = Object.values(tables).some(
+		(table) =>
+			Object.values(table.fields).some(
+				(field) => field.index && !field.unique,
+			) ||
+			(table.indexes?.some((index) => !index.unique) ?? false),
 	);
-	const hasUniqueIndexes = Object.values(tables).some((table) =>
-		Object.values(table.fields).some((field) => field.unique && field.index),
+	const hasUniqueIndexes = Object.values(tables).some(
+		(table) =>
+			Object.values(table.fields).some(
+				(field) => field.unique && field.index,
+			) ||
+			(table.indexes?.some((index) => index.unique) ?? false),
 	);
 	if (hasIndexes) {
 		coreImports.push("index");

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { ResolvedDBTableIndex } from "@better-auth/core/db/internal";
 import {
 	getDatabaseIndexStringLength,
 	getPortableDatabaseIdentifierKey,
@@ -29,7 +30,17 @@ function parsePrismaStringLiteral(value: unknown) {
 	}
 }
 
-function getPrismaIndexDefinition(property: unknown) {
+interface PrismaIndexDefinition {
+	columns: readonly string[];
+	mappedName: string | undefined;
+	setMappedName: (name: string) => void;
+	unique: boolean;
+	validFullColumns: boolean;
+}
+
+function getPrismaIndexDefinition(
+	property: unknown,
+): PrismaIndexDefinition | undefined {
 	if (
 		!isRecord(property) ||
 		property.type !== "attribute" ||
@@ -39,11 +50,12 @@ function getPrismaIndexDefinition(property: unknown) {
 	) {
 		return undefined;
 	}
+	const propertyArgs = property.args;
 
 	let columns: readonly string[] | undefined;
-	let name: string | undefined;
+	let mappedName: string | undefined;
 	let validFullColumns = false;
-	for (const argument of property.args) {
+	for (const argument of propertyArgs) {
 		if (!isRecord(argument) || !isRecord(argument.value)) continue;
 		const value = argument.value;
 		if (
@@ -54,16 +66,39 @@ function getPrismaIndexDefinition(property: unknown) {
 			columns = value.args.map((column) => String(column));
 			validFullColumns = true;
 		} else if (value.type === "keyValue" && value.key === "map") {
-			name = parsePrismaStringLiteral(value.value);
+			mappedName = parsePrismaStringLiteral(value.value);
 		}
 	}
-	if (!name) return undefined;
 	return {
 		columns: columns ?? [],
-		name,
+		mappedName,
+		setMappedName(name) {
+			propertyArgs.push({
+				type: "attributeArgument",
+				value: {
+					type: "keyValue",
+					key: "map",
+					value: JSON.stringify(name),
+				},
+			});
+		},
 		unique: property.name === "unique",
 		validFullColumns,
 	};
+}
+
+function prismaIndexMatches(
+	existing: PrismaIndexDefinition,
+	configured: ResolvedDBTableIndex,
+) {
+	return (
+		existing.validFullColumns &&
+		existing.unique === (configured.unique ?? false) &&
+		existing.columns.length === configured.columns.length &&
+		existing.columns.every(
+			(column, position) => column === configured.columns[position],
+		)
+	);
 }
 
 export const generatePrismaSchema: SchemaGenerator = async ({
@@ -226,6 +261,9 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 				if (type === "string") {
 					return isOptional ? "String?" : "String";
 				}
+				if (Array.isArray(type)) {
+					return isOptional ? "String?" : "String";
+				}
 				if (type === "number" && isBigint) {
 					return isOptional ? "BigInt?" : "BigInt";
 				}
@@ -354,7 +392,12 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 								isAlreadyExist.array = fieldTypeParts.isArray || undefined;
 							}
 						}
-						if (provider === "mysql" && attr.type === "string") {
+						if (
+							provider === "mysql" &&
+							(attr.type === "string" || Array.isArray(attr.type)) &&
+							typeof isAlreadyExist.fieldType === "string" &&
+							getFieldTypeParts(isAlreadyExist.fieldType).fieldType === "String"
+						) {
 							const tableIndexStringLength = getDatabaseIndexStringLength({
 								columnName: fieldName,
 								dialect: "mysql",
@@ -519,7 +562,10 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 						)
 						.attribute(relationField);
 				}
-				if (provider === "mysql" && attr.type === "string") {
+				if (
+					provider === "mysql" &&
+					(attr.type === "string" || Array.isArray(attr.type))
+				) {
 					const tableIndexStringLength = getDatabaseIndexStringLength({
 						columnName: fieldName,
 						dialect: "mysql",
@@ -539,27 +585,33 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 
 			for (const tableIndex of resolvedTableIndexes) {
 				const attributeName = tableIndex.unique ? "unique" : "index";
-				const existingIndex = prismaModel?.properties
-					.map(getPrismaIndexDefinition)
-					.find(
-						(index) =>
-							index &&
-							getPortableDatabaseIdentifierKey(index.name) ===
-								getPortableDatabaseIdentifierKey(tableIndex.name),
-					);
-				if (existingIndex) {
-					const matches =
-						existingIndex.validFullColumns &&
-						existingIndex.unique === (tableIndex.unique ?? false) &&
-						existingIndex.columns.length === tableIndex.columns.length &&
-						existingIndex.columns.every(
-							(column, position) => column === tableIndex.columns[position],
-						);
-					if (!matches) {
+				const existingIndexes =
+					prismaModel?.properties
+						.map(getPrismaIndexDefinition)
+						.filter(
+							(index): index is PrismaIndexDefinition => index !== undefined,
+						) ?? [];
+				const existingMappedIndex = existingIndexes.find(
+					(index) =>
+						index.mappedName !== undefined &&
+						getPortableDatabaseIdentifierKey(index.mappedName) ===
+							getPortableDatabaseIdentifierKey(tableIndex.name),
+				);
+				if (existingMappedIndex) {
+					if (!prismaIndexMatches(existingMappedIndex, tableIndex)) {
 						throw new BetterAuthError(
 							`Prisma index "${tableIndex.name}" on model "${modelName}" does not match the configured fields and uniqueness. Rename or replace the existing index, then generate the schema again.`,
 						);
 					}
+					continue;
+				}
+				const existingUnmappedIndex = existingIndexes.find(
+					(index) =>
+						index.mappedName === undefined &&
+						prismaIndexMatches(index, tableIndex),
+				);
+				if (existingUnmappedIndex) {
+					existingUnmappedIndex.setMappedName(tableIndex.name);
 					continue;
 				}
 				builder

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -1,6 +1,12 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+	getDatabaseIndexStringLength,
+	getPortableDatabaseIdentifierKey,
+	resolveDatabaseSchemaIndexes,
+} from "@better-auth/core/db/internal";
+import { BetterAuthError } from "@better-auth/core/error";
 import { capitalizeFirstLetter } from "@better-auth/core/utils/string";
 import { produceSchema } from "@mrleebo/prisma-ast";
 import { initGetFieldName, initGetModelName } from "better-auth/adapters";
@@ -8,6 +14,57 @@ import type { DBFieldType } from "better-auth/db";
 import { getAuthTables } from "better-auth/db";
 import { getPrismaVersion } from "../utils/get-package-info";
 import type { SchemaGenerator } from "./types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parsePrismaStringLiteral(value: unknown) {
+	if (typeof value !== "string") return undefined;
+	try {
+		const parsed = JSON.parse(value);
+		return typeof parsed === "string" ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function getPrismaIndexDefinition(property: unknown) {
+	if (
+		!isRecord(property) ||
+		property.type !== "attribute" ||
+		property.kind !== "object" ||
+		(property.name !== "index" && property.name !== "unique") ||
+		!Array.isArray(property.args)
+	) {
+		return undefined;
+	}
+
+	let columns: readonly string[] | undefined;
+	let name: string | undefined;
+	let validFullColumns = false;
+	for (const argument of property.args) {
+		if (!isRecord(argument) || !isRecord(argument.value)) continue;
+		const value = argument.value;
+		if (
+			value.type === "array" &&
+			Array.isArray(value.args) &&
+			value.args.every((column) => typeof column === "string")
+		) {
+			columns = value.args.map((column) => String(column));
+			validFullColumns = true;
+		} else if (value.type === "keyValue" && value.key === "map") {
+			name = parsePrismaStringLiteral(value.value);
+		}
+	}
+	if (!name) return undefined;
+	return {
+		columns: columns ?? [],
+		name,
+		unique: property.name === "unique",
+		validFullColumns,
+	};
+}
 
 export const generatePrismaSchema: SchemaGenerator = async ({
 	adapter,
@@ -41,6 +98,18 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 				model === getModelName(customModelName)
 			);
 		});
+	const resolvedIndexesByTable = resolveDatabaseSchemaIndexes(
+		Object.keys(tables)
+			.filter((tableKey) => !isMigrationDisabled(tableKey))
+			.map((tableKey) => {
+				const customModelName = tables[tableKey]?.modelName || tableKey;
+				return {
+					fields: tables[tableKey]!.fields,
+					indexes: tables[tableKey]!.indexes,
+					tableName: getModelName(customModelName),
+				};
+			}),
+	);
 
 	let schemaPrisma = "";
 	if (schemaPrismaExist) {
@@ -143,6 +212,8 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 			const customModelName = tables[table]?.modelName || table;
 			const modelName = capitalizeFirstLetter(getModelName(customModelName));
 			const fields = tables[table]?.fields;
+			const resolvedTableIndexes =
+				resolvedIndexesByTable.get(getModelName(customModelName)) ?? [];
 			function getType({
 				isBigint,
 				isOptional,
@@ -281,6 +352,23 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 								isAlreadyExist.optional =
 									fieldTypeParts.isOptional || undefined;
 								isAlreadyExist.array = fieldTypeParts.isArray || undefined;
+							}
+						}
+						if (provider === "mysql" && attr.type === "string") {
+							const tableIndexStringLength = getDatabaseIndexStringLength({
+								columnName: fieldName,
+								dialect: "mysql",
+								fields: fields ?? {},
+								indexes: resolvedTableIndexes,
+							});
+							if (tableIndexStringLength) {
+								isAlreadyExist.attributes = isAlreadyExist.attributes?.filter(
+									(attribute) => attribute.group !== "db",
+								);
+								builder
+									.model(modelName)
+									.field(fieldName)
+									.attribute(`db.VarChar(${tableIndexStringLength})`);
 							}
 						}
 						continue;
@@ -431,14 +519,54 @@ export const generatePrismaSchema: SchemaGenerator = async ({
 						)
 						.attribute(relationField);
 				}
-				if (
-					!attr.unique &&
-					!attr.references &&
-					provider === "mysql" &&
-					attr.type === "string"
-				) {
-					builder.model(modelName).field(fieldName).attribute("db.Text");
+				if (provider === "mysql" && attr.type === "string") {
+					const tableIndexStringLength = getDatabaseIndexStringLength({
+						columnName: fieldName,
+						dialect: "mysql",
+						fields: fields ?? {},
+						indexes: resolvedTableIndexes,
+					});
+					const nativeType = tableIndexStringLength
+						? `db.VarChar(${tableIndexStringLength})`
+						: !attr.unique && !attr.references
+							? "db.Text"
+							: undefined;
+					if (nativeType) {
+						builder.model(modelName).field(fieldName).attribute(nativeType);
+					}
 				}
+			}
+
+			for (const tableIndex of resolvedTableIndexes) {
+				const attributeName = tableIndex.unique ? "unique" : "index";
+				const existingIndex = prismaModel?.properties
+					.map(getPrismaIndexDefinition)
+					.find(
+						(index) =>
+							index &&
+							getPortableDatabaseIdentifierKey(index.name) ===
+								getPortableDatabaseIdentifierKey(tableIndex.name),
+					);
+				if (existingIndex) {
+					const matches =
+						existingIndex.validFullColumns &&
+						existingIndex.unique === (tableIndex.unique ?? false) &&
+						existingIndex.columns.length === tableIndex.columns.length &&
+						existingIndex.columns.every(
+							(column, position) => column === tableIndex.columns[position],
+						);
+					if (!matches) {
+						throw new BetterAuthError(
+							`Prisma index "${tableIndex.name}" on model "${modelName}" does not match the configured fields and uniqueness. Rename or replace the existing index, then generate the schema again.`,
+						);
+					}
+					continue;
+				}
+				builder
+					.model(modelName)
+					.blockAttribute(
+						`${attributeName}([${tableIndex.columns.join(", ")}], map: ${JSON.stringify(tableIndex.name)})`,
+					);
 			}
 
 			// Add many-to-many fields

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -19,6 +19,36 @@ import { cliPath } from "./utils";
 
 const execFileAsync = promisify(execFile);
 
+const compoundIndexPlugin = (): BetterAuthPlugin => ({
+	id: "compound-index-test",
+	schema: {
+		directoryUser: {
+			modelName: "directory_user",
+			fields: {
+				connectionId: {
+					type: "string",
+					fieldName: "connection_id",
+				},
+				externalId: {
+					type: "string",
+					fieldName: "external_id",
+				},
+				status: {
+					type: "string",
+					fieldName: "provisioning_status",
+				},
+			},
+			indexes: [
+				{
+					fields: ["connectionId", "externalId"],
+					unique: true,
+				},
+				{ fields: ["connectionId", "status"] },
+			],
+		},
+	},
+});
+
 describe("generate", async () => {
 	describe("command output paths", () => {
 		it("should use adapter-specific filenames when output points to an existing directory", async () => {
@@ -122,6 +152,158 @@ export const auth = betterAuth({
 		await expect(schema.code).toMatchFileSnapshot(
 			"./__snapshots__/schema.prisma",
 		);
+	});
+
+	it("should generate Prisma compound indexes with physical field names", async () => {
+		const schema = await generatePrismaSchema({
+			file: "test.prisma",
+			adapter: prismaAdapter(
+				{},
+				{
+					provider: "mysql",
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: prismaAdapter(
+					{},
+					{
+						provider: "mysql",
+					},
+				),
+				plugins: [compoundIndexPlugin()],
+			},
+		});
+
+		expect(schema.code).toContain(
+			'@@unique([connection_id, external_id], map: "directory_user_connection_id_external_id_uidx")',
+		);
+		expect(schema.code).toContain(
+			'@@index([connection_id, provisioning_status], map: "directory_user_connection_id_provisioning_status_idx")',
+		);
+		expect(schema.code).toMatch(/connection_id\s+String\s+@db\.VarChar\(191\)/);
+		expect(schema.code).toMatch(/external_id\s+String\s+@db\.VarChar\(191\)/);
+	});
+
+	it("should bound existing MySQL string fields before adding compound indexes", async () => {
+		const tmpDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "prisma-compound-index-upgrade-"),
+		);
+		const filePath = path.join(tmpDir, "schema.prisma");
+		const relativePath = path.relative(process.cwd(), filePath);
+		fs.writeFileSync(
+			filePath,
+			`
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url = env("DATABASE_URL")
+}
+
+model Directory_user {
+  id                  String @id
+  connection_id       String @db.Text
+  external_id         String @db.Text
+  provisioning_status String @db.Text
+
+  @@map("directory_user")
+}
+`,
+		);
+
+		try {
+			const schema = await generatePrismaSchema({
+				file: relativePath,
+				adapter: prismaAdapter(
+					{},
+					{
+						provider: "mysql",
+					},
+				)({} as BetterAuthOptions),
+				options: {
+					database: prismaAdapter(
+						{},
+						{
+							provider: "mysql",
+						},
+					),
+					plugins: [compoundIndexPlugin()],
+				},
+			});
+
+			expect(schema.code).toMatch(
+				/connection_id\s+String\s+@db\.VarChar\(191\)/,
+			);
+			expect(schema.code).toMatch(/external_id\s+String\s+@db\.VarChar\(191\)/);
+			expect(schema.code).toMatch(
+				/provisioning_status\s+String\s+@db\.VarChar\(191\)/,
+			);
+			expect(schema.code).toContain(
+				'@@unique([connection_id, external_id], map: "directory_user_connection_id_external_id_uidx")',
+			);
+		} finally {
+			fs.rmSync(tmpDir, { force: true, recursive: true });
+		}
+	});
+
+	it("should reject a conflicting existing Prisma compound index", async () => {
+		const tmpDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "prisma-compound-index-"),
+		);
+		const filePath = path.join(tmpDir, "schema.prisma");
+		const relativePath = path.relative(process.cwd(), filePath);
+		fs.writeFileSync(
+			filePath,
+			`
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url = env("DATABASE_URL")
+}
+
+model Directory_user {
+  id                  String @id
+  connection_id       String
+  external_id         String
+  provisioning_status String
+
+  @@index([external_id], map: "Directory_User_Connection_Id_External_Id_UIDX")
+  @@map("directory_user")
+}
+`,
+		);
+
+		try {
+			await expect(
+				generatePrismaSchema({
+					file: relativePath,
+					adapter: prismaAdapter(
+						{},
+						{
+							provider: "mysql",
+						},
+					)({} as BetterAuthOptions),
+					options: {
+						database: prismaAdapter(
+							{},
+							{
+								provider: "mysql",
+							},
+						),
+						plugins: [compoundIndexPlugin()],
+					},
+				}),
+			).rejects.toThrow(
+				'Prisma index "directory_user_connection_id_external_id_uidx" on model "Directory_user" does not match the configured fields and uniqueness.',
+			);
+		} finally {
+			fs.rmSync(tmpDir, { force: true, recursive: true });
+		}
 	});
 
 	/**
@@ -416,6 +598,74 @@ export const auth = betterAuth({
 		});
 		await expect(schema.code).toMatchFileSnapshot(
 			"./__snapshots__/auth-schema.txt",
+		);
+	});
+
+	it("should generate Drizzle compound indexes with physical field names", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{
+					provider: "mysql",
+					schema: {},
+				},
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter(
+					{},
+					{
+						provider: "mysql",
+						schema: {},
+					},
+				),
+				plugins: [compoundIndexPlugin()],
+			},
+		});
+
+		expect(schema.code).toMatch(
+			/uniqueIndex\("directory_user_connection_id_external_id_uidx"\)\.on\(\s*table\.connection_id,\s*table\.external_id,?\s*\)/,
+		);
+		expect(schema.code).toMatch(
+			/index\("directory_user_connection_id_provisioning_status_idx"\)\.on\(\s*table\.connection_id,\s*table\.provisioning_status,?\s*\)/,
+		);
+		expect(schema.code).toMatch(
+			/connection_id:\s*varchar\(["']connection_id["'], \{ length: 191 \}\)/,
+		);
+		expect(schema.code).toMatch(
+			/external_id:\s*varchar\(["']external_id["'], \{ length: 191 \}\)/,
+		);
+	});
+
+	it("should reject duplicate Drizzle field-level and table-level indexes", async () => {
+		await expect(
+			generateDrizzleSchema({
+				file: "test.drizzle",
+				adapter: drizzleAdapter(
+					{},
+					{
+						provider: "sqlite",
+						schema: {},
+					},
+				)({} as BetterAuthOptions),
+				options: {
+					plugins: [
+						{
+							id: "directory",
+							schema: {
+								directoryUser: {
+									fields: {
+										subject: { type: "string", index: true },
+									},
+									indexes: [{ fields: ["subject"] }],
+								},
+							},
+						},
+					],
+				},
+			}),
+		).rejects.toThrow(
+			'Database index name "directoryUser_subject_idx" is already reserved by field-level index metadata on table "directoryUser".',
 		);
 	});
 

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -34,7 +34,7 @@ const compoundIndexPlugin = (): BetterAuthPlugin => ({
 					fieldName: "external_id",
 				},
 				status: {
-					type: "string",
+					type: ["active", "suspended"],
 					fieldName: "provisioning_status",
 				},
 			},
@@ -182,6 +182,9 @@ export const auth = betterAuth({
 		);
 		expect(schema.code).toMatch(/connection_id\s+String\s+@db\.VarChar\(191\)/);
 		expect(schema.code).toMatch(/external_id\s+String\s+@db\.VarChar\(191\)/);
+		expect(schema.code).toMatch(
+			/provisioning_status\s+String\s+@db\.VarChar\(191\)/,
+		);
 	});
 
 	it("should bound existing MySQL string fields before adding compound indexes", async () => {
@@ -300,6 +303,75 @@ model Directory_user {
 				}),
 			).rejects.toThrow(
 				'Prisma index "directory_user_connection_id_external_id_uidx" on model "Directory_user" does not match the configured fields and uniqueness.',
+			);
+		} finally {
+			fs.rmSync(tmpDir, { force: true, recursive: true });
+		}
+	});
+
+	it("should name matching existing Prisma compound indexes", async () => {
+		const tmpDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "prisma-compound-index-name-"),
+		);
+		const filePath = path.join(tmpDir, "schema.prisma");
+		const relativePath = path.relative(process.cwd(), filePath);
+		fs.writeFileSync(
+			filePath,
+			`
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mysql"
+  url = env("DATABASE_URL")
+}
+
+model Directory_user {
+  id                  String @id
+  connection_id       String
+  external_id         String
+  provisioning_status String
+
+  @@unique([connection_id, external_id])
+  @@index([connection_id, provisioning_status])
+  @@map("directory_user")
+}
+`,
+		);
+
+		try {
+			const schema = await generatePrismaSchema({
+				file: relativePath,
+				adapter: prismaAdapter(
+					{},
+					{
+						provider: "mysql",
+					},
+				)({} as BetterAuthOptions),
+				options: {
+					database: prismaAdapter(
+						{},
+						{
+							provider: "mysql",
+						},
+					),
+					plugins: [compoundIndexPlugin()],
+				},
+			});
+			const schemaCode = schema.code ?? "";
+
+			expect(
+				schemaCode.match(/@@unique\(\[connection_id, external_id\]/g),
+			).toHaveLength(1);
+			expect(
+				schemaCode.match(/@@index\(\[connection_id, provisioning_status\]/g),
+			).toHaveLength(1);
+			expect(schemaCode).toContain(
+				'@@unique([connection_id, external_id], map: "directory_user_connection_id_external_id_uidx")',
+			);
+			expect(schemaCode).toContain(
+				'@@index([connection_id, provisioning_status], map: "directory_user_connection_id_provisioning_status_idx")',
 			);
 		} finally {
 			fs.rmSync(tmpDir, { force: true, recursive: true });
@@ -634,6 +706,9 @@ model Directory_user {
 		);
 		expect(schema.code).toMatch(
 			/external_id:\s*varchar\(["']external_id["'], \{ length: 191 \}\)/,
+		);
+		expect(schema.code).toMatch(
+			/provisioning_status:\s*mysqlEnum\("provisioning_status", \[\s*"active",\s*"suspended",?\s*\]\)/,
 		);
 	});
 

--- a/packages/cli/test/migrate.test.ts
+++ b/packages/cli/test/migrate.test.ts
@@ -84,3 +84,58 @@ describe("migrate auth instance with plugins", () => {
 		expect(res.changes).toBe(1);
 	});
 });
+
+describe("migrate an index-only schema change", () => {
+	const db = new Database(":memory:");
+	const basePlugin = {
+		id: "directory",
+		schema: {
+			directoryUser: {
+				fields: {
+					connectionId: { type: "string" },
+					externalId: { type: "string" },
+				},
+			},
+		},
+	} satisfies BetterAuthPlugin;
+	const indexedPlugin = {
+		...basePlugin,
+		schema: {
+			directoryUser: {
+				...basePlugin.schema.directoryUser,
+				indexes: [
+					{
+						fields: ["connectionId", "externalId"],
+						unique: true,
+					},
+				],
+			},
+		},
+	} satisfies BetterAuthPlugin;
+	let options = betterAuth({ database: db, plugins: [basePlugin] }).options;
+
+	beforeEach(() => {
+		vi.spyOn(process, "exit").mockImplementation((code) => code as never);
+		vi.spyOn(config, "getConfig").mockImplementation(async () => options);
+	});
+
+	it("runs when only a compound index is missing", async () => {
+		await migrateAction({ cwd: process.cwd(), yes: true });
+		options = betterAuth({ database: db, plugins: [indexedPlugin] }).options;
+		const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await migrateAction({ cwd: process.cwd(), yes: true });
+
+		expect(consoleLog).not.toHaveBeenCalledWith("🚀 No migrations needed.");
+		db.prepare(
+			"INSERT INTO directoryUser (id, connectionId, externalId) VALUES (?, ?, ?)",
+		).run("du1", "okta", "employee-1");
+		expect(() =>
+			db
+				.prepare(
+					"INSERT INTO directoryUser (id, connectionId, externalId) VALUES (?, ?, ?)",
+				)
+				.run("du2", "okta", "employee-1"),
+		).toThrow();
+	});
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,6 +89,11 @@
       "types": "./dist/db/index.d.mts",
       "default": "./dist/db/index.mjs"
     },
+    "./db/internal": {
+      "dev-source": "./src/db/internal.ts",
+      "types": "./dist/db/internal.d.mts",
+      "default": "./dist/db/internal.mjs"
+    },
     "./db/adapter": {
       "dev-source": "./src/db/adapter/index.ts",
       "types": "./dist/db/adapter/index.d.mts",
@@ -143,6 +148,9 @@
       ],
       "db": [
         "dist/db/index.d.mts"
+      ],
+      "db/internal": [
+        "dist/db/internal.d.mts"
       ],
       "db/adapter": [
         "dist/db/adapter/index.d.mts"

--- a/packages/core/src/db/database-index.test.ts
+++ b/packages/core/src/db/database-index.test.ts
@@ -65,6 +65,31 @@ describe("database indexes", () => {
 		]);
 	});
 
+	it("allows enum fields in compound indexes", () => {
+		expect(
+			resolveDatabaseTableIndexes({
+				fields: {
+					connectionId: {
+						type: "string",
+						fieldName: "connection_id",
+					},
+					status: {
+						type: ["active", "suspended"],
+						fieldName: "provisioning_status",
+					},
+				},
+				indexes: [{ fields: ["connectionId", "status"] }],
+				tableName: "directory_user",
+			}),
+		).toEqual([
+			{
+				columns: ["connection_id", "provisioning_status"],
+				name: "directory_user_connection_id_provisioning_status_idx",
+				unique: undefined,
+			},
+		]);
+	});
+
 	it("rejects malformed runtime definitions before adapters use them", () => {
 		const emptyFields = [] as unknown as DBTableIndex["fields"];
 

--- a/packages/core/src/db/database-index.test.ts
+++ b/packages/core/src/db/database-index.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from "vitest";
+import {
+	getDatabaseIndexName,
+	getDatabaseIndexStringLength,
+	resolveDatabaseSchemaIndexes,
+	resolveDatabaseTableIndexes,
+} from "./database-index";
+import type { DBTableIndex } from "./type";
+
+describe("database indexes", () => {
+	it("generates readable names within the portable database limit", () => {
+		expect(
+			getDatabaseIndexName("directory_user", {
+				fields: ["connection_id", "external_id"],
+				unique: true,
+			}),
+		).toBe("directory_user_connection_id_external_id_uidx");
+
+		const longIndex = {
+			fields: [
+				"provisioning_connection_identifier",
+				"external_directory_subject_identifier",
+			],
+			unique: true,
+		} satisfies DBTableIndex;
+		const firstName = getDatabaseIndexName(
+			"enterprise_directory_user_identity",
+			longIndex,
+		);
+		const secondName = getDatabaseIndexName(
+			"enterprise_directory_user_identity",
+			longIndex,
+		);
+
+		expect(new TextEncoder().encode(firstName).length).toBeLessThanOrEqual(63);
+		expect(firstName).toBe(secondName);
+		expect(firstName).toMatch(/_[0-9a-f]{8}_uidx$/);
+	});
+
+	it("resolves logical fields and honors an explicit portable name", () => {
+		expect(
+			resolveDatabaseTableIndexes({
+				fields: {
+					connectionId: {
+						type: "string",
+						fieldName: "connection_id",
+					},
+					externalId: { type: "string", fieldName: "external_id" },
+				},
+				indexes: [
+					{
+						fields: ["connectionId", "externalId"],
+						name: "directory_identity_uidx",
+						unique: true,
+					},
+				],
+				tableName: "directory_user",
+			}),
+		).toEqual([
+			{
+				columns: ["connection_id", "external_id"],
+				name: "directory_identity_uidx",
+				unique: true,
+			},
+		]);
+	});
+
+	it("rejects malformed runtime definitions before adapters use them", () => {
+		const emptyFields = [] as unknown as DBTableIndex["fields"];
+
+		expect(() =>
+			resolveDatabaseTableIndexes({
+				fields: { connectionId: { type: "string" } },
+				indexes: [{ fields: emptyFields }],
+				tableName: "directory_user",
+			}),
+		).toThrow(
+			'Index on table "directory_user" must include at least one field.',
+		);
+
+		expect(() =>
+			getDatabaseIndexName("directory_user", {
+				fields: ["connectionId"],
+				name: " ",
+			}),
+		).toThrow(
+			"Database index names must contain at least one visible character.",
+		);
+
+		expect(() =>
+			getDatabaseIndexName("directory_user", {
+				fields: ["connectionId"],
+				name: "a".repeat(64),
+			}),
+		).toThrow("Database index names must be at most 63 UTF-8 bytes.");
+
+		expect(() =>
+			getDatabaseIndexName("directory_user", {
+				fields: ["connectionId"],
+				name: 'directory_"lookup"',
+			}),
+		).toThrow(
+			"Database index names must start with a letter or underscore and contain only letters, numbers, and underscores.",
+		);
+
+		const fields = Object.fromEntries(
+			Array.from({ length: 17 }, (_, index) => [
+				`field${index}`,
+				{ type: "string" as const },
+			]),
+		);
+		expect(
+			resolveDatabaseTableIndexes({
+				fields,
+				indexes: [
+					{
+						fields: Array.from(
+							{ length: 16 },
+							(_, index) => `field${index}`,
+						) as unknown as DBTableIndex["fields"],
+					},
+				],
+				tableName: "portable_lookup",
+			}),
+		).toHaveLength(1);
+		expect(() =>
+			resolveDatabaseTableIndexes({
+				fields,
+				indexes: [
+					{
+						fields: Object.keys(fields) as unknown as DBTableIndex["fields"],
+					},
+				],
+				tableName: "portable_lookup",
+			}),
+		).toThrow(
+			'Index on table "portable_lookup" can include at most 16 fields so it works across supported databases.',
+		);
+	});
+
+	it("rejects index-name collisions instead of dropping a definition", () => {
+		expect(() =>
+			resolveDatabaseTableIndexes({
+				fields: {
+					a: { type: "string" },
+					a_b: { type: "string" },
+					b_c: { type: "string" },
+					c: { type: "string" },
+				},
+				indexes: [{ fields: ["a_b", "c"] }, { fields: ["a", "b_c"] }],
+				tableName: "ambiguous",
+			}),
+		).toThrow(
+			'Database index name "ambiguous_a_b_c_idx" identifies more than one index on table "ambiguous".',
+		);
+
+		expect(() =>
+			resolveDatabaseTableIndexes({
+				fields: {
+					connectionId: { type: "string" },
+					externalId: { type: "string" },
+					status: { type: "string" },
+				},
+				indexes: [
+					{
+						fields: ["connectionId", "externalId"],
+						name: "directory_lookup",
+					},
+					{
+						fields: ["connectionId", "status"],
+						name: "directory_lookup",
+					},
+				],
+				tableName: "directory_user",
+			}),
+		).toThrow(
+			'Database index name "directory_lookup" identifies more than one index on table "directory_user".',
+		);
+	});
+
+	it("rejects indexed logical aliases for the same physical table", () => {
+		expect(() =>
+			resolveDatabaseSchemaIndexes([
+				{
+					fields: { issuer: { type: "string" } },
+					indexes: [{ fields: ["issuer"] }],
+					tableName: "account",
+				},
+				{
+					fields: { providerAccountId: { type: "string" } },
+					indexes: undefined,
+					tableName: "account",
+				},
+			]),
+		).toThrow(
+			'Database schema resolves more than one indexed logical table to "account". Define table-level indexes through one logical schema key instead of aliasing multiple keys to the same database table.',
+		);
+	});
+
+	it("enforces portable schema-wide names and unique-index null semantics", () => {
+		expect(() =>
+			resolveDatabaseSchemaIndexes([
+				{
+					fields: { subject: { type: "string" } },
+					indexes: [{ fields: ["subject"], name: "shared_lookup" }],
+					tableName: "directory_user",
+				},
+				{
+					fields: { subject: { type: "string" } },
+					indexes: [{ fields: ["subject"], name: "shared_lookup" }],
+					tableName: "directory_group",
+				},
+			]),
+		).toThrow(
+			'Database index name "shared_lookup" is used by both table "directory_user" and table "directory_group".',
+		);
+
+		expect(() =>
+			resolveDatabaseSchemaIndexes([
+				{
+					fields: { subject: { type: "string" } },
+					indexes: [{ fields: ["subject"], name: "Shared_Lookup" }],
+					tableName: "directory_user",
+				},
+				{
+					fields: { subject: { type: "string" } },
+					indexes: [{ fields: ["subject"], name: "shared_lookup" }],
+					tableName: "directory_group",
+				},
+			]),
+		).toThrow(
+			'Database index name "shared_lookup" is used by both table "directory_user" and table "directory_group".',
+		);
+
+		expect(() =>
+			resolveDatabaseSchemaIndexes([
+				{
+					fields: { subject: { type: "string" } },
+					indexes: [{ fields: ["subject"], name: "directory_group" }],
+					tableName: "directory_user",
+				},
+				{
+					fields: {},
+					indexes: undefined,
+					tableName: "directory_group",
+				},
+			]),
+		).toThrow(
+			'Database index name "directory_group" conflicts with a table name.',
+		);
+
+		expect(() =>
+			resolveDatabaseSchemaIndexes([
+				{
+					fields: { subject: { type: "string" } },
+					indexes: [{ fields: ["subject"], name: "Directory_Group" }],
+					tableName: "directory_user",
+				},
+				{
+					fields: {},
+					indexes: undefined,
+					tableName: "directory_group",
+				},
+			]),
+		).toThrow(
+			'Database index name "Directory_Group" conflicts with a table name.',
+		);
+
+		expect(() =>
+			resolveDatabaseTableIndexes({
+				fields: {
+					issuer: { type: "string" },
+					providerAccountId: { type: "string", required: false },
+				},
+				indexes: [
+					{
+						fields: ["issuer", "providerAccountId"],
+						unique: true,
+					},
+				],
+				tableName: "account",
+			}),
+		).toThrow(
+			'Unique index on table "account" can only include required fields so its behavior is consistent across databases.',
+		);
+	});
+
+	it("bounds generated string columns to each dialect's index budget", () => {
+		const fields = Object.fromEntries(
+			["a", "b", "c", "d", "e"].map((field) => [
+				field,
+				{ type: "string" as const },
+			]),
+		);
+		const indexes = resolveDatabaseTableIndexes({
+			fields,
+			indexes: [{ fields: ["a", "b", "c", "d", "e"] }],
+			tableName: "wide_lookup",
+		});
+
+		expect(
+			getDatabaseIndexStringLength({
+				columnName: "a",
+				dialect: "mysql",
+				fields,
+				indexes,
+			}),
+		).toBe(153);
+		expect(
+			getDatabaseIndexStringLength({
+				columnName: "a",
+				dialect: "mssql",
+				fields,
+				indexes,
+			}),
+		).toBe(255);
+	});
+
+	it("rejects duplicate field-level and table-level index metadata", () => {
+		expect(() =>
+			resolveDatabaseSchemaIndexes([
+				{
+					fields: {
+						subject: { type: "string", index: true },
+					},
+					indexes: [{ fields: ["subject"] }],
+					tableName: "directory_identity",
+				},
+			]),
+		).toThrow(
+			'Database index name "directory_identity_subject_idx" is already reserved by field-level index metadata on table "directory_identity".',
+		);
+	});
+});

--- a/packages/core/src/db/database-index.ts
+++ b/packages/core/src/db/database-index.ts
@@ -136,8 +136,7 @@ export function resolveDatabaseTableIndexes({
 			return (
 				fieldType === "json" ||
 				fieldType === "string[]" ||
-				fieldType === "number[]" ||
-				Array.isArray(fieldType)
+				fieldType === "number[]"
 			);
 		});
 		if (unsupportedField) {

--- a/packages/core/src/db/database-index.ts
+++ b/packages/core/src/db/database-index.ts
@@ -1,0 +1,352 @@
+import { BetterAuthError } from "../error";
+import type { DBFieldAttribute, DBTableIndex } from "./type";
+
+const MAX_DATABASE_INDEX_NAME_BYTES = 63;
+const MAX_DATABASE_INDEX_FIELDS = 16;
+
+export function getPortableDatabaseIdentifierKey(identifier: string) {
+	return identifier.toLowerCase();
+}
+
+function getUtf8ByteLength(value: string) {
+	return new TextEncoder().encode(value).length;
+}
+
+function truncateUtf8(value: string, maxBytes: number) {
+	let result = "";
+	let byteLength = 0;
+	for (const character of value) {
+		const characterByteLength = getUtf8ByteLength(character);
+		if (byteLength + characterByteLength > maxBytes) break;
+		result += character;
+		byteLength += characterByteLength;
+	}
+	return result;
+}
+
+function getStableIndexNameHash(value: string) {
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < value.length; index++) {
+		hash ^= value.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+/** A table-level index resolved to physical database columns. */
+export interface ResolvedDBTableIndex extends Omit<DBTableIndex, "fields"> {
+	/** Physical database column names, in index order. */
+	columns: readonly [string, ...string[]];
+	name: string;
+}
+
+export interface DBTableIndexSource {
+	fields: Readonly<Record<string, DBFieldAttribute>>;
+	indexes: readonly DBTableIndex[] | undefined;
+	tableName: string;
+}
+
+export type BoundedDatabaseIndexDialect = "mssql" | "mysql";
+
+/** Returns the stable database name for a table-level index. */
+export function getDatabaseIndexName(
+	tableName: string,
+	index: DBTableIndex,
+): string {
+	if (index.name !== undefined) {
+		if (index.name.trim().length === 0) {
+			throw new BetterAuthError(
+				"Database index names must contain at least one visible character.",
+			);
+		}
+		if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(index.name)) {
+			throw new BetterAuthError(
+				"Database index names must start with a letter or underscore and contain only letters, numbers, and underscores.",
+			);
+		}
+		if (getUtf8ByteLength(index.name) > MAX_DATABASE_INDEX_NAME_BYTES) {
+			throw new BetterAuthError(
+				`Database index names must be at most ${MAX_DATABASE_INDEX_NAME_BYTES} UTF-8 bytes.`,
+			);
+		}
+		return index.name;
+	}
+
+	const indexKind = index.unique ? "uidx" : "idx";
+	const generatedName = `${tableName}_${index.fields.join("_")}_${indexKind}`;
+	if (getUtf8ByteLength(generatedName) <= MAX_DATABASE_INDEX_NAME_BYTES) {
+		return generatedName;
+	}
+
+	const suffix = `_${getStableIndexNameHash(generatedName)}_${indexKind}`;
+	return `${truncateUtf8(
+		generatedName.slice(0, -indexKind.length - 1),
+		MAX_DATABASE_INDEX_NAME_BYTES - getUtf8ByteLength(suffix),
+	)}${suffix}`;
+}
+
+/** Returns the database name used by legacy field-level index metadata. */
+export function getDatabaseFieldIndexName(
+	tableName: string,
+	columnName: string,
+	unique: boolean,
+) {
+	return getDatabaseIndexName(tableName, {
+		fields: [columnName],
+		unique,
+	});
+}
+
+/** Resolves logical index fields to their configured database column names. */
+export function resolveDatabaseTableIndexes({
+	fields,
+	indexes,
+	tableName,
+}: {
+	fields: Readonly<Record<string, DBFieldAttribute>>;
+	indexes: readonly DBTableIndex[] | undefined;
+	tableName: string;
+}): readonly ResolvedDBTableIndex[] {
+	const resolvedIndexes = (indexes ?? []).map((index) => {
+		if (index.fields.length === 0) {
+			throw new BetterAuthError(
+				`Index on table "${tableName}" must include at least one field.`,
+			);
+		}
+		if (index.fields.length > MAX_DATABASE_INDEX_FIELDS) {
+			throw new BetterAuthError(
+				`Index on table "${tableName}" can include at most ${MAX_DATABASE_INDEX_FIELDS} fields so it works across supported databases.`,
+			);
+		}
+		if (new Set(index.fields).size !== index.fields.length) {
+			throw new BetterAuthError(
+				`Index on table "${tableName}" contains the same field more than once.`,
+			);
+		}
+		if (
+			index.unique &&
+			index.fields.some((fieldName) => fields[fieldName]?.required === false)
+		) {
+			throw new BetterAuthError(
+				`Unique index on table "${tableName}" can only include required fields so its behavior is consistent across databases.`,
+			);
+		}
+		const unsupportedField = index.fields.find((fieldName) => {
+			const fieldType = fields[fieldName]?.type;
+			return (
+				fieldType === "json" ||
+				fieldType === "string[]" ||
+				fieldType === "number[]" ||
+				Array.isArray(fieldType)
+			);
+		});
+		if (unsupportedField) {
+			throw new BetterAuthError(
+				`Index on table "${tableName}" references field "${unsupportedField}", whose type is not portably indexable.`,
+			);
+		}
+		const resolveFieldName = (fieldName: string) => {
+			const field = fields[fieldName];
+			if (!field) {
+				throw new BetterAuthError(
+					`Index on table "${tableName}" references unknown field "${fieldName}".`,
+				);
+			}
+			return field.fieldName || fieldName;
+		};
+		const [firstField, ...remainingFields] = index.fields;
+		const columns = [
+			resolveFieldName(firstField),
+			...remainingFields.map(resolveFieldName),
+		] as ResolvedDBTableIndex["columns"];
+		if (
+			new Set(columns.map(getPortableDatabaseIdentifierKey)).size !==
+			columns.length
+		) {
+			throw new BetterAuthError(
+				`Index on table "${tableName}" resolves more than one field to the same database column.`,
+			);
+		}
+
+		return {
+			columns,
+			name: getDatabaseIndexName(tableName, {
+				...index,
+				fields: columns,
+			}),
+			unique: index.unique,
+		} satisfies ResolvedDBTableIndex;
+	});
+
+	const definitionsByName = new Map<string, string>();
+	const deduplicatedIndexes: ResolvedDBTableIndex[] = [];
+	for (const index of resolvedIndexes) {
+		const definition = JSON.stringify([index.columns, index.unique ?? false]);
+		const identifierKey = getPortableDatabaseIdentifierKey(index.name);
+		const existingDefinition = definitionsByName.get(identifierKey);
+		if (existingDefinition && existingDefinition !== definition) {
+			throw new BetterAuthError(
+				`Database index name "${index.name}" identifies more than one index on table "${tableName}".`,
+			);
+		}
+		if (existingDefinition) continue;
+		definitionsByName.set(identifierKey, definition);
+		deduplicatedIndexes.push(index);
+	}
+	return deduplicatedIndexes;
+}
+
+/**
+ * Returns a safe generated string length for a column across all of its table
+ * indexes in byte-limited SQL dialects.
+ */
+export function getDatabaseIndexStringLength({
+	columnName,
+	dialect,
+	fields,
+	indexes,
+}: {
+	columnName: string;
+	dialect: BoundedDatabaseIndexDialect;
+	fields: Readonly<Record<string, DBFieldAttribute>>;
+	indexes: readonly ResolvedDBTableIndex[];
+}): number | undefined {
+	const fieldsByColumn = new Map(
+		Object.entries(fields).map(([fieldName, field]) => [
+			field.fieldName || fieldName,
+			field,
+		]),
+	);
+	const containingIndexes = indexes.filter((index) =>
+		index.columns.includes(columnName),
+	);
+	if (containingIndexes.length === 0) return undefined;
+
+	const byteBudget = dialect === "mysql" ? 3072 : 1700;
+	const bytesPerCharacter = dialect === "mysql" ? 4 : 1;
+	const defaultLength = dialect === "mysql" ? 191 : 255;
+	return containingIndexes.reduce((length, index) => {
+		const stringColumnCount = index.columns.filter((column) => {
+			const type = fieldsByColumn.get(column)?.type;
+			return type === "string" || Array.isArray(type);
+		}).length;
+		if (stringColumnCount === 0) return length;
+		const nonStringColumnBytes =
+			(index.columns.length - stringColumnCount) * 16;
+		const safeLength = Math.floor(
+			Math.max(1, byteBudget - nonStringColumnBytes) /
+				bytesPerCharacter /
+				stringColumnCount,
+		);
+		return Math.min(length, safeLength);
+	}, defaultLength);
+}
+
+/**
+ * Resolves and validates every table index as one portable database schema.
+ *
+ * Index names are schema-wide because SQLite and PostgreSQL do not scope them
+ * to an individual table.
+ */
+export function resolveDatabaseSchemaIndexes(
+	sources: readonly DBTableIndexSource[],
+): ReadonlyMap<string, readonly ResolvedDBTableIndex[]> {
+	const mergedSourcesByTable = new Map<
+		string,
+		{
+			fields: Record<string, DBFieldAttribute>;
+			indexes: DBTableIndex[];
+			tableName: string;
+		}
+	>();
+	for (const source of sources) {
+		const existingSource = mergedSourcesByTable.get(source.tableName);
+		if (existingSource) {
+			if (
+				existingSource.indexes.length > 0 ||
+				(source.indexes?.length ?? 0) > 0
+			) {
+				throw new BetterAuthError(
+					`Database schema resolves more than one indexed logical table to "${source.tableName}". Define table-level indexes through one logical schema key instead of aliasing multiple keys to the same database table.`,
+				);
+			}
+			Object.assign(existingSource.fields, source.fields);
+			continue;
+		}
+		const mergedSource: {
+			fields: Record<string, DBFieldAttribute>;
+			indexes: DBTableIndex[];
+			tableName: string;
+		} = {
+			fields: {},
+			indexes: [],
+			tableName: source.tableName,
+		};
+		Object.assign(mergedSource.fields, source.fields);
+		mergedSource.indexes.push(...(source.indexes ?? []));
+		mergedSourcesByTable.set(source.tableName, mergedSource);
+	}
+
+	const indexesByTable = new Map<string, ResolvedDBTableIndex[]>();
+	const indexOwnerByName = new Map<string, string>();
+	const tableNamesByIdentifier = new Map(
+		[...mergedSourcesByTable.keys()].map((tableName) => [
+			getPortableDatabaseIdentifierKey(tableName),
+			tableName,
+		]),
+	);
+	const fieldIndexOwnerByName = new Map<string, string>();
+
+	for (const source of mergedSourcesByTable.values()) {
+		for (const [fieldName, field] of Object.entries(source.fields)) {
+			if (!field.index && !field.unique) continue;
+			const indexName = getDatabaseFieldIndexName(
+				source.tableName,
+				field.fieldName || fieldName,
+				field.unique ?? false,
+			);
+			const identifierKey = getPortableDatabaseIdentifierKey(indexName);
+			if (tableNamesByIdentifier.has(identifierKey)) {
+				throw new BetterAuthError(
+					`Database index name "${indexName}" conflicts with a table name. Index and table names must be unique across the schema.`,
+				);
+			}
+			const existingOwner = fieldIndexOwnerByName.get(identifierKey);
+			if (existingOwner) {
+				throw new BetterAuthError(
+					`Database field-level index name "${indexName}" is used by both table "${existingOwner}" and table "${source.tableName}".`,
+				);
+			}
+			fieldIndexOwnerByName.set(identifierKey, source.tableName);
+		}
+	}
+
+	for (const source of mergedSourcesByTable.values()) {
+		const resolvedIndexes = resolveDatabaseTableIndexes(source);
+		indexesByTable.set(source.tableName, [...resolvedIndexes]);
+
+		for (const index of resolvedIndexes) {
+			const identifierKey = getPortableDatabaseIdentifierKey(index.name);
+			if (tableNamesByIdentifier.has(identifierKey)) {
+				throw new BetterAuthError(
+					`Database index name "${index.name}" conflicts with a table name. Index and table names must be unique across the schema.`,
+				);
+			}
+			const fieldIndexOwner = fieldIndexOwnerByName.get(identifierKey);
+			if (fieldIndexOwner) {
+				throw new BetterAuthError(
+					`Database index name "${index.name}" is already reserved by field-level index metadata on table "${fieldIndexOwner}". Remove the duplicate table-level index or give it a distinct name.`,
+				);
+			}
+			const indexOwner = indexOwnerByName.get(identifierKey);
+			if (indexOwner && indexOwner !== source.tableName) {
+				throw new BetterAuthError(
+					`Database index name "${index.name}" is used by both table "${indexOwner}" and table "${source.tableName}". Index names must be unique across the schema.`,
+				);
+			}
+			indexOwnerByName.set(identifierKey, source.tableName);
+		}
+	}
+
+	return indexesByTable;
+}

--- a/packages/core/src/db/get-tables.ts
+++ b/packages/core/src/db/get-tables.ts
@@ -1,5 +1,30 @@
 import type { BetterAuthOptions } from "../types";
-import type { BetterAuthDBSchema, DBFieldAttribute } from "./type";
+import { resolveDatabaseSchemaIndexes } from "./database-index";
+import type {
+	BetterAuthDBSchema,
+	DBFieldAttribute,
+	DBTableIndex,
+} from "./type";
+
+function mergeTableIndexes(
+	...indexCollections: ReadonlyArray<readonly DBTableIndex[] | undefined>
+) {
+	const indexes: DBTableIndex[] = [];
+	const seenIndexDefinitions = new Set<string>();
+	for (const index of indexCollections.flatMap(
+		(collection) => collection ?? [],
+	)) {
+		const definition = JSON.stringify([
+			index.name ?? null,
+			index.fields,
+			index.unique ?? false,
+		]);
+		if (seenIndexDefinitions.has(definition)) continue;
+		seenIndexDefinitions.add(definition);
+		indexes.push(index);
+	}
+	return indexes;
+}
 
 export const getAuthTables = (
 	options: BetterAuthOptions,
@@ -14,6 +39,7 @@ export const getAuthTables = (
 						...acc[key]?.fields,
 						...value.fields,
 					},
+					indexes: mergeTableIndexes(acc[key]?.indexes, value.indexes),
 					modelName: value.modelName || key,
 					disableMigrations:
 						value.disableMigration ?? acc[key]?.disableMigrations,
@@ -25,6 +51,7 @@ export const getAuthTables = (
 			string,
 			{
 				fields: Record<string, DBFieldAttribute>;
+				indexes?: readonly DBTableIndex[] | undefined;
 				modelName: string;
 				disableMigrations?: boolean | undefined;
 			}
@@ -64,6 +91,7 @@ export const getAuthTables = (
 	const verificationTable = {
 		verification: {
 			modelName: options.verification?.modelName || "verification",
+			indexes: verification?.indexes,
 			fields: {
 				identifier: {
 					type: "string",
@@ -104,6 +132,7 @@ export const getAuthTables = (
 	const sessionTable = {
 		session: {
 			modelName: options.session?.modelName || "session",
+			indexes: session?.indexes,
 			fields: {
 				expiresAt: {
 					type: "date",
@@ -156,9 +185,10 @@ export const getAuthTables = (
 		},
 	} satisfies BetterAuthDBSchema;
 
-	return {
+	const authTables = {
 		user: {
 			modelName: options.user?.modelName || "user",
+			indexes: user?.indexes,
 			fields: {
 				name: {
 					type: "string",
@@ -211,6 +241,7 @@ export const getAuthTables = (
 			: {}),
 		account: {
 			modelName: options.account?.modelName || "account",
+			indexes: account?.indexes,
 			fields: {
 				accountId: {
 					type: "string",
@@ -301,4 +332,18 @@ export const getAuthTables = (
 		...pluginTables,
 		...(shouldAddRateLimitTable ? rateLimitTable : {}),
 	} satisfies BetterAuthDBSchema;
+
+	resolveDatabaseSchemaIndexes(
+		Object.values(authTables)
+			.filter(
+				(table) => !("disableMigrations" in table) || !table.disableMigrations,
+			)
+			.map((table) => ({
+				fields: table.fields,
+				indexes: "indexes" in table ? table.indexes : undefined,
+				tableName: table.modelName,
+			})),
+	);
+
+	return authTables;
 };

--- a/packages/core/src/db/get-tables.ts
+++ b/packages/core/src/db/get-tables.ts
@@ -26,9 +26,7 @@ function mergeTableIndexes(
 	return indexes;
 }
 
-export const getAuthTables = (
-	options: BetterAuthOptions,
-): BetterAuthDBSchema => {
+const buildAuthTables = (options: BetterAuthOptions): BetterAuthDBSchema => {
 	const pluginSchema = (options.plugins ?? []).reduce(
 		(acc, plugin) => {
 			const schema = plugin.schema;
@@ -333,8 +331,13 @@ export const getAuthTables = (
 		...(shouldAddRateLimitTable ? rateLimitTable : {}),
 	} satisfies BetterAuthDBSchema;
 
-	resolveDatabaseSchemaIndexes(
-		Object.values(authTables)
+	return authTables;
+};
+
+export function getAuthTablesWithResolvedIndexes(options: BetterAuthOptions) {
+	const tables = buildAuthTables(options);
+	const indexesByTable = resolveDatabaseSchemaIndexes(
+		Object.values(tables)
 			.filter(
 				(table) => !("disableMigrations" in table) || !table.disableMigrations,
 			)
@@ -345,5 +348,8 @@ export const getAuthTables = (
 			})),
 	);
 
-	return authTables;
-};
+	return { indexesByTable, tables };
+}
+
+export const getAuthTables = (options: BetterAuthOptions): BetterAuthDBSchema =>
+	getAuthTablesWithResolvedIndexes(options).tables;

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -29,6 +29,7 @@ export type {
 	DBFieldAttributeConfig,
 	DBFieldType,
 	DBPrimitive,
+	DBTableIndex,
 	InferDBFieldInput,
 	InferDBFieldOutput,
 	InferDBFieldsFromOptions,

--- a/packages/core/src/db/internal.ts
+++ b/packages/core/src/db/internal.ts
@@ -9,3 +9,4 @@ export {
 	resolveDatabaseSchemaIndexes,
 	resolveDatabaseTableIndexes,
 } from "./database-index";
+export { getAuthTablesWithResolvedIndexes } from "./get-tables";

--- a/packages/core/src/db/internal.ts
+++ b/packages/core/src/db/internal.ts
@@ -1,0 +1,11 @@
+export {
+	type BoundedDatabaseIndexDialect,
+	type DBTableIndexSource,
+	getDatabaseFieldIndexName,
+	getDatabaseIndexName,
+	getDatabaseIndexStringLength,
+	getPortableDatabaseIdentifierKey,
+	type ResolvedDBTableIndex,
+	resolveDatabaseSchemaIndexes,
+	resolveDatabaseTableIndexes,
+} from "./database-index";

--- a/packages/core/src/db/plugin.ts
+++ b/packages/core/src/db/plugin.ts
@@ -1,10 +1,12 @@
-import type { DBFieldAttribute } from "./type";
+import type { DBFieldAttribute, DBTableIndex } from "./type";
 
 export type BetterAuthPluginDBSchema = {
 	[table in string]: {
 		fields: {
 			[field: string]: DBFieldAttribute;
 		};
+		/** Table-level indexes, including compound indexes. */
+		indexes?: readonly DBTableIndex[] | undefined;
 		disableMigration?: boolean | undefined;
 		modelName?: string | undefined;
 	};

--- a/packages/core/src/db/test/get-tables.test.ts
+++ b/packages/core/src/db/test/get-tables.test.ts
@@ -69,6 +69,93 @@ describe("getAuthTables", () => {
 		expect(accessTokenExpiresAtField.fieldName).toBe("accessTokenExpiresAt");
 	});
 
+	it("should propagate compound indexes from plugin schemas", () => {
+		const tables = getAuthTables({
+			plugins: [
+				{
+					id: "directory",
+					schema: {
+						directoryUser: {
+							fields: {
+								connectionId: { type: "string" },
+								externalId: { type: "string" },
+							},
+							indexes: [
+								{
+									fields: ["connectionId", "externalId"],
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		});
+
+		expect(tables.directoryUser?.indexes).toEqual([
+			{
+				fields: ["connectionId", "externalId"],
+				unique: true,
+			},
+		]);
+	});
+
+	it("should preserve compound indexes when a plugin extends a core table", () => {
+		const tables = getAuthTables({
+			plugins: [
+				{
+					id: "account-identity",
+					schema: {
+						account: {
+							fields: {
+								issuer: { type: "string" },
+								providerAccountId: { type: "string" },
+							},
+							indexes: [
+								{
+									fields: ["issuer", "providerAccountId"],
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		});
+
+		expect(tables.account?.indexes).toEqual([
+			{
+				fields: ["issuer", "providerAccountId"],
+				unique: true,
+			},
+		]);
+	});
+
+	it("should reject multiple logical tables targeting one physical table", () => {
+		expect(() =>
+			getAuthTables({
+				plugins: [
+					{
+						id: "ambiguous-schema",
+						schema: {
+							directorySubject: {
+								modelName: "directory_identity",
+								fields: { subject: { type: "string" } },
+								indexes: [{ fields: ["subject"] }],
+							},
+							directoryIdentity: {
+								modelName: "directory_identity",
+								fields: { issuer: { type: "string" } },
+							},
+						},
+					},
+				],
+			}),
+		).toThrow(
+			'Database schema resolves more than one indexed logical table to "directory_identity".',
+		);
+	});
+
 	it("should merge additionalFields into verification table metadata", () => {
 		const tables = getAuthTables({
 			verification: {
@@ -161,5 +248,45 @@ describe("getAuthTables", () => {
 		});
 
 		expect(tables.shared!.disableMigrations).toBe(true);
+	});
+
+	it("should merge distinct indexes when plugins extend the same table", () => {
+		const connectionIndex = {
+			fields: ["connectionId", "externalId"],
+			unique: true,
+		} as const;
+		const tables = getAuthTables({
+			plugins: [
+				{
+					id: "a",
+					schema: {
+						shared: {
+							fields: {
+								connectionId: { type: "string" },
+								externalId: { type: "string" },
+							},
+							indexes: [connectionIndex],
+						},
+					},
+				},
+				{
+					id: "b",
+					schema: {
+						shared: {
+							fields: { status: { type: "string" } },
+							indexes: [
+								connectionIndex,
+								{ fields: ["connectionId", "status"] },
+							],
+						},
+					},
+				},
+			],
+		});
+
+		expect(tables.shared?.indexes).toEqual([
+			connectionIndex,
+			{ fields: ["connectionId", "status"] },
+		]);
 	});
 });

--- a/packages/core/src/db/test/get-tables.test.ts
+++ b/packages/core/src/db/test/get-tables.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getAuthTables } from "../get-tables";
+import { getAuthTables, getAuthTablesWithResolvedIndexes } from "../get-tables";
 import type { SecondaryStorage } from "../type";
 
 const secondaryStorageStub: SecondaryStorage = {
@@ -154,6 +154,35 @@ describe("getAuthTables", () => {
 		).toThrow(
 			'Database schema resolves more than one indexed logical table to "directory_identity".',
 		);
+	});
+
+	it("should return resolved indexes with the constructed tables", () => {
+		const { indexesByTable, tables } = getAuthTablesWithResolvedIndexes({
+			plugins: [
+				{
+					id: "resolved-indexes",
+					schema: {
+						directoryIdentity: {
+							modelName: "directory_identity",
+							fields: {
+								issuer: { fieldName: "issuer_url", type: "string" },
+								subject: { type: "string" },
+							},
+							indexes: [{ fields: ["issuer", "subject"], unique: true }],
+						},
+					},
+				},
+			],
+		});
+
+		expect(tables.directoryIdentity?.indexes).toHaveLength(1);
+		expect(indexesByTable.get("directory_identity")).toEqual([
+			{
+				columns: ["issuer_url", "subject"],
+				name: "directory_identity_issuer_url_subject_uidx",
+				unique: true,
+			},
+		]);
 	});
 
 	it("should merge additionalFields into verification table metadata", () => {

--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -281,6 +281,16 @@ export type DBFieldAttribute<T extends DBFieldType = DBFieldType> = {
 	type: T;
 } & DBFieldAttributeConfig;
 
+/** A database index spanning one or more logical schema fields. */
+export interface DBTableIndex {
+	/** One to sixteen logical field names included in the index, in index order. */
+	fields: readonly [string, ...string[]];
+	/** Portable database index name of at most 63 UTF-8 bytes. */
+	name?: string | undefined;
+	/** Whether the indexed field tuple must be unique. */
+	unique?: boolean | undefined;
+}
+
 export type BetterAuthDBSchema = Record<
 	string,
 	{
@@ -292,6 +302,8 @@ export type BetterAuthDBSchema = Record<
 		 * The fields of the table
 		 */
 		fields: Record<string, DBFieldAttribute>;
+		/** Table-level indexes, including compound indexes. */
+		indexes?: readonly DBTableIndex[] | undefined;
 		/**
 		 * Whether to disable migrations for this table
 		 * @default false

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
 	entry: [
 		"./src/index.ts",
 		"./src/db/index.ts",
+		"./src/db/internal.ts",
 		"./src/db/adapter/index.ts",
 		"./src/async_hooks/index.ts",
 		"./src/async_hooks/pure.index.ts",

--- a/packages/drizzle-adapter/src/relations-v2/generate-drizzle-schema.test.ts
+++ b/packages/drizzle-adapter/src/relations-v2/generate-drizzle-schema.test.ts
@@ -64,6 +64,77 @@ describe("relations-v2 schema generator", () => {
 		expect(typeErrors(code)).toEqual([]);
 	});
 
+	it("generates compound indexes with physical field names", async () => {
+		const { code = "" } = await generateFor("mysql", {
+			plugins: [
+				{
+					id: "compound-index-test",
+					schema: {
+						directoryUser: {
+							modelName: "directory_user",
+							fields: {
+								connectionId: {
+									type: "string",
+									fieldName: "connection_id",
+								},
+								externalId: {
+									type: "string",
+									fieldName: "external_id",
+								},
+							},
+							indexes: [
+								{
+									fields: ["connectionId", "externalId"],
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		});
+
+		expect(code).toMatch(
+			/uniqueIndex\("directory_user_connection_id_external_id_uidx"\)\.on\(\s*table\.connection_id,\s*table\.external_id,?\s*\)/,
+		);
+		expect(code).toMatch(
+			/connection_id:\s*varchar\(["']connection_id["'], \{ length: 191 \}\)/,
+		);
+		expect(code).toMatch(
+			/external_id:\s*varchar\(["']external_id["'], \{ length: 191 \}\)/,
+		);
+		expect(typeErrors(code)).toEqual([]);
+	});
+
+	it("does not generate externally managed tables or their indexes", async () => {
+		const { code = "" } = await generate({
+			plugins: [
+				{
+					id: "external-directory",
+					schema: {
+						directoryUser: {
+							disableMigration: true,
+							fields: {
+								connectionId: { type: "string" },
+								externalId: { type: "string" },
+							},
+							indexes: [
+								{
+									fields: ["connectionId", "externalId"],
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		});
+
+		expect(code).not.toContain("directoryUser");
+		expect(code).not.toContain("directoryUser_connectionId_externalId_uidx");
+		expect(typeErrors(code)).toEqual([]);
+	});
+
 	/**
 	 * A hardcoded `export const relations = defineRelationsPart(...)` collides
 	 * with a user model whose table name is `relations` (e.g.

--- a/packages/drizzle-adapter/src/relations-v2/generate-drizzle-schema.ts
+++ b/packages/drizzle-adapter/src/relations-v2/generate-drizzle-schema.ts
@@ -11,6 +11,11 @@ import {
 	initGetFieldName,
 	initGetModelName,
 } from "@better-auth/core/db/adapter";
+import {
+	getDatabaseFieldIndexName,
+	getDatabaseIndexStringLength,
+	resolveDatabaseSchemaIndexes,
+} from "@better-auth/core/db/internal";
 import type { DrizzleAdapterConfig } from ".";
 
 interface SchemaGenerator {
@@ -119,13 +124,28 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 		schema: tables,
 		usePlural: adapterConfig?.usePlural,
 	});
+	const resolvedIndexesByTable = resolveDatabaseSchemaIndexes(
+		Object.keys(tables)
+			.filter((tableKey) => !tables[tableKey]!.disableMigrations)
+			.map((tableKey) => ({
+				fields: tables[tableKey]!.fields,
+				indexes: tables[tableKey]!.indexes,
+				tableName: getModelName(tableKey),
+			})),
+	);
 
 	for (const tableKey in tables) {
 		const table = tables[tableKey]!;
+		if (table.disableMigrations) continue;
 		const modelName = getModelName(tableKey);
 		const fields = table.fields;
+		const resolvedTableIndexes = resolvedIndexesByTable.get(modelName) ?? [];
 
-		function getType(name: string, field: DBFieldAttribute) {
+		function getType(
+			name: string,
+			field: DBFieldAttribute,
+			tableIndexStringLength?: number | undefined,
+		) {
 			// Not possible to reach, it's here to make typescript happy
 			if (!databaseType) {
 				throw new Error(
@@ -177,15 +197,17 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				string: {
 					sqlite: `text('${name}')`,
 					pg: `text('${name}')`,
-					mysql: field.unique
-						? `varchar('${name}', { length: 255 })`
-						: field.references
-							? `varchar('${name}', { length: 36 })`
-							: field.sortable
-								? `varchar('${name}', { length: 255 })`
-								: field.index
+					mysql: tableIndexStringLength
+						? `varchar('${name}', { length: ${tableIndexStringLength} })`
+						: field.unique
+							? `varchar('${name}', { length: 255 })`
+							: field.references
+								? `varchar('${name}', { length: 36 })`
+								: field.sortable
 									? `varchar('${name}', { length: 255 })`
-									: `text('${name}')`,
+									: field.index
+										? `varchar('${name}', { length: 255 })`
+										: `text('${name}')`,
 				},
 				boolean: {
 					sqlite: `integer('${name}', { mode: 'boolean' })`,
@@ -260,7 +282,11 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			}
 		}
 
-		type Index = { type: "uniqueIndex" | "index"; name: string; on: string };
+		type Index = {
+			type: "uniqueIndex" | "index";
+			name: string;
+			on: readonly string[];
+		};
 
 		const indexes: Index[] = [];
 
@@ -270,13 +296,23 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			const code: string[] = [`, (table) => [`];
 
 			for (const index of indexes) {
-				code.push(`  ${index.type}("${index.name}").on(table.${index.on}),`);
+				code.push(
+					`  ${index.type}(${JSON.stringify(index.name)}).on(${index.on.map((fieldName) => `table.${fieldName}`).join(", ")}),`,
+				);
 			}
 
 			code.push(`]`);
 
 			return code.join("\n");
 		};
+
+		for (const tableIndex of resolvedTableIndexes) {
+			indexes.push({
+				type: tableIndex.unique ? "uniqueIndex" : "index",
+				name: tableIndex.name,
+				on: tableIndex.columns,
+			});
+		}
 
 		const schema = `export const ${modelName} = ${tableFunction}("${convertToSnakeCase(
 			modelName,
@@ -287,19 +323,30 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 						.map((field) => {
 							const attr = fields[field]!;
 							const fieldName = attr.fieldName || field;
-							let type = getType(fieldName, attr);
+							let type = getType(
+								fieldName,
+								attr,
+								databaseType === "mysql"
+									? getDatabaseIndexStringLength({
+											columnName: fieldName,
+											dialect: "mysql",
+											fields,
+											indexes: resolvedTableIndexes,
+										})
+									: undefined,
+							);
 
 							if (attr.index && !attr.unique) {
 								indexes.push({
 									type: "index",
-									name: `${modelName}_${fieldName}_idx`,
-									on: fieldName,
+									name: getDatabaseFieldIndexName(modelName, fieldName, false),
+									on: [fieldName],
 								});
 							} else if (attr.index && attr.unique) {
 								indexes.push({
 									type: "uniqueIndex",
-									name: `${modelName}_${fieldName}_uidx`,
-									on: fieldName,
+									name: getDatabaseFieldIndexName(modelName, fieldName, true),
+									on: [fieldName],
 								});
 							}
 
@@ -373,6 +420,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	// Build schema object import for defineRelationsPart
 	const schemaObjectKeys: string[] = [];
 	for (const tableKey in tables) {
+		if (tables[tableKey]!.disableMigrations) continue;
 		const modelName = getModelName(tableKey);
 		schemaObjectKeys.push(modelName);
 	}
@@ -394,6 +442,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	// Process all tables to build relations
 	for (const tableKey in tables) {
 		const table = tables[tableKey]!;
+		if (table.disableMigrations) continue;
 		const modelName = getModelName(tableKey);
 		const modelRelations: RelationDef[] = [];
 
@@ -403,6 +452,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 
 		for (const [fieldName, field] of foreignFields) {
 			const referencedModel = field.references!.model;
+			if (tables[referencedModel]?.disableMigrations) continue;
 			const targetModelName = getModelName(referencedModel);
 			const fromField = getFieldName({ model: tableKey, field: fieldName });
 			const toField = getFieldName({
@@ -433,7 +483,8 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 
 		// 2. Find all OTHER tables that reference THIS table (creates "many" relations)
 		const otherModels = Object.entries(tables).filter(
-			([modelName]) => modelName !== tableKey,
+			([modelName, otherTable]) =>
+				modelName !== tableKey && !otherTable.disableMigrations,
 		);
 
 		for (const [otherTableKey, otherTable] of otherModels) {
@@ -719,11 +770,19 @@ function generateImport({
 	}
 
 	//handle indexes
-	const hasIndexes = Object.values(tables).some((table) =>
-		Object.values(table.fields).some((field) => field.index && !field.unique),
+	const hasIndexes = Object.values(tables).some(
+		(table) =>
+			Object.values(table.fields).some(
+				(field) => field.index && !field.unique,
+			) ||
+			(table.indexes?.some((index) => !index.unique) ?? false),
 	);
-	const hasUniqueIndexes = Object.values(tables).some((table) =>
-		Object.values(table.fields).some((field) => field.unique && field.index),
+	const hasUniqueIndexes = Object.values(tables).some(
+		(table) =>
+			Object.values(table.fields).some(
+				(field) => field.unique && field.index,
+			) ||
+			(table.indexes?.some((index) => index.unique) ?? false),
 	);
 	if (hasIndexes) {
 		coreImports.push("index");

--- a/packages/mongo-adapter/src/mongodb-adapter.test.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.test.ts
@@ -1,3 +1,4 @@
+import type { Db } from "mongodb";
 import { ObjectId, UUID } from "mongodb";
 import { describe, expect, it, vi } from "vitest";
 import { mongodbAdapter } from "./mongodb-adapter";
@@ -9,6 +10,161 @@ describe("mongodb-adapter", () => {
 		} as any;
 		const adapter = mongodbAdapter(db);
 		expect(adapter).toBeDefined();
+	});
+
+	it("creates configured compound indexes before the first write", async () => {
+		let resolveIndexSetup: (indexName: string) => void = () => {};
+		const indexSetup = new Promise<string>((resolve) => {
+			resolveIndexSetup = resolve;
+		});
+		const createIndex = vi.fn(() => indexSetup);
+		const insertOne = vi.fn(async (document: Record<string, unknown>) => ({
+			insertedId: document._id,
+		}));
+		const db = {
+			collection: vi.fn(() => ({ createIndex, insertOne })),
+		};
+		const adapter = mongodbAdapter(db as unknown as Db, {
+			transaction: false,
+		})({
+			plugins: [
+				{
+					id: "directory",
+					schema: {
+						directoryUser: {
+							modelName: "directory_user",
+							fields: {
+								connectionId: {
+									type: "string",
+									fieldName: "connection_id",
+								},
+								externalId: {
+									type: "string",
+									fieldName: "external_id",
+								},
+							},
+							indexes: [
+								{
+									fields: ["connectionId", "externalId"],
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		});
+
+		const firstCreate = adapter.create({
+			model: "directoryUser",
+			data: { connectionId: "okta", externalId: "employee-1" },
+		});
+		const secondCreate = adapter.create({
+			model: "directoryUser",
+			data: { connectionId: "okta", externalId: "employee-2" },
+		});
+
+		await vi.waitFor(() => {
+			expect(createIndex).toHaveBeenCalledWith(
+				{ connection_id: 1, external_id: 1 },
+				{
+					name: "directory_user_connection_id_external_id_uidx",
+					unique: true,
+				},
+			);
+		});
+		expect(db.collection).toHaveBeenCalledWith("directory_user");
+		expect(createIndex).toHaveBeenCalledOnce();
+		expect(insertOne).not.toHaveBeenCalled();
+
+		resolveIndexSetup("connection_id_1_external_id_1");
+		await Promise.all([firstCreate, secondCreate]);
+
+		expect(createIndex).toHaveBeenCalledOnce();
+		expect(insertOne).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not create indexes for tables with migrations disabled", async () => {
+		const createIndex = vi.fn();
+		const insertOne = vi.fn(async (document: Record<string, unknown>) => ({
+			insertedId: document._id,
+		}));
+		const db = {
+			collection: vi.fn(() => ({ createIndex, insertOne })),
+		};
+		const adapter = mongodbAdapter(db as unknown as Db, {
+			transaction: false,
+		})({
+			plugins: [
+				{
+					id: "externally-managed-directory",
+					schema: {
+						directoryUser: {
+							disableMigration: true,
+							fields: {
+								connectionId: { type: "string" },
+								externalId: { type: "string" },
+							},
+							indexes: [
+								{
+									fields: ["connectionId", "externalId"],
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		});
+
+		await adapter.create({
+			model: "directoryUser",
+			data: { connectionId: "okta", externalId: "employee-1" },
+		});
+
+		expect(createIndex).not.toHaveBeenCalled();
+		expect(insertOne).toHaveBeenCalledOnce();
+	});
+
+	it("allows duplicate cleanup before the first index-enforcing mutation", async () => {
+		const createIndex = vi.fn();
+		const deleteMany = vi.fn(async () => ({ deletedCount: 2 }));
+		const db = {
+			collection: vi.fn(() => ({ createIndex, deleteMany })),
+		};
+		const adapter = mongodbAdapter(db as unknown as Db, {
+			transaction: false,
+		})({
+			plugins: [
+				{
+					id: "directory",
+					schema: {
+						directoryUser: {
+							fields: {
+								connectionId: { type: "string" },
+								externalId: { type: "string" },
+							},
+							indexes: [
+								{
+									fields: ["connectionId", "externalId"],
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		});
+
+		await expect(
+			adapter.deleteMany({
+				model: "directoryUser",
+				where: [{ field: "connectionId", value: "duplicate" }],
+			}),
+		).resolves.toBe(2);
+
+		expect(createIndex).not.toHaveBeenCalled();
+		expect(deleteMany).toHaveBeenCalledOnce();
 	});
 
 	it("consumeOne returns the deleted document from Mongo metadata", async () => {

--- a/packages/mongo-adapter/src/mongodb-adapter.test.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.test.ts
@@ -84,6 +84,58 @@ describe("mongodb-adapter", () => {
 		expect(insertOne).toHaveBeenCalledTimes(2);
 	});
 
+	it("resolves configured indexes once per model", async () => {
+		let indexFieldReads = 0;
+		const createIndex = vi.fn(async () => "connection_id_1_external_id_1");
+		const insertOne = vi.fn(async (document: Record<string, unknown>) => ({
+			insertedId: document._id,
+		}));
+		const db = {
+			collection: vi.fn(() => ({ createIndex, insertOne })),
+		};
+		const adapter = mongodbAdapter(db as unknown as Db, {
+			transaction: false,
+		})({
+			plugins: [
+				{
+					id: "directory",
+					schema: {
+						directoryUser: {
+							fields: {
+								connectionId: { type: "string" },
+								externalId: { type: "string" },
+							},
+							indexes: [
+								{
+									get fields() {
+										indexFieldReads++;
+										return ["connectionId", "externalId"] as const;
+									},
+									unique: true,
+								},
+							],
+						},
+					},
+				},
+			],
+		});
+
+		await adapter.create({
+			model: "directoryUser",
+			data: { connectionId: "okta", externalId: "employee-1" },
+		});
+		const readsAfterFirstWrite = indexFieldReads;
+
+		await adapter.create({
+			model: "directoryUser",
+			data: { connectionId: "okta", externalId: "employee-2" },
+		});
+
+		expect(indexFieldReads).toBe(readsAfterFirstWrite);
+		expect(createIndex).toHaveBeenCalledOnce();
+		expect(insertOne).toHaveBeenCalledTimes(2);
+	});
+
 	it("does not create indexes for tables with migrations disabled", async () => {
 		const createIndex = vi.fn();
 		const insertOne = vi.fn(async (document: Record<string, unknown>) => ({

--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -7,6 +7,7 @@ import type {
 	Where,
 } from "@better-auth/core/db/adapter";
 import { createAdapterFactory } from "@better-auth/core/db/adapter";
+import { resolveDatabaseTableIndexes } from "@better-auth/core/db/internal";
 import type { ClientSession, Db, MongoClient } from "mongodb";
 import { ObjectId, UUID } from "mongodb";
 import {
@@ -65,6 +66,7 @@ export const mongodbAdapter = (
 	config?: MongoDBAdapterConfig | undefined,
 ) => {
 	let lazyOptions: BetterAuthOptions | null;
+	const indexSetupByDefinition = new Map<string, Promise<string>>();
 
 	const getCustomIdGenerator = (options: BetterAuthOptions) => {
 		const generator = options.advanced?.database?.generateId;
@@ -88,6 +90,51 @@ export const mongodbAdapter = (
 		}) => {
 			const customIdGen = getCustomIdGenerator(options);
 			const useUUIDs = options.advanced?.database?.generateId === "uuid";
+
+			const ensureModelIndexes = async (model: string) => {
+				const defaultModelName = getDefaultModelName(model);
+				const table = schema[defaultModelName];
+				if (!table || table.disableMigrations) return;
+				const indexes = resolveDatabaseTableIndexes({
+					fields: table.fields,
+					indexes: table.indexes,
+					tableName: model,
+				});
+
+				await Promise.all(
+					indexes.map((index) => {
+						const physicalFieldNames = index.columns.map((fieldName) =>
+							fieldName === "id" ? "_id" : fieldName,
+						);
+						const indexDefinition = JSON.stringify([
+							model,
+							index.name,
+							physicalFieldNames,
+							index.unique ?? false,
+						]);
+						const existingIndexSetup =
+							indexSetupByDefinition.get(indexDefinition);
+						if (existingIndexSetup) return existingIndexSetup;
+
+						const indexFields = Object.fromEntries(
+							physicalFieldNames.map((field) => [field, 1] as const),
+						);
+						const indexSetup = Promise.resolve().then(() =>
+							db.collection(model).createIndex(indexFields, {
+								name: index.name,
+								unique: index.unique ?? false,
+							}),
+						);
+						indexSetupByDefinition.set(indexDefinition, indexSetup);
+						void indexSetup.catch(() => {
+							if (indexSetupByDefinition.get(indexDefinition) === indexSetup) {
+								indexSetupByDefinition.delete(indexDefinition);
+							}
+						});
+						return indexSetup;
+					}),
+				);
+			};
 
 			function coerceToIdType(value: string): ObjectId | UUID {
 				if (useUUIDs) return new UUID(value);
@@ -342,6 +389,7 @@ export const mongodbAdapter = (
 
 			return {
 				async create({ model, data: values }) {
+					await ensureModelIndexes(model);
 					const res = await db.collection(model).insertOne(values, { session });
 					const insertedData = { _id: res.insertedId.toString(), ...values };
 					return insertedData as any;
@@ -592,6 +640,7 @@ export const mongodbAdapter = (
 					return res[0]?.total ?? 0;
 				},
 				async update({ model, where, update: values }) {
+					await ensureModelIndexes(model);
 					const clause = convertWhereClause({ where, model });
 
 					const res = await db.collection(model).findOneAndUpdate(
@@ -608,6 +657,7 @@ export const mongodbAdapter = (
 					return doc as any;
 				},
 				async updateMany({ model, where, update: values }) {
+					await ensureModelIndexes(model);
 					const clause = convertWhereClause({ where, model });
 
 					const res = await db.collection(model).updateMany(
@@ -639,6 +689,7 @@ export const mongodbAdapter = (
 					return ((doc as any)?.value as any) ?? null;
 				},
 				async incrementOne({ model, where, increment, set }) {
+					await ensureModelIndexes(model);
 					const clause = convertWhereClause({ where, model });
 					// Only include operators that carry fields. An empty `$inc: {}`
 					// errors on MongoDB server < 5.0, and a set-only guarded

--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -90,16 +90,31 @@ export const mongodbAdapter = (
 		}) => {
 			const customIdGen = getCustomIdGenerator(options);
 			const useUUIDs = options.advanced?.database?.generateId === "uuid";
+			const resolvedIndexesByModel = new Map<
+				string,
+				ReturnType<typeof resolveDatabaseTableIndexes>
+			>();
 
-			const ensureModelIndexes = async (model: string) => {
+			const getResolvedModelIndexes = (model: string) => {
+				const cachedIndexes = resolvedIndexesByModel.get(model);
+				if (cachedIndexes) return cachedIndexes;
+
 				const defaultModelName = getDefaultModelName(model);
 				const table = schema[defaultModelName];
-				if (!table || table.disableMigrations) return;
-				const indexes = resolveDatabaseTableIndexes({
-					fields: table.fields,
-					indexes: table.indexes,
-					tableName: model,
-				});
+				const indexes =
+					!table || table.disableMigrations
+						? []
+						: resolveDatabaseTableIndexes({
+								fields: table.fields,
+								indexes: table.indexes,
+								tableName: model,
+							});
+				resolvedIndexesByModel.set(model, indexes);
+				return indexes;
+			};
+
+			const ensureModelIndexes = async (model: string) => {
+				const indexes = getResolvedModelIndexes(model);
 
 				await Promise.all(
 					indexes.map((index) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,6 +583,9 @@ importers:
 
   e2e/adapter/test/kysely-adapter:
     devDependencies:
+      '@better-auth/core':
+        specifier: workspace:*
+        version: link:../../../../packages/core
       '@better-auth/kysely-adapter':
         specifier: workspace:*
         version: link:../../../../packages/kysely-adapter


### PR DESCRIPTION
Plugin schemas need compound indexes for durable tuple identities such as an issuer plus a provider subject. Field-level uniqueness cannot express that contract or carry it consistently through schema generation, migrations, and supported adapters.

## What changes

- **Schema contract**: tables can define named or generated `indexes` with 1–16 logical fields, including compound unique constraints.
- **Portable validation**: one resolver maps logical fields to physical columns and rejects collisions, unsupported types, duplicate fields, and incompatible unique-null semantics before an adapter runs.
- **Schema output**: Better Auth migrations and generated Drizzle or Prisma schemas emit the resolved index definition.
- **Runtime enforcement**: MongoDB creates configured indexes before index-enforcing writes, while SQL migrations inspect existing definitions and reject conflicts.
- **Adapter parity**: end-to-end coverage verifies tuple uniqueness across PostgreSQL, MySQL, SQLite, SQL Server, and MongoDB.

> [!IMPORTANT]
> Existing installations must generate and apply a migration to introduce new indexes. An existing index with the same name but different ordered columns or uniqueness must be corrected or removed first. MySQL and SQL Server installations with unsafe unbounded indexed strings stop with remediation rather than silently truncating data.

<details>
<summary>Review points</summary>

- Index names are schema-wide, case-insensitive, portable identifiers of at most 63 UTF-8 bytes.
- Compound unique indexes require every field to be required so null handling remains consistent across databases.
- Long generated names are deterministic, and resolved indexes use the physical database column names.

</details>

Fixes #7862.
