### PR TITLE
docs(mcp): document CLI device authorization

### DIFF
--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -98,51 +98,115 @@ The device flow follows these steps:
 3. **Device polls for token**: The device polls the server until the user completes authorization
 4. **Access granted**: Once authorized, the device receives an access token
 
-## Issuing OAuth access tokens (OAuth Provider integration)
+## Choose the token your device needs
 
-By default, `/device/token` issues a **Better Auth session token** — ideal when the device is your own first-party app signing a user into your service.
+Device authorization can finish with two different token types. Choose the token based on what the client needs to call:
 
-If you run Better Auth as an [OAuth Provider](/docs/plugins/oauth-provider) and want **third-party / registered OAuth clients** (external CLIs, smart-TV apps) to use the device flow and receive a real **OAuth access token** (scoped, audience-bound, introspectable, optionally a JWT and ID token) instead of a session token, add the `deviceCodeGrant()` companion plugin from `@better-auth/oauth-provider`:
+| Use case                                                                         | Token                     | Plugins                                                             | Token endpoint  |
+| -------------------------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------- | --------------- |
+| Sign your own device into the same Better Auth application                       | Better Auth session token | `deviceAuthorization()`                                             | `/device/token` |
+| Let a registered CLI, TV app, or other public client call an OAuth-protected API | Scoped OAuth access token | `deviceAuthorization()`, `oauthProvider()`, and `deviceCodeGrant()` | `/oauth2/token` |
+
+A command-line application commonly needs the second path. The CLI cannot safely keep a client secret, and it may not have a reliable redirect listener, but it still needs a user-authorized token for your API. The device grant lets the user approve the request in a browser while the CLI receives an audience-bound OAuth access token.
+
+### Authorize a CLI to call an API
+
+Add the [JWT](/docs/plugins/jwt), Device Authorization, and [OAuth Provider](/docs/plugins/oauth-provider) plugins. `deviceCodeGrant()` connects the device verification flow to the provider's token endpoint:
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
-import { deviceAuthorization } from "better-auth/plugins";
-import { oauthProvider, deviceCodeGrant } from "@better-auth/oauth-provider"; // [!code highlight]
+import { deviceAuthorization, jwt } from "better-auth/plugins";
+import {
+  deviceCodeGrant,
+  oauthProvider,
+} from "@better-auth/oauth-provider"; // [!code highlight]
 
 export const auth = betterAuth({
   plugins: [
-    deviceAuthorization(),
-    oauthProvider({ /* ... */ }),
+    jwt(),
+    deviceAuthorization({
+      verificationUri: "/device",
+    }),
+    oauthProvider({
+      loginPage: "/sign-in",
+      consentPage: "/consent",
+      scopes: ["openid", "profile", "offline_access", "api:read"],
+      resources: ["https://api.example.com"],
+    }),
     deviceCodeGrant(), // [!code highlight]
   ],
 });
 ```
 
-This registers the `urn:ietf:params:oauth:grant-type:device_code` grant on the provider's `/oauth2/token` endpoint and advertises `device_authorization_endpoint` (pointing at `/device/code`) in the provider's discovery metadata.
+Register the CLI as a public native client and link it to the API resource. Public clients use `token_endpoint_auth_method: "none"` because an installed CLI cannot keep a shared secret confidential:
 
-The flow for a registered OAuth client:
+```ts title="register-cli.ts"
+import { DEVICE_CODE_GRANT_TYPE } from "@better-auth/oauth-provider";
 
-1. The client requests codes at `/device/code` (the advertised `device_authorization_endpoint`). The provider validates registered clients, scopes, and resource indicators before creating the authorization request.
-2. The user signs in and approves at the verification URL. The `GET /device` response includes `client_id`, `scope`, and `resource` only for the user who owns the request, so the approval page can show exactly what is requesting access without exposing that context to unauthenticated or unrelated users.
-3. The client polls **`/oauth2/token`** (not `/device/token`) with `grant_type=urn:ietf:params:oauth:grant-type:device_code`, `device_code`, and `client_id`. A `resource` parameter may be omitted to use the approved resource set, or may request a subset; it cannot add a resource after approval.
-
-```ts title="register the client with the device-code grant"
 await auth.api.adminCreateOAuthClient({
   headers,
   body: {
-    token_endpoint_auth_method: "none", // public client (CLI, TV, IoT)
+    token_endpoint_auth_method: "none",
     type: "native",
-    grant_types: ["urn:ietf:params:oauth:grant-type:device_code"],
-    scope: "openid profile email",
+    grant_types: [DEVICE_CODE_GRANT_TYPE, "refresh_token"],
+    scope: "openid profile offline_access api:read",
+    resources: ["https://api.example.com"],
   },
 });
 ```
 
-<Callout type="info">
-  Both flows can coexist. First-party device login keeps using `/device/token` (session token). To prevent a registered OAuth client's device code from being redeemed at `/device/token` for a session token, `deviceCodeGrant()` rejects `/device/token` requests whose `client_id` is a registered OAuth client and directs them to `/oauth2/token`. `deviceCodeGrant()` requires both the `deviceAuthorization()` and `oauthProvider()` plugins.
+The CLI then requests a device code for the API it intends to call:
+
+```ts title="cli.ts"
+const authBaseURL = "https://auth.example.com/api/auth";
+const clientId = "YOUR_CLIENT_ID";
+const resource = "https://api.example.com";
+
+const { data } = await authClient.device.code({
+  client_id: clientId,
+  scope: "openid profile offline_access api:read",
+  resource,
+});
+
+if (!data) throw new Error("Could not start device authorization");
+
+console.log(`Open ${data.verification_uri}`);
+console.log(`Enter code ${data.user_code}`);
+```
+
+While the user signs in and approves the request, repeat the following request at the interval returned by the device-code response:
+
+```ts title="cli.ts"
+const response = await fetch(`${authBaseURL}/oauth2/token`, {
+  method: "POST",
+  headers: {
+    "content-type": "application/x-www-form-urlencoded",
+  },
+  body: new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    device_code: data.device_code,
+    client_id: clientId,
+  }),
+});
+
+const tokens = await response.json();
+```
+
+The access token is a signed JWT whose `aud` identifies `https://api.example.com`. Send it to that API as `Authorization: Bearer <access_token>`, then verify its signature, issuer, audience, expiry, and required scopes at the API. See [API Server verification](/docs/plugins/oauth-provider#api-server). If the CLI requests `offline_access`, store the returned refresh token in the operating system's secure credential store and use it to renew short-lived access tokens.
+
+<Callout type="warn">
+  Do not call `authClient.device.token` for this OAuth flow. That client method polls `/device/token` and returns a Better Auth session token. Registered OAuth clients must poll `/oauth2/token`.
 </Callout>
 
-## Basic Usage
+`deviceCodeGrant()` registers the `urn:ietf:params:oauth:grant-type:device_code` grant and advertises `/device/code` as `device_authorization_endpoint` in provider discovery. The provider validates the registered client, scopes, and [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) resource before creating the request. The approval page can show the client, scopes, and resource to the signed-in user.
+
+<Callout type="info">
+  Both token paths can coexist. First-party device login keeps using `/device/token`. Registered OAuth clients use `/oauth2/token`; `deviceCodeGrant()` prevents their device codes from being redeemed for a Better Auth session token.
+</Callout>
+
+## First-party session flow
+
+The rest of this page describes the first-party path, where `/device/token` returns a Better Auth session token.
 
 ### Requesting Device Authorization
 

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -102,10 +102,10 @@ The device flow follows these steps:
 
 Device authorization can finish with two different token types. Choose the token based on what the client needs to call:
 
-| Use case                                                                         | Token                     | Plugins                                                             | Token endpoint  |
-| -------------------------------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------- | --------------- |
-| Sign your own device into the same Better Auth application                       | Better Auth session token | `deviceAuthorization()`                                             | `/device/token` |
-| Let a registered CLI, TV app, or other public client call an OAuth-protected API | Scoped OAuth access token | `deviceAuthorization()`, `oauthProvider()`, and `deviceCodeGrant()` | `/oauth2/token` |
+| Use case                                                                         | Token                     | Plugins                                                                      | Token endpoint  |
+| -------------------------------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------- | --------------- |
+| Sign your own device into the same Better Auth application                       | Better Auth session token | `deviceAuthorization()`                                                      | `/device/token` |
+| Let a registered CLI, TV app, or other public client call an OAuth-protected API | Scoped OAuth access token | `jwt()`, `deviceAuthorization()`, `oauthProvider()`, and `deviceCodeGrant()` | `/oauth2/token` |
 
 A command-line application commonly needs the second path. The CLI cannot safely keep a client secret, and it may not have a reliable redirect listener, but it still needs a user-authorized token for your API. The device grant lets the user approve the request in a browser while the CLI receives an audience-bound OAuth access token.
 
@@ -158,9 +158,17 @@ await auth.api.adminCreateOAuthClient({
 The CLI then requests a device code for the API it intends to call:
 
 ```ts title="cli.ts"
+import { createAuthClient } from "better-auth/client";
+import { deviceAuthorizationClient } from "better-auth/client/plugins";
+
 const authBaseURL = "https://auth.example.com/api/auth";
 const clientId = "YOUR_CLIENT_ID";
 const resource = "https://api.example.com";
+
+const authClient = createAuthClient({
+  baseURL: authBaseURL,
+  plugins: [deviceAuthorizationClient()],
+});
 
 const { data } = await authClient.device.code({
   client_id: clientId,

--- a/docs/content/docs/plugins/mcp.mdx
+++ b/docs/content/docs/plugins/mcp.mdx
@@ -81,6 +81,39 @@ Discovery follows OAuth 2.0 Authorization Server Metadata ([RFC 8414](https://da
 
 ## Usage
 
+### Add device authorization for your own CLI
+
+MCP clients normally discover the authorization server from protected resource metadata, then use the authorization code flow with PKCE. Keep that flow for general MCP compatibility.
+
+If your product also ships a command-line application, the same authorization server can let the CLI authorize through a browser without opening a local callback listener. Add the Device Authorization plugin and the OAuth Provider's `deviceCodeGrant()` companion:
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { deviceAuthorization, jwt } from "better-auth/plugins";
+import { deviceCodeGrant } from "@better-auth/oauth-provider";
+import { mcp } from "@better-auth/mcp";
+
+export const auth = betterAuth({
+  plugins: [
+    jwt(),
+    deviceAuthorization({
+      verificationUri: "/device",
+    }),
+    mcp({
+      loginPage: "/sign-in",
+      consentPage: "/consent",
+      resource: "https://api.example.com/mcp",
+      scopes: ["openid", "profile", "offline_access", "mcp:read"],
+    }),
+    deviceCodeGrant(),
+  ],
+});
+```
+
+`mcp()` is already the OAuth Provider, so this composition does not add a separate `oauthProvider()` plugin. MCP clients continue to use discovery and authorization code with PKCE. Your registered public CLI can request the same MCP resource through `/device/code` and poll `/oauth2/token` for an audience-bound access token.
+
+Only use the device grant in an MCP client that explicitly implements [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628). Adding `deviceCodeGrant()` to the server does not change the standard flow chosen by existing MCP clients. See [Authorize a CLI to call an API](/docs/plugins/device-authorization#authorize-a-cli-to-call-an-api) for client registration and token polling.
+
 ### Protected Resource Metadata
 
 The [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) `/.well-known/oauth-protected-resource` document is served automatically at the well-known root (and the resource-path-inserted alias). It tells MCP clients which authorization server protects the resource, which scopes it supports, which `resource` identifier their access tokens must be bound to, and which DPoP proof algorithms are supported.
@@ -136,6 +169,8 @@ const handler = requireMcpAuth(auth, (req, claims) => { // [!code highlight]
             maxDuration: 60,
         },
     )(req);
+}, {
+    resource: "https://api.example.com/mcp", // must match mcp({ resource }) // [!code highlight]
 });
 
 export { handler as GET, handler as POST, handler as DELETE };
@@ -143,7 +178,7 @@ export { handler as GET, handler as POST, handler as DELETE };
 
 The second argument is the verified JWT payload, not a database record. `requireMcpAuth` never exposes a refresh token; the access token is checked locally against the JWKS without a database round trip. DPoP-bound tokens must be sent as `Authorization: DPoP <access_token>` with a matching `DPoP` proof header. DPoP proof replay is rejected through your auth instance's database adapter by default, so anti-replay holds across multiple server instances; pass `dpop.replayStore` only to use a different store.
 
-By default `requireMcpAuth` reads the server's resolved base URL from the auth context and uses it as both the expected token issuer and protected resource identifier, with the JWKS at that base URL. This matches what the provider issues, so no configuration is needed for the common case. Override any value when the resource differs or `jwt.issuer` is custom:
+By default, `requireMcpAuth` reads the server's resolved Better Auth URL from the auth context and uses it as the expected issuer, resource, and JWKS base. If `mcp({ resource })` uses a different identifier, pass that same value to `requireMcpAuth`, as shown above. Override the issuer or JWKS URL when `jwt.issuer` is custom or the authorization server runs separately:
 
 ```ts
 requireMcpAuth(auth, handler, {

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -35,6 +35,7 @@ The plugin has a secured configuration by default providing ease to users unfami
 * **authorization\_code**: Code for user token exchange with PKCE and S256 requirements.
 * **refresh\_token**: Issue refresh tokens and handle access token renewal using `offline_access` scope.
 * **client\_credentials**: Machine to Machine tokens for API communication.
+* **device\_code**: Optional [Device Authorization](/docs/plugins/device-authorization#authorize-a-cli-to-call-an-api) companion grant for CLIs and limited-input clients.
 
 ## Installation
 
@@ -1797,162 +1798,11 @@ JWT access tokens always use the real user ID as `sub`, since resource servers m
 
 ### MCP
 
-You can easily make your APIs [MCP-compatible](https://modelcontextprotocol.io/specification/draft/basic/authorization) simply by adding a resource server which directs users to this OAuth 2.1 authorization server.
+Use the [`@better-auth/mcp` plugin](/docs/plugins/mcp) when an MCP server is one of your protected resources. It builds on this OAuth Provider and adds MCP defaults, RFC 9728 protected resource metadata, and route helpers that return the authorization challenge MCP clients expect.
 
-<Callout type="info">
-  If you are using "openid" and confidential MCP clients, you cannot disable the JWT plugin since `id_token` verification may not necessarily be supported via a `client_secret`.
-</Callout>
+`mcp()` is the OAuth Provider for that Better Auth instance, so do not register both `mcp()` and `oauthProvider()`. It accepts the OAuth Provider options directly. Use `requireMcpAuth` when the MCP route shares the auth instance, or `mcpHandler` when the resource server runs separately.
 
-#### Installation
-
-<Steps>
-  <Step>
-    ### Ensure Well Known Paths are correct
-
-    See [well-known endpoints](#well-known).
-  </Step>
-
-  <Step>
-    ### Add Resource Server Client
-
-    (Optional) If you have your auth configuration available locally, add the configuration as a parameter to the client to fill in these values and warn you about configuration errors. You can always override these values in the function call. If this is not supplied, typescript will guide you with the minimal configuration values needed.
-
-    ```ts title="server-client.ts"
-    import { auth } from "@/lib/auth";
-    import { createAuthClient } from "better-auth/client";
-    import { oauthProviderResourceClient } from "@better-auth/oauth-provider/resource-client"
-
-    export const serverClient = createAuthClient({
-      plugins: [oauthProviderResourceClient(auth)], // auth optional
-    });
-    ```
-  </Step>
-
-  <Step>
-    ### Add OAuth Protected Resource Metadata to your API
-
-    ```ts title="/.well-known/oauth-protected-resource/[resource-path]/route.ts"
-    import { serverClient } from "@/lib/server-client";
-
-    export const GET = async () => {
-      const metadata = await serverClient.getProtectedResourceMetadata({
-        resource: "https://api.example.com", // protected resource identifier
-        authorization_servers: ["https://auth.example.com"],
-      })
-
-      return new Response(JSON.stringify(metadata), {
-        headers: {
-          "Content-Type": "application/json",
-          "Cache-Control":
-            "public, max-age=15, stale-while-revalidate=15, stale-if-error=86400",
-        },
-      });
-    };
-    ```
-  </Step>
-
-  <Step>
-    If you use the [`cimd`](/docs/plugins/cimd) plugin or `allowUnauthenticatedClientRegistration`, you must ensure that your API Server is a confidential client itself:
-
-    ```ts
-    await auth.api.createOAuthClient({
-      headers,
-      body: {
-        redirect_uris: [redirectUri],
-      }
-    });
-    ```
-
-    These values should be used in the verify options `remoteVerify.clientId` and `remoteVerify.clientSecret`. Additionally, `remoteVerify.introspectUrl` would be something like `${BASE_URL}/${AUTH_PATH}/oauth2/introspect`.
-
-    <Callout type="info">
-      If you choose not to support the [`cimd`](/docs/plugins/cimd) plugin or `allowUnauthenticatedClientRegistration` (and only `allowDynamicClientRegistration`), the MCP client (ie. ChatGPT, Anthropic, Gemini) would need to allow you to put in a public client\_id in their UI or at runtime while chatting with the AI.
-    </Callout>
-  </Step>
-
-  <Step>
-    ### Handle MCP Errors for your API
-
-    Set `verifyOptions.audience` to your protected resource identifier. If omitted, the resource client falls back to the authorization server base URL as the expected audience.
-
-    * Using the client `verifyAccessTokenRequest` function
-
-    See [Verification](#verification) for verification examples.
-
-    * With auth available, use the client `verifyAccessTokenRequest` function to automatically determine endpoints
-
-    ```ts title="api/[endpoint].ts"
-    import { auth } from "@/lib/auth";
-    import { serverClient } from "@/lib/server-client";
-
-    export const GET = async (req: Request) => {
-      const payload = await serverClient.verifyAccessTokenRequest(
-        req,
-        {
-          verifyOptions: {
-            audience: "https://api.example.com",
-          }
-        }
-      );
-      // ...continue
-    }
-    ```
-
-    * Using `mcpHandler` helper
-
-    ```ts title="api/[transport]/route.ts"
-    import { createMcpHandler } from "mcp-handler";
-    import { mcpHandler } from "@better-auth/oauth-provider";
-    import { z } from "zod";
-
-    const handler = mcpHandler({
-      jwksUrl: "https://auth.example.com/api/auth/jwks",
-      verifyOptions: {
-        issuer: "https://auth.example.com",
-        audience: "https://api.example.com",
-      },
-    }, (req, jwt) => {
-      return createMcpHandler(
-        (server) => {
-          server.registerTool(
-            "echo", {
-              description: "Echo a message",
-              inputSchema: {
-                message: z.string(),
-              },
-            },
-            async ({ message }) => {
-              return {
-                content: [
-                  {
-                    type: "text",
-                    text: `Echo: ${message}${
-                      jwt?.sub
-                        ? ` for user ${jwt.sub}`
-                        : ""
-                    }`,
-                  },
-                ],
-              };
-            }
-          );
-        }, {
-          serverInfo: {
-            name: "demo-better-auth",
-            version: "1.0.0",
-          }
-        }, {
-          basePath: "/api",
-          maxDuration: 60,
-          verboseLogs: true,
-        }
-      )(req);
-    });
-
-    export { handler as GET, handler as POST, handler as DELETE };
-    ```
-  </Step>
-</Steps>
+The MCP plugin can also support a separate registered CLI through the device grant. MCP clients keep their discovery-driven authorization code flow, while the CLI asks the same provider for a resource-bound token through device authorization. See [Add device authorization for your own CLI](/docs/plugins/mcp#add-device-authorization-for-your-own-cli).
 
 ## Schema
 

--- a/packages/mcp/src/plugin.test.ts
+++ b/packages/mcp/src/plugin.test.ts
@@ -1,3 +1,7 @@
+import {
+	DEVICE_CODE_GRANT_TYPE,
+	deviceCodeGrant,
+} from "@better-auth/oauth-provider";
 import { oauthProviderClient } from "@better-auth/oauth-provider/client";
 import { createAuthClient } from "better-auth/client";
 import { generateRandomString } from "better-auth/crypto";
@@ -7,6 +11,7 @@ import {
 	DPOP_SIGNING_ALGORITHMS,
 	refreshAccessTokenRequest,
 } from "better-auth/oauth2";
+import { deviceAuthorization } from "better-auth/plugins/device-authorization";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
 import { beforeAll, describe, expect, it, onTestFinished, vi } from "vitest";
@@ -123,6 +128,38 @@ describe("mcp plugin", async () => {
 			expect(metadata.id_token_signing_alg_values_supported).not.toContain(
 				"none",
 			);
+		});
+
+		it("composes with device authorization and advertises the device-code grant", async () => {
+			const deviceBaseURL = "http://localhost:3011";
+			const { auth: deviceAuth } = await getTestInstance({
+				baseURL: deviceBaseURL,
+				plugins: [
+					jwt(),
+					deviceAuthorization(),
+					mcp({
+						loginPage: "/login",
+						consentPage: "/consent",
+						resource: `${deviceBaseURL}/api/auth`,
+						silenceWarnings: {
+							oauthAuthServerConfig: true,
+							openidConfig: true,
+						},
+					}),
+					deviceCodeGrant(),
+				],
+			});
+
+			const metadata =
+				(await deviceAuth.api.getOAuthServerConfig()) as unknown as {
+					device_authorization_endpoint?: string;
+					grant_types_supported?: string[];
+				};
+
+			expect(metadata.device_authorization_endpoint).toBe(
+				`${deviceBaseURL}/api/auth/device/code`,
+			);
+			expect(metadata.grant_types_supported).toContain(DEVICE_CODE_GRANT_TYPE);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Document the two outcomes of device authorization and make the token boundary explicit:

- first-party device sign-in returns a Better Auth session token from `/device/token`
- registered public clients such as CLIs receive resource-bound OAuth tokens from `/oauth2/token`

The device authorization guide now covers the complete CLI-to-API path, including public client registration, resource linkage, device-code initiation, OAuth token polling, API verification, and refresh-token storage.

## MCP integration

Better Auth 1.7 moves MCP support to `@better-auth/mcp`, where `mcp()` is an OAuth Provider preset. The MCP guide now shows how to compose `mcp()`, `deviceAuthorization()`, and `deviceCodeGrant()` so standard MCP clients retain discovery and authorization code with PKCE while a product's own CLI can use RFC 8628 against the same authorization server.

The OAuth Provider page now points to the MCP package as the canonical integration instead of duplicating a stale MCP setup. The MCP route example also passes the configured resource to `requireMcpAuth`, ensuring the verifier checks the audience issued by `mcp({ resource })`.

This documents the supported architecture for the use case discussed in #10350 without moving OAuth token issuance into the standalone device authorization plugin.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the complete CLI device authorization flow and makes the session vs OAuth token boundary explicit. Adds a step‑by‑step CLI→API setup and shows how to compose `mcp()`, `deviceAuthorization()`, and `deviceCodeGrant()` so CLIs poll `/oauth2/token` for resource‑bound tokens while first‑party devices keep using `/device/token`.

- **New Features**
  - Device Authorization docs: add token choice matrix; full CLI setup with `jwt()`, `deviceAuthorization()`, `oauthProvider()`, and `deviceCodeGrant()`; public native client registration with linked `resources`; `/oauth2/token` polling example; verify `aud` at the API and store refresh tokens; warn not to use `/device/token` for OAuth clients.
  - MCP docs: new “Add device authorization for your own CLI” section; compose `mcp()` + `deviceAuthorization()` + `deviceCodeGrant()` (no separate `oauthProvider()` needed); pass `resource` to `requireMcpAuth`; note this doesn’t change the standard MCP PKCE flow.
  - OAuth Provider docs: point MCP readers to `@better-auth/mcp` and list `device_code` as an optional grant.
  - Tests: ensure MCP + device authorization advertises `device_authorization_endpoint` and includes the `device_code` grant in discovery.

<sup>Written for commit f440f64bc7a6a5ff8c00210dd701d17578c8de12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

