### PR TITLE
fix(redis-storage): use SCAN instead of KEYS to avoid blocking Redis

### DIFF
--- a/.changeset/redis-storage-scan.md
+++ b/.changeset/redis-storage-scan.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/redis-storage": patch
+---
+
+Enumerate keys with `SCAN` instead of `KEYS` in `listKeys()` and `clear()` so large keyspaces no longer block the Redis server. Escape glob metacharacters in the key prefix so `clear()` cannot match keys outside the store, and make `clear()` a safe no-op on an empty store.

--- a/packages/redis-storage/src/redis-storage.ts
+++ b/packages/redis-storage/src/redis-storage.ts
@@ -127,6 +127,12 @@ return value
 			await client.del(prefixKey(key));
 		},
 
+		/**
+		 * Lists every key under the configured prefix, with the prefix stripped.
+		 *
+		 * Keys are enumerated with `SCAN`, which may report the same key on more
+		 * than one page, so the result is de-duplicated. Order is not guaranteed.
+		 */
 		async listKeys(): Promise<string[]> {
 			const keys = new Set<string>();
 			for await (const batch of scanBatches()) {
@@ -137,9 +143,24 @@ return value
 			return [...keys];
 		},
 
+		/**
+		 * Deletes every key under the configured prefix.
+		 *
+		 * **Not atomic.** Keys are enumerated with `SCAN` and deleted page by
+		 * page, so if Redis errors or the connection drops mid-iteration the
+		 * returned promise rejects *after* earlier pages have already been
+		 * deleted, leaving the store partially cleared. A rejection therefore
+		 * means "an unknown subset of keys may already be gone", not "nothing
+		 * changed" — unlike a single blocking `DEL`, which either removes
+		 * everything or nothing.
+		 *
+		 * `clear()` is safe to call again: it is idempotent, so callers that need
+		 * a fully empty store (e.g. revoking every session or rate-limit counter)
+		 * should retry until it resolves. An already-empty store is a no-op.
+		 */
 		async clear(): Promise<void> {
-			// Batches from `scanBatches` are always non-empty, so DEL always
-			// receives at least one key and an empty store is a safe no-op.
+			// `scanBatches` only yields non-empty pages, so DEL always receives at
+			// least one key and an empty store never issues an invalid zero-arg DEL.
 			for await (const batch of scanBatches()) {
 				await client.del(...batch);
 			}

--- a/packages/redis-storage/src/redis-storage.ts
+++ b/packages/redis-storage/src/redis-storage.ts
@@ -64,6 +64,13 @@ return value
 	// How many keys Redis samples per SCAN round-trip. A hint, not a limit.
 	const SCAN_COUNT = 100;
 
+	// The SCAN MATCH argument is a glob pattern, so any glob metacharacter in
+	// the prefix (`* ? [ ] \`) would match unrelated keys and let `clear()`
+	// delete data outside this store. Escape them so the prefix matches
+	// literally. Stored keys still use the raw prefix (see `prefixKey`), so
+	// `keyPrefix.length` remains the correct amount to strip in `listKeys`.
+	const escapedPrefix = keyPrefix.replace(/[\\*?[\]]/g, "\\$&");
+
 	// Iterate every prefixed key with SCAN instead of KEYS. KEYS walks the
 	// entire keyspace in a single blocking call, which stalls the Redis
 	// server on large datasets; SCAN pages through the keyspace cursor by
@@ -76,7 +83,7 @@ return value
 			const [nextCursor, batch] = await client.scan(
 				cursor,
 				"MATCH",
-				`${keyPrefix}*`,
+				`${escapedPrefix}*`,
 				"COUNT",
 				SCAN_COUNT,
 			);
@@ -144,15 +151,21 @@ return value
 		},
 
 		/**
-		 * Deletes every key under the configured prefix.
+		 * Deletes the keys under the configured prefix that exist for the full
+		 * duration of the scan.
 		 *
 		 * **Not atomic.** Keys are enumerated with `SCAN` and deleted page by
 		 * page, so if Redis errors or the connection drops mid-iteration the
 		 * returned promise rejects *after* earlier pages have already been
 		 * deleted, leaving the store partially cleared. A rejection therefore
 		 * means "an unknown subset of keys may already be gone", not "nothing
-		 * changed" — unlike a single blocking `DEL`, which either removes
+		 * changed", unlike a single blocking `DEL`, which either removes
 		 * everything or nothing.
+		 *
+		 * **Concurrent writes may survive.** `SCAN` only guarantees keys present
+		 * throughout the walk are returned, so a key written by another client
+		 * while `clear()` is running may be missed. A resolved call is therefore
+		 * not proof the store is empty when writes happen concurrently.
 		 *
 		 * `clear()` is safe to call again: it is idempotent, so callers that need
 		 * a fully empty store (e.g. revoking every session or rate-limit counter)

--- a/packages/redis-storage/src/redis-storage.ts
+++ b/packages/redis-storage/src/redis-storage.ts
@@ -61,6 +61,32 @@ return value
 		error instanceof Error &&
 		error.message.toLowerCase().includes("unknown command");
 
+	// How many keys Redis samples per SCAN round-trip. A hint, not a limit.
+	const SCAN_COUNT = 100;
+
+	// Iterate every prefixed key with SCAN instead of KEYS. KEYS walks the
+	// entire keyspace in a single blocking call, which stalls the Redis
+	// server on large datasets; SCAN pages through the keyspace cursor by
+	// cursor without blocking. SCAN may return the same key in more than one
+	// page, so consumers that need uniqueness must dedupe. Each yielded batch
+	// is non-empty.
+	async function* scanBatches(): AsyncGenerator<string[]> {
+		let cursor = "0";
+		do {
+			const [nextCursor, batch] = await client.scan(
+				cursor,
+				"MATCH",
+				`${keyPrefix}*`,
+				"COUNT",
+				SCAN_COUNT,
+			);
+			cursor = nextCursor;
+			if (batch.length > 0) {
+				yield batch;
+			}
+		} while (cursor !== "0");
+	}
+
 	return {
 		async get(key: string) {
 			return client.get(prefixKey(key));
@@ -102,13 +128,21 @@ return value
 		},
 
 		async listKeys(): Promise<string[]> {
-			const keys = await client.keys(`${keyPrefix}*`);
-			return keys.map((key) => key.replace(keyPrefix, ""));
+			const keys = new Set<string>();
+			for await (const batch of scanBatches()) {
+				for (const key of batch) {
+					keys.add(key.slice(keyPrefix.length));
+				}
+			}
+			return [...keys];
 		},
 
 		async clear(): Promise<void> {
-			const keys = await client.keys(`${keyPrefix}*`);
-			await client.del(...keys);
+			// Batches from `scanBatches` are always non-empty, so DEL always
+			// receives at least one key and an empty store is a safe no-op.
+			for await (const batch of scanBatches()) {
+				await client.del(...batch);
+			}
 		},
 	} satisfies SecondaryStorage & {
 		listKeys: () => Promise<string[]>;

--- a/packages/redis-storage/src/redis-storage.ts
+++ b/packages/redis-storage/src/redis-storage.ts
@@ -135,10 +135,12 @@ return value
 		},
 
 		/**
-		 * Lists every key under the configured prefix, with the prefix stripped.
+		 * Lists the keys under the configured prefix, with the prefix stripped.
 		 *
-		 * Keys are enumerated with `SCAN`, which may report the same key on more
-		 * than one page, so the result is de-duplicated. Order is not guaranteed.
+		 * Keys are enumerated with `SCAN`, a best-effort walk: it may report the
+		 * same key on more than one page, so the result is de-duplicated, and
+		 * keys added or removed while the scan runs may or may not appear. Order
+		 * is not guaranteed.
 		 */
 		async listKeys(): Promise<string[]> {
 			const keys = new Set<string>();
@@ -151,8 +153,7 @@ return value
 		},
 
 		/**
-		 * Deletes the keys under the configured prefix that exist for the full
-		 * duration of the scan.
+		 * Deletes keys under the configured prefix.
 		 *
 		 * **Not atomic.** Keys are enumerated with `SCAN` and deleted page by
 		 * page, so if Redis errors or the connection drops mid-iteration the
@@ -162,10 +163,11 @@ return value
 		 * changed", unlike a single blocking `DEL`, which either removes
 		 * everything or nothing.
 		 *
-		 * **Concurrent writes may survive.** `SCAN` only guarantees keys present
-		 * throughout the walk are returned, so a key written by another client
-		 * while `clear()` is running may be missed. A resolved call is therefore
-		 * not proof the store is empty when writes happen concurrently.
+		 * **Best-effort while the keyspace changes.** `SCAN` is a best-effort
+		 * enumeration: keys added or removed while the scan runs may or may not
+		 * be returned, and a key may be returned more than once. A resolved call
+		 * is therefore not proof the store is empty when other clients are
+		 * writing concurrently.
 		 *
 		 * `clear()` is safe to call again: it is idempotent, so callers that need
 		 * a fully empty store (e.g. revoking every session or rate-limit counter)

--- a/packages/redis-storage/test/redis-storage.test.ts
+++ b/packages/redis-storage/test/redis-storage.test.ts
@@ -104,6 +104,93 @@ describe("redisStorage", () => {
 		);
 	});
 
+	it("clears every prefixed key by paging through SCAN", async () => {
+		const scanMock = vi
+			.fn()
+			.mockResolvedValueOnce(["42", ["ba:session:1"]])
+			.mockResolvedValueOnce(["0", ["ba:rate:1"]]);
+		const delMock = vi.fn().mockResolvedValue(1);
+		const keysMock = vi.fn();
+		const storage = redisStorage({
+			client: {
+				scan: scanMock,
+				del: delMock,
+				keys: keysMock,
+			} as any,
+			keyPrefix: "ba:",
+		});
+
+		await expect(storage.clear()).resolves.toBeUndefined();
+		// KEYS blocks the server on large keyspaces and must never be used.
+		expect(keysMock).not.toHaveBeenCalled();
+		expect(scanMock).toHaveBeenNthCalledWith(
+			1,
+			"0",
+			"MATCH",
+			"ba:*",
+			"COUNT",
+			100,
+		);
+		// The second call resumes from the cursor returned by the first.
+		expect(scanMock).toHaveBeenNthCalledWith(
+			2,
+			"42",
+			"MATCH",
+			"ba:*",
+			"COUNT",
+			100,
+		);
+		expect(delMock).toHaveBeenCalledTimes(2);
+		expect(delMock).toHaveBeenNthCalledWith(1, "ba:session:1");
+		expect(delMock).toHaveBeenNthCalledWith(2, "ba:rate:1");
+	});
+
+	it("does not call DEL when clearing an empty store", async () => {
+		const scanMock = vi.fn().mockResolvedValue(["0", []]);
+		// Redis rejects DEL with zero keys ("ERR wrong number of arguments"),
+		// so an empty clear must never reach the client.
+		const delMock = vi
+			.fn()
+			.mockRejectedValue(
+				new Error("ERR wrong number of arguments for 'del' command"),
+			);
+		const storage = redisStorage({
+			client: {
+				scan: scanMock,
+				del: delMock,
+			} as any,
+			keyPrefix: "ba:",
+		});
+
+		await expect(storage.clear()).resolves.toBeUndefined();
+		expect(scanMock).toHaveBeenCalledTimes(1);
+		expect(delMock).not.toHaveBeenCalled();
+	});
+
+	it("lists keys via SCAN, stripping the prefix and deduping across pages", async () => {
+		// SCAN may return the same key on more than one page; the deduped
+		// result must still contain each key exactly once.
+		const scanMock = vi
+			.fn()
+			.mockResolvedValueOnce(["7", ["ba:session:1", "ba:session:2"]])
+			.mockResolvedValueOnce(["0", ["ba:session:2", "ba:rate:1"]]);
+		const keysMock = vi.fn();
+		const storage = redisStorage({
+			client: {
+				scan: scanMock,
+				keys: keysMock,
+			} as any,
+			keyPrefix: "ba:",
+		});
+
+		await expect(storage.listKeys()).resolves.toEqual([
+			"session:1",
+			"session:2",
+			"rate:1",
+		]);
+		expect(keysMock).not.toHaveBeenCalled();
+	});
+
 	it("only sets the ttl on the call that creates the key", async () => {
 		const evalMock = vi.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(2);
 		const storage = redisStorage({

--- a/packages/redis-storage/test/redis-storage.test.ts
+++ b/packages/redis-storage/test/redis-storage.test.ts
@@ -167,6 +167,31 @@ describe("redisStorage", () => {
 		expect(delMock).not.toHaveBeenCalled();
 	});
 
+	it("propagates a mid-iteration failure, leaving earlier pages deleted", async () => {
+		// clear() is documented as non-atomic: pages already deleted stay
+		// deleted when a later page fails. This pins that contract so a future
+		// change to atomic-only deletion is a conscious, tested decision.
+		const scanMock = vi
+			.fn()
+			.mockResolvedValueOnce(["9", ["ba:session:1"]])
+			.mockResolvedValueOnce(["0", ["ba:session:2"]]);
+		const delMock = vi
+			.fn()
+			.mockResolvedValueOnce(1)
+			.mockRejectedValueOnce(
+				new Error("READONLY You can't write against a read only replica."),
+			);
+		const storage = redisStorage({
+			client: { scan: scanMock, del: delMock } as any,
+			keyPrefix: "ba:",
+		});
+
+		await expect(storage.clear()).rejects.toThrow("READONLY");
+		// The first page was deleted before the second page threw.
+		expect(delMock).toHaveBeenNthCalledWith(1, "ba:session:1");
+		expect(delMock).toHaveBeenNthCalledWith(2, "ba:session:2");
+	});
+
 	it("lists keys via SCAN, stripping the prefix and deduping across pages", async () => {
 		// SCAN may return the same key on more than one page; the deduped
 		// result must still contain each key exactly once.

--- a/packages/redis-storage/test/redis-storage.test.ts
+++ b/packages/redis-storage/test/redis-storage.test.ts
@@ -208,12 +208,30 @@ describe("redisStorage", () => {
 			keyPrefix: "ba:",
 		});
 
-		await expect(storage.listKeys()).resolves.toEqual([
-			"session:1",
-			"session:2",
-			"rate:1",
-		]);
+		// listKeys() documents that order is not guaranteed, so assert on
+		// contents (sorted) rather than a specific order.
+		const result = await storage.listKeys();
+		expect([...result].sort()).toEqual(["rate:1", "session:1", "session:2"]);
 		expect(keysMock).not.toHaveBeenCalled();
+	});
+
+	it("escapes glob metacharacters in the prefix so SCAN matches it literally", async () => {
+		// A prefix like "ba[1]:" is a glob pattern to Redis; unescaped it would
+		// match unrelated keys (e.g. "ba1:...") and let clear() delete them.
+		const scanMock = vi.fn().mockResolvedValue(["0", []]);
+		const storage = redisStorage({
+			client: { scan: scanMock } as any,
+			keyPrefix: "ba[1]:",
+		});
+
+		await storage.clear();
+		expect(scanMock).toHaveBeenCalledWith(
+			"0",
+			"MATCH",
+			"ba\\[1\\]:*",
+			"COUNT",
+			100,
+		);
 	});
 
 	it("only sets the ttl on the call that creates the key", async () => {


### PR DESCRIPTION
## Summary

`@better-auth/redis-storage` enumerated the keyspace with the Redis **`KEYS`** command in both `listKeys()` and `clear()`. `KEYS` walks the **entire** keyspace in a single blocking call and stalls the single-threaded Redis server on large datasets, a well-known production anti-pattern that the [Redis docs](https://redis.io/docs/latest/commands/keys/) explicitly warn against. As a side effect, `clear()` also threw on an **empty** store because it forwarded `DEL` with zero keys.

This PR replaces `KEYS` with a shared, cursor-based **`SCAN`** iterator.

Closes #10506

## Why `KEYS` is a problem

Redis is single-threaded. While `KEYS better-auth:*` scans every key in the database, **all** other clients are blocked, not just Better Auth.

```mermaid
sequenceDiagram
    participant App as Better Auth
    participant Redis as Redis (single-threaded)
    participant Other as Other clients

    rect rgba(220,50,50,0.12)
    note over App,Other: Before: KEYS blocks the whole server
    App->>Redis: KEYS better-auth:*
    Note over Redis: Scans ENTIRE keyspace<br/>in one blocking call
    Other--xRedis: GET/SET queued & stalled
    Redis-->>App: all keys (after full scan)
    end

    rect rgba(50,160,80,0.12)
    note over App,Other: After: SCAN pages without blocking
    loop until cursor = "0"
        App->>Redis: SCAN cursor MATCH better-auth:* COUNT 100
        Redis-->>App: nextCursor, page of keys
        Other->>Redis: GET/SET served between pages
    end
    end
```

## Changes

A shared `scanBatches()` async generator pages through the keyspace with `SCAN` (non-blocking, `COUNT 100` per round-trip) and yields only non-empty pages.

### `listKeys()`

```diff
 async listKeys(): Promise<string[]> {
-  const keys = await client.keys(`${keyPrefix}*`);
-  return keys.map((key) => key.replace(keyPrefix, ""));
+  const keys = new Set<string>();
+  for await (const batch of scanBatches()) {
+    for (const key of batch) {
+      keys.add(key.slice(keyPrefix.length));
+    }
+  }
+  return [...keys];
 }
```

- Dedupes with a `Set` because **`SCAN` may return the same key on more than one page** (whereas `KEYS` returned uniques). This preserves the previous output contract.
- Strips the prefix with `.slice(keyPrefix.length)` instead of `.replace(keyPrefix, "")`, which is strictly more correct. `.replace` would strip the first *mid-string* occurrence if a key ever re-contained the prefix.

### `clear()`

```diff
 async clear(): Promise<void> {
-  const keys = await client.keys(`${keyPrefix}*`);
-  await client.del(...keys);
+  // Batches from `scanBatches` are always non-empty, so DEL always
+  // receives at least one key and an empty store is a safe no-op.
+  for await (const batch of scanBatches()) {
+    await client.del(...batch);
+  }
 }
```

- Deletes each page as it is scanned, so it never accumulates a huge key array nor issues one oversized `DEL`.
- Because the iterator only yields non-empty pages, `DEL` always gets ≥1 key. This **also fixes** the empty-store crash: an empty keyspace yields nothing and `DEL` is never called, instead of throwing `ERR wrong number of arguments for 'del' command`.

## Tests

Added/updated unit tests in the package's existing mocked-client style (no live Redis needed):

- **`clears every prefixed key by paging through SCAN`**: asserts the cursor loop resumes from the returned cursor, `DEL` runs per page, and `KEYS` is never called.
- **`does not call DEL when clearing an empty store`**: drives `SCAN` returning `["0", []]`; the mock's `DEL` rejects with the real Redis arity error, and the test proves `DEL` is never reached.
- **`lists keys via SCAN, stripping the prefix and deduping across pages`**: feeds an overlapping key across two pages and asserts the result is deduped and prefix-stripped.

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

`pnpm typecheck` (`tsc --build`) passes clean; the `client.scan(cursor, "MATCH", ..., "COUNT", ...)` call satisfies ioredis's typed overloads.

## Compatibility / risk

- No API-signature change: `listKeys()` and `clear()` keep their signatures. `listKeys()` also keeps its observable behavior: it now dedupes explicitly (via a `Set`) to preserve the uniqueness `KEYS` guaranteed under `SCAN`.
- `SCAN` is supported by every Redis version Better Auth targets and works across Node.js, Bun, Deno, and Cloudflare Workers.
- **One deliberate behavioral change reviewers should note:** `clear()` is **no longer atomic**. The old `KEYS` + single `DEL` removed everything or nothing; per-page deletion means a Redis error or dropped connection mid-iteration rejects the promise *after* earlier pages are already deleted, leaving the store partially cleared. This is the intended trade-off for bounded, non-blocking deletes, and `clear()` is idempotent and safe to retry to reach a fully empty store. The failure mode is now documented in `clear()`'s JSDoc and pinned by a test. (Thanks to the Greptile review for flagging this.)

## Note on screenshots

This is a server-side/runtime change with no UI surface, so a screenshot isn't applicable. The sequence diagram above illustrates the blocking-vs-paging behavior instead.
