### PR TITLE
fix(db): always set a ttl on secondary-storage verification reservations

### DIFF
--- a/.changeset/verification-reservation-ttl.md
+++ b/.changeset/verification-reservation-ttl.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Always set a positive TTL when reserving a verification value in secondary storage. A reservation with under a second of remaining lifetime floored to a TTL of `0`, which secondary storage implementations read as "no expiry", leaving the entry stored permanently.

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1962,5 +1962,45 @@ describe("internal adapter test", async () => {
 			expect(first).toBe(true);
 			expect(second).toBe(true);
 		});
+
+		it("always sets a ttl on the secondary-storage reservation", async () => {
+			// A reservation whose remaining lifetime is under one second floors to
+			// a ttl of 0. Secondary storage implementations treat a zero ttl as
+			// "no expiry" (e.g. redis SETEX is skipped in favour of SET), so the
+			// tombstone would be written permanently and leak. Callers can hit
+			// this with an externally supplied expiry: the SAML replay guard
+			// derives `expiresAt` from the assertion's NotOnOrAfter plus the
+			// clock skew, which is exactly the bound the timestamp validator
+			// allows, so an assertion arriving in its final second lands here.
+			const dataMap = new Map<string, string>();
+			const ttlMap = new Map<string, number>();
+			const adapter = await makeAdapter({
+				secondaryStorage: {
+					set(key: string, value: string, ttl?: number) {
+						dataMap.set(key, value);
+						if (ttl) ttlMap.set(key, ttl);
+					},
+					get(key: string) {
+						return dataMap.get(key) || null;
+					},
+					delete(key: string) {
+						dataMap.delete(key);
+						ttlMap.delete(key);
+					},
+				},
+			});
+
+			const reserved = await adapter.reserveVerificationValue({
+				identifier: "reserve:expiring-now",
+				value: "jti-expiring",
+				expiresAt: new Date(Date.now() + 100),
+			});
+
+			expect(reserved).toBe(true);
+			const key = "verification:reserve:expiring-now";
+			expect(dataMap.has(key)).toBe(true);
+			// Without a ttl the key would never expire.
+			expect(ttlMap.get(key)).toBeGreaterThan(0);
+		});
 	});
 });

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1437,7 +1437,11 @@ export const createInternalAdapter = (
 						value: data.value,
 						expiresAt: data.expiresAt,
 					}),
-					getTTLSeconds(data.expiresAt),
+					// A sub-second remaining lifetime floors to 0, which secondary
+					// storage implementations read as "no expiry" and would persist
+					// the reservation forever. Keep the tombstone alive for the rest
+					// of its (sub-second) window instead of leaking it.
+					Math.max(getTTLSeconds(data.expiresAt), 1),
 				);
 				return true;
 			}


### PR DESCRIPTION
## Summary

`reserveVerificationValue` wrote its secondary-storage reservation with `getTTLSeconds(data.expiresAt)`, which floors to `0` once the remaining lifetime drops below one second. Secondary storage implementations treat a zero TTL as "no expiry", so the reservation was stored **permanently** and never reclaimed.

Closes #10569

## The mismatch

`getTTLSeconds` clamps at zero:

```ts
return Math.max(Math.floor((expiresMs - now) / 1000), 0);
```

and `@better-auth/redis-storage` reads a zero TTL as "store forever":

```ts
if (ttl !== undefined && ttl > 0) {
	await client.setex(prefixedKey, ttl, value);
} else {
	await client.set(prefixedKey, value); // no expiry
}
```

The caller means "no time left"; the store hears "keep this forever".

## Why it is reachable

The only non-test caller is the SAML replay guard, and its expiry comes from IdP-supplied input:

```ts
// packages/sso/src/routes/saml-pipeline.ts
const expiresAt = conditions?.notOnOrAfter
	? new Date(conditions.notOnOrAfter).getTime() + clockSkew
	: Date.now() + constants.DEFAULT_ASSERTION_TTL_MS;
```

```ts
// packages/sso/src/saml/timestamp.ts
if (now > notOnOrAfterTime + clockSkew) { /* reject as expired */ }
```

The bound the validator accepts and the reservation expiry are the same value, so an assertion arriving in the final second of its skew-extended validity is accepted and floors to a TTL of `0`. With the default 5 minute clock skew, an assertion whose `NotOnOrAfter` is already ~5 minutes stale still passes and lands exactly on that boundary.

## The fix

```diff
-					getTTLSeconds(data.expiresAt),
+					// A sub-second remaining lifetime floors to 0, which secondary
+					// storage implementations read as "no expiry" and would persist
+					// the reservation forever. Keep the tombstone alive for the rest
+					// of its (sub-second) window instead of leaking it.
+					Math.max(getTTLSeconds(data.expiresAt), 1),
```

The two sibling verification writes in the same file already guard with `if (ttl > 0)`; this path was the odd one out. I used a one second floor rather than skipping the write, because skipping would silently drop replay protection for that assertion, while the floor both preserves the tombstone for its remaining window and guarantees it expires.

## Tests

Added `always sets a ttl on the secondary-storage reservation`, using the mock-storage style already in this file. It reserves with a 100ms expiry and asserts the stored key carries a positive TTL.

Verified it fails on the unpatched code with `received "undefined"` for the TTL while the key itself is present, which is the permanent-key signature, and passes after the fix.

`internal-adapter.test.ts` 52/52, the full `packages/sso` suite 441/441, and `pnpm typecheck` exits 0.

## Scope note

I audited every `secondaryStorage.set` call in `internal-adapter.ts` and the same flooring issue exists in three session paths (`refreshUserSessions`, and the `active-sessions` list writes on session update and delete, which guard on raw millisecond expiry while passing a whole-second TTL).

Those are deliberately **not** in this PR: the existing test `should calculate TTL correctly with Math.floor for secondary storage` asserts `expect(capturedTTLs.at(-1)).toBe(0)` for a 500ms session, so changing them means changing behaviour the suite currently pins. Those entries are also a storage leak only, not an auth bypass, since the read path re-validates `expiresAt` and rejects expired sessions regardless of the stored TTL.

Happy to extend this PR to cover them and update that test if you would like.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure verification reservations in secondary storage always expire by clamping TTL to at least 1s, preventing permanent tombstones when less than a second remains. This covers the SAML replay guard path and stops storage leaks while keeping replay protection.

- **Bug Fixes**
  - Clamp TTL with Math.max(getTTLSeconds(expiresAt), 1) in reserveVerificationValue to avoid zero-TTL “store forever” behavior.
  - Add a test that asserts a positive TTL is set for sub-second expiries.

<sup>Written for commit a369c907b576675d2089054444274f468c025e16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

