### PR TITLE
fix(open-api): include plugin user fields on sign-up/update bodies

### DIFF
--- a/.changeset/openapi-user-input-fields.md
+++ b/.changeset/openapi-user-input-fields.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+OpenAPI now includes `user.additionalFields` and plugin user schema fields (e.g. username plugin `username` / `displayUsername`) on `/sign-up/email` and `/update-user` request bodies.

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -4403,9 +4403,16 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
                     "description": "The password of the user",
                     "type": "string",
                   },
+                  "preferences": {
+                    "type": "string",
+                  },
                   "rememberMe": {
                     "description": "If this is false, the session will not be remembered. Default is \`true\`.",
                     "type": "boolean",
+                  },
+                  "role": {
+                    "default": "user",
+                    "type": "string",
                   },
                 },
                 "required": [
@@ -4917,6 +4924,13 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
                   },
                   "name": {
                     "description": "The name of the user",
+                    "type": "string",
+                  },
+                  "preferences": {
+                    "type": "string",
+                  },
+                  "role": {
+                    "default": "user",
                     "type": "string",
                   },
                 },

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -475,9 +475,9 @@ function getUserInputRequestBodyFields(options: BetterAuthOptions) {
 	for (const [key, field] of Object.entries(fields)) {
 		if (!field || field.input === false) continue;
 		properties[key] = dbFieldToRequestBodyProperty(field);
-		// Match parseUserInput create behavior: required unless explicitly false,
-		// and not when a static default fills the value for the client.
-		if (field.required !== false && field.defaultValue === undefined) {
+		// Match parseUserInput create behavior: only enforce required when the
+		// field explicitly opts in, and not when a static default fills the value.
+		if (field.required === true && field.defaultValue === undefined) {
 			required.push(key);
 		}
 	}

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -415,6 +415,124 @@ function getRequestBody(
 	};
 }
 
+/**
+ * Paths that accept `user.additionalFields` and plugin user schema fields via
+ * `parseUserInput`. Their static OpenAPI request bodies need those fields merged in.
+ */
+const USER_INPUT_BODY_PATHS = new Set(["/sign-up/email", "/update-user"]);
+
+function dbFieldToRequestBodyProperty(field: DBFieldAttribute): OpenAPISchema {
+	if (field.type === "date") {
+		return { type: "string", format: "date-time" };
+	}
+	if (field.type === "json") {
+		return { type: "object", additionalProperties: true };
+	}
+	if (field.type === "string[]") {
+		return { type: "array", items: { type: "string" } };
+	}
+	if (field.type === "number[]") {
+		return { type: "array", items: { type: "number" } };
+	}
+	if (Array.isArray(field.type)) {
+		return {
+			type: "string",
+			enum: field.type,
+		};
+	}
+	const schema: OpenAPISchema = {
+		type: field.type,
+	};
+	if (
+		field.defaultValue !== undefined &&
+		typeof field.defaultValue !== "function"
+	) {
+		schema.default = field.defaultValue;
+	}
+	return schema;
+}
+
+/**
+ * Collect client-writable user fields from `user.additionalFields` and plugin
+ * schemas. Mirrors `getFields(..., "input")` used by `parseUserInput`.
+ */
+function getUserInputRequestBodyFields(options: BetterAuthOptions) {
+	let fields: Record<string, DBFieldAttribute> = {
+		...(options.user?.additionalFields ?? {}),
+	};
+	for (const plugin of options.plugins || []) {
+		const pluginUserFields = plugin.schema?.user?.fields;
+		if (pluginUserFields) {
+			fields = {
+				...fields,
+				...pluginUserFields,
+			};
+		}
+	}
+
+	const properties: Record<string, OpenAPISchema> = {};
+	const required: string[] = [];
+	for (const [key, field] of Object.entries(fields)) {
+		if (!field || field.input === false) continue;
+		properties[key] = dbFieldToRequestBodyProperty(field);
+		// Match parseUserInput create behavior: required unless explicitly false,
+		// and not when a static default fills the value for the client.
+		if (field.required !== false && field.defaultValue === undefined) {
+			required.push(key);
+		}
+	}
+	return { properties, required };
+}
+
+function applyUserInputFieldsToRequestBody(
+	path: string,
+	requestBody: OpenAPIRequestBody | undefined,
+	options: BetterAuthOptions,
+): OpenAPIRequestBody | undefined {
+	if (!USER_INPUT_BODY_PATHS.has(path)) {
+		return requestBody;
+	}
+
+	const { properties: inputProperties, required: inputRequired } =
+		getUserInputRequestBodyFields(options);
+	if (Object.keys(inputProperties).length === 0) {
+		return requestBody;
+	}
+
+	const existingSchema = requestBody?.content?.["application/json"]?.schema;
+	const properties: Record<string, OpenAPISchema> = {
+		...(existingSchema?.properties ?? {}),
+	};
+	for (const [key, value] of Object.entries(inputProperties)) {
+		if (properties[key] === undefined) {
+			properties[key] = value;
+		}
+	}
+
+	const required = new Set(existingSchema?.required ?? []);
+	if (path === "/sign-up/email") {
+		for (const key of inputRequired) {
+			if (properties[key] !== undefined) {
+				required.add(key);
+			}
+		}
+	}
+
+	return {
+		...requestBody,
+		content: {
+			"application/json": {
+				schema: {
+					...(existingSchema ?? {}),
+					type: existingSchema?.type ?? "object",
+					properties,
+					...(required.size > 0 ? { required: Array.from(required) } : {}),
+				},
+			},
+		},
+	};
+}
+
 function toOpenApiSchema(zodType: z.ZodType<unknown>): OpenAPISchema {
 	if (zodType instanceof z.ZodOptional) {
 		return toOpenApiSchema(unwrapZodSchema(zodType));
@@ -820,7 +938,11 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 		for (const method of methods.filter(
 			(m) => m === "POST" || m === "PATCH" || m === "PUT",
 		)) {
-			const body = getRequestBody(options);
+			const body = applyUserInputFieldsToRequestBody(
+				value.path,
+				getRequestBody(options),
+				ctx.options,
+			);
 			paths[path] = {
 				...paths[path],
 				[method.toLowerCase()]: {

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -394,6 +394,43 @@ describe("open-api", async () => {
 		expect(updateUserSchema.required ?? []).not.toContain("preferences");
 	});
 
+	it("should mark explicitly required additionalFields as required on sign-up", async () => {
+		const { auth: authWithRequiredField } = await getTestInstance(
+			{
+				plugins: [openAPI()],
+				user: {
+					additionalFields: {
+						nickname: {
+							type: "string",
+							required: true,
+						},
+						optionalNote: {
+							type: "string",
+						},
+					},
+				},
+			},
+			{
+				disableTestUser: true,
+			},
+		);
+		const schema = await authWithRequiredField.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, Path>;
+		const signUpSchema = getPostRequestBody(paths, "/sign-up/email").content[
+			"application/json"
+		].schema;
+
+		expect(getSchemaProperty(signUpSchema, "nickname")).toEqual({
+			type: "string",
+		});
+		expect(getSchemaProperty(signUpSchema, "optionalNote")).toEqual({
+			type: "string",
+		});
+		expect(signUpSchema.required).toContain("nickname");
+		// omitted required matches parseUserInput (only truthy required is enforced)
+		expect(signUpSchema.required).not.toContain("optionalNote");
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/10430
 	 */

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -4,6 +4,7 @@ import * as z from "zod";
 import { createAuthEndpoint } from "../../api";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { emailOTP } from "../email-otp";
+import { username } from "../username";
 import { openAPI } from ".";
 import type { OpenAPISchema, Path } from "./generator";
 
@@ -361,6 +362,70 @@ describe("open-api", async () => {
 		});
 		expect(schemas["User"]!.required).toContain("role");
 		expect(schemas["User"]!.required).not.toContain("preferences");
+	});
+
+	it("should include additionalFields on sign-up and update-user request bodies", async () => {
+		const schema = await auth.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, Path>;
+
+		const signUpBody = getPostRequestBody(paths, "/sign-up/email");
+		const signUpSchema = signUpBody.content["application/json"].schema;
+		expect(getSchemaProperty(signUpSchema, "role")).toEqual({
+			type: "string",
+			default: "user",
+		});
+		expect(getSchemaProperty(signUpSchema, "preferences")).toEqual({
+			type: "string",
+		});
+		// role has a defaultValue, so clients are not required to send it
+		expect(signUpSchema.required).not.toContain("role");
+		expect(signUpSchema.required).not.toContain("preferences");
+
+		const updateUserBody = getPostRequestBody(paths, "/update-user");
+		const updateUserSchema = updateUserBody.content["application/json"].schema;
+		expect(getSchemaProperty(updateUserSchema, "role")).toEqual({
+			type: "string",
+			default: "user",
+		});
+		expect(getSchemaProperty(updateUserSchema, "preferences")).toEqual({
+			type: "string",
+		});
+		expect(updateUserSchema.required ?? []).not.toContain("role");
+		expect(updateUserSchema.required ?? []).not.toContain("preferences");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10430
+	 */
+	it("should include username plugin fields on sign-up and update-user request bodies", async () => {
+		const { auth: authWithUsername } = await getTestInstance({
+			plugins: [openAPI(), username()],
+		});
+		const schema = await authWithUsername.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, Path>;
+
+		const signUpBody = getPostRequestBody(paths, "/sign-up/email");
+		const signUpSchema = signUpBody.content["application/json"].schema;
+		expect(getSchemaProperty(signUpSchema, "username")).toEqual({
+			type: "string",
+		});
+		expect(getSchemaProperty(signUpSchema, "displayUsername")).toEqual({
+			type: "string",
+		});
+		expect(signUpSchema.required).toEqual(
+			expect.arrayContaining(["name", "email", "password"]),
+		);
+		expect(signUpSchema.required).not.toContain("username");
+		expect(signUpSchema.required).not.toContain("displayUsername");
+
+		const updateUserBody = getPostRequestBody(paths, "/update-user");
+		const updateUserSchema = updateUserBody.content["application/json"].schema;
+		expect(getSchemaProperty(updateUserSchema, "username")).toEqual({
+			type: "string",
+		});
+		expect(getSchemaProperty(updateUserSchema, "displayUsername")).toEqual({
+			type: "string",
+		});
 	});
 
 	it("should omit runtime-generated defaults from model schemas", async () => {


### PR DESCRIPTION

- Merge `user.additionalFields` and plugin user schema fields into OpenAPI request bodies for `/sign-up/email` and `/update-user`
- Fixes username plugin fields (`username`, `displayUsername`) missing from the generated OpenAPI spec despite being accepted at runtime via `parseUserInput`
- Add regression tests covering additionalFields and the username plugin

Fixes #10430
