### PR TITLE
fix(db): skip null-parsed session token in findSessions instead of returning early

### DIFF
--- a/.changeset/skip-invalid-secondary-sessions.md
+++ b/.changeset/skip-invalid-secondary-sessions.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Skip invalid secondary-storage session entries without discarding other valid sessions.

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -987,6 +987,54 @@ describe("internal adapter test", async () => {
 		);
 	});
 
+	it("findSessions should skip a null-parse token without discarding other sessions", async () => {
+		const testMap = new Map<string, string>();
+
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				set(key: string, value: string, ttl?: number) {
+					testMap.set(key, value);
+				},
+				get(key: string) {
+					return testMap.get(key) || null;
+				},
+				delete(key: string) {
+					testMap.delete(key);
+				},
+			},
+		} satisfies BetterAuthOptions;
+
+		(await getMigrations(testOpts)).runMigrations();
+
+		const testCtx = await init(testOpts);
+		const testInternalAdapter = testCtx.internalAdapter;
+
+		const user = await testInternalAdapter.createUser({
+			name: "test-user-null-parse",
+			email: "test-null-parse@email.com",
+		});
+
+		// Create 3 sessions
+		const session1 = await testInternalAdapter.createSession(user.id);
+		const session2 = await testInternalAdapter.createSession(user.id);
+		const session3 = await testInternalAdapter.createSession(user.id);
+
+		// session2's stored value parses to null (JSON.parse("null") === null)
+		testMap.set(session2.token, "null");
+
+		// findSessions should still return session1 and session3
+		const sessions = await testInternalAdapter.findSessions([
+			session1.token,
+			session2.token,
+			session3.token,
+		]);
+		expect(sessions.length).toBe(2);
+		expect(sessions.map((s) => s.session.token).sort()).toEqual(
+			[session1.token, session3.token].sort(),
+		);
+	});
+
 	it("should update session and active-sessions list in secondary storage", async () => {
 		const testMap = new Map<string, string>();
 		const testExpirationMap = new Map<string, number>();

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -939,100 +939,57 @@ describe("internal adapter test", async () => {
 		expect(sessions.length).toBe(0);
 	});
 
-	it("findSessions should skip corrupt sessions without blanking the list", async () => {
-		const testMap = new Map<string, string>();
-
-		const testOpts = {
+	it.each([
+		{
+			caseName: "malformed JSON sessions",
+			storedValue: "invalid-json{{{",
+		},
+		{
+			caseName: "JSON null sessions",
+			storedValue: "null",
+		},
+	])("findSessions skips $caseName without discarding valid sessions", async ({
+		storedValue,
+	}) => {
+		const secondaryStorageValues = new Map<string, string>();
+		const options = {
 			database: new DatabaseSync(":memory:"),
 			secondaryStorage: {
 				set(key: string, value: string, ttl?: number) {
-					testMap.set(key, value);
+					secondaryStorageValues.set(key, value);
 				},
 				get(key: string) {
-					return testMap.get(key) || null;
+					return secondaryStorageValues.get(key) || null;
 				},
 				delete(key: string) {
-					testMap.delete(key);
+					secondaryStorageValues.delete(key);
 				},
 			},
 		} satisfies BetterAuthOptions;
 
-		(await getMigrations(testOpts)).runMigrations();
+		(await getMigrations(options)).runMigrations();
 
-		const testCtx = await init(testOpts);
-		const testInternalAdapter = testCtx.internalAdapter;
-
-		const user = await testInternalAdapter.createUser({
+		const { internalAdapter } = await init(options);
+		const user = await internalAdapter.createUser({
 			name: "test-user-find",
 			email: "test-find@email.com",
 		});
+		const session1 = await internalAdapter.createSession(user.id);
+		const session2 = await internalAdapter.createSession(user.id);
+		const session3 = await internalAdapter.createSession(user.id);
 
-		// Create 3 sessions
-		const session1 = await testInternalAdapter.createSession(user.id);
-		const session2 = await testInternalAdapter.createSession(user.id);
-		const session3 = await testInternalAdapter.createSession(user.id);
+		secondaryStorageValues.set(session2.token, storedValue);
 
-		// Corrupt session2 data
-		testMap.set(session2.token, "invalid-json{{{");
-
-		// findSessions should still return session1 and session3
-		const sessions = await testInternalAdapter.findSessions([
+		const sessions = await internalAdapter.findSessions([
 			session1.token,
 			session2.token,
 			session3.token,
 		]);
-		expect(sessions.length).toBe(2);
-		expect(sessions.map((s) => s.session.token).sort()).toEqual(
-			[session1.token, session3.token].sort(),
-		);
-	});
 
-	it("findSessions should skip a null-parse token without discarding other sessions", async () => {
-		const testMap = new Map<string, string>();
-
-		const testOpts = {
-			database: new DatabaseSync(":memory:"),
-			secondaryStorage: {
-				set(key: string, value: string, ttl?: number) {
-					testMap.set(key, value);
-				},
-				get(key: string) {
-					return testMap.get(key) || null;
-				},
-				delete(key: string) {
-					testMap.delete(key);
-				},
-			},
-		} satisfies BetterAuthOptions;
-
-		(await getMigrations(testOpts)).runMigrations();
-
-		const testCtx = await init(testOpts);
-		const testInternalAdapter = testCtx.internalAdapter;
-
-		const user = await testInternalAdapter.createUser({
-			name: "test-user-null-parse",
-			email: "test-null-parse@email.com",
-		});
-
-		// Create 3 sessions
-		const session1 = await testInternalAdapter.createSession(user.id);
-		const session2 = await testInternalAdapter.createSession(user.id);
-		const session3 = await testInternalAdapter.createSession(user.id);
-
-		// session2's stored value parses to null (JSON.parse("null") === null)
-		testMap.set(session2.token, "null");
-
-		// findSessions should still return session1 and session3
-		const sessions = await testInternalAdapter.findSessions([
+		expect(sessions.map(({ session }) => session.token)).toEqual([
 			session1.token,
-			session2.token,
 			session3.token,
 		]);
-		expect(sessions.length).toBe(2);
-		expect(sessions.map((s) => s.session.token).sort()).toEqual(
-			[session1.token, session3.token].sort(),
-		);
 	});
 
 	it("should update session and active-sessions list in secondary storage", async () => {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -560,7 +560,7 @@ export const createInternalAdapter = (
 								session: Session;
 								user: User;
 							};
-							if (!s) return [];
+							if (!s) continue;
 							const expiresAt = new Date(s.session.expiresAt);
 							if (options?.onlyActiveSessions && expiresAt <= new Date()) {
 								continue;


### PR DESCRIPTION
skip null-parsed session token in findSessions instead of returning early

In `findSessions`, after fetching a session token from secondary storage and parsing it, there was a guard:

```ts
if (!s) return [];
```

`return []` exits the entire function immediately, throwing away any sessions already accumulated in the loop. The correct behavior is `continue`, skip the bad token and carry on, which is exactly what the `catch` block right below does for JSON syntax errors.

The scenario that triggers this: `secondaryStorage.get(token)` returns the string `"null"` (truthy, so it passes the outer `if (sessionStringified)` check), but `JSON.parse("null")` evaluates to `null`. That makes `!s` true, and the old code would silently wipe out every valid session processed so far.

In practice this means a user with multiple active sessions could lose all of them if any one session's secondary storage entry happened to contain `"null"`, whether from a misbehaving adapter, external tooling, or a cache eviction policy.

The fix is a one-character change. A regression test covering the `JSON.parse("null")` path is included alongside the existing syntax-error test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `findSessions` to skip tokens that parse to null instead of returning early, so valid sessions aren’t dropped. Users with multiple sessions now get correct results even if one token’s secondary storage value is `"null"` or malformed JSON.

- **Bug Fixes**
  - Replaces `return []` with `continue` when parsed value is `null` in `findSessions`.
  - Expands regression tests to cover both malformed JSON and `"null"` entries, ensuring other valid sessions are still returned.

<sup>Written for commit 94860d3d8727c740f5301c1c64bbd32f57f48c2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

