### PR TITLE
fix(two-factor): reject reused TOTP codes on step-up verification

### DIFF
--- a/.changeset/fix-totp-single-use-replay.md
+++ b/.changeset/fix-totp-single-use-replay.md
@@ -1,0 +1,15 @@
+---
+"better-auth": patch
+---
+
+fix(two-factor): reject reused TOTP codes on the step-up verification path
+
+When `verifyTOTP` ran with an already-active session (step-up / re-verification),
+a code that had already been successfully validated was accepted again and again,
+because the `twoFactor` row recorded no consumed time step and — unlike the
+sign-in path — there is no per-challenge verification row to consume. Step-up
+verification now records the last consumed time step (`lastUsedStep`) and rejects
+any candidate step at or below it, enforcing the one-time use required by
+RFC 6238 §5.2 and OWASP ASVS 5.0 §6.5.1. The new field is nullable, so existing
+rows are treated as having no consumed step and the first verification always
+succeeds.

--- a/packages/better-auth/src/plugins/two-factor/schema.ts
+++ b/packages/better-auth/src/plugins/two-factor/schema.ts
@@ -55,6 +55,18 @@ export const schema = {
 				input: false,
 				returned: false,
 			},
+			// The most recent TOTP time-step consumed on the step-up
+			// (re-verification) path. Step-up verification rejects any candidate
+			// step <= this value, enforcing RFC 6238 §5.2 one-time use where the
+			// active session leaves no per-challenge row to consume. Nullable so
+			// pre-migration rows (and document stores predating the column) are
+			// treated as "no step consumed yet" and the first use always succeeds.
+			lastUsedStep: {
+				type: "number",
+				required: false,
+				input: false,
+				returned: false,
+			},
 		},
 	},
 } satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -297,19 +297,56 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 				? await beginAttempt(DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS)
 				: null;
 			let status: boolean;
+			let matchedStep: number | null = null;
 			try {
 				const decrypted = await symmetricDecrypt({
 					key: ctx.context.secretConfig,
 					data: twoFactor.secret,
 				});
-				status = await createOTP(decrypted, {
+				const otp = createOTP(decrypted, {
 					period: opts.period,
 					digits: opts.digits,
-				}).verify(ctx.body.code);
+				});
+				// Walk the same ±1 acceptance window the util's verify() uses, but
+				// capture WHICH time step matched so one-time use can be enforced.
+				// currentStep is read once so a Date.now() tick across a period
+				// boundary cannot shift the window between deciding validity and
+				// recording the consumed step.
+				const window = 1;
+				const currentStep = Math.floor(Date.now() / (opts.period * 1000));
+				for (let i = -window; i <= window; i++) {
+					const candidateStep = currentStep + i;
+					const candidate = await otp.hotp(candidateStep);
+					if (candidate === ctx.body.code) {
+						matchedStep = candidateStep;
+						break;
+					}
+				}
+				status = matchedStep !== null;
 			} catch (error) {
 				// A server error before the code is checked must not spend the slot.
 				await attempt?.restore();
 				throw error;
+			}
+			// Enforce RFC 6238 §5.2 one-time use on the step-up (re-verification)
+			// path. Here the session is already active, so there is no per-challenge
+			// verification row to consume — nothing stops the exact same code from
+			// being accepted again and again. Reject a code whose step was already
+			// consumed, or any earlier step still inside the acceptance window. The
+			// sign-in path is intentionally left to its existing single-use guard:
+			// its 2FA challenge row is consumed atomically on success, which already
+			// blocks replay against that challenge. lastUsedStep is null on
+			// pre-migration rows (and document stores predating the column), so the
+			// first use is always allowed; the monotonic `<=` also rejects delayed
+			// replays of an older in-window step.
+			if (
+				!isSignIn &&
+				status &&
+				matchedStep !== null &&
+				typeof twoFactor.lastUsedStep === "number" &&
+				matchedStep <= twoFactor.lastUsedStep
+			) {
+				status = false;
 			}
 			if (!status) {
 				await attempt?.recordFailure();
@@ -358,7 +395,21 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 					where: [{ field: "id", value: twoFactor.id }],
 				});
 			}
-			return valid(ctx);
+			// Issue the session first; valid() runs any remaining side effects and
+			// only a genuinely successful validation reaches the step below.
+			const result = await valid(ctx);
+			// Burn the consumed time step on the step-up path so this code — and any
+			// earlier step still inside the acceptance window — cannot be verified
+			// again on the active session (RFC 6238 §5.2). Scoped to !isSignIn to
+			// match the guard above; matchedStep is non-null whenever status is true.
+			if (!isSignIn && matchedStep !== null) {
+				await ctx.context.adapter.update({
+					model: twoFactorTable,
+					update: { lastUsedStep: matchedStep },
+					where: [{ field: "id", value: twoFactor.id }],
+				});
+			}
+			return result;
 		},
 	);
 

--- a/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
@@ -712,3 +712,85 @@ describe("two-factor security: OTP attempts are atomic under concurrency", async
 		expect(successCount).toBeLessThanOrEqual(1);
 	});
 });
+
+/**
+ * Regression coverage for TOTP one-time use on the step-up (re-verification)
+ * path (RFC 6238 §5.2 / OWASP ASVS 5.0 §6.5.1). When `verifyTOTP` runs with an
+ * already-active session there is no per-challenge verification row to consume,
+ * so before the fix the exact same code was accepted again and again. The
+ * `twoFactor` row now records the last consumed time step and rejects any
+ * candidate step at or below it. Each test uses its own instance so the
+ * persisted `lastUsedStep` cannot leak between them.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10387
+ */
+describe("two-factor security: step-up TOTP codes are single-use (RFC 6238 §5.2)", () => {
+	async function setupTotpUser() {
+		const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [twoFactor({ skipVerificationOnEnable: true })],
+		});
+		const { headers } = await signInWithTestUser();
+		const enableRes = await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+		// skipVerificationOnEnable activates 2FA immediately and rotates the
+		// session, so use the cookies from the enable response going forward.
+		const sessionHeaders = convertSetCookieToCookie(enableRes.headers);
+		const dbUser = await db.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: testUser.email }],
+		});
+		const row = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: dbUser?.id as string }],
+		});
+		const secret = await symmetricDecrypt({
+			key: DEFAULT_SECRET,
+			data: row!.secret,
+		});
+		return { auth, secret, sessionHeaders };
+	}
+
+	it("rejects a code reused on the step-up (active session) path", async () => {
+		const { auth, secret, sessionHeaders } = await setupTotpUser();
+		const code = await createOTP(secret).totp();
+
+		// First use on the active session must succeed.
+		const first = await auth.api.verifyTOTP({
+			body: { code },
+			headers: sessionHeaders,
+		});
+		expect(first.token).toBeDefined();
+
+		// Reusing the same code (same time step) must now be rejected. The
+		// step-up path has no challenge to burn, so before the fix this returned
+		// success on every repeat.
+		await expect(
+			auth.api.verifyTOTP({ body: { code }, headers: sessionHeaders }),
+		).rejects.toThrow();
+	});
+
+	it("accepts a step-up code exactly once across repeated attempts", async () => {
+		const { auth, secret, sessionHeaders } = await setupTotpUser();
+		const code = await createOTP(secret).totp();
+
+		// The reported repro accepted the same code 3/3 times. Verify it now
+		// succeeds exactly once and is rejected on every later attempt.
+		let successes = 0;
+		for (let i = 0; i < 3; i++) {
+			try {
+				const res = await auth.api.verifyTOTP({
+					body: { code },
+					headers: sessionHeaders,
+				});
+				if (res.token) successes++;
+			} catch {
+				// Replay rejected — expected after the first success.
+			}
+		}
+		expect(successes).toBe(1);
+	});
+});

--- a/packages/better-auth/src/plugins/two-factor/types.ts
+++ b/packages/better-auth/src/plugins/two-factor/types.ts
@@ -109,4 +109,5 @@ export interface TwoFactorTable {
 	verified: boolean;
 	failedVerificationCount?: number;
 	lockedUntil?: Date | null;
+	lastUsedStep?: number | null;
 }


### PR DESCRIPTION
## Summary

TOTP codes could be verified more than once on the **step-up (re-verification)
path** — i.e. calling `verifyTOTP` while a session is already active (for
sensitive-action re-authentication). Because the `twoFactor` row recorded no
consumed time step, and the step-up path has no per-challenge verification row
to consume, the *same* code was accepted again and again.

This violates the one-time-use requirement of **RFC 6238 §5.2** ("The verifier
MUST NOT accept the second attempt of the OTP after the successful validation
has been issued for the first OTP") and **OWASP ASVS 5.0 §6.5.1**.

Closes #10387

## Changes

- **schema**: add a nullable `lastUsedStep` field to the `twoFactor` model,
  following the existing `failedVerificationCount` / `lockedUntil` non-breaking
  pattern (`required: false`, `input: false`, `returned: false`).
- **`totp/verifyTOTP`**: walk the same ±1 acceptance window the OTP util's
  `verify()` uses, but capture *which* time step matched. On the step-up path
  (`!isSignIn`), reject a code whose matched step is `<= lastUsedStep`, and
  record the consumed step after a successful verification.
- **types**: add `lastUsedStep?: number | null` to `TwoFactorTable`.
- **changeset**: patch.

Legacy-safe: `lastUsedStep` is `null` on pre-migration rows (and document stores
predating the column), so the first verification always succeeds. The monotonic
`<=` also rejects delayed replays of an older step still inside the window.

## Scope: step-up path only (by design)

The fix is intentionally scoped to the **step-up** path, which is the
unambiguous vector the issue leads with (the reported repro accepts the same
code 3/3 times on an active session) and which has **no** existing protection.

The issue also notes a **sign-in** vector (a code used in challenge A being
accepted in a new challenge B). I did **not** change the sign-in path here,
because:

- The sign-in path already consumes its per-challenge verification row
  atomically on success, which blocks replay against that challenge.
- Extending strict single-use across *separate* sign-in challenges changes
  established behavior that the repo's own recently-added 2FA security tests
  rely on — e.g. `two-factor.account-lockout.test.ts` reuses a correct code
  across multiple challenges, and one test performs two back-to-back successful
  sign-in verifications with the same code. That is a broader contract decision
  I'd rather leave to maintainers than fold into this fix.

Happy to extend enforcement to the sign-in path (and update those tests) in a
follow-up if you'd like it covered here.

## Testing

Added two regression tests to `two-factor.security.test.ts` (each in its own
instance so `lastUsedStep` cannot leak between them), both proven failing-first
on the current code and passing with the fix:

- a reused step-up code is rejected on the second attempt;
- a step-up code succeeds exactly once across three repeated attempts (the
  reported 3/3 repro).

```
pnpm exec vitest run src/plugins/two-factor/   # 85 passed (4 files)
pnpm run typecheck                             # clean
pnpm exec biome check <changed files>          # clean
```

All existing two-factor tests continue to pass unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents TOTP code reuse during step-up (re-verification). We now record the matched time step and reject any code at or below the last used step, enforcing single-use.

- **Bug Fixes**
  - Schema: add nullable lastUsedStep to twoFactor (not exposed in input/response).
  - verifyTOTP: capture the matched step across the ±1 window, reject replays on step-up, and persist lastUsedStep after success. Sign-in flow is unchanged.
  - Types: add lastUsedStep to TwoFactorTable.
  - Tests: add regression tests ensuring a step-up code succeeds once and replays are rejected; backward-compatible for existing rows.

<sup>Written for commit fb11d55578dd94854163cd2d3aea2070a6c8fc14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

