### PR TITLE
docs(oauth): clarify provider field ownership

### DIFF
--- a/docs/content/docs/authentication/google.mdx
+++ b/docs/content/docs/authentication/google.mdx
@@ -161,6 +161,14 @@ socialProviders: {
 
 Set `hd: "*"` to allow any Google Workspace hosted domain. Tokens with no `hd` claim are rejected whenever `hd` is configured.
 
+<Callout type="warn">
+  A custom `getUserInfo` callback replaces Google's built-in callback-path `hd`
+  check. Validate the claim from a trusted provider response and return `null`
+  when it is missing or does not match. Direct ID-token sign-in follows the
+  provider's ID-token verification path, while Google One Tap enforces the
+  configured `hd` separately.
+</Callout>
+
 ### Always ask to select an account
 
 If you want to always ask the user to select an account, you pass the `prompt` parameter to the provider, setting it to `select_account`.

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -606,7 +606,8 @@ To add custom fields, use the `additionalFields` property in the `user` or `sess
 * `type`: The data type of the field (e.g., "string", "number", "boolean").
 * `required`: A boolean indicating if the field is mandatory.
 * `defaultValue`: The default value for the field (note: this only applies in the JavaScript layer; in the database, the field will be optional).
-* `input`: This determines whether a value can be provided when creating a new record (default: `true`). If there are additional fields, like `role`, that should not be provided by the user during signup, you can set this to `false`.
+* `input`: Whether Better Auth accepts the field when creating or updating a record (default: `true`). For user fields, this includes values from API input and `mapProfileToUser`. Set this to `false` for server-owned fields such as `role`.
+* `returned`: Whether Better Auth includes the stored field in response bodies (default: `true`). This does not affect whether input can write the field.
 
 Here's an example of how to extend the user schema with additional fields:
 
@@ -646,7 +647,7 @@ const res = await auth.api.signUpEmail({
 });
 
 //user object
-res.user.role; // > "admin"
+res.user.role; // > "user"
 res.user.lang; // > "fr"
 ```
 
@@ -657,9 +658,16 @@ res.user.lang; // > "fr"
   client side.
 </Callout>
 
-If you're using social / OAuth providers, you may want to provide `mapProfileToUser` to map the profile data to the user object. This can populate additional fields from the provider's profile when those fields allow input.
+For `user.additionalFields`, `input` and `returned` are independent:
 
-Fields marked `input: false` stay server-owned during OAuth provisioning. Provider profile values for those fields are ignored, and configured `defaultValue` values still apply when OAuth creates a user.
+| Configuration                       | Input behavior                                                                                                                                                    | Response behavior             |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `{ input: true, returned: true }`   | API input and provider profile mapping can supply the field.                                                                                                      | The stored field is included. |
+| `{ input: true, returned: false }`  | API input and provider profile mapping can supply the field.                                                                                                      | The stored field is omitted.  |
+| `{ input: false, returned: true }`  | API input and provider profile mapping cannot supply the field. A configured `defaultValue` can initialize it; otherwise use an application-owned database write. | The stored field is included. |
+| `{ input: false, returned: false }` | API input and provider profile mapping cannot supply the field. A configured `defaultValue` can initialize it; otherwise use an application-owned database write. | The stored field is omitted.  |
+
+If you're using a social or OAuth provider, `mapProfileToUser` can populate additional fields from the provider profile when those fields allow input. The mapper runs on your server, but Better Auth still treats its return value as provider input. Fields marked `input: false` stay server-owned, provider values for those fields are ignored, and configured `defaultValue` values still apply when OAuth creates a user. See [server-owned fields and authorization claims](/docs/concepts/oauth#server-owned-fields-and-authorization-claims) for secure handling patterns.
 
 **Example: Mapping Profile to User For `firstName` and `lastName`**
 

--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -458,11 +458,9 @@ A boolean value that determines whether to override the user information in the 
 
 ### mapProfileToUser
 
-A custom function to map the user profile returned from the provider to the user object in your database.
+Use `mapProfileToUser` to change the default user mapping or populate additional user fields from the provider profile.
 
-Useful, if you have additional fields in your user object you want to populate from the provider's profile. Or if you want to change how by default the user object is mapped.
-
-`mapProfileToUser` follows the input rules from `user.additionalFields`. It can populate additional fields that allow input, but provider values for fields marked `input: false` are ignored during OAuth sign-up, sign-in profile override, and account-link profile sync. Use server-side provisioning code to set server-owned fields such as roles, bans, or internal flags.
+Better Auth treats the function's return value as provider input, even though the function runs on your server. It applies the input rules from `user.additionalFields` during OAuth sign-up, sign-in profile override, and account-link profile sync. Mapped fields that allow input are parsed and stored, while mapped values for fields marked `input: false` are ignored.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
@@ -485,11 +483,20 @@ export const auth = betterAuth({
 ```
 
 <Callout type="info">
-  You may want to pass additional fields into the user object in `mapProfileToUser`,
-  to do this, you must configure the `user.additionalFields` [option](/docs/concepts/database#extending-core-schema)
-  and allow those fields as input.
-  (The same applies for stateless auth setups)
+  Declare mapped fields in the `user.additionalFields`
+  [option](/docs/concepts/database#extending-core-schema) and allow those fields
+  as input. The same rule applies to stateless auth setups.
 </Callout>
+
+#### Server-Owned Fields and Authorization Claims
+
+Keep security-sensitive fields such as roles, bans, internal flags, and organization membership at `input: false`. Do not enable input only so `mapProfileToUser` can persist a provider claim, because the same setting also lets generic sign-up and user-update requests supply that field.
+
+`input` and `returned` control separate directions. For example, `{ input: false, returned: true }` defines a readable server-owned field. API input and `mapProfileToUser` cannot supply it, but Better Auth includes its stored value in responses.
+
+If a provider claim controls who may sign in, enforce the policy before Better Auth completes OAuth sign-in. Do not defer the check until after sign-in, because Better Auth may already have issued a valid session. Prefer a provider-specific option when one exists, such as the Google provider's [`hd` option](/docs/authentication/google#restrict-sign-in-to-google-workspace) for a Google Workspace domain. For flows that invoke [`getUserInfo`](/docs/concepts/oauth#getuserinfo), a custom implementation can verify the provider response and return `null` when the policy fails. Configure equivalent enforcement for separate sign-in paths that do not invoke `getUserInfo`.
+
+If you also need to store the verified claim, keep the field at `input: false` and write it with your application's database layer. Use `defaultValue` only for a static value that applies to every user created through that auth configuration, not for a value derived from a provider profile.
 
 ### refreshAccessToken
 


### PR DESCRIPTION
`mapProfileToUser` runs on the server, which makes it easy to misread `input: false` as a client-only restriction. Better Auth treats mapped profile values as provider input, so this PR documents that boundary and directs authorization policies to checks that run before session issuance.

## What changes

- **Field directionality**: explains `input` and `returned` as independent controls, including all 4 combinations and how defaults or application writes populate server-owned fields.
- **Authorization claims**: warns against enabling `input` solely to persist provider claims, and points users to provider-specific enforcement or flow-scoped `getUserInfo` validation.
- **Google Workspace**: documents the custom `getUserInfo` caveat for provider-level `hd` enforcement.
- **Example accuracy**: fixes the `role` example to match its configured `"user"` default.

This is a documentation-only change; runtime behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies OAuth docs on provider vs server field ownership and directionality. Adds `input`/`returned` guidance for `user.additionalFields`, explains that `mapProfileToUser` is treated as provider input, directs authorization checks to run before session issuance (incl. Google Workspace `hd` with custom `getUserInfo`), and fixes the `role` example; no runtime changes.

<sup>Written for commit 3a09fa9bae336811d02e81714ab0890f05818fb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

