### PR TITLE
fix(custom-session): forward session cookie cleanup when session is null

### DIFF
--- a/.changeset/custom-session-expired-cookie-cleanup.md
+++ b/.changeset/custom-session-expired-cookie-cleanup.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix `customSession()` leaving stale session cookies in the browser. When the session is expired or no longer exists, `get-session` now expires the `session_token` / `session_data` cookies as it does without the plugin, instead of returning `null` with no `Set-Cookie` headers.

--- a/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
+++ b/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
@@ -312,6 +312,63 @@ describe("Custom Session Plugin Tests", async () => {
 		});
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10567
+	 */
+	it("should expire the session cookies when the session is no longer valid", async () => {
+		const staleOptions = {
+			plugins: [
+				customSession(async ({ user, session }) => {
+					return { user, session };
+				}),
+			],
+		} satisfies BetterAuthOptions;
+
+		const {
+			auth: staleAuth,
+			client: staleClient,
+			signInWithTestUser: signInWithStaleUser,
+			db,
+		} = await getTestInstance(staleOptions, {
+			clientOptions: {
+				plugins: [customSessionClient<{ options: typeof staleOptions }>()],
+			},
+		});
+
+		const { headers } = await signInWithStaleUser();
+		const activeSession = await staleAuth.api.getSession({ headers });
+		const sessionToken = activeSession?.session.token;
+		if (!sessionToken) throw new Error("expected an active session");
+
+		// Revoke the backing session row while the client keeps its cookies.
+		await db.delete({
+			model: "session",
+			where: [{ field: "token", value: sessionToken }],
+		});
+
+		let setCookies: string[] = [];
+		const session = await staleClient.getSession({
+			fetchOptions: {
+				headers,
+				onResponse(context) {
+					setCookies = context.response.headers.getSetCookie();
+				},
+			},
+		});
+
+		expect(session.data).toBeNull();
+
+		const parsedCookies = new Map(
+			setCookies.flatMap((cookieString) =>
+				Array.from(parseSetCookieHeader(cookieString).entries()),
+			),
+		);
+		const expiredSessionToken = parsedCookies.get("better-auth.session_token");
+		expect(expiredSessionToken).toBeDefined();
+		expect(expiredSessionToken?.value).toBe("");
+		expect(expiredSessionToken?.["max-age"]).toBe(0);
+	});
+
 	it.skipIf(globalThis.gc == null)(
 		"should not create memory leaks with multiple plugin instances",
 		async () => {

--- a/packages/better-auth/src/plugins/custom-session/index.ts
+++ b/packages/better-auth/src/plugins/custom-session/index.ts
@@ -107,22 +107,28 @@ export const customSession = <
 					}).catch((e) => {
 						return null;
 					});
+					/**
+					 * Forwarded before the null check, so that the inner call's
+					 * cookie cleanup (`deleteSessionCookie`) still reaches the
+					 * response when the session is missing or expired.
+					 */
+					if (session?.headers) {
+						for (const cookieStr of session.headers.getSetCookie()) {
+							const parsed = parseSetCookieHeader(cookieStr);
+							parsed.forEach((attrs, name) => {
+								ctx.setCookie(name, attrs.value, toCookieOptions(attrs));
+							});
+						}
+						session.headers.delete("set-cookie");
+
+						session.headers.forEach((value, key) => {
+							ctx.setHeader(key, value);
+						});
+					}
 					if (!session?.response) {
 						return ctx.json(null);
 					}
 					const fnResult = await fn(session.response as any, ctx);
-
-					for (const cookieStr of session.headers.getSetCookie()) {
-						const parsed = parseSetCookieHeader(cookieStr);
-						parsed.forEach((attrs, name) => {
-							ctx.setCookie(name, attrs.value, toCookieOptions(attrs));
-						});
-					}
-					session.headers.delete("set-cookie");
-
-					session.headers.forEach((value, key) => {
-						ctx.setHeader(key, value);
-					});
 					return ctx.json(fnResult);
 				},
 			),


### PR DESCRIPTION
### What

`customSession()`'s `/get-session` endpoint returned early when the inner `getSession()` call produced a `null` response, which discarded the `Set-Cookie` headers that call had accumulated on its own `returnHeaders`.

The core endpoint calls `deleteSessionCookie(ctx)` on the not-found/expired branch, so without the plugin an invalid session cookie is expired on the response. With the plugin the response carried no `Set-Cookie` at all, so the stale `session_token` / `session_data` cookies stayed in the browser indefinitely and every later request performed a full session lookup for a token that no longer exists.

This moves the cookie/header forwarding above the null check, so the inner call's cleanup reaches the response regardless of whether a session was found. The forwarding logic itself is unchanged, and `fn()` is still only invoked when there is a session.

### Verification

Added a regression test in `packages/better-auth/src/plugins/custom-session/custom-session.test.ts` that signs in, deletes the backing session row while the client keeps its cookies, then calls `get-session` through the plugin and asserts the response expires `better-auth.session_token` (`value: ""`, `max-age: 0`).

```
npx vitest run packages/better-auth/src/plugins/custom-session/custom-session.test.ts
```

- Before the fix: the new test fails (no `Set-Cookie` for `better-auth.session_token`).
- After the fix: 13 passed.
- `npx vitest run packages/better-auth/src/plugins` -> 1220 passed; the only failure is `oauth-proxy` "database mode + UUID", which needs the Postgres container (`ECONNREFUSED 127.0.0.1:5432`) and is unrelated to this change.
- `pnpm typecheck` passes.

Fixes #10567

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `customSession()` so expired or revoked sessions clear cookies by forwarding `Set-Cookie` and headers from the inner `getSession()` before the null check. This prevents stale `better-auth.session_token`/`session_data` cookies and avoids extra session lookups.

- **Bug Fixes**
  - Forward cookies/headers before the null check (only when present) so `deleteSessionCookie` reaches the response; behavior with valid sessions is unchanged.
  - Added a regression test that deletes the DB session and asserts `better-auth.session_token` is expired (`value: ""`, `max-age: 0`).

<sup>Written for commit a0c8cf7329101e68397537817cf9e9e421b80985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

