### PR TITLE
feat(sso): add transactional OIDC user resolution

### DIFF
--- a/.changeset/schema-preserving-sso-user-resolution.md
+++ b/.changeset/schema-preserving-sso-user-resolution.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/sso": minor
+"@better-auth/core": minor
+"better-auth": minor
+---
+
+Add transactional OIDC user resolution so applications can link verified issuer and subject pairs to exact existing users while preserving or updating the local profile.

--- a/docs/content/docs/plugins/sso.mdx
+++ b/docs/content/docs/plugins/sso.mdx
@@ -346,6 +346,62 @@ If the Identity Provider is misconfigured or unreachable, registration will fail
 * Discovery errors are structured and well-defined
 * Public-client IdPs or mock servers may require overriding `tokenEndpointAuthentication`
 
+### Resolve OIDC Users
+
+Use `resolveUser` when an OIDC identity must be mapped to an existing Better Auth user instead of relying on email matching. The resolver runs on every OIDC sign-in. It is not used for SAML callbacks.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { sso } from "@better-auth/sso";
+import { findProvisionedUserBySubject } from "@/lib/provisioning";
+
+const auth = betterAuth({
+    plugins: [
+        sso({
+            resolveUser: async (input, context) => {
+                if (input.providerId !== "workforce") {
+                    return { action: "continue" };
+                }
+
+                const provisionedUser = await findProvisionedUserBySubject({
+                    providerId: input.providerId,
+                    issuer: input.accountKey.issuer,
+                    subject: input.accountKey.providerAccountId,
+                    database: context.database,
+                });
+
+                if (!provisionedUser) {
+                    return {
+                        action: "reject",
+                        code: "PROVISIONED_USER_NOT_FOUND",
+                    };
+                }
+
+                return {
+                    action: "link",
+                    userId: provisionedUser.userId,
+                    profile: "preserve",
+                };
+            },
+        }),
+    ],
+});
+```
+
+`accountKey.issuer` and `accountKey.providerAccountId` come from the validated ID Token's exact `iss` and `sub` claims. Subject matching is case-sensitive. `providerUser` contains normalized profile fields, while `providerClaims` contains the protocol-accepted raw claims used for that profile. Do not treat every profile field or raw claim as having the same verification guarantees as the issuer and subject; apply any application-specific validation before using them for authorization.
+
+`findProvisionedUserBySubject` is application-owned in this example. It should resolve the exact provider, issuer, and subject tuple through the transaction-scoped `database` adapter. Do not fall back to matching an email address when the exact provisioned subject is absent.
+
+The resolver returns one of three decisions:
+
+* `{ action: "continue" }` continues the normal SSO sign-in behavior.
+* `{ action: "link", userId, profile }` links the exact OIDC account to that user. Use `profile: "preserve"` to keep the local profile or `profile: "update"` to update it from the provider profile.
+* `{ action: "reject", code, message? }` rejects the sign-in with an application-defined error.
+
+The callback receives the active transaction adapter as `context.database`. Keep resolver work database-local and idempotent because a fresh SSO authentication attempt may invoke it again; an already consumed OIDC callback is not replayed. Better Auth requires native database transactions and transaction async-context support before calling the resolver. If secondary storage is configured, set `session.storeSessionInDatabase: true` and leave `session.preserveSessionInDatabase` unset or `false` so the database remains the session fallback.
+
+Database writes made through the transaction adapter during resolution, account linking, profile updates, and database session creation commit or roll back together. Network calls and other external side effects performed by the resolver or database hooks cannot be rolled back. Account and session cookies are published only after commit. Secondary-storage session mirroring and other deferred hooks run after commit; failures are logged without undoing the committed database session or suppressing its cookies.
+
 ### Register a SAML Provider
 
 To register a SAML provider, use the `registerSSOProvider` endpoint with SAML configuration details. The provider will act as a Service Provider (SP) and integrate with your Identity Provider (IdP).

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -750,4 +750,5 @@ export {
 	createSessionStore,
 	getAccountCookie,
 	getChunkedCookie,
+	setAccountCookie,
 } from "./session-store";

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1171,6 +1171,54 @@ describe("internal adapter test", async () => {
 		expect(testMap.has(`active-sessions-${user.id}`)).toBe(false);
 	});
 
+	it("defers secondary session creation until commit and discards it on rollback", async () => {
+		const testMap = new Map<string, string>();
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: createStringSecondaryStorage(testMap),
+			session: { storeSessionInDatabase: true },
+		} satisfies BetterAuthOptions;
+		(await getMigrations(testOpts)).runMigrations();
+		const testCtx = await init(testOpts);
+		const user = await testCtx.internalAdapter.createUser(
+			{
+				name: "deferred-session-user",
+				email: "deferred-session@example.com",
+			},
+			{ method: "test" },
+		);
+
+		const committed = await runWithTransaction(testCtx.adapter, async () => {
+			const session = await testCtx.internalAdapter.createSession(
+				user.id,
+				undefined,
+				undefined,
+				undefined,
+				{ deferSecondaryStorageWrites: true },
+			);
+			expect(testMap.has(session.token)).toBe(false);
+			return session;
+		});
+		expect(testMap.has(committed.token)).toBe(true);
+
+		let rolledBackToken = "";
+		await expect(
+			runWithTransaction(testCtx.adapter, async () => {
+				const session = await testCtx.internalAdapter.createSession(
+					user.id,
+					undefined,
+					undefined,
+					undefined,
+					{ deferSecondaryStorageWrites: true },
+				);
+				rolledBackToken = session.token;
+				expect(testMap.has(session.token)).toBe(false);
+				throw new Error("rollback");
+			}),
+		).rejects.toThrow("rollback");
+		expect(testMap.has(rolledBackToken)).toBe(false);
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/pull/10390#discussion_r3585595438
 	 */

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1220,6 +1220,44 @@ describe("internal adapter test", async () => {
 	});
 
 	/**
+	 * @see https://github.com/better-auth/better-auth/pull/10473#discussion_r3626724281
+	 */
+	it("rejects deferred secondary-only session creation when persistence fails", async () => {
+		const testMap = new Map<string, string>();
+		const secondaryStorage = createStringSecondaryStorage(testMap);
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				...secondaryStorage,
+				set: async () => {
+					throw new Error("secondary storage unavailable");
+				},
+			},
+		} satisfies BetterAuthOptions;
+		(await getMigrations(testOpts)).runMigrations();
+		const testCtx = await init(testOpts);
+		const user = await testCtx.internalAdapter.createUser(
+			{
+				name: "failed-deferred-session-user",
+				email: "failed-deferred-session@example.com",
+			},
+			{ method: "test" },
+		);
+
+		await expect(
+			runWithTransaction(testCtx.adapter, () =>
+				testCtx.internalAdapter.createSession(
+					user.id,
+					undefined,
+					undefined,
+					undefined,
+					{ deferSecondaryStorageWrites: true },
+				),
+			),
+		).rejects.toThrow("secondary storage unavailable");
+	});
+
+	/**
 	 * @see https://github.com/better-auth/better-auth/pull/10390#discussion_r3585595438
 	 */
 	it("preserves sessions created after user session deletion is requested", async () => {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -441,6 +441,9 @@ export const createInternalAdapter = (
 			dontRememberMe?: boolean | undefined,
 			override?: (Partial<Session> & Record<string, any>) | undefined,
 			overrideAll?: boolean | undefined,
+			storageOptions?:
+				| { deferSecondaryStorageWrites?: boolean | undefined }
+				| undefined,
 		) => {
 			const headers: Headers | undefined = await (async () => {
 				const ctx = await getCurrentAuthContext().catch(() => null);
@@ -484,78 +487,84 @@ export const createInternalAdapter = (
 				...defaultAdditionalFields,
 				...(overrideAll ? rest : {}),
 			} satisfies Partial<Session>;
+			const mirrorSessionToSecondaryStorage = async (sessionData: Session) => {
+				if (!secondaryStorage) return sessionData;
+				const currentList = await secondaryStorage.get(
+					`active-sessions-${userId}`,
+				);
+
+				let list: { token: string; expiresAt: number }[] = [];
+				const now = Date.now();
+				if (currentList) {
+					list = safeJSONParse(currentList) || [];
+					list = list.filter(
+						(session) =>
+							session.expiresAt > now && session.token !== data.token,
+					);
+				}
+
+				const sorted = [
+					...list,
+					{ token: data.token, expiresAt: data.expiresAt.getTime() },
+				].sort((a, b) => a.expiresAt - b.expiresAt);
+				const furthestSessionExp =
+					sorted.at(-1)?.expiresAt ?? data.expiresAt.getTime();
+				const furthestSessionTTL = getTTLSeconds(furthestSessionExp, now);
+				if (furthestSessionTTL > 0) {
+					await secondaryStorage.set(
+						`active-sessions-${userId}`,
+						JSON.stringify(sorted),
+						furthestSessionTTL,
+					);
+				}
+
+				const user = await (await getCurrentAdapter(adapter)).findOne<User>({
+					model: "user",
+					where: [{ field: "id", value: userId }],
+				});
+				const sessionTTL = getTTLSeconds(data.expiresAt, now);
+				if (sessionTTL > 0) {
+					await secondaryStorage.set(
+						data.token,
+						JSON.stringify({ session: sessionData, user }),
+						sessionTTL,
+					);
+				}
+				return sessionData;
+			};
 			const res = await createWithHooks(
 				data,
 				"session",
 				secondaryStorage
 					? {
 							fn: async (sessionData) => {
-								/**
-								 * store the session token for the user
-								 * so we can retrieve it later for listing sessions
-								 */
-								const currentList = await secondaryStorage.get(
-									`active-sessions-${userId}`,
-								);
-
-								let list: { token: string; expiresAt: number }[] = [];
-								const now = Date.now();
-
-								if (currentList) {
-									list = safeJSONParse(currentList) || [];
-									list = list.filter(
-										(session) =>
-											session.expiresAt > now && session.token !== data.token,
-									);
-								}
-
-								const sorted = [
-									...list,
-									{ token: data.token, expiresAt: data.expiresAt.getTime() },
-								].sort((a, b) => a.expiresAt - b.expiresAt);
-								const furthestSessionExp =
-									sorted.at(-1)?.expiresAt ?? data.expiresAt.getTime();
-								const furthestSessionTTL = getTTLSeconds(
-									furthestSessionExp,
-									now,
-								);
-								if (furthestSessionTTL > 0) {
-									await secondaryStorage.set(
-										`active-sessions-${userId}`,
-										JSON.stringify(sorted),
-										furthestSessionTTL,
-									);
-								}
-
-								const user = await (
-									await getCurrentAdapter(adapter)
-								).findOne<User>({
-									model: "user",
-									where: [
-										{
-											field: "id",
-											value: userId,
-										},
-									],
-								});
-								const sessionTTL = getTTLSeconds(data.expiresAt, now);
-								if (sessionTTL > 0) {
-									await secondaryStorage.set(
-										data.token,
-										JSON.stringify({
-											session: sessionData,
-											user,
-										}),
-										sessionTTL,
-									);
-								}
-
-								return sessionData;
+								return storageOptions?.deferSecondaryStorageWrites
+									? sessionData
+									: mirrorSessionToSecondaryStorage(sessionData as Session);
 							},
 							executeMainFn: storeInDb,
 						}
 					: undefined,
 			);
+			if (
+				secondaryStorage &&
+				storageOptions?.deferSecondaryStorageWrites &&
+				res
+			) {
+				await queueAfterTransactionHook(
+					async () => {
+						await mirrorSessionToSecondaryStorage(res as Session);
+					},
+					{
+						onError(error) {
+							logger.error(
+								"Failed to mirror committed session to secondary storage",
+								error,
+							);
+						},
+					},
+				);
+			}
 			return res as Session;
 		},
 		findSession: async (

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -450,6 +450,9 @@ export const createInternalAdapter = (
 				return ctx?.headers || ctx?.request?.headers;
 			})();
 			const storeInDb = options.session?.storeSessionInDatabase;
+			const databaseSessionFallbackEnabled =
+				storeInDb === true &&
+				options.session?.preserveSessionInDatabase !== true;
 			const {
 				// always ignore override id - new sessions must have new ids
 				id: _,
@@ -555,14 +558,16 @@ export const createInternalAdapter = (
 					async () => {
 						await mirrorSessionToSecondaryStorage(res as Session);
 					},
-					{
-						onError(error) {
-							logger.error(
-								"Failed to mirror committed session to secondary storage",
-								error,
-							);
-						},
-					},
+					databaseSessionFallbackEnabled
+						? {
+								onError(error: unknown) {
+									logger.error(
+										"Failed to mirror committed session to secondary storage",
+										error,
+									);
+								},
+							}
+						: undefined,
 				);
 			}
 			return res as Session;

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -2,7 +2,10 @@ import type {
 	GenericEndpointContext,
 	UserProvisioningSource,
 } from "@better-auth/core";
-import { runWithTransaction } from "@better-auth/core/context";
+import {
+	queueAfterTransactionHook,
+	runWithTransaction,
+} from "@better-auth/core/context";
 import { isDevelopment } from "@better-auth/core/env";
 import { APIError } from "@better-auth/core/error";
 import { createEmailVerificationToken } from "../api";
@@ -478,12 +481,22 @@ export async function handleOAuthUserInfo(
 		(c.context.options.emailVerification?.sendOnSignUp ??
 			requireEmailVerification)
 	) {
-		await dispatchVerificationEmail(c, user, callbackURL);
+		await dispatchVerificationEmail(
+			c,
+			user,
+			callbackURL,
+			opts.deferNonDatabaseWrites,
+		);
 	}
 
 	if (requireEmailVerification && !user.emailVerified) {
 		if (!isRegister && c.context.options.emailVerification?.sendOnSignIn) {
-			await dispatchVerificationEmail(c, user, callbackURL);
+			await dispatchVerificationEmail(
+				c,
+				user,
+				callbackURL,
+				opts.deferNonDatabaseWrites,
+			);
 		}
 		return {
 			error: OAUTH_CALLBACK_ERROR_CODES.EMAIL_NOT_VERIFIED,
@@ -531,34 +544,42 @@ async function dispatchVerificationEmail(
 	c: GenericEndpointContext,
 	user: User,
 	callbackURL: string | undefined,
+	deferUntilAfterTransaction?: boolean | undefined,
 ) {
 	const sendVerificationEmail =
 		c.context.options.emailVerification?.sendVerificationEmail;
 	if (!sendVerificationEmail) {
 		return;
 	}
-	try {
-		const token = await createEmailVerificationToken(
-			c.context.secret,
-			user.email,
-			undefined,
-			c.context.options.emailVerification?.expiresIn,
-		);
-		const url = `${c.context.baseURL}/verify-email?token=${token}&callbackURL=${encodeURIComponent(
-			callbackURL || "/",
-		)}`;
-		await c.context.runInBackgroundOrAwait(
-			sendVerificationEmail(
-				{
-					user,
-					url,
-					token,
-				},
-				c.request,
-			),
-		);
-	} catch (e) {
-		c.context.logger.error("Failed to send OAuth verification email", e);
+	const send = async () => {
+		try {
+			const token = await createEmailVerificationToken(
+				c.context.secret,
+				user.email,
+				undefined,
+				c.context.options.emailVerification?.expiresIn,
+			);
+			const url = `${c.context.baseURL}/verify-email?token=${token}&callbackURL=${encodeURIComponent(
+				callbackURL || "/",
+			)}`;
+			await c.context.runInBackgroundOrAwait(
+				sendVerificationEmail(
+					{
+						user,
+						url,
+						token,
+					},
+					c.request,
+				),
+			);
+		} catch (e) {
+			c.context.logger.error("Failed to send OAuth verification email", e);
+		}
+	};
+	if (deferUntilAfterTransaction) {
+		await queueAfterTransactionHook(send);
+	} else {
+		await send();
 	}
 }
 

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -4,6 +4,7 @@ import type {
 } from "@better-auth/core";
 import { runWithTransaction } from "@better-auth/core/context";
 import { isDevelopment } from "@better-auth/core/env";
+import { APIError } from "@better-auth/core/error";
 import { createEmailVerificationToken } from "../api";
 import { setAccountCookie } from "../cookies/session-store";
 import { parseAdditionalUserInputFromProviderProfile } from "../db";
@@ -27,6 +28,14 @@ export async function handleOAuthUserInfo(
 		isTrustedProvider?: boolean | undefined;
 		trustProviderByName?: boolean | undefined;
 		source?: UserProvisioningSource | undefined;
+		selectedUser?:
+			| {
+					userId: string;
+					profile: "preserve" | "update";
+			  }
+			| undefined;
+		deferNonDatabaseWrites?: boolean | undefined;
+		requireExactAccountBinding?: boolean | undefined;
 	},
 ) {
 	const { userInfo, account, callbackURL, disableSignUp, overrideUserInfo } =
@@ -35,6 +44,9 @@ export async function handleOAuthUserInfo(
 		method: "oauth",
 		oauth: { providerId: account.providerId },
 	};
+	const requireExactAccountBinding =
+		!!opts.selectedUser || opts.requireExactAccountBinding === true;
+	let pendingAccountCookie: Account | null = null;
 	const accountOwner = await c.context.internalAdapter
 		.findAccountOwnerByKey({
 			issuer: account.issuer,
@@ -61,10 +73,44 @@ export async function handleOAuthUserInfo(
 	}
 	const dbUser = await (async () => {
 		if (accountOwner?.kind === "owned") {
+			if (
+				opts.selectedUser &&
+				accountOwner.user.id !== opts.selectedUser.userId
+			) {
+				throw new APIError("CONFLICT", {
+					code: "account_ownership_conflict",
+					message: "Account is already linked to another user",
+				});
+			}
+			if (
+				requireExactAccountBinding &&
+				accountOwner.account.providerId !== account.providerId
+			) {
+				throw new APIError("CONFLICT", {
+					code: "account_provider_conflict",
+					message: "Account is already linked through another provider",
+				});
+			}
 			return {
 				user: accountOwner.user,
 				linkedAccount: accountOwner.account,
 				accounts: [accountOwner.account],
+			};
+		}
+		if (opts.selectedUser) {
+			const selectedUser = await c.context.internalAdapter.findUserById(
+				opts.selectedUser.userId,
+			);
+			if (!selectedUser) {
+				throw new APIError("NOT_FOUND", {
+					code: "user_not_found",
+					message: "User not found",
+				});
+			}
+			return {
+				user: selectedUser,
+				linkedAccount: null,
+				accounts: [],
 			};
 		}
 
@@ -79,6 +125,7 @@ export async function handleOAuthUserInfo(
 			accounts: emailMatch.accounts,
 		};
 	})().catch((e) => {
+		if (isAPIError(e)) throw e;
 		c.context.logger.error(
 			"Better auth was unable to query your database.\nError: ",
 			e,
@@ -109,10 +156,11 @@ export async function handleOAuthUserInfo(
 			const requireLocalEmailVerified =
 				accountLinking?.requireLocalEmailVerified ?? true;
 			if (
-				(!isTrustedProvider && !userInfo.emailVerified) ||
-				(requireLocalEmailVerified && !dbUser.user.emailVerified) ||
-				accountLinking?.enabled === false ||
-				accountLinking?.disableImplicitLinking === true
+				!opts.selectedUser &&
+				((!isTrustedProvider && !userInfo.emailVerified) ||
+					(requireLocalEmailVerified && !dbUser.user.emailVerified) ||
+					accountLinking?.enabled === false ||
+					accountLinking?.disableImplicitLinking === true)
 			) {
 				if (isDevelopment()) {
 					c.context.logger.warn(
@@ -134,7 +182,7 @@ export async function handleOAuthUserInfo(
 					},
 					source: { ...source, action: "link-account" },
 				});
-				await c.context.internalAdapter.linkAccount({
+				const createdAccount = await c.context.internalAdapter.linkAccount({
 					providerId: account.providerId,
 					issuer: account.issuer,
 					providerAccountId: account.providerAccountId,
@@ -146,6 +194,29 @@ export async function handleOAuthUserInfo(
 					refreshTokenExpiresAt: account.refreshTokenExpiresAt,
 					scope: account.scope,
 				});
+				if (!createdAccount) {
+					return {
+						error: "unable to link account",
+						data: null,
+					};
+				}
+				if (
+					requireExactAccountBinding &&
+					(createdAccount.issuer !== account.issuer ||
+						createdAccount.providerAccountId !== account.providerAccountId ||
+						createdAccount.providerId !== account.providerId ||
+						createdAccount.userId !== dbUser.user.id)
+				) {
+					throw new APIError("CONFLICT", {
+						code: "account_hook_binding_conflict",
+						message: "Account hook changed the selected authentication binding",
+					});
+				}
+				if (c.context.options.account?.storeAccountCookie) {
+					if (opts.deferNonDatabaseWrites)
+						pendingAccountCookie = createdAccount;
+					else await setAccountCookie(c, createdAccount);
+				}
 			} catch (e) {
 				if (isAPIError(e)) {
 					throw e;
@@ -162,6 +233,7 @@ export async function handleOAuthUserInfo(
 			// promoted to the local row so subsequent flows treat it as verified.
 			// FIXME(next-minor): unreachable once the gate becomes unconditional.
 			if (
+				!opts.selectedUser &&
 				userInfo.emailVerified &&
 				!dbUser.user.emailVerified &&
 				userInfo.email.toLowerCase() === dbUser.user.email
@@ -171,8 +243,11 @@ export async function handleOAuthUserInfo(
 				});
 			}
 
-			user =
-				(await applyUpdateUserInfoOnLink(c, dbUser.user.id, userInfo)) ?? user;
+			if (!opts.selectedUser) {
+				user =
+					(await applyUpdateUserInfoOnLink(c, dbUser.user.id, userInfo)) ??
+					user;
+			}
 		} else {
 			const { id: _providerAccountId, ...providerUserInfo } = userInfo;
 			await assertValidUserInfo(c, {
@@ -207,20 +282,44 @@ export async function handleOAuthUserInfo(
 					: {};
 
 			if (c.context.options.account?.storeAccountCookie) {
-				await setAccountCookie(c, {
+				const accountCookie = {
 					...linkedAccount,
 					...freshTokens,
-				});
+				};
+				if (opts.deferNonDatabaseWrites) pendingAccountCookie = accountCookie;
+				else await setAccountCookie(c, accountCookie);
 			}
 
 			if (Object.keys(freshTokens).length > 0) {
-				await c.context.internalAdapter.updateAccount(
+				const updatedAccount = await c.context.internalAdapter.updateAccount(
 					linkedAccount.id,
 					freshTokens,
 				);
+				if (!updatedAccount) {
+					return {
+						error: "unable to update account",
+						data: null,
+					};
+				}
+				if (
+					requireExactAccountBinding &&
+					(updatedAccount.issuer !== account.issuer ||
+						updatedAccount.providerAccountId !== account.providerAccountId ||
+						updatedAccount.providerId !== account.providerId ||
+						updatedAccount.userId !== dbUser.user.id)
+				) {
+					throw new APIError("CONFLICT", {
+						code: "account_hook_binding_conflict",
+						message: "Account hook changed the selected authentication binding",
+					});
+				}
+				if (opts.deferNonDatabaseWrites && pendingAccountCookie) {
+					pendingAccountCookie = updatedAccount;
+				}
 			}
 
 			if (
+				!opts.selectedUser &&
 				userInfo.emailVerified &&
 				!dbUser.user.emailVerified &&
 				userInfo.email.toLowerCase() === dbUser.user.email
@@ -230,7 +329,11 @@ export async function handleOAuthUserInfo(
 				});
 			}
 		}
-		if (overrideUserInfo) {
+		if (
+			opts.selectedUser
+				? opts.selectedUser.profile === "update"
+				: overrideUserInfo
+		) {
 			const {
 				id: _id,
 				email: _email,
@@ -262,6 +365,16 @@ export async function handleOAuthUserInfo(
 				c.context.logger.warn(
 					"Could not update user info during OAuth sign in; preserving existing user for session.",
 				);
+			}
+			if (
+				opts.selectedUser &&
+				updatedUser &&
+				updatedUser.id !== opts.selectedUser.userId
+			) {
+				throw new APIError("CONFLICT", {
+					code: "user_hook_selection_conflict",
+					message: "User hook changed the selected user",
+				});
 			}
 			user = updatedUser ?? user;
 		}
@@ -318,9 +431,22 @@ export async function handleOAuthUserInfo(
 					return { createdUser, createdAccount };
 				},
 			);
+			if (
+				requireExactAccountBinding &&
+				(createdAccount.issuer !== account.issuer ||
+					createdAccount.providerAccountId !== account.providerAccountId ||
+					createdAccount.providerId !== account.providerId ||
+					createdAccount.userId !== createdUser.id)
+			) {
+				throw new APIError("CONFLICT", {
+					code: "account_hook_binding_conflict",
+					message: "Account hook changed the selected authentication binding",
+				});
+			}
 			user = createdUser;
 			if (c.context.options.account?.storeAccountCookie) {
-				await setAccountCookie(c, createdAccount);
+				if (opts.deferNonDatabaseWrites) pendingAccountCookie = createdAccount;
+				else await setAccountCookie(c, createdAccount);
 			}
 		} catch (e) {
 			if (isAPIError(e)) {
@@ -366,13 +492,28 @@ export async function handleOAuthUserInfo(
 		};
 	}
 
-	const session = await c.context.internalAdapter.createSession(user.id);
+	const session = await c.context.internalAdapter.createSession(
+		user.id,
+		undefined,
+		undefined,
+		undefined,
+		{ deferSecondaryStorageWrites: opts.deferNonDatabaseWrites === true },
+	);
 	if (!session) {
 		return {
 			error: "unable to create session",
 			data: null,
 			isRegister: false,
 		};
+	}
+	if (
+		requireExactAccountBinding &&
+		session.userId !== (opts.selectedUser?.userId ?? user.id)
+	) {
+		throw new APIError("CONFLICT", {
+			code: "session_hook_user_conflict",
+			message: "Session hook changed the selected user",
+		});
 	}
 
 	return {
@@ -382,6 +523,7 @@ export async function handleOAuthUserInfo(
 		},
 		error: null,
 		isRegister,
+		accountCookie: pendingAccountCookie,
 	};
 }
 

--- a/packages/core/src/context/transaction.test.ts
+++ b/packages/core/src/context/transaction.test.ts
@@ -136,6 +136,47 @@ describe("runWithTransaction", () => {
 		);
 	});
 
+	it("reports unhandled after-commit failures and continues later committed hooks", async () => {
+		const { adapter } = createTransactionHarness();
+		const onAfterCommitHookError = vi.fn(() => {
+			throw new Error("custom logger failed");
+		});
+		const events: string[] = [];
+
+		await expect(
+			runWithTransaction(
+				adapter,
+				async () => {
+					await queueAfterTransactionHook(async () => {
+						throw new Error("account after-hook failed");
+					});
+					await queueAfterTransactionHook(async () => {
+						events.push("later hook");
+					});
+					return "committed";
+				},
+				{ onAfterCommitHookError },
+			),
+		).resolves.toBe("committed");
+		expect(onAfterCommitHookError).toHaveBeenCalledWith(
+			expect.objectContaining({ message: "account after-hook failed" }),
+		);
+		expect(events).toEqual(["later hook"]);
+	});
+
+	it("keeps legacy after-commit failures rejecting when no handler is provided", async () => {
+		const { adapter } = createTransactionHarness();
+
+		await expect(
+			runWithTransaction(adapter, async () => {
+				await queueAfterTransactionHook(async () => {
+					throw new Error("legacy hook failure");
+				});
+				return "committed";
+			}),
+		).rejects.toThrow("legacy hook failure");
+	});
+
 	it("does not retry an immediately executed hook when it fails", async () => {
 		const hook = vi.fn(async () => {
 			throw new Error("hook failed");

--- a/packages/core/src/context/transaction.ts
+++ b/packages/core/src/context/transaction.ts
@@ -100,6 +100,9 @@ export const runWithTransaction = async <
 >(
 	adapter: DBAdapter<Options>,
 	fn: () => R,
+	options?: {
+		onAfterCommitHookError?: (error: unknown) => void | Promise<void>;
+	},
 ): Promise<R> => {
 	let called = false;
 	return ensureAsyncStorage()
@@ -132,7 +135,16 @@ export const runWithTransaction = async <
 				throw error;
 			}
 			for (const hook of pendingHooks) {
-				await hook();
+				try {
+					await hook();
+				} catch (error) {
+					if (!options?.onAfterCommitHookError) throw error;
+					try {
+						await options.onAfterCommitHookError(error);
+					} catch {
+						// Reporting cannot roll back committed work or suppress later hooks.
+					}
+				}
 			}
 			return result!;
 		})

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -133,6 +133,9 @@ export interface InternalAdapter<
 		dontRememberMe?: boolean | undefined,
 		override?: (Partial<Session> & Record<string, any>) | undefined,
 		overrideAll?: boolean | undefined,
+		storageOptions?:
+			| { deferSecondaryStorageWrites?: boolean | undefined }
+			| undefined,
 	): Promise<Session>;
 
 	findSession(token: string): Promise<{

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -73,12 +73,14 @@
   },
   "devDependencies": {
     "@better-auth/core": "workspace:*",
+    "@better-auth/kysely-adapter": "workspace:*",
     "@types/body-parser": "^1.19.6",
     "@types/express": "^5.0.6",
     "better-auth": "workspace:*",
     "better-call": "catalog:",
     "body-parser": "^2.2.2",
     "express": "^5.2.1",
+    "kysely": "catalog:",
     "oauth2-mock-server": "^9.0.0",
     "tsdown": "catalog:"
   },

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -52,6 +52,10 @@ import type {
 	SSOOptions,
 	SSOProvider,
 	SSOProviderSchema,
+	SSOProviderUserProfile,
+	SSOUserResolution,
+	SSOUserResolutionContext,
+	SSOUserResolutionInput,
 } from "./types";
 import { PACKAGE_VERSION } from "./version";
 
@@ -61,6 +65,10 @@ export type {
 	SAMLIdentityProviderMetadata,
 	SSOOptions,
 	SSOProvider,
+	SSOProviderUserProfile,
+	SSOUserResolution,
+	SSOUserResolutionContext,
+	SSOUserResolutionInput,
 };
 
 declare module "@better-auth/core" {

--- a/packages/sso/src/oidc-user-resolution-http-e2e.test.ts
+++ b/packages/sso/src/oidc-user-resolution-http-e2e.test.ts
@@ -53,6 +53,7 @@ describe("SSO OIDC user resolution HTTP", () => {
 	const identityProvider = new OAuth2Server();
 	let subject = "directory-user-1";
 	let email = "idp.employee@example.com";
+	let emailVerified = true;
 	let userInfoSubject: string | undefined;
 	let omitIdToken = false;
 	let beforeTokenSigning: (() => void) | undefined;
@@ -65,7 +66,7 @@ describe("SSO OIDC user resolution HTTP", () => {
 				sub: userInfoSubject ?? subject,
 				email,
 				name: "Directory Employee",
-				email_verified: true,
+				email_verified: emailVerified,
 			};
 			response.statusCode = 200;
 		});
@@ -74,7 +75,7 @@ describe("SSO OIDC user resolution HTTP", () => {
 			token.payload.sub = subject;
 			token.payload.email = email;
 			token.payload.name = "Directory Employee";
-			token.payload.email_verified = true;
+			token.payload.email_verified = emailVerified;
 		});
 		identityProvider.service.on("beforeResponse", (response) => {
 			if (omitIdToken) response.body.id_token = undefined;
@@ -91,6 +92,7 @@ describe("SSO OIDC user resolution HTTP", () => {
 			await cleanup();
 		}
 		userInfoSubject = undefined;
+		emailVerified = true;
 		omitIdToken = false;
 		beforeTokenSigning = undefined;
 	});
@@ -444,12 +446,18 @@ describe("SSO OIDC user resolution HTTP", () => {
 		expect(await instance.db.count({ model: "session", where: [] })).toBe(0);
 	});
 
-	it("rolls back resolver and authentication writes without publishing cookies", async ({
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/10473#discussion_r3629488656
+	 */
+	it("rolls back resolver and authentication writes without publishing side effects", async ({
 		onTestFinished,
 	}) => {
 		subject = "rollback-user";
 		email = "rollback@example.com";
+		emailVerified = false;
 		let markerUserId = "";
+		let rejectSessionCreation = true;
+		const sendVerificationEmail = vi.fn();
 		const instance = await createInstance(
 			{
 				resolveUser: async (_input, context) => {
@@ -464,8 +472,16 @@ describe("SSO OIDC user resolution HTTP", () => {
 			onTestFinished,
 			{
 				account: { storeAccountCookie: true },
+				emailVerification: {
+					sendOnSignUp: true,
+					sendVerificationEmail,
+				},
 				databaseHooks: {
-					session: { create: { before: () => false } },
+					session: {
+						create: {
+							before: () => (rejectSessionCreation ? false : undefined),
+						},
+					},
 				},
 			},
 		);
@@ -497,12 +513,20 @@ describe("SSO OIDC user resolution HTTP", () => {
 		);
 		expect(await instance.db.count({ model: "account", where: [] })).toBe(0);
 		expect(await instance.db.count({ model: "session", where: [] })).toBe(0);
+		expect(sendVerificationEmail).not.toHaveBeenCalled();
 		expect(
 			await instance.db.findOne<User>({
 				model: "user",
 				where: [{ field: "id", value: marker.id }],
 			}),
 		).toMatchObject({ name: "marker" });
+
+		rejectSessionCreation = false;
+		const committedSignIn = await completeSignIn(instance.baseURL);
+		expect(committedSignIn.callback.headers.get("location")).toBe(
+			`${instance.baseURL}/employee`,
+		);
+		expect(sendVerificationEmail).toHaveBeenCalledTimes(1);
 	});
 
 	it("rejects another provider alias for an existing subject even on default resolution", async ({

--- a/packages/sso/src/oidc-user-resolution-http-e2e.test.ts
+++ b/packages/sso/src/oidc-user-resolution-http-e2e.test.ts
@@ -1,0 +1,803 @@
+import { DatabaseSync } from "node:sqlite";
+import { NodeSqliteDialect } from "@better-auth/kysely-adapter/node-sqlite-dialect";
+import type { Account, DBTransactionAdapter, User } from "better-auth";
+import { getHttpTestInstance } from "better-auth/test";
+import { Kysely } from "kysely";
+import { OAuth2Server } from "oauth2-mock-server";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+import { getMigrations } from "../../better-auth/src/db/get-migration";
+import { sso } from ".";
+import type { SSOOptions, SSOUserResolutionInput } from "./types";
+
+type CookieJar = Map<string, string>;
+
+function storeResponseCookies(response: Response, cookies: CookieJar): void {
+	for (const setCookie of response.headers.getSetCookie()) {
+		const separatorIndex = setCookie.indexOf(";");
+		const cookie =
+			separatorIndex < 0 ? setCookie : setCookie.slice(0, separatorIndex);
+		const separator = cookie.indexOf("=");
+		if (separator < 1) continue;
+		const name = cookie.slice(0, separator);
+		const value = cookie.slice(separator + 1);
+		if (value) cookies.set(name, value);
+		else cookies.delete(name);
+	}
+}
+
+function cookieHeader(cookies: CookieJar): string {
+	return [...cookies].map(([name, value]) => `${name}=${value}`).join("; ");
+}
+
+async function fetchJSON<T>(
+	url: string,
+	init: RequestInit,
+	cookies?: CookieJar,
+): Promise<{ response: Response; body: T }> {
+	const headers = new Headers(init.headers);
+	if (cookies?.size) headers.set("cookie", cookieHeader(cookies));
+	const response = await fetch(url, { ...init, headers });
+	if (cookies) storeResponseCookies(response, cookies);
+	return { response, body: (await response.json()) as T };
+}
+
+describe("SSO OIDC user resolution HTTP", () => {
+	const identityProvider = new OAuth2Server();
+	let subject = "directory-user-1";
+	let email = "idp.employee@example.com";
+	let userInfoSubject: string | undefined;
+	let omitIdToken = false;
+	let beforeTokenSigning: (() => void) | undefined;
+	const deferredCleanups: Array<() => Promise<void>> = [];
+
+	beforeAll(async () => {
+		await identityProvider.issuer.keys.generate("RS256");
+		identityProvider.service.on("beforeUserinfo", (response) => {
+			response.body = {
+				sub: userInfoSubject ?? subject,
+				email,
+				name: "Directory Employee",
+				email_verified: true,
+			};
+			response.statusCode = 200;
+		});
+		identityProvider.service.on("beforeTokenSigning", (token) => {
+			beforeTokenSigning?.();
+			token.payload.sub = subject;
+			token.payload.email = email;
+			token.payload.name = "Directory Employee";
+			token.payload.email_verified = true;
+		});
+		identityProvider.service.on("beforeResponse", (response) => {
+			if (omitIdToken) response.body.id_token = undefined;
+		});
+		await identityProvider.start(undefined, "127.0.0.1");
+	});
+
+	afterAll(async () => {
+		await identityProvider.stop();
+	});
+
+	afterEach(async () => {
+		for (const cleanup of deferredCleanups.splice(0).reverse()) {
+			await cleanup();
+		}
+		userInfoSubject = undefined;
+		omitIdToken = false;
+		beforeTokenSigning = undefined;
+	});
+
+	function provider(providerId = "workforce") {
+		return {
+			domain: "example.com",
+			providerId,
+			oidcConfig: {
+				issuer: identityProvider.issuer.url!,
+				clientId: "workforce-client",
+				clientSecret: "workforce-secret",
+				pkce: false,
+				discoveryEndpoint: `${identityProvider.issuer.url}/.well-known/openid-configuration`,
+			},
+		} satisfies NonNullable<SSOOptions["defaultSSO"]>[number];
+	}
+
+	async function createInstance(
+		options: Omit<SSOOptions, "defaultSSO">,
+		registerCleanup: (cleanup: () => Promise<void>) => void,
+		authOptions: Record<string, unknown> = {},
+		providers = [provider()],
+	) {
+		const sqlite = new DatabaseSync(":memory:");
+		const db = new Kysely({
+			dialect: new NodeSqliteDialect({ database: sqlite }),
+		});
+		const instance = await getHttpTestInstance(
+			{
+				...authOptions,
+				database: {
+					db,
+					type: "sqlite",
+					transaction: true,
+				},
+				plugins: [sso({ ...options, defaultSSO: providers })],
+				trustedOrigins: [identityProvider.issuer.url!],
+			},
+			{ disableTestUser: true, testWith: "sqlite" },
+		);
+		const migrations = await getMigrations(instance.auth.options);
+		await migrations.runMigrations();
+		registerCleanup(async () => {
+			await db.destroy();
+		});
+		registerCleanup(() => instance.server.close());
+		return Object.assign(instance, { sqlite });
+	}
+
+	async function completeSignIn(baseURL: string, providerId = "workforce") {
+		const cookies: CookieJar = new Map();
+		const signIn = await fetchJSON<{ url: string }>(
+			`${baseURL}/api/auth/sign-in/sso`,
+			{
+				method: "POST",
+				headers: { "content-type": "application/json", origin: baseURL },
+				body: JSON.stringify({
+					providerId,
+					callbackURL: `${baseURL}/employee`,
+				}),
+			},
+			cookies,
+		);
+		expect(signIn.response.status).toBe(200);
+		const authorization = await fetch(signIn.body.url, { redirect: "manual" });
+		const callbackURL = authorization.headers.get("location");
+		if (!callbackURL)
+			throw new Error("OIDC provider did not return a callback");
+		const callback = await fetch(callbackURL, {
+			headers: { cookie: cookieHeader(cookies) },
+			redirect: "manual",
+		});
+		storeResponseCookies(callback, cookies);
+		return { callback, cookies };
+	}
+
+	it("links the exact selected user without email fallback and resolves returning sign-ins", async ({
+		onTestFinished,
+	}) => {
+		subject = "directory-user-1";
+		email = "distinct-provider@example.com";
+		const firstProviderEmail = email;
+		let selectedUserId = "";
+		const inputs: SSOUserResolutionInput[] = [];
+		const databases: DBTransactionAdapter[] = [];
+		const validationActions: string[] = [];
+		const instance = await createInstance(
+			{
+				disableImplicitSignUp: true,
+				resolveUser(input, context) {
+					inputs.push(input);
+					databases.push(context.database);
+					return {
+						action: "link",
+						userId: selectedUserId,
+						profile: "preserve",
+					};
+				},
+			},
+			onTestFinished,
+			{
+				account: { storeAccountCookie: true },
+				user: {
+					validateUserInfo({ source }: { source: { action: string } }) {
+						validationActions.push(source.action);
+					},
+				},
+				databaseHooks: {
+					account: {
+						create: {
+							after() {
+								throw new Error("committed account after-hook failure");
+							},
+						},
+					},
+				},
+			},
+		);
+		const context = await instance.auth.$context;
+		const selectedUser = await context.adapter.create<User>({
+			model: "user",
+			data: {
+				email: "provisioned@example.com",
+				emailVerified: false,
+				name: "Provisioned Employee",
+				image: "https://directory.example/avatar.png",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		selectedUserId = selectedUser.id;
+
+		const first = await completeSignIn(instance.baseURL);
+		expect(first.callback.headers.get("location")).toBe(
+			`${instance.baseURL}/employee`,
+		);
+		expect(first.callback.headers.getSetCookie().join(";")).toContain(
+			"account_data=",
+		);
+		expect(first.callback.headers.getSetCookie().join(";")).toContain(
+			"session_token=",
+		);
+		email = "changed-by-provider@example.com";
+		await completeSignIn(instance.baseURL);
+
+		expect(inputs).toHaveLength(2);
+		expect(inputs[0]).toMatchObject({
+			protocol: "oidc",
+			providerId: "workforce",
+			accountKey: {
+				issuer: identityProvider.issuer.url,
+				providerAccountId: subject,
+			},
+			providerUser: { email: firstProviderEmail },
+			providerClaims: { sub: subject },
+		});
+		expect(databases).toHaveLength(2);
+		expect(validationActions).toEqual(["link-account", "sign-in"]);
+		const users = await instance.db.findMany<User>({
+			model: "user",
+			where: [],
+		});
+		expect(users).toHaveLength(1);
+		expect(users[0]).toMatchObject({
+			id: selectedUser.id,
+			email: "provisioned@example.com",
+			emailVerified: false,
+			name: "Provisioned Employee",
+			image: "https://directory.example/avatar.png",
+		});
+		const accounts = await instance.db.findMany<Account>({
+			model: "account",
+			where: [],
+		});
+		expect(accounts).toHaveLength(1);
+		expect(accounts[0]).toMatchObject({
+			issuer: identityProvider.issuer.url,
+			providerAccountId: subject,
+			providerId: "workforce",
+			userId: selectedUser.id,
+		});
+	});
+
+	it("preserves an unverified selected profile on a same-email first link", async ({
+		onTestFinished,
+	}) => {
+		subject = "preserved-profile-user";
+		email = "same-email@example.com";
+		let selectedUserId = "";
+		const instance = await createInstance(
+			{
+				resolveUser: () => ({
+					action: "link",
+					userId: selectedUserId,
+					profile: "preserve",
+				}),
+			},
+			onTestFinished,
+		);
+		const context = await instance.auth.$context;
+		const selectedUser = await context.adapter.create<User>({
+			model: "user",
+			data: {
+				email,
+				emailVerified: false,
+				name: "SCIM Name",
+				image: "https://directory.example/scim.png",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		selectedUserId = selectedUser.id;
+
+		expect(
+			(await completeSignIn(instance.baseURL)).callback.headers.get("location"),
+		).toBe(`${instance.baseURL}/employee`);
+		expect(
+			await instance.db.findOne<User>({
+				model: "user",
+				where: [{ field: "id", value: selectedUser.id }],
+			}),
+		).toMatchObject({
+			email,
+			emailVerified: false,
+			name: "SCIM Name",
+			image: "https://directory.example/scim.png",
+		});
+	});
+
+	it("updates an explicitly selected user from the provider profile", async ({
+		onTestFinished,
+	}) => {
+		subject = "provider-profile-user";
+		email = "provider-profile@example.com";
+		let selectedUserId = "";
+		const instance = await createInstance(
+			{
+				resolveUser: () => ({
+					action: "link",
+					userId: selectedUserId,
+					profile: "update",
+				}),
+			},
+			onTestFinished,
+		);
+		const context = await instance.auth.$context;
+		const selected = await context.adapter.create<User>({
+			model: "user",
+			data: {
+				email: "old-profile@example.com",
+				emailVerified: false,
+				name: "Old Profile",
+				image: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		selectedUserId = selected.id;
+
+		expect(
+			(await completeSignIn(instance.baseURL)).callback.headers.get("location"),
+		).toBe(`${instance.baseURL}/employee`);
+		expect(
+			await instance.db.findOne<User>({
+				model: "user",
+				where: [{ field: "id", value: selected.id }],
+			}),
+		).toMatchObject({
+			email,
+			emailVerified: false,
+			name: "Directory Employee",
+		});
+	});
+
+	it("rejects missing selected users and account ownership conflicts", async ({
+		onTestFinished,
+	}) => {
+		subject = "selected-user-conflict";
+		email = "selected-user-conflict@example.com";
+		let selectedUserId = "missing-user";
+		const instance = await createInstance(
+			{
+				resolveUser: () => ({
+					action: "link",
+					userId: selectedUserId,
+					profile: "preserve",
+				}),
+			},
+			onTestFinished,
+		);
+
+		const missing = await completeSignIn(instance.baseURL);
+		expect(
+			new URL(
+				missing.callback.headers.get("location")!,
+				instance.baseURL,
+			).searchParams.get("error"),
+		).toBe("user_not_found");
+
+		const context = await instance.auth.$context;
+		const owner = await context.adapter.create<User>({
+			model: "user",
+			data: {
+				email: "owner@example.com",
+				emailVerified: true,
+				name: "Owner",
+				image: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		const selected = await context.adapter.create<User>({
+			model: "user",
+			data: {
+				email: "selected@example.com",
+				emailVerified: true,
+				name: "Selected",
+				image: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		await context.internalAdapter.createAccount({
+			issuer: identityProvider.issuer.url!,
+			providerAccountId: subject,
+			providerId: "workforce",
+			userId: owner.id,
+		});
+		selectedUserId = selected.id;
+
+		const conflict = await completeSignIn(instance.baseURL);
+		expect(
+			new URL(
+				conflict.callback.headers.get("location")!,
+				instance.baseURL,
+			).searchParams.get("error"),
+		).toBe("account_ownership_conflict");
+		expect(await instance.db.count({ model: "session", where: [] })).toBe(0);
+
+		instance.sqlite.exec("PRAGMA foreign_keys = OFF");
+		instance.sqlite.prepare('DELETE FROM "user" WHERE "id" = ?').run(owner.id);
+		instance.sqlite.exec("PRAGMA foreign_keys = ON");
+		const orphaned = await completeSignIn(instance.baseURL);
+		expect(
+			new URL(
+				orphaned.callback.headers.get("location")!,
+				instance.baseURL,
+			).searchParams.get("error"),
+		).toBe("unable to link account");
+		expect(await instance.db.count({ model: "session", where: [] })).toBe(0);
+	});
+
+	it("rolls back resolver and authentication writes without publishing cookies", async ({
+		onTestFinished,
+	}) => {
+		subject = "rollback-user";
+		email = "rollback@example.com";
+		let markerUserId = "";
+		const instance = await createInstance(
+			{
+				resolveUser: async (_input, context) => {
+					await context.database.update({
+						model: "user",
+						where: [{ field: "id", value: markerUserId }],
+						update: { name: "must roll back" },
+					});
+					return { action: "continue" };
+				},
+			},
+			onTestFinished,
+			{
+				account: { storeAccountCookie: true },
+				databaseHooks: {
+					session: { create: { before: () => false } },
+				},
+			},
+		);
+		const context = await instance.auth.$context;
+		const marker = await context.adapter.create<User>({
+			model: "user",
+			data: {
+				email: "marker@example.com",
+				emailVerified: true,
+				name: "marker",
+				image: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		markerUserId = marker.id;
+
+		const signIn = await completeSignIn(instance.baseURL);
+		const redirect = new URL(
+			signIn.callback.headers.get("location")!,
+			instance.baseURL,
+		);
+		expect(redirect.searchParams.get("error")).toBe("unable to create session");
+		expect(signIn.callback.headers.getSetCookie().join(";")).not.toContain(
+			"account_data=",
+		);
+		expect(signIn.callback.headers.getSetCookie().join(";")).not.toContain(
+			"session_token=",
+		);
+		expect(await instance.db.count({ model: "account", where: [] })).toBe(0);
+		expect(await instance.db.count({ model: "session", where: [] })).toBe(0);
+		expect(
+			await instance.db.findOne<User>({
+				model: "user",
+				where: [{ field: "id", value: marker.id }],
+			}),
+		).toMatchObject({ name: "marker" });
+	});
+
+	it("rejects another provider alias for an existing subject even on default resolution", async ({
+		onTestFinished,
+	}) => {
+		subject = "provider-conflict-user";
+		email = "provider-conflict@example.com";
+		const instance = await createInstance(
+			{ resolveUser: () => ({ action: "continue" }) },
+			onTestFinished,
+			{},
+			[provider("workforce"), provider("another-workforce")],
+		);
+		expect(
+			(await completeSignIn(instance.baseURL)).callback.headers.get("location"),
+		).toBe(`${instance.baseURL}/employee`);
+		const conflict = await completeSignIn(
+			instance.baseURL,
+			"another-workforce",
+		);
+		const redirect = new URL(
+			conflict.callback.headers.get("location")!,
+			instance.baseURL,
+		);
+		expect(redirect.searchParams.get("error")).toBe(
+			"account_provider_conflict",
+		);
+		expect(await instance.db.count({ model: "account", where: [] })).toBe(1);
+	});
+
+	it("keeps case-distinct OIDC subjects as different account keys", async ({
+		onTestFinished,
+	}) => {
+		subject = "CaseSensitiveSubject";
+		email = "case-sensitive@example.com";
+		const instance = await createInstance(
+			{ resolveUser: () => ({ action: "continue" }) },
+			onTestFinished,
+		);
+
+		expect(
+			(await completeSignIn(instance.baseURL)).callback.headers.get("location"),
+		).toBe(`${instance.baseURL}/employee`);
+		subject = "casesensitivesubject";
+		email = "case-sensitive-lower@example.com";
+		expect(
+			(await completeSignIn(instance.baseURL)).callback.headers.get("location"),
+		).toBe(`${instance.baseURL}/employee`);
+
+		const accounts = await instance.db.findMany<Account>({
+			model: "account",
+			where: [],
+		});
+		expect(
+			accounts.map(({ providerAccountId }) => providerAccountId).sort(),
+		).toEqual(["CaseSensitiveSubject", "casesensitivesubject"].sort());
+	});
+
+	it("rejects a persisted provider replacement between token exchange and finalization", async ({
+		onTestFinished,
+	}) => {
+		subject = "provider-replacement-user";
+		email = "provider-replacement@example.com";
+		let resolverCalls = 0;
+		const instance = await createInstance(
+			{
+				resolveUser: () => {
+					resolverCalls += 1;
+					return { action: "continue" };
+				},
+			},
+			onTestFinished,
+			{},
+			[],
+		);
+		const context = await instance.auth.$context;
+		const owner = await context.adapter.create<User>({
+			model: "user",
+			data: {
+				email: "provider-owner@example.com",
+				emailVerified: true,
+				name: "Provider Owner",
+				image: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		});
+		instance.sqlite
+			.prepare('UPDATE "user" SET "id" = ? WHERE "id" = ?')
+			.run("default", owner.id);
+		await context.adapter.create({
+			model: "ssoProvider",
+			data: {
+				issuer: identityProvider.issuer.url!,
+				domain: "example.com",
+				oidcConfig: JSON.stringify(provider().oidcConfig),
+				samlConfig: null,
+				userId: "default",
+				providerId: "workforce",
+				organizationId: null,
+			},
+		});
+		beforeTokenSigning = () => {
+			instance.sqlite
+				.prepare('UPDATE "ssoProvider" SET "id" = ? WHERE "providerId" = ?')
+				.run("replacement-provider-row", "workforce");
+		};
+
+		const signIn = await completeSignIn(instance.baseURL);
+		expect(
+			new URL(
+				signIn.callback.headers.get("location")!,
+				instance.baseURL,
+			).searchParams.get("error"),
+		).toBe("SSO_PROVIDER_CHANGED");
+		expect(resolverCalls).toBe(0);
+		expect(await instance.db.count({ model: "account", where: [] })).toBe(0);
+	});
+
+	it("returns committed session cookies when secondary mirroring fails", async ({
+		onTestFinished,
+	}) => {
+		subject = "secondary-storage-failure-user";
+		email = "secondary-storage-failure@example.com";
+		const secondaryValues = new Map<string, string>();
+		const mirrorSet = vi.fn(async (key: string, value: string) => {
+			if (key.startsWith("active-sessions-")) {
+				throw new Error("secondary storage unavailable");
+			}
+			secondaryValues.set(key, value);
+		});
+		const instance = await createInstance(
+			{ resolveUser: () => ({ action: "continue" }) },
+			onTestFinished,
+			{
+				secondaryStorage: {
+					get: async (key: string) => secondaryValues.get(key) ?? null,
+					getAndDelete: async (key: string) => {
+						const value = secondaryValues.get(key) ?? null;
+						secondaryValues.delete(key);
+						return value;
+					},
+					set: mirrorSet,
+					increment: async (key: string) => {
+						const value = Number(secondaryValues.get(key) ?? 0) + 1;
+						secondaryValues.set(key, String(value));
+						return value;
+					},
+					delete: async (key: string) => {
+						secondaryValues.delete(key);
+					},
+				},
+				session: { storeSessionInDatabase: true },
+			},
+		);
+
+		const signIn = await completeSignIn(instance.baseURL);
+		expect(signIn.callback.headers.get("location")).toBe(
+			`${instance.baseURL}/employee`,
+		);
+		expect(signIn.callback.headers.getSetCookie().join(";")).toContain(
+			"session_token=",
+		);
+		expect(await instance.db.count({ model: "session", where: [] })).toBe(1);
+		expect(mirrorSet).toHaveBeenCalled();
+	});
+
+	it("rejects missing ID Tokens and UserInfo subject mismatches before resolution", async ({
+		onTestFinished,
+	}) => {
+		subject = "verified-token-user";
+		email = "verified-token@example.com";
+		let resolverCalls = 0;
+		const instance = await createInstance(
+			{
+				resolveUser: () => {
+					resolverCalls += 1;
+					return { action: "continue" };
+				},
+			},
+			onTestFinished,
+		);
+
+		omitIdToken = true;
+		const missingToken = await completeSignIn(instance.baseURL);
+		expect(
+			new URL(
+				missingToken.callback.headers.get("location")!,
+				instance.baseURL,
+			).searchParams.get("error_description"),
+		).toBe("id_token_required_for_user_resolution");
+		omitIdToken = false;
+
+		userInfoSubject = "different-userinfo-subject";
+		const mismatch = await completeSignIn(instance.baseURL);
+		expect(
+			new URL(
+				mismatch.callback.headers.get("location")!,
+				instance.baseURL,
+			).searchParams.get("error_description"),
+		).toBe("id_token_userinfo_subject_mismatch");
+		userInfoSubject = undefined;
+		expect(resolverCalls).toBe(0);
+	});
+
+	it("fails before resolution when native transactions are unavailable", async ({
+		onTestFinished,
+	}) => {
+		subject = "unsupported-transaction-user";
+		email = "unsupported-transaction@example.com";
+		let resolverCalls = 0;
+		const instance = await createInstance(
+			{
+				resolveUser: () => {
+					resolverCalls += 1;
+					return { action: "continue" };
+				},
+			},
+			onTestFinished,
+		);
+		const context = await instance.auth.$context;
+		if (!context.adapter.options) throw new Error("Missing adapter options");
+		context.adapter.options.adapterConfig.transaction = false;
+
+		const signIn = await completeSignIn(instance.baseURL);
+		expect(
+			new URL(
+				signIn.callback.headers.get("location")!,
+				instance.baseURL,
+			).searchParams.get("error"),
+		).toBe("SSO_USER_RESOLUTION_REQUIRES_NATIVE_TRANSACTIONS");
+		expect(resolverCalls).toBe(0);
+	});
+
+	it.each([
+		["account", "account_hook_binding_conflict"],
+		["session", "session_hook_user_conflict"],
+	] as const)("rejects %s hook attempts to rewrite the selected binding", async (hookModel, expectedError) => {
+		subject = `${hookModel}-hook-rewrite-user`;
+		email = `${hookModel}-hook-rewrite@example.com`;
+		let selectedUserId = "";
+		let otherUserId = "";
+		const databaseHooks =
+			hookModel === "account"
+				? {
+						account: {
+							create: {
+								before: () => ({ data: { userId: otherUserId } }),
+							},
+						},
+					}
+				: {
+						session: {
+							create: {
+								before: () => ({ data: { userId: otherUserId } }),
+							},
+						},
+					};
+		const instance = await createInstance(
+			{
+				resolveUser: () => ({
+					action: "link",
+					userId: selectedUserId,
+					profile: "preserve",
+				}),
+			},
+			(cleanup) => deferredCleanups.push(cleanup),
+			{ databaseHooks },
+		);
+		const context = await instance.auth.$context;
+		const createUser = (name: string, address: string) =>
+			context.adapter.create<User>({
+				model: "user",
+				data: {
+					email: address,
+					emailVerified: true,
+					name,
+					image: null,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+				},
+			});
+		const selected = await createUser("selected-user", "selected@example.com");
+		const other = await createUser("other-user", "other@example.com");
+		selectedUserId = selected.id;
+		otherUserId = other.id;
+
+		const signIn = await completeSignIn(instance.baseURL);
+		expect(
+			new URL(
+				signIn.callback.headers.get("location")!,
+				instance.baseURL,
+			).searchParams.get("error"),
+		).toBe(expectedError);
+		expect(await instance.db.count({ model: "account", where: [] })).toBe(0);
+		expect(await instance.db.count({ model: "session", where: [] })).toBe(0);
+	});
+});

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -49,6 +49,7 @@ describe("SSO", async () => {
 	});
 
 	server.service.on("beforeTokenSigning", (token, req) => {
+		token.payload.sub = "oauth2";
 		token.payload.email = "sso-user@localhost:8000.com";
 		token.payload.email_verified = true;
 		token.payload.name = "Test User";
@@ -1079,6 +1080,7 @@ describe("provisionUser should only be called for new users", async () => {
 			userInfoResponse.statusCode = 200;
 		});
 		server.service.on("beforeTokenSigning", (token) => {
+			token.payload.sub = "provision-test-sub";
 			token.payload.email = "provision-test@localhost.com";
 			token.payload.email_verified = true;
 			token.payload.name = "Provision Test";
@@ -1236,6 +1238,7 @@ describe("provisionUserOnEveryLogin should call provisionUser on every sign-in",
 			userInfoResponse.statusCode = 200;
 		});
 		server.service.on("beforeTokenSigning", (token) => {
+			token.payload.sub = "provision-every-login-sub";
 			token.payload.email = "provision-every-login@localhost.com";
 			token.payload.email_verified = true;
 			token.payload.name = "Provision Every Login";
@@ -1367,6 +1370,7 @@ describe("SSO shared redirectURI", async () => {
 	};
 
 	const tokenHandler = (token: any) => {
+		token.payload.sub = "shared-redirect-user";
 		token.payload.email = "shared-redirect@test.com";
 		token.payload.email_verified = true;
 		token.payload.name = "Shared Redirect User";
@@ -2418,6 +2422,7 @@ describe("SSO OIDC hook rejection redirect", async () => {
 	});
 
 	hookServer.service.on("beforeTokenSigning", (token) => {
+		token.payload.sub = "rejected-sub";
 		token.payload.email = "rejected@test.com";
 		token.payload.email_verified = true;
 	});
@@ -2648,7 +2653,7 @@ describe("SSO OIDC IDP-initiated bounce", async () => {
 			stateNonce!,
 		);
 		const parsedState = JSON.parse(verification!.value);
-		expect(parsedState.serverContext?.ssoProviderId).toBe(
+		expect(parsedState.serverContext?.ssoProviderReference?.providerId).toBe(
 			"idp-initiated-shared",
 		);
 		expect(parsedState.ssoProviderId).toBeUndefined();

--- a/packages/sso/src/oidc/discovery.ts
+++ b/packages/sso/src/oidc/discovery.ts
@@ -402,6 +402,21 @@ export async function fetchOIDCEndpointResponse(
 	return response;
 }
 
+/** Enforces the OpenID Connect authorized-party rules for ID Tokens. */
+export function assertOIDCAuthorizedParty(
+	payload: { aud?: string | readonly string[] | undefined; azp?: unknown },
+	clientId: string,
+): void {
+	const hasMultipleAudiences =
+		Array.isArray(payload.aud) && payload.aud.length > 1;
+	if (
+		(hasMultipleAudiences && payload.azp === undefined) ||
+		(payload.azp !== undefined && payload.azp !== clientId)
+	) {
+		throw new Error("OIDC ID token authorized party does not match the client");
+	}
+}
+
 /**
  * Validate an OIDC ID token using the same endpoint fetch policy as the rest of
  * the SSO OIDC flow.
@@ -419,10 +434,14 @@ export async function validateOIDCIdToken(
 		[customFetch]: (url, init) =>
 			fetchOIDCEndpointResponse("jwksEndpoint", url, init, isTrustedOrigin),
 	});
-	return jwtVerify(token, jwks, {
+	const verified = await jwtVerify(token, jwks, {
 		audience: options.audience,
 		issuer: options.issuer,
 	});
+	if (typeof options.audience === "string") {
+		assertOIDCAuthorizedParty(verified.payload, options.audience);
+	}
+	return verified;
 }
 
 /**

--- a/packages/sso/src/oidc/id-token.test.ts
+++ b/packages/sso/src/oidc/id-token.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { assertOIDCAuthorizedParty } from "./discovery";
+
+describe("OIDC authorized party validation", () => {
+	it("accepts the configured client as azp for a multi-audience token", () => {
+		expect(() =>
+			assertOIDCAuthorizedParty(
+				{ aud: ["workforce-client", "api"], azp: "workforce-client" },
+				"workforce-client",
+			),
+		).not.toThrow();
+	});
+
+	it.each([
+		[{ aud: ["workforce-client", "api"] }, "missing azp"],
+		[
+			{ aud: ["workforce-client", "api"], azp: "another-client" },
+			"incorrect azp",
+		],
+		[{ aud: "workforce-client", azp: "another-client" }, "incorrect azp"],
+	])("rejects %s (%s)", (payload: {
+		aud: string | string[];
+		azp?: string;
+	}, _label) => {
+		expect(() =>
+			assertOIDCAuthorizedParty(payload, "workforce-client"),
+		).toThrow("OIDC ID token authorized party does not match the client");
+	});
+});

--- a/packages/sso/src/provider-lock.test.ts
+++ b/packages/sso/src/provider-lock.test.ts
@@ -1,0 +1,27 @@
+import type { AuthContext } from "better-auth";
+import { describe, expect, it, vi } from "vitest";
+import { lockSSOProviderForAccountLink } from "./routes/providers";
+
+describe("SSO provider account-link locking", () => {
+	it("does not bypass a persisted provider owned by user default", async () => {
+		const update = vi.fn(async () => null);
+		const context = {
+			adapter: { update } as unknown as AuthContext["adapter"],
+		} as AuthContext;
+
+		await expect(
+			lockSSOProviderForAccountLink(
+				{ context },
+				{
+					id: "provider-row-1",
+					providerId: "workforce",
+					issuer: "https://idp.example.com",
+					userId: "default",
+				},
+			),
+		).rejects.toThrow(
+			"SSO provider changed while account linking was in progress",
+		);
+		expect(update).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/sso/src/provider-reference.test.ts
+++ b/packages/sso/src/provider-reference.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+	computeSSOProviderReference,
+	isCurrentSSOProviderReference,
+	parseSSOProviderReference,
+} from "./provider-reference";
+import type { SSOOptions, SSOProvider } from "./types";
+
+function configuredProvider(clientSecret = "secret") {
+	return {
+		issuer: "https://idp.example.com",
+		providerId: "workforce",
+		userId: "default",
+		domain: "example.com",
+		oidcConfig: {
+			issuer: "https://idp.example.com",
+			clientId: "workforce-client",
+			clientSecret,
+			pkce: false,
+			discoveryEndpoint:
+				"https://idp.example.com/.well-known/openid-configuration",
+			authorizationEndpoint: "https://idp.example.com/authorize",
+			tokenEndpoint: "https://idp.example.com/token",
+			jwksEndpoint: "https://idp.example.com/jwks",
+		},
+	} satisfies SSOProvider<SSOOptions>;
+}
+
+describe("SSO provider references", () => {
+	it("binds state to non-secret authentication configuration", async () => {
+		const reference = await computeSSOProviderReference(configuredProvider());
+		expect(
+			await isCurrentSSOProviderReference(
+				configuredProvider("rotated-secret"),
+				reference,
+			),
+		).toBe(true);
+		expect(
+			await isCurrentSSOProviderReference(
+				{
+					...configuredProvider(),
+					oidcConfig: {
+						...configuredProvider().oidcConfig,
+						tokenEndpoint: "https://attacker.example/token",
+					},
+				},
+				reference,
+			),
+		).toBe(false);
+	});
+
+	it("binds persisted providers to the same database row", async () => {
+		const provider = {
+			...configuredProvider(),
+			id: "provider-row-1",
+			userId: "default",
+		};
+		const reference = await computeSSOProviderReference(provider);
+		expect(reference.source).toEqual({
+			type: "persisted",
+			recordId: "provider-row-1",
+		});
+		expect(
+			await isCurrentSSOProviderReference(
+				{ ...provider, id: "provider-row-2" },
+				reference,
+			),
+		).toBe(false);
+	});
+
+	it("rejects malformed state", () => {
+		expect(parseSSOProviderReference({ providerId: "workforce" })).toBeNull();
+	});
+});

--- a/packages/sso/src/provider-reference.test.ts
+++ b/packages/sso/src/provider-reference.test.ts
@@ -60,6 +60,7 @@ describe("SSO provider references", () => {
 			type: "persisted",
 			recordId: "provider-row-1",
 		});
+		expect(await isCurrentSSOProviderReference(provider, reference)).toBe(true);
 		expect(
 			await isCurrentSSOProviderReference(
 				{ ...provider, id: "provider-row-2" },

--- a/packages/sso/src/provider-reference.ts
+++ b/packages/sso/src/provider-reference.ts
@@ -1,0 +1,148 @@
+import { base64Url } from "@better-auth/utils/base64";
+import { createHash } from "@better-auth/utils/hash";
+import type { OIDCConfig, SSOOptions, SSOProvider } from "./types";
+
+export const SSO_PROVIDER_STATE_KEY = "ssoProviderReference";
+
+type ReferencedProvider = SSOProvider<SSOOptions> & { id?: string | undefined };
+
+export interface SSOProviderReference {
+	providerId: string;
+	source: { type: "configured" } | { type: "persisted"; recordId: string };
+	authenticationConfigurationFingerprint: string;
+}
+
+function serializeCanonical(value: unknown): string {
+	if (value === null) return "null";
+	if (Array.isArray(value)) {
+		return `[${value
+			.map((entry) =>
+				entry === undefined ? "null" : serializeCanonical(entry),
+			)
+			.join(",")}]`;
+	}
+	switch (typeof value) {
+		case "boolean":
+		case "number":
+		case "string":
+			return JSON.stringify(value);
+		case "object": {
+			const entries = Object.entries(value)
+				.filter(([, entry]) => entry !== undefined)
+				.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+			return `{${entries
+				.map(
+					([key, entry]) =>
+						`${JSON.stringify(key)}:${serializeCanonical(entry)}`,
+				)
+				.join(",")}}`;
+		}
+		default:
+			throw new TypeError(
+				"SSO provider configuration must be JSON-serializable",
+			);
+	}
+}
+
+function withoutOIDCSecret(
+	configuration: OIDCConfig | undefined,
+): Omit<OIDCConfig, "clientSecret"> | undefined {
+	if (!configuration) return undefined;
+	const result = { ...configuration };
+	result.clientSecret = undefined;
+	return result;
+}
+
+function getProviderSource(provider: ReferencedProvider) {
+	return typeof provider.id === "string" && provider.id.length > 0
+		? ({ type: "persisted", recordId: provider.id } as const)
+		: ({ type: "configured" } as const);
+}
+
+async function computeProviderAuthenticationFingerprint(
+	provider: ReferencedProvider,
+): Promise<string> {
+	const digest = await createHash("SHA-256").digest(
+		serializeCanonical({
+			domain: provider.domain,
+			domainVerified:
+				"domainVerified" in provider ? provider.domainVerified : undefined,
+			issuer: provider.issuer,
+			organizationId: provider.organizationId,
+			oidcConfig: withoutOIDCSecret(provider.oidcConfig),
+		}),
+	);
+	return base64Url.encode(new Uint8Array(digest), { padding: false });
+}
+
+export async function computeSSOProviderReference(
+	provider: ReferencedProvider,
+): Promise<SSOProviderReference> {
+	return {
+		providerId: provider.providerId,
+		source: getProviderSource(provider),
+		authenticationConfigurationFingerprint:
+			await computeProviderAuthenticationFingerprint(provider),
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseSSOProviderReference(
+	value: unknown,
+): SSOProviderReference | null {
+	if (!isRecord(value) || !isRecord(value.source)) return null;
+	const providerId = value.providerId;
+	const authenticationConfigurationFingerprint =
+		value.authenticationConfigurationFingerprint;
+	const source = value.source;
+	if (
+		typeof providerId !== "string" ||
+		providerId.length === 0 ||
+		typeof authenticationConfigurationFingerprint !== "string" ||
+		authenticationConfigurationFingerprint.length === 0
+	) {
+		return null;
+	}
+	if (source.type === "configured") {
+		return {
+			providerId,
+			source: { type: "configured" },
+			authenticationConfigurationFingerprint,
+		};
+	}
+	if (
+		source.type === "persisted" &&
+		typeof source.recordId === "string" &&
+		source.recordId.length > 0
+	) {
+		return {
+			providerId,
+			source: { type: "persisted", recordId: source.recordId },
+			authenticationConfigurationFingerprint,
+		};
+	}
+	return null;
+}
+
+export async function isCurrentSSOProviderReference(
+	provider: ReferencedProvider,
+	reference: SSOProviderReference | null,
+): Promise<boolean> {
+	if (!reference || reference.providerId !== provider.providerId) return false;
+	const source = getProviderSource(provider);
+	if (source.type !== reference.source.type) return false;
+	if (
+		source.type === "persisted" &&
+		(reference.source.type !== "persisted" ||
+			source.recordId !== reference.source.recordId)
+	) {
+		return false;
+	}
+	return (
+		reference.authenticationConfigurationFingerprint ===
+		(await computeProviderAuthenticationFingerprint(provider))
+	);
+}

--- a/packages/sso/src/routes/providers.ts
+++ b/packages/sso/src/routes/providers.ts
@@ -50,6 +50,7 @@ interface SSOProviderRecord {
 }
 
 type ProviderIdentitySnapshot = {
+	id?: string | undefined;
 	providerId: string;
 	issuer: string;
 	userId?: string | undefined;
@@ -206,14 +207,14 @@ export async function lockSSOProviderForAccountLink(
 	ctx: { context: AuthContext },
 	provider: ProviderIdentitySnapshot,
 ) {
+	if (typeof provider.id !== "string") {
+		return;
+	}
 	const lockedProvider = await lockSSOProviderRow(
 		ctx.context.adapter,
 		provider.providerId,
 	);
 	if (!lockedProvider) {
-		if (provider.userId === "default") {
-			return;
-		}
 		throw new APIError("CONFLICT", {
 			code: "SSO_PROVIDER_CHANGED",
 			message: "SSO provider changed while account linking was in progress",

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1,4 +1,7 @@
-import { runWithTransaction } from "@better-auth/core/context";
+import {
+	getCurrentAdapter,
+	runWithTransaction,
+} from "@better-auth/core/context";
 import { isAPIError } from "@better-auth/core/utils/is-api-error";
 import type {
 	PrivateKeyJwtSigningAlgorithm,
@@ -21,13 +24,16 @@ import {
 	getSessionFromCtx,
 	sessionMiddleware,
 } from "better-auth/api";
-import { deleteSessionCookie, setSessionCookie } from "better-auth/cookies";
+import {
+	deleteSessionCookie,
+	setAccountCookie,
+	setSessionCookie,
+} from "better-auth/cookies";
 import { generateRandomString } from "better-auth/crypto";
 import {
 	additionalAuthorizationParamsSchema,
 	handleOAuthUserInfo,
 } from "better-auth/oauth2";
-import { decodeJwt } from "jose";
 import type { BindingContext } from "samlify/types/src/entity";
 import type { RequestInfo } from "samlify/types/src/types";
 import * as z from "zod";
@@ -43,6 +49,13 @@ import {
 	validateOIDCEndpointUrls,
 	validateOIDCIdToken,
 } from "../oidc";
+import type { SSOProviderReference } from "../provider-reference";
+import {
+	computeSSOProviderReference,
+	isCurrentSSOProviderReference,
+	parseSSOProviderReference,
+	SSO_PROVIDER_STATE_KEY,
+} from "../provider-reference";
 import { validateCertSources, validateConfigAlgorithms } from "../saml";
 import { SAML_ERROR_CODES } from "../saml/error-codes";
 import { generateRelayState } from "../saml-state";
@@ -57,6 +70,14 @@ import type {
 	SSOProvider,
 	SSOProviderAdditionalFieldsInput,
 } from "../types";
+import {
+	assertSSOUserResolutionAsyncContextSupport,
+	assertSSOUserResolutionNativeTransactionSupport,
+	assertSSOUserResolutionSessionStorage,
+	getFailedSSOAuthenticationResult,
+	requireSuccessfulSSOAuthentication,
+	resolveSSOUser,
+} from "../user-resolution";
 import {
 	domainMatches,
 	parseProviderEmailVerified,
@@ -1119,13 +1140,9 @@ export const signInSSO = (options?: SSOOptions) => {
 						message: "Invalid OIDC configuration. Authorization URL not found.",
 					});
 				}
-				if (options?.redirectURI?.trim()) {
-					// The shared OIDC callback resolves the provider from server-only
-					// state, so it must not be client-spoofable.
-					await addOAuthServerContext({
-						ssoProviderId: provider.providerId,
-					});
-				}
+				await addOAuthServerContext({
+					[SSO_PROVIDER_STATE_KEY]: await computeSSOProviderReference(provider),
+				});
 				const state = await generateState(ctx);
 				const redirectURI = getOIDCRedirectURI(
 					ctx.context.baseURL,
@@ -1286,6 +1303,7 @@ async function handleOIDCCallback(
 	options: SSOOptions | undefined,
 	providerId: string,
 	stateData?: Awaited<ReturnType<typeof parseState>>,
+	parsedProviderReference?: SSOProviderReference,
 ) {
 	const { code, error, error_description } = ctx.query;
 	if (!stateData) {
@@ -1297,6 +1315,11 @@ async function handleOIDCCallback(
 			`${ctx.context.baseURL}/error`;
 		throw ctx.redirect(`${errorURL}?error=invalid_state`);
 	}
+	const providerReference =
+		parsedProviderReference ??
+		parseSSOProviderReference(
+			stateData.serverContext?.[SSO_PROVIDER_STATE_KEY],
+		);
 	const { callbackURL, errorURL, newUserURL, requestSignUp } = stateData;
 	const redirectOIDCError = (error: string, description: string): never => {
 		const baseURL = errorURL || callbackURL;
@@ -1319,6 +1342,12 @@ async function handleOIDCCallback(
 			`${
 				errorURL || callbackURL
 			}?error=invalid_provider&error_description=provider not found`,
+		);
+	}
+	if (!(await isCurrentSSOProviderReference(provider, providerReference))) {
+		redirectOIDCError(
+			"invalid_state",
+			"sso_provider_changed_during_authentication",
 		);
 	}
 
@@ -1496,18 +1525,59 @@ async function handleOIDCCallback(
 			}?error=invalid_provider&error_description=token_response_not_found`,
 		);
 	}
-	let userInfo: {
+	type OIDCUserInfo = {
 		id?: string;
 		email?: string;
 		name?: string;
 		image?: string;
 		emailVerified?: boolean;
-		[key: string]: any;
-	} | null = null;
+	} & Record<string, unknown>;
+	let userInfo: OIDCUserInfo | null = null;
 	const mapping = config.mapping || {};
+	const readStringClaim = (
+		claims: Record<string, unknown>,
+		claim: string,
+	): string | undefined => {
+		const value = claims[claim];
+		return typeof value === "string" && value.length > 0 ? value : undefined;
+	};
 	// The raw, unmapped provider claims, forwarded to the validateUserInfo gate
 	// as `source.sso.profile` so a policy can inspect provider-specific fields.
 	let rawProfile: Record<string, unknown> | undefined;
+	let verifiedIdToken: Awaited<ReturnType<typeof validateOIDCIdToken>> | null =
+		null;
+
+	if (tokenResponse.idToken) {
+		const jwksEndpoint = config.jwksEndpoint;
+		if (!jwksEndpoint) {
+			redirectOIDCError("invalid_provider", "jwks_endpoint_not_found");
+		}
+		const verified = await validateOIDCIdToken(
+			tokenResponse.idToken,
+			jwksEndpoint!,
+			{ audience: config.clientId, issuer: provider.issuer },
+			(url) => ctx.context.isTrustedOrigin(url),
+		).catch((error) => {
+			if (error instanceof DiscoveryError) {
+				redirectOIDCError("invalid_provider", error.message);
+			}
+			ctx.context.logger.error(error);
+			return null;
+		});
+		if (!verified) {
+			redirectOIDCError("invalid_provider", "token_not_verified");
+		}
+		if (!readStringClaim(verified!.payload, "sub")) {
+			redirectOIDCError("invalid_provider", "id_token_subject_missing");
+		}
+		verifiedIdToken = verified!;
+	}
+	if (options?.resolveUser && !verifiedIdToken) {
+		redirectOIDCError(
+			"invalid_provider",
+			"id_token_required_for_user_resolution",
+		);
+	}
 
 	if (config.userInfoEndpoint) {
 		const userInfoResponse = await fetchOIDCEndpoint<Record<string, unknown>>(
@@ -1536,6 +1606,12 @@ async function handleOIDCCallback(
 		const rawUserInfo =
 			userInfoResponse.data ??
 			redirectOIDCError("invalid_provider", "userinfo_response_not_found");
+		if (verifiedIdToken && rawUserInfo.sub !== verifiedIdToken.payload.sub) {
+			redirectOIDCError(
+				"invalid_provider",
+				"id_token_userinfo_subject_mismatch",
+			);
+		}
 		rawProfile = rawUserInfo;
 		userInfo = {
 			...Object.fromEntries(
@@ -1544,71 +1620,35 @@ async function handleOIDCCallback(
 					rawUserInfo[value],
 				]),
 			),
-			id: rawUserInfo.sub as string | undefined,
-			email: rawUserInfo[mapping.email || "email"] as string | undefined,
+			id: readStringClaim(rawUserInfo, "sub"),
+			email: readStringClaim(rawUserInfo, mapping.email || "email"),
 			emailVerified: options?.trustEmailVerified
 				? parseProviderEmailVerified(
 						rawUserInfo[mapping.emailVerified || "email_verified"],
 					)
 				: false,
-			name: rawUserInfo[mapping.name || "name"] as string | undefined,
-			image: rawUserInfo[mapping.image || "picture"] as string | undefined,
+			name: readStringClaim(rawUserInfo, mapping.name || "name"),
+			image: readStringClaim(rawUserInfo, mapping.image || "picture"),
 		};
-	} else if (tokenResponse.idToken) {
-		const idToken = decodeJwt(tokenResponse.idToken);
-		rawProfile = idToken as Record<string, unknown>;
-		if (!config.jwksEndpoint) {
-			throw ctx.redirect(
-				`${
-					errorURL || callbackURL
-				}?error=invalid_provider&error_description=jwks_endpoint_not_found`,
-			);
-		}
-		const verified = await validateOIDCIdToken(
-			tokenResponse.idToken,
-			config.jwksEndpoint,
-			{
-				audience: config.clientId,
-				issuer: provider.issuer,
-			},
-			(url) => ctx.context.isTrustedOrigin(url),
-		).catch((e) => {
-			if (e instanceof DiscoveryError) {
-				redirectOIDCError("invalid_provider", e.message);
-			}
-			ctx.context.logger.error(e);
-			return null;
-		});
-		if (!verified) {
-			throw ctx.redirect(
-				`${
-					errorURL || callbackURL
-				}?error=invalid_provider&error_description=token_not_verified`,
-			);
-		}
-
+	} else if (verifiedIdToken) {
+		const idToken = verifiedIdToken.payload;
+		rawProfile = idToken;
 		userInfo = {
 			...Object.fromEntries(
 				Object.entries(mapping.extraFields || {}).map(([key, value]) => [
 					key,
-					verified.payload[value],
+					idToken[value],
 				]),
 			),
-			id: verified.payload.sub,
-			email: idToken[mapping.email || "email"],
+			id: idToken.sub,
+			email: readStringClaim(idToken, mapping.email || "email"),
 			emailVerified: options?.trustEmailVerified
 				? parseProviderEmailVerified(
 						idToken[mapping.emailVerified || "email_verified"],
 					)
 				: false,
-			name: idToken[mapping.name || "name"],
-			image: idToken[mapping.image || "picture"],
-		} as {
-			id?: string;
-			email?: string;
-			name?: string;
-			image?: string;
-			emailVerified?: boolean;
+			name: readStringClaim(idToken, mapping.name || "name"),
+			image: readStringClaim(idToken, mapping.image || "picture"),
 		};
 	} else {
 		throw ctx.redirect(
@@ -1627,6 +1667,22 @@ async function handleOIDCCallback(
 	}
 	const userInfoEmail = userInfo.email;
 	const userInfoId = userInfo.id;
+	const { id: _providerSubject, ...providerUserAttributes } = userInfo;
+	const providerUser = {
+		...providerUserAttributes,
+		email: userInfoEmail,
+		name: typeof userInfo.name === "string" ? userInfo.name : "",
+		image: typeof userInfo.image === "string" ? userInfo.image : undefined,
+		emailVerified: options?.trustEmailVerified
+			? userInfo.emailVerified === true
+			: false,
+	};
+	const accountKey = {
+		issuer:
+			(verifiedIdToken && readStringClaim(verifiedIdToken.payload, "iss")) ||
+			provider.issuer,
+		providerAccountId: userInfoId,
+	};
 	const isTrustedProvider =
 		"domainVerified" in provider &&
 		(provider as { domainVerified?: boolean }).domainVerified === true &&
@@ -1634,53 +1690,125 @@ async function handleOIDCCallback(
 
 	let linked: Awaited<ReturnType<typeof handleOAuthUserInfo>>;
 	try {
-		linked = await runWithTransaction(ctx.context.adapter, async () => {
-			await lockSSOProviderForAccountLink(ctx, provider);
-			return handleOAuthUserInfo(ctx, {
-				userInfo: {
-					email: userInfoEmail,
-					name: userInfo.name || "",
-					id: userInfoId,
-					image: userInfo.image,
-					emailVerified: options?.trustEmailVerified
-						? userInfo.emailVerified || false
-						: false,
+		if (options?.resolveUser) {
+			assertSSOUserResolutionNativeTransactionSupport(ctx.context.adapter);
+			assertSSOUserResolutionSessionStorage(ctx.context.options);
+			await assertSSOUserResolutionAsyncContextSupport();
+		}
+		linked = await runWithTransaction(
+			ctx.context.adapter,
+			async () => {
+				await lockSSOProviderForAccountLink(ctx, provider);
+				const currentProvider = await resolveOIDCProvider(
+					ctx,
+					options,
+					providerId,
+					await getCurrentAdapter(ctx.context.adapter),
+				);
+				if (
+					!currentProvider ||
+					!(await isCurrentSSOProviderReference(
+						currentProvider,
+						providerReference,
+					))
+				) {
+					throw new APIError("CONFLICT", {
+						code: "SSO_PROVIDER_CHANGED",
+						message:
+							"SSO provider changed while account linking was in progress",
+					});
+				}
+				const resolution = options?.resolveUser
+					? await resolveSSOUser(
+							options.resolveUser,
+							{
+								protocol: "oidc",
+								providerId: provider.providerId,
+								accountKey,
+								providerUser,
+								providerClaims: rawProfile ?? {},
+							},
+							await getCurrentAdapter(ctx.context.adapter),
+							ctx.context.logger,
+						)
+					: undefined;
+				if (resolution?.action === "reject") {
+					throw new APIError("FORBIDDEN", {
+						code: resolution.code,
+						...(resolution.message === undefined
+							? {}
+							: { message: resolution.message }),
+					});
+				}
+				const authentication = await handleOAuthUserInfo(ctx, {
+					userInfo: {
+						...providerUser,
+						email: providerUser.email,
+						name: providerUser.name,
+						id: userInfoId,
+						image: providerUser.image,
+						emailVerified: providerUser.emailVerified,
+					},
+					account: {
+						idToken: tokenResponse.idToken,
+						accessToken: tokenResponse.accessToken,
+						refreshToken: tokenResponse.refreshToken,
+						issuer: accountKey.issuer,
+						providerAccountId: userInfoId,
+						providerId: provider.providerId,
+						accessTokenExpiresAt: tokenResponse.accessTokenExpiresAt,
+						refreshTokenExpiresAt: tokenResponse.refreshTokenExpiresAt,
+						scope: tokenResponse.scopes?.join(","),
+					},
+					callbackURL,
+					disableSignUp: options?.disableImplicitSignUp && !requestSignUp,
+					overrideUserInfo: config.overrideUserInfo,
+					source: {
+						method: "sso-oidc",
+						sso: { providerId: provider.providerId, profile: rawProfile },
+					},
+					isTrustedProvider,
+					// SSO provider ids are user-controlled and live in the same namespace
+					// as social providers. Never inherit trust from the global
+					// `trustedProviders` list by name — rely solely on the SSO-specific
+					// `isTrustedProvider` (verified domain ownership) computed above.
+					trustProviderByName: false,
+					selectedUser:
+						resolution?.action === "link"
+							? {
+									userId: resolution.userId,
+									profile: resolution.profile,
+								}
+							: undefined,
+					deferNonDatabaseWrites: !!options?.resolveUser,
+					requireExactAccountBinding: !!options?.resolveUser,
+				});
+				return options?.resolveUser
+					? requireSuccessfulSSOAuthentication(authentication)
+					: authentication;
+			},
+			{
+				onAfterCommitHookError(error) {
+					ctx.context.logger.error(
+						"Committed SSO authentication after-hook failed",
+						error,
+					);
 				},
-				account: {
-					idToken: tokenResponse.idToken,
-					accessToken: tokenResponse.accessToken,
-					refreshToken: tokenResponse.refreshToken,
-					issuer: provider.issuer,
-					providerAccountId: userInfoId,
-					providerId: provider.providerId,
-					accessTokenExpiresAt: tokenResponse.accessTokenExpiresAt,
-					refreshTokenExpiresAt: tokenResponse.refreshTokenExpiresAt,
-					scope: tokenResponse.scopes?.join(","),
-				},
-				callbackURL,
-				disableSignUp: options?.disableImplicitSignUp && !requestSignUp,
-				overrideUserInfo: config.overrideUserInfo,
-				source: {
-					method: "sso-oidc",
-					sso: { providerId: provider.providerId, profile: rawProfile },
-				},
-				isTrustedProvider,
-				// SSO provider ids are user-controlled and live in the same namespace
-				// as social providers. Never inherit trust from the global
-				// `trustedProviders` list by name — rely solely on the SSO-specific
-				// `isTrustedProvider` (verified domain ownership) computed above.
-				trustProviderByName: false,
-			});
-		});
+			},
+		);
 	} catch (e) {
-		if (isAPIError(e) && e.body?.code) {
+		const failedAuthentication = getFailedSSOAuthenticationResult(e);
+		if (failedAuthentication) {
+			linked = failedAuthentication;
+		} else if (isAPIError(e) && e.body?.code) {
 			const baseURL = errorURL || callbackURL;
 			const params = new URLSearchParams({ error: e.body.code });
 			if (e.body.message) params.set("error_description", e.body.message);
 			const sep = baseURL.includes("?") ? "&" : "?";
 			throw ctx.redirect(`${baseURL}${sep}${params.toString()}`);
+		} else {
+			throw e;
 		}
-		throw e;
 	}
 	if (linked.error) {
 		const baseURL = errorURL || callbackURL;
@@ -1717,6 +1845,9 @@ async function handleOIDCCallback(
 		provisioningOptions: options?.organizationProvisioning,
 	});
 
+	if ("accountCookie" in linked && linked.accountCookie) {
+		await setAccountCookie(ctx, linked.accountCookie);
+	}
 	await setSessionCookie(ctx, {
 		session,
 		user,
@@ -1763,6 +1894,7 @@ async function resolveOIDCProvider(
 	ctx: any,
 	options: SSOOptions | undefined,
 	providerId: string,
+	adapter = ctx.context.adapter,
 ): Promise<SSOProvider<SSOOptions> | null> {
 	const matchingDefault = options?.defaultSSO?.find(
 		(defaultProvider) => defaultProvider.providerId === providerId,
@@ -1775,7 +1907,7 @@ async function resolveOIDCProvider(
 			...(options?.domainVerification?.enabled ? { domainVerified: true } : {}),
 		} as SSOProvider<SSOOptions>;
 	}
-	return ctx.context.adapter
+	return adapter
 		.findOne({
 			model: "ssoProvider",
 			where: [{ field: "providerId", value: providerId }],
@@ -1822,11 +1954,9 @@ async function bounceIfIdpInitiated(
 		return;
 	}
 
-	if (options?.redirectURI?.trim()) {
-		// The shared OIDC callback resolves the provider from server-only state,
-		// so it must not be client-spoofable.
-		await addOAuthServerContext({ ssoProviderId: provider.providerId });
-	}
+	await addOAuthServerContext({
+		[SSO_PROVIDER_STATE_KEY]: await computeSSOProviderReference(provider),
+	});
 	const state = await generateState(ctx);
 	const redirectURI = getOIDCRedirectURI(
 		ctx.context.baseURL,
@@ -1892,17 +2022,23 @@ export const callbackSSOShared = (options?: SSOOptions) => {
 				throw ctx.redirect(`${errorURL}?error=invalid_state`);
 			}
 
-			const providerId = stateData.serverContext?.ssoProviderId as
-				| string
-				| undefined;
-			if (!providerId) {
+			const providerReference = parseSSOProviderReference(
+				stateData.serverContext?.[SSO_PROVIDER_STATE_KEY],
+			);
+			if (!providerReference) {
 				const errorURL = stateData.errorURL || stateData.callbackURL;
 				throw ctx.redirect(
-					`${errorURL}?error=invalid_state&error_description=missing_provider_id`,
+					`${errorURL}?error=invalid_state&error_description=missing_sso_provider_reference`,
 				);
 			}
 
-			return handleOIDCCallback(ctx, options, providerId, stateData);
+			return handleOIDCCallback(
+				ctx,
+				options,
+				providerReference.providerId,
+				stateData,
+				providerReference,
+			);
 		},
 	);
 };

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1667,7 +1667,9 @@ async function handleOIDCCallback(
 	}
 	const userInfoEmail = userInfo.email;
 	const userInfoId = userInfo.id;
-	const { id: _providerSubject, ...providerUserAttributes } = userInfo;
+	const providerUserAttributes = Object.fromEntries(
+		Object.entries(userInfo).filter(([key]) => key !== "id"),
+	);
 	const providerUser = {
 		...providerUserAttributes,
 		email: userInfoEmail,

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -1,4 +1,9 @@
-import type { Awaitable, OAuth2Tokens, User } from "better-auth";
+import type {
+	Awaitable,
+	DBTransactionAdapter,
+	OAuth2Tokens,
+	User,
+} from "better-auth";
 import type {
 	DBFieldAttribute,
 	FieldAttributeToObject,
@@ -276,7 +281,56 @@ export type SSOProviderSchema<O extends SSOOptions> = {
 	};
 };
 
+/** Decision returned by an SSO user resolver. */
+export type SSOUserResolution =
+	| { action: "continue" }
+	| {
+			action: "link";
+			userId: string;
+			profile: "preserve" | "update";
+	  }
+	| { action: "reject"; code: string; message?: string | undefined };
+
+/** Normalized provider attributes available to an SSO user resolver. */
+export type SSOProviderUserProfile = {
+	email: string;
+	emailVerified: boolean;
+	name: string;
+	image?: string | null | undefined;
+} & Record<string, unknown>;
+
+/** OIDC identity and profile data available to an application's SSO resolver. */
+export interface SSOUserResolutionInput {
+	protocol: "oidc";
+	providerId: string;
+	accountKey: {
+		issuer: string;
+		providerAccountId: string;
+	};
+	providerUser: SSOProviderUserProfile;
+	providerClaims: Record<string, unknown>;
+}
+
+/** Transaction-bound capabilities available while resolving an SSO user. */
+export interface SSOUserResolutionContext {
+	database: DBTransactionAdapter;
+}
+
 export interface SSOOptions {
+	/**
+	 * Resolve a verified OIDC issuer and subject to a Better Auth user.
+	 *
+	 * `accountKey` is derived from the validated ID Token. Profile fields and raw
+	 * claims are protocol-accepted provider data and may require application-level
+	 * validation. The callback runs on every OIDC sign-in inside the same native
+	 * database transaction as account finalization and session creation.
+	 */
+	resolveUser?:
+		| ((
+				input: SSOUserResolutionInput,
+				context: SSOUserResolutionContext,
+		  ) => Awaitable<SSOUserResolution>)
+		| undefined;
 	/**
 	 * custom function to provision a user when they sign in with an SSO provider.
 	 */

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -318,7 +318,13 @@ export interface SSOUserResolutionContext {
 
 export interface SSOOptions {
 	/**
-	 * Resolve a verified OIDC issuer and subject to a Better Auth user.
+	 * Resolve a verified provider identity to a Better Auth user.
+	 *
+	 * Currently invoked for OIDC callbacks only.
+	 *
+	 * TODO: Invoke this resolver for SAML callbacks after normalizing the verified
+	 * IdP entity ID as `accountKey.issuer` and the signed NameID as
+	 * `accountKey.providerAccountId`.
 	 *
 	 * `accountKey` is derived from the validated ID Token. Profile fields and raw
 	 * claims are protocol-accepted provider data and may require application-level

--- a/packages/sso/src/user-resolution.test.ts
+++ b/packages/sso/src/user-resolution.test.ts
@@ -1,0 +1,124 @@
+import type { BetterAuthOptions, DBTransactionAdapter } from "better-auth";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import type { SSOProviderUserProfile, SSOUserResolutionInput } from "./types";
+import {
+	assertSSOUserResolutionAsyncContextSupport,
+	assertSSOUserResolutionSessionStorage,
+	resolveSSOUser,
+} from "./user-resolution";
+
+const input = {
+	protocol: "oidc",
+	providerId: "workforce",
+	accountKey: {
+		issuer: "https://idp.example.com",
+		providerAccountId: "directory-user-1",
+	},
+	providerUser: {
+		email: "employee@example.com",
+		emailVerified: true,
+		name: "Directory Employee",
+		image: null,
+	},
+	providerClaims: { sub: "directory-user-1" },
+} satisfies SSOUserResolutionInput;
+
+const database = {} as DBTransactionAdapter;
+
+describe("SSO user resolution", () => {
+	it("fails closed when database transaction async context is unavailable", async () => {
+		await expect(
+			assertSSOUserResolutionAsyncContextSupport(async () => {
+				throw new Error("AsyncLocalStorage unavailable");
+			}),
+		).rejects.toMatchObject({
+			status: "NOT_IMPLEMENTED",
+			body: { code: "SSO_USER_RESOLUTION_REQUIRES_ASYNC_CONTEXT" },
+		});
+	});
+	it("exposes mapped provider profile fields as unknown", () => {
+		const mappedProviderUser = {
+			email: "employee@example.com",
+			emailVerified: true,
+			name: "Directory Employee",
+			image: null,
+			department: "Engineering",
+		} satisfies SSOProviderUserProfile;
+		expectTypeOf(mappedProviderUser.department).toEqualTypeOf<string>();
+		expectTypeOf<
+			SSOUserResolutionInput["providerUser"]["department"]
+		>().toEqualTypeOf<unknown>();
+	});
+
+	it("logs resolver exceptions while returning a stable error", async () => {
+		const privateError = new Error("private directory topology");
+		const logger = { error: vi.fn() };
+
+		await expect(
+			resolveSSOUser(
+				() => {
+					throw privateError;
+				},
+				input,
+				database,
+				logger,
+			),
+		).rejects.toMatchObject({
+			body: {
+				code: "SSO_USER_RESOLUTION_FAILED",
+				message: "Unable to resolve the SSO user",
+			},
+		});
+		expect(logger.error).toHaveBeenCalledWith(
+			"SSO user resolution failed",
+			privateError,
+		);
+	});
+
+	it("logs malformed decisions without logging their value", async () => {
+		const logger = { error: vi.fn() };
+		const malformedResolver = (() => ({
+			action: "link",
+			userId: "user-1",
+		})) as never;
+
+		await expect(
+			resolveSSOUser(malformedResolver, input, database, logger),
+		).rejects.toMatchObject({
+			body: { code: "SSO_USER_RESOLUTION_FAILED" },
+		});
+		expect(logger.error).toHaveBeenCalledWith(
+			"SSO user resolver returned an invalid decision",
+		);
+	});
+
+	it("requires a database session fallback when secondary storage is configured", () => {
+		const secondaryStorage = {
+			get: async () => null,
+			getAndDelete: async () => null,
+			set: async () => {},
+			increment: async () => 1,
+			delete: async () => {},
+		};
+		expect(() =>
+			assertSSOUserResolutionSessionStorage({
+				secondaryStorage,
+			} satisfies BetterAuthOptions),
+		).toThrow("SSO user resolution requires database-backed sessions");
+		expect(() =>
+			assertSSOUserResolutionSessionStorage({
+				secondaryStorage,
+				session: { storeSessionInDatabase: true },
+			} satisfies BetterAuthOptions),
+		).not.toThrow();
+		expect(() =>
+			assertSSOUserResolutionSessionStorage({
+				secondaryStorage,
+				session: {
+					storeSessionInDatabase: true,
+					preserveSessionInDatabase: true,
+				},
+			} satisfies BetterAuthOptions),
+		).toThrow("SSO user resolution requires database-backed sessions");
+	});
+});

--- a/packages/sso/src/user-resolution.ts
+++ b/packages/sso/src/user-resolution.ts
@@ -1,0 +1,155 @@
+import { getCurrentDBAdapterAsyncLocalStorage } from "@better-auth/core/context";
+import type {
+	DBAdapter,
+	DBTransactionAdapter,
+	GenericEndpointContext,
+} from "better-auth";
+import { APIError } from "better-auth/api";
+import type { handleOAuthUserInfo } from "better-auth/oauth2";
+import type {
+	SSOOptions,
+	SSOUserResolution,
+	SSOUserResolutionInput,
+} from "./types";
+
+const SSO_AUTHENTICATION_FAILURE = Symbol("SSO_AUTHENTICATION_FAILURE");
+
+type SSOAuthenticationResult = Awaited<ReturnType<typeof handleOAuthUserInfo>>;
+type SSOAuthenticationFailure = Error & {
+	readonly [SSO_AUTHENTICATION_FAILURE]: true;
+	readonly result: SSOAuthenticationResult;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function isSSOUserResolution(value: unknown): value is SSOUserResolution {
+	if (!isRecord(value)) return false;
+	if (value.action === "continue") return true;
+	if (value.action === "link") {
+		return (
+			isNonEmptyString(value.userId) &&
+			(value.profile === "preserve" || value.profile === "update")
+		);
+	}
+	return (
+		value.action === "reject" &&
+		isNonEmptyString(value.code) &&
+		(value.message === undefined || typeof value.message === "string")
+	);
+}
+
+type ResolutionLogger = Pick<
+	GenericEndpointContext["context"]["logger"],
+	"error"
+>;
+
+function logFailure(
+	logger: ResolutionLogger,
+	message: string,
+	error?: unknown,
+): void {
+	try {
+		logger.error(message, ...(error === undefined ? [] : [error]));
+	} catch {
+		// A custom logger must not change the stable authentication failure.
+	}
+}
+
+function resolutionFailure(): APIError {
+	return new APIError("INTERNAL_SERVER_ERROR", {
+		code: "SSO_USER_RESOLUTION_FAILED",
+		message: "Unable to resolve the SSO user",
+	});
+}
+
+export async function resolveSSOUser(
+	resolveUser: NonNullable<SSOOptions["resolveUser"]>,
+	input: SSOUserResolutionInput,
+	database: DBTransactionAdapter,
+	logger: ResolutionLogger,
+): Promise<SSOUserResolution> {
+	let resolution: unknown;
+	try {
+		resolution = await resolveUser(input, { database });
+	} catch (error) {
+		logFailure(logger, "SSO user resolution failed", error);
+		throw resolutionFailure();
+	}
+	if (!isSSOUserResolution(resolution)) {
+		logFailure(logger, "SSO user resolver returned an invalid decision");
+		throw resolutionFailure();
+	}
+	return resolution;
+}
+
+export function assertSSOUserResolutionNativeTransactionSupport(
+	adapter: Pick<DBAdapter, "options">,
+): void {
+	if (typeof adapter.options?.adapterConfig.transaction === "function") return;
+	throw new APIError("NOT_IMPLEMENTED", {
+		code: "SSO_USER_RESOLUTION_REQUIRES_NATIVE_TRANSACTIONS",
+		message:
+			"SSO user resolution requires a database adapter with native transaction support",
+	});
+}
+
+export async function assertSSOUserResolutionAsyncContextSupport(
+	getStorage: typeof getCurrentDBAdapterAsyncLocalStorage = getCurrentDBAdapterAsyncLocalStorage,
+): Promise<void> {
+	try {
+		await getStorage();
+	} catch {
+		throw new APIError("NOT_IMPLEMENTED", {
+			code: "SSO_USER_RESOLUTION_REQUIRES_ASYNC_CONTEXT",
+			message:
+				"SSO user resolution requires database transaction async context support",
+		});
+	}
+}
+
+export function assertSSOUserResolutionSessionStorage(
+	options: GenericEndpointContext["context"]["options"],
+): void {
+	if (
+		!options.secondaryStorage ||
+		(options.session?.storeSessionInDatabase === true &&
+			options.session.preserveSessionInDatabase !== true)
+	) {
+		return;
+	}
+	throw new APIError("NOT_IMPLEMENTED", {
+		code: "SSO_USER_RESOLUTION_REQUIRES_DATABASE_SESSIONS",
+		message:
+			"SSO user resolution requires database-backed sessions with database fallback",
+	});
+}
+
+export function requireSuccessfulSSOAuthentication(
+	result: SSOAuthenticationResult,
+): SSOAuthenticationResult {
+	if (!result.error) return result;
+	throw Object.assign(new Error("SSO authentication failed"), {
+		[SSO_AUTHENTICATION_FAILURE]: true as const,
+		result,
+	}) satisfies SSOAuthenticationFailure;
+}
+
+export function getFailedSSOAuthenticationResult(
+	error: unknown,
+): SSOAuthenticationResult | undefined {
+	if (
+		!(error instanceof Error) ||
+		!(SSO_AUTHENTICATION_FAILURE in error) ||
+		error[SSO_AUTHENTICATION_FAILURE] !== true ||
+		!("result" in error)
+	) {
+		return undefined;
+	}
+	return (error as SSOAuthenticationFailure).result;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1623,6 +1623,9 @@ importers:
       '@better-auth/core':
         specifier: workspace:*
         version: link:../core
+      '@better-auth/kysely-adapter':
+        specifier: workspace:*
+        version: link:../kysely-adapter
       '@types/body-parser':
         specifier: ^1.19.6
         version: 1.19.6
@@ -1641,6 +1644,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      kysely:
+        specifier: 0.28.17
+        version: 0.28.17
       oauth2-mock-server:
         specifier: ^9.0.0
         version: 9.0.0


### PR DESCRIPTION
OIDC sign-in could only follow email-based account discovery, which prevents a SCIM-provisioned user from being selected by verified issuer and subject without changing the core user schema. This adds an explicit resolution hook that can continue, link an exact user, or reject the sign-in inside one database transaction.

## What changes

- **Public contract:** `resolveUser` receives the verified OIDC identity, provider context, and candidate profile, then returns `continue`, `link`, or `reject`.
- **Identity binding:** linking uses verified `iss` and `sub`, checks `azp` and UserInfo subject consistency, and preserves provider-reference continuity.
- **Atomicity:** user, account, and session writes commit together; cookies and secondary-storage writes wait until the database commit succeeds.
- **Failure behavior:** resolvers fail closed on invalid selections, identity conflicts, transaction rollbacks, and providers without the required transaction guarantees.

> [!NOTE]
> This hook applies to OIDC providers. SAML behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds transactional OIDC user resolution to `@better-auth/sso`, letting apps link a verified `iss/sub` to an exact user and commit account + session atomically. OAuth state now carries a non‑spoofable provider reference, and cookies, verification emails, and secondary storage writes run only after commit; after‑commit failures are logged, and secondary‑only session persistence errors still bubble up.

- **New Features**
  - `resolveUser(input, context)` for OIDC; returns `continue`, `link`, or `reject`.
  - Provider continuity: OAuth state stores an `ssoProviderReference` (non‑secret auth config fingerprint); the callback re‑validates it and locks the provider row (works with shared redirect and IdP‑initiated flows).
  - Exact binding enforcement with clear conflicts (`account_ownership_conflict`, `account_provider_conflict`, `account_hook_binding_conflict`, `user_hook_selection_conflict`, `session_hook_user_conflict`).
  - Stronger token checks: requires an ID Token; enforces `azp` for multi‑audience tokens; `UserInfo.sub` must equal `ID Token.sub`; case‑sensitive subject matching.
  - Atomic auth: account cookie, verification emails, and secondary session mirroring defer until commit; failures after commit are reported without blocking later hooks. Secondary‑only session persistence errors still reject.

- **Migration**
  - Requires native DB transactions and transaction async‑context; fails with explicit errors if missing.
  - If using secondary storage, enable database‑backed sessions with fallback: set `session.storeSessionInDatabase: true` and do not set `session.preserveSessionInDatabase`.
  - OIDC must supply a valid ID Token with `sub`; enforces `azp` for multi‑audience; `UserInfo.sub` must match the ID Token; subjects are case‑sensitive.
  - Resolver currently applies to OIDC only; SAML remains unchanged (follow‑up planned).

<sup>Written for commit 38ce0e0ebb4408792eabe3e1e884c200db7531a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

