### PR TITLE
feat(sso): add native SAML ForceAuthn support

### DIFF
--- a/packages/sso/src/providers.test.ts
+++ b/packages/sso/src/providers.test.ts
@@ -1629,6 +1629,139 @@ describe("SSO provider read endpoints", () => {
 			expect(response.status).toBe(400);
 		});
 	});
+
+	describe("SAML forceAuthn persistence", () => {
+		type Auth = ReturnType<typeof createTestAuth>["auth"];
+
+		const registerWithForceAuthn = (
+			auth: Auth,
+			headers: Headers,
+			providerId: string,
+			forceAuthn?: boolean,
+		) =>
+			auth.api.registerSSOProvider({
+				body: {
+					providerId,
+					issuer: "https://idp.example.com",
+					domain: "example.com",
+					samlConfig: {
+						entryPoint: "https://idp.example.com/sso",
+						cert: TEST_CERT,
+						callbackUrl: "http://localhost:3000/api/sso/callback",
+						audience: "my-audience",
+						wantAssertionsSigned: true,
+						// Only include forceAuthn when the caller sets it, so the
+						// unset case exercises the opt-in default.
+						...(forceAuthn === undefined ? {} : { forceAuthn }),
+						spMetadata: {},
+					},
+				},
+				headers,
+			});
+
+		const ownerHeaders = (
+			getAuthHeaders: ReturnType<typeof createTestAuth>["getAuthHeaders"],
+		) =>
+			getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+		it("persists forceAuthn=true on register", async () => {
+			const { auth, getAuthHeaders } = createTestAuth(false);
+			const headers = await ownerHeaders(getAuthHeaders);
+
+			await registerWithForceAuthn(auth, headers, "saml-force-true", true);
+
+			const response = await auth.api.getSSOProvider({
+				query: { providerId: "saml-force-true" },
+				headers,
+			});
+
+			expect(response.samlConfig?.forceAuthn).toBe(true);
+		});
+
+		it("persists forceAuthn=false on register", async () => {
+			const { auth, getAuthHeaders } = createTestAuth(false);
+			const headers = await ownerHeaders(getAuthHeaders);
+
+			await registerWithForceAuthn(auth, headers, "saml-force-false", false);
+
+			const response = await auth.api.getSSOProvider({
+				query: { providerId: "saml-force-false" },
+				headers,
+			});
+
+			expect(response.samlConfig?.forceAuthn).toBe(false);
+		});
+
+		it("leaves forceAuthn unset on register when not provided (opt-in)", async () => {
+			const { auth, getAuthHeaders } = createTestAuth(false);
+			const headers = await ownerHeaders(getAuthHeaders);
+
+			await registerWithForceAuthn(auth, headers, "saml-force-unset");
+
+			const response = await auth.api.getSSOProvider({
+				query: { providerId: "saml-force-unset" },
+				headers,
+			});
+
+			expect(response.samlConfig?.forceAuthn).toBeUndefined();
+		});
+
+		it("enables forceAuthn via update-provider", async () => {
+			const { auth, getAuthHeaders } = createTestAuth(false);
+			const headers = await ownerHeaders(getAuthHeaders);
+
+			await registerWithForceAuthn(auth, headers, "saml-force-update");
+
+			const updated = await auth.api.updateSSOProvider({
+				body: {
+					providerId: "saml-force-update",
+					samlConfig: { forceAuthn: true },
+				},
+				headers,
+			});
+
+			expect(updated.samlConfig?.forceAuthn).toBe(true);
+		});
+
+		it("disables forceAuthn via update-provider", async () => {
+			const { auth, getAuthHeaders } = createTestAuth(false);
+			const headers = await ownerHeaders(getAuthHeaders);
+
+			await registerWithForceAuthn(auth, headers, "saml-force-disable", true);
+
+			const updated = await auth.api.updateSSOProvider({
+				body: {
+					providerId: "saml-force-disable",
+					samlConfig: { forceAuthn: false },
+				},
+				headers,
+			});
+
+			expect(updated.samlConfig?.forceAuthn).toBe(false);
+		});
+
+		it("preserves forceAuthn across unrelated partial updates", async () => {
+			const { auth, getAuthHeaders } = createTestAuth(false);
+			const headers = await ownerHeaders(getAuthHeaders);
+
+			await registerWithForceAuthn(auth, headers, "saml-force-preserve", true);
+
+			const updated = await auth.api.updateSSOProvider({
+				body: {
+					providerId: "saml-force-preserve",
+					samlConfig: { audience: "new-audience" },
+				},
+				headers,
+			});
+
+			expect(updated.samlConfig?.audience).toBe("new-audience");
+			expect(updated.samlConfig?.forceAuthn).toBe(true);
+		});
+	});
 });
 
 /**

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -230,6 +230,7 @@ function sanitizeProvider(
 					audience: samlConfig.audience,
 					wantAssertionsSigned: samlConfig.wantAssertionsSigned,
 					authnRequestsSigned: samlConfig.authnRequestsSigned,
+					forceAuthn: samlConfig.forceAuthn,
 					identifierFormat: samlConfig.identifierFormat,
 					signatureAlgorithm: samlConfig.signatureAlgorithm,
 					digestAlgorithm: samlConfig.digestAlgorithm,
@@ -445,6 +446,7 @@ function mergeSAMLConfig(
 			updates.wantAssertionsSigned ?? current.wantAssertionsSigned,
 		authnRequestsSigned:
 			updates.authnRequestsSigned ?? current.authnRequestsSigned,
+		forceAuthn: updates.forceAuthn ?? current.forceAuthn,
 		identifierFormat: updates.identifierFormat ?? current.identifierFormat,
 		signatureAlgorithm:
 			updates.signatureAlgorithm ?? current.signatureAlgorithm,

--- a/packages/sso/src/routes/schemas.ts
+++ b/packages/sso/src/routes/schemas.ts
@@ -79,6 +79,7 @@ const samlConfigSchema = z.object({
 		.optional(),
 	wantAssertionsSigned: z.boolean().optional(),
 	authnRequestsSigned: z.boolean().optional(),
+	forceAuthn: z.boolean().optional(),
 	signatureAlgorithm: z.string().optional(),
 	digestAlgorithm: z.string().optional(),
 	identifierFormat: z.string().optional(),

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -340,6 +340,13 @@ const ssoProviderBodySchema = z.object({
 			}),
 			wantAssertionsSigned: z.boolean().optional(),
 			authnRequestsSigned: z.boolean().optional(),
+			forceAuthn: z
+				.boolean()
+				.meta({
+					description:
+						'Emit ForceAuthn="true" on the SAML AuthnRequest, asking the IdP to re-authenticate the user. Opt-in: omitted from the request when unset.',
+				})
+				.optional(),
 			signatureAlgorithm: z.string().optional(),
 			digestAlgorithm: z.string().optional(),
 			identifierFormat: z.string().optional(),
@@ -868,6 +875,7 @@ export const registerSSOProvider = <O extends SSOOptions>(options: O) => {
 								spMetadata: body.samlConfig.spMetadata,
 								wantAssertionsSigned: body.samlConfig.wantAssertionsSigned,
 								authnRequestsSigned: body.samlConfig.authnRequestsSigned,
+								forceAuthn: body.samlConfig.forceAuthn,
 								signatureAlgorithm: body.samlConfig.signatureAlgorithm,
 								digestAlgorithm: body.samlConfig.digestAlgorithm,
 								identifierFormat: body.samlConfig.identifierFormat,
@@ -1386,10 +1394,9 @@ export const signInSSO = (options?: SSOOptions) => {
 						encPrivateKeyPass: idpData.encPrivateKeyPass,
 					});
 				}
-				const loginRequest = sp.createLoginRequest(
-					idp,
-					"redirect",
-				) as BindingContext & {
+				const loginRequest = sp.createLoginRequest(idp, "redirect", {
+					forceAuthn: parsedSamlConfig.forceAuthn,
+				}) as BindingContext & {
 					entityEndpoint: string;
 					type: string;
 					id: string;

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -5,6 +5,7 @@ import {
 	randomUUID,
 } from "node:crypto";
 import type { createServer } from "node:http";
+import { inflateRawSync } from "node:zlib";
 import { betterFetch } from "@better-fetch/fetch";
 import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
@@ -964,6 +965,97 @@ describe("SAML SSO without signed AuthnRequests", async () => {
 		// When authnRequestsSigned is false (default), no Signature should be in the URL
 		expect(signInResponse.url).not.toContain("Signature=");
 		expect(signInResponse.url).not.toContain("SigAlg=");
+	});
+});
+
+describe("SAML SSO with ForceAuthn", async () => {
+	/**
+	 * Decodes the `<samlp:AuthnRequest>` XML carried by an HTTP-Redirect
+	 * binding URL. Per SAML 2.0 Bindings §3.4.4.1 the request is raw-DEFLATE
+	 * compressed then base64-encoded in the `SAMLRequest` query parameter.
+	 */
+	const decodeAuthnRequest = (redirectUrl: string): string => {
+		const samlRequest = new URL(redirectUrl).searchParams.get("SAMLRequest");
+		if (!samlRequest) {
+			throw new Error("redirect URL is missing the SAMLRequest parameter");
+		}
+		return inflateRawSync(Buffer.from(samlRequest, "base64")).toString("utf8");
+	};
+
+	const buildAuth = (forceAuthn?: boolean) => {
+		const data = {
+			user: [],
+			session: [],
+			verification: [],
+			account: [],
+			ssoProvider: [],
+		};
+
+		return betterAuth({
+			database: memoryAdapter(data),
+			baseURL: "http://localhost:3000",
+			emailAndPassword: {
+				enabled: true,
+			},
+			plugins: [
+				sso({
+					defaultSSO: [
+						{
+							domain: "localhost:8081",
+							providerId: "forceauthn-saml",
+							samlConfig: {
+								issuer: "http://localhost:8081",
+								entryPoint: "http://localhost:8081/api/sso/saml2/idp/redirect",
+								cert: certificate,
+								callbackUrl: "http://localhost:8081/dashboard",
+								wantAssertionsSigned: false,
+								// Only set forceAuthn when the test supplies it, so the
+								// unset case exercises the opt-in default.
+								...(forceAuthn === undefined ? {} : { forceAuthn }),
+								idpMetadata: {
+									metadata: idpMetadata,
+								},
+								spMetadata: {
+									metadata: spMetadata,
+								},
+								identifierFormat:
+									"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+							},
+						},
+					],
+				}),
+			],
+		});
+	};
+
+	const signIn = (auth: ReturnType<typeof buildAuth>) =>
+		auth.api.signInSSO({
+			body: {
+				providerId: "forceauthn-saml",
+				callbackURL: "http://localhost:3000/dashboard",
+			},
+		});
+
+	it('emits ForceAuthn="true" when forceAuthn is enabled', async () => {
+		const signInResponse = await signIn(buildAuth(true));
+		const authnRequest = decodeAuthnRequest(signInResponse.url);
+		expect(authnRequest).toContain('ForceAuthn="true"');
+	});
+
+	it("omits ForceAuthn from the AuthnRequest when it is unset (opt-in default)", async () => {
+		const signInResponse = await signIn(buildAuth());
+		const authnRequest = decodeAuthnRequest(signInResponse.url);
+		expect(authnRequest).not.toContain("ForceAuthn");
+	});
+
+	it("never emits ForceAuthn across repeated sign-ins when not opted in", async () => {
+		// A provider that never opted in must never force re-authentication,
+		// even across repeated sign-ins.
+		const auth = buildAuth();
+		const first = decodeAuthnRequest((await signIn(auth)).url);
+		const second = decodeAuthnRequest((await signIn(auth)).url);
+		expect(first).not.toContain("ForceAuthn");
+		expect(second).not.toContain("ForceAuthn");
 	});
 });
 

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -78,6 +78,12 @@ export interface SAMLConfig {
 	};
 	wantAssertionsSigned?: boolean | undefined;
 	authnRequestsSigned?: boolean | undefined;
+	/**
+	 * When `true`, the generated SAML AuthnRequest sets `ForceAuthn="true"`,
+	 * asking the IdP to re-authenticate the user even if they have an existing
+	 * session. Opt-in: when unset, no `ForceAuthn` attribute is emitted.
+	 */
+	forceAuthn?: boolean | undefined;
 	signatureAlgorithm?: string | undefined;
 	digestAlgorithm?: string | undefined;
 	identifierFormat?: string | undefined;


### PR DESCRIPTION
## What

Adds an opt-in `forceAuthn` option to the SAML SSO provider config. When set to `true`, the generated `<samlp:AuthnRequest>` carries `ForceAuthn="true"`, asking the IdP to re-authenticate the user rather than reuse an existing session (SAML 2.0 Core §3.4.1). This is the standard SAML mechanism for forcing conscious re-authentication — e.g. so a stale IdP session on a shared device can't sign a user into the wrong account, or for step-up on sensitive actions. It's the SAML counterpart to OIDC's `prompt=login` / `prompt=select_account`.

## Design: opt-in, no default

`forceAuthn` is **optional and only emitted when explicitly configured**. When unset, no `ForceAuthn` attribute is written at all, so existing SAML logins are completely unchanged. This deliberately avoids defaulting to `true`, which would silently force re-authentication on every SAML login for all users. It mirrors the per-request, opt-in approach of the merged OIDC `additionalParams` work (#9305).

## How

`forceAuthn` is threaded exactly like the existing `authnRequestsSigned` boolean:

- `SAMLConfig` type
- register (`ssoProviderBodySchema`) + update (`samlConfigSchema`) Zod schemas
- register persistence + update merge (`mergeSAMLConfig`)
- sanitized read output (`sanitizeProvider`)

The sign-in handler passes the stored value straight through to samlify:

```ts
sp.createLoginRequest(idp, "redirect", { forceAuthn: parsedSamlConfig.forceAuthn })
```

`samlify` (already a dependency) natively accepts `forceAuthn` in `CreateLoginRequestOptions` and drops the attribute entirely when the value is `undefined`, so the opt-in behaviour falls out for free — no `?? true` fallback.

## Tests

- **AuthnRequest generation** (`saml.test.ts`): decodes the deflated `SAMLRequest` and asserts `ForceAuthn="true"` is present when enabled, and absent when unset (including across repeated sign-ins).
- **Persistence** (`providers.test.ts`): register/update persist `forceAuthn` (both `true` and `false`); unset stays unset; unrelated partial updates preserve the stored value.

`pnpm --filter @better-auth/sso typecheck` and the full `@better-auth/sso` test suite pass locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `forceAuthn` flag to SAML SSO that, when enabled, sends `ForceAuthn="true"` in the AuthnRequest to require the IdP to re-authenticate the user. The default is unchanged behavior (no attribute), so existing flows are unaffected.

- **New Features**
  - Added `forceAuthn?: boolean` to SAML provider config; emits `ForceAuthn="true"` only when set.
  - Wired through `SAMLConfig`, `ssoProviderBodySchema`, `samlConfigSchema`, persistence/merge/sanitize, and passed to `samlify` via `sp.createLoginRequest(..., { forceAuthn })`.
  - Tests cover AuthnRequest generation (present/absent) and persistence across register/update.

- **Migration**
  - No action needed. Disabled by default. Enable per provider by setting `samlConfig.forceAuthn = true`.

<sup>Written for commit c42276cbf378acab6abea0d97b0ceaacc7e5906b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

