### PR TITLE
fix(mcp): export MCPOptions so consumer declaration emit can name it

### DIFF
--- a/.changeset/export-mcp-options.md
+++ b/.changeset/export-mcp-options.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Export the `MCPOptions` interface from the MCP plugin. It was the only plugin options type left unexported, so any consumer compiling with `declaration: true` that exports a value typed by the auth instance failed with TS4023 ("has or is using name 'MCPOptions' … but cannot be named"). The interface is now exported like its siblings (e.g. `BearerOptions`) and reachable through the `better-auth/plugins` barrel, giving declaration emit a portable path to name it. Type-only change, no runtime impact.

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -46,7 +46,7 @@ declare module "@better-auth/core" {
 	}
 }
 
-interface MCPOptions {
+export interface MCPOptions {
 	loginPage: string;
 	resource?: string | undefined;
 	oidcConfig?: OIDCOptions | undefined;


### PR DESCRIPTION
## Problem

`MCPOptions` is the only plugin options interface that is not exported. Any consumer compiled with `declaration: true` that exports a value typed by the auth instance fails:

```
error TS4023: Exported variable 'auth' has or is using name 'MCPOptions' from external module ".../better-auth/dist/plugins/mcp/index" but cannot be named.
```

The declaration emitter has no accessible path to name a type that was never exported, and there is no consumer-side workaround. Reported in #10532 (reproduced on 1.6.11, still present on 1.6.25).

## Fix

Add `export` to the `interface MCPOptions` declaration, exactly as its siblings do (`BearerOptions`, etc.). Because `packages/better-auth/src/plugins/index.ts` already does `export * from "./mcp"`, and `./plugins` is in the package `exports` map, the interface immediately becomes reachable as `import("better-auth/plugins").MCPOptions` — a portable path declaration emit can synthesize. Type-only, one word, no runtime impact.

## Verification

Minimal reproduction of the mechanism (an unexported interface used by an exported value, `declaration: true`):

```ts
// before: interface Opts {...}          -> TS4023 on the exported consumer
// after:  export interface Opts {...}    -> clean
```

`tsc` reports TS4023 before the export and nothing after. The barrel re-export gives the same portable name in this package.

## A note on the exports map

The issue also suggests adding a `./plugins/mcp` subpath to the `exports` map (mirroring the existing `./plugins/mcp/client`). I left that out on purpose: the barrel path above already resolves the error without it, so the one-line export is the minimal fix. If you'd prefer the symmetry with `./plugins/mcp/client` — a direct `import("better-auth/plugins/mcp").MCPOptions` — I'm happy to add the subpath entry in this PR; it's a design call on the package surface that's yours to make.

## Ticket

Fixes #10532


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported `MCPOptions` from the MCP plugin to fix TS4023 for consumers compiling with `declaration: true` by making the type reachable via `better-auth/plugins`; type-only change with no runtime impact. Fixes #10532.

<sup>Written for commit 13379bad797124a50a252543f1ed428ceab44aa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

