### PR TITLE
fix(scim): add RFC-required fields to ServiceProviderConfig

### DIFF
--- a/.changeset/fix-scim-service-provider-config-openapi-required.md
+++ b/.changeset/fix-scim-service-provider-config-openapi-required.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": patch
+---
+
+Mark the RFC-required `ServiceProviderConfig` fields as `required` in the generated OpenAPI schema (root, `bulk`, `filter`, and `meta`), so schema-validating clients actually catch a response that's missing them instead of treating the fields as optional.

--- a/.changeset/fix-scim-service-provider-config.md
+++ b/.changeset/fix-scim-service-provider-config.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": patch
+---
+
+Add RFC 7643 §5 required fields to the `ServiceProviderConfig` response: `filter.maxResults`, `bulk.maxOperations`, `bulk.maxPayloadSize`, `id`, and `meta.location`.

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -1425,9 +1425,15 @@ export const getSCIMServiceProviderConfig = createAuthEndpoint(
 	},
 	async (ctx) => {
 		return ctx.json({
+			id: "ServiceProviderConfig",
 			patch: { supported: true },
-			bulk: { supported: false },
-			filter: { supported: true },
+			// `bulk.maxOperations`/`maxPayloadSize` are REQUIRED by RFC 7643 §5
+			// even when `supported` is `false`.
+			bulk: { supported: false, maxOperations: 0, maxPayloadSize: 0 },
+			// `maxResults` is REQUIRED when `filter.supported` is `true`. This
+			// mirrors the adapter's default `findMany` cap enforced in
+			// `listSCIMUsers` (see the pagination issue tracked separately).
+			filter: { supported: true, maxResults: 100 },
 			changePassword: { supported: false },
 			sort: { supported: false },
 			etag: { supported: false },
@@ -1444,6 +1450,10 @@ export const getSCIMServiceProviderConfig = createAuthEndpoint(
 			schemas: ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
 			meta: {
 				resourceType: "ServiceProviderConfig",
+				location: getResourceURL(
+					"/scim/v2/ServiceProviderConfig",
+					ctx.context.baseURL,
+				),
 			},
 		});
 	},

--- a/packages/scim/src/scim-metadata.ts
+++ b/packages/scim/src/scim-metadata.ts
@@ -5,6 +5,7 @@ const MetadataFieldSupportOpenAPISchema = {
 			type: "boolean",
 		},
 	},
+	required: ["supported"] as string[],
 };
 
 export const ServiceProviderOpenAPISchema = {
@@ -83,6 +84,7 @@ export const ServiceProviderOpenAPISchema = {
 		"filter",
 		"changePassword",
 		"sort",
+		"etag",
 		"authenticationSchemes",
 		"schemas",
 		"meta",

--- a/packages/scim/src/scim-metadata.ts
+++ b/packages/scim/src/scim-metadata.ts
@@ -10,9 +10,25 @@ const MetadataFieldSupportOpenAPISchema = {
 export const ServiceProviderOpenAPISchema = {
 	type: "object",
 	properties: {
+		id: {
+			type: "string",
+		},
 		patch: MetadataFieldSupportOpenAPISchema,
-		bulk: MetadataFieldSupportOpenAPISchema,
-		filter: MetadataFieldSupportOpenAPISchema,
+		bulk: {
+			type: "object",
+			properties: {
+				supported: { type: "boolean" },
+				maxOperations: { type: "integer" },
+				maxPayloadSize: { type: "integer" },
+			},
+		},
+		filter: {
+			type: "object",
+			properties: {
+				supported: { type: "boolean" },
+				maxResults: { type: "integer" },
+			},
+		},
 		changePassword: MetadataFieldSupportOpenAPISchema,
 		sort: MetadataFieldSupportOpenAPISchema,
 		etag: MetadataFieldSupportOpenAPISchema,
@@ -49,6 +65,9 @@ export const ServiceProviderOpenAPISchema = {
 			type: "object",
 			properties: {
 				resourceType: {
+					type: "string",
+				},
+				location: {
 					type: "string",
 				},
 			},

--- a/packages/scim/src/scim-metadata.ts
+++ b/packages/scim/src/scim-metadata.ts
@@ -21,6 +21,7 @@ export const ServiceProviderOpenAPISchema = {
 				maxOperations: { type: "integer" },
 				maxPayloadSize: { type: "integer" },
 			},
+			required: ["supported", "maxOperations", "maxPayloadSize"] as string[],
 		},
 		filter: {
 			type: "object",
@@ -28,6 +29,7 @@ export const ServiceProviderOpenAPISchema = {
 				supported: { type: "boolean" },
 				maxResults: { type: "integer" },
 			},
+			required: ["supported", "maxResults"] as string[],
 		},
 		changePassword: MetadataFieldSupportOpenAPISchema,
 		sort: MetadataFieldSupportOpenAPISchema,
@@ -71,8 +73,20 @@ export const ServiceProviderOpenAPISchema = {
 					type: "string",
 				},
 			},
+			required: ["resourceType", "location"] as string[],
 		},
 	},
+	required: [
+		"id",
+		"patch",
+		"bulk",
+		"filter",
+		"changePassword",
+		"sort",
+		"authenticationSchemes",
+		"schemas",
+		"meta",
+	] as string[],
 } as const;
 
 export const ResourceTypeOpenAPISchema = {

--- a/packages/scim/src/scim.test.ts
+++ b/packages/scim/src/scim.test.ts
@@ -172,6 +172,8 @@ describe("SCIM", () => {
 				    },
 				  ],
 				  "bulk": {
+				    "maxOperations": 0,
+				    "maxPayloadSize": 0,
 				    "supported": false,
 				  },
 				  "changePassword": {
@@ -181,9 +183,12 @@ describe("SCIM", () => {
 				    "supported": false,
 				  },
 				  "filter": {
+				    "maxResults": 100,
 				    "supported": true,
 				  },
+				  "id": "ServiceProviderConfig",
 				  "meta": {
+				    "location": "http://localhost:3000/api/auth/scim/v2/ServiceProviderConfig",
 				    "resourceType": "ServiceProviderConfig",
 				  },
 				  "patch": {


### PR DESCRIPTION
Fixes #10413

RFC 7643 §5 marks three `ServiceProviderConfig` sub-fields REQUIRED that the response was missing, and §3 requires `id` and recommends `meta.location` on every SCIM resource:

- `filter.maxResults` was absent despite `filter.supported: true`.
- `bulk.maxOperations` and `bulk.maxPayloadSize` were absent from the `bulk` object - required regardless of whether `bulk.supported` is `true` or `false`.
- `id` was missing from the response body entirely.
- `meta.location` was missing from the `meta` object.

Strict SCIM clients (Okta, Azure AD, Rippling) that validate this response against the RFC schema fail at startup without these fields, and clients with no default of their own may over-paginate without `filter.maxResults` to go on.

Purely additive change to a static response object - no behavioral risk. `filter.maxResults` is set to `100` to match the adapter's current `findMany` default cap (tracked separately in #10398).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add RFC 7643-required fields to the SCIM ServiceProviderConfig in `@better-auth/scim` and mark them required in the OpenAPI schema to unblock strict clients and align pagination defaults. Purely additive response change.

- **Bug Fixes**
  - ServiceProviderConfig now includes: id, meta.location, bulk.maxOperations=0, bulk.maxPayloadSize=0, filter.maxResults=100.
  - OpenAPI marks these fields as required, adds `etag` to the root required list, and requires `supported` on toggle fields.
  - Tests updated for the new response shape.

<sup>Written for commit 1b163215477c991bc142da95093a77184f5793f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

