### PR TITLE
docs: fix description metadata in comparison.mdx

### DIFF
--- a/docs/content/docs/comparison.mdx
+++ b/docs/content/docs/comparison.mdx
@@ -1,6 +1,6 @@
 ---
 title: Comparison
-description: Comparison of Better Auth versus over other auth libraries and services.
+description: Comparison of Better Auth versus other auth libraries and services.
 ---
 
 > <p className="text-orange-400 dark:text-orange-200">Comparison is the thief of joy.</p>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix grammatical error in the comparison page description: change "versus over other" to "versus other" for clearer wording.

<sup>Written for commit 47e1201dd3ab661cb9d51ace2e1adb99984da55d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

