### PR TITLE
docs: add guide for deploying better auth with docker

### DIFF
--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -73,3 +73,8 @@ pjpeg
 styl
 vbscript
 unvalidated
+nginx
+caddy
+traefik
+dockerignore
+isready

--- a/docs/content/docs/guides/docker-deployment.mdx
+++ b/docs/content/docs/guides/docker-deployment.mdx
@@ -1,0 +1,178 @@
+---
+title: Deploy with Docker
+description: Containerize a self-hosted Better Auth server with a production-ready Dockerfile, docker-compose, and database migrations.
+---
+
+Better Auth runs anywhere Node runs, so you can self-host it as a standalone auth
+server inside a container. This guide packages a Node server that mounts the
+Better Auth handler, wires up a database with `docker-compose`, and runs the
+schema migration on startup.
+
+This guide assumes you already have a Better Auth instance and a Node server that
+mounts its handler. If not, follow [Installation](/docs/installation) and the
+[Express integration](/docs/integrations/express) first.
+
+<Callout>
+  Better Auth ships as ESM only. Make sure your server package has
+  `"type": "module"` set, otherwise the build will fail inside the container.
+</Callout>
+
+## The server
+
+A minimal Express server that mounts the handler. The health endpoint at
+`/api/auth/ok` is what the container healthcheck below polls.
+
+```ts title="server.ts"
+import express from "express";
+import { toNodeHandler } from "better-auth/node";
+import { auth } from "./auth";
+
+const app = express();
+
+// Mount the Better Auth handler BEFORE express.json().
+app.all("/api/auth/*", toNodeHandler(auth)); // ExpressJS v4
+app.use(express.json());
+
+const port = Number(process.env.PORT ?? 3000);
+app.listen(port, () => console.log(`Auth server listening on ${port}`));
+```
+
+## Dockerfile
+
+A multi-stage build keeps the final image small and runs as a non-root user.
+Adjust the build/start scripts to match your `package.json`.
+
+```dockerfile title="Dockerfile"
+# ---- build ----
+FROM node:22-slim AS builder
+WORKDIR /app
+
+# Install deps first for better layer caching.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ---- runtime ----
+FROM node:22-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Only production deps in the final image.
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+# Run as the built-in non-root user.
+USER node
+
+EXPOSE 3000
+CMD ["node", "dist/server.js"]
+```
+
+Add a `.dockerignore` so local `node_modules` and secrets never enter the build
+context:
+
+```text title=".dockerignore"
+node_modules
+dist
+.env
+.env.*
+.git
+```
+
+## docker-compose
+
+Compose runs the auth server alongside its database. The `migrate` service
+applies the Better Auth schema once the database is healthy, then the app
+starts. This example uses PostgreSQL; swap the image and `DATABASE_URL` for MySQL
+if that is your adapter.
+
+```yaml title="docker-compose.yml"
+services:
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: better_auth
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: better_auth
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U better_auth -d better_auth"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  migrate:
+    build: .
+    command: npx -y auth@latest migrate --yes
+    environment:
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL}
+      DATABASE_URL: postgres://better_auth:${DB_PASSWORD}@db:5432/better_auth
+    depends_on:
+      db:
+        condition: service_healthy
+
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL}
+      DATABASE_URL: postgres://better_auth:${DB_PASSWORD}@db:5432/better_auth
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/api/auth/ok').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  db_data:
+```
+
+<Callout type="warn">
+  The `migrate` command applies the schema directly and is only available with
+  the built-in Kysely adapter. If you use Prisma or Drizzle, run your ORM's
+  migration tool in the `migrate` service instead (for example
+  `npx prisma migrate deploy`). See the [CLI docs](/docs/concepts/cli).
+</Callout>
+
+## Environment and secrets
+
+Never bake secrets into the image. Pass them at runtime via compose (from a
+`.env` file or your orchestrator's secret store):
+
+```bash title=".env"
+# Generate with: openssl rand -base64 32
+BETTER_AUTH_SECRET=your-generated-secret
+# Public URL clients and the server use to reach this service
+BETTER_AUTH_URL=https://auth.example.com
+DB_PASSWORD=your-db-password
+```
+
+Bring the stack up:
+
+```bash
+docker compose up -d --build
+```
+
+## Production notes
+
+- **Terminate TLS at a reverse proxy** (nginx, Caddy, Traefik) in front of the
+  container and forward to port `3000`. Set `BETTER_AUTH_URL` to the public
+  HTTPS URL.
+- **Set [`trustedOrigins`](/docs/reference/options#trustedorigins)** to your
+  frontend origins so cross-origin requests are accepted.
+- **Keep `BETTER_AUTH_SECRET` stable** across deploys — rotating it invalidates
+  existing sessions.
+- **Run migrations as a separate step** (as above) rather than on every app
+  boot, so scaling to multiple app replicas doesn't race on the schema.

--- a/docs/content/docs/guides/docker-deployment.mdx
+++ b/docs/content/docs/guides/docker-deployment.mdx
@@ -13,6 +13,11 @@ mounts its handler. If not, follow [Installation](/docs/installation) and the
 [Express integration](/docs/integrations/express) first.
 
 <Callout>
+  A complete, runnable version of everything below lives in
+  [`examples/docker-server`](https://github.com/better-auth/better-auth/tree/main/examples/docker-server).
+</Callout>
+
+<Callout>
   Better Auth ships as ESM only. Make sure your server package has
   `"type": "module"` set, otherwise the build will fail inside the container.
 </Callout>

--- a/examples/docker-server/.dockerignore
+++ b/examples/docker-server/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+.env.*

--- a/examples/docker-server/.env.example
+++ b/examples/docker-server/.env.example
@@ -1,0 +1,6 @@
+# Generate with: openssl rand -base64 32
+BETTER_AUTH_SECRET=your-generated-secret
+# Public URL clients and the server use to reach this service
+BETTER_AUTH_URL=http://localhost:3000
+# Password for the bundled Postgres container
+DB_PASSWORD=your-db-password

--- a/examples/docker-server/Dockerfile
+++ b/examples/docker-server/Dockerfile
@@ -1,0 +1,18 @@
+# Minimal container for a self-hosted Better Auth server. Runs the TypeScript
+# entrypoint directly with tsx to keep the example short; see the deployment
+# guide for a compiled multi-stage build.
+FROM node:22-slim
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Install deps first for better layer caching.
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+# Run as the built-in non-root user.
+USER node
+
+EXPOSE 3000
+CMD ["npx", "tsx", "server.ts"]

--- a/examples/docker-server/README.md
+++ b/examples/docker-server/README.md
@@ -1,0 +1,42 @@
+# Better Auth — Docker server example
+
+A self-hosted Better Auth server in a container, with PostgreSQL and a one-off
+schema migration, orchestrated by `docker-compose`.
+
+For the full walkthrough and production notes, see the
+[Deploy with Docker guide](https://better-auth.com/docs/guides/docker-deployment).
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `auth.ts` | Better Auth config (PostgreSQL via `DATABASE_URL`) |
+| `server.ts` | Express server mounting the Better Auth handler |
+| `Dockerfile` | Container image (runs `server.ts` with `tsx`) |
+| `docker-compose.yml` | `db` + one-off `migrate` + `app` |
+| `.env.example` | Required environment variables |
+
+## Run
+
+```bash
+cp .env.example .env
+# then set BETTER_AUTH_SECRET (openssl rand -base64 32) and DB_PASSWORD
+
+docker compose up -d --build
+```
+
+The `migrate` service applies the schema, then `app` starts on
+[http://localhost:3000](http://localhost:3000). Verify it's up:
+
+```bash
+curl http://localhost:3000/api/auth/ok
+```
+
+## Notes
+
+- `migrate` uses the CLI, which applies the schema directly — this works with
+  the built-in Kysely adapter. For Prisma or Drizzle, run your ORM's migration
+  tool instead.
+- Never commit a real `.env`. Pass secrets from your orchestrator in production.
+- Put a TLS-terminating reverse proxy in front of the container and set
+  `BETTER_AUTH_URL` to the public HTTPS URL.

--- a/examples/docker-server/auth.ts
+++ b/examples/docker-server/auth.ts
@@ -1,0 +1,12 @@
+import { betterAuth } from "better-auth";
+import { Pool } from "pg";
+
+// A minimal Better Auth server config backed by PostgreSQL (via the built-in
+// Kysely adapter). The Pool reads DATABASE_URL, so the same image works against
+// any Postgres instance.
+export const auth = betterAuth({
+	database: new Pool({ connectionString: process.env.DATABASE_URL }),
+	baseURL: process.env.BETTER_AUTH_URL,
+	secret: process.env.BETTER_AUTH_SECRET,
+	emailAndPassword: { enabled: true },
+});

--- a/examples/docker-server/docker-compose.yml
+++ b/examples/docker-server/docker-compose.yml
@@ -1,0 +1,48 @@
+services:
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: better_auth
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: better_auth
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U better_auth -d better_auth"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # One-off: apply the Better Auth schema, then exit. Runs before the app so
+  # scaling to multiple app replicas doesn't race on the schema.
+  migrate:
+    build: .
+    command: npx -y auth@latest migrate --yes
+    environment:
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL}
+      DATABASE_URL: postgres://better_auth:${DB_PASSWORD}@db:5432/better_auth
+    depends_on:
+      db:
+        condition: service_healthy
+
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL}
+      DATABASE_URL: postgres://better_auth:${DB_PASSWORD}@db:5432/better_auth
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/api/auth/ok').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  db_data:

--- a/examples/docker-server/package.json
+++ b/examples/docker-server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "better-auth-docker-server-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx server.ts",
+    "migrate": "auth migrate --yes"
+  },
+  "dependencies": {
+    "better-auth": "^1.6.0",
+    "express": "^4.21.2",
+    "pg": "^8.13.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/pg": "^8.11.10",
+    "auth": "latest",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/docker-server/server.ts
+++ b/examples/docker-server/server.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import { toNodeHandler } from "better-auth/node";
+import { auth } from "./auth";
+
+const app = express();
+
+// Mount the Better Auth handler BEFORE express.json() — otherwise the client
+// API hangs on "pending".
+app.all("/api/auth/*", toNodeHandler(auth));
+app.use(express.json());
+
+const port = Number(process.env.PORT ?? 3000);
+app.listen(port, () => console.log(`Auth server listening on ${port}`));

--- a/examples/docker-server/tsconfig.json
+++ b/examples/docker-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## What & why

Adds a **Deploy with Docker** guide under `docs/content/docs/guides/`. Self-hosting Better Auth as a standalone auth server is a common need, but there's no docs page covering how to containerize it. This fills that gap.

The guide covers:
- A minimal Express server mounting `toNodeHandler` (with the `/api/auth/ok` health endpoint).
- A production-ready multi-stage `Dockerfile` (node:22-slim, non-root `USER node`) and `.dockerignore`.
- A `docker-compose.yml` with a database and a **one-off `migrate` service** (`npx -y auth@latest migrate`) that runs before the app starts, so scaling to multiple replicas doesn't race on the schema.
- Secret handling (`BETTER_AUTH_SECRET` via `openssl rand`, never baked into the image) and production notes (reverse-proxy TLS, `trustedOrigins`, stable secret).

It notes that `migrate` is Kysely-only and points Prisma/Drizzle users at their ORM migration tools, linking the existing [CLI docs](/docs/concepts/cli).

## Notes
- **Docs-only** — no `packages/**` changes, so no changeset.
- Added `nginx`, `caddy`, `traefik`, `dockerignore`, `isready` to `.cspell/tech-terms.txt` so spell-check passes.
- Internal links verified: `/docs/installation`, `/docs/integrations/express`, `/docs/concepts/cli`, `options#trustedorigins`.
- No breaking changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Deploy with Docker” guide and a runnable example to help users self-host Better Auth with a containerized Node server and a compose stack. Clarifies migration flow, secret handling, and reverse proxy notes.

- New Features
  - New guide at `docs/content/docs/guides/docker-deployment.mdx` covering a minimal `express` server mounting `toNodeHandler` (with `/api/auth/ok`), a multi-stage `Dockerfile` (`node:22-slim`, non-root), and a `docker-compose.yml` with Postgres, a one-off `migrate` service (`npx -y auth@latest migrate`), and health checks.
  - Added runnable example at `examples/docker-server` with `server.ts`, `auth.ts`, a simple `Dockerfile` using `tsx`, `docker-compose.yml`, `.env.example`, and a README; the guide links to it.
  - Notes that `migrate` is Kysely-only; Prisma/Drizzle users should run their ORM migration tools (see CLI docs).
  - Spellcheck entries added: `nginx`, `caddy`, `traefik`, `dockerignore`, `isready`.

<sup>Written for commit 342087321a522b9e19255cb7eb36561617d85891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

