### PR TITLE
Fix checkOrgaizationSlug return handling

### DIFF
--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -320,16 +320,27 @@ export const checkOrganizationSlug = <O extends OrganizationOptions>(
 		},
 		async (ctx) => {
 			const orgAdapter = getOrgAdapter<O>(ctx.context, options);
-			const org = await orgAdapter.findOrganizationBySlug(ctx.body.slug);
-			if (!org) {
-				return ctx.json({
-					status: true,
-				});
-			}
+			try{
+				const org = await orgAdapter.findOrganizationBySlug(ctx.body.slug);
+				if (!org) {
+					return ctx.json({
+						status: true,
+					});
+				} else if(org){
+					return ctx.json({
+						status: false,
+					});
+				}
+			}catch(error){
+			// Should not throw unless findOrganizationBySlug can fail somehow??
+			// If so i dont know what the error code should be
 			throw APIError.from(
 				"BAD_REQUEST",
-				ORGANIZATION_ERROR_CODES.ORGANIZATION_SLUG_ALREADY_TAKEN,
+				"An unknown error occured",
 			);
+			}
+			
+			
 		},
 	);
 


### PR DESCRIPTION
This function is throwing when a match is found which is unintuitive a it would return {status:true} without a match. Not sure if the try catch is necessary?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes checkOrganizationSlug to return a boolean status instead of throwing when a slug already exists, making the API consistent and easier for clients to consume.

- **Bug Fixes**
  - Return `{ status: true }` when the slug is available; `{ status: false }` when it’s taken.
  - Add try/catch around `findOrganizationBySlug`; throw a `BAD_REQUEST` with a generic message only on unexpected adapter errors.

<sup>Written for commit f66d93aeb1629b3a9f504994fc7c8f59b480977f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

