### PR TITLE
docs: simplify waitUntil import for Cloudflare Workers

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -692,7 +692,7 @@ export const auth = betterAuth({
 
 Configure background task handling for deferred operations. Background tasks allow non-critical operations (like cleanup, analytics, timing-attack mitigation, or rate limit counter updates) to run after the response is sent. This can significantly improve response times on serverless platforms.
 
-Some examples are: `waitUntil` from `@vercel/functions` on Vercel, or `ctx.waitUntil` on Cloudflare Workers. See the examples below for more details.
+Some examples are: `waitUntil` from `@vercel/functions` on Vercel, or `waitUntil` from `cloudflare:workers` on Cloudflare Workers. See the examples below for more details.
 
 <Callout type="warn">
   Enabling this introduces eventual consistency where the response returns optimistic data before the database is updated. Only enable if your application can tolerate this trade-off for improved latency.
@@ -717,19 +717,15 @@ Some examples are: `waitUntil` from `@vercel/functions` on Vercel, or `ctx.waitU
   <Tab value="Cloudflare Workers">
     ```ts
     import { betterAuth } from "better-auth";
-    import { AsyncLocalStorage } from "node:async_hooks";
-
-    const execCtxStorage = new AsyncLocalStorage<ExecutionContext>();
+    import { waitUntil } from "cloudflare:workers";
 
     export const auth = betterAuth({
       advanced: {
         backgroundTasks: {
-          handler: (p) => execCtxStorage.getStore()?.waitUntil(p),
+          handler: waitUntil,
         },
       },
     });
-
-    // In your request handler, wrap with execCtxStorage.run(ctx, ...)
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
## What

Update the Cloudflare Workers background tasks documentation to show the simpler `waitUntil` import directly from `cloudflare:workers`, instead of the previous pattern using `AsyncLocalStorage` to pass the execution context.

## Why

Cloudflare [added `waitUntil` as a direct import](https://developers.cloudflare.com/changelog/post/2025-08-08-add-waituntil-cloudflare-workers/) from `cloudflare:workers` in August 2025. This eliminates the need to thread `ctx` through your codebase or use workarounds like `AsyncLocalStorage` to access it in background task handlers.

The `AsyncLocalStorage` pattern still works, so this is purely a simplification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Cloudflare Workers docs to import `waitUntil` directly from `cloudflare:workers`, replacing the `AsyncLocalStorage`-based `ctx.waitUntil` pattern. This simplifies the background task example and removes the need to pass `ExecutionContext` through handlers.

<sup>Written for commit b93aaa2ee71dc05bbc42f3491fa1256d4a1095cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

