### PR TITLE
fix(sso): read SAML login InResponseTo from extract.response

### DIFF
--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -431,9 +431,11 @@ export async function processSAMLResponse(
 	}
 
 	// 12. InResponseTo validation
-	const inResponseTo = (extract as SAMLAssertionExtract).inResponseTo as
-		| string
-		| undefined;
+	// samlify nests the Response element's attributes under `response`, so the
+	// value must be read from `response.inResponseTo`. This matches the logout
+	// pipeline in `sso.ts`, which already reads the correct path.
+	const inResponseTo = (extract as SAMLAssertionExtract).response
+		?.inResponseTo as string | undefined;
 	const shouldValidateInResponseTo =
 		options?.saml?.enableInResponseToValidation !== false;
 

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -116,7 +116,24 @@ export interface SAMLSessionRecord {
 export interface SAMLAssertionExtract {
 	nameID?: string;
 	sessionIndex?: string;
+	/**
+	 * @deprecated Never populated. samlify's `loginResponseFields` extractor
+	 * places the Response element's attributes under the `response` key, so this
+	 * top-level field is always `undefined`. Read `response.inResponseTo`
+	 * instead. Retained only to avoid a breaking change to the exported type.
+	 */
 	inResponseTo?: string;
+	/**
+	 * Attributes of the `<samlp:Response>` element, as extracted by samlify
+	 * (`{ key: 'response', localPath: ['Response'], attributes: ['ID',
+	 * 'IssueInstant', 'Destination', 'InResponseTo'] }`).
+	 */
+	response?: {
+		id?: string;
+		issueInstant?: string;
+		destination?: string;
+		inResponseTo?: string;
+	};
 	conditions?: {
 		notBefore?: string;
 		notOnOrAfter?: string;


### PR DESCRIPTION
Fixes #10504.

## The bug

`samlify`'s `loginResponseFields` extractor places the `<samlp:Response>` element's attributes under the `response` key:

```ts
{ key: 'response', localPath: ['Response'], attributes: ['ID', 'IssueInstant', 'Destination', 'InResponseTo'] }
```

The login pipeline reads it from the top level instead:

```ts
// packages/sso/src/routes/saml-pipeline.ts
const inResponseTo = (extract as SAMLAssertionExtract).inResponseTo;  // always undefined
```

so the value is always `undefined`. The logout pipeline in `sso.ts` already reads the correct path (`extract?.response?.inResponseTo`), so this aligns login with logout.

## Impact

It fails differently depending on one option, and the default is the quieter of the two:

| `allowIdpInitiated` | Behaviour |
|---|---|
| `true` (default) | Every SP-initiated login takes the unsolicited branch, so **InResponseTo replay validation never runs** — while appearing configured. |
| `false` | **Every SP-initiated login is rejected** with `unsolicited_response` / "IdP-initiated SSO not allowed". |

The combination means InResponseTo binding cannot currently be enforced: leaving the default silently skips the check, and disabling IdP-initiated SSO blocks all logins.

## The change

- `saml-pipeline.ts` — read `extract.response?.inResponseTo`.
- `types.ts` — `SAMLAssertionExtract` gains the nested `response` shape samlify actually produces. The top-level `inResponseTo` is marked `@deprecated` rather than removed, to avoid a breaking change to the exported type; it was read in exactly one place, the line this PR fixes.

## Verification

Reproduced against a SAML fixture that mints genuine signed assertions and drives the real ACS:

- the assertion verifies with no signature or certificate error;
- `InResponseTo` is present on both `<samlp:Response>` and `<saml:SubjectConfirmationData>`;
- the AuthnRequest record is stored under a matching `saml-authn-request:<id>` identifier;
- the only failure is `SAML InResponseTo validation failed: ... InResponseTo missing`.

With the accessor corrected, the same assertion completes the login and establishes a session, and a replay of that assertion is then rejected — i.e. the replay reservation starts working as intended.

I have not added a regression test in this PR; `packages/sso` has no existing coverage referencing `inResponseTo`, and I did not want to guess at the fixture conventions you would prefer. Happy to add one in whatever shape you would like — a unit test asserting the extraction path, or an end-to-end assertion test.

Per #10504 this appears to be a regression: PR #9055 fixed this previously, and the fix looks to have been lost when SAML processing moved into `saml-pipeline.ts`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SAML login by reading `InResponseTo` from `extract.response.inResponseTo`, matching `samlify` output and the logout path. Restores replay validation for SP-initiated logins and avoids unsolicited rejections when `allowIdpInitiated` is false.

- **Bug Fixes**
  - `packages/sso/src/routes/saml-pipeline.ts`: read `extract.response?.inResponseTo` in the login pipeline.
  - `packages/sso/src/types.ts`: add `response` attributes to `SAMLAssertionExtract`; deprecate top-level `inResponseTo`.

<sup>Written for commit 2da833fa88c09923599d2004567afd9b35f34c58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

