### PR TITLE
docs: fix awkward wording in comparison.mdx

### DIFF
--- a/docs/content/docs/comparison.mdx
+++ b/docs/content/docs/comparison.mdx
@@ -5,7 +5,7 @@ description: Comparison of Better Auth versus other auth libraries and services.
 
 > <p className="text-orange-400 dark:text-orange-200">Comparison is the thief of joy.</p>
 
-Here are some key reasons why you may want to use Better Auth over other auth libraries and services.
+Here are some key reasons why you may want to use Better Auth instead of other auth libraries and services.
 
 ### vs Other Auth Libraries
 

--- a/docs/content/docs/comparison.mdx
+++ b/docs/content/docs/comparison.mdx
@@ -1,11 +1,11 @@
 ---
 title: Comparison
-description: Comparison of Better Auth versus over other auth libraries and services.
+description: Comparison of Better Auth over other auth libraries and services.
 ---
 
 > <p className="text-orange-400 dark:text-orange-200">Comparison is the thief of joy.</p>
 
-Here are non detailed reasons why you may want to use Better Auth over other auth libraries and services.
+Here are some key reasons why you may want to use Better Auth over other auth libraries and services.
 
 ### vs Other Auth Libraries
 


### PR DESCRIPTION
cleaning up `comparison.mdx` intro

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished wording in the Comparison docs for clarity by changing "Here are non detailed reasons" to "Here are some key reasons".

<sup>Written for commit 72ebca35a254bef5b3a60e20ab92d93c82d90fd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

