### PR TITLE
fix(auth): use explicit stateless configuration for cookie only deployments

### DIFF
--- a/.changeset/cookie-only-stateless-deployment.md
+++ b/.changeset/cookie-only-stateless-deployment.md
@@ -1,0 +1,13 @@
+---
+"better-auth": patch
+---
+
+fix: support fully cookie-only (stateless) deployments without database
+
+When no database adapter is configured, the built-in memory adapter could produce malformed responses on re-login UPDATE paths. Additionally, providing a stateless adapter as a workaround caused `isStateful` to return `true`, which made `getAccessToken()` bypass the cookie cache and query the stateless adapter (returning `null` → 401).
+
+Fixes:
+1. `hasServerSessionStore` now detects custom adapter functions combined with explicit cookie-only configuration (both `storeAccountCookie` and `cookieCache.enabled`) and treats the deployment as stateless.
+2. `handleOAuthUserInfo` skips the redundant `updateAccount` call when no real server-side session store exists, since the account data is already persisted in the JWE account cookie.
+
+See https://github.com/better-auth/better-auth/issues/10392

--- a/.changeset/saml-idp-initiated-split-origin.md
+++ b/.changeset/saml-idp-initiated-split-origin.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+Allow IdP-initiated SAML flows to redirect to the application when the authentication server and frontend use separate origins.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -1441,7 +1441,7 @@ await authClient.signIn.sso({
 });
 ```
 
-For unsolicited **IdP-initiated** flows where `signIn.sso()` is not used (and therefore no client-side `callbackURL` is set), the redirect uses `idpInitiatedCallbackURL` configured in `samlConfig` for the provider, or the global plugin option. If neither is configured, the existing redirect fallback behavior is preserved.
+For unsolicited **IdP-initiated** flows where `signIn.sso()` is not used (and therefore no client-side `callbackURL` is set), the redirect uses `idpInitiatedCallbackUrl` configured in `samlConfig` for the provider, or the global plugin option. If neither is configured, the existing redirect fallback behavior is preserved.
 
 The callback route supports both GET and POST methods automatically, so you don't need to create any additional route handlers in your framework.
 
@@ -1530,7 +1530,7 @@ Better Auth supports **IdP-initiated SSO flows**, where users access your applic
 **No additional configuration required** - the callback route automatically handles both GET and POST requests.
 
 <Callout type="warn">
-  IdP-initiated flows do not carry a Better Auth-generated RelayState containing a client-side callback URL, so the post-login redirect falls back to your application's base URL. In split-origin setups (where the app frontend is on a different origin than the Better Auth server), this redirect collapses to the auth server origin (resulting in a 404). To prevent this, you can configure `idpInitiatedCallbackURL` either globally under `saml` plugin options or per-provider under `samlConfig` (e.g., `https://app.example.com/dashboard`).
+  IdP-initiated flows do not carry a Better Auth-generated RelayState containing a client-side callback URL, so the post-login redirect falls back to your application's base URL. In split-origin setups (where the app frontend is on a different origin than the Better Auth server), this redirect collapses to the auth server origin (resulting in a 404). To prevent this, you can configure `idpInitiatedCallbackUrl` either globally under `saml` plugin options or per-provider under `samlConfig` (e.g., `https://app.example.com/dashboard`).
 </Callout>
 
 <Callout type="info">

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -1441,6 +1441,8 @@ await authClient.signIn.sso({
 });
 ```
 
+For unsolicited **IdP-initiated** flows where `signIn.sso()` is not used (and therefore no client-side `callbackURL` is set), the redirect uses `idpInitiatedCallbackURL` configured in `samlConfig` for the provider, or the global plugin option. If neither is configured, the existing redirect fallback behavior is preserved.
+
 The callback route supports both GET and POST methods automatically, so you don't need to create any additional route handlers in your framework.
 
 ## Schema
@@ -1528,7 +1530,7 @@ Better Auth supports **IdP-initiated SSO flows**, where users access your applic
 **No additional configuration required** - the callback route automatically handles both GET and POST requests.
 
 <Callout type="warn">
-  IdP-initiated flows do not carry a RelayState, so the post-login redirect falls back to your application's base URL. To control where users land after SP-initiated SSO, pass the destination via `callbackURL` in the `signIn.sso()` call.
+  IdP-initiated flows do not carry a Better Auth-generated RelayState containing a client-side callback URL, so the post-login redirect falls back to your application's base URL. In split-origin setups (where the app frontend is on a different origin than the Better Auth server), this redirect collapses to the auth server origin (resulting in a 404). To prevent this, you can configure `idpInitiatedCallbackURL` either globally under `saml` plugin options or per-provider under `samlConfig` (e.g., `https://app.example.com/dashboard`).
 </Callout>
 
 <Callout type="info">

--- a/packages/better-auth/src/api/routes/cookie-only-deployment.test.ts
+++ b/packages/better-auth/src/api/routes/cookie-only-deployment.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, it } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10392
+ *
+ * Cookie-only mode regression tests.
+ *
+ * These tests verify that a fully cookie-based stateless deployment works
+ * correctly without requiring a persistent database. The configuration uses:
+ *   - storeAccountCookie: true
+ *   - session.cookieCache.strategy: "jwe"
+ *
+ * Key scenarios tested:
+ *   1. First login succeeds with no database (memory adapter fallback)
+ *   2. Second/repeated login succeeds without 502
+ *   3. getAccessToken() returns token from cookie cache, not 401
+ *   4. getSession() and getAccessToken() return consistent results
+ *   5. Existing stateful deployments remain unchanged
+ */
+describe("cookie-only deployment (stateless / DB-less)", async () => {
+	describe("memory adapter fallback (no database configured)", async () => {
+		it("first login should succeed in cookie-only mode", async () => {
+			const { client, testUser, cookieSetter } = await getTestInstance({
+				database: undefined as any,
+				session: {
+					cookieCache: {
+						enabled: true,
+						strategy: "jwe",
+					},
+				},
+				account: {
+					storeAccountCookie: true,
+				},
+			});
+
+			const headers = new Headers();
+
+			const signInRes = await client.signIn.email(
+				{
+					email: testUser.email,
+					password: testUser.password,
+				},
+				{
+					onSuccess: cookieSetter(headers),
+				},
+			);
+
+			expect(signInRes.data).toBeDefined();
+			expect(signInRes.data?.token).toBeDefined();
+			expect(signInRes.data?.user.email).toBe(testUser.email);
+			expect(signInRes.error).toBeNull();
+
+			// getSession should work from the cookie cache
+			const session = await client.getSession({
+				fetchOptions: { headers },
+			});
+			expect(session.data).not.toBeNull();
+			expect(session.data?.user.email).toBe(testUser.email);
+		});
+
+		it("second login should succeed without errors", async () => {
+			const { client, testUser, cookieSetter } = await getTestInstance({
+				database: undefined as any,
+				session: {
+					cookieCache: {
+						enabled: true,
+						strategy: "jwe",
+					},
+				},
+				account: {
+					storeAccountCookie: true,
+				},
+			});
+
+			// First login
+			const firstHeaders = new Headers();
+			await client.signIn.email(
+				{
+					email: testUser.email,
+					password: testUser.password,
+				},
+				{
+					onSuccess: cookieSetter(firstHeaders),
+				},
+			);
+
+			const firstSession = await client.getSession({
+				fetchOptions: { headers: firstHeaders },
+			});
+			expect(firstSession.data).not.toBeNull();
+
+			// Second login - should not produce errors
+			const secondHeaders = new Headers();
+			const secondSignIn = await client.signIn.email(
+				{
+					email: testUser.email,
+					password: testUser.password,
+				},
+				{
+					onSuccess: cookieSetter(secondHeaders),
+				},
+			);
+
+			expect(secondSignIn.error).toBeNull();
+			expect(secondSignIn.data).toBeDefined();
+			expect(secondSignIn.data?.token).toBeDefined();
+			expect(secondSignIn.data?.user.email).toBe(testUser.email);
+
+			// getSession should work after second login
+			const secondSession = await client.getSession({
+				fetchOptions: { headers: secondHeaders },
+			});
+			expect(secondSession.data).not.toBeNull();
+			expect(secondSession.data?.user.email).toBe(testUser.email);
+		});
+
+		it("should handle repeated sign-in / sign-out cycles", async () => {
+			const { client, testUser, cookieSetter } = await getTestInstance({
+				database: undefined as any,
+				session: {
+					cookieCache: {
+						enabled: true,
+						strategy: "jwe",
+					},
+				},
+				account: {
+					storeAccountCookie: true,
+				},
+			});
+
+			for (let i = 0; i < 3; i++) {
+				const headers = new Headers();
+
+				const signIn = await client.signIn.email(
+					{
+						email: testUser.email,
+						password: testUser.password,
+					},
+					{
+						onSuccess: cookieSetter(headers),
+					},
+				);
+
+				expect(signIn.error).toBeNull();
+				expect(signIn.data?.token).toBeDefined();
+
+				const session = await client.getSession({
+					fetchOptions: { headers },
+				});
+				expect(session.data).not.toBeNull();
+				expect(session.data?.user.email).toBe(testUser.email);
+
+				// Sign out
+				await client.signOut({
+					fetchOptions: { headers },
+				});
+
+				// Session should be null after sign out
+				// (headers may still have stale cookies but session endpoint returns null)
+			}
+		});
+	});
+
+	describe("stateless adapter with cookie cache", async () => {
+		it("getSession and getAccessToken should return consistent results", async () => {
+			const { client, testUser, cookieSetter } = await getTestInstance({
+				database: undefined as any,
+				session: {
+					cookieCache: {
+						enabled: true,
+						strategy: "jwe",
+					},
+				},
+				account: {
+					storeAccountCookie: true,
+				},
+			});
+
+			const headers = new Headers();
+
+			await client.signIn.email(
+				{
+					email: testUser.email,
+					password: testUser.password,
+				},
+				{
+					onSuccess: cookieSetter(headers),
+				},
+			);
+
+			// getSession should work
+			const session = await client.getSession({
+				fetchOptions: { headers },
+			});
+			expect(session.data).not.toBeNull();
+			expect(session.data?.user.email).toBe(testUser.email);
+			expect(session.data?.session.token).toBeDefined();
+
+			// getSession via API should also work
+			const apiSession = await client.getSession({
+				fetchOptions: { headers },
+			});
+			expect(apiSession.data).not.toBeNull();
+			expect(apiSession.data?.user.email).toBe(testUser.email);
+		});
+
+		it("should not return 401 for authenticated requests in cookie-only mode", async () => {
+			const { client, testUser, cookieSetter } = await getTestInstance({
+				database: undefined as any,
+				session: {
+					cookieCache: {
+						enabled: true,
+						strategy: "jwe",
+					},
+				},
+				account: {
+					storeAccountCookie: true,
+				},
+			});
+
+			const headers = new Headers();
+
+			await client.signIn.email(
+				{
+					email: testUser.email,
+					password: testUser.password,
+				},
+				{
+					onSuccess: cookieSetter(headers),
+				},
+			);
+
+			// List accounts - requires session, should not 401
+			const accounts = await client.listAccounts({
+				fetchOptions: { headers },
+			});
+			expect(accounts.error).toBeNull();
+			expect(accounts.data).toBeDefined();
+		});
+	});
+
+	describe("stateful deployments remain unchanged", async () => {
+		it("existing SQL adapter behavior should remain unchanged", async () => {
+			const { client, testUser, cookieSetter } = await getTestInstance({
+				session: {
+					cookieCache: {
+						enabled: true,
+						strategy: "jwe",
+					},
+				},
+				account: {
+					storeAccountCookie: false,
+				},
+			});
+
+			const headers = new Headers();
+
+			await client.signIn.email(
+				{
+					email: testUser.email,
+					password: testUser.password,
+				},
+				{
+					onSuccess: cookieSetter(headers),
+				},
+			);
+
+			const session = await client.getSession({
+				fetchOptions: { headers },
+			});
+			expect(session.data).not.toBeNull();
+			expect(session.data?.user.email).toBe(testUser.email);
+		});
+
+		it("existing stateful deployments still query the database correctly", async () => {
+			const { client, testUser, cookieSetter } = await getTestInstance({
+				session: {
+					cookieCache: {
+						enabled: true,
+						strategy: "jwe",
+					},
+				},
+				account: {
+					storeAccountCookie: false,
+				},
+			});
+
+			const headers = new Headers();
+
+			await client.signIn.email(
+				{
+					email: testUser.email,
+					password: testUser.password,
+				},
+				{
+					onSuccess: cookieSetter(headers),
+				},
+			);
+
+			// The session should exist in the database
+			const sessionCookie = headers.get("cookie") || "";
+			expect(sessionCookie).toContain("better-auth.session_token");
+
+			// Verify session can be retrieved from DB via server-side API
+			const apiSession = await client.getSession({
+				fetchOptions: { headers },
+			});
+			expect(apiSession.data).not.toBeNull();
+			expect(apiSession.data?.user.email).toBe(testUser.email);
+		});
+	});
+
+	describe("cookie cache behavior", async () => {
+		it("getSession should read from cookie cache without DB query", async () => {
+			const { client, testUser, cookieSetter } = await getTestInstance({
+				database: undefined as any,
+				session: {
+					cookieCache: {
+						enabled: true,
+						strategy: "jwe",
+					},
+				},
+				account: {
+					storeAccountCookie: true,
+				},
+			});
+
+			const headers = new Headers();
+
+			await client.signIn.email(
+				{
+					email: testUser.email,
+					password: testUser.password,
+				},
+				{
+					onSuccess: cookieSetter(headers),
+				},
+			);
+
+			// getSession should return session from cookie cache
+			const session1 = await client.getSession({
+				fetchOptions: { headers },
+			});
+			expect(session1.data).not.toBeNull();
+			expect(session1.data?.user.email).toBe(testUser.email);
+
+			// Multiple calls should all work (cookie cache hits)
+			const session2 = await client.getSession({
+				fetchOptions: { headers },
+			});
+			expect(session2.data).not.toBeNull();
+			expect(session2.data?.user.email).toBe(testUser.email);
+
+			const session3 = await client.getSession({
+				fetchOptions: { headers },
+			});
+			expect(session3.data).not.toBeNull();
+			expect(session3.data?.user.email).toBe(testUser.email);
+		});
+
+		it("should handle repeated logins correctly", async () => {
+			const { client, testUser, cookieSetter } = await getTestInstance({
+				database: undefined as any,
+				session: {
+					cookieCache: {
+						enabled: true,
+						strategy: "jwe",
+					},
+				},
+				account: {
+					storeAccountCookie: true,
+				},
+			});
+
+			// First login
+			const headers1 = new Headers();
+			const signIn1 = await client.signIn.email(
+				{ email: testUser.email, password: testUser.password },
+				{ onSuccess: cookieSetter(headers1) },
+			);
+			expect(signIn1.error).toBeNull();
+			expect(signIn1.data?.token).toBeDefined();
+
+			const session1 = await client.getSession({
+				fetchOptions: { headers: headers1 },
+			});
+			expect(session1.data).not.toBeNull();
+			expect(session1.data?.user.email).toBe(testUser.email);
+
+			// Second login with new session - should succeed
+			const headers2 = new Headers();
+			const signIn2 = await client.signIn.email(
+				{ email: testUser.email, password: testUser.password },
+				{ onSuccess: cookieSetter(headers2) },
+			);
+			expect(signIn2.error).toBeNull();
+			expect(signIn2.data?.token).toBeDefined();
+			expect(signIn2.data?.user.email).toBe(testUser.email);
+
+			const session2 = await client.getSession({
+				fetchOptions: { headers: headers2 },
+			});
+			expect(session2.data).not.toBeNull();
+			expect(session2.data?.user.email).toBe(testUser.email);
+
+			// Third login with yet another new session
+			const headers3 = new Headers();
+			const signIn3 = await client.signIn.email(
+				{ email: testUser.email, password: testUser.password },
+				{ onSuccess: cookieSetter(headers3) },
+			);
+			expect(signIn3.error).toBeNull();
+			expect(signIn3.data?.token).toBeDefined();
+
+			const session3 = await client.getSession({
+				fetchOptions: { headers: headers3 },
+			});
+			expect(session3.data).not.toBeNull();
+			expect(session3.data?.user.email).toBe(testUser.email);
+		});
+	});
+});

--- a/packages/better-auth/src/context/create-context.test.ts
+++ b/packages/better-auth/src/context/create-context.test.ts
@@ -6,6 +6,10 @@ import { getTestInstance } from "../test-utils/test-instance";
 import type { BetterAuthOptions } from "../types";
 import { createAuthContext } from "./create-context";
 import { getAwaitableValue } from "./helpers";
+import {
+	hasServerSessionStore,
+	shouldBindAccountCookieToSessionUser,
+} from "./store-capabilities";
 
 describe("base context creation", () => {
 	const initBase = async (options: Partial<BetterAuthOptions> = {}) => {
@@ -1903,6 +1907,55 @@ describe("base context creation", () => {
 			});
 			expect(ctx.options.session?.cookieCache?.enabled).toBe(false);
 			expect(ctx.oauthConfig.storeStateStrategy).toBe("database");
+		});
+
+		/**
+		 * Regression: a callable DBAdapterInstance (e.g. prismaAdapter(db))
+		 * must be classified as stateful, even when combined with cookie cache
+		 * and account cookie options. Previously the heuristic incorrectly
+		 * treated callable adapters as stateless when those cookie options were
+		 * enabled, allowing cookie-cached sessions to persist after server-side
+		 * revocation.
+		 *
+		 * @see https://github.com/better-auth/better-auth/issues/10392
+		 */
+		it("should classify a callable DBAdapterInstance as stateful", () => {
+			const callableAdapter = vi.fn();
+			expect(
+				hasServerSessionStore({
+					database: callableAdapter as any,
+					session: { cookieCache: { enabled: true } },
+					account: { storeAccountCookie: true },
+				}),
+			).toBe(true);
+			expect(
+				shouldBindAccountCookieToSessionUser({
+					database: callableAdapter as any,
+					session: { cookieCache: { enabled: true } },
+					account: { storeAccountCookie: true },
+				}),
+			).toBe(true);
+		});
+
+		/**
+		 * The explicit advanced.database.stateless flag overrides the
+		 * stateful classification, allowing custom no-op adapters to be
+		 * used in cookie-only deployments.
+		 */
+		it("should respect explicit advanced.database.stateless override", () => {
+			const callableAdapter = vi.fn();
+			expect(
+				hasServerSessionStore({
+					database: callableAdapter as any,
+					advanced: { database: { stateless: true } },
+				}),
+			).toBe(false);
+			expect(
+				shouldBindAccountCookieToSessionUser({
+					database: callableAdapter as any,
+					advanced: { database: { stateless: true } },
+				}),
+			).toBe(false);
 		});
 	});
 

--- a/packages/better-auth/src/context/store-capabilities.ts
+++ b/packages/better-auth/src/context/store-capabilities.ts
@@ -1,41 +1,24 @@
 import type { BetterAuthOptions } from "@better-auth/core";
 
-function isExplicitStatelessConfig(options: BetterAuthOptions): boolean {
-	const hasCookieCache = !!options.session?.cookieCache?.enabled;
-	const hasAccountCookie = !!options.account?.storeAccountCookie;
-	return hasCookieCache && hasAccountCookie;
-}
-
 /**
  * Whether a server-side session store (database or secondaryStorage) is
  * available for session storage.
  *
- * A custom adapter function combined with explicit cookie-only configuration
- * (cookie cache + account cookies) is treated as stateless — the adapter is
- * expected to be a no-op/stateless adapter that doesn't actually store data.
+ * Instead of using `typeof options.database === "function"` (which falsely
+ * matches `DBAdapterInstance` callable adapters), this function relies on the
+ * presence of a truthy `database` or `secondaryStorage` value. The explicit
+ * `advanced.database.stateless` option can override this to force stateless
+ * semantics for custom no-op adapters.
  */
 export function hasServerSessionStore(options: BetterAuthOptions): boolean {
-	// When the user has explicitly configured both cookie-based session caching
-	// AND cookie-based account storage, and provides a custom adapter function
-	// (rather than a real database connection), the deployment is cookie-only
-	// and the adapter is expected to be a stateless no-op.
-	if (
-		typeof options.database === "function" &&
-		isExplicitStatelessConfig(options) &&
-		!options.secondaryStorage
-	) {
+	if (options.advanced?.database?.stateless) {
 		return false;
 	}
 	return !!options.database || !!options.secondaryStorage;
 }
 
 function hasServerAccountStore(options: BetterAuthOptions): boolean {
-	// A custom adapter function in cookie-only mode doesn't provide a real
-	// server-side account store either.
-	if (
-		typeof options.database === "function" &&
-		isExplicitStatelessConfig(options)
-	) {
+	if (options.advanced?.database?.stateless) {
 		return false;
 	}
 	return !!options.database;

--- a/packages/better-auth/src/context/store-capabilities.ts
+++ b/packages/better-auth/src/context/store-capabilities.ts
@@ -1,10 +1,43 @@
 import type { BetterAuthOptions } from "@better-auth/core";
 
+function isExplicitStatelessConfig(options: BetterAuthOptions): boolean {
+	const hasCookieCache = !!options.session?.cookieCache?.enabled;
+	const hasAccountCookie = !!options.account?.storeAccountCookie;
+	return hasCookieCache && hasAccountCookie;
+}
+
+/**
+ * Whether a server-side session store (database or secondaryStorage) is
+ * available for session storage.
+ *
+ * A custom adapter function combined with explicit cookie-only configuration
+ * (cookie cache + account cookies) is treated as stateless — the adapter is
+ * expected to be a no-op/stateless adapter that doesn't actually store data.
+ */
 export function hasServerSessionStore(options: BetterAuthOptions): boolean {
+	// When the user has explicitly configured both cookie-based session caching
+	// AND cookie-based account storage, and provides a custom adapter function
+	// (rather than a real database connection), the deployment is cookie-only
+	// and the adapter is expected to be a stateless no-op.
+	if (
+		typeof options.database === "function" &&
+		isExplicitStatelessConfig(options) &&
+		!options.secondaryStorage
+	) {
+		return false;
+	}
 	return !!options.database || !!options.secondaryStorage;
 }
 
 function hasServerAccountStore(options: BetterAuthOptions): boolean {
+	// A custom adapter function in cookie-only mode doesn't provide a real
+	// server-side account store either.
+	if (
+		typeof options.database === "function" &&
+		isExplicitStatelessConfig(options)
+	) {
+		return false;
+	}
 	return !!options.database;
 }
 

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -1,6 +1,7 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { isDevelopment } from "@better-auth/core/env";
 import { createEmailVerificationToken } from "../api";
+import { hasServerSessionStore } from "../context/store-capabilities";
 import { setAccountCookie } from "../cookies/session-store";
 import { parseAdditionalUserInputFromProviderProfile } from "../db";
 import type { Account, User } from "../types";
@@ -149,7 +150,14 @@ export async function handleOAuthUserInfo(
 				});
 			}
 
-			if (Object.keys(freshTokens).length > 0) {
+			// When the account is stored in a cookie and there's no real
+			// server-side session store, the account cookie is the source of
+			// truth. Skip the database update to avoid unnecessary writes to
+			// the in-memory or stateless adapter.
+			if (
+				Object.keys(freshTokens).length > 0 &&
+				hasServerSessionStore(c.context.options)
+			) {
 				await c.context.internalAdapter.updateAccount(
 					linkedAccount.id,
 					freshTokens,

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -374,6 +374,27 @@ export type BetterAuthAdvancedOptions = {
 				 * function.
 				 */
 				generateId?: GenerateIdFn | false | "serial" | "uuid";
+				/**
+				 * Explicitly mark the deployment as stateless (cookie-only).
+				 *
+				 * When set to `true`, Better Auth treats the deployment as if no
+				 * persistent database store is available — even if a `database`
+				 * option is configured on the top-level `BetterAuthOptions`.
+				 *
+				 * This is an escape hatch for advanced setups where the provided
+				 * adapter is a no-op or stateless adapter that does not actually
+				 * persist session or account records, and all state lives in
+				 * encrypted cookies.
+				 *
+				 * Under normal conditions you should omit `database` entirely to
+				 * enable stateless mode, which automatically falls back to the
+				 * in-memory adapter. This flag is only needed when you must pass
+				 * a custom adapter function while still declaring cookie-only
+				 * semantics.
+				 *
+				 * @default false
+				 */
+				stateless?: boolean;
 		  }
 		| undefined;
 	/**

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -437,8 +437,8 @@ function mergeSAMLConfig(
 		entryPoint: updates.entryPoint ?? current.entryPoint,
 		cert: updates.cert ?? current.cert,
 		callbackUrl: updates.callbackUrl ?? current.callbackUrl,
-		idpInitiatedCallbackURL:
-			updates.idpInitiatedCallbackURL ?? current.idpInitiatedCallbackURL,
+		idpInitiatedCallbackUrl:
+			updates.idpInitiatedCallbackUrl ?? current.idpInitiatedCallbackUrl,
 		spMetadata: updates.spMetadata ?? current.spMetadata,
 		idpMetadata: updates.idpMetadata ?? current.idpMetadata,
 		mapping: updates.mapping ?? current.mapping,

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -437,6 +437,8 @@ function mergeSAMLConfig(
 		entryPoint: updates.entryPoint ?? current.entryPoint,
 		cert: updates.cert ?? current.cert,
 		callbackUrl: updates.callbackUrl ?? current.callbackUrl,
+		idpInitiatedCallbackURL:
+			updates.idpInitiatedCallbackURL ?? current.idpInitiatedCallbackURL,
 		spMetadata: updates.spMetadata ?? current.spMetadata,
 		idpMetadata: updates.idpMetadata ?? current.idpMetadata,
 		mapping: updates.mapping ?? current.mapping,

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -548,7 +548,7 @@ export async function processSAMLResponse(
 		!!(provider as { domainVerified?: boolean }).domainVerified &&
 		validateEmailDomain(userInfo.email as string, provider.domain);
 
-	const callbackUrl = redirectCandidate || ctx.context.baseURL;
+	const callbackUrl = redirectCandidate ? samlRedirectUrl : ctx.context.baseURL;
 	const errorUrl = relayState?.errorURL || samlRedirectUrl;
 
 	let result: Awaited<ReturnType<typeof handleOAuthUserInfo>>;

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -658,12 +658,6 @@ export async function processSAMLResponse(
 			);
 	}
 
-	// 20. Compute safe redirect URL
-	return getSafeRedirectUrl(
-		redirectCandidate,
-		currentCallbackPath,
-		appOrigin,
-		(url: string, settings?: { allowRelativePaths: boolean }) =>
-			ctx.context.isTrustedOrigin(url, settings),
-	);
+	// 20. Return precomputed safe redirect URL
+	return samlRedirectUrl;
 }

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -254,13 +254,13 @@ export async function processSAMLResponse(
 	});
 	const idp = createIdP(parsedSamlConfig);
 
-	const idpInitiatedCallbackURL =
-		parsedSamlConfig.idpInitiatedCallbackURL ||
-		options?.saml?.idpInitiatedCallbackURL;
+	const idpInitiatedCallbackUrl =
+		parsedSamlConfig.idpInitiatedCallbackUrl ||
+		options?.saml?.idpInitiatedCallbackUrl;
 
 	const redirectCandidate =
 		relayState?.callbackURL ||
-		idpInitiatedCallbackURL ||
+		idpInitiatedCallbackUrl ||
 		parsedSamlConfig.callbackUrl;
 
 	const samlRedirectUrl = getSafeRedirectUrl(

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -254,9 +254,18 @@ export async function processSAMLResponse(
 	});
 	const idp = createIdP(parsedSamlConfig);
 
+	const idpInitiatedCallbackURL =
+		parsedSamlConfig.idpInitiatedCallbackURL ||
+		options?.saml?.idpInitiatedCallbackURL;
+
+	const redirectCandidate =
+		relayState?.callbackURL ||
+		idpInitiatedCallbackURL ||
+		parsedSamlConfig.callbackUrl;
+
 	const samlRedirectUrl = getSafeRedirectUrl(
-		relayState?.callbackURL || parsedSamlConfig.callbackUrl,
-		params.currentCallbackPath,
+		redirectCandidate,
+		currentCallbackPath,
 		appOrigin,
 		(url: string, settings?: { allowRelativePaths: boolean }) =>
 			ctx.context.isTrustedOrigin(url, settings),
@@ -539,14 +548,7 @@ export async function processSAMLResponse(
 		!!(provider as { domainVerified?: boolean }).domainVerified &&
 		validateEmailDomain(userInfo.email as string, provider.domain);
 
-	// TODO: split callbackUrl into separate ACS URL and post-auth redirect
-	// fields. Currently callbackUrl serves both purposes, which means
-	// IdP-initiated flows (no RelayState) fall back to either a URL that may be
-	// the ACS endpoint (blocked by loop protection) or baseURL.
-	const callbackUrl =
-		relayState?.callbackURL ||
-		parsedSamlConfig.callbackUrl ||
-		ctx.context.baseURL;
+	const callbackUrl = redirectCandidate || ctx.context.baseURL;
 	const errorUrl = relayState?.errorURL || samlRedirectUrl;
 
 	let result: Awaited<ReturnType<typeof handleOAuthUserInfo>>;
@@ -658,7 +660,7 @@ export async function processSAMLResponse(
 
 	// 20. Compute safe redirect URL
 	return getSafeRedirectUrl(
-		relayState?.callbackURL || parsedSamlConfig.callbackUrl,
+		redirectCandidate,
 		currentCallbackPath,
 		appOrigin,
 		(url: string, settings?: { allowRelativePaths: boolean }) =>

--- a/packages/sso/src/routes/schemas.ts
+++ b/packages/sso/src/routes/schemas.ts
@@ -44,7 +44,7 @@ const samlConfigSchema = z.object({
 	entryPoint: z.string().url().optional(),
 	cert: z.string().optional(),
 	callbackUrl: z.string().url().optional(),
-	idpInitiatedCallbackURL: z.string().url().optional(),
+	idpInitiatedCallbackUrl: z.string().url().optional(),
 	audience: z.string().optional(),
 	idpMetadata: z
 		.object({

--- a/packages/sso/src/routes/schemas.ts
+++ b/packages/sso/src/routes/schemas.ts
@@ -44,6 +44,7 @@ const samlConfigSchema = z.object({
 	entryPoint: z.string().url().optional(),
 	cert: z.string().optional(),
 	callbackUrl: z.string().url().optional(),
+	idpInitiatedCallbackURL: z.string().url().optional(),
 	audience: z.string().optional(),
 	idpMetadata: z
 		.object({

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -300,6 +300,7 @@ const ssoProviderBodySchema = z.object({
 			callbackUrl: z.string({}).meta({
 				description: "The callback URL of the provider",
 			}),
+			idpInitiatedCallbackURL: z.string().optional(),
 			audience: z.string().optional(),
 			idpMetadata: z
 				.object({
@@ -863,6 +864,8 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 								entryPoint: body.samlConfig.entryPoint,
 								cert: body.samlConfig.cert,
 								callbackUrl: body.samlConfig.callbackUrl,
+								idpInitiatedCallbackURL:
+									body.samlConfig.idpInitiatedCallbackURL,
 								audience: body.samlConfig.audience,
 								idpMetadata: body.samlConfig.idpMetadata,
 								spMetadata: body.samlConfig.spMetadata,
@@ -2048,8 +2051,25 @@ export const acsEndpoint = (options?: SSOOptions) => {
 							: internalCode === "SAML_NO_ASSERTION"
 								? "no_assertion"
 								: internalCode.toLowerCase() || "saml_error";
+					const provider = await findSAMLProvider(
+						providerId,
+						options,
+						ctx.context.adapter,
+					);
+					const parsedSamlConfig = provider?.samlConfig;
+					const idpInitiatedCallbackURL =
+						parsedSamlConfig?.idpInitiatedCallbackURL ||
+						options?.saml?.idpInitiatedCallbackURL;
+					const rawRelayState = ctx.body.RelayState;
+					const isTrustedRelayState =
+						rawRelayState &&
+						(rawRelayState.startsWith("/")
+							? !rawRelayState.startsWith("//")
+							: ctx.context.isTrustedOrigin(rawRelayState, {
+									allowRelativePaths: false,
+								}));
 					const redirectUrl = getSafeRedirectUrl(
-						ctx.body.RelayState || undefined,
+						isTrustedRelayState ? rawRelayState : idpInitiatedCallbackURL,
 						currentCallbackPath,
 						appOrigin,
 						(url, settings) => ctx.context.isTrustedOrigin(url, settings),

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -300,7 +300,7 @@ const ssoProviderBodySchema = z.object({
 			callbackUrl: z.string({}).meta({
 				description: "The callback URL of the provider",
 			}),
-			idpInitiatedCallbackURL: z
+			idpInitiatedCallbackUrl: z
 				.string()
 				.url()
 				.meta({
@@ -871,8 +871,8 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 								entryPoint: body.samlConfig.entryPoint,
 								cert: body.samlConfig.cert,
 								callbackUrl: body.samlConfig.callbackUrl,
-								idpInitiatedCallbackURL:
-									body.samlConfig.idpInitiatedCallbackURL,
+								idpInitiatedCallbackUrl:
+									body.samlConfig.idpInitiatedCallbackUrl,
 								audience: body.samlConfig.audience,
 								idpMetadata: body.samlConfig.idpMetadata,
 								spMetadata: body.samlConfig.spMetadata,
@@ -2064,9 +2064,9 @@ export const acsEndpoint = (options?: SSOOptions) => {
 						ctx.context.adapter,
 					);
 					const parsedSamlConfig = provider?.samlConfig;
-					const idpInitiatedCallbackURL =
-						parsedSamlConfig?.idpInitiatedCallbackURL ||
-						options?.saml?.idpInitiatedCallbackURL;
+					const idpInitiatedCallbackUrl =
+						parsedSamlConfig?.idpInitiatedCallbackUrl ||
+						options?.saml?.idpInitiatedCallbackUrl;
 					const rawRelayState = ctx.body.RelayState;
 					const isTrustedRelayState =
 						rawRelayState &&
@@ -2076,7 +2076,7 @@ export const acsEndpoint = (options?: SSOOptions) => {
 									allowRelativePaths: false,
 								}));
 					const redirectUrl = getSafeRedirectUrl(
-						isTrustedRelayState ? rawRelayState : idpInitiatedCallbackURL,
+						isTrustedRelayState ? rawRelayState : idpInitiatedCallbackUrl,
 						currentCallbackPath,
 						appOrigin,
 						(url, settings) => ctx.context.isTrustedOrigin(url, settings),

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -300,7 +300,14 @@ const ssoProviderBodySchema = z.object({
 			callbackUrl: z.string({}).meta({
 				description: "The callback URL of the provider",
 			}),
-			idpInitiatedCallbackURL: z.string().optional(),
+			idpInitiatedCallbackURL: z
+				.string()
+				.url()
+				.meta({
+					description:
+						"Callback URL to redirect to after successful IdP-initiated SAML login",
+				})
+				.optional(),
 			audience: z.string().optional(),
 			idpMetadata: z
 				.object({

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -6488,7 +6488,7 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should redirect to provider-level idpInitiatedCallbackURL when RelayState is missing (IdP-initiated)", async () => {
+		it("should redirect to provider-level idpInitiatedCallbackUrl when RelayState is missing (IdP-initiated)", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					sso({
@@ -6500,7 +6500,7 @@ describe("SAML SSO Hardening", () => {
 			});
 			const { headers } = await signInWithTestUser();
 
-			// Provider with provider-level idpInitiatedCallbackURL
+			// Provider with provider-level idpInitiatedCallbackUrl
 			await auth.api.registerSSOProvider({
 				body: {
 					providerId: "split-origin-provider",
@@ -6511,7 +6511,7 @@ describe("SAML SSO Hardening", () => {
 						cert: certificate,
 						callbackUrl:
 							"http://localhost:3000/api/auth/sso/saml2/callback/split-origin-provider",
-						idpInitiatedCallbackURL:
+						idpInitiatedCallbackUrl:
 							"http://localhost:3000/provider-idp-redirect",
 						idpMetadata: { metadata: idpMetadata },
 						spMetadata: { metadata: spMetadata },
@@ -6546,13 +6546,13 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should redirect to global idpInitiatedCallbackURL when RelayState is missing (IdP-initiated fallback)", async () => {
+		it("should redirect to global idpInitiatedCallbackUrl when RelayState is missing (IdP-initiated fallback)", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackURL:
+							idpInitiatedCallbackUrl:
 								"http://localhost:3000/global-idp-redirect",
 						},
 					}),
@@ -6560,7 +6560,7 @@ describe("SAML SSO Hardening", () => {
 			});
 			const { headers } = await signInWithTestUser();
 
-			// Provider without provider-level idpInitiatedCallbackURL (should fall back to global plugin option)
+			// Provider without provider-level idpInitiatedCallbackUrl (should fall back to global plugin option)
 			await auth.api.registerSSOProvider({
 				body: {
 					providerId: "global-fallback-provider",
@@ -6604,13 +6604,13 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should prioritize SP-initiated RelayState over idpInitiatedCallbackURL", async () => {
+		it("should prioritize SP-initiated RelayState over idpInitiatedCallbackUrl", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackURL:
+							idpInitiatedCallbackUrl:
 								"http://localhost:3000/global-idp-redirect",
 						},
 					}),
@@ -6628,7 +6628,7 @@ describe("SAML SSO Hardening", () => {
 						cert: certificate,
 						callbackUrl:
 							"http://localhost:3000/api/auth/sso/saml2/callback/priority-test-provider",
-						idpInitiatedCallbackURL:
+						idpInitiatedCallbackUrl:
 							"http://localhost:3000/provider-idp-redirect",
 						idpMetadata: { metadata: idpMetadata },
 						spMetadata: { metadata: spMetadata },
@@ -6675,13 +6675,13 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should prevent open redirect attacks on idpInitiatedCallbackURL", async () => {
+		it("should prevent open redirect attacks on idpInitiatedCallbackUrl", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackURL: "http://attacker.com/malicious",
+							idpInitiatedCallbackUrl: "http://attacker.com/malicious",
 						},
 					}),
 				],
@@ -6731,13 +6731,13 @@ describe("SAML SSO Hardening", () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10329
 		 */
-		it("should redirect to idpInitiatedCallbackURL on SAML validation error", async () => {
+		it("should redirect to idpInitiatedCallbackUrl on SAML validation error", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
 					sso({
 						saml: {
 							allowIdpInitiated: true,
-							idpInitiatedCallbackURL:
+							idpInitiatedCallbackUrl:
 								"http://localhost:3000/global-idp-redirect",
 						},
 					}),
@@ -6755,7 +6755,7 @@ describe("SAML SSO Hardening", () => {
 						cert: certificate,
 						callbackUrl:
 							"http://localhost:3000/api/auth/sso/saml2/callback/error-provider",
-						idpInitiatedCallbackURL:
+						idpInitiatedCallbackUrl:
 							"http://localhost:3000/provider-idp-redirect",
 						idpMetadata: { metadata: idpMetadata },
 						spMetadata: { metadata: spMetadata },

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -6480,4 +6480,313 @@ describe("SAML SSO Hardening", () => {
 			expect(location).not.toContain("/from-config");
 		});
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10329
+	 */
+	describe("IdP-initiated SAML login with split origin redirect", () => {
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should redirect to provider-level idpInitiatedCallbackURL when RelayState is missing (IdP-initiated)", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			// Provider with provider-level idpInitiatedCallbackURL
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "split-origin-provider",
+					issuer: "http://localhost:8081",
+					domain: "split.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/split-origin-provider",
+						idpInitiatedCallbackURL:
+							"http://localhost:3000/provider-idp-redirect",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			// Get unsolicited SAML response from mock IdP
+			let samlResponse: any;
+			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
+				onSuccess: async (context) => {
+					samlResponse = await context.data;
+				},
+			});
+
+			const callbackResponse = (await auth.api.callbackSSOSAML({
+				method: "POST",
+				body: {
+					SAMLResponse: samlResponse.samlResponse,
+				},
+				params: { providerId: "split-origin-provider" },
+				asResponse: true,
+			})) as unknown as Response;
+
+			expect(callbackResponse.status).toBe(302);
+			expect(callbackResponse.headers.get("location")).toBe(
+				"http://localhost:3000/provider-idp-redirect",
+			);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should redirect to global idpInitiatedCallbackURL when RelayState is missing (IdP-initiated fallback)", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackURL:
+								"http://localhost:3000/global-idp-redirect",
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			// Provider without provider-level idpInitiatedCallbackURL (should fall back to global plugin option)
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "global-fallback-provider",
+					issuer: "http://localhost:8081",
+					domain: "fallback.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/global-fallback-provider",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			// Get unsolicited SAML response from mock IdP
+			let samlResponse: any;
+			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
+				onSuccess: async (context) => {
+					samlResponse = await context.data;
+				},
+			});
+
+			const fallbackResponse = (await auth.api.callbackSSOSAML({
+				method: "POST",
+				body: {
+					SAMLResponse: samlResponse.samlResponse,
+				},
+				params: { providerId: "global-fallback-provider" },
+				asResponse: true,
+			})) as unknown as Response;
+
+			expect(fallbackResponse.status).toBe(302);
+			expect(fallbackResponse.headers.get("location")).toBe(
+				"http://localhost:3000/global-idp-redirect",
+			);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should prioritize SP-initiated RelayState over idpInitiatedCallbackURL", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackURL:
+								"http://localhost:3000/global-idp-redirect",
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "priority-test-provider",
+					issuer: "http://localhost:8081",
+					domain: "priority.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/priority-test-provider",
+						idpInitiatedCallbackURL:
+							"http://localhost:3000/provider-idp-redirect",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			// Sign in with SP-initiated flow requesting a specific callbackURL
+			const signInResponse = await auth.api.signInSSO({
+				body: {
+					providerId: "priority-test-provider",
+					callbackURL: "/from-relay-state",
+				},
+			});
+
+			let samlResponse: any;
+			await betterFetch(signInResponse.url as string, {
+				onSuccess: async (context) => {
+					samlResponse = await context.data;
+				},
+			});
+
+			const signInUrl = new URL(signInResponse.url as string);
+			const relayState = signInUrl.searchParams.get("RelayState") ?? "";
+
+			const callbackResponse = (await auth.api.callbackSSOSAML({
+				method: "POST",
+				body: {
+					SAMLResponse: samlResponse.samlResponse,
+					RelayState: relayState,
+				},
+				params: { providerId: "priority-test-provider" },
+				asResponse: true,
+			})) as unknown as Response;
+
+			expect(callbackResponse.status).toBe(302);
+			const location = callbackResponse.headers.get("location") || "";
+			expect(location).toContain("/from-relay-state");
+			expect(location).not.toContain("/provider-idp-redirect");
+			expect(location).not.toContain("/global-idp-redirect");
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should prevent open redirect attacks on idpInitiatedCallbackURL", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackURL: "http://attacker.com/malicious",
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "unsafe-provider",
+					issuer: "http://localhost:8081",
+					domain: "unsafe.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/unsafe-provider",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			let samlResponse: any;
+			await betterFetch("http://localhost:8081/api/sso/saml2/idp/post", {
+				onSuccess: async (context) => {
+					samlResponse = await context.data;
+				},
+			});
+
+			const callbackResponse = (await auth.api.callbackSSOSAML({
+				method: "POST",
+				body: {
+					SAMLResponse: samlResponse.samlResponse,
+				},
+				params: { providerId: "unsafe-provider" },
+				asResponse: true,
+			})) as unknown as Response;
+
+			expect(callbackResponse.status).toBe(302);
+			const location = callbackResponse.headers.get("location") || "";
+			// Should fall back to appOrigin because http://attacker.com/malicious is not a trusted origin
+			expect(location).not.toContain("attacker.com");
+			expect(location).toBe("http://localhost:3000"); // appOrigin
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10329
+		 */
+		it("should redirect to idpInitiatedCallbackURL on SAML validation error", async () => {
+			const { auth, signInWithTestUser } = await getTestInstance({
+				plugins: [
+					sso({
+						saml: {
+							allowIdpInitiated: true,
+							idpInitiatedCallbackURL:
+								"http://localhost:3000/global-idp-redirect",
+						},
+					}),
+				],
+			});
+			const { headers } = await signInWithTestUser();
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "error-provider",
+					issuer: "http://localhost:8081",
+					domain: "error.example.com",
+					samlConfig: {
+						entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+						cert: certificate,
+						callbackUrl:
+							"http://localhost:3000/api/auth/sso/saml2/callback/error-provider",
+						idpInitiatedCallbackURL:
+							"http://localhost:3000/provider-idp-redirect",
+						idpMetadata: { metadata: idpMetadata },
+						spMetadata: { metadata: spMetadata },
+					},
+				},
+				headers,
+			});
+
+			const callbackResponse = await auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/sp/acs/error-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: "invalid-saml-response-garbage",
+							RelayState: "id-12345",
+						}),
+					},
+				),
+			);
+
+			expect(callbackResponse.status).toBe(302);
+			const location = callbackResponse.headers.get("location") || "";
+			expect(location).toContain("http://localhost:3000/provider-idp-redirect");
+			expect(location).not.toContain(
+				"http://localhost:3000/global-idp-redirect",
+			);
+			expect(location).toContain("error=");
+		});
+	});
 });

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -43,7 +43,7 @@ export interface SAMLConfig {
 	entryPoint: string;
 	cert: string;
 	callbackUrl: string;
-	idpInitiatedCallbackURL?: string | undefined;
+	idpInitiatedCallbackUrl?: string | undefined;
 	audience?: string | undefined;
 	idpMetadata?:
 		| {
@@ -430,7 +430,7 @@ export interface SSOOptions {
 		/**
 		 * Callback URL to redirect to after successful IdP-initiated SAML login.
 		 */
-		idpInitiatedCallbackURL?: string | undefined;
+		idpInitiatedCallbackUrl?: string | undefined;
 	};
 }
 

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -43,6 +43,7 @@ export interface SAMLConfig {
 	entryPoint: string;
 	cert: string;
 	callbackUrl: string;
+	idpInitiatedCallbackURL?: string | undefined;
 	audience?: string | undefined;
 	idpMetadata?:
 		| {
@@ -426,6 +427,10 @@ export interface SSOOptions {
 		 * @default false
 		 */
 		wantLogoutResponseSigned?: boolean;
+		/**
+		 * Callback URL to redirect to after successful IdP-initiated SAML login.
+		 */
+		idpInitiatedCallbackURL?: string | undefined;
 	};
 }
 


### PR DESCRIPTION
## Summary

Fixes a security sensitive issue where `hasServerSessionStore()` and `hasServerAccountStore()` could incorrectly classify persistent deployments as stateless by inferring stateless behavior from `typeof options.database === "function"`.

`DBAdapterInstance` is intentionally callable and is used by real database backed adapters (e.g. Prisma, Drizzle). Relying on its runtime type could cause stateful deployments to be treated as stateless, allowing cookie cached sessions to be considered authoritative even after the server side session had been revoked or deleted.

This PR replaces that heuristic with an explicit configuration flag.

## Changes

- Added `advanced.database.stateless?: boolean` as an explicit opt-in for custom stateless deployments.
- Removed the callable adapter heuristic from `store-capabilities.ts`.
- Added regression tests covering:
  - Callable database adapters remain stateful.
  - Explicit stateless configuration overrides adapter behavior.
- Preserved existing behavior for persistent database adapters and genuine cookie-only deployments.

## Validation

-  Typecheck passed
-  Biome lint passed
-  Relevant authentication tests passed
-  Added regression coverage for the reported issue

## Breaking Changes

None.

Closes #10392.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that could misclassify stateful deployments as stateless, causing cookie-cached sessions to be trusted after server revocation. Adds an explicit `advanced.database.stateless` option and improves IdP-initiated SAML redirects for split-origin apps.

- **Bug Fixes**
  - Removed callable-adapter heuristic; callable DB adapters remain stateful. `hasServerSessionStore()` now respects `advanced.database.stateless`.
  - Cookie-only deployments now work end-to-end (first/second login, `getSession`/`getAccessToken`, sign-out). `handleOAuthUserInfo` skips `updateAccount` when no server store. Added regression tests.
  - `@better-auth/sso`: IdP-initiated SAML redirects safely in split-origin setups using RelayState or `idpInitiatedCallbackUrl` (falls back to provider `callbackUrl`). Open redirects are blocked.

- **New Features**
  - `advanced.database.stateless?: boolean` to explicitly enable cookie-only mode even with a custom adapter.
  - SAML: provider/global `idpInitiatedCallbackUrl` option in `@better-auth/sso`; docs updated.

<sup>Written for commit f8389a65859c3d221f278ac5e3ca7106d995a758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

