### PR TITLE
fix(organization): return standard INVITATION_NOT_FOUND error code in get-invitation

### DIFF
--- a/.changeset/six-bugs-worry.md
+++ b/.changeset/six-bugs-worry.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The /organization/get-invitation endpoint now correctly returns the INVITATION_NOT_FOUND error code when invitation is missing, expired, or no longer pending

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -1182,9 +1182,10 @@ export const getInvitation = <O extends OrganizationOptions>(options: O) =>
 				invitation.status !== "pending" ||
 				invitation.expiresAt < new Date()
 			) {
-				throw APIError.fromStatus("BAD_REQUEST", {
-					message: "Invitation not found!",
-				});
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
+				);
 			}
 			if (invitation.email.toLowerCase() !== session.user.email.toLowerCase()) {
 				throw APIError.from(


### PR DESCRIPTION
### Description

**What changed?**
Updated the `/organization/get-invitation` endpoint to throw `APIError.from("BAD_REQUEST", ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND)` instead of `APIError.fromStatus`.

**Why?**
Previously, when an invitation was invalid, expired, or not in pending status, the endpoint returned `{ message: "Invitation not found!" }` without a `code` property. This prevented frontend/SDK consumers from programmatically checking `error.code === ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND`, forcing fragile string matching against `error.message`.

### Related Issues

Closes  #10509 

### Breaking Changes

None. This restores expected error code handling consistent with other organization endpoints.

### UI Changes

N/A (API/backend change only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return the standard INVITATION_NOT_FOUND error code from /organization/get-invitation when the invitation is missing, expired, or not pending. This restores consistent error handling so clients can check error.code instead of parsing messages.

<sup>Written for commit 4341ac0c108a8078a14621461f90a1bbc58cb0fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

