### PR TITLE
feat: drizzle v1 relations syntax

### DIFF
--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -315,14 +315,15 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			/**
 			 * Disambiguates multiple relations between the same two tables.
 			 */
-			relationName?: string;
+			alias?: string;
 			/**
 			 * Foreign key field name and reference details (only for "one" relations).
 			 */
 			reference?: {
-				field: string;
-				references: string;
+				from: string;
+				to: string;
 			};
+			optional?: boolean;
 		};
 
 		const oneRelations: Relation[] = [];
@@ -369,12 +370,13 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 				key: relationKey,
 				model: getModelName(referencedModel),
 				type: "one",
-				relationName: hasMultipleRelations
+				alias: hasMultipleRelations
 					? `${getModelName(tableKey)}_${fieldName}`
 					: undefined,
+				optional: field.required !== false ? false : undefined,
 				reference: {
-					field: fieldRef,
-					references: referenceRef,
+					from: fieldRef,
+					to: referenceRef,
 				},
 			});
 		}
@@ -416,9 +418,19 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 					key: relationKey,
 					model: getModelName(modelName),
 					type: relationType,
-					relationName: hasMultipleRelations
+					alias: hasMultipleRelations
 						? `${getModelName(modelName)}_${fieldName}`
 						: undefined,
+					reference: {
+						from: `${getModelName(tableKey)}.${getFieldName({
+							model: tableKey,
+							field: field.references!.field || "id",
+						})}`,
+						to: `${getModelName(modelName)}.${getFieldName({
+							model: modelName,
+							field: fieldName,
+						})}`,
+					},
 				});
 			}
 		}
@@ -433,23 +445,20 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 		const hasOne = hasForwardOne || hasReverseOne;
 		const hasMany = hasReverseMany;
 
-		const renderOneRelation = (relation: Relation) =>
-			relation.reference
-				? ` ${relation.key}: one(${relation.model}, {
-					fields: [${relation.reference.field}],
-					references: [${relation.reference.references}],
-					${relation.relationName ? `relationName: "${relation.relationName}",` : ""}
-				})`
-				: "";
+		const renderOneRelation = (relation: Relation) => {
+			if (!relation.reference) return "";
 
-		const renderReverseRelation = ({
-			key,
-			model,
-			type,
-			relationName,
-		}: Relation) => {
+			return `${relation.key}: r.one.${relation.model}({
+			from: r.${relation.reference.from},
+			to: r.${relation.reference.to},
+			${relation.optional === false ? "optional: false," : ""}
+			${relation.alias ? `alias: ${JSON.stringify(relation.alias)},` : ""}
+		})`;
+		};
+
+		const renderReverseRelation = ({ key, model, type, alias }: Relation) => {
 			const relationFn = type === "one" ? "one" : "many";
-			return ` ${key}: ${relationFn}(${model}${relationName ? `, { relationName: "${relationName}" }` : ""})`;
+			return ` ${key}: ${relationFn}(${model}${alias ? `, { alias: "${alias}" }` : ""})`;
 		};
 
 		if (hasOne || hasMany) {
@@ -491,7 +500,7 @@ function generateImport({
 	tables: BetterAuthDBSchema;
 	options: BetterAuthOptions;
 }) {
-	const rootImports: string[] = ["relations"];
+	const rootImports: string[] = ["defineRelations"];
 	const coreImports: string[] = [];
 
 	let hasBigint = false;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the Drizzle schema generator to the v1 relations API. Generated schemas now use `defineRelations` and the new builder with `from`/`to`, `alias`, and `optional`.

- **Refactors**
  - Replace `relations` import with `defineRelations`.
  - Move from `one(Model, { fields, references })` to `r.one.Model({ from, to })`; same for `many` where applicable.
  - Rename `relationName` to `alias`.
  - Add `optional` support (emits `optional: false` for required relations).
  - Generate `from`/`to` paths for reverse relations.

<sup>Written for commit a076d11c434ccd8f4ee14017d9a126feeea82c0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

