### PR TITLE
feat(oauth-provider): export verifyOAuthQueryParams for host-rendered consent pages

### DIFF
--- a/.changeset/export-verify-oauth-query-params.md
+++ b/.changeset/export-verify-oauth-query-params.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Export `verifyOAuthQueryParams` from the package root, so an application that renders its own consent page can verify the `sig`/`exp` this plugin's `signParams` puts on the authorization query before it renders anything.

--- a/packages/oauth-provider/src/index.ts
+++ b/packages/oauth-provider/src/index.ts
@@ -6,4 +6,5 @@ export {
 	oidcServerMetadata,
 } from "./metadata";
 export { getOAuthProviderState, oauthProvider } from "./oauth";
+export { verifyOAuthQueryParams } from "./utils";
 export type * from "./types";


### PR DESCRIPTION
## What

Re-exports the existing `verifyOAuthQueryParams` from the `@better-auth/oauth-provider` package root. It is already `export`ed from `src/utils/index.ts` — this only adds it to the package's public surface in `src/index.ts`. No behavior change.

## Why

An application that hosts **its own** consent page (rather than using a redirect to a bundled one) receives the authorization query as a plain query string on its own `GET /consent` route. That query is signed by this plugin's `signParams` (`sig` + `exp`), but there is currently no exported way for the host app to verify that signature before it renders.

Without it, a hosted consent page can only see that a `client_id` is *present*. Anyone who knows a registered `client_id` can then load the app's own branded consent screen, on the real IdP origin, with an arbitrary-looking request — a phishing / consent-fatigue surface. The grant itself still fails closed at the POST step (that path *does* verify), so this is display-only, but the page should never have rendered in the first place.

`verifyOAuthQueryParams` is exactly the check the plugin already runs at its own two internal call sites (both throwing `invalid_signature`), so exporting it lets a host app run the *identical* check rather than reimplementing the HMAC/canonicalization scheme — a reimplementation would be a second copy of a security check that can silently drift and start accepting forged queries.

## Current workaround

We patch the package (via pnpm `patchedDependencies`) purely to add this one export. This PR is the exit path for that patch.

## Changes

- `packages/oauth-provider/src/index.ts`: `export { verifyOAuthQueryParams } from "./utils";`
- changeset (patch)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export `verifyOAuthQueryParams` from the `@better-auth/oauth-provider` package root so host-rendered consent pages can verify the signed auth query (`sig`/`exp`) before rendering. This prevents showing consent screens for forged or expired requests by using the same signature check as the provider.

- **New Features**
  - `verifyOAuthQueryParams` is now importable from the package root.
  - Lets apps validate the authorization query without reimplementing signature logic.
  - No breaking changes; existing flows remain the same.

<sup>Written for commit cc70f42069b46b473ca4787c40c4241abd4844ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

