### PR TITLE
Fix anonymous plugin session cleanup

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -115,6 +115,39 @@ export const createInternalAdapter = (
 		}
 	}
 
+	const deleteUserSessions = async (userId: string) => {
+		if (secondaryStorage) {
+			const activeSession = await secondaryStorage.get(
+				`active-sessions-${userId}`,
+			);
+			const sessions = activeSession
+				? safeJSONParse<{ token: string }[]>(activeSession)
+				: [];
+			if (!sessions) return;
+			for (const session of sessions) {
+				await secondaryStorage.delete(session.token);
+			}
+			await secondaryStorage.delete(`active-sessions-${userId}`);
+
+			if (
+				!options.session?.storeSessionInDatabase ||
+				ctx.options.session?.preserveSessionInDatabase
+			) {
+				return;
+			}
+		}
+		await deleteManyWithHooks(
+			[
+				{
+					field: "userId",
+					value: userId,
+				},
+			],
+			"session",
+			undefined,
+		);
+	};
+
 	return {
 		createOAuthUser: async (
 			user: Omit<User, "id" | "createdAt" | "updatedAt">,
@@ -285,18 +318,7 @@ export const createInternalAdapter = (
 			return total;
 		},
 		deleteUser: async (userId: string) => {
-			if (!secondaryStorage || options.session?.storeSessionInDatabase) {
-				await deleteManyWithHooks(
-					[
-						{
-							field: "userId",
-							value: userId,
-						},
-					],
-					"session",
-					undefined,
-				);
-			}
+			await deleteUserSessions(userId);
 			await deleteManyWithHooks(
 				[
 					{
@@ -781,38 +803,7 @@ export const createInternalAdapter = (
 				undefined,
 			);
 		},
-		deleteUserSessions: async (userId: string) => {
-			if (secondaryStorage) {
-				const activeSession = await secondaryStorage.get(
-					`active-sessions-${userId}`,
-				);
-				const sessions = activeSession
-					? safeJSONParse<{ token: string }[]>(activeSession)
-					: [];
-				if (!sessions) return;
-				for (const session of sessions) {
-					await secondaryStorage.delete(session.token);
-				}
-				await secondaryStorage.delete(`active-sessions-${userId}`);
-
-				if (
-					!options.session?.storeSessionInDatabase ||
-					ctx.options.session?.preserveSessionInDatabase
-				) {
-					return;
-				}
-			}
-			await deleteManyWithHooks(
-				[
-					{
-						field: "userId",
-						value: userId,
-					},
-				],
-				"session",
-				undefined,
-			);
-		},
+		deleteUserSessions,
 		deleteSessions: async (sessionTokens: string[]) => {
 			if (secondaryStorage) {
 				for (const sessionToken of sessionTokens) {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -115,7 +115,7 @@ export const createInternalAdapter = (
 		}
 	}
 
-	const deleteUserSessions = async (userId: string) => {
+	const deleteUserSessions = async (userId: string, forceDatabaseDelete?: boolean) => {
 		if (secondaryStorage) {
 			const activeSession = await secondaryStorage.get(
 				`active-sessions-${userId}`,
@@ -131,7 +131,7 @@ export const createInternalAdapter = (
 
 			if (
 				!options.session?.storeSessionInDatabase ||
-				ctx.options.session?.preserveSessionInDatabase
+				(!forceDatabaseDelete && ctx.options.session?.preserveSessionInDatabase)
 			) {
 				return;
 			}
@@ -318,7 +318,7 @@ export const createInternalAdapter = (
 			return total;
 		},
 		deleteUser: async (userId: string) => {
-			await deleteUserSessions(userId);
+			await deleteUserSessions(userId, true);
 			await deleteManyWithHooks(
 				[
 					{

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -339,14 +339,8 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 							return;
 						}
 						try {
-							await ctx.context.internalAdapter.deleteUserSessions(
-								session.user.id,
-							);
 							await ctx.context.internalAdapter.deleteUser(session.user.id);
 						} catch (error) {
-							// TODO: collapse session+user cleanup into `internalAdapter.deleteUser`
-							// to remove the partial-state window where sessions are deleted but
-							// the user row remains.
 							ctx.context.logger.error(
 								"Failed to clean up anonymous user during post-link cleanup",
 								{ anonymousUserId: session.user.id, error },


### PR DESCRIPTION
Consolidates anonymous user and session cleanup into the internal adapter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates anonymous user and session cleanup into the `better-auth` internal adapter to avoid partial-state issues. `internalAdapter.deleteUser` now uses a shared `deleteUserSessions` to remove sessions from secondary storage and the DB (forcing DB deletion even if `session.preserveSessionInDatabase` is enabled) before deleting the user, and the anonymous plugin no longer deletes sessions separately.

<sup>Written for commit 222a6370211f84d7ada62ab44f094affab6f31c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

