### PR TITLE
fix(email-otp): preserve otp after password validation errors

### DIFF
--- a/.changeset/preserve-email-otp-reset.md
+++ b/.changeset/preserve-email-otp-reset.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Allow users to retry email OTP password resets after entering an invalid password.

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -249,6 +249,36 @@ describe("email-otp", async () => {
 		expect(data?.user).toBeDefined();
 	});
 
+	it.for([
+		{
+			invalidPassword: "short",
+			validationError: "PASSWORD_TOO_SHORT",
+		},
+		{
+			invalidPassword: "a".repeat(129),
+			validationError: "PASSWORD_TOO_LONG",
+		},
+	])("should preserve OTP after $validationError", async (testCase) => {
+		await client.emailOtp.requestPasswordReset({
+			email: testUser.email,
+		});
+		const passwordResetOtp = otp;
+
+		const invalidReset = await client.emailOtp.resetPassword({
+			email: testUser.email,
+			otp: passwordResetOtp,
+			password: testCase.invalidPassword,
+		});
+		expect(invalidReset.error?.code).toBe(testCase.validationError);
+
+		const validReset = await client.emailOtp.resetPassword({
+			email: testUser.email,
+			otp: passwordResetOtp,
+			password: "valid-password",
+		});
+		expect(validReset.data?.success).toBe(true);
+	});
+
 	it("should reset password using deprecated forgetPassword endpoint (backward compatibility)", async () => {
 		await client.forgetPassword.emailOtp({
 			email: testUser.email,

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -933,6 +933,14 @@ export const resetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) =>
 		},
 		async (ctx) => {
 			const email = ctx.body.email.toLowerCase();
+			const minPasswordLength = ctx.context.password.config.minPasswordLength;
+			if (ctx.body.password.length < minPasswordLength) {
+				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
+			}
+			const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
+			if (ctx.body.password.length > maxPasswordLength) {
+				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
+			}
 
 			// Use atomic verification to prevent race conditions
 			await atomicVerifyOTP(
@@ -947,14 +955,6 @@ export const resetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			});
 			if (!user) {
 				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.USER_NOT_FOUND);
-			}
-			const minPasswordLength = ctx.context.password.config.minPasswordLength;
-			if (ctx.body.password.length < minPasswordLength) {
-				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_SHORT);
-			}
-			const maxPasswordLength = ctx.context.password.config.maxPasswordLength;
-			if (ctx.body.password.length > maxPasswordLength) {
-				throw APIError.from("BAD_REQUEST", BASE_ERROR_CODES.PASSWORD_TOO_LONG);
 			}
 			const passwordHash = await ctx.context.password.hash(ctx.body.password);
 			const account = user.accounts?.find(


### PR DESCRIPTION
> This PR addresses a [Discord issue](https://discord.com/channels/1288403910284935179/1288403910284935182/1445592492496916500) where the verificationValue is deleted immediately after validation, forcing users to restart the OTP flow if they fail to enter the correct value on the first try. OTP reuse can be controlled with `allowedAttempts`.


#6498 rework