### PR TITLE
fix(rate-limit): await database cleanup by default

### DIFF
--- a/.changeset/await-rate-limit-cleanup.md
+++ b/.changeset/await-rate-limit-cleanup.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Ensure database rate-limit cleanup completes when no background task handler is configured.

--- a/packages/better-auth/src/api/rate-limiter/index.ts
+++ b/packages/better-auth/src/api/rate-limiter/index.ts
@@ -180,7 +180,7 @@ function createDatabaseStorageWrapper(
 				set: { count: 1, lastRequest: now },
 			});
 			if (reset) {
-				deleteExpiredRows(now);
+				await deleteExpiredRows(now);
 				return { allowed: true, retryAfter: null };
 			}
 			return consume(key, rule);
@@ -221,13 +221,13 @@ function createDatabaseStorageWrapper(
 
 	// Best-effort sweep of clearly-expired rows to bound table growth. A failure
 	// here never blocks the request.
-	const deleteExpiredRows = (now: number) => {
+	const deleteExpiredRows = async (now: number) => {
 		const longestWindow = Math.max(
 			ctx.rateLimit.window,
 			...getDefaultSpecialRules().map((r) => r.window),
 		);
 		const cutoff = now - longestWindow * 1000;
-		ctx.runInBackground(
+		await ctx.runInBackgroundOrAwait(
 			db
 				.deleteMany({
 					model,

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -166,6 +166,62 @@ describe("atomic concurrent enforcement", () => {
 	}
 });
 
+describe("database cleanup", async () => {
+	const { auth, client } = await getTestInstance({
+		rateLimit: {
+			enabled: true,
+			storage: "database",
+			window: 10,
+			max: 20,
+		},
+	});
+	const ctx = await auth.$context;
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10618
+	 */
+	it("awaits expired row cleanup when no background handler is configured", async () => {
+		await ctx.adapter.create({
+			model: "rateLimit",
+			data: {
+				key: "127.0.0.1|/get-session",
+				count: 1,
+				lastRequest: Date.now() - 11_000,
+			},
+		});
+
+		let releaseCleanup = () => {};
+		const cleanupGate = new Promise<void>((resolve) => {
+			releaseCleanup = resolve;
+		});
+		const originalDeleteMany = ctx.adapter.deleteMany.bind(ctx.adapter);
+		const deleteMany = vi
+			.spyOn(ctx.adapter, "deleteMany")
+			.mockImplementation(async (data) => {
+				await cleanupGate;
+				return originalDeleteMany(data);
+			});
+
+		let requestSettled = false;
+		const request = client.getSession().finally(() => {
+			requestSettled = true;
+		});
+
+		let settledBeforeCleanup: boolean;
+		try {
+			await vi.waitFor(() => expect(deleteMany).toHaveBeenCalledOnce());
+			await Promise.resolve();
+			settledBeforeCleanup = requestSettled;
+		} finally {
+			releaseCleanup();
+		}
+
+		await request;
+		deleteMany.mockRestore();
+		expect(settledBeforeCleanup).toBe(false);
+	});
+});
+
 describe("custom rate limiting storage", async () => {
 	const store = new Map<string, string>();
 	const expirationMap = new Map<string, number>();

--- a/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
+++ b/packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts
@@ -214,10 +214,10 @@ describe("database cleanup", async () => {
 			settledBeforeCleanup = requestSettled;
 		} finally {
 			releaseCleanup();
+			deleteMany.mockRestore();
 		}
 
 		await request;
-		deleteMany.mockRestore();
 		expect(settledBeforeCleanup).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

- Await expired database rate-limit cleanup when no background task handler is configured.
- Preserve deferred cleanup when a background task handler is available.
- Add a regression test and patch changeset.

Closes #10618

## Testing

- `pnpm vitest packages/better-auth/src/api/rate-limiter/rate-limiter.test.ts --run`
- `pnpm typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the database rate limiter to await expired-row cleanup when no background task handler is configured. Prevents races and stale rows; still defers cleanup when a handler exists.

- **Bug Fixes**
  - Await `deleteExpiredRows` and use `ctx.runInBackgroundOrAwait` to block or defer based on handler in `better-auth`.
  - Added a regression test for cleanup sequencing and ensured the cleanup spy is always restored; requests don’t settle before cleanup. Closes #10618.

<sup>Written for commit 3c054b27fd4eb460e6a461a032af2f5b8decea1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

