### PR TITLE
docs: add @mailkite/better-auth and @mailkite/better-auth-inbox to community plugins

### DIFF
--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -342,4 +342,26 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/stewartjarod.png",
 		},
 	},
+	{
+		name: "@mailkite/better-auth",
+		url: "https://github.com/mailkite/mailkite-better-auth",
+		description:
+			"Send magic links, email OTPs, verification, password resets and organization invitations through MailKite. Wires the verification and reset callbacks automatically; app-branded templates, no schema, no runtime dependencies.",
+		author: {
+			name: "MailKite",
+			github: "mailkite",
+			avatar: "https://github.com/mailkite.png",
+		},
+	},
+	{
+		name: "@mailkite/better-auth-inbox",
+		url: "https://github.com/mailkite/mailkite-better-auth-inbox",
+		description:
+			"Give your app a real mailbox. Receive email as signature-verified webhooks, then list, read, thread and reply through session-scoped endpoints — scoped per user or per organization.",
+		author: {
+			name: "MailKite",
+			github: "mailkite",
+			avatar: "https://github.com/mailkite.png",
+		},
+	},
 ];


### PR DESCRIPTION
Resubmitting after #10535, which @bytaesu closed with:

> this package only declares better-auth as a peerDeps and may not conform to the plugin type contract. Please follow the guide and implement a compatible plugin

That was correct. `@mailkite/better-auth@0.1.0` was a factory returning five email callbacks with `better-auth` as an *optional* peer dependency — not a plugin. This PR lists two packages that are.

### `@mailkite/better-auth` — outbound

Sends Better Auth's transactional email through MailKite. Rewritten against [Create your first plugin](https://better-auth.com/docs/guides/your-first-plugin):

- Returns a `BetterAuthPlugin` with `id: "mailkite"` and a `version`.
- `init()` returns an options patch supplying `emailVerification.sendVerificationEmail` and `emailAndPassword.sendResetPassword`. Since `runPluginInit` merges with `defu(userOptions, pluginOptions)`, an app that already set either keeps its own — the plugin only fills gaps. Installing it never enables an auth method by itself.
- The other three (`sendMagicLink`, `sendVerificationOTP`, `sendInvitationEmail`) are read from the closure of `magicLink` / `emailOTP` / `organization`, so no plugin can inject them. The returned object carries them for explicit wiring, which keeps one `mailkite()` call covering all five surfaces.
- `better-auth` is a **required** peer dependency and a devDependency.

It deliberately declares no `schema` and no `endpoints`. It's a transport — it owns no tables and adds no routes, and an app shouldn't have to run a migration to send a password-reset email.

### `@mailkite/better-auth-inbox` — inbound

Every email surface Better Auth has is outbound. This one adds the other half: a mailbox the app can receive on.

- `id: "mailkite-inbox"`, typed `satisfies BetterAuthPlugin`
- `schema` — `mailkiteMailbox`, `mailkiteMessage`
- Six `endpoints` via `createAuthEndpoint`; every read behind `sessionMiddleware`
- `rateLimit` rules for `/mailkite/inbox/*`, tighter on provisioning
- Client plugin with `$InferServerPlugin` and `pathMethods`
- Maps onto your `organization` plugin: `forOrganization: true` gives a team a shared inbox, scoped to the session's active organization

### A live demo, if you want to poke at it

**https://better-auth.mailkite.dev** — a Next.js app on Cloudflare Workers with Better Auth on D1 and both plugins wired. Source: https://github.com/mailkite/better-auth-demo

`/signup` sends a verification email the plugin supplied via `init()` — no callback written by hand. `/login` does magic link, email OTP and password. `/inbox` claims a real address, receives real mail, and replies from it.

I built it before filing this, and it earned its keep: it surfaced four defects in the inbox plugin that 23 passing unit tests had missed. Every one survived because a test asserted what my implementation did rather than what the API actually returns, against a fetch stub I also wrote — so the suite agreed with the bug and stayed green. They're fixed, the broken versions are deprecated on npm, and the suite now asserts the wire contract. I mention it because "we have tests" is worth nothing if the tests agree with the bug, and you have no reason to take my word on either package after last time.

### Verification

Both packages: `npm test` boots a real `betterAuth()` on the memory adapter and drives the plugin through actual requests rather than asserting against a fake — 39 tests for the sender, 28 for the inbox. Both run `tsc --noEmit` against `BetterAuthPlugin`, and the sender additionally against the option types of `magicLink`, `emailOTP` and `organization`, so a signature change upstream fails our build rather than a user's runtime.

That typecheck caught two real bugs the day it was added: our OTP template had no copy for the `change-email` type, so those emails rendered sign-in wording, and `sendVerificationOTP` / `sendInvitationEmail` needed to return `Promise<void>` rather than `void`.

One tenant-isolation bug in the inbox is worth flagging, since it's the kind of thing a reviewer should worry about: listing short-circuited on "caller owns no mailboxes" *before* validating an explicit `mailboxId`, so probing a foreign id gave different responses depending on whether the caller owned anything — an oracle for which ids exist. Found by a test, fixed, and there's a regression test asserting both callers get byte-identical responses.

### Links

- `@mailkite/better-auth` — [npm](https://www.npmjs.com/package/@mailkite/better-auth) · [source](https://github.com/mailkite/mailkite-better-auth) · [docs](https://mailkite.dev/docs/auth/better-auth)
- `@mailkite/better-auth-inbox` — [npm](https://www.npmjs.com/package/@mailkite/better-auth-inbox) · [source](https://github.com/mailkite/mailkite-better-auth-inbox) · [docs](https://mailkite.dev/docs/auth/better-auth-inbox)
- Demo — [live](https://better-auth.mailkite.dev) · [source](https://github.com/mailkite/better-auth-demo)

Both MIT, zero runtime dependencies. Only `docs/lib/community-plugins-data.ts` changes — one entry each, matching the existing shape.

Happy to split this into two PRs, or drop the sender and list only the inbox, if you'd rather not take two entries from one vendor.

Disclosure, same as last time: I maintain MailKite, and this was AI-assisted per your AI policy. I've reviewed all of it and am glad to go through any part of it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@mailkite/better-auth` and `@mailkite/better-auth-inbox` to the Community Plugins list. Both conform to the Better Auth plugin contract; one handles outbound email, the other provides an inbox with schema and endpoints.

- **New Features**
  - `@mailkite/better-auth`: Sends magic links, OTPs, verification, resets, and org invites via MailKite; auto-wires verification and reset callbacks; no schema or endpoints.
  - `@mailkite/better-auth-inbox`: Adds a mailbox with schema and session-protected endpoints for listing, reading, threading, and replying; supports user and organization scopes.

<sup>Written for commit a56975a830901f200bbed77ede059d1debb7c537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

