### PR TITLE
feat(sso)!: resolve provisioned users before authentication

### DIFF
--- a/.changeset/sso-provider-user-resolution.md
+++ b/.changeset/sso-provider-user-resolution.md
@@ -1,0 +1,11 @@
+---
+"@better-auth/core": minor
+"@better-auth/sso": minor
+"better-auth": minor
+---
+
+Add transaction-bound SSO user resolution for OIDC and SAML. The new `resolveUser` callback can use a verified provider identity to select an existing Better Auth User, apply the default authentication behavior, or reject authentication. Exact links must declare whether Better Auth preserves the local User profile or updates it from the verified provider profile.
+
+Provider profiles passed to `authenticateProviderUser` no longer include the provider subject as a Better Auth User ID. The option is renamed from `userInfo` to `providerUser`, with provider identity supplied separately.
+
+OAuth Proxy callback packages now store `providerUser` instead of `userInfo`. Deploy the proxy and application on the same Better Auth version; mixed-version deployments reject these encrypted callback packages.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -638,7 +638,7 @@ const res = await auth.api.signInSSO({
 
 Note: If email is provided and loginHint is not specified, email will be sent as the login\_hint to OIDC providers automatically. SAML flows do not support login\_hint.
 
-When a user is authenticated, if the user does not exist, the user will be provisioned using the `provisionUser` function. By default, `provisionUser` only runs when a new user is registered. If you want to run it on every login (e.g. to sync upstream identity provider profile changes), set `provisionUserOnEveryLogin` to `true`. If the organization provisioning is enabled and a provider is associated with an organization, the user will be added to the organization.
+After authentication creates or finds a User, the `provisionUser` callback can create application resources or synchronize external systems. By default, it runs only when Better Auth creates a User. Set `provisionUserOnEveryLogin` to `true` to run it after every successful SSO login. If organization provisioning is enabled and the provider belongs to an organization, Better Auth also adds the User to that organization.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
@@ -666,6 +666,64 @@ const auth = betterAuth({
 ## Provisioning
 
 The SSO plugin provides powerful provisioning capabilities to automatically set up users and manage their organization memberships when they sign in through SSO providers.
+
+### Resolve an existing User
+
+Use `resolveUser` when an external provisioning system creates the Better Auth User before their first SSO login. The callback runs for every OIDC and SAML login after Better Auth verifies and locks the provider, but before it resolves or writes the Identity, Account, User, or Session.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { sso } from "@better-auth/sso";
+import { directoryUsers } from "./directory-users";
+
+export const auth = betterAuth({
+  plugins: [
+    sso({
+      resolveUser: async (
+        { providerInstanceId, identity },
+        { database },
+      ) => {
+        const directoryUser = await directoryUsers.findBySSOIdentity(
+          {
+            providerInstanceId,
+            identityIssuer: identity.issuer,
+            providerSubject: identity.providerAccountId,
+          },
+          database,
+        );
+
+        if (!directoryUser?.active) {
+          return {
+            action: "reject",
+            code: "DIRECTORY_USER_NOT_ACTIVE",
+          };
+        }
+
+        return {
+          action: "link",
+          userId: directoryUser.userId,
+          profile: "preserve",
+        };
+      },
+    }),
+  ],
+});
+```
+
+Return one of these decisions:
+
+* `{ action: "default" }` uses Better Auth's standard Identity match, trusted email linking, and implicit sign-up behavior.
+* `{ action: "link", userId, profile: "preserve" }` selects that exact User and keeps the existing User profile. Use this when SCIM or your application owns profile fields.
+* `{ action: "link", userId, profile: "provider" }` selects that exact User and updates their mutable profile from the verified provider data for this login.
+* `{ action: "reject", code, message? }` rejects authentication before it creates or changes authentication records.
+
+The callback receives the canonical Identity namespace and provider subject that Better Auth will persist, the normalized provider User, the raw verified provider claims, and the exact provider-instance ID. Resolve users with stable, verified identifiers. Do not link by an unverified email address.
+
+`database` is the active transaction adapter. Resolver reads and application writes made through it commit or roll back with the complete authentication flow. Configuring `resolveUser` therefore requires a database adapter with native interactive transactions, including for providers declared in `defaultSSO`.
+
+<Callout type="info">
+  `resolveUser` selects or rejects a User before authentication. `provisionUser` runs after successful authentication and cannot change which User was authenticated.
+</Callout>
 
 ### User Provisioning
 
@@ -1643,6 +1701,8 @@ For a detailed guide on setting up SAML SSO with examples for Okta and testing w
 
 ### Server
 
+**resolveUser**: Resolve a verified OIDC or SAML identity before authentication. The callback can use Better Auth's default behavior, link an exact User with an explicit profile policy, or reject the login. Requires native interactive transactions.
+
 **provisionUser**: A custom function to provision a user when they sign in with an SSO provider.
 
 **provisionUserOnEveryLogin**: If `true`, the `provisionUser` callback runs on every login, not just on registration. Defaults to `false`.
@@ -1656,6 +1716,10 @@ For a detailed guide on setting up SAML SSO with examples for Okta and testing w
 If you want to allow account linking for specific trusted providers, enable the `accountLinking` option in your auth config and specify those providers in the `trustedProviders` list.
 
 export const ssoOptionsType = {
+	resolveUser: {
+		description: "Resolve a verified provider identity before SSO authentication.",
+		type: "function",
+	},
 	provisionUser: {
 		description: "A custom function to provision a user when they sign in with an SSO provider.",
 		type: "function",

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -253,8 +253,6 @@ export const callbackOAuth = createAuthEndpoint(
 				OAUTH_CALLBACK_ERROR_CODES.UNABLE_TO_GET_USER_INFO,
 			);
 		}
-		const { providerAccountId } = identityKey;
-
 		if (!callbackURL) {
 			c.context.logger.error("No callback URL found");
 			throw redirectOnError(OAUTH_CALLBACK_ERROR_CODES.NO_CALLBACK_URL);
@@ -404,6 +402,7 @@ export const callbackOAuth = createAuthEndpoint(
 			c.context.logger.error(missingEmailLogMessage(provider.id));
 			return redirectOnError(OAUTH_CALLBACK_ERROR_CODES.EMAIL_NOT_FOUND);
 		}
+		const { id: _providerSubject, ...providerUser } = userInfo;
 		const accountData = {
 			providerId: provider.id,
 			providerInstanceId: provider.id,
@@ -413,9 +412,8 @@ export const callbackOAuth = createAuthEndpoint(
 		let result: Awaited<ReturnType<typeof authenticateProviderUser>>;
 		try {
 			result = await authenticateProviderUser(c, {
-				userInfo: {
-					...userInfo,
-					id: providerAccountId,
+				providerUser: {
+					...providerUser,
 					email: userInfo.email,
 					name: userInfo.name || "",
 				},

--- a/packages/better-auth/src/api/routes/sign-in.ts
+++ b/packages/better-auth/src/api/routes/sign-in.ts
@@ -323,11 +323,11 @@ export const signInSocial = <O extends BetterAuthOptions>() =>
 					userInfo.data,
 				);
 				const providerProfile = toOAuthProfileRecord(userInfo.data);
+				const { id: _providerSubject, ...providerUser } = userInfo.user;
 				const data = await authenticateProviderUser(c, {
-					userInfo: {
-						...userInfo.user,
+					providerUser: {
+						...providerUser,
 						email: userInfo.user.email,
-						id: identityKey.providerAccountId,
 						name: userInfo.user.name || "",
 						image: userInfo.user.image,
 						emailVerified: userInfo.user.emailVerified || false,

--- a/packages/better-auth/src/oauth2/provider-user.test.ts
+++ b/packages/better-auth/src/oauth2/provider-user.test.ts
@@ -1,5 +1,11 @@
 import { DatabaseSync } from "node:sqlite";
 import type {
+	AuthContext,
+	GenericEndpointContext,
+	ProviderUserProfile,
+	ProviderUserResolution,
+} from "@better-auth/core";
+import type {
 	DiscordProfile,
 	GoogleProfile,
 } from "@better-auth/core/social-providers";
@@ -26,6 +32,7 @@ import { getMigrations } from "../db/get-migration";
 import { getTestInstance } from "../test-utils/test-instance";
 import type { User } from "../types";
 import { DEFAULT_SECRET } from "../utils/constants";
+import { authenticateProviderUser } from "./provider-user";
 
 let mockEmail = "";
 let mockEmailVerified = true;
@@ -41,6 +48,321 @@ afterEach(() => {
 });
 
 afterAll(() => server.close());
+
+describe("authenticateProviderUser - explicit user resolution", () => {
+	const providerUser = {
+		email: "provider@example.com",
+		emailVerified: false,
+		name: "Provider User",
+		image: null,
+	} satisfies ProviderUserProfile;
+
+	async function createLocalUser(
+		context: Promise<unknown>,
+		user: Pick<User, "id" | "email" | "name"> &
+			Partial<Pick<User, "emailVerified" | "image">>,
+	) {
+		const authContext = (await context) as AuthContext;
+		await authContext.adapter.create({
+			model: "user",
+			forceAllowId: true,
+			data: {
+				...user,
+				emailVerified: user.emailVerified ?? true,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		return authContext;
+	}
+
+	async function authenticate(
+		context: Promise<unknown>,
+		options: {
+			providerAccountId?: string | undefined;
+			providerUser?: ProviderUserProfile | undefined;
+			resolution: ProviderUserResolution;
+			disableSignUp?: boolean | undefined;
+			overrideUserInfo?: boolean | undefined;
+		},
+	) {
+		const authContext = (await context) as AuthContext;
+		return authenticateProviderUser(
+			{ context: authContext } as unknown as GenericEndpointContext,
+			{
+				providerUser: options.providerUser ?? providerUser,
+				identity: {
+					issuer: "https://idp.example.com",
+					providerAccountId: options.providerAccountId ?? "provider-subject",
+				},
+				account: {
+					providerId: "enterprise-sso",
+					providerInstanceId: "enterprise-connection",
+				},
+				resolution: options.resolution,
+				disableSignUp: options.disableSignUp,
+				overrideUserInfo: options.overrideUserInfo,
+			},
+		);
+	}
+
+	it("links the provider identity to the selected user when sign-up and implicit linking are disabled", async () => {
+		const { auth } = await getTestInstance(
+			{
+				account: {
+					accountLinking: {
+						enabled: false,
+						disableImplicitLinking: true,
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+		const context = await createLocalUser(auth.$context, {
+			id: "selected-user",
+			email: "local@example.com",
+			name: "Local User",
+		});
+
+		const result = await authenticate(auth.$context, {
+			resolution: {
+				action: "link",
+				userId: "selected-user",
+				profile: "preserve",
+			},
+			disableSignUp: true,
+		});
+
+		expect(result).toMatchObject({
+			error: null,
+			isRegister: false,
+			data: { user: { id: "selected-user", email: "local@example.com" } },
+		});
+		const links =
+			await context.internalAdapter.listUserAccounts("selected-user");
+		expect(links).toEqual([
+			expect.objectContaining({
+				identity: expect.objectContaining({
+					issuer: "https://idp.example.com",
+					providerAccountId: "provider-subject",
+				}),
+				account: expect.objectContaining({
+					providerInstanceId: "enterprise-connection",
+				}),
+			}),
+		]);
+	});
+
+	it("rejects before querying or writing authentication records", async () => {
+		const { auth } = await getTestInstance(undefined, {
+			disableTestUser: true,
+		});
+		const context = await auth.$context;
+		const identityLookup = vi.spyOn(
+			context.internalAdapter,
+			"findUserByIdentityKey",
+		);
+		const accountLink = vi.spyOn(context.internalAdapter, "linkAccount");
+		const sessionCreation = vi.spyOn(context.internalAdapter, "createSession");
+
+		await expect(
+			authenticate(auth.$context, {
+				resolution: {
+					action: "reject",
+					code: "scim_subject_inactive",
+					message: "The provisioned user is inactive",
+				},
+			}),
+		).rejects.toMatchObject({
+			body: {
+				code: "scim_subject_inactive",
+				message: "The provisioned user is inactive",
+			},
+		});
+		expect(identityLookup).not.toHaveBeenCalled();
+		expect(accountLink).not.toHaveBeenCalled();
+		expect(sessionCreation).not.toHaveBeenCalled();
+	});
+
+	it("rejects a missing selected user with USER_NOT_FOUND", async () => {
+		const { auth } = await getTestInstance(undefined, {
+			disableTestUser: true,
+		});
+		const context = await auth.$context;
+
+		await expect(
+			authenticate(auth.$context, {
+				resolution: {
+					action: "link",
+					userId: "missing-user",
+					profile: "preserve",
+				},
+			}),
+		).rejects.toMatchObject({
+			body: { code: "USER_NOT_FOUND" },
+		});
+		expect(
+			await context.internalAdapter.findIdentityByKey({
+				issuer: "https://idp.example.com",
+				providerAccountId: "provider-subject",
+			}),
+		).toBeNull();
+	});
+
+	it("rejects an identity already owned by a different user", async () => {
+		const { auth } = await getTestInstance(undefined, {
+			disableTestUser: true,
+		});
+		const context = await createLocalUser(auth.$context, {
+			id: "first-user",
+			email: "first@example.com",
+			name: "First User",
+		});
+		await createLocalUser(auth.$context, {
+			id: "second-user",
+			email: "second@example.com",
+			name: "Second User",
+		});
+		await authenticate(auth.$context, {
+			providerAccountId: "shared-provider-subject",
+			resolution: {
+				action: "link",
+				userId: "first-user",
+				profile: "preserve",
+			},
+		});
+
+		await expect(
+			authenticate(auth.$context, {
+				providerAccountId: "shared-provider-subject",
+				resolution: {
+					action: "link",
+					userId: "second-user",
+					profile: "preserve",
+				},
+			}),
+		).rejects.toMatchObject({
+			status: "CONFLICT",
+			body: { code: "identity_already_linked" },
+		});
+		expect(
+			await context.internalAdapter.listUserAccounts("second-user"),
+		).toEqual([]);
+		expect(
+			await context.internalAdapter.findUserByIdentityKey({
+				issuer: "https://idp.example.com",
+				providerAccountId: "shared-provider-subject",
+			}),
+		).toMatchObject({ user: { id: "first-user" } });
+	});
+
+	it("preserves the local profile when ambient settings request provider updates", async () => {
+		const { auth } = await getTestInstance(
+			{
+				account: {
+					accountLinking: {
+						updateUserInfoOnLink: true,
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+		const context = await createLocalUser(auth.$context, {
+			id: "application-profile-user",
+			email: "application@example.com",
+			emailVerified: false,
+			name: "Application Name",
+			image: "https://application.example.com/avatar.png",
+		});
+		const providerProfile = {
+			email: "application@example.com",
+			emailVerified: true,
+			name: "Provider Name",
+			image: "https://provider.example.com/avatar.png",
+		} satisfies ProviderUserProfile;
+		const resolution = {
+			action: "link",
+			userId: "application-profile-user",
+			profile: "preserve",
+		} satisfies ProviderUserResolution;
+
+		await authenticate(auth.$context, {
+			providerUser: providerProfile,
+			resolution,
+			overrideUserInfo: true,
+		});
+		await authenticate(auth.$context, {
+			providerUser: providerProfile,
+			resolution,
+			overrideUserInfo: true,
+		});
+
+		expect(
+			await context.internalAdapter.findUserById("application-profile-user"),
+		).toMatchObject({
+			email: "application@example.com",
+			emailVerified: false,
+			name: "Application Name",
+			image: "https://application.example.com/avatar.png",
+		});
+	});
+
+	it("applies the exact provider profile when ambient settings preserve the local user", async () => {
+		const { auth } = await getTestInstance(
+			{
+				account: {
+					accountLinking: {
+						updateUserInfoOnLink: false,
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+		const context = await createLocalUser(auth.$context, {
+			id: "provider-profile-user",
+			email: "local-profile@example.com",
+			emailVerified: true,
+			name: "Local Name",
+			image: "https://local.example.com/avatar.png",
+		});
+		const providerProfile = {
+			email: "provider-profile@example.com",
+			emailVerified: false,
+			name: "Provider Name",
+			image: "https://provider.example.com/avatar.png",
+		} satisfies ProviderUserProfile;
+
+		const result = await authenticate(auth.$context, {
+			providerUser: providerProfile,
+			resolution: {
+				action: "link",
+				userId: "provider-profile-user",
+				profile: "provider",
+			},
+			overrideUserInfo: false,
+		});
+
+		expect(result).toMatchObject({
+			error: null,
+			data: {
+				user: {
+					email: "provider-profile@example.com",
+					emailVerified: false,
+					name: "Provider Name",
+					image: "https://provider.example.com/avatar.png",
+				},
+			},
+		});
+		expect(
+			await context.internalAdapter.findUserById("provider-profile-user"),
+		).toMatchObject({
+			email: "provider-profile@example.com",
+			emailVerified: false,
+			name: "Provider Name",
+			image: "https://provider.example.com/avatar.png",
+		});
+	});
+});
 
 describe("oauth2 - email verification on link", async () => {
 	const { auth, client, cookieSetter } = await getTestInstance({

--- a/packages/better-auth/src/oauth2/provider-user.ts
+++ b/packages/better-auth/src/oauth2/provider-user.ts
@@ -1,10 +1,13 @@
 import type {
 	AuthenticatedProviderAccountBinding,
 	GenericEndpointContext,
+	ProviderUserProfile,
+	ProviderUserResolution,
 	UserProvisioningSource,
 } from "@better-auth/core";
 import type { IdentityKey } from "@better-auth/core/db";
 import { isDevelopment } from "@better-auth/core/env";
+import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import { createEmailVerificationToken } from "../api";
 import { setAccountCookie } from "../cookies/session-store";
 import { parseAdditionalUserInputFromProviderProfile } from "../db";
@@ -14,13 +17,13 @@ import { assertValidUserInfo } from "../utils/validate-user-info";
 import { OAUTH_CALLBACK_ERROR_CODES, redirectOnError } from "./errors";
 import { setTokenUtil } from "./utils";
 
-// TODO(#9124): v2 widens `User.email` to nullable; every `userInfo.email.toLowerCase()`
+// TODO(#9124): v2 widens `User.email` to nullable; every `providerUser.email.toLowerCase()`
 // call below needs null-safety before account recognition can be fully
 // independent from email-based implicit linking.
 export async function authenticateProviderUser(
 	c: GenericEndpointContext,
 	opts: {
-		userInfo: Omit<User, "createdAt" | "updatedAt">;
+		providerUser: ProviderUserProfile;
 		identity: IdentityKey;
 		account: Pick<
 			Account,
@@ -39,16 +42,30 @@ export async function authenticateProviderUser(
 		isTrustedProvider?: boolean | undefined;
 		trustProviderByName?: boolean | undefined;
 		source?: UserProvisioningSource | undefined;
+		resolution?: ProviderUserResolution | undefined;
 	},
 ) {
 	const {
-		userInfo,
+		providerUser,
 		identity,
 		account,
 		callbackURL,
 		disableSignUp,
 		overrideUserInfo,
 	} = opts;
+	const resolution = opts.resolution ?? { action: "default" };
+	if (resolution.action === "reject") {
+		throw new APIError("FORBIDDEN", {
+			code: resolution.code,
+			...(resolution.message === undefined
+				? {}
+				: { message: resolution.message }),
+		});
+	}
+	const shouldApplyProviderProfile =
+		resolution.action === "link"
+			? resolution.profile === "provider"
+			: overrideUserInfo === true;
 	const source = opts.source ?? {
 		method: "oauth",
 		oauth: { providerId: account.providerId },
@@ -75,6 +92,15 @@ export async function authenticateProviderUser(
 	}
 	const dbUser = await (async () => {
 		if (identityOwner?.kind === "owned") {
+			if (
+				resolution.action === "link" &&
+				identityOwner.user.id !== resolution.userId
+			) {
+				throw new APIError("CONFLICT", {
+					code: "identity_already_linked",
+					message: "Identity is already linked to another user",
+				});
+			}
 			const linkedAccount = await c.context.internalAdapter.findAccountByKey({
 				identityId: identityOwner.identity.id,
 				providerInstanceId: account.providerInstanceId,
@@ -84,11 +110,28 @@ export async function authenticateProviderUser(
 				identity: identityOwner.identity,
 				linkedAccount,
 				matchedByIdentity: true,
+				selectedByResolution: resolution.action === "link",
+			};
+		}
+		const selectedUser =
+			resolution.action === "link"
+				? await c.context.internalAdapter.findUserById(resolution.userId)
+				: null;
+		if (resolution.action === "link" && !selectedUser) {
+			throw APIError.from("NOT_FOUND", BASE_ERROR_CODES.USER_NOT_FOUND);
+		}
+		if (selectedUser) {
+			return {
+				user: selectedUser,
+				identity: null,
+				linkedAccount: null,
+				matchedByIdentity: false,
+				selectedByResolution: true,
 			};
 		}
 
 		const emailMatch = await c.context.internalAdapter.findUserByEmail(
-			userInfo.email.toLowerCase(),
+			providerUser.email.toLowerCase(),
 			{ includeAccounts: false },
 		);
 		if (!emailMatch) return null;
@@ -97,8 +140,12 @@ export async function authenticateProviderUser(
 			identity: null,
 			linkedAccount: null,
 			matchedByIdentity: false,
+			selectedByResolution: false,
 		};
 	})().catch((e) => {
+		if (isAPIError(e)) {
+			throw e;
+		}
 		c.context.logger.error(
 			"Better auth was unable to query your database.\nError: ",
 			e,
@@ -119,8 +166,9 @@ export async function authenticateProviderUser(
 				(opts.trustProviderByName !== false &&
 					c.context.trustedProviders.includes(account.providerId));
 			const implicitLinkingRejected =
+				!dbUser.selectedByResolution &&
 				!dbUser.matchedByIdentity &&
-				((!isTrustedProvider && !userInfo.emailVerified) ||
+				((!isTrustedProvider && !providerUser.emailVerified) ||
 					!dbUser.user.emailVerified ||
 					accountLinking?.enabled === false ||
 					accountLinking?.disableImplicitLinking === true);
@@ -136,12 +184,11 @@ export async function authenticateProviderUser(
 				};
 			}
 			try {
-				const { id: _providerAccountId, ...providerUserInfo } = userInfo;
 				await assertValidUserInfo(c, {
 					user: {
-						...providerUserInfo,
+						...providerUser,
 						id: dbUser.user.id,
-						email: userInfo.email.toLowerCase(),
+						email: providerUser.email.toLowerCase(),
 					},
 					source: { ...source, action: "link-account" },
 				});
@@ -175,15 +222,17 @@ export async function authenticateProviderUser(
 					data: null,
 				};
 			}
-			user =
-				(await applyUpdateUserInfoOnLink(c, dbUser.user.id, userInfo)) ?? user;
+			if (resolution.action === "default") {
+				user =
+					(await applyUpdateUserInfoOnLink(c, dbUser.user.id, providerUser)) ??
+					user;
+			}
 		} else {
-			const { id: _providerAccountId, ...providerUserInfo } = userInfo;
 			await assertValidUserInfo(c, {
 				user: {
-					...providerUserInfo,
+					...providerUser,
 					id: dbUser.user.id,
-					email: userInfo.email.toLowerCase(),
+					email: providerUser.email.toLowerCase(),
 				},
 				source: { ...source, action: "sign-in" },
 			});
@@ -227,41 +276,42 @@ export async function authenticateProviderUser(
 			}
 
 			if (
-				userInfo.emailVerified &&
+				resolution.action === "default" &&
+				providerUser.emailVerified &&
 				!dbUser.user.emailVerified &&
-				userInfo.email.toLowerCase() === dbUser.user.email
+				providerUser.email.toLowerCase() === dbUser.user.email
 			) {
 				await c.context.internalAdapter.updateUser(dbUser.user.id, {
 					emailVerified: true,
 				});
 			}
 		}
-		if (overrideUserInfo) {
+		if (shouldApplyProviderProfile) {
 			const {
-				id: _id,
 				email: _email,
 				emailVerified: _emailVerified,
 				name,
 				image,
 				...providerProfile
-			} = userInfo;
+			} = providerUser;
 			const additionalUserFields = parseAdditionalUserInputFromProviderProfile(
 				c.context.options,
 				providerProfile,
 				"update",
 			);
-			// update user info from the provider if overrideUserInfo is true
 			const updatedUser = await c.context.internalAdapter.updateUser(
 				dbUser.user.id,
 				{
 					name,
 					image,
 					...additionalUserFields,
-					email: userInfo.email.toLowerCase(),
+					email: providerUser.email.toLowerCase(),
 					emailVerified:
-						userInfo.email.toLowerCase() === dbUser.user.email
-							? dbUser.user.emailVerified || userInfo.emailVerified
-							: userInfo.emailVerified,
+						resolution.action === "link"
+							? providerUser.emailVerified
+							: providerUser.email.toLowerCase() === dbUser.user.email
+								? dbUser.user.emailVerified || providerUser.emailVerified
+								: providerUser.emailVerified,
 				},
 			);
 			if (updatedUser == null) {
@@ -281,13 +331,12 @@ export async function authenticateProviderUser(
 		}
 		try {
 			const {
-				id: _id,
 				email: _email,
 				emailVerified: _emailVerified,
 				name,
 				image,
 				...providerProfile
-			} = userInfo;
+			} = providerUser;
 			const additionalUserFields = parseAdditionalUserInputFromProviderProfile(
 				c.context.options,
 				providerProfile,
@@ -308,8 +357,8 @@ export async function authenticateProviderUser(
 					name,
 					image,
 					...additionalUserFields,
-					email: userInfo.email.toLowerCase(),
-					emailVerified: userInfo.emailVerified,
+					email: providerUser.email.toLowerCase(),
+					emailVerified: providerUser.emailVerified,
 				},
 				{
 					source,

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -1,6 +1,7 @@
 import type {
 	BetterAuthPlugin,
 	GenericEndpointContext,
+	ProviderUserProfile,
 	SecretConfig,
 } from "@better-auth/core";
 import {
@@ -25,7 +26,7 @@ import { authenticateProviderUser } from "../../oauth2/provider-user";
 import { getOAuthCallbackPath } from "../../oauth2/utils";
 import type { StateData } from "../../state";
 import { parseGenericState } from "../../state";
-import type { Account, User } from "../../types";
+import type { Account } from "../../types";
 import { isAPIError } from "../../utils/is-api-error";
 import { getOrigin } from "../../utils/url";
 import { PACKAGE_VERSION } from "../../version";
@@ -104,7 +105,7 @@ type OAuthProxyStatePackage = {
  * @internal
  */
 type PassthroughPayload = {
-	userInfo: Omit<User, "createdAt" | "updatedAt">;
+	providerUser: ProviderUserProfile;
 	identity: IdentityKey;
 	account: Pick<
 		Account,
@@ -251,7 +252,7 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 					// Validate required payload fields
 					if (
 						typeof payload.timestamp !== "number" ||
-						!payload.userInfo ||
+						!payload.providerUser ||
 						!payload.identity ||
 						typeof payload.identity.issuer !== "string" ||
 						typeof payload.identity.providerAccountId !== "string" ||
@@ -293,7 +294,7 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 					let result: Awaited<ReturnType<typeof authenticateProviderUser>>;
 					try {
 						result = await authenticateProviderUser(ctx, {
-							userInfo: payload.userInfo,
+							providerUser: payload.providerUser,
 							identity: payload.identity,
 							account: payload.account,
 							callbackURL: payload.callbackURL,
@@ -540,8 +541,7 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 							stateData.callbackURL;
 
 						const payload: PassthroughPayload = {
-							userInfo: {
-								id: identityKey.providerAccountId,
+							providerUser: {
 								email: userInfo.email,
 								name: userInfo.name || "",
 								image: userInfo.image,

--- a/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/oauth-proxy.test.ts
@@ -544,8 +544,7 @@ describe("oauth-proxy", async () => {
 				data: encryptedProfile!,
 			});
 			const payload = parseJSON<{
-				userInfo: {
-					id: string;
+				providerUser: {
 					email: string;
 					name?: string;
 					emailVerified: boolean;
@@ -564,8 +563,8 @@ describe("oauth-proxy", async () => {
 				timestamp: number;
 			}>(decrypted);
 
-			expect(payload.userInfo).toBeDefined();
-			expect(payload.userInfo.email).toBe("user@email.com");
+			expect(payload.providerUser).toBeDefined();
+			expect(payload.providerUser.email).toBe("user@email.com");
 			expect(payload.account).toBeDefined();
 			expect(payload.account.providerId).toBe("google");
 			expect(payload.identity).toEqual({
@@ -916,8 +915,7 @@ describe("oauth-proxy", async () => {
 
 			// Create expired profile payload
 			const payload = {
-				userInfo: {
-					id: "123",
+				providerUser: {
 					email: "user@email.com",
 					name: "Test User",
 					emailVerified: true,
@@ -970,8 +968,7 @@ describe("oauth-proxy", async () => {
 
 			// Create payload that's 10 seconds old (older than maxAge of 5)
 			const payload = {
-				userInfo: {
-					id: "123",
+				providerUser: {
 					email: "user@email.com",
 					name: "Test User",
 					emailVerified: true,
@@ -1069,13 +1066,13 @@ describe("oauth-proxy", async () => {
 				data: encryptedProfile!,
 			});
 			const payload = parseJSON<{
-				userInfo: unknown;
+				providerUser: unknown;
 				account: {
 					providerId: string;
 				};
 			}>(decrypted);
 
-			expect(payload.userInfo).toBeDefined();
+			expect(payload.providerUser).toBeDefined();
 			expect(payload.account).toBeDefined();
 			expect(payload.account.providerId).toBe("google");
 		});
@@ -1098,8 +1095,7 @@ describe("oauth-proxy", async () => {
 
 			// Test missing timestamp
 			const payloadMissingTimestamp = {
-				userInfo: {
-					id: "123",
+				providerUser: {
 					email: "user@email.com",
 					name: "Test User",
 					emailVerified: true,
@@ -1132,8 +1128,8 @@ describe("oauth-proxy", async () => {
 				},
 			);
 
-			// Test missing userInfo
-			const payloadMissingUserInfo = {
+			// Test missing providerUser
+			const payloadMissingProviderUser = {
 				account: {
 					providerId: "google",
 					accessToken: "test",
@@ -1149,7 +1145,7 @@ describe("oauth-proxy", async () => {
 
 			const encrypted2 = await symmetricEncrypt({
 				key: secret,
-				data: JSON.stringify(payloadMissingUserInfo),
+				data: JSON.stringify(payloadMissingProviderUser),
 			});
 
 			await client.$fetch(
@@ -1164,8 +1160,7 @@ describe("oauth-proxy", async () => {
 
 			// Test non-numeric timestamp (should not bypass validation)
 			const payloadStringTimestamp = {
-				userInfo: {
-					id: "123",
+				providerUser: {
 					email: "user@email.com",
 					name: "Test User",
 					emailVerified: true,
@@ -1355,8 +1350,7 @@ describe("oauth-proxy", async () => {
 
 			// Create profile payload for the SAME email
 			const payload = {
-				userInfo: {
-					id: "google-user-id",
+				providerUser: {
 					email: "user@email.com",
 					name: "New Name",
 					emailVerified: true,
@@ -1525,8 +1519,7 @@ describe("oauth-proxy", async () => {
 
 			// Create a valid payload with a state that doesn't exist in DB
 			const payload = {
-				userInfo: {
-					id: "123",
+				providerUser: {
 					email: "test@email.com",
 					name: "Test User",
 					emailVerified: true,

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -175,8 +175,7 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 					// Google `sub` wins, never whichever local user happens to share the
 					// token's email.
 					const result = await authenticateProviderUser(ctx, {
-						userInfo: {
-							id: sub,
+						providerUser: {
 							email,
 							emailVerified,
 							name: typeof name === "string" ? name : "",

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -52,4 +52,8 @@ export type {
 	ClientFetchOption,
 	ClientStore,
 } from "./plugin-client";
+export type {
+	ProviderUserProfile,
+	ProviderUserResolution,
+} from "./provider-user";
 export type { SecretConfig } from "./secret";

--- a/packages/core/src/types/provider-user.ts
+++ b/packages/core/src/types/provider-user.ts
@@ -1,0 +1,53 @@
+import type { User } from "../db";
+
+type ProviderUserIdentityField = "id" | "createdAt" | "updatedAt";
+type ProviderUserBaseProfile = Omit<User, ProviderUserIdentityField>;
+
+/**
+ * User attributes asserted by an external identity provider.
+ *
+ * The provider subject is deliberately excluded. Provider subjects identify
+ * external identities; they are not Better Auth User IDs.
+ * Additional mapped attributes remain available as `unknown` by default so
+ * callers must validate provider-controlled claim values before using them.
+ */
+export type ProviderUserProfile<
+	AdditionalFields extends Record<string, unknown> = Record<string, unknown>,
+> = ProviderUserBaseProfile &
+	Omit<
+		AdditionalFields,
+		keyof ProviderUserBaseProfile | ProviderUserIdentityField
+	> & {
+		[Field in ProviderUserIdentityField]?: never;
+	};
+
+/** Application decision for a verified provider identity. */
+export type ProviderUserResolution =
+	| {
+			/**
+			 * Use Better Auth's standard provider flow: match an existing identity,
+			 * fall back to email-based account linking, then create a user when
+			 * sign-up is allowed.
+			 */
+			action: "default";
+	  }
+	| {
+			/** Link the verified provider identity to a specific Better Auth user. */
+			action: "link";
+			/** Better Auth user that owns the verified provider identity. */
+			userId: string;
+			/**
+			 * Choose `preserve` to leave every local User field unchanged, or
+			 * `provider` to apply the verified provider profile exactly for this
+			 * sign-in.
+			 */
+			profile: "preserve" | "provider";
+	  }
+	| {
+			/** Reject authentication before identity, account, user, or session writes. */
+			action: "reject";
+			/** Stable application error code returned to the caller. */
+			code: string;
+			/** Optional human-readable error message returned to the caller. */
+			message?: string | undefined;
+	  };

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -53,6 +53,9 @@ import type {
 	SSOOptions,
 	SSOProvider,
 	SSOProviderSchema,
+	SSOUserResolution,
+	SSOUserResolutionContext,
+	SSOUserResolutionInput,
 } from "./types";
 import { PACKAGE_VERSION } from "./version";
 
@@ -62,6 +65,9 @@ export type {
 	SAMLIdentityProviderMetadata,
 	SSOOptions,
 	SSOProvider,
+	SSOUserResolution,
+	SSOUserResolutionContext,
+	SSOUserResolutionInput,
 };
 
 declare module "@better-auth/core" {

--- a/packages/sso/src/oidc-user-resolution-http-e2e.test.ts
+++ b/packages/sso/src/oidc-user-resolution-http-e2e.test.ts
@@ -1,0 +1,752 @@
+import type { DBTransactionAdapter, User } from "better-auth";
+import { getHttpTestInstance } from "better-auth/test";
+import { OAuth2Server } from "oauth2-mock-server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { sso } from ".";
+import type { SSOOptions, SSOUserResolutionInput } from "./types";
+
+type CookieJar = Map<string, string>;
+
+type OIDCProfile = {
+	subject: string;
+	email: string;
+	name: string;
+};
+
+function storeResponseCookies(response: Response, cookies: CookieJar): void {
+	for (const setCookie of response.headers.getSetCookie()) {
+		const attributesIndex = setCookie.indexOf(";");
+		const cookie = setCookie.slice(
+			0,
+			attributesIndex === -1 ? setCookie.length : attributesIndex,
+		);
+		const separatorIndex = cookie.indexOf("=");
+		if (separatorIndex < 1) continue;
+		const name = cookie.slice(0, separatorIndex);
+		const value = cookie.slice(separatorIndex + 1);
+		if (value) {
+			cookies.set(name, value);
+		} else {
+			cookies.delete(name);
+		}
+	}
+}
+
+function getCookieHeader(cookies: CookieJar): string {
+	return [...cookies].map(([name, value]) => `${name}=${value}`).join("; ");
+}
+
+async function fetchJSON<T>(
+	url: string,
+	init: RequestInit,
+	cookies?: CookieJar,
+): Promise<{ response: Response; body: T }> {
+	const headers = new Headers(init.headers);
+	if (cookies?.size) headers.set("cookie", getCookieHeader(cookies));
+	const response = await fetch(url, { ...init, headers });
+	if (cookies) storeResponseCookies(response, cookies);
+	return { response, body: (await response.json()) as T };
+}
+
+describe("SSO OIDC user resolution HTTP end-to-end", () => {
+	const identityProvider = new OAuth2Server();
+	let profile: OIDCProfile = {
+		subject: "directory-user-1",
+		email: "idp.employee@example.com",
+		name: "Directory Employee",
+	};
+
+	beforeAll(async () => {
+		await identityProvider.issuer.keys.generate("RS256");
+		identityProvider.service.on("beforeUserinfo", (response) => {
+			response.body = {
+				sub: profile.subject,
+				email: profile.email,
+				name: profile.name,
+				email_verified: true,
+			};
+			response.statusCode = 200;
+		});
+		identityProvider.service.on("beforeTokenSigning", (token) => {
+			token.payload.sub = profile.subject;
+			token.payload.email = profile.email;
+			token.payload.name = profile.name;
+			token.payload.email_verified = true;
+		});
+		await identityProvider.start(undefined, "127.0.0.1");
+	});
+
+	afterAll(async () => {
+		await identityProvider.stop();
+	});
+
+	async function createInstance(
+		options: Omit<SSOOptions, "defaultSSO">,
+		registerCleanup: (cleanup: () => Promise<void>) => void,
+		defaultSSO: NonNullable<SSOOptions["defaultSSO"]> = [
+			{
+				domain: "example.com",
+				providerId: "workforce",
+				oidcConfig: {
+					issuer: identityProvider.issuer.url!,
+					clientId: "workforce-client",
+					clientSecret: "workforce-secret",
+					pkce: false,
+					discoveryEndpoint: `${identityProvider.issuer.url}/.well-known/openid-configuration`,
+				},
+			},
+		],
+	) {
+		const instance = await getHttpTestInstance(
+			{
+				emailAndPassword: { enabled: true },
+				trustedOrigins: [identityProvider.issuer.url!],
+				plugins: [
+					sso({
+						...options,
+						defaultSSO,
+					}),
+				],
+			},
+			{ disableTestUser: true, testWith: "sqlite" },
+		);
+		registerCleanup(() => instance.server.close());
+		return instance;
+	}
+
+	async function createPasswordUser(
+		baseURL: string,
+		email: string,
+		cookies?: CookieJar,
+	): Promise<{ id: string; email: string }> {
+		const signUp = await fetchJSON<{ user: { id: string; email: string } }>(
+			`${baseURL}/api/auth/sign-up/email`,
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					origin: baseURL,
+				},
+				body: JSON.stringify({
+					email,
+					password: "employee-password",
+					name: "Provisioned Employee",
+				}),
+			},
+			cookies,
+		);
+		expect(signUp.response.status).toBe(200);
+		return signUp.body.user;
+	}
+
+	async function completeSignIn(
+		baseURL: string,
+		providerId = "workforce",
+	): Promise<{
+		callback: Response;
+		cookies: CookieJar;
+	}> {
+		const cookies: CookieJar = new Map();
+		const signIn = await fetchJSON<{ url: string }>(
+			`${baseURL}/api/auth/sign-in/sso`,
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					origin: baseURL,
+				},
+				body: JSON.stringify({
+					providerId,
+					callbackURL: `${baseURL}/employee`,
+				}),
+			},
+			cookies,
+		);
+		expect(signIn.response.status).toBe(200);
+
+		const authorization = await fetch(signIn.body.url, { redirect: "manual" });
+		const callbackURL = authorization.headers.get("location");
+		if (!callbackURL)
+			throw new Error("OIDC provider did not return a callback");
+		const callback = await fetch(callbackURL, {
+			method: "GET",
+			headers: { cookie: getCookieHeader(cookies) },
+			redirect: "manual",
+		});
+		storeResponseCookies(callback, cookies);
+		return { callback, cookies };
+	}
+
+	it("links a bare provisioned user and resolves returning sign-ins again", async ({
+		onTestFinished,
+	}) => {
+		profile = {
+			subject: "directory-user-1",
+			email: "idp.employee@example.com",
+			name: "Directory Employee",
+		};
+		let provisionedUserId = "";
+		const resolverInputs: SSOUserResolutionInput[] = [];
+		const resolverDatabases: DBTransactionAdapter[] = [];
+		const instance = await createInstance(
+			{
+				disableImplicitSignUp: true,
+				resolveUser: async (input, context) => {
+					resolverInputs.push(input);
+					resolverDatabases.push(context.database);
+					const user = await context.database.findOne<{ id: string }>({
+						model: "user",
+						where: [{ field: "id", value: provisionedUserId }],
+					});
+					return user
+						? { action: "link", userId: user.id, profile: "preserve" }
+						: { action: "reject", code: "SCIM_USER_NOT_PROVISIONED" };
+				},
+			},
+			onTestFinished,
+		);
+		// This stack isolates SSO resolution. The SCIM stack replaces this direct
+		// adapter seed with provisioning through the SCIM HTTP API.
+		const context = await instance.auth.$context;
+		const provisionedUser = await context.adapter.create<User>({
+			model: "user",
+			data: {
+				email: "provisioned.employee@example.com",
+				emailVerified: true,
+				name: "Provisioned Employee",
+				image: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		provisionedUserId = provisionedUser.id;
+		expect(
+			await instance.db.findMany({ model: "identity", where: [] }),
+		).toHaveLength(0);
+		expect(
+			await instance.db.findMany({ model: "account", where: [] }),
+		).toHaveLength(0);
+
+		const firstSignIn = await completeSignIn(instance.baseURL);
+		expect(firstSignIn.callback.headers.get("location")).toBe(
+			`${instance.baseURL}/employee`,
+		);
+		const firstSession = await fetchJSON<{
+			user: { id: string; email: string; name: string };
+		}>(
+			`${instance.baseURL}/api/auth/get-session`,
+			{ method: "GET" },
+			firstSignIn.cookies,
+		);
+		expect(firstSession.response.status).toBe(200);
+		expect(firstSession.body.user).toMatchObject({
+			id: provisionedUser.id,
+			email: provisionedUser.email,
+			name: provisionedUser.name,
+		});
+
+		const returningSignIn = await completeSignIn(instance.baseURL);
+		expect(returningSignIn.callback.headers.get("location")).toBe(
+			`${instance.baseURL}/employee`,
+		);
+		expect(resolverInputs).toHaveLength(2);
+		expect(resolverInputs[0]).toMatchObject({
+			protocol: "oidc",
+			providerId: "workforce",
+			providerInstanceId: "sso:config:workforce",
+			identity: {
+				issuer: identityProvider.issuer.url,
+				providerAccountId: profile.subject,
+			},
+			providerUser: {
+				email: profile.email,
+				name: profile.name,
+			},
+			providerClaims: {
+				sub: profile.subject,
+				email: profile.email,
+			},
+		});
+		expect(resolverInputs[0]?.providerUser).not.toHaveProperty("id");
+		expect(resolverDatabases).toHaveLength(2);
+		expect(
+			await instance.db.findMany({ model: "user", where: [] }),
+		).toHaveLength(1);
+		const identities = await instance.db.findMany<{
+			id: string;
+			userId: string;
+		}>({
+			model: "identity",
+			where: [{ field: "issuer", value: identityProvider.issuer.url! }],
+		});
+		expect(identities).toHaveLength(1);
+		expect(identities[0]?.userId).toBe(provisionedUser.id);
+		const accounts = await instance.db.findMany<{
+			identityId: string;
+			providerInstanceId: string;
+		}>({
+			model: "account",
+			where: [
+				{
+					field: "providerInstanceId",
+					value: "sso:config:workforce",
+				},
+			],
+		});
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]?.identityId).toBe(identities[0]?.id);
+	});
+
+	it("uses default resolution for standard OIDC sign-up and authentication", async ({
+		onTestFinished,
+	}) => {
+		profile = {
+			subject: "default-resolution-user",
+			email: "default.resolution@example.com",
+			name: "Default Resolution Employee",
+		};
+		let resolverCallCount = 0;
+		const instance = await createInstance(
+			{
+				resolveUser: () => {
+					resolverCallCount += 1;
+					return { action: "default" };
+				},
+			},
+			onTestFinished,
+		);
+
+		const signIn = await completeSignIn(instance.baseURL);
+		expect(signIn.callback.headers.get("location")).toBe(
+			`${instance.baseURL}/employee`,
+		);
+		const session = await fetchJSON<{
+			user: { id: string; email: string; name: string };
+		}>(
+			`${instance.baseURL}/api/auth/get-session`,
+			{ method: "GET" },
+			signIn.cookies,
+		);
+		expect(session.response.status).toBe(200);
+		expect(session.body.user).toMatchObject({
+			email: profile.email,
+			name: profile.name,
+		});
+		expect(resolverCallCount).toBe(1);
+		expect(
+			await instance.db.findMany({ model: "user", where: [] }),
+		).toHaveLength(1);
+		expect(
+			await instance.db.findMany({
+				model: "identity",
+				where: [{ field: "userId", value: session.body.user.id }],
+			}),
+		).toHaveLength(1);
+		expect(
+			await instance.db.findMany({
+				model: "session",
+				where: [{ field: "userId", value: session.body.user.id }],
+			}),
+		).toHaveLength(1);
+	});
+
+	it("resolves a dynamically registered OIDC provider through HTTP", async ({
+		onTestFinished,
+	}) => {
+		profile = {
+			subject: "persisted-provider-user",
+			email: "persisted.provider@example.com",
+			name: "Persisted Provider Employee",
+		};
+		const resolverInputs: SSOUserResolutionInput[] = [];
+		const instance = await createInstance(
+			{
+				resolveUser: (input) => {
+					resolverInputs.push(input);
+					return { action: "default" };
+				},
+			},
+			onTestFinished,
+			[],
+		);
+		const adminCookies: CookieJar = new Map();
+		const administrator = await createPasswordUser(
+			instance.baseURL,
+			"directory.administrator@example.com",
+			adminCookies,
+		);
+		const providerId = "persisted-workforce";
+		const registration = await fetchJSON<{ providerId: string }>(
+			`${instance.baseURL}/api/auth/sso/register`,
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					origin: instance.baseURL,
+				},
+				body: JSON.stringify({
+					issuer: identityProvider.issuer.url,
+					domain: "persisted.example.com",
+					providerId,
+					oidcConfig: {
+						clientId: "persisted-workforce-client",
+						clientSecret: "persisted-workforce-secret",
+						pkce: false,
+						discoveryEndpoint: `${identityProvider.issuer.url}/.well-known/openid-configuration`,
+					},
+				}),
+			},
+			adminCookies,
+		);
+		expect(registration.response.status).toBe(200);
+		expect(registration.body.providerId).toBe(providerId);
+		const provider = await instance.db.findOne<{ id: string }>({
+			model: "ssoProvider",
+			where: [{ field: "providerId", value: providerId }],
+		});
+		if (!provider)
+			throw new Error("Registered OIDC provider was not persisted");
+
+		const signIn = await completeSignIn(instance.baseURL, providerId);
+		expect(signIn.callback.headers.get("location")).toBe(
+			`${instance.baseURL}/employee`,
+		);
+		const session = await fetchJSON<{
+			user: { id: string; email: string; name: string };
+		}>(
+			`${instance.baseURL}/api/auth/get-session`,
+			{ method: "GET" },
+			signIn.cookies,
+		);
+		expect(session.response.status).toBe(200);
+		expect(session.body.user).toMatchObject({
+			email: profile.email,
+			name: profile.name,
+		});
+		expect(session.body.user.id).not.toBe(administrator.id);
+		expect(resolverInputs).toHaveLength(1);
+		const providerInstanceId = `sso:provider:${provider.id}`;
+		expect(resolverInputs[0]).toMatchObject({
+			protocol: "oidc",
+			providerId,
+			providerInstanceId,
+			identity: {
+				issuer: `${providerInstanceId}:oidc`,
+				providerAccountId: profile.subject,
+			},
+		});
+		expect(
+			await instance.db.findMany({
+				model: "account",
+				where: [
+					{
+						field: "providerInstanceId",
+						value: providerInstanceId,
+					},
+				],
+			}),
+		).toHaveLength(1);
+	});
+
+	it("rejects an unprovisioned same-email user without implicit fallback", async ({
+		onTestFinished,
+	}) => {
+		profile = {
+			subject: "unprovisioned-directory-user",
+			email: "unprovisioned.employee@example.com",
+			name: "Unprovisioned Employee",
+		};
+		let sameEmailUserId = "";
+		const instance = await createInstance(
+			{
+				resolveUser: async (_input, context) => {
+					await context.database.update({
+						model: "user",
+						where: [{ field: "id", value: sameEmailUserId }],
+						update: { name: "This update must roll back" },
+					});
+					return {
+						action: "reject",
+						code: "SCIM_USER_NOT_PROVISIONED",
+						message: "This directory user is not provisioned",
+					};
+				},
+			},
+			onTestFinished,
+		);
+		const sameEmailUser = await createPasswordUser(
+			instance.baseURL,
+			profile.email,
+		);
+		sameEmailUserId = sameEmailUser.id;
+		const recordCountsBefore = {
+			users: await instance.db.count({ model: "user", where: [] }),
+			identities: await instance.db.count({ model: "identity", where: [] }),
+			accounts: await instance.db.count({ model: "account", where: [] }),
+			sessions: await instance.db.count({ model: "session", where: [] }),
+		};
+
+		const signIn = await completeSignIn(instance.baseURL);
+		expect(signIn.callback.status).toBe(302);
+		const errorRedirect = new URL(
+			signIn.callback.headers.get("location")!,
+			instance.baseURL,
+		);
+		expect(errorRedirect.searchParams.get("error")).toBe(
+			"SCIM_USER_NOT_PROVISIONED",
+		);
+		expect(errorRedirect.searchParams.get("error_description")).toBe(
+			"This directory user is not provisioned",
+		);
+		expect(
+			await fetchJSON<{ user: { id: string } } | null>(
+				`${instance.baseURL}/api/auth/get-session`,
+				{ method: "GET" },
+				signIn.cookies,
+			),
+		).toMatchObject({ body: null });
+		expect({
+			users: await instance.db.count({ model: "user", where: [] }),
+			identities: await instance.db.count({ model: "identity", where: [] }),
+			accounts: await instance.db.count({ model: "account", where: [] }),
+			sessions: await instance.db.count({ model: "session", where: [] }),
+		}).toEqual(recordCountsBefore);
+		expect(
+			await instance.db.findOne<{ name: string }>({
+				model: "user",
+				where: [{ field: "id", value: sameEmailUser.id }],
+			}),
+		).toMatchObject({ name: "Provisioned Employee" });
+	});
+
+	it("rolls back resolver writes when authentication returns a failure", async ({
+		onTestFinished,
+	}) => {
+		profile = {
+			subject: "signup-disabled-directory-user",
+			email: "signup.disabled@example.com",
+			name: "Signup Disabled Employee",
+		};
+		let existingUserId = "";
+		const instance = await createInstance(
+			{
+				disableImplicitSignUp: true,
+				resolveUser: async (_input, context) => {
+					await context.database.update({
+						model: "user",
+						where: [{ field: "id", value: existingUserId }],
+						update: { name: "This resolver update must roll back" },
+					});
+					return { action: "default" };
+				},
+			},
+			onTestFinished,
+		);
+		const existingUser = await createPasswordUser(
+			instance.baseURL,
+			"existing.employee@example.com",
+		);
+		existingUserId = existingUser.id;
+		const recordCountsBefore = {
+			users: await instance.db.count({ model: "user", where: [] }),
+			identities: await instance.db.count({ model: "identity", where: [] }),
+			accounts: await instance.db.count({ model: "account", where: [] }),
+			sessions: await instance.db.count({ model: "session", where: [] }),
+		};
+
+		const signIn = await completeSignIn(instance.baseURL);
+
+		expect(signIn.callback.status).toBe(302);
+		const errorRedirect = new URL(
+			signIn.callback.headers.get("location")!,
+			instance.baseURL,
+		);
+		expect(errorRedirect.searchParams.get("error")).toBe("signup disabled");
+		expect({
+			users: await instance.db.count({ model: "user", where: [] }),
+			identities: await instance.db.count({ model: "identity", where: [] }),
+			accounts: await instance.db.count({ model: "account", where: [] }),
+			sessions: await instance.db.count({ model: "session", where: [] }),
+		}).toEqual(recordCountsBefore);
+		expect(
+			await instance.db.findOne<{ name: string }>({
+				model: "user",
+				where: [{ field: "id", value: existingUser.id }],
+			}),
+		).toMatchObject({ name: "Provisioned Employee" });
+	});
+
+	it("rejects a resolver link that conflicts with an existing provider identity", async ({
+		onTestFinished,
+	}) => {
+		profile = {
+			subject: "conflicting-directory-user",
+			email: "conflicting.employee@example.com",
+			name: "Conflicting Employee",
+		};
+		let resolvedUserId = "";
+		const instance = await createInstance(
+			{
+				disableImplicitSignUp: true,
+				resolveUser: () => ({
+					action: "link",
+					userId: resolvedUserId,
+					profile: "preserve",
+				}),
+			},
+			onTestFinished,
+		);
+		const firstUser = await createPasswordUser(
+			instance.baseURL,
+			"first.employee@example.com",
+		);
+		const secondUser = await createPasswordUser(
+			instance.baseURL,
+			"second.employee@example.com",
+		);
+		resolvedUserId = firstUser.id;
+		const firstSignIn = await completeSignIn(instance.baseURL);
+		expect(firstSignIn.callback.headers.get("location")).toBe(
+			`${instance.baseURL}/employee`,
+		);
+		const recordCountsAfterLink = {
+			users: await instance.db.count({ model: "user", where: [] }),
+			identities: await instance.db.count({ model: "identity", where: [] }),
+			accounts: await instance.db.count({ model: "account", where: [] }),
+			sessions: await instance.db.count({ model: "session", where: [] }),
+		};
+
+		resolvedUserId = secondUser.id;
+		const conflictingSignIn = await completeSignIn(instance.baseURL);
+		const errorRedirect = new URL(
+			conflictingSignIn.callback.headers.get("location")!,
+			instance.baseURL,
+		);
+		expect(errorRedirect.searchParams.get("error")).toBe(
+			"identity_already_linked",
+		);
+		expect({
+			users: await instance.db.count({ model: "user", where: [] }),
+			identities: await instance.db.count({ model: "identity", where: [] }),
+			accounts: await instance.db.count({ model: "account", where: [] }),
+			sessions: await instance.db.count({ model: "session", where: [] }),
+		}).toEqual(recordCountsAfterLink);
+	});
+
+	it("fails before invoking the resolver without native transactions", async ({
+		onTestFinished,
+	}) => {
+		profile = {
+			subject: "unsupported-adapter-user",
+			email: "unsupported.employee@example.com",
+			name: "Unsupported Adapter Employee",
+		};
+		let resolverCallCount = 0;
+		const instance = await createInstance(
+			{
+				resolveUser: () => {
+					resolverCallCount += 1;
+					return { action: "default" };
+				},
+			},
+			onTestFinished,
+		);
+		const context = await instance.auth.$context;
+		if (!context.adapter.options) {
+			throw new Error(
+				"Test adapter did not expose its capability configuration",
+			);
+		}
+		context.adapter.options.adapterConfig.transaction = false;
+
+		const signIn = await completeSignIn(instance.baseURL);
+		const errorRedirect = new URL(
+			signIn.callback.headers.get("location")!,
+			instance.baseURL,
+		);
+		expect(errorRedirect.searchParams.get("error")).toBe(
+			"SSO_USER_RESOLUTION_REQUIRES_NATIVE_TRANSACTIONS",
+		);
+		expect(resolverCallCount).toBe(0);
+		expect(
+			await instance.db.findMany({ model: "identity", where: [] }),
+		).toHaveLength(0);
+		expect(
+			await instance.db.findMany({ model: "account", where: [] }),
+		).toHaveLength(0);
+		expect(
+			await instance.db.findMany({ model: "session", where: [] }),
+		).toHaveLength(0);
+	});
+
+	it("normalizes thrown and malformed resolver failures", async ({
+		onTestFinished,
+	}) => {
+		profile = {
+			subject: "resolver-failure-user",
+			email: "resolver.failure@example.com",
+			name: "Resolver Failure Employee",
+		};
+		const thrownFailureInstance = await createInstance(
+			{
+				resolveUser: () => {
+					throw new Error("private directory topology");
+				},
+			},
+			onTestFinished,
+		);
+		const thrownFailure = await completeSignIn(thrownFailureInstance.baseURL);
+		const thrownFailureRedirect = new URL(
+			thrownFailure.callback.headers.get("location")!,
+			thrownFailureInstance.baseURL,
+		);
+		expect(thrownFailureRedirect.searchParams.get("error")).toBe(
+			"SSO_USER_RESOLUTION_FAILED",
+		);
+		expect(thrownFailureRedirect.searchParams.get("error_description")).toBe(
+			"Unable to resolve the SSO user",
+		);
+		expect(thrownFailureRedirect.toString()).not.toContain(
+			"directory+topology",
+		);
+
+		const malformedResolver = (() => null) as unknown as NonNullable<
+			SSOOptions["resolveUser"]
+		>;
+		const malformedResultInstance = await createInstance(
+			{ resolveUser: malformedResolver },
+			onTestFinished,
+		);
+		const malformedResult = await completeSignIn(
+			malformedResultInstance.baseURL,
+		);
+		const malformedResultRedirect = new URL(
+			malformedResult.callback.headers.get("location")!,
+			malformedResultInstance.baseURL,
+		);
+		expect(malformedResultRedirect.searchParams.get("error")).toBe(
+			"SSO_USER_RESOLUTION_FAILED",
+		);
+		expect(malformedResultRedirect.searchParams.get("error_description")).toBe(
+			"Unable to resolve the SSO user",
+		);
+		expect(
+			await malformedResultInstance.db.findMany({
+				model: "identity",
+				where: [],
+			}),
+		).toHaveLength(0);
+		expect(
+			await malformedResultInstance.db.findMany({
+				model: "account",
+				where: [],
+			}),
+		).toHaveLength(0);
+		expect(
+			await malformedResultInstance.db.findMany({
+				model: "session",
+				where: [],
+			}),
+		).toHaveLength(0);
+	});
+});

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -1,4 +1,7 @@
-import { runWithTransaction } from "@better-auth/core/context";
+import {
+	getCurrentAdapter,
+	runWithTransaction,
+} from "@better-auth/core/context";
 import { isAPIError } from "@better-auth/core/utils/is-api-error";
 import type { User } from "better-auth";
 import { APIError } from "better-auth/api";
@@ -35,6 +38,12 @@ import type {
 	SAMLSessionRecord,
 	SSOOptions,
 } from "../types";
+import {
+	assertSSOUserResolutionNativeTransactionSupport,
+	getFailedSSOAuthenticationResult,
+	requireSuccessfulSSOAuthentication,
+	resolveSSOUser,
+} from "../user-resolution";
 import {
 	parseProviderEmailVerified,
 	safeJsonParse,
@@ -538,6 +547,16 @@ export async function processSAMLResponse(
 		"domainVerified" in provider &&
 		!!(provider as { domainVerified?: boolean }).domainVerified &&
 		validateEmailDomain(userInfo.email as string, provider.domain);
+	const { id: _providerSubject, ...providerUserAttributes } = userInfo;
+	const providerUser = {
+		...providerUserAttributes,
+		email: userInfo.email as string,
+		name: (userInfo.name || userInfo.email) as string,
+	};
+	const identity = {
+		issuer: resolveSSOIdentityIssuer(provider, "saml"),
+		providerAccountId: userInfo.id as string,
+	};
 
 	// TODO: split callbackUrl into separate ACS URL and post-auth redirect
 	// fields. Currently callbackUrl serves both purposes, which means
@@ -551,19 +570,29 @@ export async function processSAMLResponse(
 
 	let result: Awaited<ReturnType<typeof authenticateProviderUser>>;
 	try {
+		if (options?.resolveUser) {
+			assertSSOUserResolutionNativeTransactionSupport(ctx.context.adapter);
+		}
 		result = await runWithTransaction(ctx.context.adapter, async () => {
 			await lockSSOProviderForAccountLink(ctx, provider);
-			return authenticateProviderUser(ctx, {
-				userInfo: {
-					email: userInfo.email as string,
-					name: (userInfo.name || userInfo.email) as string,
-					id: userInfo.id as string,
-					emailVerified: userInfo.emailVerified,
-				},
-				identity: {
-					issuer: resolveSSOIdentityIssuer(provider, "saml"),
-					providerAccountId: userInfo.id as string,
-				},
+			const resolution = options?.resolveUser
+				? await resolveSSOUser(
+						options.resolveUser,
+						{
+							protocol: "saml",
+							providerId: provider.providerId,
+							providerInstanceId: provider.instance.providerInstanceId,
+							identity,
+							providerUser,
+							providerClaims: attributes,
+						},
+						await getCurrentAdapter(ctx.context.adapter),
+						ctx.context.logger,
+					)
+				: undefined;
+			const authentication = await authenticateProviderUser(ctx, {
+				providerUser,
+				identity,
 				account: {
 					providerId: provider.providerId,
 					providerInstanceId: provider.instance.providerInstanceId,
@@ -578,18 +607,26 @@ export async function processSAMLResponse(
 				},
 				isTrustedProvider,
 				trustProviderByName: false,
+				resolution,
 			});
+			return options?.resolveUser
+				? requireSuccessfulSSOAuthentication(authentication)
+				: authentication;
 		});
 	} catch (e) {
-		if (isAPIError(e) && e.body?.code) {
+		const failedAuthentication = getFailedSSOAuthenticationResult(e);
+		if (failedAuthentication) {
+			result = failedAuthentication;
+		} else if (isAPIError(e) && e.body?.code) {
 			throw ctx.redirect(
 				buildSAMLRedirectUrl(errorUrl, {
 					error: e.body.code,
 					...(e.body.message ? { error_description: e.body.message } : {}),
 				}),
 			);
+		} else {
+			throw e;
 		}
-		throw e;
 	}
 
 	if (result.error) {

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1,4 +1,7 @@
-import { runWithTransaction } from "@better-auth/core/context";
+import {
+	getCurrentAdapter,
+	runWithTransaction,
+} from "@better-auth/core/context";
 import { isAPIError } from "@better-auth/core/utils/is-api-error";
 import type {
 	PrivateKeyJwtSigningAlgorithm,
@@ -65,6 +68,12 @@ import type {
 	SSOProvider,
 	SSOProviderAdditionalFieldsInput,
 } from "../types";
+import {
+	assertSSOUserResolutionNativeTransactionSupport,
+	getFailedSSOAuthenticationResult,
+	requireSuccessfulSSOAuthentication,
+	resolveSSOUser,
+} from "../user-resolution";
 import {
 	domainMatches,
 	parseProviderEmailVerified,
@@ -1659,25 +1668,46 @@ async function handleOIDCCallback(
 		"domainVerified" in provider &&
 		(provider as { domainVerified?: boolean }).domainVerified === true &&
 		validateEmailDomain(userInfoEmail, provider.domain);
+	const { id: _providerSubject, ...providerUserAttributes } = userInfo;
+	const providerUser = {
+		...providerUserAttributes,
+		email: userInfoEmail,
+		name: userInfo.name || "",
+		image: userInfo.image,
+		emailVerified: options?.trustEmailVerified
+			? userInfo.emailVerified || false
+			: false,
+	};
+	const identity = {
+		issuer: identityIssuer,
+		providerAccountId: userInfoId,
+	};
 
 	let linked: Awaited<ReturnType<typeof authenticateProviderUser>>;
 	try {
+		if (options?.resolveUser) {
+			assertSSOUserResolutionNativeTransactionSupport(ctx.context.adapter);
+		}
 		linked = await runWithTransaction(ctx.context.adapter, async () => {
 			await lockSSOProviderForAccountLink(ctx, provider);
-			return authenticateProviderUser(ctx, {
-				userInfo: {
-					email: userInfoEmail,
-					name: userInfo.name || "",
-					id: userInfoId,
-					image: userInfo.image,
-					emailVerified: options?.trustEmailVerified
-						? userInfo.emailVerified || false
-						: false,
-				},
-				identity: {
-					issuer: identityIssuer,
-					providerAccountId: userInfoId,
-				},
+			const resolution = options?.resolveUser
+				? await resolveSSOUser(
+						options.resolveUser,
+						{
+							protocol: "oidc",
+							providerId: provider.providerId,
+							providerInstanceId: provider.instance.providerInstanceId,
+							identity,
+							providerUser,
+							providerClaims: rawProfile ?? {},
+						},
+						await getCurrentAdapter(ctx.context.adapter),
+						ctx.context.logger,
+					)
+				: undefined;
+			const authentication = await authenticateProviderUser(ctx, {
+				providerUser,
+				identity,
 				account: {
 					idToken: tokenResponse.idToken,
 					accessToken: tokenResponse.accessToken,
@@ -1699,17 +1729,25 @@ async function handleOIDCCallback(
 				// An SSO alias is only a routing label. Trust comes from the
 				// verified SSO authority, not another provider with the same name.
 				trustProviderByName: false,
+				resolution,
 			});
+			return options?.resolveUser
+				? requireSuccessfulSSOAuthentication(authentication)
+				: authentication;
 		});
 	} catch (e) {
-		if (isAPIError(e) && e.body?.code) {
+		const failedAuthentication = getFailedSSOAuthenticationResult(e);
+		if (failedAuthentication) {
+			linked = failedAuthentication;
+		} else if (isAPIError(e) && e.body?.code) {
 			const baseURL = errorURL || callbackURL;
 			const params = new URLSearchParams({ error: e.body.code });
 			if (e.body.message) params.set("error_description", e.body.message);
 			const sep = baseURL.includes("?") ? "&" : "?";
 			throw ctx.redirect(`${baseURL}${sep}${params.toString()}`);
+		} else {
+			throw e;
 		}
-		throw e;
 	}
 	if (linked.error) {
 		const baseURL = errorURL || callbackURL;

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -3315,6 +3315,416 @@ describe("SAML SSO", async () => {
 	});
 });
 
+function createUserResolutionSAMLProvider(providerId: string) {
+	return {
+		domain: "example.com",
+		providerId,
+		samlConfig: {
+			issuer: "http://localhost:8081",
+			entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+			cert: certificate,
+			wantAssertionsSigned: false,
+			signatureAlgorithm: "sha256",
+			digestAlgorithm: "sha256",
+			idpMetadata: { metadata: idpMetadata },
+			spMetadata: { metadata: spMetadata },
+			identifierFormat:
+				"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+		},
+	};
+}
+
+async function fetchMockSAMLResponse(signInUrl: string): Promise<string> {
+	const response = await fetch(signInUrl);
+	const body: unknown = await response.json();
+	if (
+		!body ||
+		typeof body !== "object" ||
+		!("samlResponse" in body) ||
+		typeof body.samlResponse !== "string"
+	) {
+		throw new Error("Mock SAML provider did not return a SAML response");
+	}
+	return body.samlResponse;
+}
+
+async function completeUserResolutionSAMLSignIn(
+	handler: (request: Request) => Promise<Response>,
+	providerId: string,
+): Promise<Response> {
+	const signInResponse = await handler(
+		new Request("http://localhost:3000/api/auth/sign-in/sso", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				origin: "http://localhost:3000",
+			},
+			body: JSON.stringify({
+				providerId,
+				callbackURL: "http://localhost:3000/employee",
+			}),
+		}),
+	);
+	const signInBody: unknown = await signInResponse.json();
+	if (
+		!signInBody ||
+		typeof signInBody !== "object" ||
+		!("url" in signInBody) ||
+		typeof signInBody.url !== "string"
+	) {
+		throw new Error("SAML sign-in did not return an identity provider URL");
+	}
+	const signInUrl = new URL(signInBody.url);
+	return handler(
+		new Request(
+			`http://localhost:3000/api/auth/sso/saml2/sp/acs/${providerId}`,
+			{
+				method: "POST",
+				headers: {
+					"content-type": "application/x-www-form-urlencoded",
+					cookie: signInResponse.headers.get("set-cookie") ?? "",
+				},
+				body: new URLSearchParams({
+					SAMLResponse: await fetchMockSAMLResponse(signInBody.url),
+					RelayState: signInUrl.searchParams.get("RelayState") ?? "",
+				}),
+			},
+		),
+	);
+}
+
+describe("SAML SSO user resolution", () => {
+	it("links an exact local user without treating the provider subject as its user ID", async () => {
+		const providerId = "saml-user-resolution";
+		const providerInstanceId = `sso:config:${providerId}`;
+		const identityIssuer = `${providerInstanceId}:saml`;
+		const localUserEmail = "test@test.com";
+		let resolutionCount = 0;
+		const { auth, db } = await getTestInstance({
+			plugins: [
+				sso({
+					disableImplicitSignUp: true,
+					defaultSSO: [createUserResolutionSAMLProvider(providerId)],
+					saml: { enableInResponseToValidation: false },
+					resolveUser: async (input, context) => {
+						resolutionCount += 1;
+						expect(input).toMatchObject({
+							protocol: "saml",
+							providerId,
+							providerInstanceId,
+							identity: {
+								issuer: identityIssuer,
+								providerAccountId: "test@email.com",
+							},
+							providerUser: {
+								email: "test@email.com",
+							},
+							providerClaims: {
+								email: "test@email.com",
+							},
+						});
+						expect(input.providerUser).not.toHaveProperty("id");
+						const user = await context.database.findOne<{ id: string }>({
+							model: "user",
+							where: [{ field: "email", value: localUserEmail }],
+						});
+						return user
+							? { action: "link", userId: user.id, profile: "preserve" }
+							: { action: "reject", code: "SCIM_USER_NOT_PROVISIONED" };
+					},
+				}),
+			],
+		});
+		const localUser = await db.findOne<{
+			id: string;
+			name: string;
+			email: string;
+			emailVerified: boolean;
+			image: string | null;
+		}>({
+			model: "user",
+			where: [{ field: "email", value: localUserEmail }],
+		});
+		if (!localUser) throw new Error("Local test user was not created");
+		const sessionsBeforeSignIn = await db.findMany({
+			model: "session",
+			where: [{ field: "userId", value: localUser.id }],
+		});
+
+		const callback = await completeUserResolutionSAMLSignIn(
+			auth.handler,
+			providerId,
+		);
+
+		expect(callback.status).toBe(302);
+		expect(callback.headers.get("location")).toBe(
+			"http://localhost:3000/employee",
+		);
+		const sessionToken = parseSetCookieHeader(
+			callback.headers.get("set-cookie") ?? "",
+		).get("better-auth.session_token")?.value;
+		if (!sessionToken)
+			throw new Error("SAML callback did not create a session");
+		const sessionResponse = await auth.handler(
+			new Request("http://localhost:3000/api/auth/get-session", {
+				headers: {
+					cookie: `better-auth.session_token=${sessionToken}`,
+				},
+			}),
+		);
+		expect(sessionResponse.status).toBe(200);
+		expect(await sessionResponse.json()).toEqual({
+			session: expect.objectContaining({ userId: localUser.id }),
+			user: {
+				createdAt: expect.any(String),
+				email: localUser.email,
+				emailVerified: localUser.emailVerified,
+				id: localUser.id,
+				image: localUser.image,
+				name: localUser.name,
+				updatedAt: expect.any(String),
+			},
+		});
+		expect(resolutionCount).toBe(1);
+		expect(await db.findMany({ model: "user", where: [] })).toHaveLength(1);
+		const identities = await db.findMany<{ id: string; userId: string }>({
+			model: "identity",
+			where: [
+				{ field: "issuer", value: identityIssuer },
+				{ field: "providerAccountId", value: "test@email.com" },
+			],
+		});
+		const linkedIdentity = identities[0];
+		if (!linkedIdentity) throw new Error("SAML identity was not linked");
+		expect(identities).toEqual([
+			expect.objectContaining({ userId: localUser.id }),
+		]);
+		expect(
+			await db.findMany({
+				model: "account",
+				where: [
+					{ field: "identityId", value: linkedIdentity.id },
+					{ field: "providerInstanceId", value: providerInstanceId },
+				],
+			}),
+		).toHaveLength(1);
+		expect(
+			await db.findMany({
+				model: "session",
+				where: [{ field: "userId", value: localUser.id }],
+			}),
+		).toHaveLength(sessionsBeforeSignIn.length + 1);
+	});
+
+	it("gates a returning identity and rejects it without authentication writes", async () => {
+		const providerId = "saml-returning-user-resolution";
+		const providerInstanceId = `sso:config:${providerId}`;
+		const localUserEmail = "test@test.com";
+		let isActive = true;
+		let resolutionCount = 0;
+		const { auth, db } = await getTestInstance({
+			plugins: [
+				sso({
+					disableImplicitSignUp: true,
+					defaultSSO: [createUserResolutionSAMLProvider(providerId)],
+					saml: { enableInResponseToValidation: false },
+					resolveUser: async (_input, context) => {
+						resolutionCount += 1;
+						const user = await context.database.findOne<{ id: string }>({
+							model: "user",
+							where: [{ field: "email", value: localUserEmail }],
+						});
+						if (!user) {
+							return {
+								action: "reject",
+								code: "SCIM_USER_NOT_PROVISIONED",
+							};
+						}
+						if (!isActive) {
+							await context.database.update({
+								model: "user",
+								where: [{ field: "id", value: user.id }],
+								update: { name: "This resolver update must roll back" },
+							});
+							return {
+								action: "reject",
+								code: "SCIM_USER_INACTIVE",
+								message: "The provisioned user is inactive",
+							};
+						}
+						return {
+							action: "link",
+							userId: user.id,
+							profile: "preserve",
+						};
+					},
+				}),
+			],
+		});
+
+		const completeSignIn = async () => {
+			return completeUserResolutionSAMLSignIn(auth.handler, providerId);
+		};
+
+		const firstCallback = await completeSignIn();
+		expect(firstCallback.headers.get("location")).toBe(
+			"http://localhost:3000/employee",
+		);
+		const recordsBeforeRejection = {
+			accounts: await db.findMany({ model: "account", where: [] }),
+			identities: await db.findMany({ model: "identity", where: [] }),
+			sessions: await db.findMany({ model: "session", where: [] }),
+			users: await db.findMany({ model: "user", where: [] }),
+		};
+
+		isActive = false;
+		const rejectedCallback = await completeSignIn();
+		const rejectionLocation = new URL(
+			rejectedCallback.headers.get("location") ?? "http://localhost:3000",
+		);
+		expect(rejectionLocation.searchParams.get("error")).toBe(
+			"SCIM_USER_INACTIVE",
+		);
+		expect(rejectionLocation.searchParams.get("error_description")).toBe(
+			"The provisioned user is inactive",
+		);
+		expect(resolutionCount).toBe(2);
+		expect(
+			await db.findMany({
+				model: "account",
+				where: [{ field: "providerInstanceId", value: providerInstanceId }],
+			}),
+		).toHaveLength(1);
+		expect(await db.findMany({ model: "account", where: [] })).toEqual(
+			recordsBeforeRejection.accounts,
+		);
+		expect(await db.findMany({ model: "identity", where: [] })).toEqual(
+			recordsBeforeRejection.identities,
+		);
+		expect(await db.findMany({ model: "session", where: [] })).toEqual(
+			recordsBeforeRejection.sessions,
+		);
+		expect(await db.findMany({ model: "user", where: [] })).toEqual(
+			recordsBeforeRejection.users,
+		);
+	});
+
+	it("rolls back resolver writes when authentication returns a failure", async () => {
+		const providerId = "saml-signup-disabled-user-resolution";
+		let existingUserId = "";
+		const { auth, db } = await getTestInstance({
+			plugins: [
+				sso({
+					disableImplicitSignUp: true,
+					defaultSSO: [createUserResolutionSAMLProvider(providerId)],
+					saml: { enableInResponseToValidation: false },
+					resolveUser: async (_input, context) => {
+						await context.database.update({
+							model: "user",
+							where: [{ field: "id", value: existingUserId }],
+							update: { name: "This resolver update must roll back" },
+						});
+						return { action: "default" };
+					},
+				}),
+			],
+		});
+		const existingUser = await db.findOne<{ id: string; name: string }>({
+			model: "user",
+			where: [{ field: "email", value: "test@test.com" }],
+		});
+		if (!existingUser) throw new Error("Local test user was not created");
+		existingUserId = existingUser.id;
+		const recordCountsBefore = {
+			users: (await db.findMany({ model: "user", where: [] })).length,
+			identities: (await db.findMany({ model: "identity", where: [] })).length,
+			accounts: (await db.findMany({ model: "account", where: [] })).length,
+			sessions: (await db.findMany({ model: "session", where: [] })).length,
+		};
+
+		const callback = await completeUserResolutionSAMLSignIn(
+			auth.handler,
+			providerId,
+		);
+
+		expect(callback.status).toBe(302);
+		const errorRedirect = new URL(
+			callback.headers.get("location") ?? "http://localhost:3000",
+		);
+		expect(errorRedirect.searchParams.get("error")).toBe("signup_disabled");
+		expect({
+			users: (await db.findMany({ model: "user", where: [] })).length,
+			identities: (await db.findMany({ model: "identity", where: [] })).length,
+			accounts: (await db.findMany({ model: "account", where: [] })).length,
+			sessions: (await db.findMany({ model: "session", where: [] })).length,
+		}).toEqual(recordCountsBefore);
+		expect(
+			await db.findOne<{ name: string }>({
+				model: "user",
+				where: [{ field: "id", value: existingUser.id }],
+			}),
+		).toMatchObject({ name: existingUser.name });
+	});
+
+	it.each([
+		{
+			name: "throws",
+			resolveUser: async () => {
+				throw new Error("sensitive resolver failure");
+			},
+		},
+		{
+			name: "returns a malformed result",
+			resolveUser: async () => ({}) as never,
+		},
+	])("uses a stable failure when the resolver $name", async ({
+		resolveUser,
+	}) => {
+		const providerId = `saml-failed-user-resolution-${randomUUID()}`;
+		const { auth, db } = await getTestInstance({
+			plugins: [
+				sso({
+					defaultSSO: [createUserResolutionSAMLProvider(providerId)],
+					saml: { enableInResponseToValidation: false },
+					resolveUser,
+				}),
+			],
+		});
+		const recordsBeforeCallback = {
+			accounts: await db.findMany({ model: "account", where: [] }),
+			identities: await db.findMany({ model: "identity", where: [] }),
+			sessions: await db.findMany({ model: "session", where: [] }),
+			users: await db.findMany({ model: "user", where: [] }),
+		};
+
+		const callback = await completeUserResolutionSAMLSignIn(
+			auth.handler,
+			providerId,
+		);
+		const failureLocation = new URL(
+			callback.headers.get("location") ?? "http://localhost:3000",
+		);
+		expect(failureLocation.searchParams.get("error")).toBe(
+			"SSO_USER_RESOLUTION_FAILED",
+		);
+		expect(failureLocation.searchParams.get("error_description")).toBe(
+			"Unable to resolve the SSO user",
+		);
+		expect(await db.findMany({ model: "account", where: [] })).toEqual(
+			recordsBeforeCallback.accounts,
+		);
+		expect(await db.findMany({ model: "identity", where: [] })).toEqual(
+			recordsBeforeCallback.identities,
+		);
+		expect(await db.findMany({ model: "session", where: [] })).toEqual(
+			recordsBeforeCallback.sessions,
+		);
+		expect(await db.findMany({ model: "user", where: [] })).toEqual(
+			recordsBeforeCallback.users,
+		);
+	});
+});
+
 describe("SAML SSO with custom fields", () => {
 	const ssoOptions = {
 		modelName: "sso_provider",

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -1,11 +1,22 @@
-import type { Awaitable, OAuth2Tokens, User } from "better-auth";
+import type {
+	Awaitable,
+	DBTransactionAdapter,
+	OAuth2Tokens,
+	ProviderUserProfile,
+	ProviderUserResolution,
+	User,
+} from "better-auth";
 import type {
 	DBFieldAttribute,
 	FieldAttributeToObject,
+	IdentityKey,
 	InferAdditionalFieldsFromPluginOptions,
 	RemoveFieldsWithReturnedFalse,
 } from "better-auth/db";
 import type { AlgorithmValidationOptions } from "./saml/algorithms";
+
+/** Decision returned by an SSO user resolver. */
+export type SSOUserResolution = ProviderUserResolution;
 
 export interface OIDCMapping {
 	email?: string | undefined;
@@ -276,7 +287,46 @@ export type SSOProviderSchema<O extends SSOOptions> = {
 	};
 };
 
+/** Verified provider data available to an application's SSO user resolver. */
+export interface SSOUserResolutionInput<
+	AdditionalFields extends Record<string, unknown> = Record<string, unknown>,
+> {
+	/** The authentication protocol that verified the provider identity. */
+	protocol: "oidc" | "saml";
+	/** The public routing identifier configured for the SSO provider. */
+	providerId: string;
+	/** The immutable identifier for this specific SSO provider configuration. */
+	providerInstanceId: string;
+	/** The canonical Identity namespace and provider subject Better Auth persists. */
+	identity: IdentityKey;
+	/** Normalized user attributes, including custom mapped provider fields. */
+	providerUser: ProviderUserProfile<AdditionalFields>;
+	/** Raw verified claims supplied by the identity provider. */
+	providerClaims: Record<string, unknown>;
+}
+
+/** Transaction-bound capabilities available while resolving an SSO user. */
+export interface SSOUserResolutionContext {
+	/** The active database transaction used for the complete authentication flow. */
+	database: DBTransactionAdapter;
+}
+
 export interface SSOOptions {
+	/**
+	 * Resolve a verified provider identity to an existing Better Auth user.
+	 *
+	 * The callback runs for every sign-in inside the same native transaction as
+	 * identity linking and session creation. `default` applies Better Auth's
+	 * standard identity, email-linking, and sign-up behavior. `link` selects an
+	 * exact local User with an explicit profile-ownership policy. `reject` stops
+	 * authentication before any Identity, Account, User, or Session write.
+	 */
+	resolveUser?:
+		| ((
+				input: SSOUserResolutionInput,
+				context: SSOUserResolutionContext,
+		  ) => Awaitable<SSOUserResolution>)
+		| undefined;
 	/**
 	 * custom function to provision a user when they sign in with an SSO provider.
 	 */

--- a/packages/sso/src/user-resolution.test.ts
+++ b/packages/sso/src/user-resolution.test.ts
@@ -1,0 +1,98 @@
+import type { DBTransactionAdapter, ProviderUserProfile } from "better-auth";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import type { SSOOptions, SSOUserResolutionInput } from "./types";
+import { resolveSSOUser } from "./user-resolution";
+
+const input = {
+	protocol: "oidc",
+	providerId: "workforce",
+	providerInstanceId: "sso:config:workforce",
+	identity: {
+		issuer: "https://idp.example.com",
+		providerAccountId: "directory-user-1",
+	},
+	providerUser: {
+		email: "employee@example.com",
+		emailVerified: true,
+		name: "Directory Employee",
+		image: null,
+	},
+	providerClaims: { sub: "directory-user-1" },
+} satisfies SSOUserResolutionInput;
+
+const database = {} as DBTransactionAdapter;
+
+describe("SSO user resolution", () => {
+	it("preserves mapped provider profile field types", () => {
+		const mappedProviderUser = {
+			email: "employee@example.com",
+			emailVerified: true,
+			name: "Directory Employee",
+			image: null,
+			department: "Engineering",
+		} satisfies ProviderUserProfile;
+		type WorkforceResolutionInput = SSOUserResolutionInput<{
+			department: string;
+			employeeNumber: number;
+		}>;
+
+		expectTypeOf(mappedProviderUser.department).toEqualTypeOf<string>();
+		expectTypeOf<
+			WorkforceResolutionInput["providerUser"]["department"]
+		>().toEqualTypeOf<string>();
+		expectTypeOf<
+			WorkforceResolutionInput["providerUser"]["employeeNumber"]
+		>().toEqualTypeOf<number>();
+		expectTypeOf<
+			SSOUserResolutionInput["providerUser"]["department"]
+		>().toEqualTypeOf<unknown>();
+		expectTypeOf<
+			WorkforceResolutionInput["providerUser"]["email"]
+		>().toEqualTypeOf<string>();
+		expectTypeOf<
+			WorkforceResolutionInput["providerUser"]["id"]
+		>().toEqualTypeOf<undefined>();
+	});
+
+	it("logs resolver exceptions while returning a stable error", async () => {
+		const privateError = new Error("private directory topology");
+		const logger = { error: vi.fn() };
+
+		await expect(
+			resolveSSOUser(
+				() => {
+					throw privateError;
+				},
+				input,
+				database,
+				logger,
+			),
+		).rejects.toMatchObject({
+			body: {
+				code: "SSO_USER_RESOLUTION_FAILED",
+				message: "Unable to resolve the SSO user",
+			},
+		});
+		expect(logger.error).toHaveBeenCalledWith(
+			"SSO user resolution failed",
+			privateError,
+		);
+	});
+
+	it("logs malformed decisions without logging their value", async () => {
+		const logger = { error: vi.fn() };
+		const malformedResolver = (() => ({
+			action: "link",
+			userId: "user-1",
+		})) as unknown as NonNullable<SSOOptions["resolveUser"]>;
+
+		await expect(
+			resolveSSOUser(malformedResolver, input, database, logger),
+		).rejects.toMatchObject({
+			body: { code: "SSO_USER_RESOLUTION_FAILED" },
+		});
+		expect(logger.error).toHaveBeenCalledWith(
+			"SSO user resolver returned an invalid decision",
+		);
+	});
+});

--- a/packages/sso/src/user-resolution.ts
+++ b/packages/sso/src/user-resolution.ts
@@ -1,0 +1,143 @@
+import { hasNativeTransactionSupport } from "@better-auth/core/context";
+import type {
+	DBAdapter,
+	DBTransactionAdapter,
+	GenericEndpointContext,
+} from "better-auth";
+import { APIError } from "better-auth/api";
+import type { authenticateProviderUser } from "better-auth/oauth2";
+import type {
+	SSOOptions,
+	SSOUserResolution,
+	SSOUserResolutionInput,
+} from "./types";
+
+const SSO_USER_RESOLUTION_FAILED = "SSO_USER_RESOLUTION_FAILED" as const;
+const SSO_USER_RESOLUTION_REQUIRES_NATIVE_TRANSACTIONS =
+	"SSO_USER_RESOLUTION_REQUIRES_NATIVE_TRANSACTIONS" as const;
+const SSO_AUTHENTICATION_FAILURE = Symbol("SSO_AUTHENTICATION_FAILURE");
+
+type SSOAuthenticationResult = Awaited<
+	ReturnType<typeof authenticateProviderUser>
+>;
+
+type SSOAuthenticationFailure = Error & {
+	readonly [SSO_AUTHENTICATION_FAILURE]: true;
+	readonly result: SSOAuthenticationResult;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function isSSOUserResolution(value: unknown): value is SSOUserResolution {
+	if (!isRecord(value)) return false;
+	if (value.action === "default") return true;
+	if (value.action === "link") {
+		return (
+			isNonEmptyString(value.userId) &&
+			(value.profile === "preserve" || value.profile === "provider")
+		);
+	}
+	return (
+		value.action === "reject" &&
+		isNonEmptyString(value.code) &&
+		(value.message === undefined || typeof value.message === "string")
+	);
+}
+
+type SSOUserResolutionLogger = Pick<
+	GenericEndpointContext["context"]["logger"],
+	"error"
+>;
+
+function logSSOUserResolutionFailure(
+	logger: SSOUserResolutionLogger,
+	message: string,
+	error?: unknown,
+): void {
+	try {
+		logger.error(message, ...(error === undefined ? [] : [error]));
+	} catch {
+		// A custom logger must not change the stable authentication failure.
+	}
+}
+
+function userResolutionFailure(): APIError {
+	return new APIError("INTERNAL_SERVER_ERROR", {
+		code: SSO_USER_RESOLUTION_FAILED,
+		message: "Unable to resolve the SSO user",
+	});
+}
+
+/**
+ * Calls and validates an application SSO resolver without exposing exceptions
+ * or malformed JavaScript values to the authentication response.
+ */
+export async function resolveSSOUser(
+	resolveUser: NonNullable<SSOOptions["resolveUser"]>,
+	input: SSOUserResolutionInput,
+	database: DBTransactionAdapter,
+	logger: SSOUserResolutionLogger,
+): Promise<SSOUserResolution> {
+	let resolution: unknown;
+	try {
+		resolution = await resolveUser(input, { database });
+	} catch (error) {
+		logSSOUserResolutionFailure(logger, "SSO user resolution failed", error);
+		throw userResolutionFailure();
+	}
+	if (!isSSOUserResolution(resolution)) {
+		logSSOUserResolutionFailure(
+			logger,
+			"SSO user resolver returned an invalid decision",
+		);
+		throw userResolutionFailure();
+	}
+	return resolution;
+}
+
+/** Ensures SSO resolution and authentication can share one atomic boundary. */
+export function assertSSOUserResolutionNativeTransactionSupport(
+	adapter: Pick<DBAdapter, "options">,
+): void {
+	if (hasNativeTransactionSupport(adapter)) return;
+	throw new APIError("NOT_IMPLEMENTED", {
+		code: SSO_USER_RESOLUTION_REQUIRES_NATIVE_TRANSACTIONS,
+		message:
+			"SSO user resolution requires a database adapter with native transaction support",
+	});
+}
+
+/**
+ * Converts a returned authentication failure into an exception so the shared
+ * user-resolution transaction cannot commit resolver or authentication writes.
+ */
+export function requireSuccessfulSSOAuthentication(
+	result: SSOAuthenticationResult,
+): SSOAuthenticationResult {
+	if (!result.error) return result;
+	throw Object.assign(new Error("SSO authentication failed"), {
+		[SSO_AUTHENTICATION_FAILURE]: true as const,
+		result,
+	}) satisfies SSOAuthenticationFailure;
+}
+
+/** Returns the original result carried by a transaction rollback sentinel. */
+export function getFailedSSOAuthenticationResult(
+	error: unknown,
+): SSOAuthenticationResult | undefined {
+	if (
+		!(error instanceof Error) ||
+		!(SSO_AUTHENTICATION_FAILURE in error) ||
+		error[SSO_AUTHENTICATION_FAILURE] !== true ||
+		!("result" in error)
+	) {
+		return undefined;
+	}
+	return (error as SSOAuthenticationFailure).result;
+}


### PR DESCRIPTION
> [!NOTE]
> Stacked on #10406. Review the Identity and provider-account boundary first.

Provisioning systems can create a Better Auth User before that person authenticates. SSO previously had no explicit way to bind a verified provider subject to that existing User, which encouraged email matching, duplicate users, or application-specific account writes outside the authentication transaction.

## What changes

- Adds a transaction-bound `resolveUser` callback for both OIDC and SAML.
- Supports three explicit decisions: use the default flow, link an exact User, or reject authentication.
- Requires linked users to choose whether local profile fields are preserved or updated from verified provider data.
- Separates provider profile attributes from the canonical provider Identity key.
- Keeps custom mapped profile fields available with safe `unknown` defaults and opt-in precise generics.
- Carries the same provider-user contract through OAuth Proxy callback packages.

> [!IMPORTANT]
> This changes the internal OAuth authentication contract from `userInfo` to `providerUser` plus a separate `identity`. OAuth Proxy applications and proxies must run the same Better Auth version. Configuring `resolveUser` requires native interactive transactions.

<details>
<summary>Authentication invariants</summary>

- The resolver runs after provider verification and locking, before Identity, Account, User, or Session writes.
- Resolver database work and the complete authentication graph share one transaction.
- Returned authentication failures roll back resolver writes while preserving existing redirect behavior.
- Provider subjects never become Better Auth User IDs.
- Exact linking never falls back to email and rejects conflicts with an Identity already owned by another User.
- `profile: "preserve"` keeps provisioning-owned fields; `profile: "provider"` applies the verified profile for that login.
- Resolver exceptions and malformed decisions return a stable public error without exposing private details.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a transaction-bound SSO user resolution step for OIDC and SAML so apps can link a verified provider subject to an existing User, use the default flow, or reject before any writes. Separates provider identity from profile and replaces `userInfo` with `providerUser` across core and `oauth-proxy`.

- **New Features**
  - `resolveUser` in `@better-auth/sso` runs after provider verification/locking inside the same transaction and returns: `default`, `link { userId, profile: "preserve" | "provider" }`, or `reject { code, message? }`. The callback receives `providerInstanceId`, `identity`, normalized `providerUser`, raw `providerClaims`, and a transactional `database`.
  - Enforces exact linking: rejects conflicts (`identity_already_linked`) and missing users (`USER_NOT_FOUND`). Resolver exceptions or invalid decisions return a stable `SSO_USER_RESOLUTION_FAILED`.
  - Provider subject is separate from the profile; choose to preserve local fields or apply the verified provider profile for that login. Types exported: `ProviderUserProfile`, `ProviderUserResolution` (core) and `SSOUserResolution`, `SSOUserResolutionInput`, `SSOUserResolutionContext` (sso). Works through OAuth Proxy.

- **Migration**
  - OAuth contract change: `userInfo` → `providerUser` with separate `identity` across core, `oauth-proxy`, One Tap, and internal routes.
  - Proxy compatibility: run application and proxy on the same Better Auth version; mixed versions are rejected.
  - `resolveUser` requires adapters with native interactive transactions; otherwise authentication fails early with `SSO_USER_RESOLUTION_REQUIRES_NATIVE_TRANSACTIONS`.

<sup>Written for commit 8fc6cd23b90709a78c0fa9f3a3a0e353cbd0e114. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

