### PR TITLE
docs: fix wrong import path in facebook.mdx

### DIFF
--- a/docs/content/docs/authentication/facebook.mdx
+++ b/docs/content/docs/authentication/facebook.mdx
@@ -56,7 +56,7 @@ description: Facebook provider setup and usage.
     * `provider`: The provider to use. It should be set to `facebook`.
 
     ```ts title="auth-client.ts"
-    import { createAuthClient } from "better-auth/auth-client"
+    import { createAuthClient } from "better-auth/client"
     const authClient = createAuthClient()
 
     const signIn = async () => {


### PR DESCRIPTION
The client example imports from `better-auth/auth-client` but the correct path is `better-auth/client`, consistent with all other provider docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the Facebook provider docs to import from `better-auth/client`. Replaces `better-auth/auth-client` to match other provider docs and avoid copy-paste errors.

<sup>Written for commit 379913f6ec517c8d6475dae017d92a64354ab96f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

