### PR TITLE
fix(cookies): tighten CookieAttributes index signature type (#10441)

### DIFF
--- a/packages/better-auth/src/cookies/cookie-utils.ts
+++ b/packages/better-auth/src/cookies/cookie-utils.ts
@@ -17,9 +17,7 @@ export interface CookieAttributes {
 	httponly?: boolean | undefined;
 	partitioned?: boolean | undefined;
 	samesite?: ("strict" | "lax" | "none") | undefined;
-	// TODO: tighten to `string | number | boolean | Date | undefined`.
-	// Kept as `any` for now to preserve the public type surface.
-	[key: string]: any;
+	[key: string]: string | number | boolean | Date | undefined;
 }
 
 interface ParsedCookieOptions {


### PR DESCRIPTION
###  Summary

This PR addresses the `TODO` in `packages/better-auth/src/cookies/cookie-utils.ts` by tightening the `CookieAttributes` index signature from `any` to `string | number | boolean | Date | undefined`. 

This change enhances type safety across cookie attribute consumers while keeping the type signature aligned with valid RFC 6265 cookie attributes and the repository's type-safety guidelines.

Fixes #10441

---

###  Verification & Testing

- **Type Checking**: Verified via `pnpm typecheck` across all monorepo packages (0 errors).
- **Linter & Formatting**: Passed pre-commit hooks (`biome` and spell check).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened the `CookieAttributes` index signature in `packages/better-auth/src/cookies/cookie-utils.ts` from `any` to `string | number | boolean | Date | undefined` to improve type safety and match valid RFC 6265 attributes (fixes #10441). No runtime changes; only safer typing for cookie attribute consumers.

<sup>Written for commit 9b61a5622597036e9bd2b28be15c0e038af055f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

