### PR TITLE
feat(email-otp,phone-number): add rememberMe to OTP sign-in flows

### DIFF
--- a/.changeset/remember-me-otp-sign-in.md
+++ b/.changeset/remember-me-otp-sign-in.md
@@ -1,0 +1,5 @@
+---
+"better-auth": minor
+---
+
+Add optional `rememberMe` to email OTP sign-in (`signIn.emailOtp`) and phone OTP verify (`phoneNumber.verify`), matching email/password and phone password behavior. Also clear a stale `dont_remember` cookie when establishing a remembered session so later refreshes stay persistent.

--- a/.changeset/remember-me-otp-sign-in.md
+++ b/.changeset/remember-me-otp-sign-in.md
@@ -1,5 +1,5 @@
 ---
-"better-auth": minor
+"better-auth": patch
 ---
 
 Add optional `rememberMe` to email OTP sign-in (`signIn.emailOtp`) and phone OTP verify (`phoneNumber.verify`), matching email/password and phone password behavior. Also clear a stale `dont_remember` cookie when establishing a remembered session so later refreshes stay persistent.

--- a/docs/content/docs/plugins/email-otp.mdx
+++ b/docs/content/docs/plugins/email-otp.mdx
@@ -136,6 +136,10 @@ Once the user provides the OTP, you can sign in the user using the `signIn.email
        * User profile image URL. Only used when the user is registering for the first time.
        */
       image?: string = "https://example.com/image.png"
+      /**
+       * If false, the user will be signed out when the browser is closed. (optional) (default: true)
+       */
+      rememberMe?: boolean = true
   }
   ```
 </APIMethod>

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -106,6 +106,11 @@ After the OTP is sent, users can verify their phone number by providing the code
        * Requires an active session.
        */
       updatePhoneNumber?: boolean = false
+      /**
+       * If false, the user will be signed out when the browser is closed.
+       * Only applies when a session is created. (optional) (default: true)
+       */
+      rememberMe?: boolean = true
   }
   ```
 </APIMethod>

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -705,6 +705,43 @@ describe("getSessionCookie", async () => {
 		);
 	});
 
+	it("should expire a stale dont_remember cookie on a later remembered sign-in", async () => {
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			secret: "better-auth.secret",
+		});
+		const headers = new Headers();
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+				rememberMe: false,
+			},
+			{
+				onSuccess: cookieSetter(headers),
+			},
+		);
+		expect(headers.get("cookie")).toContain("better-auth.dont_remember");
+
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+			},
+			{
+				headers,
+				onSuccess(c) {
+					const parsed = parseSetCookieHeader(
+						c.response.headers.get("set-cookie") || "",
+					);
+					const sessionToken = parsed.get("better-auth.session_token");
+					expect(sessionToken?.["max-age"]).toBeDefined();
+					expect(parsed.get("better-auth.dont_remember")?.["max-age"]).toBe(0);
+				},
+			},
+		);
+	});
+
 	it("should return null if the cookie is invalid", async () => {
 		const { client, testUser } = await getTestInstance({
 			session: {

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -307,6 +307,10 @@ export async function setSessionCookie(
 			ctx.context.secret,
 			ctx.context.authCookies.dontRememberToken.attributes,
 		);
+	} else if (dontRememberMeCookie) {
+		// Clear a stale marker so a later remembered sign-in stays persistent
+		// across session refreshes that read this cookie.
+		expireCookie(ctx, ctx.context.authCookies.dontRememberToken);
 	}
 	await setCookieCache(ctx, session, dontRememberMe);
 	ctx.context.setNewSession(session);

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -2571,3 +2571,98 @@ describe("email-otp send origin/CSRF protection", async () => {
 		expect(sendVerificationOTP).toHaveBeenCalledTimes(1);
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10412
+ */
+describe("email-otp rememberMe", async () => {
+	let otp = "";
+	const { client, testUser } = await getTestInstance(
+		{
+			plugins: [
+				emailOTP({
+					async sendVerificationOTP({ otp: _otp }) {
+						otp = _otp;
+					},
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [emailOTPClient()],
+			},
+		},
+	);
+
+	it("should set a persistent session cookie by default on email OTP sign-in", async () => {
+		await client.emailOtp.sendVerificationOtp({
+			email: testUser.email,
+			type: "sign-in",
+		});
+
+		await client.signIn.emailOtp(
+			{
+				email: testUser.email,
+				otp,
+			},
+			{
+				onSuccess(ctx) {
+					const cookies = parseSetCookieHeader(
+						ctx.response.headers.get("set-cookie") || "",
+					);
+					const sessionToken = cookies.get("better-auth.session_token");
+					expect(sessionToken).toBeDefined();
+					expect(sessionToken?.["max-age"]).toBeDefined();
+					expect(cookies.get("better-auth.dont_remember")).toBeUndefined();
+				},
+			},
+		);
+	});
+
+	it("should clear max-age when email OTP sign-in uses rememberMe: false", async () => {
+		await client.emailOtp.sendVerificationOtp({
+			email: testUser.email,
+			type: "sign-in",
+		});
+
+		await client.signIn.emailOtp(
+			{
+				email: testUser.email,
+				otp,
+				rememberMe: false,
+			},
+			{
+				onSuccess(ctx) {
+					const cookies = parseSetCookieHeader(
+						ctx.response.headers.get("set-cookie") || "",
+					);
+					const sessionToken = cookies.get("better-auth.session_token");
+					expect(sessionToken).toBeDefined();
+					expect(sessionToken?.["max-age"]).toBeUndefined();
+					expect(cookies.get("better-auth.dont_remember")).toBeDefined();
+				},
+			},
+		);
+	});
+
+	it("should clear max-age when email/password uses rememberMe: false (control)", async () => {
+		await client.signIn.email(
+			{
+				email: testUser.email,
+				password: testUser.password,
+				rememberMe: false,
+			},
+			{
+				onSuccess(ctx) {
+					const cookies = parseSetCookieHeader(
+						ctx.response.headers.get("set-cookie") || "",
+					);
+					const sessionToken = cookies.get("better-auth.session_token");
+					expect(sessionToken).toBeDefined();
+					expect(sessionToken?.["max-age"]).toBeUndefined();
+					expect(cookies.get("better-auth.dont_remember")).toBeDefined();
+				},
+			},
+		);
+	});
+});

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -2595,6 +2595,7 @@ describe("email-otp rememberMe", async () => {
 	);
 
 	it("should set a persistent session cookie by default on email OTP sign-in", async () => {
+		expect.assertions(3);
 		await client.emailOtp.sendVerificationOtp({
 			email: testUser.email,
 			type: "sign-in",
@@ -2620,6 +2621,7 @@ describe("email-otp rememberMe", async () => {
 	});
 
 	it("should clear max-age when email OTP sign-in uses rememberMe: false", async () => {
+		expect.assertions(3);
 		await client.emailOtp.sendVerificationOtp({
 			email: testUser.email,
 			type: "sign-in",
@@ -2629,27 +2631,6 @@ describe("email-otp rememberMe", async () => {
 			{
 				email: testUser.email,
 				otp,
-				rememberMe: false,
-			},
-			{
-				onSuccess(ctx) {
-					const cookies = parseSetCookieHeader(
-						ctx.response.headers.get("set-cookie") || "",
-					);
-					const sessionToken = cookies.get("better-auth.session_token");
-					expect(sessionToken).toBeDefined();
-					expect(sessionToken?.["max-age"]).toBeUndefined();
-					expect(cookies.get("better-auth.dont_remember")).toBeDefined();
-				},
-			},
-		);
-	});
-
-	it("should clear max-age when email/password uses rememberMe: false (control)", async () => {
-		await client.signIn.email(
-			{
-				email: testUser.email,
-				password: testUser.password,
 				rememberMe: false,
 			},
 			{

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -587,6 +587,13 @@ const signInEmailOTPBodySchema = z
 					"User profile image URL. Only used if the user is registering for the first time.",
 			})
 			.optional(),
+		rememberMe: z
+			.boolean()
+			.meta({
+				description:
+					"If this is false, the session will not be remembered. Default is `true`.",
+			})
+			.optional(),
 	})
 	.and(z.record(z.string(), z.any()));
 
@@ -642,8 +649,16 @@ export const signInEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			},
 		},
 		async (ctx) => {
-			const { email: rawEmail, otp, name, image, ...rest } = ctx.body;
+			const {
+				email: rawEmail,
+				otp,
+				name,
+				image,
+				rememberMe,
+				...rest
+			} = ctx.body;
 			const email = rawEmail.toLowerCase();
+			const dontRememberMe = rememberMe === false;
 
 			// Use atomic verification to prevent race conditions
 			await atomicVerifyOTP(ctx, opts, toOTPIdentifier("sign-in", email), otp);
@@ -667,11 +682,16 @@ export const signInEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				});
 				const session = await ctx.context.internalAdapter.createSession(
 					newUser.id,
+					dontRememberMe,
 				);
-				await setSessionCookie(ctx, {
-					session,
-					user: newUser,
-				});
+				await setSessionCookie(
+					ctx,
+					{
+						session,
+						user: newUser,
+					},
+					dontRememberMe,
+				);
 				return ctx.json({
 					token: session.token,
 					user: parseUserOutput(ctx.context.options, newUser),
@@ -687,11 +707,16 @@ export const signInEmailOTP = (opts: RequiredEmailOTPOptions) =>
 
 			const session = await ctx.context.internalAdapter.createSession(
 				user.user.id,
+				dontRememberMe,
 			);
-			await setSessionCookie(ctx, {
-				session,
-				user: user.user,
-			});
+			await setSessionCookie(
+				ctx,
+				{
+					session,
+					user: user.user,
+				},
+				dontRememberMe,
+			);
 			return ctx.json({
 				token: session.token,
 				user: parseUserOutput(ctx.context.options, user.user),

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseSetCookieHeader } from "../../cookies/cookie-utils";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { bearer } from "../bearer";
 import { phoneNumber } from ".";
@@ -1281,5 +1282,132 @@ describe("custom verifyOTP", async () => {
 		});
 		expect(user.data?.user.phoneNumber).toBe(updatedPhoneNumber);
 		expect(user.data?.user.phoneNumberVerified).toBe(true);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10412
+ */
+describe("phone-number rememberMe", async () => {
+	let otp = "";
+	const testPhoneNumber = "+15551234567";
+
+	const { client, auth } = await getTestInstance(
+		{
+			plugins: [
+				phoneNumber({
+					async sendOTP({ code }) {
+						otp = code;
+					},
+					signUpOnVerification: {
+						getTempEmail(phoneNumber) {
+							return `temp-${phoneNumber}@example.com`;
+						},
+					},
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [phoneNumberClient()],
+			},
+		},
+	);
+
+	it("should set a persistent session cookie by default on phone OTP verify", async () => {
+		await client.phoneNumber.sendOtp({
+			phoneNumber: testPhoneNumber,
+		});
+
+		await client.phoneNumber.verify(
+			{
+				phoneNumber: testPhoneNumber,
+				code: otp,
+			},
+			{
+				onSuccess(ctx) {
+					const cookies = parseSetCookieHeader(
+						ctx.response.headers.get("set-cookie") || "",
+					);
+					const sessionToken = cookies.get("better-auth.session_token");
+					expect(sessionToken).toBeDefined();
+					expect(sessionToken?.["max-age"]).toBeDefined();
+					expect(cookies.get("better-auth.dont_remember")).toBeUndefined();
+				},
+			},
+		);
+	});
+
+	it("should clear max-age when phone OTP verify uses rememberMe: false", async () => {
+		const otherPhone = "+15559876543";
+		await client.phoneNumber.sendOtp({
+			phoneNumber: otherPhone,
+		});
+
+		await client.phoneNumber.verify(
+			{
+				phoneNumber: otherPhone,
+				code: otp,
+				rememberMe: false,
+			},
+			{
+				onSuccess(ctx) {
+					const cookies = parseSetCookieHeader(
+						ctx.response.headers.get("set-cookie") || "",
+					);
+					const sessionToken = cookies.get("better-auth.session_token");
+					expect(sessionToken).toBeDefined();
+					expect(sessionToken?.["max-age"]).toBeUndefined();
+					expect(cookies.get("better-auth.dont_remember")).toBeDefined();
+				},
+			},
+		);
+	});
+
+	it("should clear max-age when signIn.phoneNumber uses rememberMe: false (control)", async () => {
+		const passwordPhone = "+15551112222";
+		const headers = new Headers();
+		await client.phoneNumber.sendOtp({
+			phoneNumber: passwordPhone,
+		});
+		await client.phoneNumber.verify(
+			{
+				phoneNumber: passwordPhone,
+				code: otp,
+			},
+			{
+				onSuccess: (ctx) => {
+					const setCookie = ctx.response.headers.get("set-cookie") || "";
+					const cookies = parseSetCookieHeader(setCookie);
+					const token = cookies.get("better-auth.session_token")?.value;
+					expect(token).toBeDefined();
+					headers.set("cookie", `better-auth.session_token=${token}`);
+				},
+			},
+		);
+
+		await auth.api.setPassword({
+			body: { newPassword: "password123" },
+			headers,
+		});
+
+		await client.signIn.phoneNumber(
+			{
+				phoneNumber: passwordPhone,
+				password: "password123",
+				rememberMe: false,
+			},
+			{
+				onSuccess(ctx) {
+					const cookies = parseSetCookieHeader(
+						ctx.response.headers.get("set-cookie") || "",
+					);
+					const sessionToken = cookies.get("better-auth.session_token");
+					expect(sessionToken).toBeDefined();
+					expect(sessionToken?.["max-age"]).toBeUndefined();
+					expect(cookies.get("better-auth.dont_remember")).toBeDefined();
+				},
+			},
+		);
 	});
 });

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1292,7 +1292,7 @@ describe("phone-number rememberMe", async () => {
 	let otp = "";
 	const testPhoneNumber = "+15551234567";
 
-	const { client, auth } = await getTestInstance(
+	const { client } = await getTestInstance(
 		{
 			plugins: [
 				phoneNumber({
@@ -1315,6 +1315,7 @@ describe("phone-number rememberMe", async () => {
 	);
 
 	it("should set a persistent session cookie by default on phone OTP verify", async () => {
+		expect.assertions(3);
 		await client.phoneNumber.sendOtp({
 			phoneNumber: testPhoneNumber,
 		});
@@ -1339,6 +1340,7 @@ describe("phone-number rememberMe", async () => {
 	});
 
 	it("should clear max-age when phone OTP verify uses rememberMe: false", async () => {
+		expect.assertions(3);
 		const otherPhone = "+15559876543";
 		await client.phoneNumber.sendOtp({
 			phoneNumber: otherPhone,
@@ -1348,53 +1350,6 @@ describe("phone-number rememberMe", async () => {
 			{
 				phoneNumber: otherPhone,
 				code: otp,
-				rememberMe: false,
-			},
-			{
-				onSuccess(ctx) {
-					const cookies = parseSetCookieHeader(
-						ctx.response.headers.get("set-cookie") || "",
-					);
-					const sessionToken = cookies.get("better-auth.session_token");
-					expect(sessionToken).toBeDefined();
-					expect(sessionToken?.["max-age"]).toBeUndefined();
-					expect(cookies.get("better-auth.dont_remember")).toBeDefined();
-				},
-			},
-		);
-	});
-
-	it("should clear max-age when signIn.phoneNumber uses rememberMe: false (control)", async () => {
-		const passwordPhone = "+15551112222";
-		const headers = new Headers();
-		await client.phoneNumber.sendOtp({
-			phoneNumber: passwordPhone,
-		});
-		await client.phoneNumber.verify(
-			{
-				phoneNumber: passwordPhone,
-				code: otp,
-			},
-			{
-				onSuccess: (ctx) => {
-					const setCookie = ctx.response.headers.get("set-cookie") || "";
-					const cookies = parseSetCookieHeader(setCookie);
-					const token = cookies.get("better-auth.session_token")?.value;
-					expect(token).toBeDefined();
-					headers.set("cookie", `better-auth.session_token=${token}`);
-				},
-			},
-		);
-
-		await auth.api.setPassword({
-			body: { newPassword: "password123" },
-			headers,
-		});
-
-		await client.signIn.phoneNumber(
-			{
-				phoneNumber: passwordPhone,
-				password: "password123",
 				rememberMe: false,
 			},
 			{

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -342,6 +342,17 @@ const verifyPhoneNumberBodySchema = z
 					"Check if there is a session and update the phone number. Eg: true",
 			})
 			.optional(),
+		/**
+		 * If this is false, the session will not be remembered
+		 * @default true
+		 */
+		rememberMe: z
+			.boolean()
+			.meta({
+				description:
+					"If this is false, the session will not be remembered. Default is `true`.",
+			})
+			.optional(),
 	})
 	.and(z.record(z.string(), z.any()));
 
@@ -564,6 +575,7 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 						code,
 						disableSession,
 						updatePhoneNumber,
+						rememberMe,
 						...rest
 					} = ctx.body;
 					const additionalFields = parseUserInput(
@@ -615,8 +627,10 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			);
 
 			if (!ctx.body.disableSession) {
+				const dontRememberMe = ctx.body.rememberMe === false;
 				const session = await ctx.context.internalAdapter.createSession(
 					user.id,
+					dontRememberMe,
 				);
 				if (!session) {
 					throw APIError.from(
@@ -624,10 +638,14 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 						BASE_ERROR_CODES.FAILED_TO_CREATE_SESSION,
 					);
 				}
-				await setSessionCookie(ctx, {
-					session,
-					user,
-				});
+				await setSessionCookie(
+					ctx,
+					{
+						session,
+						user,
+					},
+					dontRememberMe,
+				);
 				return ctx.json({
 					status: true,
 					token: session.token,


### PR DESCRIPTION
closes https://github.com/better-auth/better-auth/issues/10412
- Add optional `rememberMe` to `signIn.emailOtp` and `phoneNumber.verify` so OTP sessions can use browser-session cookies when set to `false`
- Document the new field on both plugin API surfaces
- Cover default persistent cookies and `rememberMe: false` session-cookie behavior in tests
