### PR TITLE
docs: update stripe api version number

### DIFF
--- a/docs/content/docs/plugins/stripe.mdx
+++ b/docs/content/docs/plugins/stripe.mdx
@@ -53,7 +53,7 @@ The Stripe plugin integrates Stripe's payment and subscription functionality wit
     import Stripe from "stripe"
 
     const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-        apiVersion: "2026-03-25.dahlia", // Latest API version as of Stripe SDK v22.0.0
+        apiVersion: "2026-06-24.dahlia", // Latest API version as of Stripe SDK v22.0.0
     })
 
     export const auth = betterAuth({


### PR DESCRIPTION
Updates the `@better-auth/stripe` plugin set up instructions with the correct Stripe API version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `@better-auth/stripe` setup guide to use Stripe API version 2026-06-24.dahlia in the example, matching Stripe SDK v22.0.0. Prevents confusion and errors when copying the snippet.

<sup>Written for commit 5eeaf0123e6d1dbfe1fa07be67d3ea4386008cc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

