### PR TITLE
perf(nextjs): memoize next/headers dynamic import to fix ESM hook CPU usage

### DIFF
--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -5,6 +5,14 @@ import { parseSetCookieHeader, toCookieOptions } from "../cookies";
 import { PACKAGE_VERSION } from "../version";
 import { warnIfCookiePluginNotLast } from "./cookie-plugin-guard";
 
+let nextHeadersPromise: Promise<typeof import("next/headers.js")> | undefined;
+const loadNextHeaders = () => {
+	if (process.env.NODE_ENV !== "production") {
+		return import("next/headers.js");
+	}
+	return (nextHeadersPromise ??= import("next/headers.js"));
+};
+
 export function toNextJsHandler(
 	auth:
 		| {
@@ -50,7 +58,7 @@ export const nextCookies = () => {
 							ReturnType<typeof import("next/headers.js").headers>
 						>;
 						try {
-							const { headers } = await import("next/headers.js");
+							const { headers } = await loadNextHeaders();
 							headersStore = await headers();
 						} catch {
 							return;
@@ -92,7 +100,7 @@ export const nextCookies = () => {
 								ReturnType<typeof import("next/headers.js").cookies>
 							>;
 							try {
-								const { cookies } = await import("next/headers.js");
+								const { cookies } = await loadNextHeaders();
 								cookieHelper = await cookies();
 							} catch (error) {
 								if (


### PR DESCRIPTION
Fixes #10466. The \
extCookies()\ plugin was previously re-importing \
ext/headers.js\ on every request, which caused significant CPU usage when ESM loader hooks (like Sentry or OpenTelemetry) were active. This PR memoizes the import promise at module scope in production, bypassing the expensive dynamic import on subsequent requests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoize the `next/headers.js` dynamic import in the Next.js integration to stop re-importing on every request and reduce CPU usage when ESM loader hooks (e.g., Sentry, OpenTelemetry) are active. In production we cache and reuse the import promise; development behavior is unchanged.

<sup>Written for commit 61c1d8d9194cbf80d5a6bb62f9deb6ceed1765ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

