### PR TITLE
fix: respect disableSignup in one tap

### DIFF
--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -27,7 +27,13 @@ export function toNextJsHandler(
 let nextHeadersPromise: Promise<typeof import("next/headers.js")> | undefined;
 const loadNextHeaders = () => {
 	if (process.env.NODE_ENV === "production") {
-		return (nextHeadersPromise ??= import("next/headers.js"));
+		if (!nextHeadersPromise) {
+			nextHeadersPromise = import("next/headers.js").catch((err) => {
+				nextHeadersPromise = undefined;
+				throw err;
+			});
+		}
+		return nextHeadersPromise;
 	}
 	return import("next/headers.js");
 };

--- a/packages/better-auth/src/integrations/next-js.ts
+++ b/packages/better-auth/src/integrations/next-js.ts
@@ -24,6 +24,14 @@ export function toNextJsHandler(
 	};
 }
 
+let nextHeadersPromise: Promise<typeof import("next/headers.js")> | undefined;
+const loadNextHeaders = () => {
+	if (process.env.NODE_ENV === "production") {
+		return (nextHeadersPromise ??= import("next/headers.js"));
+	}
+	return import("next/headers.js");
+};
+
 export const nextCookies = () => {
 	let hasWarned = false;
 
@@ -50,7 +58,7 @@ export const nextCookies = () => {
 							ReturnType<typeof import("next/headers.js").headers>
 						>;
 						try {
-							const { headers } = await import("next/headers.js");
+							const { headers } = await loadNextHeaders();
 							headersStore = await headers();
 						} catch {
 							return;
@@ -92,7 +100,7 @@ export const nextCookies = () => {
 								ReturnType<typeof import("next/headers.js").cookies>
 							>;
 							try {
-								const { cookies } = await import("next/headers.js");
+								const { cookies } = await loadNextHeaders();
 								cookieHelper = await cookies();
 							} catch (error) {
 								if (

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -179,7 +179,7 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 							idToken,
 							scope: "openid,profile,email",
 						},
-						disableSignUp: options?.disableSignup,
+						disableSignUp: options?.disableSignup ?? googleProvider?.disableSignUp,
 					});
 					if (result.error) {
 						throw new APIError("UNAUTHORIZED", {


### PR DESCRIPTION
Fixes one tap authentication to properly respect the disableSignup configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes One Tap auth to enforce the disable sign‑up setting and hardens Next.js integration by memoizing the `next/headers.js` import in production with retry on failure.

- **Bug Fixes**
  - One Tap now respects `options.disableSignup` and falls back to `googleProvider.disableSignUp`.

- **Refactors**
  - Memoized dynamic import of `next/headers.js` via `loadNextHeaders` for `nextCookies` in production, with failed imports resetting the cache to allow retries.

<sup>Written for commit c5375f23ba5ee1f39b092853fcb3a5d73930812d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

