### PR TITLE
docs: document form-based sign-in for progressive enhancement

### DIFF
--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -125,6 +125,107 @@ await authClient.signOut({
 });
 ```
 
+### Form-based sign-in (progressive enhancement)
+
+The `/sign-in/email` and `/sign-up/email` endpoints accept `application/x-www-form-urlencoded` request bodies in addition to JSON. This lets a plain HTML `<form>` sign a user in or up even when client-side JavaScript hasn't loaded yet or is disabled — the [progressive enhancement](https://svelte.dev/docs/kit/form-actions#Progressive-enhancement) pattern. The form field names map one-to-one to the JSON body documented above: `email` and `password` (plus `name` for sign-up), and the optional `callbackURL` and `rememberMe` fields.
+
+<Callout type="info">
+  These routes are protected against first-login CSRF using [Fetch Metadata](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/CSRF#fetch_metadata) and origin validation, so a cross-site navigation that tries to submit the form is rejected without needing a CSRF token or client-side JavaScript. Same-origin submissions are allowed. See <Link href="/docs/reference/security#csrf-protection">CSRF Protection</Link> for details.
+</Callout>
+
+#### Using a server handler (recommended)
+
+The most robust way to support clients without JavaScript is to submit the form to a server handler that calls the Better Auth server API and then issues a real redirect. This works with zero client-side JavaScript and progressively enhances when JavaScript is available.
+
+<Tabs items={["Next.js", "SvelteKit"]}>
+  <Tab value="Next.js">
+    Add the <Link href="/docs/integrations/next#server-action-cookies">`nextCookies`</Link> plugin so the session cookie set by `signInEmail` is forwarded to the browser, then submit the form to a Server Action:
+
+    ```tsx title="app/sign-in/page.tsx"
+    import { auth } from "@/lib/auth";
+    import { headers } from "next/headers";
+    import { redirect } from "next/navigation";
+
+    async function signIn(formData: FormData) {
+      "use server";
+      await auth.api.signInEmail({
+        body: {
+          email: formData.get("email") as string,
+          password: formData.get("password") as string,
+        },
+        headers: await headers(),
+      });
+      redirect("/dashboard");
+    }
+
+    export default function SignInPage() {
+      return (
+        <form action={signIn}>
+          <input type="email" name="email" required />
+          <input type="password" name="password" required />
+          <button type="submit">Sign in</button>
+        </form>
+      );
+    }
+    ```
+  </Tab>
+
+  <Tab value="SvelteKit">
+    Add the <Link href="/docs/integrations/svelte-kit#server-action-cookies">`sveltekitCookies`</Link> plugin, then handle the submission in a form action:
+
+    ```ts title="src/routes/sign-in/+page.server.ts"
+    import { auth } from "$lib/auth";
+    import { fail, redirect } from "@sveltejs/kit";
+    import type { Actions } from "./$types";
+
+    export const actions: Actions = {
+      default: async ({ request }) => {
+        const formData = await request.formData();
+        try {
+          await auth.api.signInEmail({
+            body: {
+              email: formData.get("email") as string,
+              password: formData.get("password") as string,
+            },
+            headers: request.headers,
+          });
+        } catch {
+          return fail(401, { message: "Invalid email or password" });
+        }
+        redirect(303, "/dashboard");
+      },
+    };
+    ```
+
+    ```svelte title="src/routes/sign-in/+page.svelte"
+    <form method="POST">
+      <input type="email" name="email" required />
+      <input type="password" name="password" required />
+      <button type="submit">Sign in</button>
+    </form>
+    ```
+  </Tab>
+</Tabs>
+
+#### Posting directly to the endpoint
+
+If you don't have a server handler, you can point the form straight at the Better Auth endpoint. Set the form `action` to the sign-in route under your Better Auth base path (`/api/auth` by default) and the `method` to `POST`:
+
+```html
+<form method="POST" action="/api/auth/sign-in/email">
+  <input type="email" name="email" required />
+  <input type="password" name="password" required />
+  <input type="hidden" name="callbackURL" value="/dashboard" />
+  <button type="submit">Sign in</button>
+</form>
+```
+
+On success the endpoint sets the session cookie and responds with `200 OK`, a `Location` header pointing at `callbackURL`, and a JSON body.
+
+<Callout type="warn">
+  Because the endpoint responds with `200` (not a `3xx` status), a browser without JavaScript will not automatically follow the `Location` header — it renders the JSON response instead. For a genuine no-JS redirect, use the server-handler approach above, which issues a real redirect. Post directly to the endpoint only when JavaScript reads the response and performs the navigation, or when a server route proxies the endpoint and turns the response into a redirect.
+</Callout>
+
 ### Email Verification
 
 To enable email verification, you need to pass a function that sends a verification email with a link. The `sendVerificationEmail` function takes a data object with the following properties:


### PR DESCRIPTION
Closes #6204.

Documents form-based sign-in for progressive enhancement (works without client JS) - which the maintainer confirmed on the issue is supported but not yet documented.

Adds a "Form-based sign-in (progressive enhancement)" section to `docs/content/docs/authentication/email-password.mdx`:
- The sign-in / sign-up endpoints accept `application/x-www-form-urlencoded`, with their field mapping.
- A CSRF note (the form-CSRF middleware uses Fetch Metadata + origin, blocking cross-site navigation).
- A recommended server-handler pattern (Next.js Server Action + SvelteKit form action) that redirects with no client JS, plus a plain `<form>` posting directly to the endpoint with an honest note about the `200` + `Location` response.

Endpoints, fields, and the CSRF behavior are grounded in the source (`sign-in.ts`, `sign-up.ts`, `origin-check.ts`'s `formCsrfMiddleware`, and the sign-in tests).

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted); every endpoint/field is grounded in the source and the MDX compiles.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented form-based sign-in for progressive enhancement so HTML forms work without client JavaScript. Adds a new section explaining `application/x-www-form-urlencoded` submissions to `/sign-in/email` and `/sign-up/email`, field mapping, CSRF protections, Next.js/SvelteKit server-handler patterns for real redirects, and the direct-endpoint behavior (`200 OK` with `Location`).

<sup>Written for commit f00395a22d6ef3f061aaa31856a123d4ad7548ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

