### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/npm-dist-tag.yml
+++ b/.github/workflows/npm-dist-tag.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `24`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `24` (using `24` where a concrete pin is needed).

- `.github/workflows/npm-dist-tag.yml`
  - `node-version: 22.x` → `node-version: 24.x`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `24`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align CI with the project’s Node.js requirement by setting `node-version: 24.x` in `.github/workflows/npm-dist-tag.yml`. This ensures the publish job runs on Node 24 to match `engines.node`, `volta.node`, and `.nvmrc`, avoiding mismatched runtimes.

<sup>Written for commit 5f937cb64380a47bdf88b764edc6e14486ab1e63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

