### PR TITLE
refactor(oauth-provider)!: replace client `type` with `application_type`

### DIFF
--- a/.changeset/insufficient-scope-challenge.md
+++ b/.changeset/insufficient-scope-challenge.md
@@ -1,6 +1,12 @@
 ---
 "@better-auth/oauth-provider": minor
+"@better-auth/core": minor
 "@better-auth/mcp": minor
+"better-auth": minor
 ---
 
-Answer insufficient-scope failures with an RFC 6750 `403` `insufficient_scope` `WWW-Authenticate` challenge, per the MCP 2026-07-28 scope-challenge guidance. `requireMcpAuth` and `mcpHandler` accept a `scopes` option enforced against the token's `scope` claim, and handler-thrown `FORBIDDEN` errors produce the same step-up challenge.
+MCP clients that hit a scope wall now learn exactly which scopes to ask for. A request whose access token is missing required scopes is answered with a `403` and an RFC 6750 `insufficient_scope` `WWW-Authenticate` challenge naming every missing scope at once, so the client can step up its authorization in one round-trip instead of one browser redirect per missing scope.
+
+`requireMcpAuth` and `mcpHandler` accept a `scopes` option, enforced against the token's `scope` claim. Handlers that decide scopes per tool throw the new `insufficientScopeError(scopes, description?)` from `better-auth/oauth2` to raise the same challenge for scopes only they know about.
+
+Permission denials are left alone. A plain `FORBIDDEN` stays a plain `403` with no challenge, since re-authorizing cannot grant access that scopes were never gating, and errors thrown by your route handler reach your framework's error handling unchanged.

--- a/.changeset/insufficient-scope-challenge.md
+++ b/.changeset/insufficient-scope-challenge.md
@@ -1,0 +1,6 @@
+---
+"@better-auth/oauth-provider": minor
+"@better-auth/mcp": minor
+---
+
+Answer insufficient-scope failures with an RFC 6750 `403` `insufficient_scope` `WWW-Authenticate` challenge, per the MCP 2026-07-28 scope-challenge guidance. `requireMcpAuth` and `mcpHandler` accept a `scopes` option enforced against the token's `scope` claim, and handler-thrown `FORBIDDEN` errors produce the same step-up challenge.

--- a/.changeset/oauth-client-application-type.md
+++ b/.changeset/oauth-client-application-type.md
@@ -1,0 +1,10 @@
+---
+"@better-auth/oauth-provider": minor
+"@better-auth/cimd": minor
+---
+
+OAuth clients describe their profile with one field, `application_type`, instead of two overlapping ones. The non-standard `type` field is removed, and its `web` and `native` values move to `application_type`; `user-agent-based` has no replacement, since a browser app registers with `token_endpoint_auth_method: "none"`, which already marks it public.
+
+This release is breaking. Registration requests and the client management APIs no longer accept `type`, and client responses no longer return it. Replace `type: "web"` with `application_type: "web"`, `type: "native"` with `application_type: "native"`, and drop `type: "user-agent-based"`. A `native` client is now always treated as public, so PKCE is required for it even when the client registered with `require_pkce: false`.
+
+The client table gains an `applicationType` column and no longer uses `type`. Run a migration after upgrading with `npx auth migrate` or `npx auth generate`. Existing clients keep working; those that had set `type` are treated as if no application type was declared, which leaves their redirect URIs unconstrained.

--- a/.changeset/register-application-type.md
+++ b/.changeset/register-application-type.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+Accept `application_type` (OIDC Registration §2, required of MCP clients by the MCP 2026-07-28 spec) in dynamic client registration. When provided, redirect URIs are constrained to the declared type: `native` clients may use custom schemes, loopback `http`, or `https`; `web` clients require `https` on non-loopback hosts. Omitting the parameter keeps prior behavior.

--- a/.changeset/register-application-type.md
+++ b/.changeset/register-application-type.md
@@ -1,5 +1,8 @@
 ---
 "@better-auth/oauth-provider": minor
+"@better-auth/cimd": minor
 ---
 
-Accept `application_type` (OIDC Registration §2, required of MCP clients by the MCP 2026-07-28 spec) in dynamic client registration. When provided, redirect URIs are constrained to the declared type: `native` clients may use custom schemes, loopback `http`, or `https`; `web` clients require `https` on non-loopback hosts. Omitting the parameter keeps prior behavior.
+Client registration accepts `application_type` (OIDC Registration §2), which the MCP 2026-07-28 spec requires MCP clients to send. When provided, redirect URIs are constrained to what the declared type allows: `native` clients may use custom schemes, loopback `http`, or claimed `https` links; `web` clients require `https` on non-loopback hosts. Omitting the parameter leaves redirect URIs unconstrained.
+
+The constraint applies to both registration paths: dynamic client registration and Client ID Metadata Documents, which the same spec revision makes the preferred mechanism. A registration that sends both `application_type` and `type` must keep them consistent, so a client record cannot claim two different profiles.

--- a/docs/content/docs/plugins/cimd.mdx
+++ b/docs/content/docs/plugins/cimd.mdx
@@ -7,7 +7,7 @@ description: Unauthenticated dynamic client discovery for Better Auth's OAuth pr
 
 [Client ID Metadata Documents](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/) let clients identify themselves to your authorization server without prior registration. Instead of sending a pre-registered `client_id`, the client sends the HTTPS URL of a metadata document it hosts. Your server fetches that document, validates it, and creates (or refreshes) a public client record.
 
-This is the mechanism [MCP](https://modelcontextprotocol.io/specification/draft/basic/authorization#client-id-metadata-documents-flow) uses so authorization servers can discover clients on the fly.
+This is the mechanism [MCP](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#client-id-metadata-documents-flow) uses so authorization servers can discover clients on the fly.
 
 The plugin extends [`@better-auth/oauth-provider`](./oauth-provider) by contributing a `ClientDiscovery` entry through its extension surface, so every OAuth endpoint that authenticates a client (authorize, token, introspect, revoke, userinfo, PAR, logout) works seamlessly with URL-format `client_id` values.
 
@@ -87,7 +87,7 @@ cimd({
 ```
 
 <Callout type="info">
-  For [MCP auth](https://modelcontextprotocol.io/specification/draft/basic/authorization#client-registration-approaches) only deployments, we recommend disabling the `allowUnauthenticatedClientRegistration` option in `oauth-provider`. CIMD handles client identity and prevents duplicate registrations for the same `client_id` URL. Keep `allowUnauthenticatedClientRegistration` only if you need registration fallback — be aware this can create duplicate client records.
+  For [MCP auth](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#client-registration-approaches) only deployments, we recommend disabling the `allowUnauthenticatedClientRegistration` option in `oauth-provider`. CIMD handles client identity and prevents duplicate registrations for the same `client_id` URL. Keep `allowUnauthenticatedClientRegistration` only if you need registration fallback — be aware this can create duplicate client records.
 </Callout>
 
 ### Options
@@ -214,4 +214,4 @@ The `clientDiscovery` extension field accepts a single `ClientDiscovery` or an a
 
 * [OAuth Provider plugin](./oauth-provider) — the host plugin this one extends.
 * [IETF draft: Client ID Metadata Document](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/)
-* [MCP authorization spec — CIMD flow](https://modelcontextprotocol.io/specification/draft/basic/authorization#client-id-metadata-documents-flow)
+* [MCP authorization spec — CIMD flow](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#client-id-metadata-documents-flow)

--- a/docs/content/docs/plugins/device-authorization.mdx
+++ b/docs/content/docs/plugins/device-authorization.mdx
@@ -147,7 +147,7 @@ await auth.api.adminCreateOAuthClient({
   headers,
   body: {
     token_endpoint_auth_method: "none",
-    type: "native",
+    application_type: "native",
     grant_types: [DEVICE_CODE_GRANT_TYPE, "refresh_token"],
     scope: "openid profile offline_access api:read",
     resources: ["https://api.example.com"],

--- a/docs/content/docs/plugins/mcp.mdx
+++ b/docs/content/docs/plugins/mcp.mdx
@@ -130,7 +130,7 @@ mcp({
 
 ### MCP Session Handling
 
-Use `requireMcpAuth` to protect an MCP route. It reads the `Authorization` header, verifies Bearer access tokens against the authorization server's JWKS (signature, issuer, audience, and expiry), and enforces [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) DPoP proofs when the access token is DPoP-bound. Unauthenticated requests receive a JSON-RPC `401` with the RFC 9728 `WWW-Authenticate` header, so MCP clients can start the authorization flow.
+Use `requireMcpAuth` to protect an MCP route. It reads the `Authorization` header, verifies Bearer access tokens against the authorization server's JWKS (signature, issuer, audience, and expiry), and enforces [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) DPoP proofs when the access token is DPoP-bound. Unauthenticated requests receive a JSON-RPC `401` with the RFC 9728 `WWW-Authenticate` header, so MCP clients can start the authorization flow. Tokens missing a required scope receive a `403` with an [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1) `insufficient_scope` challenge, which MCP clients use to step up their authorization.
 
 ```ts title="api/[transport]/route.ts"
 import { auth } from "@/lib/auth";
@@ -186,6 +186,15 @@ requireMcpAuth(auth, handler, {
     issuer: "https://auth.example.com", // override when jwt.issuer is custom
     jwksUrl: "https://auth.example.com/api/auth/jwks",
     scope: "openid profile" // advertised in the 401 challenge
+})
+```
+
+To require scopes, pass `scopes`. A token missing any of them is rejected with a `403` and an `insufficient_scope` challenge that advertises the required scopes, so the client can re-authorize with them ([step-up authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#step-up-authorization-flow)). A handler-thrown `FORBIDDEN` `APIError` produces the same challenge, for per-tool scope decisions:
+
+```ts
+requireMcpAuth(auth, handler, {
+    resource: "https://api.example.com/mcp",
+    scopes: ["mcp:tools"], // enforced against the token's scope claim
 })
 ```
 
@@ -282,4 +291,4 @@ const handler = mcpHandler( // [!code highlight]
 )
 ```
 
-`mcpHandler` returns the same RFC 9728 `WWW-Authenticate` response for unauthenticated requests. For resources whose identifier is not a URL (for example a URN), pass `resourceMetadataMappings` to map each resource to its metadata URL.
+`mcpHandler` returns the same RFC 9728 `WWW-Authenticate` response for unauthenticated requests. For resources whose identifier is not a URL (for example a URN), pass `resourceMetadataMappings` to map each resource to its metadata URL. Set `scopes` in the first argument to require scopes; a token missing any of them receives the same `403` `insufficient_scope` challenge as `requireMcpAuth`.

--- a/docs/content/docs/plugins/mcp.mdx
+++ b/docs/content/docs/plugins/mcp.mdx
@@ -128,7 +128,7 @@ mcp({
 })
 ```
 
-### MCP Session Handling
+### Protecting an MCP Route
 
 Use `requireMcpAuth` to protect an MCP route. It reads the `Authorization` header, verifies Bearer access tokens against the authorization server's JWKS (signature, issuer, audience, and expiry), and enforces [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) DPoP proofs when the access token is DPoP-bound. Unauthenticated requests receive a JSON-RPC `401` with the RFC 9728 `WWW-Authenticate` header, so MCP clients can start the authorization flow. Tokens missing a required scope receive a `403` with an [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1) `insufficient_scope` challenge, which MCP clients use to step up their authorization.
 
@@ -189,7 +189,7 @@ requireMcpAuth(auth, handler, {
 })
 ```
 
-To require scopes, pass `scopes`. A token missing any of them is rejected with a `403` and an `insufficient_scope` challenge that advertises the required scopes, so the client can re-authorize with them ([step-up authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#step-up-authorization-flow)). A handler-thrown `FORBIDDEN` `APIError` produces the same challenge, for per-tool scope decisions:
+To require scopes, pass `scopes`. A token missing any of them is rejected with a `403` and an `insufficient_scope` challenge naming every missing scope, so the client can re-authorize for all of them at once ([step-up authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#step-up-authorization-flow)):
 
 ```ts
 requireMcpAuth(auth, handler, {
@@ -197,6 +197,23 @@ requireMcpAuth(auth, handler, {
     scopes: ["mcp:tools"], // enforced against the token's scope claim
 })
 ```
+
+When the required scopes depend on the request — one tool needs more than another — throw `insufficientScopeError` from the handler to challenge for exactly those scopes:
+
+```ts
+import { insufficientScopeError } from "better-auth/oauth2";
+
+requireMcpAuth(auth, async (req, jwt) => {
+    if (isAdminTool(req) && !hasScope(jwt, "mcp:admin")) {
+        throw insufficientScopeError(["mcp:admin"]);
+    }
+    return handle(req, jwt);
+})
+```
+
+<Callout type="warn">
+  Reach for this only when re-authorizing would actually help. A denial the user cannot fix by granting scopes — they are not a member of the organization, the record belongs to someone else — should stay an ordinary `403`: challenging sends them through consent to no effect. Errors your handler throws for any other reason propagate to your framework unchanged.
+</Callout>
 
 ## Configuration
 

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -448,7 +448,9 @@ const client = await authClient.oauth2.register({
 
 For all endpoint parameters, see [RFC 7591 Registration](https://datatracker.ietf.org/doc/html/rfc7591#section-2).
 
-When `application_type` ([OIDC Registration §2](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata)) is provided, redirect URIs are constrained to what the declared type allows: `native` clients may use custom schemes, loopback `http` redirects, or claimed `https` links — plain `http` on a routable host is rejected; `web` clients require `https` redirect URIs on non-loopback hosts. MCP clients are required to send an appropriate `application_type` by the [MCP 2026-07-28 spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/client-registration#application-type-and-redirect-uri-constraints). When omitted, no `application_type` constraints are applied.
+When `application_type` ([OIDC Registration §2](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata)) is provided, redirect URIs are constrained to what the declared type allows. A `native` client may use custom schemes, loopback `http` redirects, or claimed `https` links ([RFC 8252 §7](https://datatracker.ietf.org/doc/html/rfc8252#section-7)); plain `http` on a routable host is rejected. A `web` client requires `https` redirect URIs on non-loopback hosts. Sending both `application_type` and `type` requires them to agree. When `application_type` is omitted, no constraints are applied.
+
+The [MCP 2026-07-28 spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/client-registration#application-type-and-redirect-uri-constraints) requires MCP clients to send an appropriate `application_type`. The same constraints apply to clients identified by a [Client ID Metadata Document](/docs/plugins/cimd).
 
 Note the following parameters are not yet supported:
 

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -448,7 +448,7 @@ const client = await authClient.oauth2.register({
 
 For all endpoint parameters, see [RFC 7591 Registration](https://datatracker.ietf.org/doc/html/rfc7591#section-2).
 
-When `application_type` ([OIDC Registration §2](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata)) is provided, redirect URIs are constrained to what the declared type allows. A `native` client may use custom schemes, loopback `http` redirects, or claimed `https` links ([RFC 8252 §7](https://datatracker.ietf.org/doc/html/rfc8252#section-7)); plain `http` on a routable host is rejected. A `web` client requires `https` redirect URIs on non-loopback hosts. Sending both `application_type` and `type` requires them to agree. When `application_type` is omitted, no constraints are applied.
+When `application_type` ([OIDC Registration §2](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata)) is provided, redirect URIs are constrained to what the declared type allows. A `native` client may use custom schemes, loopback `http` redirects, or claimed `https` links ([RFC 8252 §7](https://datatracker.ietf.org/doc/html/rfc8252#section-7)); plain `http` on a routable host is rejected. A `web` client requires `https` redirect URIs on non-loopback hosts, and is the only type that may authenticate at the token endpoint with a secret; a `native` client is always treated as public, so PKCE is required for it. When `application_type` is omitted, no constraints are applied.
 
 The [MCP 2026-07-28 spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/client-registration#application-type-and-redirect-uri-constraints) requires MCP clients to send an appropriate `application_type`. The same constraints apply to clients identified by a [Client ID Metadata Document](/docs/plugins/cimd).
 
@@ -2005,10 +2005,10 @@ export const oauthClientTableFields = [
     isOptional: true,
   },
   {
-    name: "type",
+    name: "application_type",
     type: "string",
     description:
-      "Type of OAuth client. Supports: ['web', 'native', 'user-agent-based']",
+      "OIDC Registration application type. Supports: ['web', 'native']. Native clients are always treated as public.",
     isOptional: true,
   },
   {

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -422,7 +422,7 @@ oauthProvider({
 To enable open client registration without a Better Auth session, additionally set `allowUnauthenticatedClientRegistration: true` in your auth config. Public clients are registered with `token_endpoint_auth_method: "none"`. Confidential clients receive a one-time `client_secret` in the registration response.
 
 <Callout type="info">
-  For MCP public-client identity, [Client ID Metadata Documents](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/991) are [available](/docs/plugins/cimd).
+  For MCP public-client identity, use [Client ID Metadata Documents](/docs/plugins/cimd). The [MCP 2026-07-28 spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/client-registration) deprecates Dynamic Client Registration in favor of CIMD; DCR remains supported for backwards compatibility.
 </Callout>
 
 ```ts title="auth.ts"
@@ -447,6 +447,8 @@ const client = await authClient.oauth2.register({
 ```
 
 For all endpoint parameters, see [RFC 7591 Registration](https://datatracker.ietf.org/doc/html/rfc7591#section-2).
+
+When `application_type` ([OIDC Registration §2](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata)) is provided, redirect URIs are constrained to what the declared type allows: `native` clients may use custom schemes, loopback `http` redirects, or claimed `https` links — plain `http` on a routable host is rejected; `web` clients require `https` redirect URIs on non-loopback hosts. MCP clients are required to send an appropriate `application_type` by the [MCP 2026-07-28 spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/client-registration#application-type-and-redirect-uri-constraints). When omitted, no `application_type` constraints are applied.
 
 Note the following parameters are not yet supported:
 

--- a/packages/cimd/src/cimd.test.ts
+++ b/packages/cimd/src/cimd.test.ts
@@ -274,4 +274,68 @@ describe("Client ID Metadata Document - integration", async () => {
 		});
 		expect(errorStatus).toBeGreaterThanOrEqual(400);
 	});
+
+	it("enforces application_type redirect URI constraints from the metadata document", async ({
+		onTestFinished,
+	}) => {
+		const originalFetch = globalThis.fetch.bind(globalThis);
+		const nativeClientUrl = "https://native.example.com/client-metadata.json";
+		const loopbackRedirect = "http://127.0.0.1:5099/callback";
+		vi.stubGlobal(
+			"fetch",
+			vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.href
+							: input.url;
+				if (url === nativeClientUrl) {
+					return Promise.resolve(
+						new Response(
+							JSON.stringify({
+								client_id: nativeClientUrl,
+								client_name: "Mislabelled Native Client",
+								// A loopback interception redirect belongs to a native
+								// client; declaring `web` contradicts it.
+								application_type: "web",
+								redirect_uris: [loopbackRedirect],
+								token_endpoint_auth_method: "none",
+							}),
+							{ status: 200, headers: { "content-type": "application/json" } },
+						),
+					);
+				}
+				return originalFetch(input, init);
+			}),
+		);
+		onTestFinished(() => {
+			vi.unstubAllGlobals();
+		});
+
+		const { headers } = await signInWithTestUser();
+		const authedClient = createAuthClient({
+			plugins: [oauthProviderClient()],
+			baseURL: authServerBaseUrl,
+			fetchOptions: { customFetchImpl, headers },
+		});
+
+		const authorizeUrl =
+			`${authServerBaseUrl}/api/auth/oauth2/authorize` +
+			`?client_id=${encodeURIComponent(nativeClientUrl)}` +
+			`&response_type=code` +
+			`&redirect_uri=${encodeURIComponent(loopbackRedirect)}` +
+			`&scope=openid` +
+			`&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM` +
+			`&code_challenge_method=S256`;
+
+		let errorStatus = 0;
+		await authedClient.$fetch(authorizeUrl, {
+			method: "GET",
+			onError(ctx) {
+				errorStatus = ctx.response.status;
+			},
+		});
+		expect(errorStatus).toBeGreaterThanOrEqual(400);
+	});
 });

--- a/packages/cimd/src/client-store.ts
+++ b/packages/cimd/src/client-store.ts
@@ -99,7 +99,6 @@ const ALLOWED_METADATA_FIELDS = new Set([
 	"post_logout_redirect_uris",
 	"subject_type",
 	"application_type",
-	"type",
 	"jwks",
 	"jwks_uri",
 ]);

--- a/packages/cimd/src/client-store.ts
+++ b/packages/cimd/src/client-store.ts
@@ -98,6 +98,7 @@ const ALLOWED_METADATA_FIELDS = new Set([
 	"software_statement",
 	"post_logout_redirect_uris",
 	"subject_type",
+	"application_type",
 	"type",
 	"jwks",
 	"jwks_uri",

--- a/packages/core/src/oauth2/index.ts
+++ b/packages/core/src/oauth2/index.ts
@@ -101,6 +101,7 @@ export type {
 } from "./verify";
 export {
 	getJwks,
+	insufficientScopeError,
 	requestToResourceInput,
 	verifyAccessTokenRequest,
 	verifyBearerToken,

--- a/packages/core/src/oauth2/verify.test.ts
+++ b/packages/core/src/oauth2/verify.test.ts
@@ -115,6 +115,30 @@ describe("verifyBearerToken", () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9654
 	 */
+	it("should report every missing scope in one insufficient_scope failure", async () => {
+		// RFC 6750 §3.1: one scope per challenge would cost the user a browser
+		// round-trip for each missing scope.
+		const { publicJWK, privateKey, kid } = await createTestJWKS();
+		const token = await createSignedToken(privateKey, kid, {
+			scope: "files:read",
+		});
+		mockJWKSResponse(publicJWK);
+
+		await expect(
+			verifyBearerToken(token, {
+				jwksUrl,
+				verifyOptions: { issuer, audience },
+				scopes: ["files:read", "files:write", "files:delete"],
+			}),
+		).rejects.toMatchObject({
+			status: "FORBIDDEN",
+			body: {
+				error: "insufficient_scope",
+				scope: "files:write files:delete",
+			},
+		});
+	});
+
 	it("should translate jose claim validation failures to unauthorized API errors", async () => {
 		const { publicJWK, privateKey, kid } = await createTestJWKS();
 		const token = await createSignedToken(privateKey, kid, {

--- a/packages/core/src/oauth2/verify.ts
+++ b/packages/core/src/oauth2/verify.ts
@@ -444,19 +444,45 @@ async function verifyAccessTokenPayload(
 
 	// Check scopes if provided
 	if (opts.scopes) {
-		const validScopes = new Set(
+		const grantedScopes = new Set(
 			(payload.scope as string | undefined)?.split(" "),
 		);
-		for (const sc of opts.scopes) {
-			if (!validScopes.has(sc)) {
-				throw new APIError("FORBIDDEN", {
-					message: `invalid scope ${sc}`,
-				});
-			}
+		// RFC 6750 §3.1: report every missing scope at once. Challenging with one
+		// scope at a time costs the user a browser round-trip per scope.
+		const missingScopes = opts.scopes.filter(
+			(scope) => !grantedScopes.has(scope),
+		);
+		if (missingScopes.length > 0) {
+			throw insufficientScopeError(missingScopes);
 		}
 	}
 
 	return payload;
+}
+
+/**
+ * Build the RFC 6750 §3.1 insufficient-scope failure: the access token is valid
+ * but lacks scopes the operation needs.
+ *
+ * Resource-server challenge builders turn this into a `403` carrying a
+ * `WWW-Authenticate: Bearer error="insufficient_scope"` challenge that names
+ * `scopes`, so the client knows what to request when it re-authorizes. Throw it
+ * from a route handler to challenge for scopes only that operation needs; a
+ * plain `FORBIDDEN` stays a plain `403`, since a permission denial the client
+ * cannot fix by re-authorizing must not send the user through consent again.
+ *
+ * @param scopes - Every scope the operation requires but the token lacks.
+ */
+export function insufficientScopeError(
+	scopes: string[],
+	description = `access token is missing required scope: ${scopes.join(" ")}`,
+): APIError {
+	return new APIError("FORBIDDEN", {
+		message: description,
+		error: "insufficient_scope",
+		error_description: description,
+		scope: scopes.join(" "),
+	});
 }
 
 function throwDpopUnauthorized(

--- a/packages/mcp/src/challenge-response.ts
+++ b/packages/mcp/src/challenge-response.ts
@@ -1,0 +1,37 @@
+import { raiseResourceServerChallenge } from "@better-auth/oauth-provider";
+import { APIError } from "better-call";
+
+/**
+ * Answer a failed request with a JSON-RPC error carrying the RFC 6750 / RFC
+ * 9728 `WWW-Authenticate` challenge for the resource.
+ *
+ * Only authorization failures become a response. Anything else — including
+ * whatever the route handler threw — propagates unchanged, so handler errors
+ * keep their type and stack for the framework's error handling.
+ */
+export function toChallengeResponse(
+	error: unknown,
+	resource: string | string[],
+	opts?: Parameters<typeof raiseResourceServerChallenge>[2],
+): Response {
+	try {
+		raiseResourceServerChallenge(error, resource, opts);
+	} catch (challengeError) {
+		// Errors it does not answer are rethrown as-is, so identity distinguishes
+		// a challenge it built from the original travelling back out.
+		if (challengeError === error || !(challengeError instanceof APIError)) {
+			throw challengeError;
+		}
+		const headers = new Headers(challengeError.headers as HeadersInit);
+		headers.set("Content-Type", "application/json");
+		return new Response(
+			JSON.stringify({
+				jsonrpc: "2.0",
+				error: { code: -32000, message: challengeError.message },
+				id: null,
+			}),
+			{ status: challengeError.statusCode, headers },
+		);
+	}
+	throw error;
+}

--- a/packages/mcp/src/handler.test.ts
+++ b/packages/mcp/src/handler.test.ts
@@ -1,0 +1,77 @@
+import { insufficientScopeError } from "better-auth/oauth2";
+import { APIError } from "better-call";
+import type { JWTPayload } from "jose";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mcpHandler } from "./handler";
+
+const { verifyAccessTokenRequest } = vi.hoisted(() => ({
+	verifyAccessTokenRequest: vi.fn(),
+}));
+
+vi.mock("better-auth/oauth2", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("better-auth/oauth2")>();
+	return { ...actual, verifyAccessTokenRequest };
+});
+
+const verifyOptions = {
+	verifyOptions: {
+		issuer: "https://app.example.com",
+		audience: "https://app.example.com/mcp",
+	},
+};
+
+const request = () =>
+	new Request("https://app.example.com/mcp", {
+		headers: { Authorization: "Bearer access-token" },
+	});
+
+describe("mcpHandler", () => {
+	beforeEach(() => {
+		verifyAccessTokenRequest.mockReset();
+	});
+
+	it("answers a scope failure with a 403 insufficient_scope challenge", async () => {
+		verifyAccessTokenRequest.mockRejectedValue(
+			insufficientScopeError(["mcp:write"]),
+		);
+
+		const response = await mcpHandler(
+			{ ...verifyOptions, scopes: ["mcp:write"] },
+			async () => new Response("unreachable"),
+		)(request());
+
+		expect(response.status).toBe(403);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			`Bearer error="insufficient_scope", scope="mcp:write", resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/mcp", error_description="access token is missing required scope: mcp:write"`,
+		);
+	});
+
+	it("propagates a handler error with its type and stack intact", async () => {
+		class ToolExecutionError extends Error {}
+		const failure = new ToolExecutionError("database connection lost");
+		verifyAccessTokenRequest.mockResolvedValue({
+			sub: "user-1",
+		} satisfies JWTPayload);
+
+		await expect(
+			mcpHandler(verifyOptions, async () => {
+				throw failure;
+			})(request()),
+		).rejects.toBe(failure);
+	});
+
+	it("propagates a handler-thrown permission denial unchanged", async () => {
+		const denial = new APIError("FORBIDDEN", {
+			message: "user is not a member of this organization",
+		});
+		verifyAccessTokenRequest.mockResolvedValue({
+			sub: "user-2",
+		} satisfies JWTPayload);
+
+		await expect(
+			mcpHandler(verifyOptions, async () => {
+				throw denial;
+			})(request()),
+		).rejects.toBe(denial);
+	});
+});

--- a/packages/mcp/src/handler.ts
+++ b/packages/mcp/src/handler.ts
@@ -10,6 +10,8 @@ import type { JWTPayload } from "jose";
 /**
  * A request middleware handler that verifies an MCP access token and responds
  * with an RFC 9728 `WWW-Authenticate` header for unauthenticated requests.
+ * When `verifyOptions.scopes` is set, tokens missing a required scope receive
+ * a 403 with an RFC 6750 `insufficient_scope` challenge instead.
  *
  * @external
  */
@@ -19,7 +21,12 @@ export const mcpHandler = (
 	handler: (req: Request, jwt: JWTPayload) => Awaitable<Response>,
 	opts?: {
 		/** Maps non-url (ie urn, client) resources to resource_metadata */
-		resourceMetadataMappings: Record<string, string>;
+		resourceMetadataMappings?: Record<string, string>;
+		/**
+		 * Space-delimited scopes to advertise in `WWW-Authenticate` challenges
+		 * (RFC 6750). Defaults to `verifyOptions.scopes` when those are set.
+		 */
+		scope?: string;
 	},
 ) => {
 	return async (req: Request) => {
@@ -28,7 +35,9 @@ export const mcpHandler = (
 				requestToResourceInput(req),
 				verifyOptions,
 			);
-			return handler(req, token);
+			// Awaited so a handler-thrown FORBIDDEN rejects inside this try and
+			// gets turned into an insufficient_scope challenge below.
+			return await handler(req, token);
 		} catch (error) {
 			try {
 				raiseResourceServerChallenge(
@@ -36,6 +45,7 @@ export const mcpHandler = (
 					verifyOptions.verifyOptions.audience,
 					{
 						...opts,
+						scope: opts?.scope ?? verifyOptions.scopes?.join(" "),
 						dpopSigningAlgorithms: verifyOptions.dpop?.signingAlgorithms,
 					},
 				);

--- a/packages/mcp/src/handler.ts
+++ b/packages/mcp/src/handler.ts
@@ -1,17 +1,16 @@
 import type { Awaitable } from "@better-auth/core";
-import { raiseResourceServerChallenge } from "@better-auth/oauth-provider";
 import {
 	requestToResourceInput,
 	verifyAccessTokenRequest,
 } from "better-auth/oauth2";
-import { APIError } from "better-call";
 import type { JWTPayload } from "jose";
+import { toChallengeResponse } from "./challenge-response";
 
 /**
  * A request middleware handler that verifies an MCP access token and responds
  * with an RFC 9728 `WWW-Authenticate` header for unauthenticated requests.
  * When `verifyOptions.scopes` is set, tokens missing a required scope receive
- * a 403 with an RFC 6750 `insufficient_scope` challenge instead.
+ * a 403 with an RFC 6750 `insufficient_scope` challenge naming them instead.
  *
  * @external
  */
@@ -35,36 +34,15 @@ export const mcpHandler = (
 				requestToResourceInput(req),
 				verifyOptions,
 			);
-			// Awaited so a handler-thrown FORBIDDEN rejects inside this try and
-			// gets turned into an insufficient_scope challenge below.
+			// Awaited so a handler-thrown insufficient-scope error rejects inside
+			// this try and becomes a step-up challenge.
 			return await handler(req, token);
 		} catch (error) {
-			try {
-				raiseResourceServerChallenge(
-					error,
-					verifyOptions.verifyOptions.audience,
-					{
-						...opts,
-						scope: opts?.scope ?? verifyOptions.scopes?.join(" "),
-						dpopSigningAlgorithms: verifyOptions.dpop?.signingAlgorithms,
-					},
-				);
-			} catch (err) {
-				if (err instanceof APIError) {
-					const headers = new Headers(err.headers as HeadersInit);
-					headers.set("Content-Type", "application/json");
-					return new Response(
-						JSON.stringify({
-							jsonrpc: "2.0",
-							error: { code: -32000, message: err.message },
-							id: null,
-						}),
-						{ status: err.statusCode, headers },
-					);
-				}
-				throw new Error(String(err));
-			}
-			throw new Error(String(error));
+			return toChallengeResponse(error, verifyOptions.verifyOptions.audience, {
+				...opts,
+				scope: opts?.scope ?? verifyOptions.scopes?.join(" "),
+				dpopSigningAlgorithms: verifyOptions.dpop?.signingAlgorithms,
+			});
 		}
 	};
 };

--- a/packages/mcp/src/require-mcp-auth.test.ts
+++ b/packages/mcp/src/require-mcp-auth.test.ts
@@ -180,6 +180,95 @@ describe("requireMcpAuth", () => {
 		);
 	});
 
+	it("enforces required scopes against the token's scope claim", async () => {
+		verifyAccessTokenRequest.mockResolvedValue({
+			sub: "user-3",
+			scope: "mcp:read mcp:write",
+		} satisfies JWTPayload);
+		const response = await requireMcpAuth(
+			authWith("https://app.example.com", "https://app.example.com/api/auth"),
+			async () => Response.json({ ok: true }),
+			{ scopes: ["mcp:read"] },
+		)(
+			new Request("https://app.example.com/mcp", {
+				headers: { Authorization: "Bearer access-token" },
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(verifyAccessTokenRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				authorizationHeader: "Bearer access-token",
+			}),
+			expect.objectContaining({
+				scopes: ["mcp:read"],
+			}),
+		);
+	});
+
+	it("answers a scope failure with a 403 insufficient_scope challenge", async () => {
+		verifyAccessTokenRequest.mockRejectedValue(
+			new APIError("FORBIDDEN", { message: "invalid scope mcp:write" }),
+		);
+		const response = await requireMcpAuth(
+			authWith("https://app.example.com", "https://app.example.com/api/auth"),
+			async () => new Response("unreachable"),
+			{ scopes: ["mcp:write"] },
+		)(
+			new Request("https://app.example.com/mcp", {
+				headers: { Authorization: "Bearer access-token" },
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			`Bearer error="insufficient_scope", scope="mcp:write", resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/auth", error_description="invalid scope mcp:write"`,
+		);
+	});
+
+	it("answers a handler-thrown FORBIDDEN with a 403 insufficient_scope challenge", async () => {
+		verifyAccessTokenRequest.mockResolvedValue({
+			sub: "user-4",
+			scope: "mcp:read",
+		} satisfies JWTPayload);
+		const response = await requireMcpAuth(
+			authWith("https://app.example.com", "https://app.example.com/api/auth"),
+			async () => {
+				throw new APIError("FORBIDDEN", {
+					message: "tool requires mcp:admin",
+				});
+			},
+			{ scope: "mcp:admin" },
+		)(
+			new Request("https://app.example.com/mcp", {
+				headers: { Authorization: "Bearer access-token" },
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			`Bearer error="insufficient_scope", scope="mcp:admin", resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/auth", error_description="tool requires mcp:admin"`,
+		);
+	});
+
+	it("derives the challenge scope hint from enforced scopes when no hint is set", async () => {
+		verifyAccessTokenRequest.mockRejectedValue(
+			new APIError("UNAUTHORIZED", {
+				message: "missing authorization header",
+			}),
+		);
+		const response = await requireMcpAuth(
+			authWith("https://app.example.com", "https://app.example.com/api/auth"),
+			async () => new Response("unreachable"),
+			{ scopes: ["mcp:read", "mcp:write"] },
+		)(new Request("https://app.example.com/mcp"));
+
+		expect(response.status).toBe(401);
+		expect(response.headers.get("WWW-Authenticate")).toBe(
+			`Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/auth", scope="mcp:read mcp:write"`,
+		);
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/pull/9992
 	 */

--- a/packages/mcp/src/require-mcp-auth.test.ts
+++ b/packages/mcp/src/require-mcp-auth.test.ts
@@ -1,3 +1,4 @@
+import { insufficientScopeError } from "better-auth/oauth2";
 import { APIError } from "better-call";
 import type { JWTPayload } from "jose";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -208,7 +209,7 @@ describe("requireMcpAuth", () => {
 
 	it("answers a scope failure with a 403 insufficient_scope challenge", async () => {
 		verifyAccessTokenRequest.mockRejectedValue(
-			new APIError("FORBIDDEN", { message: "invalid scope mcp:write" }),
+			insufficientScopeError(["mcp:write"]),
 		);
 		const response = await requireMcpAuth(
 			authWith("https://app.example.com", "https://app.example.com/api/auth"),
@@ -222,11 +223,11 @@ describe("requireMcpAuth", () => {
 
 		expect(response.status).toBe(403);
 		expect(response.headers.get("WWW-Authenticate")).toBe(
-			`Bearer error="insufficient_scope", scope="mcp:write", resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/auth", error_description="invalid scope mcp:write"`,
+			`Bearer error="insufficient_scope", scope="mcp:write", resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/auth", error_description="access token is missing required scope: mcp:write"`,
 		);
 	});
 
-	it("answers a handler-thrown FORBIDDEN with a 403 insufficient_scope challenge", async () => {
+	it("lets a handler challenge for the scopes its tool needs", async () => {
 		verifyAccessTokenRequest.mockResolvedValue({
 			sub: "user-4",
 			scope: "mcp:read",
@@ -234,11 +235,9 @@ describe("requireMcpAuth", () => {
 		const response = await requireMcpAuth(
 			authWith("https://app.example.com", "https://app.example.com/api/auth"),
 			async () => {
-				throw new APIError("FORBIDDEN", {
-					message: "tool requires mcp:admin",
-				});
+				throw insufficientScopeError(["mcp:admin"], "tool requires mcp:admin");
 			},
-			{ scope: "mcp:admin" },
+			{ scope: "mcp:read" },
 		)(
 			new Request("https://app.example.com/mcp", {
 				headers: { Authorization: "Bearer access-token" },
@@ -249,6 +248,53 @@ describe("requireMcpAuth", () => {
 		expect(response.headers.get("WWW-Authenticate")).toBe(
 			`Bearer error="insufficient_scope", scope="mcp:admin", resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/auth", error_description="tool requires mcp:admin"`,
 		);
+	});
+
+	it("propagates a handler-thrown permission denial unchanged", async () => {
+		// Re-authorizing cannot grant organization membership, so this must not
+		// become a scope challenge that loops the user through consent.
+		verifyAccessTokenRequest.mockResolvedValue({
+			sub: "user-5",
+			scope: "mcp:read",
+		} satisfies JWTPayload);
+		const denial = new APIError("FORBIDDEN", {
+			message: "user is not a member of this organization",
+		});
+
+		await expect(
+			requireMcpAuth(
+				authWith("https://app.example.com", "https://app.example.com/api/auth"),
+				async () => {
+					throw denial;
+				},
+				{ scopes: ["mcp:read"] },
+			)(
+				new Request("https://app.example.com/mcp", {
+					headers: { Authorization: "Bearer access-token" },
+				}),
+			),
+		).rejects.toBe(denial);
+	});
+
+	it("propagates a handler error with its type and stack intact", async () => {
+		class ToolExecutionError extends Error {}
+		const failure = new ToolExecutionError("database connection lost");
+		verifyAccessTokenRequest.mockResolvedValue({
+			sub: "user-6",
+		} satisfies JWTPayload);
+
+		await expect(
+			requireMcpAuth(
+				authWith("https://app.example.com", "https://app.example.com/api/auth"),
+				async () => {
+					throw failure;
+				},
+			)(
+				new Request("https://app.example.com/mcp", {
+					headers: { Authorization: "Bearer access-token" },
+				}),
+			),
+		).rejects.toBe(failure);
 	});
 
 	it("derives the challenge scope hint from enforced scopes when no hint is set", async () => {

--- a/packages/mcp/src/require-mcp-auth.ts
+++ b/packages/mcp/src/require-mcp-auth.ts
@@ -1,8 +1,5 @@
 import type { Awaitable } from "@better-auth/core";
-import {
-	ResourceUriSchema,
-	raiseResourceServerChallenge,
-} from "@better-auth/oauth-provider";
+import { ResourceUriSchema } from "@better-auth/oauth-provider";
 import type {
 	DpopReplayReservations,
 	DpopReplayStore,
@@ -13,8 +10,8 @@ import {
 	verifyAccessTokenRequest,
 } from "better-auth/oauth2";
 import type { BetterAuthOptions } from "better-auth/types";
-import { APIError } from "better-call";
 import type { JWTPayload } from "jose";
+import { toChallengeResponse } from "./challenge-response";
 
 interface RequireMcpAuthOptions {
 	/**
@@ -41,8 +38,8 @@ interface RequireMcpAuthOptions {
 	/**
 	 * Scopes the access token must include, enforced against the token's
 	 * `scope` claim. A token missing any of them is rejected with a 403 and an
-	 * RFC 6750 `insufficient_scope` challenge, so MCP clients can step up
-	 * their authorization.
+	 * RFC 6750 `insufficient_scope` challenge naming every missing scope, so MCP
+	 * clients can step up their authorization in one round-trip.
 	 */
 	scopes?: string[];
 	/**
@@ -63,31 +60,16 @@ interface RequireMcpAuthOptions {
 	};
 }
 
-const errorResponse = (error: APIError): Response => {
-	const headers = new Headers(error.headers as HeadersInit);
-	headers.set("Content-Type", "application/json");
-	return new Response(
-		JSON.stringify({
-			jsonrpc: "2.0",
-			error: { code: -32000, message: error.message },
-			id: null,
-		}),
-		{
-			status: error.statusCode,
-			headers,
-		},
-	);
-};
-
 /**
  * Protects an MCP server route handler. Verifies the bearer access token
  * against the authorization server's JWKS (checking signature, issuer,
  * audience, and expiry) and forwards the verified JWT payload to the handler.
  * Unauthenticated requests receive a JSON-RPC 401 with the RFC 9728
  * `WWW-Authenticate` header so MCP clients can start the authorization flow.
- * Tokens missing a required scope — and handler-thrown `FORBIDDEN` errors —
- * receive a 403 with an RFC 6750 `insufficient_scope` challenge so clients
- * can step up their authorization.
+ * Tokens missing a required scope receive a 403 with an RFC 6750
+ * `insufficient_scope` challenge naming the missing scopes, so clients can step
+ * up their authorization; a handler can raise the same challenge for scopes only
+ * it knows about by throwing `insufficientScopeError`.
  *
  * For a resource server that runs separately from the authorization server, or
  * a server using a dynamic `baseURL`, use {@link mcpHandler} with explicit
@@ -143,24 +125,15 @@ export const requireMcpAuth = <
 						opts?.dpop?.replayStore ?? createDpopReplayStore(internalAdapter),
 				},
 			});
-			// Awaited so a handler-thrown FORBIDDEN rejects inside this try and
-			// gets turned into an insufficient_scope challenge below.
+			// Awaited so a handler-thrown insufficient-scope error rejects inside
+			// this try and becomes a step-up challenge.
 			return await handler(req, jwt);
 		} catch (error) {
-			try {
-				raiseResourceServerChallenge(error, resource, {
-					scope: opts?.scope ?? opts?.scopes?.join(" "),
-					resourceMetadataMappings: opts?.resourceMetadataMappings,
-					dpopSigningAlgorithms: opts?.dpop?.signingAlgorithms,
-				});
-			} catch (challengeError) {
-				if (challengeError instanceof APIError) {
-					return errorResponse(challengeError);
-				}
-				if (challengeError instanceof Error) throw challengeError;
-				throw new Error(String(challengeError));
-			}
-			throw new Error(String(error));
+			return toChallengeResponse(error, resource, {
+				scope: opts?.scope ?? opts?.scopes?.join(" "),
+				resourceMetadataMappings: opts?.resourceMetadataMappings,
+				dpopSigningAlgorithms: opts?.dpop?.signingAlgorithms,
+			});
 		}
 	};
 };

--- a/packages/mcp/src/require-mcp-auth.ts
+++ b/packages/mcp/src/require-mcp-auth.ts
@@ -34,9 +34,17 @@ interface RequireMcpAuthOptions {
 	jwksUrl?: string;
 	/**
 	 * Space-delimited scopes to advertise in the `WWW-Authenticate` challenge
-	 * (RFC 6750), hinting which scopes the client should request.
+	 * (RFC 6750), hinting which scopes the client should request. Defaults to
+	 * the enforced `scopes` when those are set.
 	 */
 	scope?: string;
+	/**
+	 * Scopes the access token must include, enforced against the token's
+	 * `scope` claim. A token missing any of them is rejected with a 403 and an
+	 * RFC 6750 `insufficient_scope` challenge, so MCP clients can step up
+	 * their authorization.
+	 */
+	scopes?: string[];
 	/**
 	 * Maps a non-URL `resource` (an RFC 8707 `urn:` identifier or a client id) to
 	 * the URL of its protected resource metadata. Required when `resource` is not
@@ -55,7 +63,7 @@ interface RequireMcpAuthOptions {
 	};
 }
 
-const unauthorized = (error: APIError): Response => {
+const errorResponse = (error: APIError): Response => {
 	const headers = new Headers(error.headers as HeadersInit);
 	headers.set("Content-Type", "application/json");
 	return new Response(
@@ -77,6 +85,9 @@ const unauthorized = (error: APIError): Response => {
  * audience, and expiry) and forwards the verified JWT payload to the handler.
  * Unauthenticated requests receive a JSON-RPC 401 with the RFC 9728
  * `WWW-Authenticate` header so MCP clients can start the authorization flow.
+ * Tokens missing a required scope — and handler-thrown `FORBIDDEN` errors —
+ * receive a 403 with an RFC 6750 `insufficient_scope` challenge so clients
+ * can step up their authorization.
  *
  * For a resource server that runs separately from the authorization server, or
  * a server using a dynamic `baseURL`, use {@link mcpHandler} with explicit
@@ -121,6 +132,7 @@ export const requireMcpAuth = <
 		try {
 			const jwt = await verifyAccessTokenRequest(requestToResourceInput(req), {
 				verifyOptions: { issuer, audience: resource },
+				scopes: opts?.scopes,
 				jwksUrl,
 				dpop: {
 					proofMaxAgeSeconds: opts?.dpop?.proofMaxAgeSeconds,
@@ -131,17 +143,19 @@ export const requireMcpAuth = <
 						opts?.dpop?.replayStore ?? createDpopReplayStore(internalAdapter),
 				},
 			});
-			return handler(req, jwt);
+			// Awaited so a handler-thrown FORBIDDEN rejects inside this try and
+			// gets turned into an insufficient_scope challenge below.
+			return await handler(req, jwt);
 		} catch (error) {
 			try {
 				raiseResourceServerChallenge(error, resource, {
-					scope: opts?.scope,
+					scope: opts?.scope ?? opts?.scopes?.join(" "),
 					resourceMetadataMappings: opts?.resourceMetadataMappings,
 					dpopSigningAlgorithms: opts?.dpop?.signingAlgorithms,
 				});
 			} catch (challengeError) {
 				if (challengeError instanceof APIError) {
-					return unauthorized(challengeError);
+					return errorResponse(challengeError);
 				}
 				if (challengeError instanceof Error) throw challengeError;
 				throw new Error(String(challengeError));

--- a/packages/oauth-provider/src/device-code.test.ts
+++ b/packages/oauth-provider/src/device-code.test.ts
@@ -61,7 +61,6 @@ describe("oauth-provider device-code grant", async () => {
 				token_endpoint_auth_method: "none",
 				grant_types: grantTypes,
 				scope: "openid profile email",
-				type: "native",
 			},
 		});
 		return created!.client_id;
@@ -353,7 +352,6 @@ describe("oauth-provider device-code grant", async () => {
 				token_endpoint_auth_method: "none",
 				grant_types: [DEVICE_CODE_GRANT_TYPE],
 				scope: "openid",
-				type: "native",
 			},
 		});
 
@@ -380,7 +378,6 @@ describe("oauth-provider device-code grant", async () => {
 				token_endpoint_auth_method: "client_secret_basic",
 				grant_types: [DEVICE_CODE_GRANT_TYPE],
 				scope: "openid",
-				type: "web",
 			},
 		});
 
@@ -480,7 +477,6 @@ describe("oauth-provider device-code grant expiry", async () => {
 				token_endpoint_auth_method: "none",
 				grant_types: [DEVICE_CODE_GRANT_TYPE],
 				scope: "openid",
-				type: "native",
 			},
 		});
 		const clientId = created!.client_id;

--- a/packages/oauth-provider/src/extensions.test.ts
+++ b/packages/oauth-provider/src/extensions.test.ts
@@ -273,7 +273,6 @@ describe("oauth-provider extensions", async () => {
 				token_endpoint_auth_method: extensionAuthMethod,
 				grant_types: [extensionGrant],
 				scope: "openid email vc",
-				type: "web",
 			},
 		});
 		expect(adminClient?.client_id).toBeDefined();
@@ -289,7 +288,6 @@ describe("oauth-provider extensions", async () => {
 				token_endpoint_auth_method: extensionAuthMethod,
 				grant_types: [extensionGrant],
 				scope: "openid email vc",
-				type: "web",
 			},
 		});
 		expect(registeredClient?.client_id).toBeDefined();
@@ -311,7 +309,6 @@ describe("oauth-provider extensions", async () => {
 					grant_types: [extensionGrant],
 					response_types: ["code"],
 					scope: "openid email vc",
-					type: "web",
 				},
 			});
 		} catch (e) {
@@ -336,7 +333,6 @@ describe("oauth-provider extensions", async () => {
 					grant_types: [extensionGrant],
 					jwks_uri: "https://127.0.0.1/jwks",
 					scope: "openid email vc",
-					type: "web",
 				},
 			});
 		} catch (e) {
@@ -362,7 +358,6 @@ describe("oauth-provider extensions", async () => {
 					jwks: [{ kty: "RSA", n: "test", e: "test-exponent" }],
 					jwks_uri: "https://client.example.com/jwks",
 					scope: "openid email vc",
-					type: "web",
 				},
 			});
 		} catch (e) {
@@ -397,7 +392,6 @@ describe("oauth-provider extensions", async () => {
 			body: {
 				grant_types: [extensionGrant],
 				scope: "openid email vc",
-				type: "web",
 			},
 		});
 		const response = await client.$fetch("/oauth2/token", {
@@ -496,7 +490,6 @@ describe("oauth-provider extensions", async () => {
 				token_endpoint_auth_method: extensionAuthMethod,
 				grant_types: [extensionGrant],
 				scope: "openid email vc",
-				type: "web",
 			},
 		});
 		expect(oauthClient?.client_id).toBeDefined();
@@ -608,7 +601,6 @@ describe("oauth-provider extensions", async () => {
 				token_endpoint_auth_method: extensionAuthMethod,
 				grant_types: [extensionOpaqueGrant],
 				scope: "openid email vc",
-				type: "web",
 			},
 		});
 		const response = await client.$fetch("/oauth2/token", {
@@ -975,7 +967,6 @@ describe("oauth-provider extensions", async () => {
 				token_endpoint_auth_method: extensionAuthMethod,
 				grant_types: [extensionOpaqueGrant],
 				scope: "openid email vc",
-				type: "web",
 			},
 		});
 		const tokenResponse = await client.$fetch<{ access_token: string }>(
@@ -1025,7 +1016,6 @@ describe("oauth-provider extensions", async () => {
 				token_endpoint_auth_method: extensionAuthMethod,
 				grant_types: [extensionGrant],
 				scope: "openid email vc",
-				type: "web",
 			},
 		});
 		const response = await client.$fetch("/oauth2/token", {
@@ -1052,7 +1042,6 @@ describe("oauth-provider extensions", async () => {
 				token_endpoint_auth_method: extensionAuthMethod,
 				grant_types: [extensionOpaqueGrant],
 				scope: "openid email vc",
-				type: "web",
 			},
 		});
 		const tokenResponse = await client.$fetch<{ access_token: string }>(
@@ -1134,7 +1123,6 @@ describe("oauth-provider extensions", async () => {
 				token_endpoint_auth_method: extensionAuthMethod,
 				grant_types: [extensionOpaqueBoundGrant],
 				scope: "openid email vc",
-				type: "web",
 			},
 		});
 		const clientAuth = {

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1598,12 +1598,12 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 													public: {
 														type: "boolean",
 														description:
-															"Whether the client is public as determined by the type",
+															"Whether the client is a public client",
 													},
-													type: {
+													application_type: {
 														type: "string",
-														description: "Type of the client",
-														enum: ["web", "native", "user-agent-based"],
+														description: "OIDC Registration application type",
+														enum: ["web", "native"],
 													},
 													disabled: {
 														type: "boolean",

--- a/packages/oauth-provider/src/oauthClient/index.ts
+++ b/packages/oauth-provider/src/oauthClient/index.ts
@@ -48,7 +48,7 @@ export const adminCreateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 				jwks_uri: z.string().optional(),
 				grant_types: grantTypesSchema.optional(),
 				response_types: z.array(z.enum(["code"])).optional(),
-				type: z.enum(["web", "native", "user-agent-based"]).optional(),
+				application_type: z.enum(["web", "native"]).optional(),
 				// SERVER_ONLY applicable fields
 				client_secret_expires_at: z
 					.union([z.string(), z.number()])
@@ -177,13 +177,12 @@ export const adminCreateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 											},
 											public: {
 												type: "boolean",
-												description:
-													"Whether the client is public as determined by the type",
+												description: "Whether the client is a public client",
 											},
-											type: {
+											application_type: {
 												type: "string",
-												description: "Type of the client",
-												enum: ["web", "native", "user-agent-based"],
+												description: "OIDC Registration application type",
+												enum: ["web", "native"],
 											},
 											disabled: {
 												type: "boolean",
@@ -250,7 +249,7 @@ export const createOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 				jwks_uri: z.string().optional(),
 				grant_types: grantTypesSchema.optional(),
 				response_types: z.array(z.enum(["code"])).optional(),
-				type: z.enum(["web", "native", "user-agent-based"]).optional(),
+				application_type: z.enum(["web", "native"]).optional(),
 				// RFC 9449 §5.2: client asks for DPoP-bound access tokens.
 				dpop_bound_access_tokens: z.boolean().optional(),
 			}),
@@ -368,13 +367,12 @@ export const createOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 											},
 											public: {
 												type: "boolean",
-												description:
-													"Whether the client is public as determined by the type",
+												description: "Whether the client is a public client",
 											},
-											type: {
+											application_type: {
 												type: "string",
-												description: "Type of the client",
-												enum: ["web", "native", "user-agent-based"],
+												description: "OIDC Registration application type",
+												enum: ["web", "native"],
 											},
 											disabled: {
 												type: "boolean",
@@ -509,7 +507,7 @@ export const adminUpdateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 					// NOTE: token_endpoint_auth_method is currently immutable since it changes isPublic definition
 					grant_types: grantTypesSchema.optional(),
 					response_types: z.array(z.enum(["code"])).optional(),
-					type: z.enum(["web", "native", "user-agent-based"]).optional(),
+					application_type: z.enum(["web", "native"]).optional(),
 					// SERVER_ONLY applicable fields
 					client_secret_expires_at: z
 						.union([z.string(), z.number()])
@@ -559,7 +557,7 @@ export const updateOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 					// NOTE: token_endpoint_auth_method is currently immutable since it changes isPublic definition
 					grant_types: grantTypesSchema.optional(),
 					response_types: z.array(z.enum(["code"])).optional(),
-					type: z.enum(["web", "native", "user-agent-based"]).optional(),
+					application_type: z.enum(["web", "native"]).optional(),
 				}),
 			}),
 			metadata: {

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -110,37 +110,12 @@ describe("oauth register", async () => {
 		expect(response.error?.status).toBe(400);
 	});
 
-	it("should fail type check for public client request", async () => {
-		const response = await serverClient.oauth2.register({
-			token_endpoint_auth_method: "none",
-			type: "web",
-			redirect_uris: [redirectUri],
-		});
-		expect(response.error?.status).toBe(400);
-	});
-
-	it.for([
-		"native",
-		"user-agent-based",
-	] as OAuthClient["type"][])("should fail with type '%s' check for confidential client request", async (type) => {
-		const response = await serverClient.oauth2.register({
-			token_endpoint_auth_method: "client_secret_post",
-			type,
-			redirect_uris: [redirectUri],
-		});
-		expect(response.error?.status).toBe(400);
-	});
-
-	it.for([
-		"native",
-		"user-agent-based",
-	] as OAuthClient["type"][])("should register public '%s' client with minimum requirements via server", async (type) => {
+	it("should register public client with minimum requirements via server", async () => {
 		const response = await auth.api.adminCreateOAuthClient({
 			headers,
 			body: {
 				token_endpoint_auth_method: "none",
 				redirect_uris: [redirectUri],
-				type,
 			},
 		});
 		expect(response?.client_id).toBeDefined();
@@ -182,7 +157,6 @@ describe("oauth register", async () => {
 			response_types: ["code"],
 			//---- RFC6749 Spec ----//
 			public: true, // test never set on this (based off of token_endpoint_auth_method)
-			type: "web",
 			//---- Not Part of RFC7591 Spec ----//
 			disabled: false,
 		};
@@ -234,10 +208,9 @@ describe("oauth register", async () => {
 		expect(response.data?.disabled).toBeFalsy();
 	});
 
-	it("should preserve confidential method and type for authenticated registration", async () => {
+	it("should preserve the confidential auth method for authenticated registration", async () => {
 		const response = await serverClient.oauth2.register({
 			token_endpoint_auth_method: "client_secret_post",
-			type: "web",
 			redirect_uris: [redirectUri],
 		});
 		expect(response.data?.client_id).toBeDefined();
@@ -245,7 +218,6 @@ describe("oauth register", async () => {
 		expect(response.data?.token_endpoint_auth_method).toBe(
 			"client_secret_post",
 		);
-		expect(response.data?.type).toBe("web");
 		expect(response.data?.public).toBeFalsy();
 	});
 
@@ -480,7 +452,6 @@ describe("oauth register", async () => {
 		const response = await serverClient.oauth2.register({
 			redirect_uris: [redirectUri],
 			token_endpoint_auth_method: "none",
-			type: "native",
 			backchannel_logout_uri: `${rpBaseUrl}/logout/backchannel`,
 		});
 		expect(response.data?.client_id).toBeDefined();
@@ -645,10 +616,9 @@ describe("oauth register - unauthenticated", async () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/8588
 	 */
-	it("should preserve type 'web' for unauthenticated confidential DCR", async () => {
+	it("should keep unauthenticated confidential DCR confidential", async () => {
 		const response = await unauthenticatedClient.oauth2.register({
 			token_endpoint_auth_method: "client_secret_post",
-			type: "web",
 			redirect_uris: [redirectUri],
 		});
 		expect(response.data?.client_id).toBeDefined();
@@ -656,7 +626,7 @@ describe("oauth register - unauthenticated", async () => {
 		expect(response.data?.token_endpoint_auth_method).toBe(
 			"client_secret_post",
 		);
-		expect(response.data?.type).toBe("web");
+		expect(response.data?.public).toBeFalsy();
 	});
 
 	/**
@@ -1427,7 +1397,7 @@ describe("oauth register - protected dynamic registration", async () => {
 
 describe("oauth register - application_type", async () => {
 	const authServerBaseUrl = "http://localhost:3000";
-	const { customFetchImpl } = await getTestInstance({
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		baseURL: authServerBaseUrl,
 		plugins: [
 			jwt(),
@@ -1507,25 +1477,42 @@ describe("oauth register - application_type", async () => {
 		expect(body.application_type).toBe("web");
 	});
 
-	it("rejects an application_type that contradicts type", async () => {
-		const response = await register({
-			type: "web",
-			application_type: "native",
-			redirect_uris: ["https://rp.example.com/callback"],
-		});
-		expect(response.status).toBe(400);
-		const body = (await response.json()) as { error_description?: string };
-		expect(body.error_description).toContain("conflicts with type");
-	});
+	it("forces PKCE on a native client even when the client opts out", async () => {
+		// A native client cannot keep a secret, so it is public whatever auth
+		// method it registered with, and `require_pkce: false` cannot waive PKCE
+		// for it. The same client declared `web` is taken at its word.
+		const { headers } = await signInWithTestUser();
+		const authorizeWithoutPkce = async (
+			applicationType: "web" | "native",
+			redirectUri: string,
+		) => {
+			const created = await auth.api.adminCreateOAuthClient({
+				headers,
+				body: {
+					application_type: applicationType,
+					token_endpoint_auth_method: "client_secret_post",
+					require_pkce: false,
+					redirect_uris: [redirectUri],
+				},
+			});
+			const response = await customFetchImpl(
+				`${authServerBaseUrl}/api/auth/oauth2/authorize?${new URLSearchParams({
+					client_id: created!.client_id!,
+					response_type: "code",
+					redirect_uri: redirectUri,
+					scope: "openid",
+				})}`,
+				{ method: "GET", redirect: "manual" },
+			);
+			return response.headers.get("location") ?? "";
+		};
 
-	it("accepts a user-agent-based client declaring the web application type", async () => {
-		const response = await register({
-			type: "user-agent-based",
-			application_type: "web",
-			token_endpoint_auth_method: "none",
-			redirect_uris: ["https://spa.example.com/callback"],
-		});
-		expect(response.status).toBe(201);
+		expect(
+			await authorizeWithoutPkce("native", "com.example.pkce:/cb"),
+		).toContain("pkce+is+required");
+		expect(
+			await authorizeWithoutPkce("web", "https://rp.example.com/pkce-cb"),
+		).not.toContain("pkce+is+required");
 	});
 
 	it("keeps prior behavior when application_type is omitted", async () => {

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -1424,3 +1424,98 @@ describe("oauth register - protected dynamic registration", async () => {
 		expect(tokenBody.user_id).toBeUndefined();
 	});
 });
+
+describe("oauth register - application_type", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const { customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			jwt(),
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				allowDynamicClientRegistration: true,
+				allowUnauthenticatedClientRegistration: true,
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+		],
+	});
+
+	const register = (body: Record<string, unknown>) =>
+		customFetchImpl(`${authServerBaseUrl}/api/auth/oauth2/register`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(body),
+		});
+
+	it("registers a native client with loopback and custom-scheme redirect URIs", async () => {
+		const response = await register({
+			application_type: "native",
+			token_endpoint_auth_method: "none",
+			redirect_uris: [
+				"http://localhost:3005/callback",
+				"http://127.0.0.1:3005/callback",
+				"com.example.app:/callback",
+			],
+		});
+		expect(response.status).toBe(201);
+		const body = (await response.json()) as OAuthClient;
+		expect(body.application_type).toBe("native");
+	});
+
+	it("rejects a native client with an http redirect URI on a routable host", async () => {
+		const response = await register({
+			application_type: "native",
+			token_endpoint_auth_method: "none",
+			redirect_uris: ["http://example.com/callback"],
+		});
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { error?: string };
+		expect(body.error).toBe("invalid_redirect_uri");
+	});
+
+	it("rejects a web client with an http redirect URI", async () => {
+		const response = await register({
+			application_type: "web",
+			redirect_uris: ["http://example.com/callback"],
+		});
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { error?: string };
+		expect(body.error).toBe("invalid_redirect_uri");
+	});
+
+	it("rejects a web client with a loopback redirect URI", async () => {
+		const response = await register({
+			application_type: "web",
+			redirect_uris: ["https://localhost:3005/callback"],
+		});
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { error?: string };
+		expect(body.error).toBe("invalid_redirect_uri");
+	});
+
+	it("registers a web client with an https redirect URI", async () => {
+		const response = await register({
+			application_type: "web",
+			redirect_uris: ["https://rp.example.com/callback"],
+		});
+		expect(response.status).toBe(201);
+		const body = (await response.json()) as OAuthClient;
+		expect(body.application_type).toBe("web");
+	});
+
+	it("keeps prior behavior when application_type is omitted", async () => {
+		// OIDC Registration defaults application_type to "web", but enforcing
+		// that default would break existing localhost integrations; constraints
+		// only apply when the parameter is sent explicitly.
+		const response = await register({
+			redirect_uris: ["http://localhost:5000/api/auth/callback/test"],
+		});
+		expect(response.status).toBe(201);
+		const body = (await response.json()) as OAuthClient;
+		expect(body.application_type).toBeUndefined();
+	});
+});

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -1507,6 +1507,27 @@ describe("oauth register - application_type", async () => {
 		expect(body.application_type).toBe("web");
 	});
 
+	it("rejects an application_type that contradicts type", async () => {
+		const response = await register({
+			type: "web",
+			application_type: "native",
+			redirect_uris: ["https://rp.example.com/callback"],
+		});
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { error_description?: string };
+		expect(body.error_description).toContain("conflicts with type");
+	});
+
+	it("accepts a user-agent-based client declaring the web application type", async () => {
+		const response = await register({
+			type: "user-agent-based",
+			application_type: "web",
+			token_endpoint_auth_method: "none",
+			redirect_uris: ["https://spa.example.com/callback"],
+		});
+		expect(response.status).toBe(201);
+	});
+
 	it("keeps prior behavior when application_type is omitted", async () => {
 		// OIDC Registration defaults application_type to "web", but enforcing
 		// that default would break existing localhost integrations; constraints

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -258,27 +258,6 @@ export async function checkOAuthClient(
 		});
 	}
 
-	// Check value of type, if sent, matches isPublic
-	if (clientWithDefaults.type) {
-		if (
-			isPublic &&
-			!(
-				clientWithDefaults.type === "native" ||
-				clientWithDefaults.type === "user-agent-based"
-			)
-		) {
-			throw new APIError("BAD_REQUEST", {
-				error: "invalid_client_metadata",
-				error_description: `Type must be 'native' or 'user-agent-based' for public applications`,
-			});
-		} else if (!isPublic && !(clientWithDefaults.type === "web")) {
-			throw new APIError("BAD_REQUEST", {
-				error: "invalid_client_metadata",
-				error_description: `Type must be 'web' for confidential applications`,
-			});
-		}
-	}
-
 	const grantTypes = clientWithDefaults.grant_types ?? [];
 	const responseTypes = clientWithDefaults.response_types;
 
@@ -293,19 +272,6 @@ export async function checkOAuthClient(
 			error_description:
 				"Redirect URIs are required for authorization_code and implicit grant types",
 		});
-	}
-
-	// `type` and `application_type` both describe the client profile, so a
-	// registration that sends both must not contradict itself.
-	if (clientWithDefaults.type && clientWithDefaults.application_type) {
-		const impliedApplicationType =
-			clientWithDefaults.type === "native" ? "native" : "web";
-		if (impliedApplicationType !== clientWithDefaults.application_type) {
-			throw new APIError("BAD_REQUEST", {
-				error: "invalid_client_metadata",
-				error_description: `application_type '${clientWithDefaults.application_type}' conflicts with type '${clientWithDefaults.type}'`,
-			});
-		}
 	}
 
 	// OIDC Registration §2 `application_type`, required of MCP clients by
@@ -765,7 +731,7 @@ export function oauthToSchema(input: OAuthClient): SchemaClient<Scope[]> {
 		response_types: responseTypes,
 		// RFC6749 Spec
 		public: _public,
-		type,
+		application_type: applicationType,
 		// Not Part of RFC7591 Spec
 		disabled,
 		skip_consent: skipConsent,
@@ -833,7 +799,7 @@ export function oauthToSchema(input: OAuthClient): SchemaClient<Scope[]> {
 		jwksUri: jwksUri,
 		// RFC6749 Spec
 		public: _public,
-		type,
+		applicationType,
 		// All other metadata
 		skipConsent,
 		enableEndSession,
@@ -884,7 +850,7 @@ export function schemaToOAuth(input: SchemaClient<Scope[]>): OAuthClient {
 		responseTypes,
 		// RFC6749 Spec
 		public: _public,
-		type,
+		applicationType,
 		// Jwks
 		jwks,
 		jwksUri,
@@ -946,7 +912,7 @@ export function schemaToOAuth(input: SchemaClient<Scope[]>): OAuthClient {
 		response_types: responseTypes ?? undefined,
 		// RFC6749 Spec
 		public: _public ?? undefined,
-		type: type ?? undefined,
+		application_type: applicationType ?? undefined,
 		// Not Part of RFC7591 Spec
 		disabled: disabled ?? undefined,
 		skip_consent: skipConsent ?? undefined,

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -295,10 +295,24 @@ export async function checkOAuthClient(
 		});
 	}
 
-	// OIDC Registration §2 / MCP SEP-837: when `application_type` is sent,
-	// constrain redirect URIs to what the declared type allows. Only enforced
-	// when the parameter is explicit, so registrations predating this check
-	// keep working.
+	// `type` and `application_type` both describe the client profile, so a
+	// registration that sends both must not contradict itself.
+	if (clientWithDefaults.type && clientWithDefaults.application_type) {
+		const impliedApplicationType =
+			clientWithDefaults.type === "native" ? "native" : "web";
+		if (impliedApplicationType !== clientWithDefaults.application_type) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description: `application_type '${clientWithDefaults.application_type}' conflicts with type '${clientWithDefaults.type}'`,
+			});
+		}
+	}
+
+	// OIDC Registration §2 `application_type`, required of MCP clients by
+	// SEP-837. Native redirect URIs follow RFC 8252 §7 (custom scheme, loopback
+	// http, or claimed https link) rather than OIDC's narrower list, which
+	// predates claimed https links. Only enforced when the parameter is
+	// explicit, so registrations that omit it keep working.
 	if (clientWithDefaults.application_type) {
 		for (const uri of clientWithDefaults.redirect_uris ?? []) {
 			const url = new URL(uri);
@@ -307,8 +321,8 @@ export async function checkOAuthClient(
 			const isLoopback = (isHttp || isHttps) && isLoopbackHost(url.hostname);
 			if (clientWithDefaults.application_type === "native") {
 				// Native clients redirect to custom schemes, loopback http
-				// interception servers, or claimed https links — never plain
-				// http on a routable host.
+				// interception servers, or claimed https links; never plain http
+				// on a routable host.
 				if (isHttp && !isLoopback) {
 					throw new APIError("BAD_REQUEST", {
 						error: "invalid_redirect_uri",

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -295,6 +295,35 @@ export async function checkOAuthClient(
 		});
 	}
 
+	// OIDC Registration §2 / MCP SEP-837: when `application_type` is sent,
+	// constrain redirect URIs to what the declared type allows. Only enforced
+	// when the parameter is explicit, so registrations predating this check
+	// keep working.
+	if (clientWithDefaults.application_type) {
+		for (const uri of clientWithDefaults.redirect_uris ?? []) {
+			const url = new URL(uri);
+			const isHttp = url.protocol === "http:";
+			const isHttps = url.protocol === "https:";
+			const isLoopback = (isHttp || isHttps) && isLoopbackHost(url.hostname);
+			if (clientWithDefaults.application_type === "native") {
+				// Native clients redirect to custom schemes, loopback http
+				// interception servers, or claimed https links — never plain
+				// http on a routable host.
+				if (isHttp && !isLoopback) {
+					throw new APIError("BAD_REQUEST", {
+						error: "invalid_redirect_uri",
+						error_description: `native clients must not use http redirect URIs on non-loopback hosts: ${uri}`,
+					});
+				}
+			} else if (!isHttps || isLoopback) {
+				throw new APIError("BAD_REQUEST", {
+					error: "invalid_redirect_uri",
+					error_description: `web clients require https redirect URIs on non-loopback hosts: ${uri}`,
+				});
+			}
+		}
+	}
+
 	// Validate correlation between grant_types and response_types
 	const supportedGrantTypes = new Set(getSupportedGrantTypes(opts));
 	for (const grantType of grantTypes) {

--- a/packages/oauth-provider/src/resource-challenge.test.ts
+++ b/packages/oauth-provider/src/resource-challenge.test.ts
@@ -1,3 +1,4 @@
+import { insufficientScopeError } from "better-auth/oauth2";
 import { APIError } from "better-call";
 import { describe, expect, it } from "vitest";
 import { raiseResourceServerChallenge } from "./resource-challenge";
@@ -40,9 +41,8 @@ describe("resource server challenge", () => {
 	it("answers insufficient scope with an RFC 6750 403 challenge", () => {
 		try {
 			raiseResourceServerChallenge(
-				new APIError("FORBIDDEN", { message: "invalid scope files:write" }),
+				insufficientScopeError(["files:write", "files:delete"]),
 				"https://api.example.com/mcp/tools",
-				{ scope: "files:write" },
 			);
 		} catch (error) {
 			const apiError = error as APIError;
@@ -50,38 +50,54 @@ describe("resource server challenge", () => {
 			expect(apiError.status).toBe("FORBIDDEN");
 			expect(apiError.statusCode).toBe(403);
 			expect(headers.get("WWW-Authenticate")).toBe(
-				'Bearer error="insufficient_scope", scope="files:write", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp/tools", error_description="invalid scope files:write"',
+				'Bearer error="insufficient_scope", scope="files:write files:delete", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp/tools", error_description="access token is missing required scope: files:write files:delete"',
 			);
 			return;
 		}
 		throw new Error("expected challenge");
 	});
 
-	it("omits the scope param from a 403 challenge when none is configured", () => {
+	it("challenges for the scopes the token lacks, not the configured hint", () => {
+		// The hint tells an unauthenticated client where to start; re-authorizing
+		// only helps if the challenge names what is actually missing.
 		try {
 			raiseResourceServerChallenge(
-				new APIError("FORBIDDEN", { message: "write access required" }),
+				insufficientScopeError(["files:write"]),
 				"https://api.example.com",
+				{ scope: "files:read" },
 			);
 		} catch (error) {
-			const apiError = error as APIError;
-			const headers = new Headers(apiError.headers);
-			expect(apiError.statusCode).toBe(403);
-			expect(headers.get("WWW-Authenticate")).toBe(
-				'Bearer error="insufficient_scope", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource", error_description="write access required"',
-			);
+			const headers = new Headers((error as APIError).headers);
+			expect(headers.get("WWW-Authenticate")).toContain('scope="files:write"');
 			return;
 		}
 		throw new Error("expected challenge");
+	});
+
+	it("propagates a forbidden error that is not a scope failure", () => {
+		// A permission denial re-authorizing cannot fix must stay a plain 403;
+		// challenging would send the user through consent to no effect.
+		const denial = new APIError("FORBIDDEN", {
+			message: "user is not a member of this organization",
+		});
+		expect(() =>
+			raiseResourceServerChallenge(denial, "https://api.example.com"),
+		).toThrow(denial);
+		try {
+			raiseResourceServerChallenge(denial, "https://api.example.com");
+		} catch (error) {
+			expect(
+				new Headers((error as APIError).headers).get("WWW-Authenticate"),
+			).toBeNull();
+		}
 	});
 
 	it("resolves a mapped resource_metadata URL in a 403 challenge", () => {
 		try {
 			raiseResourceServerChallenge(
-				new APIError("FORBIDDEN", { message: "invalid scope mcp:tools" }),
+				insufficientScopeError(["mcp:tools"]),
 				"urn:example:mcp",
 				{
-					scope: "mcp:tools",
 					resourceMetadataMappings: {
 						"urn:example:mcp":
 							"https://api.example.com/.well-known/oauth-protected-resource",
@@ -93,7 +109,7 @@ describe("resource server challenge", () => {
 			const headers = new Headers(apiError.headers);
 			expect(apiError.statusCode).toBe(403);
 			expect(headers.get("WWW-Authenticate")).toBe(
-				'Bearer error="insufficient_scope", scope="mcp:tools", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource", error_description="invalid scope mcp:tools"',
+				'Bearer error="insufficient_scope", scope="mcp:tools", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource", error_description="access token is missing required scope: mcp:tools"',
 			);
 			return;
 		}
@@ -103,9 +119,10 @@ describe("resource server challenge", () => {
 	it("strips header-injection characters from 403 challenge params", () => {
 		try {
 			raiseResourceServerChallenge(
-				new APIError("FORBIDDEN", {
-					message: 'bad "scope"\r\nSet-Cookie: x=y',
-				}),
+				insufficientScopeError(
+					["files:write"],
+					'bad "scope"\r\nSet-Cookie: x=y',
+				),
 				"https://api.example.com",
 			);
 		} catch (error) {

--- a/packages/oauth-provider/src/resource-challenge.test.ts
+++ b/packages/oauth-provider/src/resource-challenge.test.ts
@@ -37,6 +37,91 @@ describe("resource server challenge", () => {
 		);
 	});
 
+	it("answers insufficient scope with an RFC 6750 403 challenge", () => {
+		try {
+			raiseResourceServerChallenge(
+				new APIError("FORBIDDEN", { message: "invalid scope files:write" }),
+				"https://api.example.com/mcp/tools",
+				{ scope: "files:write" },
+			);
+		} catch (error) {
+			const apiError = error as APIError;
+			const headers = new Headers(apiError.headers);
+			expect(apiError.status).toBe("FORBIDDEN");
+			expect(apiError.statusCode).toBe(403);
+			expect(headers.get("WWW-Authenticate")).toBe(
+				'Bearer error="insufficient_scope", scope="files:write", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp/tools", error_description="invalid scope files:write"',
+			);
+			return;
+		}
+		throw new Error("expected challenge");
+	});
+
+	it("omits the scope param from a 403 challenge when none is configured", () => {
+		try {
+			raiseResourceServerChallenge(
+				new APIError("FORBIDDEN", { message: "write access required" }),
+				"https://api.example.com",
+			);
+		} catch (error) {
+			const apiError = error as APIError;
+			const headers = new Headers(apiError.headers);
+			expect(apiError.statusCode).toBe(403);
+			expect(headers.get("WWW-Authenticate")).toBe(
+				'Bearer error="insufficient_scope", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource", error_description="write access required"',
+			);
+			return;
+		}
+		throw new Error("expected challenge");
+	});
+
+	it("resolves a mapped resource_metadata URL in a 403 challenge", () => {
+		try {
+			raiseResourceServerChallenge(
+				new APIError("FORBIDDEN", { message: "invalid scope mcp:tools" }),
+				"urn:example:mcp",
+				{
+					scope: "mcp:tools",
+					resourceMetadataMappings: {
+						"urn:example:mcp":
+							"https://api.example.com/.well-known/oauth-protected-resource",
+					},
+				},
+			);
+		} catch (error) {
+			const apiError = error as APIError;
+			const headers = new Headers(apiError.headers);
+			expect(apiError.statusCode).toBe(403);
+			expect(headers.get("WWW-Authenticate")).toBe(
+				'Bearer error="insufficient_scope", scope="mcp:tools", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource", error_description="invalid scope mcp:tools"',
+			);
+			return;
+		}
+		throw new Error("expected challenge");
+	});
+
+	it("strips header-injection characters from 403 challenge params", () => {
+		try {
+			raiseResourceServerChallenge(
+				new APIError("FORBIDDEN", {
+					message: 'bad "scope"\r\nSet-Cookie: x=y',
+				}),
+				"https://api.example.com",
+			);
+		} catch (error) {
+			const apiError = error as APIError;
+			const headers = new Headers(apiError.headers);
+			const challenge = headers.get("WWW-Authenticate");
+			expect(challenge).not.toContain("\r");
+			expect(challenge).not.toContain("\n");
+			expect(challenge).toContain(
+				'error_description="bad \\"scope\\" Set-Cookie: x=y"',
+			);
+			return;
+		}
+		throw new Error("expected challenge");
+	});
+
 	it("emits RFC 9449 DPoP challenges for invalid DPoP proofs", () => {
 		try {
 			raiseResourceServerChallenge(

--- a/packages/oauth-provider/src/resource-challenge.ts
+++ b/packages/oauth-provider/src/resource-challenge.ts
@@ -54,6 +54,22 @@ function buildDpopChallenge(
 	].join(", ");
 }
 
+function extractInsufficientScope(
+	error: APIError,
+): { scope?: string; description: string } | null {
+	const body = error.body as
+		| { error?: unknown; error_description?: unknown; scope?: unknown }
+		| undefined;
+	if (body?.error !== "insufficient_scope") return null;
+	return {
+		scope: typeof body.scope === "string" ? body.scope : undefined,
+		description:
+			typeof body.error_description === "string"
+				? body.error_description
+				: error.message,
+	};
+}
+
 function resolveResourceMetadataUrl(
 	value: string,
 	opts?: { resourceMetadataMappings?: Record<string, string> },
@@ -77,16 +93,37 @@ function resolveResourceMetadataUrl(
 	return resourceMetadata;
 }
 
+function buildBearerChallenge(
+	resource: string | string[],
+	opts: { resourceMetadataMappings?: Record<string, string> } | undefined,
+	authParams: (metadataUrl: string) => (string | false | undefined)[],
+): string {
+	const resources = Array.isArray(resource) ? resource : [resource];
+	return resources
+		.map((value) => {
+			const params = authParams(resolveResourceMetadataUrl(value, opts)).filter(
+				(param) => !!param,
+			);
+			return `Bearer ${params.join(", ")}`;
+		})
+		.join(", ");
+}
+
 /**
  * Raise an OAuth resource-server challenge for a failed access-token request.
  *
  * Missing/invalid bearer credentials are reported with RFC 6750 plus the RFC
- * 9728 `resource_metadata` pointer. Insufficient-scope failures are reported
- * with RFC 6750 §3.1's `insufficient_scope` challenge on a 403 so clients can
- * step up their authorization. DPoP-bound-token failures are reported with
- * RFC 9449's `DPoP` challenge so clients know which proof algorithms to use.
- * Non-URL resources (for example a `urn:` or a client id) resolve their
- * metadata URL through `resourceMetadataMappings`.
+ * 9728 `resource_metadata` pointer. Insufficient-scope failures (built with
+ * `insufficientScopeError`) are reported with RFC 6750 §3.1's
+ * `insufficient_scope` challenge on a 403 naming the scopes the token lacks, so
+ * clients can step up their authorization. DPoP-bound-token failures are
+ * reported with RFC 9449's `DPoP` challenge so clients know which proof
+ * algorithms to use. Non-URL resources (for example a `urn:` or a client id)
+ * resolve their metadata URL through `resourceMetadataMappings`.
+ *
+ * Every other error is rethrown unchanged, including a plain `FORBIDDEN`: a
+ * permission denial that re-authorizing cannot fix must not be answered with a
+ * challenge that sends the user through consent for scopes they already hold.
  *
  * @internal
  */
@@ -98,7 +135,11 @@ export function raiseResourceServerChallenge(
 		resourceMetadataMappings?: Record<string, string>;
 		/** DPoP JWS algorithms to advertise in RFC 9449 challenges. */
 		dpopSigningAlgorithms?: readonly string[];
-		/** Space-delimited scopes to advertise in RFC 6750 bearer challenges. */
+		/**
+		 * Space-delimited scopes to advertise in RFC 6750 bearer challenges,
+		 * hinting what an unauthenticated client should request. An
+		 * insufficient-scope failure advertises the scopes it names instead.
+		 */
 		scope?: string;
 	},
 ): never {
@@ -110,44 +151,46 @@ export function raiseResourceServerChallenge(
 				{ "WWW-Authenticate": buildDpopChallenge(error, opts) },
 			);
 		}
-		const resources = Array.isArray(resource) ? resource : [resource];
-		const wwwAuthenticateValue = resources
-			.map((value) => {
-				const metadataUrl = resolveResourceMetadataUrl(value, opts);
-				let challenge = `Bearer resource_metadata="${metadataUrl}"`;
-				if (opts?.scope) {
-					challenge += `, scope="${quoteAuthParam(opts.scope)}"`;
-				}
-				return challenge;
-			})
-			.join(", ");
 		throw new APIError(
 			"UNAUTHORIZED",
 			{ message: error.message },
-			{ "WWW-Authenticate": wwwAuthenticateValue },
+			{
+				"WWW-Authenticate": buildBearerChallenge(
+					resource,
+					opts,
+					(metadataUrl) => [
+						`resource_metadata="${metadataUrl}"`,
+						opts?.scope && `scope="${quoteAuthParam(opts.scope)}"`,
+					],
+				),
+			},
 		);
 	}
-	if (isAPIError(error) && error.status === "FORBIDDEN") {
+	const insufficientScope = isAPIError(error)
+		? extractInsufficientScope(error)
+		: null;
+	if (insufficientScope) {
 		// RFC 6750 §3.1: a token that is valid but lacks the scopes the
 		// operation needs answers with 403 and an `insufficient_scope`
-		// challenge, so the client can step up via re-authorization.
-		const resources = Array.isArray(resource) ? resource : [resource];
-		const wwwAuthenticateValue = resources
-			.map((value) => {
-				const metadataUrl = resolveResourceMetadataUrl(value, opts);
-				let challenge = `Bearer error="insufficient_scope"`;
-				if (opts?.scope) {
-					challenge += `, scope="${quoteAuthParam(opts.scope)}"`;
-				}
-				challenge += `, resource_metadata="${metadataUrl}"`;
-				challenge += `, error_description="${quoteAuthParam(error.message)}"`;
-				return challenge;
-			})
-			.join(", ");
+		// challenge naming them, so the client can step up via re-authorization.
+		// `opts.scope` is only a fallback: the scopes the token actually lacks
+		// are the ones re-authorizing has to add.
+		const scope = insufficientScope.scope ?? opts?.scope;
 		throw new APIError(
 			"FORBIDDEN",
-			{ message: error.message },
-			{ "WWW-Authenticate": wwwAuthenticateValue },
+			{ message: insufficientScope.description },
+			{
+				"WWW-Authenticate": buildBearerChallenge(
+					resource,
+					opts,
+					(metadataUrl) => [
+						`error="insufficient_scope"`,
+						scope && `scope="${quoteAuthParam(scope)}"`,
+						`resource_metadata="${metadataUrl}"`,
+						`error_description="${quoteAuthParam(insufficientScope.description)}"`,
+					],
+				),
+			},
 		);
 	}
 	if (error instanceof Error) {

--- a/packages/oauth-provider/src/resource-challenge.ts
+++ b/packages/oauth-provider/src/resource-challenge.ts
@@ -54,11 +54,36 @@ function buildDpopChallenge(
 	].join(", ");
 }
 
+function resolveResourceMetadataUrl(
+	value: string,
+	opts?: { resourceMetadataMappings?: Record<string, string> },
+): string {
+	// Opaque absolute URIs (for example `urn:`) parse with an `origin` of
+	// "null", so only origin-based URLs derive the well-known metadata URL;
+	// everything else needs an explicit mapping.
+	const url = URL.canParse?.(value) ? new URL(value) : null;
+	if (url && url.origin !== "null") {
+		const resourcePath = url.pathname.endsWith("/")
+			? url.pathname.slice(0, -1)
+			: url.pathname;
+		return `${url.origin}/.well-known/oauth-protected-resource${resourcePath}${url.search}`;
+	}
+	const resourceMetadata = opts?.resourceMetadataMappings?.[value];
+	if (!resourceMetadata) {
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			message: `missing resource_metadata mapping for ${value}`,
+		});
+	}
+	return resourceMetadata;
+}
+
 /**
  * Raise an OAuth resource-server challenge for a failed access-token request.
  *
  * Missing/invalid bearer credentials are reported with RFC 6750 plus the RFC
- * 9728 `resource_metadata` pointer. DPoP-bound-token failures are reported with
+ * 9728 `resource_metadata` pointer. Insufficient-scope failures are reported
+ * with RFC 6750 §3.1's `insufficient_scope` challenge on a 403 so clients can
+ * step up their authorization. DPoP-bound-token failures are reported with
  * RFC 9449's `DPoP` challenge so clients know which proof algorithms to use.
  * Non-URL resources (for example a `urn:` or a client id) resolve their
  * metadata URL through `resourceMetadataMappings`.
@@ -88,28 +113,8 @@ export function raiseResourceServerChallenge(
 		const resources = Array.isArray(resource) ? resource : [resource];
 		const wwwAuthenticateValue = resources
 			.map((value) => {
-				// Opaque absolute URIs (for example `urn:`) parse with an
-				// `origin` of "null", so only origin-based URLs derive the
-				// well-known metadata URL; everything else needs an explicit
-				// mapping.
-				const url = URL.canParse?.(value) ? new URL(value) : null;
-				if (url && url.origin !== "null") {
-					const resourcePath = url.pathname.endsWith("/")
-						? url.pathname.slice(0, -1)
-						: url.pathname;
-					let challenge = `Bearer resource_metadata="${url.origin}/.well-known/oauth-protected-resource${resourcePath}${url.search}"`;
-					if (opts?.scope) {
-						challenge += `, scope="${quoteAuthParam(opts.scope)}"`;
-					}
-					return challenge;
-				}
-				const resourceMetadata = opts?.resourceMetadataMappings?.[value];
-				if (!resourceMetadata) {
-					throw new APIError("INTERNAL_SERVER_ERROR", {
-						message: `missing resource_metadata mapping for ${value}`,
-					});
-				}
-				let challenge = `Bearer resource_metadata="${resourceMetadata}"`;
+				const metadataUrl = resolveResourceMetadataUrl(value, opts);
+				let challenge = `Bearer resource_metadata="${metadataUrl}"`;
 				if (opts?.scope) {
 					challenge += `, scope="${quoteAuthParam(opts.scope)}"`;
 				}
@@ -118,6 +123,29 @@ export function raiseResourceServerChallenge(
 			.join(", ");
 		throw new APIError(
 			"UNAUTHORIZED",
+			{ message: error.message },
+			{ "WWW-Authenticate": wwwAuthenticateValue },
+		);
+	}
+	if (isAPIError(error) && error.status === "FORBIDDEN") {
+		// RFC 6750 §3.1: a token that is valid but lacks the scopes the
+		// operation needs answers with 403 and an `insufficient_scope`
+		// challenge, so the client can step up via re-authorization.
+		const resources = Array.isArray(resource) ? resource : [resource];
+		const wwwAuthenticateValue = resources
+			.map((value) => {
+				const metadataUrl = resolveResourceMetadataUrl(value, opts);
+				let challenge = `Bearer error="insufficient_scope"`;
+				if (opts?.scope) {
+					challenge += `, scope="${quoteAuthParam(opts.scope)}"`;
+				}
+				challenge += `, resource_metadata="${metadataUrl}"`;
+				challenge += `, error_description="${quoteAuthParam(error.message)}"`;
+				return challenge;
+			})
+			.join(", ");
+		throw new APIError(
+			"FORBIDDEN",
 			{ message: error.message },
 			{ "WWW-Authenticate": wwwAuthenticateValue },
 		);

--- a/packages/oauth-provider/src/schema.ts
+++ b/packages/oauth-provider/src/schema.ts
@@ -133,7 +133,7 @@ export const schema = {
 				type: "boolean",
 				required: false,
 			},
-			type: {
+			applicationType: {
 				type: "string",
 				required: false,
 			},

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1712,15 +1712,14 @@ export interface SchemaClient<
 	 */
 	public?: boolean;
 	/**
-	 * The client type
+	 * OIDC Registration application type.
 	 *
-	 * Described https://www.rfc-editor.org/rfc/rfc6749.html#section-2.1
+	 * Constrains which redirect URIs the client may register, and marks
+	 * `native` clients as public so PKCE is always required for them.
 	 *
-	 * - web - A web application (confidential client)
-	 * - native - A mobile application (public client)
-	 * - user-agent-based - A user-agent-based application (public client)
+	 * @see https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
 	 */
-	type?: "web" | "native" | "user-agent-based";
+	applicationType?: "web" | "native";
 	/**
 	 * Whether this client requires PKCE for authorization code flow.
 	 *

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -399,7 +399,6 @@ export interface OAuthClient {
 	application_type?: "web" | "native";
 	//---- RFC6749 Spec ----//
 	public?: boolean;
-	type?: "web" | "native" | "user-agent-based";
 	//---- Not Part of RFC7591 Spec ----//
 	disabled?: boolean;
 	skip_consent?: boolean;

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -390,9 +390,8 @@ export interface OAuthClient {
 	/**
 	 * OIDC Registration application type, constraining redirect URI schemes and
 	 * hosts when provided: `native` clients use custom schemes, loopback `http`
-	 * redirects, or claimed `https` links; `web` clients require `https` on a
-	 * non-loopback host. Distinct from `type`, which tracks the RFC 6749 client
-	 * profile.
+	 * redirects, or claimed `https` links (RFC 8252 §7); `web` clients require
+	 * `https` on a non-loopback host. Must agree with `type` when both are sent.
 	 *
 	 * @default "web"
 	 * @see https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata

--- a/packages/oauth-provider/src/types/oauth.ts
+++ b/packages/oauth-provider/src/types/oauth.ts
@@ -387,6 +387,17 @@ export interface OAuthClient {
 	grant_types?: GrantType[];
 	response_types?: "code"[];
 	// | "token" // NEVER SUPPORT - deprecated in OAuth 2.1
+	/**
+	 * OIDC Registration application type, constraining redirect URI schemes and
+	 * hosts when provided: `native` clients use custom schemes, loopback `http`
+	 * redirects, or claimed `https` links; `web` clients require `https` on a
+	 * non-loopback host. Distinct from `type`, which tracks the RFC 6749 client
+	 * profile.
+	 *
+	 * @default "web"
+	 * @see https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
+	 */
+	application_type?: "web" | "native";
 	//---- RFC6749 Spec ----//
 	public?: boolean;
 	type?: "web" | "native" | "user-agent-based";

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -207,6 +207,10 @@ export const clientRegistrationRequestSchema = z.object({
 	grant_types: z.array(z.string().trim().min(1)).min(1).optional(),
 	response_types: z.array(z.enum(["code"])).optional(),
 	type: z.enum(["web", "native", "user-agent-based"]).optional(),
+	// OIDC Registration §2 / MCP SEP-837: constrains redirect URI schemes and
+	// hosts when provided. Distinct from `type`, which tracks the RFC 6749
+	// client profile.
+	application_type: z.enum(["web", "native"]).optional(),
 	subject_type: z.enum(["public", "pairwise"]).optional(),
 	// RFC 9449 §5.2: client asks for DPoP-bound access tokens.
 	dpop_bound_access_tokens: z.boolean().optional(),

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -206,9 +206,7 @@ export const clientRegistrationRequestSchema = z.object({
 	jwks_uri: z.string().optional(),
 	grant_types: z.array(z.string().trim().min(1)).min(1).optional(),
 	response_types: z.array(z.enum(["code"])).optional(),
-	type: z.enum(["web", "native", "user-agent-based"]).optional(),
-	// OIDC Registration §2: constrains redirect URI schemes and hosts when
-	// provided, and must agree with `type` when both are sent.
+	// OIDC Registration §2: constrains redirect URI schemes and hosts.
 	application_type: z.enum(["web", "native"]).optional(),
 	subject_type: z.enum(["public", "pairwise"]).optional(),
 	// RFC 9449 §5.2: client asks for DPoP-bound access tokens.

--- a/packages/oauth-provider/src/types/zod.ts
+++ b/packages/oauth-provider/src/types/zod.ts
@@ -207,9 +207,8 @@ export const clientRegistrationRequestSchema = z.object({
 	grant_types: z.array(z.string().trim().min(1)).min(1).optional(),
 	response_types: z.array(z.enum(["code"])).optional(),
 	type: z.enum(["web", "native", "user-agent-based"]).optional(),
-	// OIDC Registration §2 / MCP SEP-837: constrains redirect URI schemes and
-	// hosts when provided. Distinct from `type`, which tracks the RFC 6749
-	// client profile.
+	// OIDC Registration §2: constrains redirect URI schemes and hosts when
+	// provided, and must agree with `type` when both are sent.
 	application_type: z.enum(["web", "native"]).optional(),
 	subject_type: z.enum(["public", "pairwise"]).optional(),
 	// RFC 9449 §5.2: client asks for DPoP-bound access tokens.

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -956,8 +956,7 @@ export function isPKCERequired(
 	// Determine if client is public
 	const isPublicClient =
 		client.tokenEndpointAuthMethod === "none" ||
-		client.type === "native" ||
-		client.type === "user-agent-based" ||
+		client.applicationType === "native" ||
 		client.public === true;
 
 	// PKCE always required for public clients


### PR DESCRIPTION
OAuth client registration carried two overlapping fields for one concept. `type` (`web`/`native`/`user-agent-based`) is a better-auth invention with no RFC 7591 standing; `application_type` is the OIDC Registration field, and the one the MCP spec tells clients to send. Neither was checked against the other, so a client could register as `type: "web"` and `application_type: "native"` at once and be stored claiming two profiles.

`application_type` takes over, including the column `type` used to occupy. That matters beyond naming: `type` was consulted when deciding whether a client is public and therefore always subject to PKCE, so leaving `application_type` in the untyped metadata bag would have quietly narrowed that check. It is now a first-class field, and a `native` client is public whatever auth method it registered with, even one that asked for `require_pkce: false`.

`user-agent-based` has no successor. A browser app registers with `token_endpoint_auth_method: "none"`, which already marks it public, and OIDC has no third value to map it onto. Clients that had set `type` keep working; they are read as having declared no application type, which leaves their redirect URIs unconstrained rather than retroactively rejecting them.

Stacked on #10577, which introduced `application_type`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the non‑standard OAuth client `type` with OIDC’s `application_type`, making it a first‑class field and tightening public client rules. `native` clients are always public (PKCE required), and `user-agent-based` is removed.

- **Refactors**
  - Registration and client APIs in `@better-auth/oauth-provider` now accept/return `application_type` (`web` | `native`) and no longer support `type`.
  - Publicness logic reads `application_type`; `native` is always public (PKCE enforced), `web` may use a client secret.
  - Redirect URI checks are driven by `application_type` (native: custom schemes, loopback http, claimed https; web: https on non‑loopback).

- **Migration**
  - Replace `type: "web"` with `application_type: "web"`, `type: "native"` with `application_type: "native"`, and drop `type: "user-agent-based"`.
  - Run DB migration to add the `applicationType` column and remove `type` (e.g., `npx auth migrate` or `npx auth generate`).
  - Existing clients that only set `type` continue to work and are treated as having no `application_type` (no new redirect constraints applied).

<sup>Written for commit 74cdffdddeba8b08e4455d86c2062913d6175760. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

