### PR TITLE
perf: memoize nextCookies dynamic import

### DIFF
--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -24,6 +24,14 @@ export function toNextJsHandler(
 	};
 }
 
+let nextHeadersPromise: Promise<typeof import("next/headers.js")> | undefined;
+const loadNextHeaders = () => {
+	if (process.env.NODE_ENV === "production") {
+		return (nextHeadersPromise ??= import("next/headers.js"));
+	}
+	return import("next/headers.js");
+};
+
 export const nextCookies = () => {
 	let hasWarned = false;
 
@@ -50,7 +58,7 @@ export const nextCookies = () => {
 							ReturnType<typeof import("next/headers.js").headers>
 						>;
 						try {
-							const { headers } = await import("next/headers.js");
+							const { headers } = await loadNextHeaders();
 							headersStore = await headers();
 						} catch {
 							return;
@@ -92,7 +100,7 @@ export const nextCookies = () => {
 								ReturnType<typeof import("next/headers.js").cookies>
 							>;
 							try {
-								const { cookies } = await import("next/headers.js");
+								const { cookies } = await loadNextHeaders();
 								cookieHelper = await cookies();
 							} catch (error) {
 								if (


### PR DESCRIPTION
Fixes #10466

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized the dynamic import of `next/headers.js` in `nextCookies` to avoid repeated module loads in production. This reduces overhead and speeds up header/cookie access.

- **Performance**
  - Added `loadNextHeaders()` with a cached Promise in production; dev still imports fresh for HMR.
  - Switched `headers()` and `cookies()` calls to use `loadNextHeaders()` instead of direct dynamic imports.

<sup>Written for commit 66c3143291ecd329e755915b93622e59dfa1c92e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

