### PR TITLE
feat(core): add placeholder email utility

### DIFF
--- a/.changeset/placeholder.md
+++ b/.changeset/placeholder.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Add a utility for creating stable, namespaced placeholder emails on the reserved `placeholder.invalid` domain.

--- a/packages/core/src/utils/email.test.ts
+++ b/packages/core/src/utils/email.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import * as z from "zod";
+import { createPlaceholderEmail } from "./email";
+
+describe("createPlaceholderEmail", () => {
+	it("creates a namespaced address on the reserved placeholder domain", () => {
+		expect(
+			createPlaceholderEmail({
+				identifier: "account-id",
+				namespace: "namespace",
+			}),
+		).toBe("account-id@namespace.placeholder.invalid");
+	});
+
+	it("creates an address accepted by the email schema", () => {
+		const email = createPlaceholderEmail({
+			identifier: "account-id",
+			namespace: "namespace",
+		});
+
+		expect(z.email().safeParse(email).success).toBe(true);
+	});
+
+	it("keeps equal identifiers distinct across namespaces", () => {
+		const firstEmail = createPlaceholderEmail({
+			identifier: "account-id",
+			namespace: "first",
+		});
+		const secondEmail = createPlaceholderEmail({
+			identifier: "account-id",
+			namespace: "second",
+		});
+
+		expect(firstEmail).not.toBe(secondEmail);
+	});
+});

--- a/packages/core/src/utils/email.test.ts
+++ b/packages/core/src/utils/email.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import * as z from "zod";
 import { createPlaceholderEmail } from "./email";
 
 describe("createPlaceholderEmail", () => {
@@ -10,15 +9,6 @@ describe("createPlaceholderEmail", () => {
 				namespace: "namespace",
 			}),
 		).toBe("account-id@namespace.placeholder.invalid");
-	});
-
-	it("creates an address accepted by the email schema", () => {
-		const email = createPlaceholderEmail({
-			identifier: "account-id",
-			namespace: "namespace",
-		});
-
-		expect(z.email().safeParse(email).success).toBe(true);
 	});
 
 	it("keeps equal identifiers distinct across namespaces", () => {
@@ -32,5 +22,14 @@ describe("createPlaceholderEmail", () => {
 		});
 
 		expect(firstEmail).not.toBe(secondEmail);
+	});
+
+	it("rejects an invalid address", () => {
+		expect(() =>
+			createPlaceholderEmail({
+				identifier: "account-id",
+				namespace: "",
+			}),
+		).toThrow(TypeError);
 	});
 });

--- a/packages/core/src/utils/email.ts
+++ b/packages/core/src/utils/email.ts
@@ -1,3 +1,5 @@
+import * as z from "zod";
+
 /**
  * @see https://www.rfc-editor.org/rfc/rfc6761.html#section-6.4
  */
@@ -16,10 +18,19 @@ export interface PlaceholderEmailOptions {
 
 /**
  * Creates a stable, non-routable email address for an account without an email.
+ *
+ * @throws TypeError if the generated email is invalid.
  */
 export function createPlaceholderEmail({
 	identifier,
 	namespace,
 }: PlaceholderEmailOptions): string {
-	return `${identifier}@${namespace}.${PLACEHOLDER_EMAIL_DOMAIN}`;
+	const result = z
+		.email()
+		.safeParse(`${identifier}@${namespace}.${PLACEHOLDER_EMAIL_DOMAIN}`);
+	if (!result.success) {
+		throw new TypeError("Invalid placeholder email");
+	}
+
+	return result.data;
 }

--- a/packages/core/src/utils/email.ts
+++ b/packages/core/src/utils/email.ts
@@ -1,0 +1,25 @@
+/**
+ * @see https://www.rfc-editor.org/rfc/rfc6761.html#section-6.4
+ */
+const PLACEHOLDER_EMAIL_DOMAIN = "placeholder.invalid";
+
+export interface PlaceholderEmailOptions {
+	/**
+	 * A stable identifier that distinguishes the account within the namespace.
+	 */
+	identifier: string;
+	/**
+	 * A namespace that distinguishes identical identifiers from different sources.
+	 */
+	namespace: string;
+}
+
+/**
+ * Creates a stable, non-routable email address for an account without an email.
+ */
+export function createPlaceholderEmail({
+	identifier,
+	namespace,
+}: PlaceholderEmailOptions): string {
+	return `${identifier}@${namespace}.${PLACEHOLDER_EMAIL_DOMAIN}`;
+}


### PR DESCRIPTION
## Context

Better Auth's current `User` model requires a single email address. Authentication flows that do not receive an email (such as some OAuth providers and the anonymous or phone-number plugins) must therefore synthesize one.

These placeholder addresses are currently generated inline using inconsistent formats across providers and plugins.

## Changes

This PR adds `createPlaceholderEmail` to `@better-auth/core`. It creates stable, namespaced addresses under the RFC-reserved `.invalid` domain:

`{identifier}@{namespace}.placeholder.invalid`

This PR intentionally introduces only the shared primitive. It does not change existing provider or plugin behavior.

+) Supporting users without an email, or multiple emails per user, requires a broader user-model change and is out of scope for a patch or minor release. We can revisit that separately as part of the v2 architecture work.

## Follow-up

Migrate existing inline placeholder-email generation across providers and plugins to this utility.