### PR TITLE
fix(one-tap): enforce google provider signup restrictions

### DIFF
--- a/.changeset/calm-tigers-smile.md
+++ b/.changeset/calm-tigers-smile.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Prevent Google One Tap from creating new users when sign-up is disabled for the Google provider.

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -179,7 +179,8 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 							idToken,
 							scope: "openid,profile,email",
 						},
-						disableSignUp: options?.disableSignup,
+						disableSignUp:
+							options?.disableSignup ?? googleProvider?.disableSignUp,
 					});
 					if (result.error) {
 						throw new APIError("UNAUTHORIZED", {

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -180,7 +180,7 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 							scope: "openid,profile,email",
 						},
 						disableSignUp:
-							options?.disableSignup ?? googleProvider?.disableSignUp,
+							options?.disableSignup || googleProvider?.disableSignUp,
 					});
 					if (result.error) {
 						throw new APIError("UNAUTHORIZED", {

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -638,16 +638,19 @@ describe("one-tap hosted domain (hd)", async () => {
 	});
 });
 
-describe("one-tap disableSignUp", async () => {
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10478
+ */
+describe("one-tap disableSignUp", () => {
 	afterEach(() => {
 		Object.assign(verifiedPayload, defaultVerifiedPayload);
 	});
 
-	it("rejects a new user when socialProviders.google.disableSignUp is true and creates no user", async () => {
+	it("rejects provider-disabled sign-up without creating a user", async () => {
 		verifiedPayload.email = "one-tap-disable-signup@example.com";
 		verifiedPayload.sub = "one-tap-disable-signup-sub";
 
-		const { auth, client } = await getTestInstance({
+		const { auth } = await getTestInstance({
 			socialProviders: {
 				google: {
 					clientId: "test-client",
@@ -659,15 +662,15 @@ describe("one-tap disableSignUp", async () => {
 			plugins: [oneTap()],
 		});
 
-		const res = await client.$fetch<{
-			data: unknown;
-			error: { status: number; message?: string } | null;
-		}>("/one-tap/callback", {
-			method: "POST",
-			body: { idToken: "stub-id-token" },
+		await expect(
+			auth.api.oneTapCallback({
+				body: { idToken: "stub-id-token" },
+			}),
+		).rejects.toMatchObject({
+			statusCode: 401,
+			status: "UNAUTHORIZED",
+			body: { message: "signup disabled" },
 		});
-
-		expect(res.error?.status).toBe(401);
 
 		const ctx = await auth.$context;
 		const users = await ctx.adapter.findMany<{ email: string }>({

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -637,3 +637,48 @@ describe("one-tap hosted domain (hd)", async () => {
 		expect(res.data?.token).toBeTruthy();
 	});
 });
+
+describe("one-tap disableSignUp", async () => {
+	afterEach(() => {
+		Object.assign(verifiedPayload, defaultVerifiedPayload);
+	});
+
+	it("rejects a new user when socialProviders.google.disableSignUp is true and creates no user", async () => {
+		verifiedPayload.email = "one-tap-disable-signup@example.com";
+		verifiedPayload.sub = "one-tap-disable-signup-sub";
+
+		const { auth, client } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+					disableSignUp: true,
+				},
+			},
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number; message?: string } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error?.status).toBe(401);
+
+		const ctx = await auth.$context;
+		const users = await ctx.adapter.findMany<{ email: string }>({
+			model: "user",
+			where: [
+				{
+					field: "email",
+					value: verifiedPayload.email,
+				},
+			],
+		});
+		expect(users).toHaveLength(0);
+	});
+});

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -684,4 +684,31 @@ describe("one-tap disableSignUp", () => {
 		});
 		expect(users).toHaveLength(0);
 	});
+
+	it("keeps provider sign-up disabled when One Tap enables it", async () => {
+		verifiedPayload.email = "one-tap-signup-override@example.com";
+		verifiedPayload.sub = "one-tap-signup-override-sub";
+
+		const { auth } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test-client",
+					clientSecret: "test-secret",
+					enabled: true,
+					disableSignUp: true,
+				},
+			},
+			plugins: [oneTap({ disableSignup: false })],
+		});
+
+		await expect(
+			auth.api.oneTapCallback({
+				body: { idToken: "stub-id-token" },
+			}),
+		).rejects.toMatchObject({
+			statusCode: 401,
+			status: "UNAUTHORIZED",
+			body: { message: "signup disabled" },
+		});
+	});
 });


### PR DESCRIPTION
Closes #10478

## Summary

Google One Tap previously ignored `socialProviders.google.disableSignUp`, allowing new users to sign up through One Tap even when sign-up was disabled for the Google provider.

This change makes One Tap enforce both provider-level and plugin-level sign-up restrictions. If either configuration disables sign-up, new users are rejected. A plugin-level `disableSignup: false` no longer relaxes the provider-level restriction.

## Changes

- respect `socialProviders.google.disableSignUp` in the One Tap callback
- prevent the One Tap plugin from overriding provider-level sign-up restrictions
- add regression coverage

## Testing

- added a regression test for `socialProviders.google.disableSignUp`
- verified the new test fails on the previous implementation
- verified the test passes with this change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `better-auth` One Tap to inherit `socialProviders.google.disableSignUp` and enforce provider-level restrictions. Fixes mismatch with the standard Google OAuth flow and blocks new users when sign-up is disabled.

- **Bug Fixes**
  - Provider `disableSignUp` now takes precedence; One Tap won’t re-enable sign-up even if `disableSignup: false` is set in the plugin.
  - Added regression tests using the typed API to verify rejection, no user creation, and non-override behavior.
  - Added changeset marking a patch release for `better-auth`.

<sup>Written for commit dd8546fc18a2e1e09af7a447249ebc1a71e9bc5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

