### PR TITLE
fix(passkey): return mapped WebAuthn error codes

### DIFF
--- a/.changeset/sweet-shirts-accept.md
+++ b/.changeset/sweet-shirts-accept.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/passkey": patch
+---
+
+Fix the passkey client returning SimpleWebAuthn's raw error codes instead of Better Auth's mapped error codes.

--- a/packages/passkey/src/client.test.ts
+++ b/packages/passkey/src/client.test.ts
@@ -1,24 +1,81 @@
+import { WebAuthnError } from "@simplewebauthn/browser";
 import { describe, expect, it, vi } from "vitest";
 import { getPasskeyActions } from "./client";
+import { PASSKEY_ERROR_CODES } from "./error-codes";
 
 const mocks = vi.hoisted(() => ({
 	startRegistration: vi.fn(),
 	startAuthentication: vi.fn(),
 }));
 
-vi.mock("@simplewebauthn/browser", () => ({
-	startRegistration: mocks.startRegistration,
-	startAuthentication: mocks.startAuthentication,
-	WebAuthnError: class WebAuthnError extends Error {
-		code: string;
-		constructor(code: string, message?: string) {
-			super(message ?? code);
-			this.code = code;
+vi.mock("@simplewebauthn/browser", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@simplewebauthn/browser")>();
+
+	return {
+		...actual,
+		startRegistration: mocks.startRegistration,
+		startAuthentication: mocks.startAuthentication,
+	};
+});
+
+const createRegistrationActions = () => {
+	const fetchMock = vi.fn(async (path: string) => {
+		if (path === "/passkey/generate-register-options") {
+			return {
+				data: {
+					challenge: "challenge",
+					rp: { name: "Test", id: "example.com" },
+					user: { id: "user", name: "user" },
+					pubKeyCredParams: [],
+				},
+			};
 		}
-	},
-}));
+
+		return { data: null };
+	});
+
+	return getPasskeyActions(fetchMock as never, {
+		$listPasskeys: { set: vi.fn() } as never,
+		$store: { notify: vi.fn() } as never,
+	});
+};
 
 describe("passkey client", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10447
+	 */
+	it.each([
+		["ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED", "PREVIOUSLY_REGISTERED"],
+		["ERROR_CEREMONY_ABORTED", "REGISTRATION_CANCELLED"],
+	] as const)("maps %s to the %s passkey error code", async (webAuthnCode, passkeyCode) => {
+		mocks.startRegistration.mockRejectedValueOnce(
+			new WebAuthnError({
+				code: webAuthnCode,
+				message: "WebAuthn registration failed",
+				cause: new Error("WebAuthn registration failed"),
+			}),
+		);
+		const actions = createRegistrationActions();
+
+		const result = await actions.passkey.addPasskey();
+
+		expect(result).toMatchObject({
+			data: null,
+			error: {
+				code: passkeyCode,
+				message: PASSKEY_ERROR_CODES[passkeyCode].message,
+			},
+		});
+	});
+
+	it("uses passkey error-code keys for mapped registration failures", () => {
+		const errorCodes = Object.keys(PASSKEY_ERROR_CODES);
+
+		expect(errorCodes).toContain("PREVIOUSLY_REGISTERED");
+		expect(errorCodes).toContain("REGISTRATION_CANCELLED");
+	});
+
 	it("merges registration extensions and returns WebAuthn response", async () => {
 		const fetchMock = vi.fn(async (path: string, options?: any) => {
 			if (path === "/passkey/generate-register-options") {

--- a/packages/passkey/src/client.ts
+++ b/packages/passkey/src/client.ts
@@ -74,11 +74,11 @@ export const getPasskeyActions = (
 				},
 				useBrowserAutofill: opts?.autoFill,
 			});
-		} catch (err) {
+		} catch (_err) {
 			return {
 				data: null,
 				error: {
-					code: err instanceof WebAuthnError ? err.code : "AUTH_CANCELLED",
+					code: "AUTH_CANCELLED",
 					message: PASSKEY_ERROR_CODES.AUTH_CANCELLED.message,
 					status: 400,
 					statusText: "BAD_REQUEST",
@@ -237,7 +237,7 @@ export const getPasskeyActions = (
 					return {
 						data: null,
 						error: {
-							code: e.code,
+							code: "PREVIOUSLY_REGISTERED",
 							message: PASSKEY_ERROR_CODES.PREVIOUSLY_REGISTERED.message,
 							status: 400,
 							statusText: "BAD_REQUEST",
@@ -248,7 +248,7 @@ export const getPasskeyActions = (
 					return {
 						data: null,
 						error: {
-							code: e.code,
+							code: "REGISTRATION_CANCELLED",
 							message: PASSKEY_ERROR_CODES.REGISTRATION_CANCELLED.message,
 							status: 400,
 							statusText: "BAD_REQUEST",


### PR DESCRIPTION
SimpleWebAuthn’s internal WebAuthn error codes were returned after Better Auth had selected a mapped passkey error message. As a result, client error codes did not match keys exposed through `PASSKEY_ERROR_CODES` and `$ERROR_CODES`.

- Update `packages/passkey/src/client.ts` to return `PREVIOUSLY_REGISTERED` for `ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED`.
- Update `packages/passkey/src/client.ts` to return `REGISTRATION_CANCELLED` for `ERROR_CEREMONY_ABORTED`.
- Normalize the authentication cancellation path to `AUTH_CANCELLED`.
- Add client regression tests using the real `WebAuthnError` class and mocked registration ceremonies.

Fixes #10447

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return Better Auth mapped passkey error codes in the client instead of raw `@simplewebauthn/browser` codes, so apps can rely on `PASSKEY_ERROR_CODES` consistently. Fixes #10447.

- **Bug Fixes**
  - Map ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED → PREVIOUSLY_REGISTERED.
  - Map ERROR_CEREMONY_ABORTED → REGISTRATION_CANCELLED.
  - Normalize authentication cancel to AUTH_CANCELLED; add client regression tests using the real WebAuthnError.

<sup>Written for commit 380cb4107417b1a0ab8ef44afd44fcb57656eea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

