### PR TITLE
fix(scim): support externalId filter on GET /scim/v2/Users

### DIFF
--- a/.changeset/fix-scim-externalid-case-insensitive.md
+++ b/.changeset/fix-scim-externalid-case-insensitive.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": patch
+---
+
+Match the `externalId` filter attribute name case-insensitively (e.g. `ExternalId eq "..."`, `EXTERNALID eq "..."`), per RFC 7644 §3.4.2.2 which specifies that SCIM attribute names are case-insensitive. Previously only the exact-case `externalId` was recognized before falling through to the generic filter path and returning `400`.

--- a/.changeset/fix-scim-externalid-multi-account.md
+++ b/.changeset/fix-scim-externalid-multi-account.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": patch
+---
+
+Fix `GET /scim/v2/Users?filter=externalId eq "..."` returning the wrong account's `externalId` when a user has more than one SCIM account for the same provider (possible via `linkExistingUsers`). The user-ID scoping was already correct; the resource-building step looked up the account from the unfiltered account list instead of the `externalId`-matched one.

--- a/.changeset/fix-scim-user-lifecycle.md
+++ b/.changeset/fix-scim-user-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": patch
+---
+
+Support `GET /scim/v2/Users?filter=externalId eq "..."`, the standard pre-provision existence check all major SCIM providers (Okta, Azure AD, Rippling) perform before creating a user. Previously this returned `400 The attribute "externalId" is not supported` because `externalId` lives on the `account` model (as `accountId`) rather than on the `user` model filtered by the other list filters.

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -20,7 +20,11 @@ import type { AuthMiddleware } from "./middlewares";
 import { buildUserPatch } from "./patch-operations";
 import { SCIMAPIError, SCIMErrorOpenAPISchemas } from "./scim-error";
 import type { DBFilter } from "./scim-filters";
-import { parseSCIMUserFilter, SCIMParseError } from "./scim-filters";
+import {
+	parseSCIMFilter,
+	parseSCIMUserFilter,
+	SCIMParseError,
+} from "./scim-filters";
 import {
 	ResourceTypeOpenAPISchema,
 	SCIMSchemaOpenAPISchema,
@@ -1043,7 +1047,9 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 				Resources: [],
 			} as const;
 
-			const apiFilters: DBFilter[] = parseSCIMAPIUserFilter(ctx.query?.filter);
+			const { externalId, apiFilters } = parseSCIMAPIUserFilter(
+				ctx.query?.filter,
+			);
 
 			const providerId = ctx.context.scimProvider.providerId;
 			const accounts = await ctx.context.adapter.findMany<Account>({
@@ -1051,9 +1057,18 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 				where: [{ field: "providerId", value: providerId }],
 			});
 
-			const accountUserIds = accounts.map((account) => account.userId);
+			// An `externalId` filter narrows to the account(s) whose accountId
+			// matches, before any other lookup - it's the standard pre-provision
+			// existence check every major SCIM provider performs.
+			const scopedAccounts =
+				externalId !== undefined
+					? accounts.filter((account) => account.accountId === externalId)
+					: accounts;
 
-			// No accounts exist for this provider
+			const accountUserIds = scopedAccounts.map((account) => account.userId);
+
+			// No accounts (matching the externalId filter, if any) exist for
+			// this provider
 
 			if (accountUserIds.length === 0) {
 				return ctx.json(emptyListResponse);
@@ -1699,11 +1714,26 @@ const findUserById = async (
 	return { user, account };
 };
 
-const parseSCIMAPIUserFilter = (filter?: string) => {
-	let filters: DBFilter[] = [];
+/**
+ * `externalId` lives on the `account` model (as `accountId`), not on the
+ * `user` model, so it can't be resolved through the generic
+ * `SCIMUserAttributes` map used for the other list filters. It's intercepted
+ * here and resolved by the caller against the already-fetched accounts for
+ * this provider.
+ */
+const parseSCIMAPIUserFilter = (
+	filter?: string,
+): { externalId?: string; apiFilters: DBFilter[] } => {
+	if (!filter) {
+		return { apiFilters: [] };
+	}
 
 	try {
-		filters = filter ? parseSCIMUserFilter(filter) : [];
+		const parsed = parseSCIMFilter(filter);
+		if (parsed.attribute === "externalId") {
+			return { externalId: parsed.value.replaceAll('"', ""), apiFilters: [] };
+		}
+		return { apiFilters: parseSCIMUserFilter(filter) };
 	} catch (error) {
 		throw new SCIMAPIError("BAD_REQUEST", {
 			detail:
@@ -1711,6 +1741,4 @@ const parseSCIMAPIUserFilter = (filter?: string) => {
 			scimType: "invalidFilter",
 		});
 	}
-
-	return filters;
 };

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -1730,7 +1730,8 @@ const parseSCIMAPIUserFilter = (
 
 	try {
 		const parsed = parseSCIMFilter(filter);
-		if (parsed.attribute === "externalId") {
+		// RFC 7644 §3.4.2.2: attribute names are case-insensitive.
+		if (parsed.attribute.toLowerCase() === "externalid") {
 			return { externalId: parsed.value.replaceAll('"', ""), apiFilters: [] };
 		}
 		return { apiFilters: parseSCIMUserFilter(filter) };

--- a/packages/scim/src/routes.ts
+++ b/packages/scim/src/routes.ts
@@ -1110,7 +1110,11 @@ export const listSCIMUsers = (authMiddleware: AuthMiddleware) =>
 				startIndex: 1,
 				itemsPerPage: users.length,
 				Resources: users.map((user) => {
-					const account = accounts.find((a) => a.userId === user.id);
+					// Use `scopedAccounts` (not `accounts`) so that if a user ever has
+					// more than one SCIM account row for this provider, an `externalId`
+					// filter renders the matched account's externalId - not just
+					// whichever of the user's accounts happens to be found first.
+					const account = scopedAccounts.find((a) => a.userId === user.id);
 					return createUserResource(ctx.context.baseURL, user, account);
 				}),
 			});

--- a/packages/scim/src/scim-filters.ts
+++ b/packages/scim/src/scim-filters.ts
@@ -19,7 +19,14 @@ export class SCIMParseError extends Error {}
 const SCIMFilterRegex =
 	/^\s*(?<attribute>[^\s]+)\s+(?<op>eq|ne|co|sw|ew|pr)\s*(?:(?<value>"[^"]*"|[^\s]+))?\s*$/i;
 
-const parseSCIMFilter = (filter: string) => {
+/**
+ * Parses a raw SCIM filter expression into its attribute/operator/value parts
+ * without mapping the attribute to a database field. Exposed for callers
+ * (like the `externalId` filter on `GET /scim/v2/Users`) that need to resolve
+ * an attribute against a different model than the generic `SCIMUserAttributes`
+ * map targets.
+ */
+export const parseSCIMFilter = (filter: string) => {
 	const match = filter.match(SCIMFilterRegex);
 	if (!match) {
 		throw new SCIMParseError("Invalid filter expression");

--- a/packages/scim/src/scim-users.test.ts
+++ b/packages/scim/src/scim-users.test.ts
@@ -369,6 +369,96 @@ describe("SCIM", () => {
 				}),
 			);
 		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10398
+		 */
+		it("should filter the list of users by externalId", async () => {
+			const { auth, getSCIMToken } = createTestInstance();
+			const scimToken = await getSCIMToken();
+
+			const createUser = (userName: string, externalId: string) => {
+				return auth.api.createSCIMUser({
+					body: {
+						userName,
+						externalId,
+					},
+					headers: {
+						authorization: `Bearer ${scimToken}`,
+					},
+				});
+			};
+
+			const [userA] = await Promise.all([
+				createUser("user-a", "ext-a"),
+				createUser("user-b", "ext-b"),
+			]);
+
+			const users = await auth.api.listSCIMUsers({
+				query: {
+					filter: 'externalId eq "ext-a"',
+				},
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+
+			expect(users).toMatchObject({
+				itemsPerPage: 1,
+				totalResults: 1,
+				Resources: [userA],
+			});
+		});
+
+		it("should return an empty list for an externalId filter with no matching account", async () => {
+			const { auth, getSCIMToken } = createTestInstance();
+			const scimToken = await getSCIMToken();
+
+			await auth.api.createSCIMUser({
+				body: { userName: "user-a", externalId: "ext-a" },
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+
+			const users = await auth.api.listSCIMUsers({
+				query: {
+					filter: 'externalId eq "does-not-exist"',
+				},
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+
+			expect(users).toMatchObject({
+				itemsPerPage: 0,
+				totalResults: 0,
+				Resources: [],
+			});
+		});
+
+		it("treats externalId filter values as case-sensitive (caseExact)", async () => {
+			const { auth, getSCIMToken } = createTestInstance();
+			const scimToken = await getSCIMToken();
+
+			await auth.api.createSCIMUser({
+				body: { userName: "user-a", externalId: "Ext-A" },
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+
+			const users = await auth.api.listSCIMUsers({
+				query: {
+					filter: 'externalId eq "ext-a"',
+				},
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+
+			expect(users).toMatchObject({
+				itemsPerPage: 0,
+				totalResults: 0,
+				Resources: [],
+			});
+		});
 	});
 
 	describe("GET /scim/v2/Users/:userId", () => {

--- a/packages/scim/src/scim-users.test.ts
+++ b/packages/scim/src/scim-users.test.ts
@@ -459,6 +459,31 @@ describe("SCIM", () => {
 				Resources: [],
 			});
 		});
+
+		it("treats the externalId attribute name as case-insensitive", async () => {
+			const { auth, getSCIMToken } = createTestInstance();
+			const scimToken = await getSCIMToken();
+
+			const user = await auth.api.createSCIMUser({
+				body: { userName: "user-a", externalId: "ext-a" },
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+
+			const users = await auth.api.listSCIMUsers({
+				query: {
+					filter: 'ExternalId eq "ext-a"',
+				},
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+
+			expect(users).toMatchObject({
+				itemsPerPage: 1,
+				totalResults: 1,
+				Resources: [user],
+			});
+		});
 	});
 
 	describe("GET /scim/v2/Users/:userId", () => {

--- a/packages/scim/src/scim-users.test.ts
+++ b/packages/scim/src/scim-users.test.ts
@@ -484,6 +484,51 @@ describe("SCIM", () => {
 				Resources: [user],
 			});
 		});
+
+		it("renders the matched account's externalId when a user has more than one SCIM account for this provider", async () => {
+			const { auth, authClient, getSCIMToken } = createTestInstance({
+				linkExistingUsers: true,
+			});
+			const scimToken = await getSCIMToken();
+
+			await authClient.signUp.email({
+				email: "shared@email.com",
+				password: "the password",
+				name: "Shared User",
+			});
+
+			await auth.api.createSCIMUser({
+				body: {
+					userName: "user-1",
+					externalId: "ext-a",
+					emails: [{ value: "shared@email.com" }],
+				},
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+			await auth.api.createSCIMUser({
+				body: {
+					userName: "user-2",
+					externalId: "ext-b",
+					emails: [{ value: "shared@email.com" }],
+				},
+				headers: { authorization: `Bearer ${scimToken}` },
+			});
+
+			const users = await auth.api.listSCIMUsers({
+				query: {
+					filter: 'externalId eq "ext-b"',
+				},
+				headers: {
+					authorization: `Bearer ${scimToken}`,
+				},
+			});
+
+			expect(users).toMatchObject({
+				itemsPerPage: 1,
+				totalResults: 1,
+				Resources: [{ externalId: "ext-b" }],
+			});
+		});
 	});
 
 	describe("GET /scim/v2/Users/:userId", () => {


### PR DESCRIPTION
Fixes #10419

GET /scim/v2/Users?filter=externalId eq "..." always returned 400 because externalId is missing from the SCIMUserAttributes map used to resolve list filters onto database fields. Every major SCIM provider (Okta, Azure AD, Rippling) issues this filter to check whether a user already exists before provisioning; receiving 400 causes providers to abort provisioning or fall back to unconditional POST, risking duplicate accounts on retries.

externalId lives on the account model (as accountId), not on the user model that the other list filters target, so it can't go through the generic SCIMUserAttributes map unchanged. It's intercepted before the generic filter parsing and resolved in-memory against the accounts array listSCIMUsers already fetches for this provider.

Non-breaking - this is a previously-broken code path (always 400), so no existing correct integration can rely on the old behavior. Includes tests for a match, a no-match empty result, and case-sensitivity (externalId is caseExact, unlike userName).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for externalId filtering on GET /scim/v2/Users so providers can run pre-provision checks without 400s. Handles case-insensitive attribute names and returns the correct account when users have multiple SCIM accounts.

- **Bug Fixes**
  - Intercepts externalId (case-insensitive) and matches against `accountId` to scope users before other filters.
  - Exposes `parseSCIMFilter` and updates parsing to return `{ externalId, apiFilters }` for `listSCIMUsers`.
  - Uses the scoped account when building Resources so the matched externalId is rendered for multi-account users.
  - Adds tests for a match, no match, caseExact value behavior, attribute name case-insensitivity, and multi-account rendering.

<sup>Written for commit ace79efc13356ddec6782c0a3db4b9a98631c6c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

