### PR TITLE
fix(jwt): preserve client plugin inference with jwtClient

### DIFF
--- a/.changeset/fix-jwt-client-plugin-inference.md
+++ b/.changeset/fix-jwt-client-plugin-inference.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix `jwtClient()` collapsing `createAuthClient` type inference when combined with other client plugins such as `inferAdditionalFields`. Additional user fields (for example on `updateUser`) are preserved again.

--- a/packages/better-auth/src/plugins/jwt/client.ts
+++ b/packages/better-auth/src/plugins/jwt/client.ts
@@ -1,6 +1,7 @@
 import type {
 	BetterAuthClientOptions,
 	BetterAuthClientPlugin,
+	ClientFetchOption,
 	ClientStore,
 } from "@better-auth/core";
 import type { BetterFetch } from "@better-fetch/fetch";
@@ -35,7 +36,7 @@ export const jwtClient = (options?: JwtClientOptions) => {
 			_$store: ClientStore,
 			_options: BetterAuthClientOptions | undefined,
 		) => ({
-			jwks: async (fetchOptions?: any) => {
+			jwks: async (fetchOptions?: ClientFetchOption) => {
 				return await $fetch<JSONWebKeySet>(jwksPath, {
 					method: "GET",
 					...fetchOptions,

--- a/packages/better-auth/src/plugins/jwt/client.ts
+++ b/packages/better-auth/src/plugins/jwt/client.ts
@@ -1,4 +1,9 @@
-import type { BetterAuthClientPlugin } from "@better-auth/core";
+import type {
+	BetterAuthClientOptions,
+	BetterAuthClientPlugin,
+	ClientStore,
+} from "@better-auth/core";
+import type { BetterFetch } from "@better-fetch/fetch";
 import type { JSONWebKeySet } from "jose";
 import { PACKAGE_VERSION } from "../../version";
 import type { jwt } from "./index";
@@ -25,7 +30,11 @@ export const jwtClient = (options?: JwtClientOptions) => {
 		pathMethods: {
 			[jwksPath]: "GET",
 		},
-		getActions: ($fetch) => ({
+		getActions: (
+			$fetch: BetterFetch,
+			_$store: ClientStore,
+			_options: BetterAuthClientOptions | undefined,
+		) => ({
 			jwks: async (fetchOptions?: any) => {
 				return await $fetch<JSONWebKeySet>(jwksPath, {
 					method: "GET",

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -1,8 +1,10 @@
+import type { BetterAuthClientPlugin } from "@better-auth/core";
 import type { JSONWebKeySet } from "jose";
 import { createLocalJWKSet, jwtVerify } from "jose";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { createAuthClient } from "../../client";
 import { getTestInstance } from "../../test-utils/test-instance";
+import { inferAdditionalFields } from "../additional-fields/client";
 import { jwt } from ".";
 import { jwtClient } from "./client";
 import type { JWKOptions, Jwk, JwtOptions } from "./types";
@@ -831,5 +833,42 @@ describe("toExpJWT", () => {
 			expect(() => toExpJWT("" as any, iat)).toThrow(TypeError);
 			expect(() => toExpJWT("abc123" as any, iat)).toThrow(TypeError);
 		});
+	});
+});
+
+/**
+ * Declaration emit previously narrowed `$fetch` from `$fetch<JSONWebKeySet>(...)`,
+ * making `jwtClient()` unassignable to `BetterAuthClientPlugin` and collapsing
+ * `createAuthClient` option inference when combined with other plugins.
+ *
+ * @see https://github.com/masumi-network/sokosumi/pull/3403
+ */
+describe("jwtClient types", () => {
+	it("should be assignable to BetterAuthClientPlugin", () => {
+		const plugin: BetterAuthClientPlugin = jwtClient();
+		const plugins: BetterAuthClientPlugin[] = [jwtClient()];
+		expect(plugin.id).toBe("better-auth-client");
+		expect(plugins).toHaveLength(1);
+	});
+
+	it("should preserve additional user fields when combined with inferAdditionalFields", () => {
+		const client = createAuthClient({
+			plugins: [
+				inferAdditionalFields({
+					user: {
+						logo: {
+							type: "string",
+							required: false,
+						},
+					},
+				}),
+				jwtClient(),
+			],
+		});
+
+		expectTypeOf(client.updateUser).parameter(0).toMatchTypeOf<{
+			logo?: string | undefined;
+		}>();
+		expectTypeOf(client.jwks).toBeFunction();
 	});
 });

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -866,8 +866,14 @@ describe("jwtClient types", () => {
 			],
 		});
 
-		expectTypeOf(client.updateUser).parameter(0).toMatchTypeOf<{
-			logo?: string | undefined;
+		type UpdateUserBody = NonNullable<Parameters<typeof client.updateUser>[0]>;
+
+		const body = {
+			logo: "https://example.com/logo.png",
+		} satisfies UpdateUserBody;
+		expect(body.logo).toBe("https://example.com/logo.png");
+		expectTypeOf<UpdateUserBody>().toMatchTypeOf<{
+			logo?: string | null | undefined;
 		}>();
 		expectTypeOf(client.jwks).toBeFunction();
 	});


### PR DESCRIPTION
## Summary
- Annotate `jwtClient` `getActions` with the full `BetterAuthClientPlugin` arity (`BetterFetch`, `ClientStore`, options), matching sibling client plugins like `oauth-popup`.
- Prevents declaration emit from narrowing `$fetch` via `$fetch<JSONWebKeySet>(...)`, which made `jwtClient()` unassignable to `BetterAuthClientPlugin` and collapsed `createAuthClient` option inference when combined with plugins such as `inferAdditionalFields`.
- Adds type regression tests and a `patch` changeset.

## Context
Found while bumping better-auth in [masumi-network/sokosumi#3403](https://github.com/masumi-network/sokosumi/pull/3403): with `jwtClient()` in the client plugins array, `updateUser` lost additional user fields under TypeScript 6 / Next.js build typecheck.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typing bug in `jwtClient` that collapsed `createAuthClient` plugin inference, and adds proper types to `jwks` fetch options. Additional user fields and `BetterAuthClientPlugin` compatibility are preserved.

- **Bug Fixes**
  - Annotated `getActions` with full plugin args (`BetterFetch`, `ClientStore`, options) to avoid `$fetch` narrowing in d.ts.
  - Typed `jwks` `fetchOptions` as `ClientFetchOption` to match other client plugins.
  - Restores option inference with plugins like `inferAdditionalFields` (e.g., extra user fields on `updateUser`); adds type regression tests and a patch changeset.

<sup>Written for commit 474bd045acdf080ee861afe6e35e0dcf3bf3a52f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



