### PR TITLE
docs: add agent feedback endpoint

### DIFF
--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -73,3 +73,5 @@ pjpeg
 styl
 vbscript
 unvalidated
+lpush
+ltrim

--- a/docs/app/api/feedback/route.ts
+++ b/docs/app/api/feedback/route.ts
@@ -7,6 +7,8 @@ import {
 	FEEDBACK_DESCRIPTOR,
 	feedbackSchema,
 	notifySlack,
+	sanitizeReferer,
+	sanitizeUserAgent,
 	storeFeedback,
 } from "@/lib/feedback";
 
@@ -36,9 +38,19 @@ function getRatelimit(): Ratelimit {
 /**
  * Self-describing discovery response, so an agent that finds the URL can learn
  * the payload shape without reading the docs.
+ *
+ * `endpoint` is derived from the request rather than taken from the constant,
+ * so preview and self-hosted deployments describe the host that actually
+ * served the response instead of pointing back at production.
  */
-export function GET() {
-	return NextResponse.json(FEEDBACK_DESCRIPTOR, { headers: CORS_HEADERS });
+export function GET(request: Request) {
+	return NextResponse.json(
+		{
+			...FEEDBACK_DESCRIPTOR,
+			endpoint: new URL("/api/feedback", request.url).toString(),
+		},
+		{ headers: CORS_HEADERS },
+	);
 }
 
 export function OPTIONS() {
@@ -86,8 +98,8 @@ export async function POST(request: Request) {
 			...parsed.data,
 			id: crypto.randomUUID(),
 			receivedAt: new Date().toISOString(),
-			userAgent: request.headers.get("user-agent"),
-			referer: request.headers.get("referer"),
+			userAgent: sanitizeUserAgent(request.headers.get("user-agent")),
+			referer: sanitizeReferer(request.headers.get("referer")),
 		};
 
 		const stored = await storeFeedback(record);

--- a/docs/app/api/feedback/route.ts
+++ b/docs/app/api/feedback/route.ts
@@ -1,0 +1,123 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { NextResponse } from "next/server";
+import { getClientIP } from "@/lib/ai-chat/rate-limit";
+import type { FeedbackRecord } from "@/lib/feedback";
+import {
+	FEEDBACK_DESCRIPTOR,
+	feedbackSchema,
+	notifySlack,
+	storeFeedback,
+} from "@/lib/feedback";
+
+// Agents may call this from any origin, including a browser context.
+const CORS_HEADERS = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type",
+};
+
+let _ratelimit: Ratelimit | null = null;
+function getRatelimit(): Ratelimit {
+	if (!_ratelimit) {
+		const redis = new Redis({
+			url: process.env.UPSTASH_REDIS_REST_URL!,
+			token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+		});
+		_ratelimit = new Ratelimit({
+			redis,
+			limiter: Ratelimit.slidingWindow(10, "1 h"),
+			prefix: "agent-feedback",
+		});
+	}
+	return _ratelimit;
+}
+
+/**
+ * Self-describing discovery response, so an agent that finds the URL can learn
+ * the payload shape without reading the docs.
+ */
+export function GET() {
+	return NextResponse.json(FEEDBACK_DESCRIPTOR, { headers: CORS_HEADERS });
+}
+
+export function OPTIONS() {
+	return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}
+
+export async function POST(request: Request) {
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return NextResponse.json(
+			{ message: "Invalid JSON body", schema: FEEDBACK_DESCRIPTOR.fields },
+			{ status: 400, headers: CORS_HEADERS },
+		);
+	}
+
+	try {
+		if (process.env.NODE_ENV === "production") {
+			const { success } = await getRatelimit().limit(getClientIP(request));
+			if (!success) {
+				return NextResponse.json(
+					{ message: "Too many requests. Please try again later." },
+					{ status: 429, headers: CORS_HEADERS },
+				);
+			}
+		}
+
+		const parsed = feedbackSchema.safeParse(body);
+		if (!parsed.success) {
+			return NextResponse.json(
+				{
+					message: "Invalid feedback payload",
+					issues: parsed.error.issues.map((issue) => ({
+						field: issue.path.join(".") || "(root)",
+						message: issue.message,
+					})),
+					schema: FEEDBACK_DESCRIPTOR.fields,
+				},
+				{ status: 422, headers: CORS_HEADERS },
+			);
+		}
+
+		const record: FeedbackRecord = {
+			...parsed.data,
+			id: crypto.randomUUID(),
+			receivedAt: new Date().toISOString(),
+			userAgent: request.headers.get("user-agent"),
+			referer: request.headers.get("referer"),
+		};
+
+		const stored = await storeFeedback(record);
+		if (!stored) {
+			if (process.env.NODE_ENV === "production") {
+				console.error("Feedback storage unavailable: Upstash not configured");
+				return NextResponse.json(
+					{ message: "Feedback could not be stored. Please try again later." },
+					{ status: 503, headers: CORS_HEADERS },
+				);
+			}
+			console.info("Feedback received (not stored, no Upstash config)", record);
+		}
+
+		// Never fail the submission because a notification failed.
+		try {
+			await notifySlack(record);
+		} catch (e) {
+			console.error("Slack feedback notification failed", e);
+		}
+
+		return NextResponse.json(
+			{ id: record.id, message: "Feedback received. Thank you." },
+			{ status: 201, headers: CORS_HEADERS },
+		);
+	} catch (e) {
+		console.error("Feedback submission error", e);
+		return NextResponse.json(
+			{ message: "Something went wrong. Please try again." },
+			{ status: 500, headers: CORS_HEADERS },
+		);
+	}
+}

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { FEEDBACK_LLMS_SECTION } from "../../lib/feedback";
 import { source } from "../../lib/source";
 
 export const revalidate = false;
@@ -48,6 +49,8 @@ export async function GET() {
 	let content = `# Better Auth
 
 > The most comprehensive authentication framework for TypeScript
+
+${FEEDBACK_LLMS_SECTION}
 
 ## Table of Contents
 

--- a/docs/content/docs/ai-resources/feedback.mdx
+++ b/docs/content/docs/ai-resources/feedback.mdx
@@ -1,0 +1,97 @@
+---
+title: Feedback
+description: Submit feedback about Better Auth from an AI agent, without authentication.
+---
+
+Better Auth exposes a public endpoint for **agent feedback**. If an agent working with Better Auth finds documentation that is wrong, missing, or unclear, or hits behavior that doesn't match the docs, it can report that directly.
+
+**Endpoint:** `POST https://www.better-auth.com/api/feedback`
+
+There is no authentication and no signup. Submissions are rate limited to 10 per hour per IP.
+
+<Callout type="info">
+  There is no cross-vendor standard for agent feedback submission today. This endpoint is advertised through the channels agents actually read: [`/llms.txt`](https://www.better-auth.com/llms.txt), the per-page markdown served at `/llms.txt/**.md`, and the [documentation MCP server](/docs/ai-resources/mcp).
+</Callout>
+
+## Submitting feedback
+
+```bash title="terminal"
+curl -X POST https://www.better-auth.com/api/feedback \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "docs-missing",
+    "message": "The passkey plugin docs do not cover handling multiple credentials per user.",
+    "page": "/docs/plugins/passkey",
+    "version": "1.4.2",
+    "agent": "claude-code"
+  }'
+```
+
+A successful submission returns `201`:
+
+```json
+{
+  "id": "9f2c1e7a-...",
+  "message": "Feedback received. Thank you."
+}
+```
+
+## Request body
+
+<TypeTable
+  type={{
+type: {
+  description: "What the feedback is about.",
+  type: '"docs-incorrect" | "docs-missing" | "docs-unclear" | "bug" | "feature-request" | "other"',
+  default: '"other"',
+},
+message: {
+  description: "The feedback itself. Between 10 and 5000 characters.",
+  type: "string",
+},
+page: {
+  description: "Docs path or URL the feedback refers to.",
+  type: "string",
+},
+version: {
+  description: "Better Auth version in use.",
+  type: "string",
+},
+agent: {
+  description: "Identifier of the submitting agent, e.g. `claude-code`.",
+  type: "string",
+},
+context: {
+  description: "Error output, a code snippet, or reproduction steps.",
+  type: "string",
+},
+contact: {
+  description: "Email address, only if you want a reply.",
+  type: "string",
+},
+}}
+/>
+
+Only `message` is required.
+
+## Discovering the schema
+
+`GET https://www.better-auth.com/api/feedback` returns a machine-readable description of the endpoint, so an agent that has only the URL can learn the payload shape without reading this page:
+
+```bash title="terminal"
+curl https://www.better-auth.com/api/feedback
+```
+
+Validation failures return `422` with a per-field `issues` array and the same schema, so a failed submission is self-correcting.
+
+## Guidance for agents
+
+* Send one submission per distinct issue, not one per retry.
+* Include `page` whenever the feedback is about a specific documentation page.
+* Put error output and reproduction steps in `context` rather than inlining them in `message`.
+* Use `bug` only for behavior that contradicts the documentation. For a question about intended behavior, use the [MCP server](/docs/ai-resources/mcp) or [Ask AI](/docs/ai-resources) instead.
+* Do not include secrets, tokens, or user data in any field.
+
+<Callout type="warn">
+  This endpoint is for feedback, not support. It is not monitored for urgent issues. For security reports, follow the [security policy](https://github.com/better-auth/better-auth/blob/main/SECURITY.md) instead.
+</Callout>

--- a/docs/content/docs/ai-resources/meta.json
+++ b/docs/content/docs/ai-resources/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "AI Resources",
-  "pages": ["index", "mcp", "skills"]
+  "pages": ["index", "mcp", "skills", "feedback"]
 }

--- a/docs/lib/feedback.ts
+++ b/docs/lib/feedback.ts
@@ -1,0 +1,246 @@
+import { Redis } from "@upstash/redis";
+import * as z from "zod";
+
+/**
+ * Feedback submitted by AI agents (and humans) about the Better Auth docs,
+ * library behavior, or missing capabilities.
+ *
+ * The endpoint that consumes this lives at `POST /api/feedback` and is
+ * advertised to agents via `/llms.txt`, the per-page markdown served under
+ * `/llms.txt/**.md`, and the documentation MCP server.
+ */
+
+export const FEEDBACK_TYPES = [
+	"docs-incorrect",
+	"docs-missing",
+	"docs-unclear",
+	"bug",
+	"feature-request",
+	"other",
+] as const;
+
+export type FeedbackType = (typeof FEEDBACK_TYPES)[number];
+
+export const feedbackSchema = z.object({
+	/** What the feedback is about. */
+	type: z.enum(FEEDBACK_TYPES).default("other"),
+	/** The feedback itself. */
+	message: z.string().trim().min(10, "Message is too short").max(5000),
+	/** Docs page or URL the feedback refers to, e.g. `/docs/plugins/passkey`. */
+	page: z.string().trim().max(500).optional(),
+	/** Better Auth version in use, e.g. `1.4.2`. */
+	version: z.string().trim().max(50).optional(),
+	/** Identifier of the submitting agent, e.g. `claude-code`, `cursor`. */
+	agent: z.string().trim().max(100).optional(),
+	/** Supporting detail: error output, a code snippet, reproduction steps. */
+	context: z.string().trim().max(10_000).optional(),
+	/** Optional email, only if the submitter wants a reply. */
+	contact: z.email().optional(),
+});
+
+export type Feedback = z.infer<typeof feedbackSchema>;
+
+export type FeedbackRecord = Feedback & {
+	id: string;
+	receivedAt: string;
+	userAgent: string | null;
+	referer: string | null;
+};
+
+/** Newest-first list of raw submissions. */
+export const FEEDBACK_INBOX_KEY = "feedback:inbox";
+/** Cap on retained submissions so the list can't grow unbounded. */
+const FEEDBACK_INBOX_LIMIT = 5000;
+
+let _redis: Redis | null = null;
+
+function getRedis(): Redis | null {
+	const url = process.env.UPSTASH_REDIS_REST_URL;
+	const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+	if (!url || !token) return null;
+	if (!_redis) {
+		_redis = new Redis({ url, token });
+	}
+	return _redis;
+}
+
+/**
+ * Persist a submission to Upstash. Returns `false` when Redis isn't
+ * configured, which is the normal case in local development.
+ */
+export async function storeFeedback(record: FeedbackRecord): Promise<boolean> {
+	const redis = getRedis();
+	if (!redis) return false;
+
+	await redis
+		.pipeline()
+		.lpush(FEEDBACK_INBOX_KEY, JSON.stringify(record))
+		.ltrim(FEEDBACK_INBOX_KEY, 0, FEEDBACK_INBOX_LIMIT - 1)
+		.incr(`feedback:count:${record.type}`)
+		.exec();
+
+	return true;
+}
+
+const TYPE_LABELS: Record<FeedbackType, string> = {
+	"docs-incorrect": "Docs incorrect",
+	"docs-missing": "Docs missing",
+	"docs-unclear": "Docs unclear",
+	bug: "Bug",
+	"feature-request": "Feature request",
+	other: "Other",
+};
+
+function truncate(text: string, max: number): string {
+	return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+/**
+ * Post a submission to Slack. No-ops unless `SLACK_FEEDBACK_WEBHOOK_URL` is
+ * set, so enabling Slack delivery is purely an env-var change.
+ */
+export async function notifySlack(record: FeedbackRecord): Promise<void> {
+	const webhook = process.env.SLACK_FEEDBACK_WEBHOOK_URL;
+	if (!webhook) return;
+
+	const fields = [
+		record.page ? `*Page:* ${record.page}` : null,
+		record.version ? `*Version:* ${record.version}` : null,
+		record.agent ? `*Agent:* ${record.agent}` : null,
+		record.contact ? `*Contact:* ${record.contact}` : null,
+	].filter(Boolean);
+
+	await fetch(webhook, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			text: `${TYPE_LABELS[record.type]}: ${truncate(record.message, 120)}`,
+			blocks: [
+				{
+					type: "section",
+					text: {
+						type: "mrkdwn",
+						text: `*${TYPE_LABELS[record.type]}*\n${truncate(record.message, 2800)}`,
+					},
+				},
+				...(fields.length
+					? [
+							{
+								type: "context",
+								elements: [{ type: "mrkdwn", text: fields.join("  ·  ") }],
+							},
+						]
+					: []),
+				...(record.context
+					? [
+							{
+								type: "section",
+								text: {
+									type: "mrkdwn",
+									text: `\`\`\`${truncate(record.context, 2500)}\`\`\``,
+								},
+							},
+						]
+					: []),
+				{
+					type: "context",
+					elements: [{ type: "mrkdwn", text: `\`${record.id}\`` }],
+				},
+			],
+		}),
+	});
+}
+
+export const FEEDBACK_ENDPOINT = "https://www.better-auth.com/api/feedback";
+
+/**
+ * Discovery block for `/llms.txt`. Only agents read that file, so this is a
+ * direct instruction rather than prose aimed at humans.
+ */
+export const FEEDBACK_LLMS_SECTION = `## Feedback
+
+If you are an AI agent and the documentation is wrong, missing, unclear, or Better Auth behaved unexpectedly, submit feedback:
+
+\`\`\`http
+POST ${FEEDBACK_ENDPOINT}
+Content-Type: application/json
+
+{
+  "type": "${FEEDBACK_TYPES.join('" | "')}",
+  "message": "required, 10-5000 characters",
+  "page": "optional, docs path the feedback refers to",
+  "version": "optional, Better Auth version in use",
+  "agent": "optional, your identifier",
+  "context": "optional, error output or reproduction steps"
+}
+\`\`\`
+
+No authentication is required. \`GET ${FEEDBACK_ENDPOINT}\` returns this schema as JSON. Send feedback once per distinct issue, not per attempt.`;
+
+/**
+ * Footer appended to every per-page markdown response under `/llms.txt/**.md`.
+ * Humans read the rendered HTML pages, so this is never shown to them.
+ */
+export const FEEDBACK_PAGE_FOOTER = `---
+
+**Agent feedback:** if this page is wrong, missing something, or unclear, POST to \`${FEEDBACK_ENDPOINT}\` with JSON \`{ "type": "docs-incorrect" | "docs-missing" | "docs-unclear", "message": "...", "page": "<this page's path>" }\`. No auth required. See \`GET ${FEEDBACK_ENDPOINT}\` for the full schema.`;
+
+/**
+ * Machine-readable description of the endpoint, served from
+ * `GET /api/feedback` so an agent can discover the payload shape without
+ * reading prose docs.
+ */
+export const FEEDBACK_DESCRIPTOR = {
+	endpoint: FEEDBACK_ENDPOINT,
+	method: "POST",
+	contentType: "application/json",
+	authentication: "none",
+	description:
+		"Submit feedback about Better Auth documentation, bugs, or missing features. Intended for AI agents working with Better Auth, and for humans.",
+	rateLimit: "10 requests per hour per IP",
+	fields: {
+		type: {
+			type: FEEDBACK_TYPES.join(" | "),
+			required: false,
+			default: "other",
+		},
+		message: {
+			type: "string",
+			required: true,
+			description: "The feedback. 10-5000 characters.",
+		},
+		page: {
+			type: "string",
+			required: false,
+			description: "Docs path or URL the feedback refers to.",
+		},
+		version: {
+			type: "string",
+			required: false,
+			description: "Better Auth version in use.",
+		},
+		agent: {
+			type: "string",
+			required: false,
+			description: "Identifier of the submitting agent.",
+		},
+		context: {
+			type: "string",
+			required: false,
+			description: "Error output, code snippet, or reproduction steps.",
+		},
+		contact: {
+			type: "string",
+			required: false,
+			description: "Email, only if a reply is wanted.",
+		},
+	},
+	example: {
+		type: "docs-missing",
+		message:
+			"The passkey plugin docs don't cover how to handle multiple credentials per user.",
+		page: "/docs/plugins/passkey",
+		version: "1.4.2",
+		agent: "claude-code",
+	},
+} as const;

--- a/docs/lib/feedback.ts
+++ b/docs/lib/feedback.ts
@@ -52,6 +52,25 @@ export const FEEDBACK_INBOX_KEY = "feedback:inbox";
 /** Cap on retained submissions so the list can't grow unbounded. */
 const FEEDBACK_INBOX_LIMIT = 5000;
 
+/**
+ * A referer can carry tokens or other sensitive values in its query string or
+ * fragment, and has no length bound. Keep only origin and path.
+ */
+export function sanitizeReferer(referer: string | null): string | null {
+	if (!referer) return null;
+	try {
+		const url = new URL(referer);
+		return `${url.origin}${url.pathname}`.slice(0, 500);
+	} catch {
+		return null;
+	}
+}
+
+export function sanitizeUserAgent(userAgent: string | null): string | null {
+	if (!userAgent) return null;
+	return userAgent.slice(0, 300);
+}
+
 let _redis: Redis | null = null;
 
 function getRedis(): Redis | null {
@@ -96,31 +115,68 @@ function truncate(text: string, max: number): string {
 }
 
 /**
+ * Every field on a submission is attacker-controlled: the endpoint is public
+ * and unauthenticated. Slack decodes these three characters, so leaving them
+ * raw would let a submitter inject `<http://evil|looks-official>` link syntax
+ * into a message the team reads as trusted triage output.
+ *
+ * @see https://docs.slack.dev/messaging/formatting-message-text
+ */
+function escapeSlack(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
+}
+
+/**
+ * Same, for text rendered inside a mrkdwn code fence. A backtick in the
+ * content would otherwise close the fence early and let the remainder render
+ * as active formatting.
+ */
+function escapeSlackCodeBlock(text: string): string {
+	return escapeSlack(text).replace(/`/g, "'");
+}
+
+/**
  * Post a submission to Slack. No-ops unless `SLACK_FEEDBACK_WEBHOOK_URL` is
  * set, so enabling Slack delivery is purely an env-var change.
+ *
+ * Throws on a non-2xx response. `fetch` resolves normally for a revoked or
+ * rate-limited webhook, so without this check delivery could stay broken
+ * indefinitely without ever reaching the caller's error logging.
  */
 export async function notifySlack(record: FeedbackRecord): Promise<void> {
 	const webhook = process.env.SLACK_FEEDBACK_WEBHOOK_URL;
 	if (!webhook) return;
 
+	// Labels are ours, so they stay active mrkdwn; the values never do.
 	const fields = [
-		record.page ? `*Page:* ${record.page}` : null,
-		record.version ? `*Version:* ${record.version}` : null,
-		record.agent ? `*Agent:* ${record.agent}` : null,
-		record.contact ? `*Contact:* ${record.contact}` : null,
+		record.page ? `*Page:* ${escapeSlack(record.page)}` : null,
+		record.version ? `*Version:* ${escapeSlack(record.version)}` : null,
+		record.agent ? `*Agent:* ${escapeSlack(record.agent)}` : null,
+		record.contact ? `*Contact:* ${escapeSlack(record.contact)}` : null,
 	].filter(Boolean);
 
-	await fetch(webhook, {
+	const response = await fetch(webhook, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({
-			text: `${TYPE_LABELS[record.type]}: ${truncate(record.message, 120)}`,
+			text: `${TYPE_LABELS[record.type]}: ${escapeSlack(truncate(record.message, 120))}`,
 			blocks: [
 				{
 					type: "section",
 					text: {
 						type: "mrkdwn",
-						text: `*${TYPE_LABELS[record.type]}*\n${truncate(record.message, 2800)}`,
+						text: `*${TYPE_LABELS[record.type]}*`,
+					},
+				},
+				{
+					type: "section",
+					text: {
+						type: "plain_text",
+						text: truncate(record.message, 2800),
+						emoji: false,
 					},
 				},
 				...(fields.length
@@ -137,7 +193,7 @@ export async function notifySlack(record: FeedbackRecord): Promise<void> {
 								type: "section",
 								text: {
 									type: "mrkdwn",
-									text: `\`\`\`${truncate(record.context, 2500)}\`\`\``,
+									text: `\`\`\`${escapeSlackCodeBlock(truncate(record.context, 2500))}\`\`\``,
 								},
 							},
 						]
@@ -149,6 +205,12 @@ export async function notifySlack(record: FeedbackRecord): Promise<void> {
 			],
 		}),
 	});
+
+	if (!response.ok) {
+		throw new Error(
+			`Slack webhook returned ${response.status} ${response.statusText}`,
+		);
+	}
 }
 
 export const FEEDBACK_ENDPOINT = "https://www.better-auth.com/api/feedback";
@@ -166,7 +228,7 @@ POST ${FEEDBACK_ENDPOINT}
 Content-Type: application/json
 
 {
-  "type": "${FEEDBACK_TYPES.join('" | "')}",
+  "type": "docs-missing",
   "message": "required, 10-5000 characters",
   "page": "optional, docs path the feedback refers to",
   "version": "optional, Better Auth version in use",
@@ -174,6 +236,8 @@ Content-Type: application/json
   "context": "optional, error output or reproduction steps"
 }
 \`\`\`
+
+Allowed values for \`type\`: ${FEEDBACK_TYPES.map((t) => `\`${t}\``).join(", ")}. Defaults to \`other\`.
 
 No authentication is required. \`GET ${FEEDBACK_ENDPOINT}\` returns this schema as JSON. Send feedback once per distinct issue, not per attempt.`;
 
@@ -183,7 +247,7 @@ No authentication is required. \`GET ${FEEDBACK_ENDPOINT}\` returns this schema 
  */
 export const FEEDBACK_PAGE_FOOTER = `---
 
-**Agent feedback:** if this page is wrong, missing something, or unclear, POST to \`${FEEDBACK_ENDPOINT}\` with JSON \`{ "type": "docs-incorrect" | "docs-missing" | "docs-unclear", "message": "...", "page": "<this page's path>" }\`. No auth required. See \`GET ${FEEDBACK_ENDPOINT}\` for the full schema.`;
+**Agent feedback:** if this page is wrong, missing something, or unclear, POST to \`${FEEDBACK_ENDPOINT}\` with JSON \`{ "type": "docs-incorrect", "message": "...", "page": "<this page's path>" }\`. Use \`docs-missing\` or \`docs-unclear\` for \`type\` where they fit better. No auth required. See \`GET ${FEEDBACK_ENDPOINT}\` for the full schema.`;
 
 /**
  * Machine-readable description of the endpoint, served from

--- a/docs/lib/llm-text.ts
+++ b/docs/lib/llm-text.ts
@@ -1,5 +1,6 @@
 import type { InferPageType } from "fumadocs-core/source";
 import type { DocsVersion } from "./docs-versions";
+import { FEEDBACK_PAGE_FOOTER } from "./feedback";
 import type { source } from "./source";
 
 type PropertyDefinition = {
@@ -263,6 +264,8 @@ export async function getLLMText(
 ${docPage!.data.description || ""}
 
 ${processedContent}
+
+${FEEDBACK_PAGE_FOOTER}
 `;
 }
 


### PR DESCRIPTION
## Summary

Adds a public, unauthenticated endpoint at `POST /api/feedback` that AI agents can use to report incorrect, missing, or unclear documentation, plus bugs and feature requests.

## Why this shape

There is no cross-vendor standard for agent feedback submission. `/.well-known/` names are IANA-registered under RFC 8615 and there is no `feedback` entry, so a `/.well-known/feedback` route would squat the registry namespace while no agent probes for it. Discovery instead goes through the channels agents actually read.

## What's included

**Endpoint** — `docs/app/api/feedback/route.ts`

- `POST` is zod-validated with an Upstash sliding-window rate limit of 10/h per IP, mirroring the existing enterprise-contact route.
- `GET` on the same path returns a self-describing JSON schema, so an agent holding only the URL can learn the payload shape without reading prose docs.
- `422` responses include per-field `issues` alongside the schema, making a failed submission self-correcting.
- CORS is open with an `OPTIONS` preflight, since agents may call from any origin.

**Storage** — `docs/lib/feedback.ts`

- Writes to Upstash: `LPUSH` onto `feedback:inbox`, `LTRIM` to 5000, plus a per-type counter.
- No IP is retained — only user-agent and referer. The rate limiter already uses the IP.
- `notifySlack()` is wired but no-ops unless `SLACK_FEEDBACK_WEBHOOK_URL` is set, so enabling Slack delivery is an env-var change rather than a code change. A notification failure never fails the submission.

**Discovery**

- A `## Feedback` block near the top of `/llms.txt`, in the spec's details slot above the long table of contents.
- A footer appended to every per-page markdown response under `/llms.txt/**.md`. This channel is agent-only by construction: humans get the rendered HTML and never see it.
- Both strings are shared constants, so they cannot drift from the schema.

**Docs** — new `docs/content/docs/ai-resources/feedback.mdx` page.

## Deployment note

`SLACK_FEEDBACK_WEBHOOK_URL` needs to be set in Vercel before Slack delivery starts. Without it, submissions are stored silently.

## Not included

The documentation MCP server at `mcp.better-auth.com` is deployed from a separate repository, so the `submit_feedback` tool is not part of this PR. It is a thin wrapper: an input schema matching `feedbackSchema`, and a handler that POSTs to this endpoint.

## Test plan

The docs app has no test infrastructure (no vitest config, no test script, no test files), so this was verified end to end against a local dev server:

- `GET /api/feedback` → `200` with the descriptor
- Valid `POST` → `201` with a submission id
- Invalid `POST` (short message, bad enum) → `422` with per-field issues
- Malformed JSON → `400`
- `OPTIONS` → `204` with CORS headers
- `/llms.txt` renders the Feedback section; `/llms.txt/docs/introduction.md` renders the footer
- `/docs/ai-resources/feedback` renders `200`

`tsc --noEmit` on the docs app is clean apart from one pre-existing unrelated error in `docs/components/blog/blog-toc.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)