### PR TITLE
fix(phone-number): deduplicate OTP verification rows and handle missing user on verify (#10449)

### DIFF
--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1283,3 +1283,106 @@ describe("custom verifyOTP", async () => {
 		expect(user.data?.user.phoneNumberVerified).toBe(true);
 	});
 });
+
+describe("phone-number sendOtp row deduplication", async () => {
+	let latestOtp = "";
+
+	const { client, auth } = await getTestInstance(
+		{
+			plugins: [
+				phoneNumber({
+					async sendOTP({ code }) {
+						latestOtp = code;
+					},
+					signUpOnVerification: {
+						getTempEmail(phoneNumber) {
+							return `temp-${phoneNumber}`;
+						},
+					},
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [phoneNumberClient()],
+			},
+		},
+	);
+	const authCtx = await auth.$context;
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10449
+	 */
+	it("should deduplicate verification rows when sending OTP multiple times for same phone number", async () => {
+		const phoneNumber = "+19998887777";
+		await client.phoneNumber.sendOtp({ phoneNumber });
+
+		await client.phoneNumber.sendOtp({ phoneNumber });
+		const secondCode = latestOtp;
+
+		const verifyRes = await client.phoneNumber.verify({
+			phoneNumber,
+			code: secondCode,
+		});
+		expect(verifyRes.error).toBe(null);
+		expect(verifyRes.data?.status).toBe(true);
+
+		const afterVerify =
+			await authCtx.internalAdapter.findVerificationValue(phoneNumber);
+		expect(afterVerify).toBeNull();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10449
+	 */
+	it("should deduplicate verification rows on password reset request re-send", async () => {
+		const phoneNumber = "+19998887777";
+		await client.phoneNumber.requestPasswordReset({ phoneNumber });
+		await client.phoneNumber.requestPasswordReset({ phoneNumber });
+
+		const resetIdentifier = `${phoneNumber}-request-password-reset`;
+		const consumed =
+			await authCtx.internalAdapter.consumeVerificationValue(resetIdentifier);
+		expect(consumed).not.toBeNull();
+
+		const afterConsume =
+			await authCtx.internalAdapter.findVerificationValue(resetIdentifier);
+		expect(afterConsume).toBeNull();
+	});
+});
+
+describe("verifyPhoneNumber without signUpOnVerification", async () => {
+	let otp = "";
+
+	const { client } = await getTestInstance(
+		{
+			plugins: [
+				phoneNumber({
+					async sendOTP({ code }) {
+						otp = code;
+					},
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [phoneNumberClient()],
+			},
+		},
+	);
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10449
+	 */
+	it("should return 400 when verifying non-existent user without signUpOnVerification", async () => {
+		const phoneNumber = "+17776665555";
+		await client.phoneNumber.sendOtp({ phoneNumber });
+		const res = await client.phoneNumber.verify({
+			phoneNumber,
+			code: otp,
+		});
+
+		expect(res.error).not.toBeNull();
+		expect(res.error?.status).toBe(400);
+	});
+});

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -120,6 +120,9 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 			if (opts.requireVerification) {
 				if (!user.phoneNumberVerified) {
 					const otp = generateOTP(opts.otpLength);
+					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+						phoneNumber,
+					);
 					await ctx.context.internalAdapter.createVerificationValue({
 						value: otp,
 						identifier: phoneNumber,
@@ -274,6 +277,9 @@ export const sendPhoneNumberOTP = (opts: RequiredPhoneNumberOptions) =>
 			}
 
 			const code = generateOTP(opts.otpLength);
+			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+				ctx.body.phoneNumber,
+			);
 			await ctx.context.internalAdapter.createVerificationValue({
 				value: `${code}:0`,
 				identifier: ctx.body.phoneNumber,
@@ -589,6 +595,11 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 							BASE_ERROR_CODES.FAILED_TO_CREATE_USER,
 						);
 					}
+				} else {
+					throw APIError.from(
+						"BAD_REQUEST",
+						PHONE_NUMBER_ERROR_CODES.PHONE_NUMBER_NOT_EXIST,
+					);
 				}
 			} else {
 				user =
@@ -693,6 +704,9 @@ export const requestPasswordResetPhoneNumber = (
 				],
 			});
 			const code = generateOTP(opts.otpLength);
+			await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+				`${ctx.body.phoneNumber}-request-password-reset`,
+			);
 			await ctx.context.internalAdapter.createVerificationValue({
 				value: `${code}:0`,
 				identifier: `${ctx.body.phoneNumber}-request-password-reset`,


### PR DESCRIPTION
Fixes #10449

## Summary
1. **Deduplicates OTP verification rows across all phone-number routes**: Added `deleteVerificationByIdentifier` prior to creating a new OTP row in `sendPhoneNumberOTP`, `requestPasswordResetPhoneNumber`, and `signInPhoneNumber`. This prevents duplicate row accumulation on re-send and avoids `OTP_EXPIRED` errors on stale rows.
2. **Handles missing user on verify**: Throws `BAD_REQUEST` (`PHONE_NUMBER_NOT_EXIST`) in `verifyPhoneNumber` when user is not found and `signUpOnVerification` is disabled, avoiding a `TypeError` crash on `user.id`.

## Testing
- Added regression test suites with `@see https://github.com/better-auth/better-auth/issues/10449`:
  - `should deduplicate verification rows when sending OTP multiple times for same phone number` (E2E client verification)
  - `should deduplicate verification rows on password reset request re-send`
  - `should return 400 when verifying non-existent user without signUpOnVerification`
- Passed `pnpm vitest packages/better-auth/src/plugins/phone-number/phone-number.test.ts --run`
- Passed `pnpm typecheck`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate OTP rows across send, sign-in, and password reset flows, and returns 400 when verifying a non-existent phone number with sign-up disabled.

- **Bug Fixes**
  - Delete existing verification values before creating new ones in send, sign-in, and password reset routes to avoid stale OTPs.
  - In verify, throw BAD_REQUEST with PHONE_NUMBER_NOT_EXIST when the user is missing and signUpOnVerification is off.

<sup>Written for commit a828214fe02cbc1e404efff7ee9e4f7a05300c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



