### PR TITLE
feat(organization): slug optional

### DIFF
--- a/.changeset/organization-slug-optional.md
+++ b/.changeset/organization-slug-optional.md
@@ -14,7 +14,6 @@ plugins: [
             type: "string",
             // Required schema changes
             required: false,
-            // Optional schema changes
             unique: false,
             sortable: false,
             // Optional - forces `slug` to be returned as null in responses

--- a/.changeset/organization-slug-optional.md
+++ b/.changeset/organization-slug-optional.md
@@ -12,13 +12,11 @@ plugins: [
         additionalFields: {
           slug: {
             type: 'string',
-            // Required - allows optional
+            // Optional
             required: false,
-            // optional - allows setting to null is future updates
-            nullable: true,
-            // optional - prevents slug from return on existing records
+            // Optional - forces `slug` to be returned as null in responses
             transform: {
-              output: (value) => (value = null),
+              output: () => null,
             },
           },
         }

--- a/.changeset/organization-slug-optional.md
+++ b/.changeset/organization-slug-optional.md
@@ -1,0 +1,29 @@
+---
+"better-auth": patch
+---
+
+Allows explicit optional "slug" parameter for creation via `additionalFieldsSchema` marking `slug` as optional.
+
+```ts
+plugins: [
+  organization({
+    schema: {
+      organization: {
+        additionalFields: {
+          slug: {
+            type: 'string',
+            // Required - allows optional
+            required: false,
+            // optional - allows setting to null is future updates
+            nullable: true,
+            // optional - prevents slug from return on existing records
+            transform: {
+              output: (value) => (value = null),
+            },
+          },
+        }
+      }
+    },
+  })
+]
+```

--- a/.changeset/organization-slug-optional.md
+++ b/.changeset/organization-slug-optional.md
@@ -11,9 +11,12 @@ plugins: [
       organization: {
         additionalFields: {
           slug: {
-            type: 'string',
-            // Optional
+            type: "string",
+            // Required schema changes
             required: false,
+            // Optional schema changes
+            unique: false,
+            sortable: false,
             // Optional - forces `slug` to be returned as null in responses
             transform: {
               output: () => null,

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -411,7 +411,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		},
 		updateOrganization: async (
 			organizationId: string,
-			data: Partial<OrganizationInput>,
+			data: Partial<Omit<OrganizationInput, "slug">> & { slug?: string | null },
 		): Promise<InferOrganization<O> | null> => {
 			const adapter = await getCurrentAdapter(baseAdapter);
 			const organization = await adapter.update<InferOrganization<O, false>>({

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
@@ -284,10 +284,8 @@ describe("slug optional", async () => {
 		});
 		expect(org).toBeDefined();
 		expect(org?.name).toBe("no-slug-org");
-		// slug should not be required; allow undefined, null, or empty
-		expect(
-			org?.slug === undefined || org?.slug === null || org?.slug === "",
-		).toBeTruthy();
+		// slug should not be required; allow undefined or null (empty string should remain invalid)
+		expect(org?.slug === undefined || org?.slug === null).toBeTruthy();
 	});
 
 	it("allows updating organization name when slug is optional", async () => {

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
@@ -415,7 +415,6 @@ describe("slug optional", async () => {
 								slug: {
 									type: "string",
 									required: false,
-									nullable: true,
 								},
 							},
 						},

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
@@ -253,6 +253,9 @@ describe("get-full-organization", async () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/6662
+ */
 describe("slug optional", async () => {
 	it("allows creating organization without slug when slug is optional", async () => {
 		const { auth, signInWithTestUser } = await getTestInstance({

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.test.ts
@@ -253,6 +253,234 @@ describe("get-full-organization", async () => {
 	});
 });
 
+describe("slug optional", async () => {
+	it("allows creating organization without slug when slug is optional", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				organization({
+					schema: {
+						organization: {
+							additionalFields: {
+								slug: {
+									type: "string",
+									required: false,
+								},
+							},
+						},
+					},
+				}),
+			],
+		});
+		const { headers } = await signInWithTestUser();
+		const org = await auth.api.createOrganization({
+			// @ts-expect-error slug is optional
+			body: {
+				name: "no-slug-org",
+			},
+			headers,
+		});
+		expect(org).toBeDefined();
+		expect(org?.name).toBe("no-slug-org");
+		// slug should not be required; allow undefined, null, or empty
+		expect(
+			org?.slug === undefined || org?.slug === null || org?.slug === "",
+		).toBeTruthy();
+	});
+
+	it("allows updating organization name when slug is optional", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				organization({
+					schema: {
+						organization: {
+							additionalFields: {
+								slug: {
+									type: "string",
+									required: false,
+								},
+							},
+						},
+					},
+				}),
+			],
+		});
+		const { headers } = await signInWithTestUser();
+		const org = await auth.api.createOrganization({
+			// @ts-expect-error slug is optional
+			body: {
+				name: "no-slug-org",
+			},
+			headers,
+		});
+
+		const updated = await auth.api.updateOrganization({
+			body: {
+				organizationId: org?.id,
+				data: {
+					name: "no-slug-org-updated",
+				},
+			},
+			headers,
+		});
+		expect(updated?.name).toBe("no-slug-org-updated");
+	});
+
+	it("allows setting a slug after creation and persisting it", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				organization({
+					schema: {
+						organization: {
+							additionalFields: {
+								slug: {
+									type: "string",
+									required: false,
+								},
+							},
+						},
+					},
+				}),
+			],
+		});
+		const { headers } = await signInWithTestUser();
+		const org = await auth.api.createOrganization({
+			// @ts-expect-error slug is optional
+			body: {
+				name: "no-slug-org",
+			},
+			headers,
+		});
+
+		const setSlug = await auth.api.updateOrganization({
+			body: {
+				organizationId: org?.id,
+				data: {
+					slug: "no-slug-org-slug",
+				},
+			},
+			headers,
+		});
+		expect(setSlug?.slug).toBe("no-slug-org-slug");
+	});
+
+	it("applies transform.output to force slug to null", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				organization({
+					schema: {
+						organization: {
+							additionalFields: {
+								slug: {
+									type: "string",
+									required: false,
+									transform: {
+										output: (value: any) => (value = null),
+									},
+								},
+							},
+						},
+					},
+				}),
+			],
+		});
+		const { headers } = await signInWithTestUser();
+		const org = await auth.api.createOrganization({
+			body: {
+				name: "transform-slug-org",
+				slug: "should-be-null",
+			},
+			headers,
+		});
+		expect(org).toBeDefined();
+		expect(org?.name).toBe("transform-slug-org");
+		// transform.output should force slug to null
+		expect(org?.slug).toBeNull();
+
+		const getOrg = await auth.api.getFullOrganization({
+			query: {
+				organizationId: org?.id,
+			},
+			headers,
+		});
+		expect(getOrg?.slug).toBeNull();
+	});
+
+	it("allows clearing slug by setting null or empty string", async () => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				organization({
+					schema: {
+						organization: {
+							additionalFields: {
+								slug: {
+									type: "string",
+									required: false,
+									nullable: true,
+								},
+							},
+						},
+					},
+				}),
+			],
+		});
+		const { headers } = await signInWithTestUser();
+		const org = await auth.api.createOrganization({
+			// @ts-expect-error slug is optional
+			body: {
+				name: "no-slug-org",
+			},
+			headers,
+		});
+
+		const setSlug = await auth.api.updateOrganization({
+			body: {
+				organizationId: org?.id,
+				data: {
+					slug: "temp-slug",
+				},
+			},
+			headers,
+		});
+		expect(setSlug?.slug).toBe("temp-slug");
+
+		const clearedNull = await auth.api.updateOrganization({
+			body: {
+				organizationId: org?.id,
+				data: {
+					// @ts-expect-error allow clearing slug by setting null
+					slug: null,
+				},
+			},
+			headers,
+		});
+		expect(clearedNull?.slug === null || clearedNull?.slug === "").toBeTruthy();
+
+		const setAgain = await auth.api.updateOrganization({
+			body: {
+				organizationId: org?.id,
+				data: {
+					slug: "temp-slug-2",
+				},
+			},
+			headers,
+		});
+		expect(setAgain?.slug).toBe("temp-slug-2");
+
+		const clearedEmpty = await auth.api.updateOrganization({
+			body: {
+				organizationId: org?.id,
+				data: {
+					slug: "",
+				},
+			},
+			headers,
+		});
+		expect(
+			clearedEmpty?.slug === null || clearedEmpty?.slug === "",
+		).toBeTruthy();
+	});
+});
+
 describe("organization hooks", async () => {
 	it("should apply beforeCreateOrganization hook", async () => {
 		const beforeCreateOrganization = vi.fn();

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -374,7 +374,7 @@ export const updateOrganization = <O extends OrganizationOptions>(
 	type Body = {
 		data: {
 			name?: string | undefined;
-			slug?: string | undefined;
+			slug?: string | null | undefined;
 			logo?: string | null | undefined;
 			metadata?: Record<string, any> | undefined;
 		} & Partial<InferAdditionalFieldsFromPluginOptions<"organization", O>>;

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -146,14 +146,16 @@ export const createOrganization = <O extends OrganizationOptions>(
 				);
 			}
 
-			const existingOrganization = await adapter.findOrganizationBySlug(
-				ctx.body.slug,
-			);
-			if (existingOrganization) {
-				throw APIError.from(
-					"BAD_REQUEST",
-					ORGANIZATION_ERROR_CODES.ORGANIZATION_ALREADY_EXISTS,
+			if (typeof ctx.body.slug === "string") {
+				const existingOrganization = await adapter.findOrganizationBySlug(
+					ctx.body.slug,
 				);
+				if (existingOrganization) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.ORGANIZATION_ALREADY_EXISTS,
+					);
+				}
 			}
 
 			let {
@@ -385,8 +387,8 @@ export const updateOrganization = <O extends OrganizationOptions>(
 			body: z.object({
 				data: z
 					.object({
-						...additionalFieldsSchema.shape,
 						...baseUpdateOrganizationSchema.shape,
+						...additionalFieldsSchema.shape,
 					})
 					.partial(),
 				organizationId: z

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -422,7 +422,7 @@ export interface OrganizationOptions {
 				beforeUpdateOrganization?: (data: {
 					organization: {
 						name?: string;
-						slug?: string;
+						slug?: string | null;
 						logo?: string | null;
 						metadata?: Record<string, any>;
 						[key: string]: any;
@@ -432,7 +432,7 @@ export interface OrganizationOptions {
 				}) => Promise<void | {
 					data: {
 						name?: string;
-						slug?: string;
+						slug?: string | null;
 						logo?: string | null;
 						metadata?: Record<string, any>;
 						[key: string]: any;


### PR DESCRIPTION
Allows explicit optional "slug" parameter for organization creation via `additionalFieldsSchema` marking `slug` as optional.

```ts
plugins: [
  organization({
    schema: {
      organization: {
        additionalFields: {
          slug: {
            type: "string",
            // Required schema changes
            required: false,
            unique: false,
            sortable: false,
            // Optional - forces `slug` to be returned as null in responses
            transform: {
              output: () => null,
            },
          },
        }
      }
    },
  })
]
```

**Closes:**
#6662
