### PR TITLE
fix(organization): type member/invitation role as comma-joined and custom-role output

### DIFF
--- a/.changeset/organization-role-output-type.md
+++ b/.changeset/organization-role-output-type.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix `member.role` and `invitation.role` return types to accept the comma-joined multi-role and custom-role values the runtime actually returns, instead of narrowing to the default-role union.

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -34,6 +34,33 @@ describe("organization type", () => {
 	});
 
 	/**
+	 * A member's or invitation's stored role can be several roles persisted comma-joined
+	 * (e.g. `"owner,analyst"`) and may include custom role names, so the returned `role`
+	 * type must accept an arbitrary string, not only the configured single-role union.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10533
+	 */
+	it("member/invitation role output accepts comma-joined and custom roles", () => {
+		type Options = {
+			roles: {
+				owner: typeof ownerAc;
+				admin: typeof adminAc;
+				member: typeof memberAc;
+				analyst: typeof memberAc;
+			};
+		};
+		// Known roles still keep autocomplete...
+		expectTypeOf<InferMember<Options>["role"]>().toEqualTypeOf<
+			"owner" | "admin" | "member" | "analyst" | (string & {})
+		>();
+		// ...while the comma-joined / custom string the runtime returns stays assignable.
+		const memberRole: InferMember<Options>["role"] = "owner,analyst";
+		const invitationRole: InferInvitation<Options>["role"] = "owner,analyst";
+		expect(memberRole).toBe("owner,analyst");
+		expect(invitationRole).toBe("owner,analyst");
+	});
+
+	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9135
 	 */
 	it("allows dynamic roles in create invitation input", async () => {

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -381,6 +381,19 @@ export type InferOrganizationRolesFromOption<
 		: "admin" | "member" | "owner"
 	: "admin" | "member" | "owner";
 
+/**
+ * The role stored on a member or invitation. Multiple roles are allowed and persisted
+ * comma-joined by `parseRoles` (e.g. `"owner,analyst"`), and custom role names are
+ * permitted, so the returned value is not necessarily a single default-role literal. The
+ * `(string & {})` keeps autocomplete for the known roles while accepting the comma-joined
+ * or custom string the runtime actually returns.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10533
+ */
+export type InferOrganizationRoleOutput<
+	O extends OrganizationOptions | undefined,
+> = InferOrganizationRolesFromOption<O> | (string & {});
+
 export type InvitationStatus = "pending" | "accepted" | "rejected" | "canceled";
 
 import type { DBFieldAttribute } from "@better-auth/core/db";
@@ -409,7 +422,7 @@ export type InferMember<
 		? {
 				id: string;
 				organizationId: string;
-				role: InferOrganizationRolesFromOption<O>;
+				role: InferOrganizationRoleOutput<O>;
 				createdAt: Date;
 				userId: string;
 				teamId?: string | undefined;
@@ -423,7 +436,7 @@ export type InferMember<
 		: {
 				id: string;
 				organizationId: string;
-				role: InferOrganizationRolesFromOption<O>;
+				role: InferOrganizationRoleOutput<O>;
 				createdAt: Date;
 				userId: string;
 				user: {
@@ -459,7 +472,7 @@ export type InferInvitation<
 				id: string;
 				organizationId: string;
 				email: string;
-				role: InferOrganizationRolesFromOption<O>;
+				role: InferOrganizationRoleOutput<O>;
 				status: InvitationStatus;
 				inviterId: string;
 				expiresAt: Date;
@@ -470,7 +483,7 @@ export type InferInvitation<
 				id: string;
 				organizationId: string;
 				email: string;
-				role: InferOrganizationRolesFromOption<O>;
+				role: InferOrganizationRoleOutput<O>;
 				status: InvitationStatus;
 				inviterId: string;
 				expiresAt: Date;


### PR DESCRIPTION
## Summary

`member.role` and `invitation.role` are typed as `InferOrganizationRolesFromOption<O>` — a union of the single configured role literals (`"owner" | "admin" | "member"` by default). But the stored/returned value is not a single role:

- Multiple roles are allowed and persisted **comma-joined** by `parseRoles` (`organization.ts`): `Array.isArray(roles) ? roles.join(",") : roles` → e.g. `"owner,analyst"`.
- The value may include **custom role names** not present in the default union.

So `getActiveMember()` / `getInvitation()` can return `"owner,analyst"`, which the declared type cannot represent, forcing consumers to cast or re-parse. Closes #10533.

## Fix

Introduce `InferOrganizationRoleOutput<O> = InferOrganizationRolesFromOption<O> | (string & {})` and use it for the `role` field of `InferMember` and `InferInvitation`.

The `(string & {})` follows the existing pattern in this repo (`oidc-provider`, `cookies`, `social-providers`): known roles keep autocomplete, while the comma-joined / custom string the runtime returns stays assignable. This widens **output** types only to match documented storage — input positions (assigning a role) still use the narrow union.

Both `member.role` and `invitation.role` share the same root cause: `parseRoles` is applied to both (`crud-members.ts`, `crud-invites.ts`), so both are fixed.

## Test

Type-level regression test in `organization.test.ts` (`@see #10533`): asserts the role type equals `…defaults… | (string & {})` and that `"owner,analyst"` is assignable to both member and invitation `role`. Validated with `tsc --build` (0 errors).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the role return type for organization members and invitations to accept comma-joined and custom roles (e.g., "owner,analyst"), matching runtime values. This removes casts when reading roles from `getActiveMember()` and `getInvitation()` and closes #10533.

- **Bug Fixes**
  - Added `InferOrganizationRoleOutput<O>` = `InferOrganizationRolesFromOption<O> | (string & {})` to widen only the output.
  - Applied to `InferMember["role"]` and `InferInvitation["role"]`; input types stay narrowed and keep autocomplete for known roles.
  - Added a type-level test verifying that comma-joined roles are assignable.

<sup>Written for commit 9f8865b0b312cd7f8dd084d29ec7fd4896ceacee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

