### PR TITLE
fix(client): truncate sub-millisecond ISO date fractions to milliseconds

### DIFF
--- a/packages/better-auth/src/client/parser.test.ts
+++ b/packages/better-auth/src/client/parser.test.ts
@@ -45,3 +45,22 @@ describe("parseJSON", () => {
 		expect(parseJSON("not json", { strict: false })).toBe("not json");
 	});
 });
+
+describe("parseJSON ISO date parsing", () => {
+	it.each([
+		{ name: "millisecond (3 digits)", frac: "123", expectedMs: 123 },
+		{ name: "single digit", frac: "5", expectedMs: 500 },
+		{ name: "two digits", frac: "12", expectedMs: 120 },
+		{ name: "microsecond (6 digits)", frac: "123456", expectedMs: 123 },
+		{ name: "7 digits", frac: "1234567", expectedMs: 123 },
+	])("truncates $name fractional seconds to milliseconds", ({
+		frac,
+		expectedMs,
+	}) => {
+		const value = parseJSON(`"2024-01-01T00:00:00.${frac}Z"`);
+		expect(value).toBeInstanceOf(Date);
+		expect((value as Date).getTime()).toBe(
+			Date.UTC(2024, 0, 1, 0, 0, 0, expectedMs),
+		);
+	});
+});

--- a/packages/better-auth/src/client/parser.ts
+++ b/packages/better-auth/src/client/parser.ts
@@ -64,7 +64,7 @@ function parseISODate(value: string): Date | null {
 			parseInt(hour!, 10),
 			parseInt(minute!, 10),
 			parseInt(second!, 10),
-			ms ? parseInt(ms.padEnd(3, "0"), 10) : 0,
+			ms ? parseInt(ms.slice(0, 3).padEnd(3, "0"), 10) : 0,
 		),
 	);
 


### PR DESCRIPTION
## Why

`parseISODate` (the reviver behind the client's global `jsonParser`, `parseDates` defaults to `true`) silently returns `Date` values that are **minutes wrong** for any ISO timestamp with sub-millisecond precision.

The regex accepts 1–7 fractional-second digits:

```ts
/…T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,7}))?(?:Z|…)$/
```

but the millisecond value is built with `parseInt(ms.padEnd(3, "0"), 10)`. `padEnd` only pads short strings — it never truncates — so a 4–7 digit fraction is read as that many *milliseconds*:

```
"2024-01-01T00:00:00.123456Z"  ->  00:02:03.456   (+123 s)   // should be .123
"2024-01-01T00:00:00.1234567Z" ->  00:20:34.567   (+20 min)  // should be .123
```

This violates both the function's own internal contract (its regex explicitly admits up to 7 digits) and established runtime semantics — native `new Date(iso)` truncates fractional seconds beyond milliseconds. Native JS `toISOString()` only emits 3 digits, which is why the happy path never tripped; but microsecond-precision timestamps are common from Postgres/MySQL `timestamptz` columns surfaced by adapters or `additionalFields`, and from non-JS backends. Since the reviver runs on **every** string field of **every** response, any such value comes back as a `Date` that is minutes off.

## What changed

`parseISODate` now truncates the fractional part to its first three digits before padding, so 4–7 digit fractions map to the correct millisecond value (`.123456` → `.123`), matching native `Date`. 1–3 digit fractions are unchanged.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change** — dates with >3 fractional digits now parse correctly instead of being minutes off (a bug fix, not a new opt-in)
- [ ] **Docs / tests / CI only**

## Bug fix verification

- Test path that reproduces the bug: `packages/better-auth/src/client/parser.test.ts` → `parseJSON ISO date parsing > truncates … fractional seconds to milliseconds`
- Did it go red on `main` and green on this branch? **yes** — on `main` the `microsecond (6 digits)` and `7 digits` cases fail (`expected 1704068434567 to be 1704067200123`); with the fix all 5 cases pass. Full file: 22 passed.

## Validation

```
cd packages/better-auth
pnpm exec vitest run src/client/parser.test.ts   # 22 passed
pnpm exec biome check src/client/parser.ts src/client/parser.test.ts   # clean
```
`pnpm typecheck` surfaces only pre-existing errors in unrelated files (`utils/url.ts`, `utils/password.ts`, `types/types.test.ts`, plus `TS6305` from an unbuilt `packages/core` in a partial local build) — identical with this branch stashed; the changed files add no new type errors.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code located the mismatch between the regex and the `padEnd` millisecond math; I independently reproduced it with a standalone Node script against the exact regex, confirmed the fix reproduces native `Date` truncation for 1–7 digit fractions, and verified the red→green test on the real vitest suite.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ISO timestamp parsing in the client by truncating sub-millisecond fractions to milliseconds. Prevents minutes-off `Date` values when responses include 4–7 fractional digits.

- **Bug Fixes**
  - In `parseISODate`, truncate fractional seconds with `ms.slice(0, 3).padEnd(3, "0")` to match native `Date` behavior.
  - Added regression tests covering 1–7 digit fractions.
  - Applies via the client’s global `jsonParser` used by `parseJSON` when `parseDates: true`.

<sup>Written for commit 08f84573689353d91cce93123af3585d834ba689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

