### PR TITLE
fix(email-otp): don't send an email-verification OTP to a verified address without a session

### DIFF
--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -404,14 +404,18 @@ describe("email-otp", async () => {
 	});
 
 	it("should fail on expired otp", async () => {
+		const email = "expired-otp@test.com";
+		await auth.api.signUpEmail({
+			body: { email, password: "password", name: "expired-otp" },
+		});
 		await client.emailOtp.sendVerificationOtp({
-			email: testUser.email,
+			email,
 			type: "email-verification",
 		});
 		vi.useFakeTimers();
 		await vi.advanceTimersByTimeAsync(1000 * 60 * 6);
 		const res = await client.emailOtp.verifyEmail({
-			email: testUser.email,
+			email,
 			otp,
 		});
 		expect(res.error?.status).toBe(400);
@@ -419,14 +423,18 @@ describe("email-otp", async () => {
 	});
 
 	it("should not fail on time elapsed", async () => {
+		const email = "elapsed-otp@test.com";
+		await auth.api.signUpEmail({
+			body: { email, password: "password", name: "elapsed-otp" },
+		});
 		await client.emailOtp.sendVerificationOtp({
-			email: testUser.email,
+			email,
 			type: "email-verification",
 		});
 		vi.useFakeTimers();
 		await vi.advanceTimersByTimeAsync(1000 * 60 * 4);
 		const res = await client.emailOtp.verifyEmail({
-			email: testUser.email,
+			email,
 			otp,
 		});
 		const session = await client.getSession({
@@ -2078,8 +2086,9 @@ describe("race condition protection", async () => {
 
 	it("should delete OTP after successful email verification", async () => {
 		const email = "race-verify@domain.com";
-		await client.emailOtp.sendVerificationOtp({ email, type: "sign-in" });
-		await client.signIn.emailOtp({ email, otp });
+		await auth.api.signUpEmail({
+			body: { email, password: "password", name: "race-verify" },
+		});
 
 		await client.emailOtp.sendVerificationOtp({
 			email,
@@ -2152,8 +2161,9 @@ describe("race condition protection", async () => {
 
 	it("should allow exactly one success when the same email-verification OTP is verified concurrently", async () => {
 		const email = "race-concurrent-verify@domain.com";
-		await client.emailOtp.sendVerificationOtp({ email, type: "sign-in" });
-		await client.signIn.emailOtp({ email, otp });
+		await auth.api.signUpEmail({
+			body: { email, password: "password", name: "race-concurrent" },
+		});
 
 		await client.emailOtp.sendVerificationOtp({
 			email,
@@ -2652,6 +2662,90 @@ describe("email-otp send origin/CSRF protection", async () => {
 
 		const response = await auth.handler(legitimateRequest);
 		expect(response.status).toBe(200);
+		expect(sendVerificationOTP).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("email-otp send-verification-otp on an already verified email", async () => {
+	const sendVerificationOTP = vi.fn(async () => {});
+	const { auth, client, testUser, signInWithTestUser } = await getTestInstance(
+		{
+			plugins: [
+				emailOTP({
+					sendVerificationOTP,
+					changeEmail: { enabled: true, verifyCurrentEmail: true },
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [emailOTPClient()],
+			},
+		},
+	);
+
+	const markTestUserVerified = async () => {
+		const ctx = await auth.$context;
+		const found = await ctx.internalAdapter.findUserByEmail(testUser.email);
+		await ctx.internalAdapter.updateUser(found!.user.id, {
+			emailVerified: true,
+		});
+		return ctx;
+	};
+
+	/**
+	 * `/send-verification-email` refuses to mail an already verified address for a
+	 * caller with no session, and returns the same body it would for an unknown
+	 * address. This endpoint is the same operation through a different door, so an
+	 * unauthenticated caller must not be able to use it to mail a code to a
+	 * verified address either.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/7707
+	 */
+	it("should not send an email-verification OTP for a caller with no session", async () => {
+		const ctx = await markTestUserVerified();
+		sendVerificationOTP.mockClear();
+
+		const res = await auth.handler(
+			new Request(
+				"http://localhost:3000/api/auth/email-otp/send-verification-otp",
+				{
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						email: testUser.email,
+						type: "email-verification",
+					}),
+				},
+			),
+		);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ success: true });
+		expect(sendVerificationOTP).not.toHaveBeenCalled();
+		expect(
+			await ctx.internalAdapter.findVerificationValue(
+				`email-verification-otp-${testUser.email}`,
+			),
+		).toBeFalsy();
+	});
+
+	/**
+	 * `changeEmail.verifyCurrentEmail` sends an `email-verification` OTP to the
+	 * user's current — already verified — address as a step-up, so the session
+	 * owner must keep getting one.
+	 */
+	it("should still send when the session owns the email", async () => {
+		await markTestUserVerified();
+		const { headers } = await signInWithTestUser();
+		sendVerificationOTP.mockClear();
+
+		const res = await client.emailOtp.sendVerificationOtp(
+			{ email: testUser.email, type: "email-verification" },
+			{ headers },
+		);
+
+		expect(res.data?.success).toBe(true);
 		expect(sendVerificationOTP).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -2700,6 +2700,7 @@ describe("email-otp send-verification-otp on an already verified email", async (
 	 * unauthenticated caller must not be able to use it to mail a code to a
 	 * verified address either.
 	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10614
 	 * @see https://github.com/better-auth/better-auth/issues/7707
 	 */
 	it("should not send an email-verification OTP for a caller with no session", async () => {

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -146,11 +146,25 @@ export const sendVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 					message: "Invalid OTP type",
 				});
 			}
+			const user = await ctx.context.internalAdapter.findUserByEmail(email);
+			/**
+			 * `/send-verification-email` refuses to mail an already verified address
+			 * for a caller with no session, and returns the same body it would for an
+			 * unknown one (#7707). This endpoint is the same operation, so it must not
+			 * become a second door onto that email. The session owner is still served:
+			 * `changeEmail.verifyCurrentEmail` steps up through here.
+			 */
+			if (ctx.body.type === "email-verification" && user?.user.emailVerified) {
+				const session = await getSessionFromCtx(ctx);
+				if (session?.user.id !== user.user.id) {
+					return ctx.json({ success: true });
+				}
+			}
+
 			const identifier = toOTPIdentifier(ctx.body.type, email);
 			const otp = await resolveOTP(ctx, opts, email, ctx.body.type);
 
 			const shouldSendOTP = ctx.body.type === "sign-in" && !opts.disableSignUp;
-			const user = await ctx.context.internalAdapter.findUserByEmail(email);
 			if (!user && !shouldSendOTP) {
 				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 					identifier,


### PR DESCRIPTION
Closes #10614

`/send-verification-email` will not mail an already verified address for a caller with no session, and returns the same body it would return for an unknown one (#7707, fixed in #7712). `/email-otp/send-verification-otp` with `type: "email-verification"` is the same operation and did neither, so every app on the emailOTP plugin — and in particular every app setting `overrideDefaultEmailVerification`, where OTP is the verification mechanism — keeps an unguarded second door onto that email.

The row this writes is live: `/email-otp/verify-email` accepts it and, with `autoSignInAfterVerification`, returns a session. On an already verified account that amounts to a sign-in with no password, and it stays reachable in deployments that disable `/sign-in/email-otp` specifically to avoid offering one, since `/email-otp/verify-email` is a separate route. The unauthenticated caller only has to name an address.

## Change

The user lookup now happens before the OTP is issued. When the address is already verified and the caller does not own the session for it, the endpoint returns `{ success: true }` without sending mail or writing a verification row. Doing this before `resolveOTP` rather than deleting afterwards also means a step-up OTP already in flight cannot be cancelled by a third party.

`changeEmail.verifyCurrentEmail` sends an `email-verification` OTP to the user's current, already verified address, so the session owner has to keep receiving one. That is the second test.

The condition is that the session owns the address, not merely that a session exists — being signed in as one user is not a reason to mail a code to another user's verified address. Core draws the same line one branch further down, where a session requesting a different address gets `EMAIL_MISMATCH` (`api/routes/email-verification.ts:208`). Here it stays a silent `{ success: true }`, since the point of the branch is that a verified address is indistinguishable from an unknown one.

## Tests

The regression test asserts the sessionless case sends nothing, writes nothing, and returns the same `{ success: true }` an unknown address returns. It fails on `main` on the send assertion.

Four existing tests reached this path with a user an earlier step had already verified: the two expiry tests reuse `testUser` after the first test in that describe verifies it, and two race tests created their user through `signIn.emailOtp`, which sets `emailVerified: true`. None of them assert anything about verified addresses, so they now sign up a fresh unverified user.

- `vitest packages/better-auth/src/plugins/email-otp/` — 90 passed
- `server-only-endpoints`, `captcha`, `haveibeenpwned`, `api/routes/email-verification` — 76 passed
- `pnpm typecheck` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `email-otp` from sending an email-verification OTP to an already verified address when the caller has no session. This closes a second path that could sign in to verified accounts without a password.

- **Bug Fixes**
  - Look up the user before issuing an OTP; for type "email-verification" and a verified email, return { success: true } with no email sent and no verification row unless the active session owns the email (step-up for `changeEmail.verifyCurrentEmail` still works).
  - No changes to sign-in OTPs or unverified emails.
  - Tests: switched existing cases to fresh unverified users; added a regression test for the verified-email path and referenced the upstream issues.

<sup>Written for commit c736573966b564e3c3d2c64232e8e7aac17b27f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

