### PR TITLE
chore(changeset): restore minor release levels for the 1.7 line

### DIFF
--- a/.changeset/canonical-oauth-client-registration.md
+++ b/.changeset/canonical-oauth-client-registration.md
@@ -1,5 +1,5 @@
 ---
-"@better-auth/oauth-provider": major
+"@better-auth/oauth-provider": minor
 "@better-auth/mcp": minor
 "@better-auth/cimd": minor
 ---

--- a/.changeset/cimd-plugin.md
+++ b/.changeset/cimd-plugin.md
@@ -1,5 +1,5 @@
 ---
-"@better-auth/cimd": major
+"@better-auth/cimd": minor
 "@better-auth/oauth-provider": minor
 ---
 

--- a/.changeset/mcp-oauth-provider-migration.md
+++ b/.changeset/mcp-oauth-provider-migration.md
@@ -1,5 +1,5 @@
 ---
-"@better-auth/mcp": major
+"@better-auth/mcp": minor
 "better-auth": minor
 "@better-auth/oauth-provider": minor
 ---


### PR DESCRIPTION
The changesets release PR #10496 currently targets 2.0.0-rc.3 because three changesets declare a `major` bump, and the fixed release group takes its version from the highest level any member declares. The 1.7 line ships its breaking changes as minor releases with migration notes, and `@better-auth/mcp` and `@better-auth/cimd` have no stable release to major-bump from; they version in lockstep with the group.

Declaring all three as `minor` returns the release to 1.7.0-rc.3. No changeset content changes; the migration notes already describe the breaking surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore minor release levels for the 1.7 line by changing three changesets from major to minor, so the fixed release group targets `1.7.0-rc.3` instead of `2.0.0-rc.3`. No changeset content changes; existing migration notes already cover the breaking changes for `@better-auth/oauth-provider`, `@better-auth/mcp`, and `@better-auth/cimd`.

<sup>Written for commit 3890ae98e509360cc46fcd6db8dfca68503c6a29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

