### PR TITLE
feat(scim): expose active provisioned user links

### DIFF
--- a/.changeset/scim-active-user-link.md
+++ b/.changeset/scim-active-user-link.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/scim": minor
+---
+
+Add `acquireActiveSCIMUserLink` for transaction-safe authentication of provisioned users. The helper maps an exact SCIM connection ID and `externalId` to an active Better Auth User while fencing concurrent subject changes, deactivation, deletion, and connection decommissioning.
+
+Compose the helper with SSO `resolveUser` to link the provisioned User without matching by email or `userName`.

--- a/docs/content/docs/plugins/scim/index.mdx
+++ b/docs/content/docs/plugins/scim/index.mdx
@@ -203,6 +203,71 @@ Choose the profile behavior when you link a user:
 
 Only one source can manage a Better Auth User's profile. Separate connections may link preserved sources to the same User, but one connection cannot create two SCIM resources for the same linked User.
 
+## Authenticate provisioned users with SSO
+
+Use `acquireActiveSCIMUserLink` inside the SSO plugin's `resolveUser` callback when one SCIM connection controls who can sign in through a paired OIDC provider. The helper finds an active SCIM User by its exact connection ID and `externalId`, returning `{ scimUserId, userId }` for the active link. It returns `null` for missing, inactive, deleted, tombstoned, orphaned, or decommissioned links.
+
+```ts title="auth.ts"
+import { acquireActiveSCIMUserLink, scim } from "@better-auth/scim";
+import { sso } from "@better-auth/sso";
+import { betterAuth } from "better-auth";
+
+const workforceProviderId = "acme-workforce-oidc";
+const workforceConnectionId = "workforce-acme";
+
+export const auth = betterAuth({
+  plugins: [
+    scim({ connections }),
+    sso({
+      defaultSSO: [
+        {
+          providerId: workforceProviderId,
+          domain: "acme.example",
+          oidcConfig: {
+            issuer: "https://idp.acme.example",
+            clientId: "acme-workforce-client-id",
+            clientSecret: "acme-workforce-client-secret",
+            pkce: true,
+            discoveryEndpoint:
+              "https://idp.acme.example/.well-known/openid-configuration",
+          },
+        },
+      ],
+      async resolveUser(input, context) {
+        if (input.providerId !== workforceProviderId) {
+          return { action: "continue" };
+        }
+
+        const link = await acquireActiveSCIMUserLink(
+          {
+            connectionId: workforceConnectionId,
+            externalId: input.accountKey.providerAccountId,
+          },
+          context,
+        );
+
+        return link
+          ? {
+              action: "link",
+              userId: link.userId,
+              profile: "preserve",
+            }
+          : {
+              action: "reject",
+              code: "SCIM_USER_NOT_ACTIVE",
+            };
+      },
+    }),
+  ],
+});
+```
+
+Configure the directory to send the OIDC provider's immutable, case-exact subject as the SCIM User's `externalId`. The example uses the validated OIDC `sub` from `input.accountKey.providerAccountId`. The helper never falls back to `userName`, email, another connection, or a deleted-resource tombstone.
+
+Call the helper with the `context` supplied by `resolveUser`; its `database` is the same native transaction adapter used for account linking and session creation. The helper fences the link against concurrent subject changes, source deactivation or deletion, and connection decommissioning. A direct helper caller can retry its entire transaction after a conflict.
+
+During SSO, a lifecycle conflict aborts the current authentication attempt and is returned as `SSO_USER_RESOLUTION_FAILED`; no Account or Session is created. SSO does not retry the callback automatically, and the original OIDC callback cannot be replayed. The user or client must start a fresh SSO authentication attempt, which re-evaluates the current SCIM state.
+
 ## Handle activation and deletion
 
 Use `identity.reconcileUser` to apply the combined SCIM lifecycle state to your application. The callback receives every source linked to the Better Auth User and an `active` value that is `true` while at least one source remains active.

--- a/packages/scim/package.json
+++ b/packages/scim/package.json
@@ -57,8 +57,10 @@
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "@better-auth/kysely-adapter": "workspace:*",
+    "@better-auth/sso": "workspace:*",
     "@better-auth/test-utils": "workspace:*",
     "kysely": "catalog:",
+    "oauth2-mock-server": "^9.0.0",
     "tsdown": "catalog:"
   },
   "peerDependencies": {

--- a/packages/scim/src/connection-state.ts
+++ b/packages/scim/src/connection-state.ts
@@ -37,22 +37,31 @@ export async function findDecommissionedSCIMConnectionIds(
  * or fails the transaction when retirement won the race.
  */
 export async function fenceActiveSCIMConnection(
-	database: DBTransactionAdapter,
+	database: Pick<DBTransactionAdapter, "incrementOne">,
 	connectionId: string,
-): Promise<void> {
-	const binding = await database.incrementOne<SCIMConnectionBinding>({
+): Promise<SCIMConnectionBinding> {
+	const binding = await tryFenceActiveSCIMConnection(database, connectionId);
+	if (binding) return binding;
+	throw createSCIMError("UNAUTHORIZED", {
+		detail: "SCIM connection is decommissioned",
+	});
+}
+
+/** Attempts to fence a connection without assigning an HTTP failure policy. */
+export async function tryFenceActiveSCIMConnection(
+	database: Pick<DBTransactionAdapter, "incrementOne">,
+	connectionId: string,
+): Promise<SCIMConnectionBinding | null> {
+	return database.incrementOne<SCIMConnectionBinding>({
 		model: "scimConnectionBinding",
 		where: [
 			{
 				field: "connectionKey",
 				value: createSCIMConnectionKey(connectionId),
 			},
+			{ field: "connectionId", value: connectionId },
 			{ field: "decommissionStatus", value: "active" },
 		],
 		increment: { decommissionRevision: 1 },
-	});
-	if (binding) return;
-	throw createSCIMError("UNAUTHORIZED", {
-		detail: "SCIM connection is decommissioned",
 	});
 }

--- a/packages/scim/src/identity.ts
+++ b/packages/scim/src/identity.ts
@@ -2,7 +2,12 @@ import {
 	getCurrentAdapter,
 	runWithTransaction,
 } from "@better-auth/core/context";
-import type { AuthContext, DBAdapter, DBTransactionAdapter } from "better-auth";
+import type {
+	AuthContext,
+	DBAdapter,
+	DBTransactionAdapter,
+	User,
+} from "better-auth";
 import type {
 	SCIMIdentityResolution,
 	SCIMIdentityResolutionInput,
@@ -10,18 +15,163 @@ import type {
 	SCIMIdentityState,
 	SCIMOptions,
 } from "./configuration";
-import { findDecommissionedSCIMConnectionIds } from "./connection-state";
+import {
+	createSCIMConnectionKey,
+	findDecommissionedSCIMConnectionIds,
+	tryFenceActiveSCIMConnection,
+} from "./connection-state";
 import type {
+	SCIMConnectionBinding,
 	SCIMIdentityTombstone,
 	SCIMSubject,
 	SCIMUser,
 } from "./persistence";
-import { createScopedKey } from "./resource-key";
+import { createSCIMUserExternalIdKey } from "./resource-key";
 import { createSCIMError, runSCIMApplicationCallback } from "./scim-error";
 
 export type SCIMIdentityCoordinator = ReturnType<
 	typeof createSCIMIdentityCoordinator
 >;
+
+/** Exact external directory reference for one connection-owned SCIM User. */
+export interface SCIMUserExternalIdReference {
+	connectionId: string;
+	externalId: string;
+}
+
+/** Exact Better Auth User link acquired from an active SCIM source. */
+export interface SCIMActiveUserLink {
+	scimUserId: string;
+	userId: string;
+}
+
+/** Transaction-bound database capabilities required to acquire an active link. */
+export interface SCIMActiveUserLinkContext {
+	database: Pick<DBTransactionAdapter, "findOne" | "incrementOne">;
+}
+
+/**
+ * Acquires an active provisioned User link inside the caller's transaction.
+ *
+ * The lookup is scoped to the exact SCIM connection and externalId. It never
+ * falls back to userName, email, or deleted identity tombstones. Pass the
+ * active transaction adapter supplied by the authentication resolver. A
+ * concurrent lifecycle mutation throws a SCIM conflict. A direct caller can
+ * choose to retry its entire transaction after starting from fresh state.
+ */
+export async function acquireActiveSCIMUserLink(
+	reference: SCIMUserExternalIdReference,
+	context: SCIMActiveUserLinkContext,
+): Promise<SCIMActiveUserLink | null> {
+	const externalIdKey = createSCIMUserExternalIdKey(
+		reference.connectionId,
+		reference.externalId,
+	);
+	const source = await context.database.findOne<SCIMUser>({
+		model: "scimUser",
+		where: [
+			{ field: "connectionId", value: reference.connectionId },
+			{ field: "externalIdKey", value: externalIdKey },
+			{ field: "externalId", value: reference.externalId },
+			{ field: "active", value: true },
+		],
+	});
+	if (!source) return null;
+	const binding = await context.database.findOne<SCIMConnectionBinding>({
+		model: "scimConnectionBinding",
+		where: [
+			{
+				field: "connectionKey",
+				value: createSCIMConnectionKey(reference.connectionId),
+			},
+			{ field: "connectionId", value: reference.connectionId },
+			{ field: "decommissionStatus", value: "active" },
+		],
+	});
+	if (
+		!binding ||
+		binding.provisioningDomainId !== source.provisioningDomainId
+	) {
+		return null;
+	}
+	const tombstone = await context.database.findOne<SCIMIdentityTombstone>({
+		model: "scimIdentityTombstone",
+		where: [
+			{ field: "connectionId", value: reference.connectionId },
+			{ field: "externalIdKey", value: externalIdKey },
+			{ field: "externalId", value: reference.externalId },
+		],
+	});
+	if (tombstone) return null;
+	const subject = await context.database.findOne<SCIMSubject>({
+		model: "scimSubject",
+		where: [{ field: "userId", value: source.userId }],
+	});
+	if (!subject) return null;
+	const user = await context.database.findOne<User>({
+		model: "user",
+		where: [{ field: "id", value: source.userId }],
+	});
+	if (!user) return null;
+	const acquiredSubject = await context.database.incrementOne<SCIMSubject>({
+		model: "scimSubject",
+		where: [
+			{ field: "id", value: subject.id },
+			{ field: "userId", value: source.userId },
+			{ field: "revision", value: subject.revision },
+		],
+		increment: { revision: 1 },
+		set: { updatedAt: new Date() },
+	});
+	if (!acquiredSubject) concurrentIdentityMutation();
+	const acquiredSource = await context.database.findOne<SCIMUser>({
+		model: "scimUser",
+		where: [
+			{ field: "id", value: source.id },
+			{ field: "connectionId", value: reference.connectionId },
+			{ field: "provisioningDomainId", value: binding.provisioningDomainId },
+			{ field: "userId", value: source.userId },
+			{ field: "connectionUserKey", value: source.connectionUserKey },
+			{ field: "externalIdKey", value: externalIdKey },
+			{ field: "externalId", value: reference.externalId },
+			{ field: "active", value: true },
+		],
+	});
+	if (
+		!acquiredSource ||
+		!acquiredSource.active ||
+		acquiredSource.userId !== acquiredSubject.userId
+	) {
+		concurrentIdentityMutation();
+	}
+	const acquiredUser = await context.database.findOne<User>({
+		model: "user",
+		where: [{ field: "id", value: acquiredSource.userId }],
+	});
+	if (!acquiredUser) concurrentIdentityMutation();
+	const acquiredTombstone =
+		await context.database.findOne<SCIMIdentityTombstone>({
+			model: "scimIdentityTombstone",
+			where: [
+				{ field: "connectionId", value: reference.connectionId },
+				{ field: "externalIdKey", value: externalIdKey },
+				{ field: "externalId", value: reference.externalId },
+			],
+		});
+	if (acquiredTombstone) concurrentIdentityMutation();
+	const acquiredBinding = await tryFenceActiveSCIMConnection(
+		context.database,
+		reference.connectionId,
+	);
+	if (
+		!acquiredBinding ||
+		acquiredBinding.id !== binding.id ||
+		acquiredBinding.provisioningDomainId !== acquiredSource.provisioningDomainId
+	) {
+		concurrentIdentityMutation();
+	}
+	return { scimUserId: source.id, userId: source.userId };
+}
 
 const SCIM_IDENTITY_MUTATION_CONFLICT = Symbol(
 	"scim-identity-mutation-conflict",
@@ -142,11 +292,10 @@ export function createSCIMIdentityCoordinator(options: SCIMOptions) {
 			tombstoneId?: string;
 		}> {
 			if (input.resource.externalId) {
-				const externalIdKey = createScopedKey([
-					"scim-user-external-id",
+				const externalIdKey = createSCIMUserExternalIdKey(
 					input.connectionId,
 					input.resource.externalId,
-				]);
+				);
 				const tombstone = await context.database.findOne<SCIMIdentityTombstone>(
 					{
 						model: "scimIdentityTombstone",

--- a/packages/scim/src/index.ts
+++ b/packages/scim/src/index.ts
@@ -24,7 +24,10 @@ import {
 	patchSCIMGroup,
 	replaceSCIMGroup,
 } from "./group-provisioning";
-import { createSCIMIdentityCoordinator } from "./identity";
+import {
+	acquireActiveSCIMUserLink,
+	createSCIMIdentityCoordinator,
+} from "./identity";
 import {
 	createReconcileSCIMProjectionEndpoint,
 	createSCIMProjectionCoordinator,
@@ -766,3 +769,10 @@ export type {
 	SCIMStaticBearerPrincipal,
 	SCIMTransactionContext,
 } from "./configuration";
+
+export type {
+	SCIMActiveUserLink,
+	SCIMActiveUserLinkContext,
+	SCIMUserExternalIdReference,
+} from "./identity";
+export { acquireActiveSCIMUserLink };

--- a/packages/scim/src/resource-key.test.ts
+++ b/packages/scim/src/resource-key.test.ts
@@ -1,15 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { createScopedKey } from "./resource-key";
+import { createSCIMUserExternalIdKey, createScopedKey } from "./resource-key";
 
 describe("SCIM persisted keys", () => {
 	it("remain fixed-size for provider-controlled identifiers", () => {
-		const key = createScopedKey([
-			"scim-user-external-id",
+		const key = createSCIMUserExternalIdKey(
 			"connection-a",
 			"external-id".repeat(1_000),
-		]);
+		);
 
 		expect(key).toHaveLength(43);
+	});
+
+	it("scope User externalIds by exact connection and value", () => {
+		expect(createSCIMUserExternalIdKey("connection-a", "external-id")).toBe(
+			createSCIMUserExternalIdKey("connection-a", "external-id"),
+		);
+		expect(createSCIMUserExternalIdKey("connection-a", "external-id")).not.toBe(
+			createSCIMUserExternalIdKey("connection-b", "external-id"),
+		);
+		expect(createSCIMUserExternalIdKey("connection-a", "external-id")).not.toBe(
+			createSCIMUserExternalIdKey("connection-a", "EXTERNAL-ID"),
+		);
 	});
 
 	it("preserve tuple boundaries and connection scope", () => {

--- a/packages/scim/src/resource-key.ts
+++ b/packages/scim/src/resource-key.ts
@@ -10,6 +10,14 @@ export function createScopedKey(parts: readonly string[]): string {
 	});
 }
 
+/** Create the canonical lookup key for a connection-owned SCIM User externalId. */
+export function createSCIMUserExternalIdKey(
+	connectionId: string,
+	externalId: string,
+): string {
+	return createScopedKey(["scim-user-external-id", connectionId, externalId]);
+}
+
 /** Create one unique, lexicographically stable classic-pagination key. */
 export function createSCIMOrderKey(createdAt: Date): string {
 	return `${createdAt.getTime().toString().padStart(15, "0")}:${generateId(16)}`;

--- a/packages/scim/src/scim-identity-resolution.test.ts
+++ b/packages/scim/src/scim-identity-resolution.test.ts
@@ -7,13 +7,20 @@ import type {
 import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { describe, expect, expectTypeOf, it } from "vitest";
-import type { SCIMCanonicalUser, SCIMConnectionOptions, SCIMIdentity } from ".";
-import { scim } from ".";
 import type {
+	SCIMCanonicalUser,
+	SCIMConnectionOptions,
+	SCIMIdentity,
+	SCIMUserExternalIdReference,
+} from ".";
+import { acquireActiveSCIMUserLink, scim } from ".";
+import type {
+	SCIMConnectionBinding,
 	SCIMIdentityTombstone,
 	SCIMSubject,
 	SCIMUser,
 } from "./persistence";
+import { createSCIMUserExternalIdKey } from "./resource-key";
 
 const BASE_URL = "http://localhost:3000";
 const CONNECTION_A = {
@@ -95,7 +102,7 @@ function createIdentityFixture(
 		session: [...(options.sessions ?? [])],
 		verification: [] as { id: string }[],
 		account: [] as { id: string }[],
-		scimConnectionBinding: [] as { id: string }[],
+		scimConnectionBinding: [] as SCIMConnectionBinding[],
 		scimIdentityTombstone: [] as SCIMIdentityTombstone[],
 		scimSubject: [] as SCIMSubject[],
 		scimUser: [] as SCIMUser[],
@@ -118,6 +125,19 @@ function createIdentityFixture(
 	});
 
 	return { auth, data };
+}
+
+async function acquireUserLink(
+	auth: ReturnType<typeof createIdentityFixture>["auth"],
+	reference: SCIMUserExternalIdReference,
+) {
+	const context = await auth.$context;
+	if (!context.adapter.transaction) {
+		throw new Error("Expected native transaction support");
+	}
+	return context.adapter.transaction((database) =>
+		acquireActiveSCIMUserLink(reference, { database }),
+	);
 }
 
 function authorization(token: string) {
@@ -807,5 +827,203 @@ describe("SCIM explicit identity resolution", () => {
 		expect(data.user[0]).toMatchObject({ name: "Managed Before Failure" });
 		expect(data.session).toEqual([session]);
 		expect(data.scimSubject[0]?.revision).toBe(revisionBeforeFailure);
+	});
+});
+
+describe("SCIM active User links", () => {
+	it("acquires exact case-sensitive links isolated by connection", async () => {
+		const { auth, data } = createIdentityFixture({
+			connections: [CONNECTION_A, CONNECTION_B],
+		});
+		const sourceA = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "connection-a@example.com",
+				externalId: "Case-Exact-Subject",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		const sourceB = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "connection-b@example.com",
+				externalId: "Case-Exact-Subject",
+			},
+			headers: authorization("connection-b-token"),
+		});
+
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "Case-Exact-Subject",
+			}),
+		).resolves.toEqual({
+			scimUserId: sourceA.id,
+			userId: data.scimUser.find(({ id }) => id === sourceA.id)?.userId,
+		});
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_B.id,
+				externalId: "Case-Exact-Subject",
+			}),
+		).resolves.toEqual({
+			scimUserId: sourceB.id,
+			userId: data.scimUser.find(({ id }) => id === sourceB.id)?.userId,
+		});
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "case-exact-subject",
+			}),
+		).resolves.toBeNull();
+	});
+
+	it("rejects inactive and deleted links, then follows explicit reprovisioning", async () => {
+		const { auth, data } = createIdentityFixture();
+		const firstSource = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "lifecycle@example.com",
+				externalId: "lifecycle-subject",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		const originalUserId = data.scimUser[0]?.userId;
+
+		await auth.api.patchSCIMUser({
+			params: { userId: firstSource.id },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [{ op: "replace", path: "active", value: false }],
+			},
+			headers: authorization("connection-a-token"),
+		});
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "lifecycle-subject",
+			}),
+		).resolves.toBeNull();
+
+		await auth.api.deleteSCIMUser({
+			params: { userId: firstSource.id },
+			headers: authorization("connection-a-token"),
+		});
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "lifecycle-subject",
+			}),
+		).resolves.toBeNull();
+
+		const reprovisioned = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "restored@example.com",
+				externalId: "lifecycle-subject",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "lifecycle-subject",
+			}),
+		).resolves.toEqual({
+			scimUserId: reprovisioned.id,
+			userId: originalUserId,
+		});
+	});
+
+	it("rejects tombstoned, orphaned, and missing-subject links", async () => {
+		const createProvisionedFixture = async (externalId: string) => {
+			const fixture = createIdentityFixture();
+			await fixture.auth.api.createSCIMUser({
+				body: {
+					schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+					userName: `${externalId}@example.com`,
+					externalId,
+				},
+				headers: authorization("connection-a-token"),
+			});
+			return fixture;
+		};
+
+		const tombstoned = await createProvisionedFixture("tombstoned-subject");
+		const tombstonedSource = tombstoned.data.scimUser[0]!;
+		tombstoned.data.scimIdentityTombstone.push({
+			id: "stale-tombstone",
+			connectionId: CONNECTION_A.id,
+			provisioningDomainId: tombstonedSource.provisioningDomainId,
+			externalId: "tombstoned-subject",
+			externalIdKey: createSCIMUserExternalIdKey(
+				CONNECTION_A.id,
+				"tombstoned-subject",
+			),
+			userId: tombstonedSource.userId,
+			profile: "preserve",
+			deletedAt: new Date(),
+		});
+		await expect(
+			acquireUserLink(tombstoned.auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "tombstoned-subject",
+			}),
+		).resolves.toBeNull();
+
+		const orphaned = await createProvisionedFixture("orphaned-subject");
+		orphaned.data.user.splice(0);
+		await expect(
+			acquireUserLink(orphaned.auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "orphaned-subject",
+			}),
+		).resolves.toBeNull();
+
+		const missingSubject = await createProvisionedFixture("missing-subject");
+		missingSubject.data.scimSubject.splice(0);
+		await expect(
+			acquireUserLink(missingSubject.auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "missing-subject",
+			}),
+		).resolves.toBeNull();
+	});
+
+	it("rejects decommissioned and provisioning-domain-inconsistent links", async () => {
+		const decommissioned = createIdentityFixture();
+		await decommissioned.auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "decommissioned@example.com",
+				externalId: "decommissioned-subject",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		decommissioned.data.scimConnectionBinding[0]!.decommissionStatus =
+			"complete";
+		await expect(
+			acquireUserLink(decommissioned.auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "decommissioned-subject",
+			}),
+		).resolves.toBeNull();
+
+		const inconsistent = createIdentityFixture();
+		await inconsistent.auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "inconsistent@example.com",
+				externalId: "inconsistent-subject",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		inconsistent.data.scimUser[0]!.provisioningDomainId = "different-domain";
+		await expect(
+			acquireUserLink(inconsistent.auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "inconsistent-subject",
+			}),
+		).resolves.toBeNull();
 	});
 });

--- a/packages/scim/src/scim-sso-http-e2e.test.ts
+++ b/packages/scim/src/scim-sso-http-e2e.test.ts
@@ -1,0 +1,537 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { NodeSqliteDialect } from "@better-auth/kysely-adapter/node-sqlite-dialect";
+import { sso } from "@better-auth/sso";
+import type { Account, DBTransactionAdapter } from "better-auth";
+import { getHttpTestInstance } from "better-auth/test";
+import { Kysely } from "kysely";
+import { OAuth2Server } from "oauth2-mock-server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getMigrations } from "../../better-auth/src/db/get-migration";
+import { acquireActiveSCIMUserLink, scim } from ".";
+import type { SCIMConnectionBinding, SCIMSubject } from "./persistence";
+
+const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+const SCIM_MEDIA_TYPE = "application/scim+json";
+const WORKFORCE_CONNECTION_ID = "workforce";
+const WORKFORCE_TOKEN = "workforce-scim-token";
+const CONTRACTOR_CONNECTION_ID = "contractors";
+const CONTRACTOR_TOKEN = "contractors-scim-token";
+
+type CookieJar = Map<string, string>;
+type IncrementOneInput = Parameters<DBTransactionAdapter["incrementOne"]>[0];
+
+interface SCIMUserResponse {
+	id: string;
+	active: boolean;
+}
+
+interface SessionResponse {
+	user: {
+		id: string;
+		email: string;
+		name: string;
+	};
+}
+
+function storeResponseCookies(response: Response, cookies: CookieJar): void {
+	for (const setCookie of response.headers.getSetCookie()) {
+		const attributesIndex = setCookie.indexOf(";");
+		const cookie =
+			attributesIndex < 0 ? setCookie : setCookie.slice(0, attributesIndex);
+		const separatorIndex = cookie.indexOf("=");
+		if (separatorIndex < 1) continue;
+		const name = cookie.slice(0, separatorIndex);
+		const value = cookie.slice(separatorIndex + 1);
+		if (value) cookies.set(name, value);
+		else cookies.delete(name);
+	}
+}
+
+function getCookieHeader(cookies: CookieJar): string {
+	return [...cookies].map(([name, value]) => `${name}=${value}`).join("; ");
+}
+
+async function readJSON<T>(response: Response): Promise<T> {
+	return (await response.json()) as T;
+}
+
+function createSCIMHeaders(token: string): HeadersInit {
+	return {
+		accept: SCIM_MEDIA_TYPE,
+		authorization: `Bearer ${token}`,
+		"content-type": SCIM_MEDIA_TYPE,
+	};
+}
+
+function createDeferred() {
+	let resolve!: () => void;
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+describe("SCIM-provisioned SSO authentication over HTTP", () => {
+	const identityProvider = new OAuth2Server();
+	const externalId = "directory-user-1";
+
+	beforeAll(async () => {
+		await identityProvider.issuer.keys.generate("RS256");
+		identityProvider.service.on("beforeUserinfo", (response) => {
+			response.body = {
+				sub: externalId,
+				email: "employee@identity-provider.example",
+				name: "Identity Provider Employee",
+				email_verified: true,
+			};
+			response.statusCode = 200;
+		});
+		identityProvider.service.on("beforeTokenSigning", (token) => {
+			token.payload.sub = externalId;
+			token.payload.email = "employee@identity-provider.example";
+			token.payload.name = "Identity Provider Employee";
+			token.payload.email_verified = true;
+		});
+		await identityProvider.start(undefined, "127.0.0.1");
+	});
+
+	afterAll(async () => {
+		await identityProvider.stop();
+	});
+
+	it("authenticates only the active User owned by the paired SCIM connection", async ({
+		onTestFinished,
+	}) => {
+		let resolverPause:
+			| {
+					reached: ReturnType<typeof createDeferred>;
+					release: ReturnType<typeof createDeferred>;
+			  }
+			| undefined;
+		const tempDirectory = mkdtempSync(join(tmpdir(), "better-auth-scim-sso-"));
+		const databasePath = join(tempDirectory, "auth.sqlite");
+		const sqlite = new DatabaseSync(databasePath);
+		sqlite.exec("PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000;");
+		const db = new Kysely({
+			dialect: new NodeSqliteDialect({ database: sqlite }),
+		});
+		const lifecycleSqlite = new DatabaseSync(databasePath);
+		lifecycleSqlite.exec(
+			"PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000;",
+		);
+		const lifecycleDB = new Kysely({
+			dialect: new NodeSqliteDialect({ database: lifecycleSqlite }),
+		});
+		const createSCIMPlugin = () =>
+			scim({
+				connections: [
+					{
+						id: WORKFORCE_CONNECTION_ID,
+						credentials: [
+							{
+								type: "bearer",
+								id: "workforce-token",
+								token: WORKFORCE_TOKEN,
+							},
+						],
+					},
+					{
+						id: CONTRACTOR_CONNECTION_ID,
+						credentials: [
+							{
+								type: "bearer",
+								id: "contractors-token",
+								token: CONTRACTOR_TOKEN,
+							},
+						],
+					},
+				],
+			});
+		const instance = await getHttpTestInstance(
+			{
+				database: { db, type: "sqlite", transaction: true },
+				trustedOrigins: [identityProvider.issuer.url!],
+				plugins: [
+					createSCIMPlugin(),
+					sso({
+						disableImplicitSignUp: true,
+						defaultSSO: [
+							{
+								domain: "example.com",
+								providerId: "workforce",
+								oidcConfig: {
+									issuer: identityProvider.issuer.url!,
+									clientId: "workforce-client",
+									clientSecret: "workforce-secret",
+									pkce: false,
+									discoveryEndpoint: `${identityProvider.issuer.url}/.well-known/openid-configuration`,
+								},
+							},
+						],
+						resolveUser: async (input, context) => {
+							if (input.providerId !== "workforce") {
+								return { action: "continue" };
+							}
+							const incrementOne: DBTransactionAdapter["incrementOne"] = async <
+								Row,
+							>(
+								query: IncrementOneInput,
+							) => {
+								if (resolverPause && query.model === "scimSubject") {
+									const pause = resolverPause;
+									resolverPause = undefined;
+									pause.reached.resolve();
+									await pause.release.promise;
+								}
+								return context.database.incrementOne<Row>(query);
+							};
+							const link = await acquireActiveSCIMUserLink(
+								{
+									connectionId: WORKFORCE_CONNECTION_ID,
+									externalId: input.accountKey.providerAccountId,
+								},
+								{
+									database: {
+										findOne: context.database.findOne,
+										incrementOne,
+									},
+								},
+							);
+							return link
+								? {
+										action: "link",
+										userId: link.userId,
+										profile: "preserve",
+									}
+								: {
+										action: "reject",
+										code: "SCIM_USER_NOT_ACTIVE",
+										message: "This directory user is not active",
+									};
+						},
+					}),
+				],
+			},
+			{ disableTestUser: true, testWith: "sqlite" },
+		);
+		const migrations = await getMigrations(instance.auth.options);
+		await migrations.runMigrations();
+		const lifecycleInstance = await getHttpTestInstance(
+			{
+				database: { db: lifecycleDB, type: "sqlite", transaction: true },
+				plugins: [createSCIMPlugin()],
+			},
+			{ disableTestUser: true, testWith: "sqlite" },
+		);
+		onTestFinished(async () => {
+			await Promise.all([
+				instance.server.close(),
+				lifecycleInstance.server.close(),
+			]);
+			await Promise.all([db.destroy(), lifecycleDB.destroy()]);
+			rmSync(tempDirectory, { recursive: true, force: true });
+		});
+
+		async function provisionSCIMUser(
+			token: string,
+			userName: string,
+		): Promise<SCIMUserResponse> {
+			const response = await fetch(
+				`${lifecycleInstance.baseURL}/api/auth/scim/v2/Users`,
+				{
+					method: "POST",
+					headers: createSCIMHeaders(token),
+					body: JSON.stringify({
+						schemas: [SCIM_USER_SCHEMA],
+						externalId,
+						userName,
+						name: { formatted: "Provisioned Employee" },
+						active: true,
+					}),
+				},
+			);
+			expect(response.status).toBe(201);
+			return readJSON<SCIMUserResponse>(response);
+		}
+
+		async function setSCIMUserActive(
+			userId: string,
+			active: boolean,
+		): Promise<void> {
+			const response = await fetch(
+				`${lifecycleInstance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(userId)}`,
+				{
+					method: "PATCH",
+					headers: createSCIMHeaders(WORKFORCE_TOKEN),
+					body: JSON.stringify({
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [{ op: "replace", path: "active", value: active }],
+					}),
+				},
+			);
+			expect(response.status).toBe(204);
+		}
+
+		async function deleteSCIMUser(userId: string): Promise<void> {
+			const response = await fetch(
+				`${lifecycleInstance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(userId)}`,
+				{
+					method: "DELETE",
+					headers: createSCIMHeaders(WORKFORCE_TOKEN),
+				},
+			);
+			expect(response.status).toBe(204);
+		}
+
+		async function initiateSSO() {
+			const cookies: CookieJar = new Map();
+			const signInResponse = await fetch(
+				`${instance.baseURL}/api/auth/sign-in/sso`,
+				{
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						origin: instance.baseURL,
+					},
+					body: JSON.stringify({
+						providerId: "workforce",
+						callbackURL: `${instance.baseURL}/employee`,
+					}),
+				},
+			);
+			storeResponseCookies(signInResponse, cookies);
+			expect(signInResponse.status).toBe(200);
+			const signIn = await readJSON<{ url: string }>(signInResponse);
+			const authorization = await fetch(signIn.url, { redirect: "manual" });
+			const callbackURL = authorization.headers.get("location");
+			if (!callbackURL) {
+				throw new Error("OIDC provider did not return a callback URL");
+			}
+			return { callbackURL, cookies };
+		}
+
+		async function completeSSO(flow: Awaited<ReturnType<typeof initiateSSO>>) {
+			const callback = await fetch(flow.callbackURL, {
+				headers: { cookie: getCookieHeader(flow.cookies) },
+				redirect: "manual",
+			});
+			expect(callback.status).toBe(302);
+			storeResponseCookies(callback, flow.cookies);
+			return { callback, cookies: flow.cookies };
+		}
+
+		async function signInWithSSO() {
+			return completeSSO(await initiateSSO());
+		}
+
+		async function getSession(cookies: CookieJar) {
+			const response = await fetch(`${instance.baseURL}/api/auth/get-session`, {
+				headers: { cookie: getCookieHeader(cookies) },
+			});
+			expect(response.status).toBe(200);
+			return readJSON<SessionResponse | null>(response);
+		}
+
+		async function expectRejectedSignIn() {
+			const recordsBefore = {
+				users: await lifecycleInstance.db.count({ model: "user", where: [] }),
+				accounts: await lifecycleInstance.db.count({
+					model: "account",
+					where: [],
+				}),
+				sessions: await lifecycleInstance.db.count({
+					model: "session",
+					where: [],
+				}),
+			};
+			const signIn = await signInWithSSO();
+			const location = signIn.callback.headers.get("location");
+			if (!location) throw new Error("SSO rejection did not redirect");
+			expect(
+				new URL(location, instance.baseURL).searchParams.get("error"),
+			).toBe("SCIM_USER_NOT_ACTIVE");
+			expect(await getSession(signIn.cookies)).toBeNull();
+			expect({
+				users: await lifecycleInstance.db.count({
+					model: "user",
+					where: [],
+				}),
+				accounts: await lifecycleInstance.db.count({
+					model: "account",
+					where: [],
+				}),
+				sessions: await lifecycleInstance.db.count({
+					model: "session",
+					where: [],
+				}),
+			}).toEqual(recordsBefore);
+		}
+
+		async function getFenceRevisions() {
+			const subject = await lifecycleInstance.db.findOne<SCIMSubject>({
+				model: "scimSubject",
+				where: [],
+			});
+			const connection =
+				await lifecycleInstance.db.findOne<SCIMConnectionBinding>({
+					model: "scimConnectionBinding",
+					where: [{ field: "connectionId", value: WORKFORCE_CONNECTION_ID }],
+				});
+			return {
+				subject: subject?.revision,
+				connection: connection?.decommissionRevision,
+			};
+		}
+
+		const provisioned = await provisionSCIMUser(
+			WORKFORCE_TOKEN,
+			"provisioned.employee@example.com",
+		);
+		expect(await lifecycleInstance.db.count({ model: "user", where: [] })).toBe(
+			1,
+		);
+		expect(
+			await lifecycleInstance.db.count({ model: "account", where: [] }),
+		).toBe(0);
+
+		const pauseReached = createDeferred();
+		const releaseResolver = createDeferred();
+		resolverPause = { reached: pauseReached, release: releaseResolver };
+		const conflictedFlow = await initiateSSO();
+		const conflictedCallback = completeSSO(conflictedFlow);
+		await pauseReached.promise;
+		let lifecycleMutationError: unknown;
+		let stateAfterCommittedDeactivation:
+			| {
+					revisions: Awaited<ReturnType<typeof getFenceRevisions>>;
+					accounts: number;
+					sessions: number;
+			  }
+			| undefined;
+		try {
+			await setSCIMUserActive(provisioned.id, false);
+			stateAfterCommittedDeactivation = {
+				revisions: await getFenceRevisions(),
+				accounts: await lifecycleInstance.db.count({
+					model: "account",
+					where: [],
+				}),
+				sessions: await lifecycleInstance.db.count({
+					model: "session",
+					where: [],
+				}),
+			};
+		} catch (error) {
+			lifecycleMutationError = error;
+		} finally {
+			releaseResolver.resolve();
+		}
+		const conflictedSignIn = await conflictedCallback;
+		if (lifecycleMutationError) throw lifecycleMutationError;
+		expect(
+			new URL(
+				conflictedSignIn.callback.headers.get("location")!,
+				instance.baseURL,
+			).searchParams.get("error"),
+		).toBe("SSO_USER_RESOLUTION_FAILED");
+		expect(await getSession(conflictedSignIn.cookies)).toBeNull();
+		expect(stateAfterCommittedDeactivation).toMatchObject({
+			accounts: 0,
+			sessions: 0,
+		});
+		expect({
+			revisions: await getFenceRevisions(),
+			accounts: await lifecycleInstance.db.count({
+				model: "account",
+				where: [],
+			}),
+			sessions: await lifecycleInstance.db.count({
+				model: "session",
+				where: [],
+			}),
+		}).toEqual(stateAfterCommittedDeactivation);
+		await expectRejectedSignIn();
+		await setSCIMUserActive(provisioned.id, true);
+
+		const concurrentFlows = await Promise.all([initiateSSO(), initiateSSO()]);
+		const concurrentSignIns = await Promise.all(
+			concurrentFlows.map((flow) => completeSSO(flow)),
+		);
+		expect(
+			concurrentSignIns.map(({ callback }) => callback.headers.get("location")),
+		).toEqual([`${instance.baseURL}/employee`, `${instance.baseURL}/employee`]);
+		const concurrentSessions = await Promise.all(
+			concurrentSignIns.map(({ cookies }) => getSession(cookies)),
+		);
+		const firstSession = concurrentSessions[0];
+		expect(firstSession?.user).toMatchObject({
+			email: "provisioned.employee@example.com",
+			name: "Provisioned Employee",
+		});
+		if (!firstSession) throw new Error("SSO sign-in did not create a session");
+		const provisionedUserId = firstSession.user.id;
+		expect(concurrentSessions).toEqual([
+			expect.objectContaining({
+				user: expect.objectContaining({ id: provisionedUserId }),
+			}),
+			expect.objectContaining({
+				user: expect.objectContaining({ id: provisionedUserId }),
+			}),
+		]);
+		expect(await instance.db.count({ model: "session", where: [] })).toBe(2);
+		expect(await instance.db.count({ model: "user", where: [] })).toBe(1);
+		expect(await instance.db.count({ model: "account", where: [] })).toBe(1);
+		const account = await instance.db.findOne<Account>({
+			model: "account",
+			where: [],
+		});
+		expect(account).toMatchObject({
+			issuer: identityProvider.issuer.url,
+			providerAccountId: externalId,
+			providerId: "workforce",
+			userId: provisionedUserId,
+		});
+
+		await setSCIMUserActive(provisioned.id, false);
+		expect(await instance.db.count({ model: "session", where: [] })).toBe(0);
+		await expectRejectedSignIn();
+		await setSCIMUserActive(provisioned.id, true);
+		expect(await getSession((await signInWithSSO()).cookies)).toMatchObject({
+			user: { id: provisionedUserId },
+		});
+
+		await deleteSCIMUser(provisioned.id);
+		expect(await instance.db.count({ model: "session", where: [] })).toBe(0);
+		await expectRejectedSignIn();
+		await provisionSCIMUser(
+			CONTRACTOR_TOKEN,
+			"contractor.employee@example.com",
+		);
+		await expectRejectedSignIn();
+
+		const restored = await provisionSCIMUser(
+			WORKFORCE_TOKEN,
+			"restored.employee@example.com",
+		);
+		expect(restored.id).not.toBe(provisioned.id);
+		const restoredSession = await getSession((await signInWithSSO()).cookies);
+		expect(restoredSession?.user).toMatchObject({
+			id: provisionedUserId,
+			email: "restored.employee@example.com",
+		});
+		expect(await instance.db.count({ model: "user", where: [] })).toBe(2);
+		expect(await instance.db.count({ model: "account", where: [] })).toBe(1);
+		expect(
+			await instance.db.findOne<Account>({ model: "account", where: [] }),
+		).toMatchObject({
+			issuer: identityProvider.issuer.url,
+			providerAccountId: externalId,
+			providerId: "workforce",
+			userId: provisionedUserId,
+		});
+	});
+});

--- a/packages/scim/src/scim-user-concurrency.test.ts
+++ b/packages/scim/src/scim-user-concurrency.test.ts
@@ -9,8 +9,9 @@ import { betterAuth } from "better-auth";
 import type { MemoryDB } from "better-auth/adapters/memory";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { describe, expect, it } from "vitest";
-import { scim } from ".";
+import { acquireActiveSCIMUserLink, scim } from ".";
 import type {
+	SCIMConnectionBinding,
 	SCIMGroup,
 	SCIMGroupMember,
 	SCIMIdentityTombstone,
@@ -26,6 +27,7 @@ const headers = { authorization: "Bearer test-scim-token" };
 
 interface UserDeletionData extends MemoryDB {
 	user: User[];
+	scimConnectionBinding: SCIMConnectionBinding[];
 	scimIdentityTombstone: SCIMIdentityTombstone[];
 	scimSubject: SCIMSubject[];
 	scimUser: SCIMUser[];
@@ -41,6 +43,7 @@ interface IncrementOneInput {
 }
 
 type CreateInput = Parameters<DBTransactionAdapter["create"]>[0];
+type FindOneInput = Parameters<DBTransactionAdapter["findOne"]>[0];
 
 function createData(): UserDeletionData {
 	return {
@@ -68,6 +71,13 @@ function createDeferred() {
 
 function findWhereValue(where: readonly Where[], field: string): unknown {
 	return where.find((clause) => clause.field === field)?.value;
+}
+
+function getIdentityRevisions(data: UserDeletionData) {
+	return {
+		subjectRevision: data.scimSubject[0]?.revision,
+		connectionRevision: data.scimConnectionBinding[0]?.decommissionRevision,
+	};
 }
 
 function createAuth(database: BetterAuthOptions["database"]) {
@@ -616,5 +626,166 @@ describe("SCIM User concurrency", () => {
 		expect(data.scimGroup.every((group) => group.updatedAt.getTime() > 0)).toBe(
 			true,
 		);
+	});
+
+	it("aborts active-link acquisition when the subject revision fence is lost", async () => {
+		const data = createData();
+		const auth = createAuth(memoryAdapter(data));
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: [USER_SCHEMA],
+				userName: "subject-race@example.com",
+				externalId: "subject-race",
+			},
+			headers,
+		});
+		const revisionsBeforeRace = getIdentityRevisions(data);
+		const context = await auth.$context;
+		if (!context.adapter.transaction) {
+			throw new Error("Expected native transaction support");
+		}
+
+		await expect(
+			context.adapter.transaction((transaction) => {
+				const incrementOne: DBTransactionAdapter["incrementOne"] = async <Row>(
+					input: IncrementOneInput,
+				) => {
+					if (input.model === "scimSubject") return null;
+					return transaction.incrementOne<Row>(input);
+				};
+				return acquireActiveSCIMUserLink(
+					{ connectionId: "workforce", externalId: "subject-race" },
+					{ database: { findOne: transaction.findOne, incrementOne } },
+				);
+			}),
+		).rejects.toMatchObject({ statusCode: 409 });
+		expect(getIdentityRevisions(data)).toEqual(revisionsBeforeRace);
+	});
+
+	it("returns one success and one retryable conflict when acquisitions lose the same revision race", async () => {
+		const data = createData();
+		const auth = createAuth(memoryAdapter(data));
+		const resource = await auth.api.createSCIMUser({
+			body: {
+				schemas: [USER_SCHEMA],
+				userName: "parallel-acquisition@example.com",
+				externalId: "parallel-acquisition",
+			},
+			headers,
+		});
+		const context = await auth.$context;
+		const incrementsReady = createDeferred();
+		let pendingIncrements = 0;
+		const incrementOne: DBTransactionAdapter["incrementOne"] = async <Row>(
+			input: IncrementOneInput,
+		) => {
+			if (input.model === "scimSubject") {
+				pendingIncrements += 1;
+				if (pendingIncrements === 2) incrementsReady.resolve();
+				else await incrementsReady.promise;
+			}
+			return context.adapter.incrementOne<Row>(input);
+		};
+		const database = { findOne: context.adapter.findOne, incrementOne };
+
+		const results = await Promise.allSettled([
+			acquireActiveSCIMUserLink(
+				{ connectionId: "workforce", externalId: "parallel-acquisition" },
+				{ database },
+			),
+			acquireActiveSCIMUserLink(
+				{ connectionId: "workforce", externalId: "parallel-acquisition" },
+				{ database },
+			),
+		]);
+		expect(results.filter(({ status }) => status === "fulfilled")).toEqual([
+			expect.objectContaining({
+				value: {
+					scimUserId: resource.id,
+					userId: data.scimUser[0]?.userId,
+				},
+			}),
+		]);
+		expect(results.filter(({ status }) => status === "rejected")).toEqual([
+			expect.objectContaining({
+				reason: expect.objectContaining({ statusCode: 409 }),
+			}),
+		]);
+	});
+
+	it("aborts when the source changes after subject acquisition", async () => {
+		const data = createData();
+		const auth = createAuth(memoryAdapter(data));
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: [USER_SCHEMA],
+				userName: "source-race@example.com",
+				externalId: "source-race",
+			},
+			headers,
+		});
+		const revisionsBeforeRace = getIdentityRevisions(data);
+		const context = await auth.$context;
+		if (!context.adapter.transaction) {
+			throw new Error("Expected native transaction support");
+		}
+
+		await expect(
+			context.adapter.transaction((transaction) => {
+				let subjectAcquired = false;
+				const incrementOne: DBTransactionAdapter["incrementOne"] = async <Row>(
+					input: IncrementOneInput,
+				) => {
+					const updated = await transaction.incrementOne<Row>(input);
+					if (input.model === "scimSubject" && updated) subjectAcquired = true;
+					return updated;
+				};
+				const findOne: DBTransactionAdapter["findOne"] = async <Row>(
+					input: FindOneInput,
+				) => {
+					if (subjectAcquired && input.model === "scimUser") return null;
+					return transaction.findOne<Row>(input);
+				};
+				return acquireActiveSCIMUserLink(
+					{ connectionId: "workforce", externalId: "source-race" },
+					{ database: { findOne, incrementOne } },
+				);
+			}),
+		).rejects.toMatchObject({ statusCode: 409 });
+		expect(getIdentityRevisions(data)).toEqual(revisionsBeforeRace);
+	});
+
+	it("aborts when connection decommissioning wins the final fence", async () => {
+		const data = createData();
+		const auth = createAuth(memoryAdapter(data));
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: [USER_SCHEMA],
+				userName: "connection-race@example.com",
+				externalId: "connection-race",
+			},
+			headers,
+		});
+		const revisionsBeforeRace = getIdentityRevisions(data);
+		const context = await auth.$context;
+		if (!context.adapter.transaction) {
+			throw new Error("Expected native transaction support");
+		}
+
+		await expect(
+			context.adapter.transaction((transaction) => {
+				const incrementOne: DBTransactionAdapter["incrementOne"] = async <Row>(
+					input: IncrementOneInput,
+				) => {
+					if (input.model === "scimConnectionBinding") return null;
+					return transaction.incrementOne<Row>(input);
+				};
+				return acquireActiveSCIMUserLink(
+					{ connectionId: "workforce", externalId: "connection-race" },
+					{ database: { findOne: transaction.findOne, incrementOne } },
+				);
+			}),
+		).rejects.toMatchObject({ statusCode: 409 });
+		expect(getIdentityRevisions(data)).toEqual(revisionsBeforeRace);
 	});
 });

--- a/packages/scim/src/user-provisioning.ts
+++ b/packages/scim/src/user-provisioning.ts
@@ -32,7 +32,11 @@ import type {
 } from "./persistence";
 import type { SCIMProjectionCoordinator } from "./projection";
 import { projectSCIMResourceAttributes } from "./resource-attribute-projection";
-import { createSCIMOrderKey, createScopedKey } from "./resource-key";
+import {
+	createSCIMOrderKey,
+	createSCIMUserExternalIdKey,
+	createScopedKey,
+} from "./resource-key";
 import { SCIM_RESOURCE_SCHEMA_REGISTRY } from "./resource-schema-registry";
 import { runSCIMCreateWithUniquenessCheck } from "./resource-uniqueness";
 import { createSCIMError, SCIMErrorOpenAPISchemas } from "./scim-error";
@@ -91,7 +95,7 @@ function createExternalIdKey(
 	externalId?: string,
 ): string | undefined {
 	if (!externalId) return undefined;
-	return createScopedKey(["scim-user-external-id", connectionId, externalId]);
+	return createSCIMUserExternalIdKey(connectionId, externalId);
 }
 
 function createConnectionUserKey(connectionId: string, userId: string): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1586,12 +1586,18 @@ importers:
       '@better-auth/kysely-adapter':
         specifier: workspace:*
         version: link:../kysely-adapter
+      '@better-auth/sso':
+        specifier: workspace:*
+        version: link:../sso
       '@better-auth/test-utils':
         specifier: workspace:*
         version: link:../test-utils
       kysely:
         specifier: 0.28.17
         version: 0.28.17
+      oauth2-mock-server:
+        specifier: ^9.0.0
+        version: 9.0.0
       tsdown:
         specifier: 'catalog:'
         version: 0.21.1(@arethetypeswrong/core@0.18.3)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@5.9.3)


### PR DESCRIPTION
SCIM provisioning creates and manages users, but applications had no public way to resolve an active provisioned user by connection and `externalId` for authentication. This exposes a schema-preserving lookup that composes with OIDC user resolution without guessing by email.

## What changes

- **Stable key:** expose the exact connection-scoped resource key used by provisioning through `SCIMUserExternalIdReference`.
- **Active-user lookup:** `acquireActiveSCIMUserLink` returns the linked Better Auth user only while the SCIM resource is active.
- **Lifecycle safety:** deactivated, deleted, stale, foreign-connection, and concurrent reprovisioning states fail closed.
- **Composition:** document and exercise the SCIM-to-SSO resolver flow while keeping User, Account, and SCIM schemas unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a transaction-safe helper to resolve an active SCIM‑provisioned user by exact connection and `externalId`, enabling clean SSO linking without email matching. Only links when the SCIM identity is active, owned by the connection, matches the provisioning domain, is case‑exact, and not tombstoned, with subject and connection decommission fences.

- **New Features**
  - Added `acquireActiveSCIMUserLink(reference, { database })` to return `{ scimUserId, userId }` or `null` for inactive, deleted, tombstoned, orphaned, decommissioned, or provisioning‑domain‑mismatched users; lookups are connection‑scoped and case‑exact, fenced on subject and connection revisions.
  - Exported `SCIMUserExternalIdReference`, `SCIMActiveUserLink`, `SCIMActiveUserLinkContext`, and `createSCIMUserExternalIdKey`; updated docs with a `@better-auth/sso` `resolveUser` example; added full HTTP e2e and concurrency tests using `oauth2-mock-server`.

- **Migration**
  - In `resolveUser`, call `acquireActiveSCIMUserLink({ connectionId, externalId: input.accountKey.providerAccountId }, context)`; `link` when present, otherwise `reject` with `"SCIM_USER_NOT_ACTIVE"`. Lifecycle conflicts abort as `"SSO_USER_RESOLUTION_FAILED"`.
  - Configure your directory to set OIDC `sub` as the SCIM User `externalId`. Pass the provided SSO `context` so the helper runs in the same transaction.

<sup>Written for commit dd7717e45a3c8e0e997a11f3aefa895da70947c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

