### PR TITLE
docs: fix variable shadowing in api.mdx code example

### DIFF
--- a/docs/content/docs/concepts/api.mdx
+++ b/docs/content/docs/concepts/api.mdx
@@ -82,7 +82,7 @@ The `headers` will be a `Headers` object, which you can use to get the cookies o
 
 ```ts
 const cookies = headers.getSetCookie();
-const headers = headers.get("x-custom-header");
+const customHeader = headers.get("x-custom-header");
 ```
 
 #### Getting `Response` Object


### PR DESCRIPTION
The code example at concepts/api.mdx declares `const headers =
headers.get("x-custom-header")` which shadows the outer `Headers`
object and won't compile.

Rename the inner variable to `customHeader`.

Ref: https://github.com/better-auth/better-auth/blob/main/docs/content/docs/concepts/api.mdx?plain=1#L71-L85

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix variable shadowing in the `concepts/api.mdx` code example by renaming the inner `headers` variable to `customHeader`. This makes the snippet compile and avoids confusion with the outer `Headers` object.

<sup>Written for commit 50e4fca53f029ef07f84a7d6c4f95add4e1187d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

