### PR TITLE
feat(core): inject auth-owned schema into adapter factories

### DIFF
--- a/docs/content/docs/guides/create-a-db-adapter.mdx
+++ b/docs/content/docs/guides/create-a-db-adapter.mdx
@@ -11,6 +11,32 @@ Our hope is to allow you to focus on writing database logic, and not have to wor
 Anything from custom schema configurations, custom ID generation, safe JSON parsing, key mapping, joins, and more is handled by the `createAdapterFactory` function.
 All you need to do is provide the database logic, and the `createAdapterFactory` function will handle the rest.
 
+## Logical schema ownership
+
+Better Auth distinguishes two schema layers:
+
+1. **Logical auth schema** — field and model names Better Auth uses at runtime (`accountId`, plugin fields, `user.fields` remaps, etc.). This is owned by the host `betterAuth({ ... })` init path via `getAuthTables(options)` in the same `@better-auth/core` as `better-auth`.
+2. **Physical ORM schema** — your Drizzle/Prisma/Kysely table definitions. That mapping stays adapter-local (for example Drizzle's `schema` option) and is separate from the logical auth schema.
+
+At init, Better Auth computes the logical schema once and passes it into your adapter factory as the second argument:
+
+```ts
+type DBAdapterInstance = (
+  options: BetterAuthOptions,
+  tables?: BetterAuthDBSchema,
+) => DBAdapter;
+```
+
+If you wrap `createAdapterFactory`, **forward `tables`** into the factory (including transaction clones). Do not call `getAuthTables(options)` yourself for runtime field resolution when `tables` is provided — a separately versioned adapter package can resolve a different `@better-auth/core` and rebuild a divergent field set (for example `providerAccountId` vs `accountId`).
+
+`createAdapterFactory` exposes the schema it used as `adapter.options.authTables` (the injected host schema when provided).
+
+### Versioning
+
+Keep `@better-auth/core` (and separately published adapter packages such as `@better-auth/drizzle-adapter`) on the same major/minor line as `better-auth`. Aligning versions still avoids other API mismatches beyond schema field names.
+
+CLI `generate` / `migrate` / `createSchema` flows should use `getAuthTables` from the installed `better-auth` / host core path — the same source as runtime — not an adapter-private rebuild.
+
 ## Quick Start
 
 <Steps>
@@ -36,10 +62,13 @@ All you need to do is provide the database logic, and the `createAdapterFactory`
       usePlural?: boolean;
     }
 
-    export const myAdapter = (config: CustomAdapterConfig = {}) =>
-      createAdapterFactory({
+    export const myAdapter = (config: CustomAdapterConfig = {}) => {
+      const adapterCreator = createAdapterFactory({
         // ...
       });
+      // Forward auth-owned `tables` so runtime field resolution matches better-auth.
+      return (options, tables) => adapterCreator(options, tables);
+    };
     ```
   </Step>
 

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -200,7 +200,9 @@ Most of the features of Better Auth will not work correctly.`,
 
 	checkEndpointConflicts(options, logger);
 	const cookies = getCookies(options);
-	const tables = getAuthTables(options);
+	// Prefer the auth-owned schema already injected into the adapter so
+	// ctx.tables and adapter field resolution share one logical schema instance.
+	const tables = adapter.options?.authTables ?? getAuthTables(options);
 	// TODO(#9294): allow registering the same provider multiple times under
 	// distinct ids (e.g. `google:ios`, `google:android`) to support
 	// per-platform clientSecret/redirectURI in the authorization code flow.

--- a/packages/better-auth/src/db/adapter-base.test.ts
+++ b/packages/better-auth/src/db/adapter-base.test.ts
@@ -1,0 +1,64 @@
+import type { BetterAuthOptions } from "@better-auth/core";
+import type { BetterAuthDBSchema } from "@better-auth/core/db";
+import { getAuthTables } from "@better-auth/core/db";
+import type { CustomAdapter, DBAdapter } from "@better-auth/core/db/adapter";
+import { createAdapterFactory } from "@better-auth/core/db/adapter";
+import { describe, expect, it } from "vitest";
+import { getBaseAdapter } from "./adapter-base";
+
+function createStubCustomAdapter(): CustomAdapter {
+	return {
+		create: async <T extends Record<string, unknown>>({ data }: { data: T }) =>
+			data,
+		update: async () => null,
+		updateMany: async () => 0,
+		findOne: async () => null,
+		findMany: async () => [],
+		delete: async () => {},
+		deleteMany: async () => 0,
+		consumeOne: async () => null,
+		incrementOne: async () => null,
+		count: async () => 0,
+	};
+}
+
+describe("getBaseAdapter auth-owned schema", () => {
+	it("injects host tables into the adapter factory", async () => {
+		const options: BetterAuthOptions = {
+			user: {
+				fields: {
+					email: "email_address",
+				},
+			},
+		};
+		let receivedTables: BetterAuthDBSchema | undefined;
+
+		const database = (
+			opts: BetterAuthOptions,
+			tables?: BetterAuthDBSchema,
+		): DBAdapter<BetterAuthOptions> => {
+			receivedTables = tables;
+			return createAdapterFactory({
+				config: {
+					adapterId: "stub",
+					adapterName: "Stub Adapter",
+				},
+				adapter: () => createStubCustomAdapter(),
+			})(opts, tables);
+		};
+
+		const adapter = await getBaseAdapter({ ...options, database }, async () => {
+			throw new Error("direct database path should not run");
+		});
+
+		const hostTables = getAuthTables(options);
+		expect(receivedTables).toBeDefined();
+		expect(Object.keys(receivedTables!.user!.fields)).toEqual(
+			Object.keys(hostTables.user!.fields),
+		);
+		expect(adapter.options?.authTables).toBe(receivedTables);
+		expect(adapter.options?.authTables?.user?.fields.email?.fieldName).toBe(
+			"email_address",
+		);
+	});
+});

--- a/packages/better-auth/src/db/adapter-base.ts
+++ b/packages/better-auth/src/db/adapter-base.ts
@@ -1,4 +1,5 @@
 import type { BetterAuthOptions } from "@better-auth/core";
+import type { BetterAuthDBSchema } from "@better-auth/core/db";
 import { getAuthTables } from "@better-auth/core/db";
 import type { DBAdapter } from "@better-auth/core/db/adapter";
 import { logger } from "@better-auth/core/env";
@@ -8,22 +9,27 @@ export async function getBaseAdapter(
 	options: BetterAuthOptions,
 	handleDirectDatabase: (
 		options: BetterAuthOptions,
+		tables: BetterAuthDBSchema,
 	) => Promise<DBAdapter<BetterAuthOptions>>,
 ): Promise<DBAdapter<BetterAuthOptions>> {
+	// Single source of truth for the logical auth schema: host better-auth's
+	// @better-auth/core. Adapters receive this instead of rebuilding via their
+	// own getAuthTables (which can diverge under package version skew).
+	const tables = getAuthTables(options);
+
 	let adapter: DBAdapter<BetterAuthOptions>;
 
 	if (!options.database) {
-		const tables = getAuthTables(options);
 		const memoryDB = Object.keys(tables).reduce<MemoryDB>((acc, key) => {
 			acc[key] = [];
 			return acc;
 		}, {});
 		const { memoryAdapter } = await import("@better-auth/memory-adapter");
-		adapter = memoryAdapter(memoryDB)(options);
+		adapter = memoryAdapter(memoryDB)(options, tables);
 	} else if (typeof options.database === "function") {
-		adapter = options.database(options);
+		adapter = options.database(options, tables);
 	} else {
-		adapter = await handleDirectDatabase(options);
+		adapter = await handleDirectDatabase(options, tables);
 	}
 
 	// patch for 1.3.x to ensure we have a transaction function in the adapter

--- a/packages/better-auth/src/db/adapter-kysely.ts
+++ b/packages/better-auth/src/db/adapter-kysely.ts
@@ -6,7 +6,7 @@ import { getBaseAdapter } from "./adapter-base";
 export async function getAdapter(
 	options: BetterAuthOptions,
 ): Promise<DBAdapter<BetterAuthOptions>> {
-	return getBaseAdapter(options, async (opts) => {
+	return getBaseAdapter(options, async (opts, tables) => {
 		const { createKyselyAdapter } = await import("../adapters/kysely-adapter");
 		const { kysely, databaseType, transaction } =
 			await createKyselyAdapter(opts);
@@ -21,6 +21,6 @@ export async function getAdapter(
 					? opts.database.debugLogs
 					: false,
 			transaction: transaction,
-		})(opts);
+		})(opts, tables);
 	});
 }

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { BetterAuthOptions } from "../../types";
+import { getAuthTables } from "../get-tables";
+import type { BetterAuthDBSchema } from "../type";
 import { createAdapterFactory } from "./factory";
 import type { CustomAdapter, Where } from "./index";
 
@@ -254,5 +256,240 @@ describe("createAdapterFactory atomic primitives", () => {
 				update: { value: "next" },
 			}),
 		).rejects.toThrow(/updateMany must return a finite number/);
+	});
+});
+
+describe("createAdapterFactory auth-owned schema injection", () => {
+	it("uses the injected tables instance for field resolution and authTables", async () => {
+		const options: BetterAuthOptions = {
+			account: {
+				fields: {
+					accountId: "provider_account_id",
+				},
+			},
+		};
+		const tables = getAuthTables(options);
+		let observedSchema: BetterAuthDBSchema | undefined;
+
+		const adapter = createAdapterFactory<BetterAuthOptions>({
+			config: {
+				adapterId: "schema-injection",
+				adapterName: "Schema Injection Adapter",
+			},
+			adapter: ({ schema }) => {
+				observedSchema = schema;
+				return createCustomAdapter({
+					findOne: (async ({ model, where }) => {
+						expect(model).toBe("account");
+						expect(where[0]?.field).toBe("provider_account_id");
+						return {
+							id: "acc-1",
+							provider_account_id: "oauth-sub",
+						};
+					}) as CustomAdapter["findOne"],
+				});
+			},
+		})(options, tables);
+
+		expect(observedSchema).toBe(tables);
+		expect(adapter.options?.authTables).toBe(tables);
+
+		const result = await adapter.findOne<{
+			id: string;
+			accountId: string;
+		}>({
+			model: "account",
+			where: [{ field: "accountId", value: "oauth-sub" }],
+		});
+		expect(result).toEqual({
+			id: "acc-1",
+			accountId: "oauth-sub",
+		});
+	});
+
+	it("resolves plugin-contributed fields from the injected schema", async () => {
+		const options: BetterAuthOptions = {
+			plugins: [
+				{
+					id: "custom-plugin",
+					schema: {
+						user: {
+							fields: {
+								role: {
+									type: "string",
+									required: false,
+									fieldName: "user_role",
+								},
+							},
+						},
+					},
+				},
+			],
+		};
+		const tables = getAuthTables(options);
+
+		const adapter = createAdapterFactory<BetterAuthOptions>({
+			config: {
+				adapterId: "plugin-schema",
+				adapterName: "Plugin Schema Adapter",
+			},
+			adapter: ({ getFieldName }) =>
+				createCustomAdapter({
+					create: async ({ data, model }) => {
+						expect(model).toBe("user");
+						expect(getFieldName({ model: "user", field: "role" })).toBe(
+							"user_role",
+						);
+						expect(data).toMatchObject({
+							user_role: "admin",
+						});
+						return { id: "u-1", ...data };
+					},
+				}),
+		})(options, tables);
+
+		const created = await adapter.create({
+			model: "user",
+			data: {
+				name: "Ada",
+				email: "ada@example.com",
+				emailVerified: false,
+				role: "admin",
+			},
+			forceAllowId: true,
+		});
+		expect(created).toMatchObject({
+			role: "admin",
+		});
+		expect(created).toHaveProperty("id");
+	});
+
+	it("resolves custom user.fields mappings from the injected schema", async () => {
+		const options: BetterAuthOptions = {
+			user: {
+				fields: {
+					email: "email_address",
+					name: "full_name",
+				},
+			},
+		};
+		const tables = getAuthTables(options);
+
+		const adapter = createAdapterFactory<BetterAuthOptions>({
+			config: {
+				adapterId: "custom-fields",
+				adapterName: "Custom Fields Adapter",
+			},
+			adapter: () =>
+				createCustomAdapter({
+					findMany: (async ({ model, where }) => {
+						expect(model).toBe("user");
+						expect(where?.[0]?.field).toBe("email_address");
+						return [
+							{
+								id: "u-1",
+								email_address: "ada@example.com",
+								full_name: "Ada Lovelace",
+							},
+						];
+					}) as CustomAdapter["findMany"],
+				}),
+		})(options, tables);
+
+		const users = await adapter.findMany<{
+			id: string;
+			email: string;
+			name: string;
+		}>({
+			model: "user",
+			where: [{ field: "email", value: "ada@example.com" }],
+		});
+		expect(users).toEqual([
+			{
+				id: "u-1",
+				email: "ada@example.com",
+				name: "Ada Lovelace",
+			},
+		]);
+	});
+
+	/**
+	 * Simulates an adapter package that rebuilt schema with a divergent core
+	 * (providerAccountId/issuer) while the host still uses accountId.
+	 * Injected host tables must win so OAuth account lookups keep working.
+	 */
+	it("keeps accountId resolution when injected schema differs from a divergent local rebuild", async () => {
+		const options: BetterAuthOptions = {};
+		const hostTables = getAuthTables(options);
+
+		// Divergent "adapter-local" schema shape (historical providerAccountId era).
+		// createAdapterFactory must NOT use this when host tables are injected.
+		const divergentLocal: BetterAuthDBSchema = {
+			...hostTables,
+			account: {
+				...hostTables.account!,
+				fields: {
+					providerAccountId: {
+						type: "string",
+						required: true,
+						fieldName: "providerAccountId",
+					},
+					providerId: hostTables.account!.fields.providerId!,
+					userId: hostTables.account!.fields.userId!,
+					createdAt: hostTables.account!.fields.createdAt!,
+					updatedAt: hostTables.account!.fields.updatedAt!,
+				},
+			},
+		};
+		expect(divergentLocal.account!.fields.accountId).toBeUndefined();
+		expect(hostTables.account!.fields.accountId).toBeDefined();
+
+		const adapter = createAdapterFactory<BetterAuthOptions>({
+			config: {
+				adapterId: "oauth-account-id",
+				adapterName: "OAuth AccountId Adapter",
+			},
+			adapter: ({ schema, getFieldName }) => {
+				expect(schema).toBe(hostTables);
+				expect(schema).not.toBe(divergentLocal);
+				expect(getFieldName({ model: "account", field: "accountId" })).toBe(
+					"accountId",
+				);
+				return createCustomAdapter({
+					findOne: (async ({ where }) => {
+						expect(where[0]?.field).toBe("accountId");
+						return {
+							id: "acc-1",
+							accountId: "provider-sub",
+							providerId: "google",
+							userId: "u-1",
+						};
+					}) as CustomAdapter["findOne"],
+				});
+			},
+		})(options, hostTables);
+
+		const account = await adapter.findOne({
+			model: "account",
+			where: [{ field: "accountId", value: "provider-sub" }],
+		});
+		expect(account).toMatchObject({
+			accountId: "provider-sub",
+			providerId: "google",
+		});
+	});
+
+	it("falls back to getAuthTables when tables are omitted (compat)", () => {
+		const adapter = createAdapterFactory<BetterAuthOptions>({
+			config: {
+				adapterId: "compat",
+				adapterName: "Compat Adapter",
+			},
+			adapter: () => createCustomAdapter(),
+		})({});
+
+		expect(
+			adapter.options?.authTables?.account?.fields.accountId,
+		).toBeDefined();
 	});
 });

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -8,6 +8,7 @@ import { BetterAuthError } from "../../error";
 import type { BetterAuthOptions } from "../../types";
 import { safeJSONParse } from "../../utils/json";
 import { getAuthTables } from "../get-tables";
+import type { BetterAuthDBSchema } from "../type";
 import { initGetDefaultFieldName } from "./get-default-field-name";
 import { initGetDefaultModelName } from "./get-default-model-name";
 import { initGetFieldAttributes } from "./get-field-attributes";
@@ -49,6 +50,13 @@ const createAsIsTransaction =
 
 export type AdapterFactory<Options extends BetterAuthOptions> = (
 	options: Options,
+	/**
+	 * Auth-owned logical schema from the host Better Auth init path.
+	 * Prefer this over rebuilding via `getAuthTables` so adapters cannot
+	 * diverge when a separately versioned adapter package resolves a
+	 * different `@better-auth/core`.
+	 */
+	tables?: BetterAuthDBSchema | undefined,
 ) => DBAdapter<Options>;
 
 export const createAdapterFactory =
@@ -56,7 +64,7 @@ export const createAdapterFactory =
 		adapter: customAdapter,
 		config: cfg,
 	}: AdapterFactoryOptions): AdapterFactory<Options> =>
-	(options: Options): DBAdapter<Options> => {
+	(options: Options, tables): DBAdapter<Options> => {
 		const uniqueAdapterFactoryInstanceId = Math.random()
 			.toString(36)
 			.substring(2, 15);
@@ -83,8 +91,9 @@ export const createAdapterFactory =
 			);
 		}
 
-		// End-user's Better-Auth instance's schema
-		const schema = getAuthTables(options);
+		// Prefer the auth-owned schema injected by better-auth init. Fallback to
+		// getAuthTables only for direct/legacy factory callers that omit tables.
+		const schema = tables ?? getAuthTables(options);
 
 		const debugLog = (...args: any[]) => {
 			if (config.debugLogs === true || typeof config.debugLogs === "object") {
@@ -1539,22 +1548,33 @@ export const createAdapterFactory =
 			},
 			createSchema: adapterInstance.createSchema
 				? async (_, file) => {
-						const tables = getAuthTables(options);
+						// Use the same logical schema instance as runtime field resolution.
+						const tablesForSchema = { ...schema };
 
 						if (
 							options.secondaryStorage &&
 							!options.session?.storeSessionInDatabase
 						) {
 							// biome-ignore lint/performance/noDelete: If the user has enabled secondaryStorage, as well as not specifying to store session table in DB, then createSchema shouldn't generate schema table.
-							delete tables.session;
+							delete tablesForSchema.session;
 						}
 
-						return adapterInstance.createSchema!({ file, tables });
+						return adapterInstance.createSchema!({
+							file,
+							tables: tablesForSchema,
+						});
 					}
 				: undefined,
 			options: {
 				adapterConfig: config,
 				...(adapterInstance.options ?? {}),
+				/**
+				 * Logical schema this adapter instance uses for field/model resolution.
+				 * Same object as the auth-owned `tables` when the host injected it.
+				 * Assigned last so adapter-local `schema` (physical ORM mapping) cannot
+				 * overwrite it.
+				 */
+				authTables: schema,
 			},
 			id: config.adapterId,
 

--- a/packages/core/src/db/adapter/index.ts
+++ b/packages/core/src/db/adapter/index.ts
@@ -512,6 +512,15 @@ export type DBAdapter<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	options?:
 		| ({
 				adapterConfig: DBAdapterFactoryConfig<Options>;
+				/**
+				 * Logical Better Auth schema used for field/model name resolution.
+				 * Set by `createAdapterFactory` from the auth-owned `tables` argument
+				 * when provided by the host, otherwise from a compat `getAuthTables` call.
+				 *
+				 * Named `authTables` (not `schema`) so it never collides with adapter-local
+				 * physical ORM schemas (e.g. Drizzle `config.schema`).
+				 */
+				authTables?: BetterAuthDBSchema | undefined;
 		  } & CustomAdapter["options"])
 		| undefined;
 };
@@ -636,7 +645,21 @@ export interface CustomAdapter {
 export interface DBAdapterInstance<
 	Options extends BetterAuthOptions = BetterAuthOptions,
 > {
-	(options: BetterAuthOptions): DBAdapter<Options>;
+	/**
+	 * Create a DB adapter for the given Better Auth options.
+	 *
+	 * @param options - Better Auth options for this auth instance.
+	 * @param tables - Auth-owned logical schema from the host `better-auth`
+	 *   init path (`getAuthTables` in the same `@better-auth/core` as the host).
+	 *   When provided, adapters built with `createAdapterFactory` must use this
+	 *   schema for field/model resolution instead of calling `getAuthTables`
+	 *   themselves. Physical ORM mapping (Drizzle/Prisma schemas) remains
+	 *   adapter-local and separate.
+	 */
+	(
+		options: BetterAuthOptions,
+		tables?: BetterAuthDBSchema | undefined,
+	): DBAdapter<Options>;
 }
 
 export * from "./factory";

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -1,3 +1,4 @@
+import { getAuthTables } from "@better-auth/core/db";
 import { is, Param, SQL } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 import { drizzleAdapter } from "./drizzle-adapter";
@@ -14,6 +15,29 @@ describe("drizzle-adapter", () => {
 		};
 		const adapter = drizzleAdapter(db, config);
 		expect(adapter).toBeDefined();
+	});
+
+	it("uses the auth-owned tables instance when provided by better-auth init", () => {
+		const db = {
+			_: {
+				fullSchema: {},
+			},
+		} as any;
+		const factory = drizzleAdapter(db, { provider: "sqlite" });
+		const options = {
+			secret: "test-secret-that-is-at-least-32-chars-long!!",
+			account: {
+				fields: {
+					accountId: "provider_account_id",
+				},
+			},
+		};
+		const tables = getAuthTables(options);
+		const adapter = factory(options, tables);
+		expect(adapter.options?.authTables).toBe(tables);
+		expect(
+			adapter.options?.authTables?.account?.fields.accountId?.fieldName,
+		).toBe("provider_account_id");
 	});
 
 	it("should use unique column fallback for MySQL creates without an id", async () => {

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -1,4 +1,5 @@
 import type { BetterAuthOptions } from "@better-auth/core";
+import type { BetterAuthDBSchema } from "@better-auth/core/db";
 import type {
 	AdapterFactoryCustomizeAdapterCreator,
 	AdapterFactoryOptions,
@@ -137,6 +138,7 @@ export interface DrizzleAdapterConfig {
 
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
+	let lazyTables: BetterAuthDBSchema | undefined;
 	let mysqlNoIdWarned = false;
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
@@ -1134,7 +1136,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 										transaction: false,
 									},
 									adapter: createCustomAdapter(tx, true),
-								})(lazyOptions!);
+								})(lazyOptions!, lazyTables);
 								return cb(adapter);
 							})
 					: false,
@@ -1142,8 +1144,12 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 		adapter: createCustomAdapter(db),
 	};
 	const adapter = createAdapterFactory(adapterOptions);
-	return (options: BetterAuthOptions): DBAdapter<BetterAuthOptions> => {
+	return (
+		options: BetterAuthOptions,
+		tables?: BetterAuthDBSchema,
+	): DBAdapter<BetterAuthOptions> => {
 		lazyOptions = options;
-		return adapter(options);
+		lazyTables = tables;
+		return adapter(options, tables);
 	};
 };

--- a/packages/kysely-adapter/src/kysely-adapter.ts
+++ b/packages/kysely-adapter/src/kysely-adapter.ts
@@ -1,4 +1,5 @@
 import type { BetterAuthOptions } from "@better-auth/core";
+import type { BetterAuthDBSchema } from "@better-auth/core/db";
 import type {
 	AdapterFactoryCustomizeAdapterCreator,
 	AdapterFactoryOptions,
@@ -58,6 +59,7 @@ export const kyselyAdapter = (
 	config?: KyselyAdapterConfig | undefined,
 ) => {
 	let lazyOptions: BetterAuthOptions | null = null;
+	let lazyTables: BetterAuthDBSchema | undefined;
 	let mysqlNoIdWarned = false;
 	const createCustomAdapter = (
 		db: Kysely<any>,
@@ -938,7 +940,7 @@ export const kyselyAdapter = (
 									transaction: false,
 								},
 								adapter: createCustomAdapter(trx, true),
-							})(lazyOptions!);
+							})(lazyOptions!, lazyTables);
 							return cb(adapter);
 						})
 				: false,
@@ -948,8 +950,12 @@ export const kyselyAdapter = (
 
 	const adapter = createAdapterFactory(adapterOptions);
 
-	return (options: BetterAuthOptions): DBAdapter<BetterAuthOptions> => {
+	return (
+		options: BetterAuthOptions,
+		tables?: BetterAuthDBSchema,
+	): DBAdapter<BetterAuthOptions> => {
 		lazyOptions = options;
-		return adapter(options);
+		lazyTables = tables;
+		return adapter(options, tables);
 	};
 };

--- a/packages/memory-adapter/src/memory-adapter.ts
+++ b/packages/memory-adapter/src/memory-adapter.ts
@@ -1,4 +1,5 @@
 import type { BetterAuthOptions } from "@better-auth/core";
+import type { BetterAuthDBSchema } from "@better-auth/core/db";
 import type {
 	CleanedWhere,
 	DBAdapterDebugLogOption,
@@ -124,6 +125,7 @@ export const memoryAdapter = (
 	config?: MemoryAdapterConfig | undefined,
 ) => {
 	let lazyOptions: BetterAuthOptions | null = null;
+	let lazyTables: BetterAuthDBSchema | undefined;
 
 	/**
 	 * Build an adapter factory whose operations read and write `activeDb`.
@@ -166,7 +168,10 @@ export const memoryAdapter = (
 					// `await` point.
 					const base = structuredClone(activeDb);
 					const clone = structuredClone(activeDb);
-					const trxAdapter = buildAdapterFactory(clone)(lazyOptions!);
+					const trxAdapter = buildAdapterFactory(clone)(
+						lazyOptions!,
+						lazyTables,
+					);
 					const result = await cb(trxAdapter);
 					mergeTransactionInto(activeDb, base, clone);
 					return result;
@@ -565,8 +570,9 @@ export const memoryAdapter = (
 		});
 
 	const adapterCreator = buildAdapterFactory(db);
-	return (options: BetterAuthOptions) => {
+	return (options: BetterAuthOptions, tables?: BetterAuthDBSchema) => {
 		lazyOptions = options;
-		return adapterCreator(options);
+		lazyTables = tables;
+		return adapterCreator(options, tables);
 	};
 };

--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -1,4 +1,5 @@
 import type { BetterAuthOptions } from "@better-auth/core";
+import type { BetterAuthDBSchema } from "@better-auth/core/db";
 import type {
 	AdapterFactoryCustomizeAdapterCreator,
 	AdapterFactoryOptions,
@@ -65,6 +66,7 @@ export const mongodbAdapter = (
 	config?: MongoDBAdapterConfig | undefined,
 ) => {
 	let lazyOptions: BetterAuthOptions | null;
+	let lazyTables: BetterAuthDBSchema | undefined;
 
 	const getCustomIdGenerator = (options: BetterAuthOptions) => {
 		const generator = options.advanced?.database?.generateId;
@@ -669,7 +671,10 @@ export const mongodbAdapter = (
 		};
 
 	let lazyAdapter:
-		| ((options: BetterAuthOptions) => DBAdapter<BetterAuthOptions>)
+		| ((
+				options: BetterAuthOptions,
+				tables?: BetterAuthDBSchema,
+		  ) => DBAdapter<BetterAuthOptions>)
 		| null = null;
 	let adapterOptions: AdapterFactoryOptions | null = null;
 	adapterOptions = {
@@ -690,7 +695,7 @@ export const mongodbAdapter = (
 				config?.client && (config?.transaction ?? true)
 					? async (cb) => {
 							if (!config.client) {
-								return cb(lazyAdapter!(lazyOptions!));
+								return cb(lazyAdapter!(lazyOptions!, lazyTables));
 							}
 
 							const session = config.client.startSession();
@@ -704,7 +709,7 @@ export const mongodbAdapter = (
 										transaction: false,
 									},
 									adapter: createCustomAdapter(db, session),
-								})(lazyOptions!);
+								})(lazyOptions!, lazyTables);
 
 								const result = await cb(adapter);
 
@@ -804,8 +809,12 @@ export const mongodbAdapter = (
 	};
 	lazyAdapter = createAdapterFactory(adapterOptions);
 
-	return (options: BetterAuthOptions): DBAdapter<BetterAuthOptions> => {
+	return (
+		options: BetterAuthOptions,
+		tables?: BetterAuthDBSchema,
+	): DBAdapter<BetterAuthOptions> => {
 		lazyOptions = options;
-		return lazyAdapter(options);
+		lazyTables = tables;
+		return lazyAdapter(options, tables);
 	};
 };

--- a/packages/prisma-adapter/src/prisma-adapter.ts
+++ b/packages/prisma-adapter/src/prisma-adapter.ts
@@ -1,4 +1,5 @@
 import type { Awaitable, BetterAuthOptions } from "@better-auth/core";
+import type { BetterAuthDBSchema } from "@better-auth/core/db";
 import type {
 	AdapterFactoryCustomizeAdapterCreator,
 	AdapterFactoryOptions,
@@ -72,6 +73,7 @@ type PrismaClientInternal = {
 
 export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
+	let lazyTables: BetterAuthDBSchema | undefined;
 	const createCustomAdapter =
 		(
 			prisma: PrismaClient,
@@ -794,7 +796,7 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 										transaction: false,
 									},
 									adapter: createCustomAdapter(tx, true),
-								})(lazyOptions!);
+								})(lazyOptions!, lazyTables);
 								return cb(adapter);
 							})
 					: false,
@@ -803,8 +805,12 @@ export const prismaAdapter = (prisma: PrismaClient, config: PrismaConfig) => {
 	};
 
 	const adapter = createAdapterFactory(adapterOptions);
-	return (options: BetterAuthOptions): DBAdapter<BetterAuthOptions> => {
+	return (
+		options: BetterAuthOptions,
+		tables?: BetterAuthDBSchema,
+	): DBAdapter<BetterAuthOptions> => {
 		lazyOptions = options;
-		return adapter(options);
+		lazyTables = tables;
+		return adapter(options, tables);
 	};
 };

--- a/packages/test-utils/src/adapter/create-test-suite.ts
+++ b/packages/test-utils/src/adapter/create-test-suite.ts
@@ -272,7 +272,8 @@ export const createTestSuite = <
 					disableTransformJoin: true,
 				};
 				const adapterCreator = (
-					options: BetterAuthOptions,
+					factoryOptions: BetterAuthOptions,
+					tables?: ReturnType<typeof getAuthTables>,
 				): DBAdapter<BetterAuthOptions> =>
 					createAdapterFactory({
 						config: {
@@ -349,9 +350,9 @@ export const createTestSuite = <
 								options: adapter.options,
 							};
 						},
-					})(options);
+					})(factoryOptions, tables);
 
-				return adapterCreator(options);
+				return adapterCreator(options, adapter.options?.authTables);
 			};
 
 			const resetDebugLogs = () => {

--- a/packages/test-utils/src/adapter/test-adapter.ts
+++ b/packages/test-utils/src/adapter/test-adapter.ts
@@ -38,7 +38,12 @@ export const testAdapter = async ({
 	 */
 	adapter: (
 		options: BetterAuthOptions,
-	) => Awaitable<(options: BetterAuthOptions) => DBAdapter<BetterAuthOptions>>;
+	) => Awaitable<
+		(
+			options: BetterAuthOptions,
+			tables?: ReturnType<typeof getAuthTables>,
+		) => DBAdapter<BetterAuthOptions>
+	>;
 	/**
 	 * A function that will run the database migrations.
 	 */
@@ -85,16 +90,18 @@ export const testAdapter = async ({
 		} satisfies BetterAuthOptions;
 	})();
 
+	const authTables = getAuthTables(betterAuthOptions);
 	let adapter: DBAdapter<BetterAuthOptions> = (
 		await getAdapter(betterAuthOptions)
-	)(betterAuthOptions);
+	)(betterAuthOptions, authTables);
 
 	const adapterName = adapter.options?.adapterConfig.adapterName;
 	const adapterId = adapter.options?.adapterConfig.adapterId || adapter.id;
 	const adapterDisplayName = adapterName || adapterId;
 
 	const refreshAdapter = async (betterAuthOptions: BetterAuthOptions) => {
-		adapter = (await getAdapter(betterAuthOptions))(betterAuthOptions);
+		const tables = getAuthTables(betterAuthOptions);
+		adapter = (await getAdapter(betterAuthOptions))(betterAuthOptions, tables);
 	};
 
 	/**


### PR DESCRIPTION
## Summary
- Make Better Auth the single source of truth for the **logical** auth schema at adapter runtime: host init computes `getAuthTables(options)` once and passes `tables` into adapter factories.
- Update `createAdapterFactory` / `DBAdapterInstance` to accept optional `tables`, prefer the injected schema over a second `getAuthTables` call, and expose it as `adapter.options.authTables`.
- Forward `tables` through drizzle / prisma / mongo / kysely / memory adapters (including transaction clones), reuse `authTables` on `ctx.tables`, and document logical vs physical schema ownership for adapter authors.

This prevents package-version skew (e.g. `better-auth@1.6` + `@better-auth/drizzle-adapter@1.7` resolving different `@better-auth/core` copies) from silently rebuilding divergent field sets such as `accountId` vs `providerAccountId` / `issuer`. Physical ORM mapping (Drizzle `schema`, Prisma models, etc.) remains adapter-local and is not conflated with logical auth schema ownership.

### Ownership model (before → after)
**Before:** `betterAuth` and each adapter factory independently called `getAuthTables` from whatever `@better-auth/core` their package resolved.

**After:** Host `better-auth` owns the logical schema; adapters consume the injected `tables` for field/model resolution. Compat fallback to `getAuthTables(options)` remains when `tables` is omitted.

### Migration notes
- Adapter wrappers should forward the second `tables` argument into `createAdapterFactory` (and into transaction-scoped factory recreations).
- Public adapter config APIs are otherwise unchanged; physical ORM `schema` options are unchanged.
