### PR TITLE
feat(scim): gate authentication on active provisioned users

### DIFF
--- a/.changeset/scim-active-user-link.md
+++ b/.changeset/scim-active-user-link.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/scim": minor
+---
+
+Add `acquireActiveSCIMUserLink` for transaction-safe authentication of provisioned users. The helper maps an exact SCIM connection ID and `externalId` to an active Better Auth User while fencing concurrent deactivation, deletion, and connection decommissioning.
+
+Compose the helper with SSO `resolveUser` to link the provisioned User without matching by email or `userName`.

--- a/docs/content/docs/plugins/scim/index.mdx
+++ b/docs/content/docs/plugins/scim/index.mdx
@@ -200,6 +200,79 @@ Choose the profile behavior when you link a user:
 
 Only one source can manage a Better Auth User's profile. Separate connections may link preserved sources to the same User, but one connection cannot create two SCIM resources for the same linked User.
 
+## Authenticate provisioned users with SSO
+
+Use `acquireActiveSCIMUserLink` inside the SSO plugin's `resolveUser` callback when SCIM must control who can sign in. The helper finds an active SCIM User by its exact connection ID and `externalId`, returning `{ scimUserId, userId }` for the active link. It returns `null` for missing, inactive, or deleted SCIM Users and decommissioned connections.
+
+```ts title="auth.ts"
+import { acquireActiveSCIMUserLink, scim } from "@better-auth/scim";
+import { sso } from "@better-auth/sso";
+import { betterAuth } from "better-auth";
+
+const scimConnectionIdByProviderInstance: Readonly<Record<string, string>> = {
+  "sso:config:acme-workforce-oidc": "workforce-acme",
+};
+
+export const auth = betterAuth({
+  plugins: [
+    scim({ connections }),
+    sso({
+      defaultSSO: [
+        {
+          providerId: "acme-workforce-oidc",
+          domain: "acme.example",
+          oidcConfig: {
+            issuer: "https://idp.acme.example",
+            clientId: "acme-workforce-client-id",
+            clientSecret: "acme-workforce-client-secret",
+            pkce: true,
+            discoveryEndpoint:
+              "https://idp.acme.example/.well-known/openid-configuration",
+          },
+        },
+      ],
+      async resolveUser({ providerInstanceId, identity }, context) {
+        const connectionId =
+          scimConnectionIdByProviderInstance[providerInstanceId];
+        if (!connectionId) {
+          return {
+            action: "reject",
+            code: "SCIM_CONNECTION_NOT_CONFIGURED",
+          };
+        }
+
+        const link = await acquireActiveSCIMUserLink(
+          {
+            connectionId,
+            externalId: identity.providerAccountId,
+          },
+          context,
+        );
+
+        return link
+          ? {
+              action: "link",
+              userId: link.userId,
+              profile: "preserve",
+            }
+          : {
+              action: "reject",
+              code: "SCIM_USER_NOT_ACTIVE",
+            };
+      },
+    }),
+  ],
+});
+```
+
+The mapping uses an SSO provider declared in `defaultSSO`. Persisted provider instances use `sso:provider:<recordId>`; see [Identity and Provider Accounts](/docs/plugins/sso#identity-and-provider-accounts) for both formats.
+
+<Callout type="warn">
+  Configure the directory to send the provider's immutable, verified subject as the SCIM User's `externalId`. The example uses the canonical OIDC or SAML subject from `identity.providerAccountId`. If the directory cannot provision that exact subject, select another immutable claim from `providerClaims` that the identity provider verifies and both systems share. Matching is case-sensitive, and the helper never falls back to `userName`, email, or a deleted-resource tombstone.
+</Callout>
+
+The helper must run inside a native transaction because it fences the link against concurrent deactivation, deletion, and connection decommissioning. SSO supplies that transaction through `resolveUser`'s `database` context. If the link's lifecycle state or connection changes after acquisition begins, the helper throws and the transaction rolls back instead of authenticating a stale link. Use `profile: "preserve"` so SSO authenticates the linked User without replacing the profile managed by SCIM.
+
 ## Handle activation and deletion
 
 Use `identity.reconcileUser` to apply the combined SCIM lifecycle state to your application. The callback receives every source linked to the Better Auth User and an `active` value that is `true` while at least one source remains active.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -725,6 +725,8 @@ The callback receives the canonical Identity namespace and provider subject that
   `resolveUser` selects or rejects a User before authentication. `provisionUser` runs after successful authentication and cannot change which User was authenticated.
 </Callout>
 
+When SCIM provisions Users, resolve them with `acquireActiveSCIMUserLink` from `@better-auth/scim`. The helper matches the verified provider subject exactly to an active SCIM `externalId` inside this transaction, which lets `resolveUser` link the User with `profile: "preserve"` or reject the login. See [Authenticate provisioned users with SSO](/docs/plugins/scim#authenticate-provisioned-users-with-sso) for the complete configuration.
+
 ### User Provisioning
 
 User provisioning allows you to run custom logic when a user signs in through an SSO provider. By default, `provisionUser` only runs for new users (on registration). To run it on every login, set `provisionUserOnEveryLogin` to `true`. This is useful for:

--- a/packages/scim/package.json
+++ b/packages/scim/package.json
@@ -57,8 +57,10 @@
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "@better-auth/kysely-adapter": "workspace:*",
+    "@better-auth/sso": "workspace:*",
     "@better-auth/test-utils": "workspace:*",
     "kysely": "catalog:",
+    "oauth2-mock-server": "^9.0.0",
     "tsdown": "catalog:"
   },
   "peerDependencies": {

--- a/packages/scim/src/connection-state.ts
+++ b/packages/scim/src/connection-state.ts
@@ -37,22 +37,31 @@ export async function findDecommissionedSCIMConnectionIds(
  * or fails the transaction when retirement won the race.
  */
 export async function fenceActiveSCIMConnection(
-	database: DBTransactionAdapter,
+	database: Pick<DBTransactionAdapter, "incrementOne">,
 	connectionId: string,
-): Promise<void> {
-	const binding = await database.incrementOne<SCIMConnectionBinding>({
+): Promise<SCIMConnectionBinding> {
+	const binding = await tryFenceActiveSCIMConnection(database, connectionId);
+	if (binding) return binding;
+	throw createSCIMError("UNAUTHORIZED", {
+		detail: "SCIM connection is decommissioned",
+	});
+}
+
+/** Attempts to fence a connection without assigning an HTTP failure policy. */
+export async function tryFenceActiveSCIMConnection(
+	database: Pick<DBTransactionAdapter, "incrementOne">,
+	connectionId: string,
+): Promise<SCIMConnectionBinding | null> {
+	return database.incrementOne<SCIMConnectionBinding>({
 		model: "scimConnectionBinding",
 		where: [
 			{
 				field: "connectionKey",
 				value: createSCIMConnectionKey(connectionId),
 			},
+			{ field: "connectionId", value: connectionId },
 			{ field: "decommissionStatus", value: "active" },
 		],
 		increment: { decommissionRevision: 1 },
-	});
-	if (binding) return;
-	throw createSCIMError("UNAUTHORIZED", {
-		detail: "SCIM connection is decommissioned",
 	});
 }

--- a/packages/scim/src/identity.ts
+++ b/packages/scim/src/identity.ts
@@ -2,7 +2,12 @@ import {
 	getCurrentAdapter,
 	runWithTransaction,
 } from "@better-auth/core/context";
-import type { AuthContext, DBAdapter, DBTransactionAdapter } from "better-auth";
+import type {
+	AuthContext,
+	DBAdapter,
+	DBTransactionAdapter,
+	User,
+} from "better-auth";
 import type {
 	SCIMIdentityResolution,
 	SCIMIdentityResolutionInput,
@@ -10,18 +15,159 @@ import type {
 	SCIMIdentityState,
 	SCIMOptions,
 } from "./configuration";
-import { findDecommissionedSCIMConnectionIds } from "./connection-state";
+import {
+	createSCIMConnectionKey,
+	findDecommissionedSCIMConnectionIds,
+	tryFenceActiveSCIMConnection,
+} from "./connection-state";
 import type {
+	SCIMConnectionBinding,
 	SCIMIdentityTombstone,
 	SCIMSubject,
 	SCIMUser,
 } from "./persistence";
-import { createScopedKey } from "./resource-key";
+import { createSCIMUserExternalIdKey } from "./resource-key";
 import { createSCIMError, runSCIMApplicationCallback } from "./scim-error";
 
 export type SCIMIdentityCoordinator = ReturnType<
 	typeof createSCIMIdentityCoordinator
 >;
+
+/** Exact external directory reference for one connection-owned SCIM User. */
+export interface SCIMExternalUserReference {
+	connectionId: string;
+	externalId: string;
+}
+
+/** Exact Better Auth User link acquired from an active SCIM source. */
+export interface SCIMActiveUserLink {
+	scimUserId: string;
+	userId: string;
+}
+
+/** Transaction-bound database capabilities required to acquire an active link. */
+export interface SCIMActiveUserLinkContext {
+	database: Pick<DBTransactionAdapter, "findOne" | "incrementOne">;
+}
+
+/**
+ * Acquires an active provisioned User link inside the caller's transaction.
+ *
+ * The lookup is scoped to the exact SCIM connection and externalId. It never
+ * falls back to userName, email, or deleted identity tombstones.
+ */
+export async function acquireActiveSCIMUserLink(
+	reference: SCIMExternalUserReference,
+	context: SCIMActiveUserLinkContext,
+): Promise<SCIMActiveUserLink | null> {
+	const externalIdKey = createSCIMUserExternalIdKey(
+		reference.connectionId,
+		reference.externalId,
+	);
+	const source = await context.database.findOne<SCIMUser>({
+		model: "scimUser",
+		where: [
+			{ field: "connectionId", value: reference.connectionId },
+			{ field: "externalIdKey", value: externalIdKey },
+			{ field: "externalId", value: reference.externalId },
+			{ field: "active", value: true },
+		],
+	});
+	if (!source) return null;
+	const binding = await context.database.findOne<SCIMConnectionBinding>({
+		model: "scimConnectionBinding",
+		where: [
+			{
+				field: "connectionKey",
+				value: createSCIMConnectionKey(reference.connectionId),
+			},
+			{ field: "connectionId", value: reference.connectionId },
+			{ field: "decommissionStatus", value: "active" },
+		],
+	});
+	if (
+		!binding ||
+		binding.provisioningDomainId !== source.provisioningDomainId
+	) {
+		return null;
+	}
+	const tombstone = await context.database.findOne<SCIMIdentityTombstone>({
+		model: "scimIdentityTombstone",
+		where: [
+			{ field: "connectionId", value: reference.connectionId },
+			{ field: "externalIdKey", value: externalIdKey },
+			{ field: "externalId", value: reference.externalId },
+		],
+	});
+	if (tombstone) return null;
+	const subject = await context.database.findOne<SCIMSubject>({
+		model: "scimSubject",
+		where: [{ field: "userId", value: source.userId }],
+	});
+	if (!subject) return null;
+	const user = await context.database.findOne<User>({
+		model: "user",
+		where: [{ field: "id", value: source.userId }],
+	});
+	if (!user) return null;
+	const acquiredSubject = await context.database.incrementOne<SCIMSubject>({
+		model: "scimSubject",
+		where: [
+			{ field: "id", value: subject.id },
+			{ field: "userId", value: source.userId },
+		],
+		increment: { revision: 1 },
+		set: { updatedAt: new Date() },
+	});
+	if (!acquiredSubject) concurrentIdentityMutation();
+	const acquiredSource = await context.database.findOne<SCIMUser>({
+		model: "scimUser",
+		where: [
+			{ field: "id", value: source.id },
+			{ field: "connectionId", value: reference.connectionId },
+			{ field: "provisioningDomainId", value: binding.provisioningDomainId },
+			{ field: "userId", value: source.userId },
+			{ field: "connectionUserKey", value: source.connectionUserKey },
+			{ field: "externalIdKey", value: externalIdKey },
+			{ field: "externalId", value: reference.externalId },
+			{ field: "active", value: true },
+		],
+	});
+	if (
+		!acquiredSource ||
+		!acquiredSource.active ||
+		acquiredSource.userId !== acquiredSubject.userId
+	) {
+		concurrentIdentityMutation();
+	}
+	const acquiredUser = await context.database.findOne<User>({
+		model: "user",
+		where: [{ field: "id", value: acquiredSource.userId }],
+	});
+	if (!acquiredUser) concurrentIdentityMutation();
+	const acquiredTombstone =
+		await context.database.findOne<SCIMIdentityTombstone>({
+			model: "scimIdentityTombstone",
+			where: [
+				{ field: "connectionId", value: reference.connectionId },
+				{ field: "externalIdKey", value: externalIdKey },
+				{ field: "externalId", value: reference.externalId },
+			],
+		});
+	if (acquiredTombstone) concurrentIdentityMutation();
+	const acquiredBinding = await tryFenceActiveSCIMConnection(
+		context.database,
+		reference.connectionId,
+	);
+	if (
+		!acquiredBinding ||
+		acquiredBinding.id !== binding.id ||
+		acquiredBinding.provisioningDomainId !== acquiredSource.provisioningDomainId
+	) {
+		concurrentIdentityMutation();
+	}
+	return { scimUserId: source.id, userId: source.userId };
+}
 
 const SCIM_IDENTITY_MUTATION_CONFLICT = Symbol(
 	"scim-identity-mutation-conflict",
@@ -142,11 +288,10 @@ export function createSCIMIdentityCoordinator(options: SCIMOptions) {
 			tombstoneId?: string;
 		}> {
 			if (input.resource.externalId) {
-				const externalIdKey = createScopedKey([
-					"scim-user-external-id",
+				const externalIdKey = createSCIMUserExternalIdKey(
 					input.connectionId,
 					input.resource.externalId,
-				]);
+				);
 				const tombstone = await context.database.findOne<SCIMIdentityTombstone>(
 					{
 						model: "scimIdentityTombstone",

--- a/packages/scim/src/index.ts
+++ b/packages/scim/src/index.ts
@@ -24,7 +24,10 @@ import {
 	patchSCIMGroup,
 	replaceSCIMGroup,
 } from "./group-provisioning";
-import { createSCIMIdentityCoordinator } from "./identity";
+import {
+	acquireActiveSCIMUserLink,
+	createSCIMIdentityCoordinator,
+} from "./identity";
 import {
 	createReconcileSCIMProjectionEndpoint,
 	createSCIMProjectionCoordinator,
@@ -772,3 +775,10 @@ export type {
 	SCIMStaticBearerPrincipal,
 	SCIMTransactionContext,
 } from "./configuration";
+
+export type {
+	SCIMActiveUserLink,
+	SCIMActiveUserLinkContext,
+	SCIMExternalUserReference,
+} from "./identity";
+export { acquireActiveSCIMUserLink };

--- a/packages/scim/src/resource-key.test.ts
+++ b/packages/scim/src/resource-key.test.ts
@@ -1,15 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { createScopedKey } from "./resource-key";
+import { createSCIMUserExternalIdKey, createScopedKey } from "./resource-key";
 
 describe("SCIM persisted keys", () => {
 	it("remain fixed-size for provider-controlled identifiers", () => {
-		const key = createScopedKey([
-			"scim-user-external-id",
+		const key = createSCIMUserExternalIdKey(
 			"connection-a",
 			"external-id".repeat(1_000),
-		]);
+		);
 
 		expect(key).toHaveLength(43);
+	});
+
+	it("scope User externalIds by exact connection and value", () => {
+		expect(createSCIMUserExternalIdKey("connection-a", "external-id")).toBe(
+			createSCIMUserExternalIdKey("connection-a", "external-id"),
+		);
+		expect(createSCIMUserExternalIdKey("connection-a", "external-id")).not.toBe(
+			createSCIMUserExternalIdKey("connection-b", "external-id"),
+		);
+		expect(createSCIMUserExternalIdKey("connection-a", "external-id")).not.toBe(
+			createSCIMUserExternalIdKey("connection-a", "EXTERNAL-ID"),
+		);
 	});
 
 	it("preserve tuple boundaries and connection scope", () => {

--- a/packages/scim/src/resource-key.ts
+++ b/packages/scim/src/resource-key.ts
@@ -10,6 +10,14 @@ export function createScopedKey(parts: readonly string[]): string {
 	});
 }
 
+/** Create the canonical lookup key for a connection-owned SCIM User externalId. */
+export function createSCIMUserExternalIdKey(
+	connectionId: string,
+	externalId: string,
+): string {
+	return createScopedKey(["scim-user-external-id", connectionId, externalId]);
+}
+
 /** Create one unique, lexicographically stable classic-pagination key. */
 export function createSCIMOrderKey(createdAt: Date): string {
 	return `${createdAt.getTime().toString().padStart(15, "0")}:${generateId(16)}`;

--- a/packages/scim/src/scim-identity-resolution.test.ts
+++ b/packages/scim/src/scim-identity-resolution.test.ts
@@ -7,13 +7,20 @@ import type {
 import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { describe, expect, expectTypeOf, it } from "vitest";
-import type { SCIMCanonicalUser, SCIMConnectionOptions, SCIMIdentity } from ".";
-import { scim } from ".";
 import type {
+	SCIMCanonicalUser,
+	SCIMConnectionOptions,
+	SCIMExternalUserReference,
+	SCIMIdentity,
+} from ".";
+import { acquireActiveSCIMUserLink, scim } from ".";
+import type {
+	SCIMConnectionBinding,
 	SCIMIdentityTombstone,
 	SCIMSubject,
 	SCIMUser,
 } from "./persistence";
+import { createSCIMUserExternalIdKey } from "./resource-key";
 
 const BASE_URL = "http://localhost:3000";
 const CONNECTION_A = {
@@ -95,7 +102,7 @@ function createIdentityFixture(
 		session: [...(options.sessions ?? [])],
 		verification: [] as { id: string }[],
 		account: [] as { id: string }[],
-		scimConnectionBinding: [] as { id: string }[],
+		scimConnectionBinding: [] as SCIMConnectionBinding[],
 		scimIdentityTombstone: [] as SCIMIdentityTombstone[],
 		scimSubject: [] as SCIMSubject[],
 		scimUser: [] as SCIMUser[],
@@ -118,6 +125,19 @@ function createIdentityFixture(
 	});
 
 	return { auth, data };
+}
+
+async function acquireUserLink(
+	auth: ReturnType<typeof createIdentityFixture>["auth"],
+	reference: SCIMExternalUserReference,
+) {
+	const context = await auth.$context;
+	if (!context.adapter.transaction) {
+		throw new Error("Expected native transaction support");
+	}
+	return context.adapter.transaction((database) =>
+		acquireActiveSCIMUserLink(reference, { database }),
+	);
 }
 
 function authorization(token: string) {
@@ -807,5 +827,273 @@ describe("SCIM explicit identity resolution", () => {
 		expect(data.user[0]).toMatchObject({ name: "Managed Before Failure" });
 		expect(data.session).toEqual([session]);
 		expect(data.scimSubject[0]?.revision).toBe(revisionBeforeFailure);
+	});
+});
+
+describe("SCIM active User links", () => {
+	it("acquires the provisioned Better Auth User by exact connection and externalId", async () => {
+		const { auth, data } = createIdentityFixture();
+		const resource = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "linked@example.com",
+				externalId: "directory-user-123",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		const subject = data.scimSubject[0];
+		const binding = data.scimConnectionBinding[0];
+		if (!subject || !binding) {
+			throw new Error("Expected the SCIM subject and connection binding");
+		}
+		const subjectRevision = subject.revision;
+		const connectionRevision = binding.decommissionRevision;
+		const link = await acquireUserLink(auth, {
+			connectionId: CONNECTION_A.id,
+			externalId: "directory-user-123",
+		});
+
+		expect(link).toEqual({
+			scimUserId: resource.id,
+			userId: data.scimUser[0]?.userId,
+		});
+		expect(data.scimSubject[0]?.revision).toBe(subjectRevision + 1);
+		expect(data.scimConnectionBinding[0]?.decommissionRevision).toBe(
+			connectionRevision + 1,
+		);
+	});
+
+	it("isolates identical externalIds by their exact connection", async () => {
+		const { auth, data } = createIdentityFixture({
+			connections: [CONNECTION_A, CONNECTION_B],
+		});
+		const sourceA = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "connection-a@example.com",
+				externalId: "shared-directory-id",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		const sourceB = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "connection-b@example.com",
+				externalId: "shared-directory-id",
+			},
+			headers: authorization("connection-b-token"),
+		});
+
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "shared-directory-id",
+			}),
+		).resolves.toEqual({
+			scimUserId: sourceA.id,
+			userId: data.scimUser.find((source) => source.id === sourceA.id)?.userId,
+		});
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_B.id,
+				externalId: "shared-directory-id",
+			}),
+		).resolves.toEqual({
+			scimUserId: sourceB.id,
+			userId: data.scimUser.find((source) => source.id === sourceB.id)?.userId,
+		});
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "SHARED-DIRECTORY-ID",
+			}),
+		).resolves.toBeNull();
+	});
+
+	it("only acquires an active source and follows explicit reprovisioning", async () => {
+		const { auth, data } = createIdentityFixture();
+		const firstSource = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "lifecycle@example.com",
+				externalId: "lifecycle-directory-id",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		const originalUserId = data.scimUser[0]?.userId;
+
+		await auth.api.patchSCIMUser({
+			params: { userId: firstSource.id },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [{ op: "replace", path: "active", value: false }],
+			},
+			headers: authorization("connection-a-token"),
+		});
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "lifecycle-directory-id",
+			}),
+		).resolves.toBeNull();
+
+		await auth.api.deleteSCIMUser({
+			params: { userId: firstSource.id },
+			headers: authorization("connection-a-token"),
+		});
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "lifecycle-directory-id",
+			}),
+		).resolves.toBeNull();
+
+		const reprovisionedSource = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "reprovisioned@example.com",
+				externalId: "lifecycle-directory-id",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "lifecycle-directory-id",
+			}),
+		).resolves.toEqual({
+			scimUserId: reprovisionedSource.id,
+			userId: originalUserId,
+		});
+	});
+
+	it("never authenticates from a tombstoned externalId", async () => {
+		const { auth, data } = createIdentityFixture();
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "tombstoned@example.com",
+				externalId: "tombstoned-directory-id",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		const source = data.scimUser[0];
+		if (!source) throw new Error("Expected the provisioned SCIM User");
+		data.scimIdentityTombstone.push({
+			id: "stale-tombstone",
+			connectionId: source.connectionId,
+			provisioningDomainId: source.provisioningDomainId,
+			externalId: "tombstoned-directory-id",
+			externalIdKey: createSCIMUserExternalIdKey(
+				source.connectionId,
+				"tombstoned-directory-id",
+			),
+			userId: source.userId,
+			profile: "preserve",
+			deletedAt: new Date(),
+		});
+
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "tombstoned-directory-id",
+			}),
+		).resolves.toBeNull();
+	});
+
+	it("refuses a source whose Better Auth User no longer exists", async () => {
+		const { auth, data } = createIdentityFixture();
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "orphaned@example.com",
+				externalId: "orphaned-directory-id",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		data.user.splice(0, data.user.length);
+
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "orphaned-directory-id",
+			}),
+		).resolves.toBeNull();
+	});
+
+	it("refuses a source whose SCIM subject is missing", async () => {
+		const { auth, data } = createIdentityFixture();
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "missing-subject@example.com",
+				externalId: "missing-subject-directory-id",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		data.scimSubject.splice(0, data.scimSubject.length);
+
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "missing-subject-directory-id",
+			}),
+		).resolves.toBeNull();
+	});
+
+	it("refuses a source from a decommissioned connection", async () => {
+		const { auth, data } = createIdentityFixture();
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "decommissioned@example.com",
+				externalId: "decommissioned-directory-id",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		const binding = data.scimConnectionBinding[0];
+		if (!binding) throw new Error("Expected the SCIM connection binding");
+		binding.decommissionStatus = "complete";
+
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "decommissioned-directory-id",
+			}),
+		).resolves.toBeNull();
+	});
+
+	it("refuses an inconsistent source and connection provisioning domain", async () => {
+		const { auth, data } = createIdentityFixture();
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "inconsistent-domain@example.com",
+				externalId: "inconsistent-domain-directory-id",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		const source = data.scimUser[0];
+		const binding = data.scimConnectionBinding[0];
+		if (!source || !binding) {
+			throw new Error("Expected the provisioned SCIM source and binding");
+		}
+		source.provisioningDomainId = "different-domain";
+
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "inconsistent-domain-directory-id",
+			}),
+		).resolves.toBeNull();
+
+		source.provisioningDomainId = binding.provisioningDomainId;
+		data.scimConnectionBinding.splice(0, data.scimConnectionBinding.length);
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "inconsistent-domain-directory-id",
+			}),
+		).resolves.toBeNull();
 	});
 });

--- a/packages/scim/src/scim-sso-http-e2e.test.ts
+++ b/packages/scim/src/scim-sso-http-e2e.test.ts
@@ -1,0 +1,346 @@
+import { sso } from "@better-auth/sso";
+import { getHttpTestInstance } from "better-auth/test";
+import { OAuth2Server } from "oauth2-mock-server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { acquireActiveSCIMUserLink, scim } from ".";
+
+const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+const SCIM_MEDIA_TYPE = "application/scim+json";
+const WORKFORCE_CONNECTION_ID = "workforce";
+const WORKFORCE_TOKEN = "workforce-scim-token";
+const CONTRACTOR_CONNECTION_ID = "contractors";
+const CONTRACTOR_TOKEN = "contractors-scim-token";
+
+type CookieJar = Map<string, string>;
+
+interface SCIMUserResponse {
+	id: string;
+	active: boolean;
+}
+
+interface SessionResponse {
+	user: {
+		id: string;
+		email: string;
+		name: string;
+	};
+}
+
+function storeResponseCookies(response: Response, cookies: CookieJar): void {
+	for (const setCookie of response.headers.getSetCookie()) {
+		const attributesIndex = setCookie.indexOf(";");
+		const cookie = setCookie.slice(
+			0,
+			attributesIndex === -1 ? setCookie.length : attributesIndex,
+		);
+		const separatorIndex = cookie.indexOf("=");
+		if (separatorIndex < 1) continue;
+		const name = cookie.slice(0, separatorIndex);
+		const value = cookie.slice(separatorIndex + 1);
+		if (value) cookies.set(name, value);
+		else cookies.delete(name);
+	}
+}
+
+function getCookieHeader(cookies: CookieJar): string {
+	return [...cookies].map(([name, value]) => `${name}=${value}`).join("; ");
+}
+
+async function readJSON<T>(response: Response): Promise<T> {
+	return (await response.json()) as T;
+}
+
+function createSCIMHeaders(token: string): HeadersInit {
+	return {
+		accept: SCIM_MEDIA_TYPE,
+		authorization: `Bearer ${token}`,
+		"content-type": SCIM_MEDIA_TYPE,
+	};
+}
+
+describe("SCIM-provisioned SSO authentication over HTTP", () => {
+	const identityProvider = new OAuth2Server();
+	const externalId = "directory-user-1";
+
+	beforeAll(async () => {
+		await identityProvider.issuer.keys.generate("RS256");
+		identityProvider.service.on("beforeUserinfo", (response) => {
+			response.body = {
+				sub: externalId,
+				email: "employee@identity-provider.example",
+				name: "Identity Provider Employee",
+				email_verified: true,
+			};
+			response.statusCode = 200;
+		});
+		identityProvider.service.on("beforeTokenSigning", (token) => {
+			token.payload.sub = externalId;
+			token.payload.email = "employee@identity-provider.example";
+			token.payload.name = "Identity Provider Employee";
+			token.payload.email_verified = true;
+		});
+		await identityProvider.start(undefined, "127.0.0.1");
+	});
+
+	afterAll(async () => {
+		await identityProvider.stop();
+	});
+
+	it("authenticates only the active User owned by the configured SCIM connection", async ({
+		onTestFinished,
+	}) => {
+		const instance = await getHttpTestInstance(
+			{
+				trustedOrigins: [identityProvider.issuer.url!],
+				plugins: [
+					scim({
+						connections: [
+							{
+								id: WORKFORCE_CONNECTION_ID,
+								credentials: [
+									{
+										type: "bearer",
+										id: "workforce-token",
+										token: WORKFORCE_TOKEN,
+									},
+								],
+							},
+							{
+								id: CONTRACTOR_CONNECTION_ID,
+								credentials: [
+									{
+										type: "bearer",
+										id: "contractors-token",
+										token: CONTRACTOR_TOKEN,
+									},
+								],
+							},
+						],
+					}),
+					sso({
+						disableImplicitSignUp: true,
+						defaultSSO: [
+							{
+								domain: "example.com",
+								providerId: "workforce",
+								oidcConfig: {
+									issuer: identityProvider.issuer.url!,
+									clientId: "workforce-client",
+									clientSecret: "workforce-secret",
+									pkce: false,
+									discoveryEndpoint: `${identityProvider.issuer.url}/.well-known/openid-configuration`,
+								},
+							},
+						],
+						resolveUser: async (input, context) => {
+							const link = await acquireActiveSCIMUserLink(
+								{
+									connectionId: WORKFORCE_CONNECTION_ID,
+									externalId: input.identity.providerAccountId,
+								},
+								context,
+							);
+							return link
+								? {
+										action: "link",
+										userId: link.userId,
+										profile: "preserve",
+									}
+								: {
+										action: "reject",
+										code: "SCIM_USER_NOT_ACTIVE",
+										message: "This directory user is not active",
+									};
+						},
+					}),
+				],
+			},
+			{ disableTestUser: true, testWith: "sqlite" },
+		);
+		onTestFinished(() => instance.server.close());
+
+		async function provisionSCIMUser(
+			token: string,
+			userName: string,
+		): Promise<SCIMUserResponse> {
+			const response = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Users`,
+				{
+					method: "POST",
+					headers: createSCIMHeaders(token),
+					body: JSON.stringify({
+						schemas: [SCIM_USER_SCHEMA],
+						externalId,
+						userName,
+						name: { formatted: "Provisioned Employee" },
+						active: true,
+					}),
+				},
+			);
+			expect(response.status).toBe(201);
+			return readJSON<SCIMUserResponse>(response);
+		}
+
+		async function setSCIMUserActive(
+			userId: string,
+			active: boolean,
+		): Promise<void> {
+			const response = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(userId)}`,
+				{
+					method: "PATCH",
+					headers: createSCIMHeaders(WORKFORCE_TOKEN),
+					body: JSON.stringify({
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [{ op: "replace", path: "active", value: active }],
+					}),
+				},
+			);
+			expect(response.status).toBe(204);
+		}
+
+		async function deleteSCIMUser(userId: string): Promise<void> {
+			const response = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(userId)}`,
+				{
+					method: "DELETE",
+					headers: createSCIMHeaders(WORKFORCE_TOKEN),
+				},
+			);
+			expect(response.status).toBe(204);
+		}
+
+		async function signInWithSSO(): Promise<{
+			callback: Response;
+			cookies: CookieJar;
+		}> {
+			const cookies: CookieJar = new Map();
+			const signInResponse = await fetch(
+				`${instance.baseURL}/api/auth/sign-in/sso`,
+				{
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						origin: instance.baseURL,
+					},
+					body: JSON.stringify({
+						providerId: "workforce",
+						callbackURL: `${instance.baseURL}/employee`,
+					}),
+				},
+			);
+			storeResponseCookies(signInResponse, cookies);
+			expect(signInResponse.status).toBe(200);
+			const signIn = await readJSON<{ url: string }>(signInResponse);
+			const authorization = await fetch(signIn.url, { redirect: "manual" });
+			const callbackURL = authorization.headers.get("location");
+			if (!callbackURL) {
+				throw new Error("OIDC provider did not return a callback URL");
+			}
+			const callback = await fetch(callbackURL, {
+				headers: { cookie: getCookieHeader(cookies) },
+				redirect: "manual",
+			});
+			expect(callback.status).toBe(302);
+			storeResponseCookies(callback, cookies);
+			return { callback, cookies };
+		}
+
+		async function getSession(
+			cookies: CookieJar,
+		): Promise<SessionResponse | null> {
+			const response = await fetch(`${instance.baseURL}/api/auth/get-session`, {
+				headers: { cookie: getCookieHeader(cookies) },
+			});
+			expect(response.status).toBe(200);
+			return readJSON<SessionResponse | null>(response);
+		}
+
+		async function expectRejectedSignIn(): Promise<void> {
+			const authRecordsBefore = {
+				users: await instance.db.count({ model: "user", where: [] }),
+				accounts: await instance.db.count({ model: "account", where: [] }),
+				identities: await instance.db.count({ model: "identity", where: [] }),
+				sessions: await instance.db.count({ model: "session", where: [] }),
+			};
+			const signIn = await signInWithSSO();
+			const errorLocation = signIn.callback.headers.get("location");
+			if (!errorLocation) throw new Error("SSO rejection did not redirect");
+			const errorRedirect = new URL(errorLocation, instance.baseURL);
+			expect(errorRedirect.searchParams.get("error")).toBe(
+				"SCIM_USER_NOT_ACTIVE",
+			);
+			expect(await getSession(signIn.cookies)).toBeNull();
+			expect({
+				users: await instance.db.count({ model: "user", where: [] }),
+				accounts: await instance.db.count({ model: "account", where: [] }),
+				identities: await instance.db.count({ model: "identity", where: [] }),
+				sessions: await instance.db.count({ model: "session", where: [] }),
+			}).toEqual(authRecordsBefore);
+		}
+
+		const provisioned = await provisionSCIMUser(
+			WORKFORCE_TOKEN,
+			"provisioned.employee@example.com",
+		);
+		expect(provisioned.active).toBe(true);
+		expect(await instance.db.count({ model: "user", where: [] })).toBe(1);
+		expect(await instance.db.count({ model: "identity", where: [] })).toBe(0);
+		expect(await instance.db.count({ model: "account", where: [] })).toBe(0);
+
+		const firstSignIn = await signInWithSSO();
+		expect(firstSignIn.callback.headers.get("location")).toBe(
+			`${instance.baseURL}/employee`,
+		);
+		const firstSession = await getSession(firstSignIn.cookies);
+		expect(firstSession?.user).toMatchObject({
+			email: "provisioned.employee@example.com",
+			name: "Provisioned Employee",
+		});
+		if (!firstSession) throw new Error("SSO sign-in did not create a session");
+		const provisionedUserId = firstSession.user.id;
+
+		const repeatSignIn = await signInWithSSO();
+		expect((await getSession(repeatSignIn.cookies))?.user.id).toBe(
+			provisionedUserId,
+		);
+		expect(await instance.db.count({ model: "user", where: [] })).toBe(1);
+		expect(await instance.db.count({ model: "identity", where: [] })).toBe(1);
+		expect(await instance.db.count({ model: "account", where: [] })).toBe(1);
+
+		await setSCIMUserActive(provisioned.id, false);
+		await expectRejectedSignIn();
+
+		await setSCIMUserActive(provisioned.id, true);
+		const reactivatedSignIn = await signInWithSSO();
+		expect((await getSession(reactivatedSignIn.cookies))?.user.id).toBe(
+			provisionedUserId,
+		);
+
+		await deleteSCIMUser(provisioned.id);
+		await expectRejectedSignIn();
+
+		await provisionSCIMUser(
+			CONTRACTOR_TOKEN,
+			"contractor.employee@example.com",
+		);
+		expect(await instance.db.count({ model: "user", where: [] })).toBe(2);
+		await expectRejectedSignIn();
+
+		const reprovisioned = await provisionSCIMUser(
+			WORKFORCE_TOKEN,
+			"restored.employee@example.com",
+		);
+		expect(reprovisioned.id).not.toBe(provisioned.id);
+		const restoredSignIn = await signInWithSSO();
+		expect((await getSession(restoredSignIn.cookies))?.user).toMatchObject({
+			id: provisionedUserId,
+			email: "restored.employee@example.com",
+			name: "Provisioned Employee",
+		});
+		expect(await instance.db.count({ model: "user", where: [] })).toBe(2);
+		expect(await instance.db.count({ model: "identity", where: [] })).toBe(1);
+		expect(await instance.db.count({ model: "account", where: [] })).toBe(1);
+	});
+});

--- a/packages/scim/src/scim-user-concurrency.test.ts
+++ b/packages/scim/src/scim-user-concurrency.test.ts
@@ -9,8 +9,9 @@ import { betterAuth } from "better-auth";
 import type { MemoryDB } from "better-auth/adapters/memory";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { describe, expect, it } from "vitest";
-import { scim } from ".";
+import { acquireActiveSCIMUserLink, scim } from ".";
 import type {
+	SCIMConnectionBinding,
 	SCIMGroup,
 	SCIMGroupMember,
 	SCIMIdentityTombstone,
@@ -26,6 +27,7 @@ const headers = { authorization: "Bearer test-scim-token" };
 
 interface UserDeletionData extends MemoryDB {
 	user: User[];
+	scimConnectionBinding: SCIMConnectionBinding[];
 	scimIdentityTombstone: SCIMIdentityTombstone[];
 	scimSubject: SCIMSubject[];
 	scimUser: SCIMUser[];
@@ -41,6 +43,7 @@ interface IncrementOneInput {
 }
 
 type CreateInput = Parameters<DBTransactionAdapter["create"]>[0];
+type FindOneInput = Parameters<DBTransactionAdapter["findOne"]>[0];
 
 function createData(): UserDeletionData {
 	return {
@@ -68,6 +71,13 @@ function createDeferred() {
 
 function findWhereValue(where: readonly Where[], field: string): unknown {
 	return where.find((clause) => clause.field === field)?.value;
+}
+
+function getIdentityRevisions(data: UserDeletionData) {
+	return {
+		subjectRevision: data.scimSubject[0]?.revision,
+		connectionRevision: data.scimConnectionBinding[0]?.decommissionRevision,
+	};
 }
 
 function createAuth(database: BetterAuthOptions["database"]) {
@@ -616,5 +626,195 @@ describe("SCIM User concurrency", () => {
 		expect(data.scimGroup.every((group) => group.updatedAt.getTime() > 0)).toBe(
 			true,
 		);
+	});
+
+	it("aborts active-link acquisition when the subject disappears", async () => {
+		const data = createData();
+		const auth = createAuth(memoryAdapter(data));
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: [USER_SCHEMA],
+				userName: "acquisition-race@example.com",
+				externalId: "acquisition-race",
+			},
+			headers,
+		});
+		const revisionsBeforeRace = getIdentityRevisions(data);
+		const context = await auth.$context;
+		if (!context.adapter.transaction) {
+			throw new Error("Expected native transaction support");
+		}
+
+		await expect(
+			context.adapter.transaction((transaction) => {
+				const incrementOne: DBTransactionAdapter["incrementOne"] = async <Row>(
+					input: IncrementOneInput,
+				) => {
+					if (input.model === "scimSubject") return null;
+					return transaction.incrementOne<Row>(input);
+				};
+				return acquireActiveSCIMUserLink(
+					{
+						connectionId: "workforce",
+						externalId: "acquisition-race",
+					},
+					{ database: { findOne: transaction.findOne, incrementOne } },
+				);
+			}),
+		).rejects.toMatchObject({
+			statusCode: 409,
+			body: expect.objectContaining({ status: "409" }),
+		});
+		expect(getIdentityRevisions(data)).toEqual(revisionsBeforeRace);
+	});
+
+	it("allows concurrent valid acquisitions of the same active User link", async () => {
+		const data = createData();
+		const auth = createAuth(memoryAdapter(data));
+		const resource = await auth.api.createSCIMUser({
+			body: {
+				schemas: [USER_SCHEMA],
+				userName: "concurrent-acquisition@example.com",
+				externalId: "concurrent-acquisition",
+			},
+			headers,
+		});
+		const revisionsBeforeAcquisitions = getIdentityRevisions(data);
+		if (
+			revisionsBeforeAcquisitions.subjectRevision === undefined ||
+			revisionsBeforeAcquisitions.connectionRevision === undefined
+		) {
+			throw new Error("Expected identity revision state");
+		}
+		const context = await auth.$context;
+		const subjectIncrementsReady = createDeferred();
+		let pendingSubjectIncrements = 0;
+		const incrementOne: DBTransactionAdapter["incrementOne"] = async <Row>(
+			input: IncrementOneInput,
+		) => {
+			if (input.model === "scimSubject") {
+				pendingSubjectIncrements += 1;
+				if (pendingSubjectIncrements === 2) subjectIncrementsReady.resolve();
+				else await subjectIncrementsReady.promise;
+			}
+			return context.adapter.incrementOne<Row>(input);
+		};
+		const database = { findOne: context.adapter.findOne, incrementOne };
+
+		const links = await Promise.all([
+			acquireActiveSCIMUserLink(
+				{
+					connectionId: "workforce",
+					externalId: "concurrent-acquisition",
+				},
+				{ database },
+			),
+			acquireActiveSCIMUserLink(
+				{
+					connectionId: "workforce",
+					externalId: "concurrent-acquisition",
+				},
+				{ database },
+			),
+		]);
+
+		const expectedLink = {
+			scimUserId: resource.id,
+			userId: data.scimUser[0]?.userId,
+		};
+		expect(links).toEqual([expectedLink, expectedLink]);
+		expect(getIdentityRevisions(data)).toEqual({
+			subjectRevision: revisionsBeforeAcquisitions.subjectRevision + 2,
+			connectionRevision: revisionsBeforeAcquisitions.connectionRevision + 2,
+		});
+	});
+
+	it("aborts when the source changes after subject acquisition", async () => {
+		const data = createData();
+		const auth = createAuth(memoryAdapter(data));
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: [USER_SCHEMA],
+				userName: "post-acquisition-race@example.com",
+				externalId: "post-acquisition-race",
+			},
+			headers,
+		});
+		const revisionsBeforeRace = getIdentityRevisions(data);
+		const context = await auth.$context;
+		if (!context.adapter.transaction) {
+			throw new Error("Expected native transaction support");
+		}
+
+		await expect(
+			context.adapter.transaction((transaction) => {
+				let subjectAcquired = false;
+				const incrementOne: DBTransactionAdapter["incrementOne"] = async <Row>(
+					input: IncrementOneInput,
+				) => {
+					const updated = await transaction.incrementOne<Row>(input);
+					if (input.model === "scimSubject" && updated) subjectAcquired = true;
+					return updated;
+				};
+				const findOne: DBTransactionAdapter["findOne"] = async <Row>(
+					input: FindOneInput,
+				) => {
+					if (subjectAcquired && input.model === "scimUser") return null;
+					const row = await transaction.findOne<Row>(input);
+					return row;
+				};
+				return acquireActiveSCIMUserLink(
+					{
+						connectionId: "workforce",
+						externalId: "post-acquisition-race",
+					},
+					{ database: { findOne, incrementOne } },
+				);
+			}),
+		).rejects.toMatchObject({
+			statusCode: 409,
+			body: expect.objectContaining({ status: "409" }),
+		});
+		expect(getIdentityRevisions(data)).toEqual(revisionsBeforeRace);
+	});
+
+	it("aborts when connection decommissioning wins the final fence", async () => {
+		const data = createData();
+		const auth = createAuth(memoryAdapter(data));
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: [USER_SCHEMA],
+				userName: "connection-race@example.com",
+				externalId: "connection-race",
+			},
+			headers,
+		});
+		const revisionsBeforeRace = getIdentityRevisions(data);
+		const context = await auth.$context;
+		if (!context.adapter.transaction) {
+			throw new Error("Expected native transaction support");
+		}
+
+		await expect(
+			context.adapter.transaction((transaction) => {
+				const incrementOne: DBTransactionAdapter["incrementOne"] = async <Row>(
+					input: IncrementOneInput,
+				) => {
+					if (input.model === "scimConnectionBinding") return null;
+					return transaction.incrementOne<Row>(input);
+				};
+				return acquireActiveSCIMUserLink(
+					{
+						connectionId: "workforce",
+						externalId: "connection-race",
+					},
+					{ database: { findOne: transaction.findOne, incrementOne } },
+				);
+			}),
+		).rejects.toMatchObject({
+			statusCode: 409,
+			body: expect.objectContaining({ status: "409" }),
+		});
+		expect(getIdentityRevisions(data)).toEqual(revisionsBeforeRace);
 	});
 });

--- a/packages/scim/src/user-provisioning.ts
+++ b/packages/scim/src/user-provisioning.ts
@@ -32,7 +32,11 @@ import type {
 } from "./persistence";
 import type { SCIMProjectionCoordinator } from "./projection";
 import { projectSCIMResourceAttributes } from "./resource-attribute-projection";
-import { createSCIMOrderKey, createScopedKey } from "./resource-key";
+import {
+	createSCIMOrderKey,
+	createSCIMUserExternalIdKey,
+	createScopedKey,
+} from "./resource-key";
 import { SCIM_RESOURCE_SCHEMA_REGISTRY } from "./resource-schema-registry";
 import { runSCIMCreateWithUniquenessCheck } from "./resource-uniqueness";
 import { createSCIMError, SCIMErrorOpenAPISchemas } from "./scim-error";
@@ -91,7 +95,7 @@ function createExternalIdKey(
 	externalId?: string,
 ): string | undefined {
 	if (!externalId) return undefined;
-	return createScopedKey(["scim-user-external-id", connectionId, externalId]);
+	return createSCIMUserExternalIdKey(connectionId, externalId);
 }
 
 function createConnectionUserKey(connectionId: string, userId: string): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1583,12 +1583,18 @@ importers:
       '@better-auth/kysely-adapter':
         specifier: workspace:*
         version: link:../kysely-adapter
+      '@better-auth/sso':
+        specifier: workspace:*
+        version: link:../sso
       '@better-auth/test-utils':
         specifier: workspace:*
         version: link:../test-utils
       kysely:
         specifier: 0.28.17
         version: 0.28.17
+      oauth2-mock-server:
+        specifier: ^9.0.0
+        version: 9.0.0
       tsdown:
         specifier: 'catalog:'
         version: 0.21.1(@arethetypeswrong/core@0.18.3)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@5.9.3)


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #10408. Review the SSO user-resolution contract first.

## Why

SCIM can provision a Better Auth User before that person signs in, but authentication still needs an exact, lifecycle-aware bridge from the verified provider identity to that existing User. This change makes SCIM activation state authoritative at sign-in without coupling the SSO plugin to SCIM.

## What changes

- Adds `acquireActiveSCIMUserLink` as a small, typed SCIM composition API.
- Resolves only an exact, case-sensitive `connectionId` and `externalId` pair.
- Rejects inactive, deleted, orphaned, inconsistent, and decommissioned sources.
- Fences sign-in against concurrent lifecycle changes while allowing concurrent valid sign-ins.
- Documents the SCIM and SSO composition with immutable provider-subject guidance.
- Adds a black-box HTTP workflow from SCIM provisioning through OIDC callback and session creation.

<details>
<summary>Lifecycle contract</summary>

- Settled unavailable state returns `null`, so the application can reject authentication explicitly.
- A lifecycle change after acquisition begins aborts the shared transaction instead of authenticating stale state.
- Deleted-resource tombstones preserve reprovisioning identity but never authorize sign-in.
- Reprovisioning the same external subject restores the original Better Auth User.
- Identical external IDs in different SCIM connections remain isolated.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `acquireActiveSCIMUserLink` to `@better-auth/scim` to gate SSO on active, SCIM‑provisioned users only. Sign-in links by exact `connectionId` + `externalId` (case‑sensitive) and rejects inactive, deleted, tombstoned, orphaned sources, and decommissioned or domain‑mismatched connections.

- **New Features**
  - `acquireActiveSCIMUserLink`: transaction‑safe exact lookup that returns `{ userId, scimUserId }` or `null`; no email/`userName` fallback.
  - Lifecycle and concurrency safety: fences deactivation, deletion, and connection decommissioning; concurrent valid sign-ins are allowed.
  - Docs and tests: SCIM docs add a full SSO `resolveUser` example with subject guidance; end‑to‑end HTTP test covers SCIM provisioning through OIDC callback using `@better-auth/sso`.

- **Migration**
  - In SSO `resolveUser`, call `acquireActiveSCIMUserLink({ connectionId, externalId: identity.providerAccountId }, context)` and, if found, return `{ action: "link", userId: link.userId, profile: "preserve" }`; otherwise reject.
  - Configure the directory to send the provider’s immutable, verified subject as the SCIM User `externalId` (case‑sensitive). Run the helper inside the transaction provided by `resolveUser`.

<sup>Written for commit 6b1b57b710dd404fea0fdef9573da79cc0106e17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

