### PR TITLE
fix(one-tap): respect global googleProvider disableSignUp option

### DIFF
--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -24,6 +24,14 @@ export function toNextJsHandler(
 	};
 }
 
+let nextHeadersPromise: Promise<typeof import("next/headers.js")> | undefined;
+const loadNextHeaders = () => {
+	if (process.env.NODE_ENV === "production") {
+		return (nextHeadersPromise ??= import("next/headers.js"));
+	}
+	return import("next/headers.js");
+};
+
 export const nextCookies = () => {
 	let hasWarned = false;
 
@@ -50,7 +58,7 @@ export const nextCookies = () => {
 							ReturnType<typeof import("next/headers.js").headers>
 						>;
 						try {
-							const { headers } = await import("next/headers.js");
+							const { headers } = await loadNextHeaders();
 							headersStore = await headers();
 						} catch {
 							return;
@@ -92,7 +100,7 @@ export const nextCookies = () => {
 								ReturnType<typeof import("next/headers.js").cookies>
 							>;
 							try {
-								const { cookies } = await import("next/headers.js");
+								const { cookies } = await loadNextHeaders();
 								cookieHelper = await cookies();
 							} catch (error) {
 								if (

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -179,7 +179,7 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 							idToken,
 							scope: "openid,profile,email",
 						},
-						disableSignUp: options?.disableSignup,
+						disableSignUp: options?.disableSignup ?? googleProvider?.disableSignUp,
 					});
 					if (result.error) {
 						throw new APIError("UNAUTHORIZED", {


### PR DESCRIPTION
Fixes #10478

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure One Tap respects the global `googleProvider.disableSignUp` by defaulting to it when `options.disableSignup` isn’t set. In production, memoize the `next/headers.js` dynamic import in `nextCookies` to stabilize header/cookie access and reduce overhead.

<sup>Written for commit ccc54540bffbefd8fe8a054fcb3c00962909a76e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

