### PR TITLE
feat(scim): add enterprise user attributes and interop conformance

### DIFF
--- a/.changeset/scim-enterprise-user-attributes.md
+++ b/.changeset/scim-enterprise-user-attributes.md
@@ -1,0 +1,17 @@
+---
+"@better-auth/scim": minor
+---
+
+Add the standard Enterprise User extension (`employeeNumber`, `costCenter`, `organization`, `division`, `department`, `manager`) and the classic `title`, `userType`, `preferredLanguage`, `locale`, `timezone`, `phoneNumbers`, `addresses`, `roles`, and `entitlements` User attributes, plus `name.middleName`, `name.honorificPrefix`, and `name.honorificSuffix`. All are readable, filterable by `type` or `primary`, and writable through PATCH, including the classic Microsoft Entra `manager` path aliases.
+
+Add `compatibility.microsoftEntra.acceptLegacyGroupSchema` to accept Microsoft Entra's legacy, attribute-less Group schema marker on `POST /Groups` without storing or returning it.
+
+Microsoft Entra interoperability fixes:
+
+- A bare `attributes`/`excludedAttributes` name for an Enterprise User sub-attribute (for example `?attributes=manager`) no longer drops the whole extension from the response.
+- Multi-op PATCH paths filtered by `[primary eq true]` (or `[primary eq "true"]`) with a sub-attribute target now work on `emails`, `phoneNumbers`, `addresses`, `roles`, and `entitlements`.
+- A single-element array wrapping a scalar PATCH replace value is unwrapped instead of rejected, on User scalars, Enterprise User fields, and Group `displayName` and `externalId`.
+- Removing the last sub-attribute of a complex attribute (for example `manager.value`) clears the emptied Enterprise User extension instead of leaving it declared.
+- Replacing `manager` with an empty string clears it, matching how Microsoft Entra removes a manager.
+- A PATCH with an empty `Operations` array is a valid no-op instead of an error, for both Users and Groups.
+- `PATCH /Users/:id` and `PATCH /Groups/:id` return `200 OK` with the updated resource instead of `204 No Content`.

--- a/.changeset/scim-entra-active-normalization.md
+++ b/.changeset/scim-entra-active-normalization.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": patch
+---
+
+Accept exact case-insensitive string Boolean values for SCIM User `active` and the `primary` sub-attribute of `emails`, `phoneNumbers`, `addresses`, `roles`, and `entitlements` at the HTTP ingress for Microsoft Entra interoperability.

--- a/demo/nextjs/lib/scim-demo-service.ts
+++ b/demo/nextjs/lib/scim-demo-service.ts
@@ -863,7 +863,7 @@ async function updateProfile(
 	const response = await requestSCIM(context.baseURL, resourcePath, {
 		method: "PATCH",
 		body: requestBody,
-		expectedStatus: 204,
+		expectedStatus: 200,
 	});
 	const state = await readApplicationState(context.database, scimUser.id);
 	assertState(
@@ -992,7 +992,7 @@ async function setGroups(
 			const response = await requestSCIM(context.baseURL, resourcePath, {
 				method: "PATCH",
 				body: requestBody,
-				expectedStatus: 204,
+				expectedStatus: 200,
 			});
 			operations.push(
 				createOperation({
@@ -1074,7 +1074,7 @@ async function setUserActive(
 	const response = await requestSCIM(context.baseURL, resourcePath, {
 		method: "PATCH",
 		body: requestBody,
-		expectedStatus: 204,
+		expectedStatus: 200,
 	});
 	const state = await readApplicationState(context.database, scimUser.id);
 	assertState(

--- a/docs/content/docs/plugins/scim/reference.mdx
+++ b/docs/content/docs/plugins/scim/reference.mdx
@@ -13,6 +13,7 @@ This reference describes the SCIM operations and configuration supported by `@be
 | `authentication` | `SCIMAuthenticationOptions`        | Optional. Verifies externally issued OAuth bearer access tokens.     |
 | `identity`       | `SCIMIdentity`                     | Optional. Links existing users and applies global lifecycle state.   |
 | `projection`     | `SCIMProjection`                   | Optional. Maps Groups to roles and applies application access state. |
+| `compatibility`  | `SCIMCompatibilityOptions`         | Optional. Enables narrow, provider-specific HTTP ingress shapes.     |
 
 ### Connection options
 
@@ -78,44 +79,71 @@ Requests with a body may use `application/scim+json` or `application/json`. Resp
 
 `POST` and `PUT` bodies must contain exactly one matching core schema URN:
 
-* User: `urn:ietf:params:scim:schemas:core:2.0:User`
+* User: `urn:ietf:params:scim:schemas:core:2.0:User`, optionally followed by `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`
 * Group: `urn:ietf:params:scim:schemas:core:2.0:Group`
 
-PATCH bodies must include `urn:ietf:params:scim:api:messages:2.0:PatchOp`. User and Group create or replace requests with unsupported or duplicate schema URNs return `400 Bad Request` with `scimType: "invalidValue"`.
+The Enterprise User URI may be declared without an extension object, as Microsoft Entra does in some requests, and the declaration remains in the response. An Enterprise object without its URI is invalid. PATCH bodies must include `urn:ietf:params:scim:api:messages:2.0:PatchOp`. User and Group create or replace requests with unsupported or duplicate schema URNs return `400 Bad Request` with `scimType: "invalidValue"`.
+
+### Microsoft Entra Group compatibility
+
+Microsoft's classic Entra provisioning client includes the attribute-less URI `http://schemas.microsoft.com/2006/11/ResourceManagement/ADSCIM/2.0/Group` in some `POST /Groups` schema lists. Enable the exact, input-only exception when that client targets the endpoint:
+
+```ts title="auth.ts"
+scim({
+  connections,
+  compatibility: {
+    microsoftEntra: {
+      acceptLegacyGroupSchema: true,
+    },
+  },
+});
+```
+
+The option defaults to `false`. When enabled, Better Auth removes one exact marker before validating a Group create request, then returns and stores only the standard core Group resource. The URI never appears in discovery, ResourceType metadata, OpenAPI, persistence, or responses. A marker with attributes, a duplicate marker, the marker on `PUT` or `PATCH`, another unknown extension, and the distinct Microsoft Graph SCIM URI remain invalid.
+
+The plugin passes Microsoft's [Entra SCIM Validator](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/scim-validator-tutorial) except two Preview-tool assertions: "Create a new User" (`roles`/`manager`) and "Patch User - Replace Attributes" (primary-filtered checks). Both compare the response against the string-boolean `primary` and bare-string `manager` literals the tool itself sent, which RFC 7643 typing cannot echo back without making the tool's own subsequent test execution fail its schema-typed deserialization.
 
 ## Users
 
-| Method   | Path                     | Result                                                                                           |
-| -------- | ------------------------ | ------------------------------------------------------------------------------------------------ |
-| `POST`   | `/scim/v2/Users`         | Creates a SCIM User and creates or explicitly links a Better Auth User. Returns `201`.           |
-| `GET`    | `/scim/v2/Users`         | Returns the connection's Users in a SCIM `ListResponse`.                                         |
-| `GET`    | `/scim/v2/Users/:userId` | Returns one User owned by the connection.                                                        |
-| `PUT`    | `/scim/v2/Users/:userId` | Replaces the writable profile while preserving the resource ID. Returns `200`.                   |
-| `PATCH`  | `/scim/v2/Users/:userId` | Applies ordered, atomic changes. Returns `204`, or `200` when response attributes are requested. |
-| `DELETE` | `/scim/v2/Users/:userId` | Deletes the SCIM resource while preserving the Better Auth User. Returns `204`.                  |
+| Method   | Path                     | Result                                                                                 |
+| -------- | ------------------------ | -------------------------------------------------------------------------------------- |
+| `POST`   | `/scim/v2/Users`         | Creates a SCIM User and creates or explicitly links a Better Auth User. Returns `201`. |
+| `GET`    | `/scim/v2/Users`         | Returns the connection's Users in a SCIM `ListResponse`.                               |
+| `GET`    | `/scim/v2/Users/:userId` | Returns one User owned by the connection.                                              |
+| `PUT`    | `/scim/v2/Users/:userId` | Replaces the writable profile while preserving the resource ID. Returns `200`.         |
+| `PATCH`  | `/scim/v2/Users/:userId` | Applies ordered, atomic changes. Returns `200` with the updated resource.              |
+| `DELETE` | `/scim/v2/Users/:userId` | Deletes the SCIM resource while preserving the Better Auth User. Returns `204`.        |
 
 Deleting a User also removes its direct Group memberships and projected grants, updates the affected Groups, and reconciles lifecycle and access state. When `externalId` is present, the plugin preserves the link needed to attach a later reprovisioned resource to the same Better Auth User.
 
 ### Supported User attributes
 
-| Attribute         | Behavior                                                                                    |
-| ----------------- | ------------------------------------------------------------------------------------------- |
-| `userName`        | Required and unique case-insensitively within the connection. Supplied casing is preserved. |
-| `externalId`      | Optional and unique exactly as supplied within the connection.                              |
-| `active`          | Optional lifecycle state. Defaults to `true`.                                               |
-| `displayName`     | Optional display name. The plugin derives a value when omitted.                             |
-| `name.formatted`  | Optional formatted name. The plugin derives a value when omitted.                           |
-| `name.givenName`  | Optional given name.                                                                        |
-| `name.familyName` | Optional family name.                                                                       |
-| `emails`          | Up to 20 typed email values, each no longer than 254 characters.                            |
+| Attribute                                                         | Behavior                                                                                    |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `userName`                                                        | Required and unique case-insensitively within the connection. Supplied casing is preserved. |
+| `externalId`                                                      | Optional and unique exactly as supplied within the connection.                              |
+| `active`                                                          | Optional lifecycle state. Defaults to `true`.                                               |
+| `displayName`                                                     | Optional display name. The plugin derives a value when omitted.                             |
+| `name.formatted`, `name.givenName`, `name.familyName`             | Optional name fields. The plugin derives `formatted` when omitted.                          |
+| `name.middleName`, `name.honorificPrefix`, `name.honorificSuffix` | Optional classic name fields.                                                               |
+| `emails`                                                          | Up to 20 typed email values, each no longer than 254 characters.                            |
+| `title`, `userType`, `preferredLanguage`, `locale`, `timezone`    | Optional classic User strings.                                                              |
+| `phoneNumbers`, `addresses`, `roles`, `entitlements`              | Optional bounded multi-valued attributes. At most 1 value in each attribute may be primary. |
+| `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`      | Optional standard Enterprise User extension described below.                                |
 
-Email values and types are normalized to lowercase. Each type and value pair must be unique case-insensitively. At most one email may set `primary: true`.
+RFC 7643 defines `active` as a JSON Boolean, and SCIM examples, discovery, responses, callbacks, and persisted values remain Boolean. As a narrow Microsoft Entra interoperability exception, the HTTP ingress for User `POST`, `PUT`, and `PATCH` also accepts the exact case-insensitive strings `"true"` and `"false"` for `active`, including pathless and core-schema-qualified PATCH operations. Other strings, surrounding whitespace, numbers, `null`, arrays, and objects are not coerced and return `400 Bad Request`. This normalization does not apply to Groups or unrelated attributes.
+
+Defined `type` values on `emails`, `phoneNumbers`, `addresses`, `roles`, and `entitlements` must be unique case-insensitively, matching Microsoft Entra's SCIM guidance. Multiple entries may omit `type`. Email values and defined types are normalized to lowercase; each email type and value tuple must also be unique case-insensitively, and at most one email may set `primary: true`. When PATCH sets one value as primary, Better Auth clears `primary` on every other value in that attribute.
 
 When no email is marked primary, the first work email wins, followed by the first email. If `emails` is missing or empty, `userName` must be a valid email and becomes the primary email.
 
 The formatted-name fallback order is `name.formatted`, `displayName`, the joined given and family names, then the primary email. `displayName` falls back to the resulting formatted name.
 
 A profile-managing source writes the primary email and display name to the Better Auth User. The email must be globally unique, or the request returns `409 Conflict`. Changing the email clears `emailVerified` because provisioning does not verify mailbox ownership.
+
+The Enterprise User extension supports `employeeNumber`, `costCenter`, `organization`, `division`, `department`, and `manager`. A manager accepts a nonempty identifier string, an RFC object containing `value`, `$ref`, or both, or a singleton array containing that object. Better Auth accepts a client-supplied read-only `displayName` for provider compatibility but does not persist, echo, or pass it to identity callbacks. Responses and callbacks normalize every retained manager to an object with at least `value` or `$ref`. The manager is an external reference: Better Auth does not require a matching local User or search another connection.
+
+PATCH accepts standard Enterprise paths such as `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department`. It also accepts the classic Entra aliases `manager`, `manager.value`, and `manager.$ref` as input paths, while canonical responses continue to place manager data under the Enterprise User URI. `manager.displayName` remains read-only.
 
 ```json title="Create User"
 {
@@ -141,14 +169,14 @@ A profile-managing source writes the primary email and display name to the Bette
 
 ## Groups
 
-| Method   | Path                       | Result                                                                                                                    |
-| -------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `POST`   | `/scim/v2/Groups`          | Creates a Group and its direct memberships. Returns `201`.                                                                |
-| `GET`    | `/scim/v2/Groups`          | Returns the connection's Groups in a SCIM `ListResponse`.                                                                 |
-| `GET`    | `/scim/v2/Groups/:groupId` | Returns one Group owned by the connection.                                                                                |
-| `PUT`    | `/scim/v2/Groups/:groupId` | Replaces the Group attributes and complete membership set. Returns `200`.                                                 |
-| `PATCH`  | `/scim/v2/Groups/:groupId` | Applies ordered, atomic attribute and membership changes. Returns `204`, or `200` when response attributes are requested. |
-| `DELETE` | `/scim/v2/Groups/:groupId` | Deletes the Group, memberships, and projected grants. Returns `204`.                                                      |
+| Method   | Path                       | Result                                                                                             |
+| -------- | -------------------------- | -------------------------------------------------------------------------------------------------- |
+| `POST`   | `/scim/v2/Groups`          | Creates a Group and its direct memberships. Returns `201`.                                         |
+| `GET`    | `/scim/v2/Groups`          | Returns the connection's Groups in a SCIM `ListResponse`.                                          |
+| `GET`    | `/scim/v2/Groups/:groupId` | Returns one Group owned by the connection.                                                         |
+| `PUT`    | `/scim/v2/Groups/:groupId` | Replaces the Group attributes and complete membership set. Returns `200`.                          |
+| `PATCH`  | `/scim/v2/Groups/:groupId` | Applies ordered, atomic attribute and membership changes. Returns `200` with the updated resource. |
+| `DELETE` | `/scim/v2/Groups/:groupId` | Deletes the Group, memberships, and projected grants. Returns `204`.                               |
 
 `displayName` is required and unique case-insensitively within the connection. `externalId` is optional and unique exactly as supplied.
 
@@ -159,7 +187,7 @@ Each `members[].value` must contain a SCIM User ID from the same connection. Mem
 | Method | Path                                     | Result                                                              |
 | ------ | ---------------------------------------- | ------------------------------------------------------------------- |
 | `GET`  | `/scim/v2/ServiceProviderConfig`         | Reports authentication, filter, PATCH, and pagination capabilities. |
-| `GET`  | `/scim/v2/Schemas`                       | Lists the supported User and Group schemas.                         |
+| `GET`  | `/scim/v2/Schemas`                       | Lists the core User, Enterprise User, and Group schemas.            |
 | `GET`  | `/scim/v2/Schemas/:schemaId`             | Returns one supported schema.                                       |
 | `GET`  | `/scim/v2/ResourceTypes`                 | Lists the User and Group resource types.                            |
 | `GET`  | `/scim/v2/ResourceTypes/:resourceTypeId` | Returns one resource type.                                          |
@@ -193,11 +221,11 @@ GET /api/auth/scim/v2/Groups?startIndex=1&count=25&excludedAttributes=members
 Authorization: Bearer <token>
 ```
 
-`POST` and `PUT` apply attribute selection to their resource response. PATCH returns `204 No Content` by default. When either response-attribute parameter is present, PATCH returns `200 OK` with the selected resource.
+`POST`, `PUT`, and `PATCH` all apply attribute selection to their resource response. PATCH always returns `200 OK` with the updated resource.
 
 ## PATCH
 
-A PATCH body must contain at least one operation. Operations run in array order and accept case-insensitive `add`, `replace`, and `remove` values. An omitted `op` defaults to `replace`. The complete request is atomic.
+Operations run in array order and accept case-insensitive `add`, `replace`, and `remove` values. An omitted `op` defaults to `replace`. An empty `Operations` array is a valid no-op. The complete request is atomic.
 
 ```json
 {
@@ -214,21 +242,24 @@ A PATCH body must contain at least one operation. Operations run in array order 
 
 ### User PATCH paths
 
-| Path                           | Operations                 | Behavior                                                            |
-| ------------------------------ | -------------------------- | ------------------------------------------------------------------- |
-| `userName`                     | `add`, `replace`           | Requires a non-empty value.                                         |
-| `externalId`                   | `add`, `replace`, `remove` | `remove` clears the identifier.                                     |
-| `active`                       | `add`, `replace`, `remove` | Requires a boolean. `remove` resets it to `true`.                   |
-| `displayName`                  | `add`, `replace`, `remove` | `remove` applies the formatted-name fallback.                       |
-| `name`                         | `add`, `replace`, `remove` | Accepts the supported structured name fields.                       |
-| `name.formatted`               | `add`, `replace`, `remove` | `remove` derives a formatted name.                                  |
-| `name.givenName`               | `add`, `replace`, `remove` | `remove` clears the given name.                                     |
-| `name.familyName`              | `add`, `replace`, `remove` | `remove` clears the family name.                                    |
-| `emails`                       | `add`, `replace`           | `add` appends missing entries. `replace` supplies the complete set. |
-| `emails.value`                 | `add`, `replace`           | Replaces the value on every email entry.                            |
-| `emails[type eq "work"].value` | `add`, `replace`, `remove` | Adds, replaces, or removes the selected work email.                 |
+| Path                                                                                     | Operations                 | Behavior                                                             |
+| ---------------------------------------------------------------------------------------- | -------------------------- | -------------------------------------------------------------------- |
+| `userName`                                                                               | `add`, `replace`           | Requires a non-empty value.                                          |
+| `externalId`                                                                             | `add`, `replace`, `remove` | `remove` clears the identifier.                                      |
+| `active`                                                                                 | `add`, `replace`, `remove` | Boolean after HTTP normalization. `remove` resets it to `true`.      |
+| `displayName`                                                                            | `add`, `replace`, `remove` | `remove` applies the formatted-name fallback.                        |
+| `name` and its supported subattributes                                                   | `add`, `replace`, `remove` | Preserves unspecified name fields.                                   |
+| `emails`                                                                                 | `add`, `replace`           | Adds entries or replaces the complete set.                           |
+| `emails.value`                                                                           | `add`, `replace`           | Replaces the value on every email entry.                             |
+| `emails[type eq "work"].value`                                                           | `add`, `replace`, `remove` | Selects the work email.                                              |
+| `title`, `userType`, `preferredLanguage`, `locale`, `timezone`                           | `add`, `replace`, `remove` | Updates or clears one classic User string.                           |
+| `phoneNumbers`, `addresses`, `roles`, `entitlements`, their subattributes and type paths | `add`, `replace`, `remove` | Supports complete arrays and exact `type eq "<type>"` selectors.     |
+| `enterpriseUrn` and its writable subattributes                                           | `add`, `replace`, `remove` | Preserves unspecified Enterprise fields.                             |
+| `manager`, `manager.value`, `manager.$ref`                                               | `add`, `replace`, `remove` | Classic Entra aliases for the standard Enterprise manager attribute. |
 
-User paths may include the core User schema prefix. An `add` or `replace` operation may omit `path` and provide an object of writable attributes. `id`, `schemas`, and `meta` are read-only.
+In this table, `enterpriseUrn` is `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`.
+
+User paths may include the core User schema prefix. An `add` or `replace` operation may omit `path` and provide an object of writable attributes, including flat Enterprise URI keys. Unfiltered `replace` adds a missing target, while a filtered value path with no match returns `noTarget`. `id`, `schemas`, `meta`, and `manager.displayName` are read-only.
 
 ### Group PATCH paths
 
@@ -257,12 +288,23 @@ type resolveUser = (
     connectionId: string;
     provisioningDomainId: string;
     resource: {
+      schemas: readonly string[];
       externalId?: string;
       userName: string;
       primaryEmail: string;
       displayName: string;
       name: SCIMCanonicalName;
       emails: readonly SCIMCanonicalEmail[];
+      title?: string;
+      userType?: string;
+      preferredLanguage?: string;
+      locale?: string;
+      timezone?: string;
+      phoneNumbers?: readonly SCIMCanonicalPhoneNumber[];
+      addresses?: readonly SCIMCanonicalAddress[];
+      roles?: readonly SCIMCanonicalRole[];
+      entitlements?: readonly SCIMCanonicalEntitlement[];
+      enterprise?: SCIMEnterpriseUser;
       active: boolean;
     };
   },
@@ -340,9 +382,9 @@ The connection must have authenticated at least once so a binding exists. Remove
 
 The plugin does not support the following SCIM features:
 
-* Enterprise User or custom schema extensions
-* `User.groups`, `roles`, or `entitlements`
-* Phone numbers, addresses, titles, locales, timezones, photos, or passwords
+* Custom schema extensions
+* `User.groups`
+* Passwords, instant messaging addresses, photos, or X.509 certificates
 * Nested Groups or non-User Group members
 * Bulk requests, POST-based search, `/Me`, ETags, cursors, or sorting
 * Operators other than equality and logical `and`
@@ -366,6 +408,8 @@ The plugin adds the following models. Use `auth generate` to create the exact sc
 | `scimProjectionGrant`   | Stores validated role grants and their Group sources.                           |
 
 Better Auth supplies the primary `id` field for each model. The SCIM models also reference the core `user` model where required.
+
+`scimUser.serializedAttributes` is the required, bounded source of truth for the complete non-indexed canonical profile, including Enterprise User and other extension attributes. The `formattedName`, `givenName`, `familyName`, and `serializedEmails` fields are compatibility mirrors and are not read as canonical state.
 
 ## Related
 

--- a/packages/drizzle-adapter/src/relations-v2/generate-drizzle-schema.test.ts
+++ b/packages/drizzle-adapter/src/relations-v2/generate-drizzle-schema.test.ts
@@ -3,6 +3,13 @@ import ts from "typescript";
 import { describe, expect, it } from "vitest";
 import { generateDrizzleSchema } from "./generate-drizzle-schema";
 
+const TYPE_CHECK_TIMEOUT_MS = 15_000;
+
+/** Run compiler-backed tests with their dedicated synchronous-work timeout. */
+function test(name: string, callback: () => Promise<void>): void {
+	it(name, callback, TYPE_CHECK_TIMEOUT_MS);
+}
+
 const generate = (options: BetterAuthOptions) =>
 	generateDrizzleSchema({
 		options,
@@ -65,12 +72,12 @@ function typeErrors(code: string): string[] {
 }
 
 describe("relations-v2 schema generator", () => {
-	it("generates valid TypeScript for the default schema", async () => {
+	test("generates valid TypeScript for the default schema", async () => {
 		const { code = "" } = await generate({});
 		expect(typeErrors(code)).toEqual([]);
 	});
 
-	it("generates compound indexes with physical field names", async () => {
+	test("generates compound indexes with physical field names", async () => {
 		const { code = "" } = await generateFor("mysql", {
 			plugins: [
 				{
@@ -112,7 +119,7 @@ describe("relations-v2 schema generator", () => {
 		expect(typeErrors(code)).toEqual([]);
 	});
 
-	it("does not generate externally managed tables or their indexes", async () => {
+	test("does not generate externally managed tables or their indexes", async () => {
 		const { code = "" } = await generate({
 			plugins: [
 				{
@@ -157,7 +164,7 @@ describe("relations-v2 schema generator", () => {
 			expect(code).not.toMatch(/^export const relations\s*=/m);
 		});
 
-		it("compiles without duplicate identifier errors when a model's table name is `relations`", async () => {
+		test("compiles without duplicate identifier errors when a model's table name is `relations`", async () => {
 			const { code = "" } = await generate({
 				verification: { modelName: "relations" },
 			});
@@ -202,7 +209,7 @@ describe("relations-v2 schema generator", () => {
 	 *
 	 * @see https://github.com/better-auth/better-auth/pull/10048
 	 */
-	it("serializes array, object, and quoted-string additionalField defaultValue to a literal", async () => {
+	test("serializes array, object, and quoted-string additionalField defaultValue to a literal", async () => {
 		const { code = "" } = await generate({
 			user: {
 				additionalFields: {
@@ -224,7 +231,7 @@ describe("relations-v2 schema generator", () => {
 	});
 
 	describe("schemaName (PostgreSQL namespace)", () => {
-		it("declares a pgSchema and uses schema.table() when schemaName is set", async () => {
+		test("declares a pgSchema and uses schema.table() when schemaName is set", async () => {
 			const { code = "" } = await generateDrizzleSchema({
 				options: {},
 				provider: "pg",
@@ -268,7 +275,7 @@ describe("relations-v2 schema generator", () => {
 			}
 		});
 
-		it("converts a hyphenated schemaName into a valid identifier", async () => {
+		test("converts a hyphenated schemaName into a valid identifier", async () => {
 			const { code = "" } = await generateDrizzleSchema({
 				options: {},
 				provider: "pg",
@@ -290,7 +297,7 @@ describe("relations-v2 schema generator", () => {
 			expect(code).not.toContain("pgTable");
 		});
 
-		it("avoids variable collision when schemaName is 'pg'", async () => {
+		test("avoids variable collision when schemaName is 'pg'", async () => {
 			const { code = "" } = await generateDrizzleSchema({
 				options: {},
 				provider: "pg",
@@ -303,7 +310,7 @@ describe("relations-v2 schema generator", () => {
 			expect(typeErrors(code)).toEqual([]);
 		});
 
-		it("escapes quotes and backslashes in schemaName", async () => {
+		test("escapes quotes and backslashes in schemaName", async () => {
 			const { code = "" } = await generateDrizzleSchema({
 				options: {},
 				provider: "pg",

--- a/packages/scim/src/active-normalization.ts
+++ b/packages/scim/src/active-normalization.ts
@@ -1,0 +1,142 @@
+import { stripSCIMCoreAttributePrefix } from "./resource-schema-registry";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Normalize the exact string Boolean forms accepted from SCIM providers. */
+function normalizeSCIMStringBooleanValue(value: unknown): unknown {
+	if (typeof value !== "string") return value;
+	const normalized = value.toLowerCase();
+	if (normalized === "true") return true;
+	if (normalized === "false") return false;
+	return value;
+}
+
+function normalizeActiveProperty(
+	value: Record<string, unknown>,
+): Record<string, unknown> {
+	if (!Object.hasOwn(value, "active")) return value;
+	const active = normalizeSCIMStringBooleanValue(value.active);
+	return active === value.active ? value : { ...value, active };
+}
+
+const SCIM_MULTI_VALUED_PRIMARY_ATTRIBUTES = [
+	"emails",
+	"phoneNumbers",
+	"addresses",
+	"roles",
+	"entitlements",
+] as const;
+
+function normalizeMultiValuedPrimaryEntry(entry: unknown): unknown {
+	if (!isRecord(entry) || !Object.hasOwn(entry, "primary")) return entry;
+	const primary = normalizeSCIMStringBooleanValue(entry.primary);
+	return primary === entry.primary ? entry : { ...entry, primary };
+}
+
+function normalizeMultiValuedPrimaryValue(value: unknown): unknown {
+	if (!Array.isArray(value)) return normalizeMultiValuedPrimaryEntry(value);
+	let changed = false;
+	const normalized = value.map((entry) => {
+		const result = normalizeMultiValuedPrimaryEntry(entry);
+		if (result !== entry) changed = true;
+		return result;
+	});
+	return changed ? normalized : value;
+}
+
+function normalizeResourceMultiValuedPrimaries(
+	value: Record<string, unknown>,
+): Record<string, unknown> {
+	const updates: Record<string, unknown> = {};
+	for (const attribute of SCIM_MULTI_VALUED_PRIMARY_ATTRIBUTES) {
+		if (!Object.hasOwn(value, attribute)) continue;
+		const normalized = normalizeMultiValuedPrimaryValue(value[attribute]);
+		if (normalized !== value[attribute]) updates[attribute] = normalized;
+	}
+	return Object.keys(updates).length === 0 ? value : { ...value, ...updates };
+}
+
+function normalizeUserResourceEntraCompatibility(
+	value: Record<string, unknown>,
+): Record<string, unknown> {
+	return normalizeResourceMultiValuedPrimaries(normalizeActiveProperty(value));
+}
+
+function isActivePath(path: unknown): boolean {
+	return (
+		typeof path === "string" &&
+		stripSCIMCoreAttributePrefix("User", path.trim()).toLowerCase() === "active"
+	);
+}
+
+// Whitespace tolerance must match user-patch.ts's SCIM_VALUE_PATH/SCIM_PRIMARY_VALUE_PATH,
+// or a spaced-out filter bypasses normalization and fails boolean validation downstream.
+const MULTI_VALUED_PRIMARY_PATH_PATTERN =
+	/^(emails|phonenumbers|addresses|roles|entitlements)\s*(\[[^\]]*\])?(?:\s*\.\s*(primary))?$/i;
+
+/**
+ * Matches a path targeting one of the multi-valued `primary` attributes,
+ * with or without a `[type eq "..."]` filter. `targetsPrimary` is true only
+ * when the path ends in `.primary`, in which case the operation value is the
+ * primary value itself rather than a container that holds it.
+ */
+function matchMultiValuedPrimaryPath(
+	path: unknown,
+): { targetsPrimary: boolean } | null {
+	if (typeof path !== "string") return null;
+	const stripped = stripSCIMCoreAttributePrefix("User", path.trim());
+	const match = MULTI_VALUED_PRIMARY_PATH_PATTERN.exec(stripped);
+	return match ? { targetsPrimary: Boolean(match[3]) } : null;
+}
+
+function isPathless(path: unknown): boolean {
+	return (
+		path === undefined || (typeof path === "string" && path.trim().length === 0)
+	);
+}
+
+function normalizePatchOperation(operation: unknown): unknown {
+	if (!isRecord(operation)) return operation;
+	if (isActivePath(operation.path)) {
+		const value = normalizeSCIMStringBooleanValue(operation.value);
+		return value === operation.value ? operation : { ...operation, value };
+	}
+	const primaryMatch = matchMultiValuedPrimaryPath(operation.path);
+	if (primaryMatch) {
+		const value = primaryMatch.targetsPrimary
+			? normalizeSCIMStringBooleanValue(operation.value)
+			: normalizeMultiValuedPrimaryValue(operation.value);
+		return value === operation.value ? operation : { ...operation, value };
+	}
+	if (isPathless(operation.path) && isRecord(operation.value)) {
+		const value = normalizeUserResourceEntraCompatibility(operation.value);
+		return value === operation.value ? operation : { ...operation, value };
+	}
+	return operation;
+}
+
+/**
+ * Normalize provider-compatible User `active` and multi-valued `primary`
+ * string Boolean values (Microsoft Entra) without widening the endpoint
+ * schemas or mutating the parsed request body.
+ */
+export function normalizeSCIMUserEntraCompatibilityRequestBody(
+	method: string,
+	body: unknown,
+): unknown {
+	if (!isRecord(body)) return body;
+	if (method === "POST" || method === "PUT") {
+		return normalizeUserResourceEntraCompatibility(body);
+	}
+	if (method !== "PATCH" || !Array.isArray(body.Operations)) return body;
+
+	let changed = false;
+	const operations = body.Operations.map((operation) => {
+		const normalized = normalizePatchOperation(operation);
+		if (normalized !== operation) changed = true;
+		return normalized;
+	});
+	return changed ? { ...body, Operations: operations } : body;
+}

--- a/packages/scim/src/collection-query.test.ts
+++ b/packages/scim/src/collection-query.test.ts
@@ -8,6 +8,9 @@ import {
 	parseSCIMCollectionQuery,
 } from "./collection-query";
 
+const SCIM_ENTERPRISE_USER_SCHEMA =
+	"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+
 describe("parseSCIMCollectionQuery", () => {
 	it("defaults classic pagination to the first page capped at 100 resources", () => {
 		const result = parseSCIMCollectionQuery("User", {});
@@ -145,13 +148,60 @@ describe("collection filters", () => {
 	});
 
 	it.each([
+		[
+			'displayName eq "MyPlatform BA SCIM - Admins"',
+			"MyPlatform BA SCIM - Admins",
+		],
+		['displayName eq "Research and Development"', "Research and Development"],
+		['displayName eq "Platform - \\"Admins\\""', 'Platform - "Admins"'],
+	] as const)("finds the top-level equality operator in %s", (filter, value) => {
+		expect(parseSCIMCollectionQuery("Group", { filter })).toMatchObject({
+			ok: true,
+			value: {
+				filters: [{ attribute: "displayName", operator: "eq", value }],
+			},
+		});
+	});
+
+	it("preserves top-level conjunctions when a quoted value contains and", () => {
+		expect(
+			parseSCIMCollectionQuery("Group", {
+				filter:
+					'displayName eq "Research and Development" and externalId eq "research-and-development"',
+			}),
+		).toMatchObject({
+			ok: true,
+			value: {
+				filters: [
+					{
+						attribute: "displayName",
+						operator: "eq",
+						value: "Research and Development",
+					},
+					{
+						attribute: "externalId",
+						operator: "eq",
+						value: "research-and-development",
+					},
+				],
+			},
+		});
+	});
+
+	it.each([
 		["Group", 'userName eq "ada"', "unsupported-filter-attribute"],
-		["User", 'user Name eq "ada"', "unsupported-filter-attribute"],
+		["User", 'user Name eq "ada"', "unsupported-filter-operator"],
 		["User", 'userName ne "ada"', "unsupported-filter-operator"],
+		[
+			"Group",
+			'displayName ne "MyPlatform BA SCIM - Admins"',
+			"unsupported-filter-operator",
+		],
 		["User", "userName pr", "invalid-filter-syntax"],
 		["User", "userName eq ada", "invalid-filter-value"],
 		["User", 'userName eq "ada" trailing', "invalid-filter-value"],
 		["User", "userName eq 7", "invalid-filter-value"],
+		["Group", 'displayName eq "one" ne "two"', "invalid-filter-value"],
 	] as const)("returns %s filter failures without throwing", (resourceType, filter, code) => {
 		const result =
 			resourceType === "User"
@@ -161,6 +211,26 @@ describe("collection filters", () => {
 		expect(result).toMatchObject({
 			ok: false,
 			error: { code, parameter: "filter", scimType: "invalidFilter" },
+		});
+	});
+
+	it.each([
+		["Group", 'displayName eq "unterminated'],
+		["Group", 'displayName] eq "Admins"'],
+		["User", 'emails[type eq "work".value eq "ada@example.com"'],
+	] as const)("returns invalid filter syntax for malformed %s quote or bracket state", (resourceType, filter) => {
+		const result =
+			resourceType === "User"
+				? parseSCIMCollectionQuery("User", { filter })
+				: parseSCIMCollectionQuery("Group", { filter });
+
+		expect(result).toMatchObject({
+			ok: false,
+			error: {
+				code: "invalid-filter-syntax",
+				parameter: "filter",
+				scimType: "invalidFilter",
+			},
 		});
 	});
 
@@ -209,6 +279,28 @@ describe("parseSCIMAttributeProjection", () => {
 			value: {
 				mode: "exclude",
 				excludedAttributes: new Set(["members", "meta.version"]),
+			},
+		});
+	});
+
+	it("resolves qualified Enterprise User paths by their longest schema URI", () => {
+		expect(
+			parseSCIMAttributeProjection("User", {
+				attributes: [
+					SCIM_ENTERPRISE_USER_SCHEMA,
+					`${SCIM_ENTERPRISE_USER_SCHEMA.toUpperCase()}:department`,
+					`${SCIM_ENTERPRISE_USER_SCHEMA}:manager.value`,
+				],
+			}),
+		).toEqual({
+			ok: true,
+			value: {
+				mode: "include",
+				attributes: new Set([
+					SCIM_ENTERPRISE_USER_SCHEMA.toLowerCase(),
+					`${SCIM_ENTERPRISE_USER_SCHEMA.toLowerCase()}.department`,
+					`${SCIM_ENTERPRISE_USER_SCHEMA.toLowerCase()}.manager.value`,
+				]),
 			},
 		});
 	});

--- a/packages/scim/src/collection-query.ts
+++ b/packages/scim/src/collection-query.ts
@@ -3,7 +3,10 @@ import type {
 	SCIM_RESOURCE_SCHEMA_REGISTRY,
 	SCIMResourceType,
 } from "./resource-schema-registry";
-import { stripSCIMCoreAttributePrefix } from "./resource-schema-registry";
+import {
+	resolveSCIMResponseAttributePath,
+	stripSCIMCoreAttributePrefix,
+} from "./resource-schema-registry";
 
 export type { SCIMResourceType } from "./resource-schema-registry";
 
@@ -220,6 +223,116 @@ function canonicalizeFilterAttribute(
 	}
 }
 
+interface SCIMFilterOperation {
+	rawAttribute: string;
+	rawOperator: string;
+	rawValue: string;
+}
+
+interface SCIMTopLevelWord {
+	end: number;
+	start: number;
+	value: string;
+}
+
+function invalidFilterSyntax(detail: string): SCIMQueryParseResult<never> {
+	return {
+		ok: false,
+		error: {
+			code: "invalid-filter-syntax",
+			parameter: "filter",
+			scimType: "invalidFilter",
+			detail,
+		},
+	};
+}
+
+function scanSCIMFilterTopLevel(
+	filter: string,
+): SCIMQueryParseResult<readonly SCIMTopLevelWord[]> {
+	const words: SCIMTopLevelWord[] = [];
+	let bracketDepth = 0;
+	let quoted = false;
+	let escaped = false;
+
+	for (let index = 0; index < filter.length; index += 1) {
+		const character = filter[index];
+		if (quoted) {
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (character === "\\") {
+				escaped = true;
+				continue;
+			}
+			if (character === '"') quoted = false;
+			continue;
+		}
+
+		if (character === '"') {
+			quoted = true;
+			continue;
+		}
+		if (character === "[") {
+			bracketDepth += 1;
+			continue;
+		}
+		if (character === "]") {
+			if (bracketDepth === 0) {
+				return invalidFilterSyntax(
+					"filter contains malformed quotes or brackets",
+				);
+			}
+			bracketDepth -= 1;
+			continue;
+		}
+		if (bracketDepth !== 0 || !character || !/[A-Za-z]/.test(character)) {
+			continue;
+		}
+
+		const start = index;
+		while (/[A-Za-z]/.test(filter[index + 1] ?? "")) index += 1;
+		const end = index + 1;
+		words.push({ start, end, value: filter.slice(start, end) });
+	}
+
+	if (quoted || bracketDepth !== 0) {
+		return invalidFilterSyntax("filter contains malformed quotes or brackets");
+	}
+	return { ok: true, value: words };
+}
+
+function findTopLevelFilterOperation(
+	filter: string,
+): SCIMQueryParseResult<SCIMFilterOperation | undefined> {
+	const scan = scanSCIMFilterTopLevel(filter);
+	if (!scan.ok) return scan;
+
+	for (const word of scan.value) {
+		const before = filter[word.start - 1];
+		const after = filter[word.end];
+		if (
+			before === undefined ||
+			after === undefined ||
+			!/\s/.test(before) ||
+			!/\s/.test(after)
+		) {
+			continue;
+		}
+
+		const rawAttribute = filter.slice(0, word.start).trim();
+		const rawValue = filter.slice(word.end).trim();
+		if (!rawAttribute || !rawValue) continue;
+		return {
+			ok: true,
+			value: { rawAttribute, rawOperator: word.value, rawValue },
+		};
+	}
+
+	return { ok: true, value: undefined };
+}
+
 function parseSCIMEqualityFilter(
 	resourceType: "User",
 	filter?: string,
@@ -241,36 +354,27 @@ function parseSCIMEqualityFilter(
 		return { ok: true, value: undefined };
 	}
 
-	const match = filter.trim().match(/^([\s\S]+)\s+([A-Za-z]+)\s+([\s\S]+)$/);
-	if (!match) {
-		return {
-			ok: false,
-			error: {
-				code: "invalid-filter-syntax",
-				parameter: "filter",
-				scimType: "invalidFilter",
-				detail: 'filter must use the form attribute eq "value"',
-			},
-		};
+	const parsedOperation = findTopLevelFilterOperation(filter.trim());
+	if (!parsedOperation.ok) return parsedOperation;
+	const operation = parsedOperation.value;
+	if (!operation) {
+		return invalidFilterSyntax('filter must use the form attribute eq "value"');
 	}
 
-	const [, rawAttribute, rawOperator, rawValue] = match;
-	if (rawOperator?.toLowerCase() !== "eq") {
+	const { rawAttribute, rawOperator, rawValue } = operation;
+	if (rawOperator.toLowerCase() !== "eq") {
 		return {
 			ok: false,
 			error: {
 				code: "unsupported-filter-operator",
 				parameter: "filter",
 				scimType: "invalidFilter",
-				detail: `filter operator ${rawOperator ?? ""} is not supported`,
+				detail: `filter operator ${rawOperator} is not supported`,
 			},
 		};
 	}
 
-	const attribute = canonicalizeFilterAttribute(
-		resourceType,
-		rawAttribute?.trim() ?? "",
-	);
+	const attribute = canonicalizeFilterAttribute(resourceType, rawAttribute);
 	if (!attribute) {
 		return {
 			ok: false,
@@ -278,14 +382,14 @@ function parseSCIMEqualityFilter(
 				code: "unsupported-filter-attribute",
 				parameter: "filter",
 				scimType: "invalidFilter",
-				detail: `filter attribute ${rawAttribute ?? ""} is not supported for ${resourceType}`,
+				detail: `filter attribute ${rawAttribute} is not supported for ${resourceType}`,
 			},
 		};
 	}
 
 	let value: unknown;
 	try {
-		value = JSON.parse(rawValue ?? "");
+		value = JSON.parse(rawValue);
 	} catch {
 		return {
 			ok: false,
@@ -319,79 +423,38 @@ function parseSCIMEqualityFilter(
 function splitFilterConjunction(
 	filter: string,
 ): SCIMQueryParseResult<readonly string[]> {
+	const scan = scanSCIMFilterTopLevel(filter);
+	if (!scan.ok) return scan;
 	const expressions: string[] = [];
 	let expressionStart = 0;
-	let bracketDepth = 0;
-	let quoted = false;
-	let escaped = false;
 
-	for (let index = 0; index < filter.length; index += 1) {
-		const character = filter[index];
-		if (quoted) {
-			if (escaped) {
-				escaped = false;
-				continue;
-			}
-			if (character === "\\") {
-				escaped = true;
-				continue;
-			}
-			if (character === '"') quoted = false;
-			continue;
-		}
-
-		if (character === '"') {
-			quoted = true;
-			continue;
-		}
-		if (character === "[") {
-			bracketDepth += 1;
-			continue;
-		}
-		if (character === "]") {
-			bracketDepth -= 1;
-			if (bracketDepth < 0) break;
-			continue;
-		}
-		if (bracketDepth !== 0) continue;
-
-		const token = filter.slice(index, index + 3);
-		const before = filter[index - 1];
-		const after = filter[index + 3];
+	for (const word of scan.value) {
+		const before = filter[word.start - 1];
+		const after = filter[word.end];
 		if (
-			token.toLowerCase() === "and" &&
+			word.value.toLowerCase() === "and" &&
 			before !== undefined &&
 			after !== undefined &&
 			/\s/.test(before) &&
 			/\s/.test(after)
 		) {
-			const expression = filter.slice(expressionStart, index).trim();
-			if (!expression) break;
+			const expression = filter.slice(expressionStart, word.start).trim();
+			if (!expression) {
+				return invalidFilterSyntax("filter contains an invalid conjunction");
+			}
 			expressions.push(expression);
-			expressionStart = index + 3;
-			index += 2;
+			expressionStart = word.end;
 		}
 	}
 
 	const finalExpression = filter.slice(expressionStart).trim();
-	if (
-		quoted ||
-		bracketDepth !== 0 ||
-		!finalExpression ||
-		expressions.length >= 10
-	) {
-		return {
-			ok: false,
-			error: {
-				code: "invalid-filter-syntax",
-				parameter: "filter",
-				scimType: "invalidFilter",
-				detail:
-					expressions.length >= 10
-						? "filter supports at most 10 equality expressions"
-						: "filter contains an invalid conjunction",
-			},
-		};
+	if (!finalExpression) {
+		return invalidFilterSyntax("filter contains an invalid conjunction");
+	}
+	if (expressions.length >= 10) {
+		return invalidFilterSyntax(
+			"filter supports at most 10 equality expressions",
+		);
 	}
 	expressions.push(finalExpression);
 	return { ok: true, value: expressions };
@@ -455,7 +518,7 @@ function normalizeAttributeList(
 					},
 				};
 			}
-			const normalizedAttribute = stripSCIMCoreAttributePrefix(
+			const normalizedAttribute = resolveSCIMResponseAttributePath(
 				resourceType,
 				attribute,
 			);

--- a/packages/scim/src/configuration.ts
+++ b/packages/scim/src/configuration.ts
@@ -99,6 +99,9 @@ export interface SCIMName {
 	formatted?: string;
 	givenName?: string;
 	familyName?: string;
+	middleName?: string;
+	honorificPrefix?: string;
+	honorificSuffix?: string;
 }
 
 /** One email address supplied on a SCIM User resource. */
@@ -113,6 +116,9 @@ export interface SCIMCanonicalName {
 	formatted: string;
 	givenName?: string;
 	familyName?: string;
+	middleName?: string;
+	honorificPrefix?: string;
+	honorificSuffix?: string;
 }
 
 /** A normalized email supplied to application-owned SCIM integrations. */
@@ -122,14 +128,75 @@ export interface SCIMCanonicalEmail {
 	type?: string;
 }
 
+/** A normalized phone number supplied on a SCIM User resource. */
+export interface SCIMCanonicalPhoneNumber {
+	value: string;
+	type?: string;
+	primary?: boolean;
+}
+
+/** A normalized postal address supplied on a SCIM User resource. */
+export interface SCIMCanonicalAddress {
+	formatted?: string;
+	streetAddress?: string;
+	locality?: string;
+	region?: string;
+	postalCode?: string;
+	country?: string;
+	type?: string;
+	primary?: boolean;
+}
+
+/** A normalized role supplied on a SCIM User resource. */
+export interface SCIMCanonicalRole {
+	value: string;
+	display?: string;
+	type?: string;
+	primary?: boolean;
+}
+
+/** A normalized entitlement supplied on a SCIM User resource. */
+export interface SCIMCanonicalEntitlement {
+	value: string;
+	display?: string;
+	type?: string;
+	primary?: boolean;
+}
+
+/** A manager reference containing an identifier, resource URI, or both. */
+export type SCIMCanonicalManager =
+	| { value: string; $ref?: string }
+	| { value?: string; $ref: string };
+
+/** Supported attributes from the standard Enterprise User extension. */
+export interface SCIMEnterpriseUser {
+	employeeNumber?: string;
+	costCenter?: string;
+	organization?: string;
+	division?: string;
+	department?: string;
+	manager?: SCIMCanonicalManager;
+}
+
 /** The normalized SCIM User supplied to application-owned integrations. */
 export interface SCIMCanonicalUser {
+	schemas: readonly string[];
 	externalId?: string;
 	userName: string;
 	primaryEmail: string;
 	displayName: string;
 	name: SCIMCanonicalName;
 	emails: readonly SCIMCanonicalEmail[];
+	title?: string;
+	userType?: string;
+	preferredLanguage?: string;
+	locale?: string;
+	timezone?: string;
+	phoneNumbers?: readonly SCIMCanonicalPhoneNumber[];
+	addresses?: readonly SCIMCanonicalAddress[];
+	roles?: readonly SCIMCanonicalRole[];
+	entitlements?: readonly SCIMCanonicalEntitlement[];
+	enterprise?: SCIMEnterpriseUser;
 	active: boolean;
 }
 
@@ -262,6 +329,21 @@ export interface SCIMProjection {
 	): void | Promise<void>;
 }
 
+/** Microsoft Entra provisioning client compatibility. */
+export interface SCIMMicrosoftEntraCompatibilityOptions {
+	/**
+	 * Accept Microsoft's classic, attribute-less Group schema marker on
+	 * `POST /Groups`. The marker is never advertised, persisted, or returned.
+	 * Defaults to `false`.
+	 */
+	acceptLegacyGroupSchema?: boolean;
+}
+
+/** Narrow ingress compatibility for documented provider request shapes. */
+export interface SCIMCompatibilityOptions {
+	microsoftEntra?: SCIMMicrosoftEntraCompatibilityOptions;
+}
+
 /** Configuration for the SCIM plugin. */
 export interface SCIMOptions {
 	/** Code-defined provisioning connections accepted by the SCIM endpoint. */
@@ -272,4 +354,6 @@ export interface SCIMOptions {
 	identity?: SCIMIdentity;
 	/** Optional application or tenancy projection. No projection grants access. */
 	projection?: SCIMProjection;
+	/** Narrow ingress compatibility for documented provider request shapes. */
+	compatibility?: SCIMCompatibilityOptions;
 }

--- a/packages/scim/src/discovery.test.ts
+++ b/packages/scim/src/discovery.test.ts
@@ -74,12 +74,13 @@ describe("SCIM discovery", () => {
 
 		expect(schemas).toMatchObject({
 			schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-			totalResults: 2,
+			totalResults: 3,
 			startIndex: 1,
-			itemsPerPage: 2,
+			itemsPerPage: 3,
 		});
 		expect(schemas.Resources.map((schema) => schema.id)).toEqual([
 			"urn:ietf:params:scim:schemas:core:2.0:User",
+			"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 			"urn:ietf:params:scim:schemas:core:2.0:Group",
 		]);
 		expect(resourceTypes).toMatchObject({
@@ -89,16 +90,26 @@ describe("SCIM discovery", () => {
 			itemsPerPage: 2,
 		});
 		expect(
-			resourceTypes.Resources.map(({ id, endpoint, schema }) => ({
-				id,
-				endpoint,
-				schema,
+			resourceTypes.Resources.map((resourceType) => ({
+				id: resourceType.id,
+				endpoint: resourceType.endpoint,
+				schema: resourceType.schema,
+				...("schemaExtensions" in resourceType
+					? { schemaExtensions: resourceType.schemaExtensions }
+					: {}),
 			})),
 		).toEqual([
 			{
 				id: "User",
 				endpoint: "/Users",
 				schema: "urn:ietf:params:scim:schemas:core:2.0:User",
+				schemaExtensions: [
+					{
+						schema:
+							"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+						required: false,
+					},
+				],
 			},
 			{
 				id: "Group",

--- a/packages/scim/src/discovery.ts
+++ b/packages/scim/src/discovery.ts
@@ -1,7 +1,10 @@
 import { HIDE_METADATA } from "better-auth";
 import { createAuthEndpoint } from "better-auth/api";
 import { SCIM_MAX_PAGE_SIZE } from "./collection-query";
-import { SCIM_RESOURCE_SCHEMAS } from "./resource-schema-registry";
+import {
+	SCIM_DISCOVERY_SCHEMA_DESCRIPTORS,
+	SCIM_RESOURCE_SCHEMAS,
+} from "./resource-schema-registry";
 import { createSCIMError, SCIMErrorOpenAPISchemas } from "./scim-error";
 import {
 	createSCIMOpenAPIContent,
@@ -18,8 +21,8 @@ const SCIM_LIST_RESPONSE_SCHEMA =
 const SCIM_SERVICE_PROVIDER_CONFIG_SCHEMA =
 	"urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig";
 
-const supportedSCIMSchemas = SCIM_RESOURCE_SCHEMAS.map(
-	(resource) => resource.discoverySchema,
+const supportedSCIMSchemas = SCIM_DISCOVERY_SCHEMA_DESCRIPTORS.map(
+	(descriptor) => descriptor.discoverySchema,
 );
 const supportedSCIMResourceTypes = SCIM_RESOURCE_SCHEMAS.map(
 	(resource) => resource.resourceType,
@@ -54,6 +57,14 @@ function createListResponse<T>(resources: T[]) {
 		itemsPerPage: resources.length,
 		Resources: resources,
 	};
+}
+
+function readSCIMPathIdentifier(identifier: string): string {
+	try {
+		return decodeURIComponent(identifier);
+	} catch {
+		return identifier;
+	}
 }
 
 export const getSCIMServiceProviderConfig = createAuthEndpoint(
@@ -172,8 +183,9 @@ export const getSCIMSchema = createAuthEndpoint(
 		}),
 	},
 	async (ctx) => {
+		const schemaId = readSCIMPathIdentifier(ctx.params.schemaId);
 		const schema = supportedSCIMSchemas.find(
-			(supportedSchema) => supportedSchema.id === ctx.params.schemaId,
+			(supportedSchema) => supportedSchema.id === schemaId,
 		);
 		if (!schema) {
 			throw createSCIMError("NOT_FOUND", {

--- a/packages/scim/src/group-provisioning.ts
+++ b/packages/scim/src/group-provisioning.ts
@@ -61,33 +61,22 @@ function requireGroupAttributeProjection(
 	return projection.value;
 }
 
-function requestsProjectedMutationResponse(
-	input: SCIMCollectionQueryInput,
-): boolean {
-	return (
-		input.attributes !== undefined || input.excludedAttributes !== undefined
-	);
-}
-
 const patchSCIMGroupBodySchema = z.object({
 	schemas: z
-		.array(z.string())
-		.refine((schemas) => schemas.includes(SCIM_PATCH_SCHEMA), {
-			message: "Invalid schemas for PatchOp",
+		.array(z.literal(SCIM_PATCH_SCHEMA))
+		.length(1, "schemas must contain only the PatchOp schema"),
+	// An empty array is a valid no-op PATCH (Microsoft Entra sends one).
+	Operations: z.array(
+		z.object({
+			op: z
+				.string()
+				.toLowerCase()
+				.default("replace")
+				.pipe(z.enum(["replace", "add", "remove"])),
+			path: z.string().optional(),
+			value: z.unknown().optional(),
 		}),
-	Operations: z
-		.array(
-			z.object({
-				op: z
-					.string()
-					.toLowerCase()
-					.default("replace")
-					.pipe(z.enum(["replace", "add", "remove"])),
-				path: z.string().optional(),
-				value: z.unknown().optional(),
-			}),
-		)
-		.min(1),
+	),
 });
 
 const GROUP_MEMBER_VALUE_PATH =
@@ -333,13 +322,14 @@ function parseIncrementalMembershipPatch(
 }
 
 function readPatchString(value: unknown, attribute: string): string {
-	if (typeof value !== "string" || !value.trim()) {
+	const scalar = Array.isArray(value) && value.length === 1 ? value[0] : value;
+	if (typeof scalar !== "string" || !scalar.trim()) {
 		throw createSCIMError("BAD_REQUEST", {
 			detail: `${attribute} must be a non-empty string`,
 			scimType: "invalidValue",
 		});
 	}
-	return value.trim();
+	return scalar.trim();
 }
 
 function applyGroupPatch(
@@ -1340,11 +1330,8 @@ export function patchSCIMGroup(
 					summary: "Patch SCIM Group",
 					responses: {
 						"200": {
-							description: "Projected SCIM Group resource",
+							description: "Updated SCIM Group resource",
 							content: createSCIMOpenAPIContent(OpenAPIGroupResourceSchema),
-						},
-						"204": {
-							description: "SCIM Group updated",
 						},
 						...SCIMErrorOpenAPISchemas,
 					},
@@ -1357,7 +1344,6 @@ export function patchSCIMGroup(
 			const connection = ctx.context.scimConnection;
 			const query = ctx.query ?? {};
 			const attributeProjection = requireGroupAttributeProjection(query);
-			const returnProjectedResource = requestsProjectedMutationResponse(query);
 			const group = await findSCIMGroup(
 				adapter,
 				connection,
@@ -1527,10 +1513,6 @@ export function patchSCIMGroup(
 				updatedGroup,
 			);
 			ctx.setHeader("location", completeResource.meta.location);
-			if (!returnProjectedResource) {
-				ctx.setStatus(204);
-				return;
-			}
 			return ctx.json(
 				await createProjectedGroupResource(
 					adapter,

--- a/packages/scim/src/group-schemas.ts
+++ b/packages/scim/src/group-schemas.ts
@@ -2,6 +2,13 @@ import * as z from "zod";
 
 const SCIM_GROUP_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:Group";
 
+/**
+ * Attribute-less Group marker sent by Microsoft's classic Entra provisioning
+ * client. It is an input compatibility token, not a SCIM extension schema.
+ */
+const SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA =
+	"http://schemas.microsoft.com/2006/11/ResourceManagement/ADSCIM/2.0/Group";
+
 /** Maximum number of direct User members in one canonical SCIM Group. */
 export const SCIM_MAX_GROUP_MEMBERS = 1_000;
 
@@ -21,6 +28,52 @@ export const APIGroupSchema = z.object({
 	displayName: z.string().trim().min(1),
 	members: z.array(groupMemberSchema).max(SCIM_MAX_GROUP_MEMBERS).optional(),
 });
+
+export type MicrosoftEntraGroupSchemaNormalization =
+	| { ok: true; body: unknown }
+	| { ok: false; detail: string };
+
+/**
+ * Remove the exact classic Entra Group marker from an enabled POST request.
+ * Marker attributes and duplicate marker declarations are always rejected.
+ */
+export function normalizeMicrosoftEntraGroupSchema(
+	body: unknown,
+	enabled: boolean,
+): MicrosoftEntraGroupSchemaNormalization {
+	if (typeof body !== "object" || body === null || Array.isArray(body)) {
+		return { ok: true, body };
+	}
+	if (Object.hasOwn(body, SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA)) {
+		return {
+			ok: false,
+			detail:
+				"The Microsoft Entra Group compatibility schema cannot contain attributes",
+		};
+	}
+	const schemas = Reflect.get(body, "schemas");
+	if (!Array.isArray(schemas)) return { ok: true, body };
+	const markerCount = schemas.filter(
+		(schema) => schema === SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+	).length;
+	if (markerCount === 0 || !enabled) return { ok: true, body };
+	if (markerCount !== 1) {
+		return {
+			ok: false,
+			detail:
+				"The Microsoft Entra Group compatibility schema must not be duplicated",
+		};
+	}
+	return {
+		ok: true,
+		body: {
+			...body,
+			schemas: schemas.filter(
+				(schema) => schema !== SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+			),
+		},
+	};
+}
 
 export const OpenAPIGroupResourceSchema = {
 	type: "object",

--- a/packages/scim/src/index.ts
+++ b/packages/scim/src/index.ts
@@ -2,6 +2,7 @@ import type { BetterAuthPlugin, Status } from "better-auth";
 import { BetterAuthError } from "better-auth";
 import { createAuthMiddleware } from "better-auth/api";
 import { statusCodes } from "better-call";
+import { normalizeSCIMUserEntraCompatibilityRequestBody } from "./active-normalization";
 import type { SCIMOptions } from "./configuration";
 import {
 	areValidSCIMScopes,
@@ -228,8 +229,9 @@ function createSCIMPlugin(options: SCIMOptions) {
 					),
 				};
 			}
+			let body: unknown;
 			try {
-				JSON.parse(await request.clone().text());
+				body = JSON.parse(await request.clone().text());
 			} catch {
 				return {
 					response: createSCIMErrorResponse(
@@ -239,6 +241,54 @@ function createSCIMPlugin(options: SCIMOptions) {
 					),
 				};
 			}
+			const isUserMutation =
+				/\/scim\/v2\/Users(?:\/[^/]+)?$/.test(path) &&
+				((request.method === "POST" && path.endsWith("/Users")) ||
+					(["PUT", "PATCH"].includes(request.method) &&
+						!path.endsWith("/Users")));
+			const isGroupCreate =
+				request.method === "POST" && /\/scim\/v2\/Groups$/.test(path);
+			const isGroupMutation =
+				/\/scim\/v2\/Groups(?:\/[^/]+)?$/.test(path) &&
+				(isGroupCreate ||
+					(["PUT", "PATCH"].includes(request.method) &&
+						!path.endsWith("/Groups")));
+			let normalizedBody = body;
+			if (isGroupMutation) {
+				const groupNormalization = normalizeMicrosoftEntraGroupSchema(
+					normalizedBody,
+					isGroupCreate &&
+						options.compatibility?.microsoftEntra?.acceptLegacyGroupSchema ===
+							true,
+				);
+				if (!groupNormalization.ok) {
+					return {
+						response: createSCIMErrorResponse(
+							"BAD_REQUEST",
+							groupNormalization.detail,
+							"invalidValue",
+						),
+					};
+				}
+				normalizedBody = groupNormalization.body;
+			}
+			if (isUserMutation) {
+				normalizedBody = normalizeSCIMUserEntraCompatibilityRequestBody(
+					request.method,
+					normalizedBody,
+				);
+			}
+			if (normalizedBody === body) return;
+			const headers = new Headers(request.headers);
+			headers.delete("content-length");
+			return {
+				request: new Request(request.url, {
+					method: request.method,
+					headers,
+					body: JSON.stringify(normalizedBody),
+					signal: request.signal,
+				}),
+			};
 		},
 		endpoints: {
 			decommissionSCIMConnection: createDecommissionSCIMConnectionEndpoint(

--- a/packages/scim/src/index.ts
+++ b/packages/scim/src/index.ts
@@ -25,6 +25,7 @@ import {
 	patchSCIMGroup,
 	replaceSCIMGroup,
 } from "./group-provisioning";
+import { normalizeMicrosoftEntraGroupSchema } from "./group-schemas";
 import {
 	acquireActiveSCIMUserLink,
 	createSCIMIdentityCoordinator,
@@ -84,7 +85,7 @@ function isAPIErrorLike(value: unknown): value is APIErrorLike {
 function createSCIMErrorResponse(
 	status: "BAD_REQUEST" | "UNSUPPORTED_MEDIA_TYPE",
 	detail: string,
-	scimType?: "invalidSyntax",
+	scimType?: "invalidSyntax" | "invalidValue",
 ) {
 	const error = createSCIMError(status, {
 		detail,
@@ -580,6 +581,11 @@ function createSCIMPlugin(options: SCIMOptions) {
 						required: true,
 						returned: false,
 					},
+					serializedAttributes: {
+						type: "string",
+						required: false,
+						returned: false,
+					},
 					externalId: {
 						type: "string",
 						required: false,
@@ -792,12 +798,19 @@ export type {
 	SCIMBearerCredentialOptions,
 	SCIMBearerTokenVerificationInput,
 	SCIMBearerTokenVerificationResult,
+	SCIMCanonicalAddress,
 	SCIMCanonicalEmail,
+	SCIMCanonicalEntitlement,
+	SCIMCanonicalManager,
 	SCIMCanonicalName,
+	SCIMCanonicalPhoneNumber,
+	SCIMCanonicalRole,
 	SCIMCanonicalUser,
+	SCIMCompatibilityOptions,
 	SCIMConnectionDecommissionStatus,
 	SCIMConnectionOptions,
 	SCIMEmail,
+	SCIMEnterpriseUser,
 	SCIMGroupAuthorizationSource,
 	SCIMIdentity,
 	SCIMIdentityResolution,
@@ -805,6 +818,7 @@ export type {
 	SCIMIdentityResolutionInput,
 	SCIMIdentitySource,
 	SCIMIdentityState,
+	SCIMMicrosoftEntraCompatibilityOptions,
 	SCIMName,
 	SCIMOAuthBearerPrincipal,
 	SCIMOptions,

--- a/packages/scim/src/persistence.ts
+++ b/packages/scim/src/persistence.ts
@@ -34,10 +34,16 @@ export interface SCIMUser {
 	workEmailValueIndex: string;
 	emailValueIndex: string;
 	displayName: string;
+	/** Compatibility mirror for the Better Auth 1.7 prerelease schema. */
 	formattedName: string;
+	/** Compatibility mirror for the Better Auth 1.7 prerelease schema. */
 	givenName?: string | null;
+	/** Compatibility mirror for the Better Auth 1.7 prerelease schema. */
 	familyName?: string | null;
+	/** Compatibility mirror for the Better Auth 1.7 prerelease schema. */
 	serializedEmails: string;
+	/** Authoritative complete canonical attribute payload; absent on rows persisted before this field existed. */
+	serializedAttributes?: string | null;
 	externalId?: string | null;
 	externalIdKey?: string | null;
 	active: boolean;

--- a/packages/scim/src/resource-attribute-projection.ts
+++ b/packages/scim/src/resource-attribute-projection.ts
@@ -40,11 +40,30 @@ function createAttributePathNode(): AttributePathNode {
 
 function createAttributePathTree(
 	attributePaths: ReadonlySet<string>,
+	resourceAttributeNames: readonly string[],
 ): AttributePathNode {
 	const root = createAttributePathNode();
+	const orderedResourceAttributeNames = [...resourceAttributeNames].sort(
+		(left, right) => right.length - left.length,
+	);
 
 	for (const attributePath of attributePaths) {
-		const segments = attributePath.split(".");
+		const rootAttribute = orderedResourceAttributeNames.find(
+			(attributeName) => {
+				const normalizedName = attributeName.toLowerCase();
+				return (
+					attributePath === normalizedName ||
+					attributePath.startsWith(`${normalizedName}.`)
+				);
+			},
+		);
+		const relativePath = rootAttribute
+			? attributePath.slice(rootAttribute.length).replace(/^\./, "")
+			: attributePath;
+		const segments = [
+			...(rootAttribute ? [rootAttribute] : []),
+			...(relativePath ? relativePath.split(".") : []),
+		];
 		let node = root;
 		for (const segment of segments) {
 			const normalizedSegment = segment.toLowerCase();
@@ -148,7 +167,7 @@ export function projectSCIMResourceAttributes<
 		projection.mode === "include"
 			? projection.attributes
 			: projection.excludedAttributes;
-	const tree = createAttributePathTree(attributePaths);
+	const tree = createAttributePathTree(attributePaths, Object.keys(resource));
 	const output: Record<string, unknown> = {
 		schemas: resource.schemas,
 		id: resource.id,

--- a/packages/scim/src/resource-schema-registry.ts
+++ b/packages/scim/src/resource-schema-registry.ts
@@ -7,9 +7,22 @@ import {
 import {
 	APIUserSchema,
 	OpenAPIUserResourceSchema,
+	SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR,
+	SCIM_USER_SCHEMA_DESCRIPTORS,
 	SCIMUserResourceSchema,
 	SCIMUserResourceType,
 } from "./user-schemas";
+
+interface SCIMBuiltInSchemaDescriptor {
+	id: string;
+	required: boolean;
+	canonicalAttribute?: "enterprise";
+	discoverySchema: {
+		id: string;
+		meta: { location: string };
+		[key: string]: unknown;
+	};
+}
 
 /**
  * The supported SCIM resource contract.
@@ -21,6 +34,7 @@ export const SCIM_RESOURCE_SCHEMA_REGISTRY = {
 	User: {
 		type: "User",
 		schemaId: SCIMUserResourceSchema.id,
+		schemas: SCIM_USER_SCHEMA_DESCRIPTORS,
 		inputSchema: APIUserSchema,
 		openAPISchema: OpenAPIUserResourceSchema,
 		discoverySchema: SCIMUserResourceSchema,
@@ -36,6 +50,13 @@ export const SCIM_RESOURCE_SCHEMA_REGISTRY = {
 	Group: {
 		type: "Group",
 		schemaId: SCIMGroupResourceSchema.id,
+		schemas: [
+			{
+				id: SCIMGroupResourceSchema.id,
+				required: true,
+				discoverySchema: SCIMGroupResourceSchema,
+			},
+		],
 		inputSchema: APIGroupSchema,
 		openAPISchema: OpenAPIGroupResourceSchema,
 		discoverySchema: SCIMGroupResourceSchema,
@@ -52,6 +73,15 @@ export const SCIM_RESOURCE_SCHEMAS = [
 	SCIM_RESOURCE_SCHEMA_REGISTRY.Group,
 ] as const;
 
+/** Ordered built-in schema descriptors advertised by SCIM discovery. */
+export const SCIM_DISCOVERY_SCHEMA_DESCRIPTORS = [
+	...SCIM_RESOURCE_SCHEMA_REGISTRY.User.schemas,
+	...SCIM_RESOURCE_SCHEMA_REGISTRY.Group.schemas,
+] satisfies readonly SCIMBuiltInSchemaDescriptor[];
+
+/** Standard Enterprise User descriptor owned by the User registry entry. */
+export { SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR };
+
 /** Return the case-insensitive prefix accepted on core attribute paths. */
 function getSCIMCoreAttributePrefix(resourceType: SCIMResourceType) {
 	return `${SCIM_RESOURCE_SCHEMA_REGISTRY[resourceType].schemaId}:`;
@@ -66,4 +96,87 @@ export function stripSCIMCoreAttributePrefix(
 	return attributePath.toLowerCase().startsWith(prefix.toLowerCase())
 		? attributePath.slice(prefix.length)
 		: attributePath;
+}
+
+type SCIMSchemaDescriptorEntry =
+	(typeof SCIM_RESOURCE_SCHEMA_REGISTRY)[SCIMResourceType]["schemas"][number];
+
+/**
+ * Resolve a schema-qualified or explicitly supported input-alias path to the
+ * attribute path used on one side of the wire (response serialization or
+ * canonical persistence). Longest schema identifiers win because SCIM URNs
+ * contain colons. Shares the extension's `inputPathAliases` table between
+ * both sides so a provider-side bare sub-attribute name (Microsoft Entra
+ * sends `attributes=...,manager` rather than the schema-qualified path) also
+ * matches. `mapAttribute` selects which descriptor field names the target
+ * container (`responseAttribute` or `canonicalAttribute`) so the two sides
+ * cannot drift out of sync with each other.
+ */
+function resolveSCIMAttributePath(
+	resourceType: SCIMResourceType,
+	attributePath: string,
+	mapAttribute: (descriptor: SCIMSchemaDescriptorEntry) => string | undefined,
+): string {
+	const descriptors = [
+		...SCIM_RESOURCE_SCHEMA_REGISTRY[resourceType].schemas,
+	].sort((left, right) => right.id.length - left.id.length);
+	const normalizedPath = attributePath.toLowerCase();
+
+	for (const descriptor of descriptors) {
+		const mappedAttribute = mapAttribute(descriptor);
+
+		if ("inputPathAliases" in descriptor) {
+			for (const alias of descriptor.inputPathAliases) {
+				const normalizedAlias = alias.path.toLowerCase();
+				if (
+					normalizedPath !== normalizedAlias &&
+					!normalizedPath.startsWith(`${normalizedAlias}.`)
+				) {
+					continue;
+				}
+				const suffix = attributePath.slice(alias.path.length);
+				return mappedAttribute
+					? `${mappedAttribute}.${alias.relativePath}${suffix}`
+					: `${alias.relativePath}${suffix}`;
+			}
+		}
+
+		const normalizedSchemaId = descriptor.id.toLowerCase();
+		if (normalizedPath === normalizedSchemaId) {
+			return mappedAttribute ?? attributePath;
+		}
+		const prefix = `${normalizedSchemaId}:`;
+		if (!normalizedPath.startsWith(prefix)) continue;
+
+		const relativePath = attributePath.slice(descriptor.id.length + 1);
+		return mappedAttribute
+			? `${mappedAttribute}.${relativePath}`
+			: relativePath;
+	}
+
+	return attributePath;
+}
+
+/** Resolve a schema-qualified or input-alias path to the response object's attribute path. */
+export function resolveSCIMResponseAttributePath(
+	resourceType: SCIMResourceType,
+	attributePath: string,
+): string {
+	return resolveSCIMAttributePath(resourceType, attributePath, (descriptor) =>
+		"responseAttribute" in descriptor
+			? descriptor.responseAttribute
+			: undefined,
+	);
+}
+
+/** Resolve a schema-qualified or input-alias path to the canonical persistence attribute path. */
+export function resolveSCIMCanonicalAttributePath(
+	resourceType: SCIMResourceType,
+	attributePath: string,
+): string {
+	return resolveSCIMAttributePath(resourceType, attributePath, (descriptor) =>
+		"canonicalAttribute" in descriptor
+			? descriptor.canonicalAttribute
+			: undefined,
+	);
 }

--- a/packages/scim/src/schema-conformance.test.ts
+++ b/packages/scim/src/schema-conformance.test.ts
@@ -12,6 +12,11 @@ import { SCIM_RESOURCE_SCHEMA_REGISTRY } from "./resource-schema-registry";
 import {
 	APIUserSchema,
 	OpenAPIUserResourceSchema,
+	SCIM_ENTERPRISE_USER_SCHEMA,
+	SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR,
+	SCIMCanonicalUserAttributesSchema,
+	SCIMEnterpriseUserInputSchema,
+	SCIMEnterpriseUserResourceSchema,
 	SCIMUserResourceSchema,
 } from "./user-schemas";
 
@@ -41,6 +46,17 @@ describe("SCIM core schema conformance", () => {
 		expect(SCIM_RESOURCE_SCHEMA_REGISTRY.User).toMatchObject({
 			type: "User",
 			schemaId: "urn:ietf:params:scim:schemas:core:2.0:User",
+			schemas: [
+				{
+					id: "urn:ietf:params:scim:schemas:core:2.0:User",
+					required: true,
+				},
+				{
+					id: SCIM_ENTERPRISE_USER_SCHEMA,
+					required: false,
+					canonicalAttribute: "enterprise",
+				},
+			],
 			filterAttributes: [
 				"id",
 				"userName",
@@ -52,6 +68,20 @@ describe("SCIM core schema conformance", () => {
 		expect(SCIM_RESOURCE_SCHEMA_REGISTRY.User.inputSchema).toBe(APIUserSchema);
 		expect(SCIM_RESOURCE_SCHEMA_REGISTRY.User.discoverySchema).toBe(
 			SCIMUserResourceSchema,
+		);
+		expect(SCIM_RESOURCE_SCHEMA_REGISTRY.User.schemas[1]?.discoverySchema).toBe(
+			SCIMEnterpriseUserResourceSchema,
+		);
+		const enterpriseDescriptor = SCIM_RESOURCE_SCHEMA_REGISTRY.User.schemas[1];
+		expect(enterpriseDescriptor).toBe(SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR);
+		expect(enterpriseDescriptor?.inputSchema).toBe(
+			SCIMEnterpriseUserInputSchema,
+		);
+		expect(enterpriseDescriptor?.responseAttribute).toBe(
+			SCIM_ENTERPRISE_USER_SCHEMA,
+		);
+		expect(enterpriseDescriptor?.openAPISchema).toBe(
+			OpenAPIUserResourceSchema.properties[SCIM_ENTERPRISE_USER_SCHEMA],
 		);
 		expect(SCIM_RESOURCE_SCHEMA_REGISTRY.Group).toMatchObject({
 			type: "Group",
@@ -107,7 +137,31 @@ describe("SCIM core schema conformance", () => {
 					responses: {
 						"201": {
 							content: {
-								"application/scim+json": expect.any(Object),
+								"application/scim+json": {
+									schema: {
+										properties: {
+											title: { type: "string" },
+											phoneNumbers: {
+												type: "array",
+												maxItems: 10,
+											},
+											[SCIM_ENTERPRISE_USER_SCHEMA]: {
+												type: "object",
+												properties: {
+													manager: { type: "object" },
+												},
+											},
+											schemas: {
+												items: {
+													enum: [
+														"urn:ietf:params:scim:schemas:core:2.0:User",
+														SCIM_ENTERPRISE_USER_SCHEMA,
+													],
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 						"400": {
@@ -124,7 +178,22 @@ describe("SCIM core schema conformance", () => {
 	it("advertises only the persisted User profile", () => {
 		expect(
 			SCIMUserResourceSchema.attributes.map((attribute) => attribute.name),
-		).toEqual(["userName", "displayName", "active", "name", "emails"]);
+		).toEqual([
+			"userName",
+			"displayName",
+			"active",
+			"name",
+			"emails",
+			"title",
+			"userType",
+			"preferredLanguage",
+			"locale",
+			"timezone",
+			"phoneNumbers",
+			"addresses",
+			"roles",
+			"entitlements",
+		]);
 		expect(SCIMUserResourceSchema.attributes).not.toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ name: "id" }),
@@ -167,6 +236,9 @@ describe("SCIM core schema conformance", () => {
 			"formatted",
 			"givenName",
 			"familyName",
+			"middleName",
+			"honorificPrefix",
+			"honorificSuffix",
 		]);
 		expect(getSubAttribute(name, "formatted")).toMatchObject({
 			required: false,
@@ -201,6 +273,37 @@ describe("SCIM core schema conformance", () => {
 			returned: "default",
 		});
 
+		for (const attributeName of [
+			"title",
+			"userType",
+			"preferredLanguage",
+			"locale",
+			"timezone",
+		]) {
+			expect(
+				getAttribute(SCIMUserResourceSchema.attributes, attributeName),
+			).toMatchObject({
+				required: false,
+				mutability: "readWrite",
+				returned: "default",
+			});
+		}
+		for (const attributeName of [
+			"phoneNumbers",
+			"addresses",
+			"roles",
+			"entitlements",
+		]) {
+			expect(
+				getAttribute(SCIMUserResourceSchema.attributes, attributeName),
+			).toMatchObject({
+				multiValued: true,
+				required: false,
+				mutability: "readWrite",
+				returned: "default",
+			});
+		}
+
 		expect(APIUserSchema.safeParse({ userName: "" }).success).toBe(false);
 		expect(
 			APIUserSchema.safeParse({
@@ -224,21 +327,323 @@ describe("SCIM core schema conformance", () => {
 					{ value: "second@example.com", type: "WORK" },
 				],
 			}).success,
-		).toBe(true);
+		).toBe(false);
 		expect(
 			APIUserSchema.parse({
 				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
 				userName: "ADA@EXAMPLE.COM",
 				name: {
 					formatted: "Ada Lovelace",
-					givenName: "not persisted",
+					givenName: "Ada",
 				},
 			}),
 		).toEqual({
 			schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
 			userName: "ADA@EXAMPLE.COM",
-			name: { formatted: "Ada Lovelace", givenName: "not persisted" },
+			name: { formatted: "Ada Lovelace", givenName: "Ada" },
 		});
+	});
+
+	it("validates and advertises the built-in Enterprise User extension", () => {
+		expect(
+			SCIMEnterpriseUserResourceSchema.attributes.map(
+				(attribute) => attribute.name,
+			),
+		).toEqual([
+			"employeeNumber",
+			"costCenter",
+			"organization",
+			"division",
+			"department",
+			"manager",
+		]);
+		for (const attributeName of [
+			"employeeNumber",
+			"costCenter",
+			"organization",
+			"division",
+			"department",
+		]) {
+			expect(
+				getAttribute(
+					SCIMEnterpriseUserResourceSchema.attributes,
+					attributeName,
+				),
+			).toMatchObject({
+				required: false,
+				mutability: "readWrite",
+				returned: "default",
+			});
+		}
+		const manager = getAttribute(
+			SCIMEnterpriseUserResourceSchema.attributes,
+			"manager",
+		);
+		expect(manager).toMatchObject({
+			type: "complex",
+			multiValued: false,
+			mutability: "readWrite",
+			returned: "default",
+		});
+		expect(getSubAttribute(manager, "value")).toMatchObject({
+			required: false,
+			mutability: "readWrite",
+			returned: "default",
+		});
+		expect(getSubAttribute(manager, "$ref")).toMatchObject({
+			referenceTypes: ["User"],
+			mutability: "readWrite",
+			returned: "default",
+		});
+		expect(getSubAttribute(manager, "displayName")).toMatchObject({
+			mutability: "readOnly",
+			returned: "default",
+		});
+
+		expect(
+			APIUserSchema.parse({
+				schemas: [SCIM_ENTERPRISE_USER_SCHEMA, SCIMUserResourceSchema.id],
+				userName: "entra-declared@example.com",
+			}),
+		).toEqual({
+			schemas: [SCIMUserResourceSchema.id, SCIM_ENTERPRISE_USER_SCHEMA],
+			userName: "entra-declared@example.com",
+		});
+		expect(
+			APIUserSchema.parse({
+				schemas: [SCIMUserResourceSchema.id, SCIM_ENTERPRISE_USER_SCHEMA],
+				userName: "entra-manager@example.com",
+				[SCIM_ENTERPRISE_USER_SCHEMA]: {
+					employeeNumber: " 42 ",
+					manager: " manager-1 ",
+				},
+			}),
+		).toMatchObject({
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				employeeNumber: "42",
+				manager: { value: "manager-1" },
+			},
+		});
+		expect(
+			APIUserSchema.parse({
+				schemas: [SCIMUserResourceSchema.id, SCIM_ENTERPRISE_USER_SCHEMA],
+				userName: "rfc-manager@example.com",
+				[SCIM_ENTERPRISE_USER_SCHEMA]: {
+					manager: {
+						value: "external-manager",
+						$ref: "https://directory.example/Users/external-manager",
+						displayName: "External Manager",
+					},
+				},
+				password: "not accepted",
+				ims: [{ value: "not accepted" }],
+				photos: [{ value: "not accepted" }],
+				x509Certificates: [{ value: "not accepted" }],
+			}),
+		).toEqual({
+			schemas: [SCIMUserResourceSchema.id, SCIM_ENTERPRISE_USER_SCHEMA],
+			userName: "rfc-manager@example.com",
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				manager: {
+					value: "external-manager",
+					$ref: "https://directory.example/Users/external-manager",
+				},
+			},
+		});
+		expect(
+			APIUserSchema.parse({
+				schemas: [SCIMUserResourceSchema.id, SCIM_ENTERPRISE_USER_SCHEMA],
+				userName: "entra-manager-array@example.com",
+				[SCIM_ENTERPRISE_USER_SCHEMA]: {
+					manager: [
+						{
+							value: "manager-2",
+							$ref: "/scim/v2/Users/manager-2",
+							displayName: "Manager Two",
+						},
+					],
+				},
+			}),
+		).toMatchObject({
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				manager: {
+					value: "manager-2",
+					$ref: "/scim/v2/Users/manager-2",
+				},
+			},
+		});
+		expect(
+			APIUserSchema.parse({
+				schemas: [SCIMUserResourceSchema.id, SCIM_ENTERPRISE_USER_SCHEMA],
+				userName: "reference-only-manager@example.com",
+				[SCIM_ENTERPRISE_USER_SCHEMA]: {
+					manager: {
+						$ref: "/scim/v2/Users/manager-3",
+						displayName: "Ignored client display value",
+					},
+				},
+			}),
+		).toMatchObject({
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				manager: { $ref: "/scim/v2/Users/manager-3" },
+			},
+		});
+		expect(
+			APIUserSchema.parse({
+				schemas: [SCIMUserResourceSchema.id, SCIM_ENTERPRISE_USER_SCHEMA],
+				userName: "display-only-manager@example.com",
+				[SCIM_ENTERPRISE_USER_SCHEMA]: {
+					manager: { displayName: "Ignored client display value" },
+				},
+			}),
+		).toEqual({
+			schemas: [SCIMUserResourceSchema.id, SCIM_ENTERPRISE_USER_SCHEMA],
+			userName: "display-only-manager@example.com",
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {},
+		});
+		const undeclaredEnterpriseSchema = APIUserSchema.safeParse({
+			schemas: [SCIMUserResourceSchema.id],
+			userName: "undeclared@example.com",
+			[SCIM_ENTERPRISE_USER_SCHEMA]: { employeeNumber: "42" },
+		});
+		expect(undeclaredEnterpriseSchema.success).toBe(false);
+		if (!undeclaredEnterpriseSchema.success) {
+			expect(undeclaredEnterpriseSchema.error.issues[0]).toMatchObject({
+				path: ["schemas"],
+				message: expect.stringContaining(SCIM_ENTERPRISE_USER_SCHEMA),
+			});
+		}
+		expect(
+			APIUserSchema.safeParse({
+				schemas: [
+					SCIMUserResourceSchema.id,
+					"urn:example:params:scim:schemas:extension:2.0:User",
+				],
+				userName: "unknown@example.com",
+			}).success,
+		).toBe(false);
+		expect(
+			APIUserSchema.safeParse({
+				schemas: [SCIMUserResourceSchema.id, SCIM_ENTERPRISE_USER_SCHEMA],
+				userName: "invalid-manager@example.com",
+				[SCIM_ENTERPRISE_USER_SCHEMA]: { manager: [] },
+			}).success,
+		).toBe(false);
+		expect(
+			APIUserSchema.safeParse({
+				schemas: [SCIMUserResourceSchema.id],
+				userName: "invalid-boolean@example.com",
+				phoneNumbers: [{ value: "+1-555-0100", primary: "true" }],
+			}).success,
+		).toBe(false);
+	});
+
+	it("requires unique case-insensitive defined types on User multi-valued attributes", () => {
+		const duplicateTypeCases = [
+			{
+				attribute: "emails",
+				values: [
+					{ value: "first@example.com", type: "Work", primary: true },
+					{ value: "second@example.com", type: "work" },
+				],
+			},
+			{
+				attribute: "phoneNumbers",
+				values: [
+					{ value: "+1-555-0100", type: "Work" },
+					{ value: "+1-555-0101", type: "work" },
+				],
+			},
+			{
+				attribute: "addresses",
+				values: [
+					{ formatted: "First office", type: "Work" },
+					{ formatted: "Second office", type: "work" },
+				],
+			},
+			{
+				attribute: "roles",
+				values: [
+					{ value: "first-role", type: "Work" },
+					{ value: "second-role", type: "work" },
+				],
+			},
+			{
+				attribute: "entitlements",
+				values: [
+					{ value: "first-entitlement", type: "Work" },
+					{ value: "second-entitlement", type: "work" },
+				],
+			},
+		] as const;
+
+		for (const { attribute, values } of duplicateTypeCases) {
+			expect(
+				APIUserSchema.safeParse({
+					schemas: [SCIMUserResourceSchema.id],
+					userName: `${attribute}@example.com`,
+					[attribute]: values,
+				}).success,
+				attribute,
+			).toBe(false);
+			expect(
+				SCIMCanonicalUserAttributesSchema.safeParse({
+					schemas: [SCIMUserResourceSchema.id],
+					name: { formatted: "Typed User" },
+					emails:
+						attribute === "emails"
+							? values
+							: [{ value: "typed@example.com", primary: true }],
+					...(attribute === "emails" ? {} : { [attribute]: values }),
+				}).success,
+				`${attribute} canonical`,
+			).toBe(false);
+		}
+
+		expect(
+			APIUserSchema.safeParse({
+				schemas: [SCIMUserResourceSchema.id],
+				userName: "untyped@example.com",
+				emails: [
+					{ value: "first@example.com", primary: true },
+					{ value: "second@example.com" },
+				],
+				phoneNumbers: [{ value: "+1-555-0100" }, { value: "+1-555-0101" }],
+				addresses: [
+					{ formatted: "First office" },
+					{ formatted: "Second office" },
+				],
+				roles: [{ value: "first-role" }, { value: "second-role" }],
+				entitlements: [
+					{ value: "first-entitlement" },
+					{ value: "second-entitlement" },
+				],
+			}).success,
+		).toBe(true);
+	});
+
+	it("rejects an address whose only content is its type or primary flag", () => {
+		expect(
+			APIUserSchema.safeParse({
+				schemas: [SCIMUserResourceSchema.id],
+				userName: "typeless-address@example.com",
+				addresses: [{ type: "work" }],
+			}).success,
+		).toBe(false);
+		expect(
+			APIUserSchema.safeParse({
+				schemas: [SCIMUserResourceSchema.id],
+				userName: "primary-only-address@example.com",
+				addresses: [{ type: "work", primary: true }],
+			}).success,
+		).toBe(false);
+		expect(
+			APIUserSchema.safeParse({
+				schemas: [SCIMUserResourceSchema.id],
+				userName: "content-address@example.com",
+				addresses: [{ type: "work", locality: "Cambridge" }],
+			}).success,
+		).toBe(true);
 	});
 
 	it("advertises canonical User-only Group memberships", () => {
@@ -322,6 +727,19 @@ describe("SCIM core schema conformance", () => {
 	it("requires only fields that survive every response projection", () => {
 		expect(OpenAPIUserResourceSchema.required).toEqual(["schemas", "id"]);
 		expect(OpenAPIUserResourceSchema.properties).toHaveProperty("externalId");
+		expect(OpenAPIUserResourceSchema.properties).toHaveProperty("title");
+		expect(OpenAPIUserResourceSchema.properties).toHaveProperty("phoneNumbers");
+		expect(OpenAPIUserResourceSchema.properties).toHaveProperty(
+			SCIM_ENTERPRISE_USER_SCHEMA,
+		);
+		expect(
+			OpenAPIUserResourceSchema.properties[SCIM_ENTERPRISE_USER_SCHEMA]
+				.properties.manager.properties,
+		).not.toHaveProperty("displayName");
+		expect(OpenAPIUserResourceSchema.properties.schemas.items.enum).toEqual([
+			SCIMUserResourceSchema.id,
+			SCIM_ENTERPRISE_USER_SCHEMA,
+		]);
 		expect(OpenAPIUserResourceSchema.properties.name).not.toHaveProperty(
 			"required",
 		);

--- a/packages/scim/src/scim-active-normalization.test.ts
+++ b/packages/scim/src/scim-active-normalization.test.ts
@@ -657,19 +657,19 @@ describe("SCIM User active HTTP normalization", () => {
 			scenario: "path-patch",
 			active: "false",
 			expected: false,
-			expectedStatus: 204,
+			expectedStatus: 200,
 		},
 		{
 			scenario: "pathless-patch",
 			active: "TRUE",
 			expected: true,
-			expectedStatus: 204,
+			expectedStatus: 200,
 		},
 		{
 			scenario: "schema-qualified-patch",
 			active: "FaLsE",
 			expected: false,
-			expectedStatus: 204,
+			expectedStatus: 200,
 		},
 	] satisfies {
 		scenario: StringActiveScenario;
@@ -1141,7 +1141,7 @@ describe("SCIM User multi-valued primary HTTP normalization", () => {
 					],
 				}),
 			});
-			expect(addRole.status).toBe(204);
+			expect(addRole.status).toBe(200);
 
 			const response = await fetch(userURL, {
 				method: "PATCH",
@@ -1158,7 +1158,7 @@ describe("SCIM User multi-valued primary HTTP normalization", () => {
 				}),
 			});
 
-			expect(response.status).toBe(204);
+			expect(response.status).toBe(200);
 			const resourceResponse = await fetch(userURL, {
 				headers: createSCIMHeaders(),
 			});

--- a/packages/scim/src/scim-active-normalization.test.ts
+++ b/packages/scim/src/scim-active-normalization.test.ts
@@ -1,0 +1,1236 @@
+import { DatabaseSync } from "node:sqlite";
+import { NodeSqliteDialect } from "@better-auth/kysely-adapter/node-sqlite-dialect";
+import { getMigrations } from "better-auth/db/migration";
+import { getHttpTestInstance } from "better-auth/test";
+import { describe, expect, it } from "vitest";
+import { scim } from ".";
+import { normalizeSCIMUserEntraCompatibilityRequestBody } from "./active-normalization";
+import type { SCIMProjectedUserState } from "./configuration";
+
+const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+const SCIM_MEDIA_TYPE = "application/scim+json";
+const SCIM_TOKEN = "active-normalization-token";
+
+interface SCIMUserResponse {
+	id: string;
+	active: boolean;
+}
+
+interface SCIMSchemaResponse {
+	Resources: {
+		id: string;
+		attributes: { name: string; type: string }[];
+	}[];
+}
+
+interface SCIMErrorResponse {
+	schemas: string[];
+	status: string;
+	scimType?: string;
+}
+
+type StringActiveScenario =
+	| "create"
+	| "replace"
+	| "path-patch"
+	| "pathless-patch"
+	| "schema-qualified-patch";
+
+describe("SCIM User active ingress helper", () => {
+	it.each([
+		["true", true],
+		["True", true],
+		["TRUE", true],
+		["tRuE", true],
+		["false", false],
+		["False", false],
+		["FALSE", false],
+		["fAlSe", false],
+	] as const)("normalizes the exact case-insensitive string %s at POST and PUT boundaries", (value, expected) => {
+		for (const method of ["POST", "PUT"] as const) {
+			const body = {
+				schemas: [SCIM_USER_SCHEMA],
+				userName: "boundary@example.com",
+				active: value,
+			};
+			const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
+				method,
+				body,
+			);
+
+			expect(normalized).not.toBe(body);
+			expect(normalized).toEqual({ ...body, active: expected });
+			expect(body.active).toBe(value);
+		}
+	});
+
+	it.each([
+		true,
+		false,
+		" true",
+		"true ",
+		" false ",
+		"",
+		"yes",
+		"1",
+		"0",
+		1,
+		0,
+		null,
+		[],
+		[true],
+		{},
+		{ value: true },
+	] as const)("leaves the rejected near-miss unchanged at POST and PUT boundaries", (value) => {
+		for (const method of ["POST", "PUT"] as const) {
+			const body = {
+				schemas: [SCIM_USER_SCHEMA],
+				userName: "boundary@example.com",
+				active: value,
+			};
+
+			expect(normalizeSCIMUserEntraCompatibilityRequestBody(method, body)).toBe(
+				body,
+			);
+		}
+	});
+
+	it("copies only User active containers whose values change", () => {
+		const untouchedOperation = {
+			op: "replace",
+			path: "displayName",
+			value: "False",
+		};
+		const body = {
+			schemas: [SCIM_PATCH_SCHEMA],
+			Operations: [
+				{ op: "replace", path: "active", value: "False" },
+				untouchedOperation,
+			],
+		};
+		const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
+			"PATCH",
+			body,
+		);
+
+		expect(normalized).not.toBe(body);
+		expect(normalized).toEqual({
+			...body,
+			Operations: [
+				{ op: "replace", path: "active", value: false },
+				untouchedOperation,
+			],
+		});
+		expect((normalized as typeof body).Operations[1]).toBe(untouchedOperation);
+		expect(body.Operations[0]?.value).toBe("False");
+		expect(
+			normalizeSCIMUserEntraCompatibilityRequestBody("PATCH", {
+				...body,
+				Operations: [untouchedOperation],
+			}),
+		).toEqual({ ...body, Operations: [untouchedOperation] });
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/10475
+	 */
+	it("rewrites only changed User bodies while preserving request transport", async () => {
+		const plugin = scim({
+			connections: [
+				{
+					id: "request-normalization",
+					credentials: [
+						{
+							type: "bearer",
+							id: "request-normalization-token",
+							token: "request-normalization-token",
+						},
+					],
+				},
+			],
+		});
+		const controller = new AbortController();
+		const request = new Request("https://example.com/api/auth/scim/v2/Users", {
+			method: "POST",
+			headers: {
+				authorization: "Bearer request-normalization-token",
+				"content-length": "999",
+				"content-type": SCIM_MEDIA_TYPE,
+				"x-request-marker": "preserved",
+			},
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName: "rewritten@example.com",
+				active: "False",
+			}),
+			signal: controller.signal,
+		});
+		const result = await plugin.onRequest?.(request);
+		if (!result || !("request" in result) || !result.request) {
+			throw new Error("Expected a normalized SCIM User request");
+		}
+
+		expect(result.request.method).toBe("POST");
+		expect(result.request.headers.get("authorization")).toBe(
+			"Bearer request-normalization-token",
+		);
+		expect(result.request.headers.get("x-request-marker")).toBe("preserved");
+		expect(result.request.headers.has("content-length")).toBe(false);
+		expect(await result.request.json()).toMatchObject({ active: false });
+		expect(result.request.signal.aborted).toBe(false);
+		controller.abort();
+		expect(result.request.signal.aborted).toBe(true);
+
+		const requestAcrossRuntimeBoundary = new Request(
+			"https://example.com/api/auth/scim/v2/Users",
+			{
+				method: "POST",
+				headers: {
+					authorization: "Bearer request-normalization-token",
+					"content-type": SCIM_MEDIA_TYPE,
+				},
+				body: JSON.stringify({
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "runtime-boundary@example.com",
+					active: "True",
+				}),
+			},
+		);
+		const requestLike = {
+			url: requestAcrossRuntimeBoundary.url,
+			method: requestAcrossRuntimeBoundary.method,
+			headers: requestAcrossRuntimeBoundary.headers,
+			signal: requestAcrossRuntimeBoundary.signal,
+			clone: () => requestAcrossRuntimeBoundary.clone(),
+		} as Request;
+		const boundaryResult = await plugin.onRequest?.(requestLike);
+		if (
+			!boundaryResult ||
+			!("request" in boundaryResult) ||
+			!boundaryResult.request
+		) {
+			throw new Error("Expected a runtime-boundary request to be normalized");
+		}
+		expect(await boundaryResult.request.json()).toMatchObject({ active: true });
+
+		const unchangedUser = new Request(
+			"https://example.com/api/auth/scim/v2/Users",
+			{
+				method: "POST",
+				headers: { "content-type": SCIM_MEDIA_TYPE },
+				body: JSON.stringify({
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "native@example.com",
+					active: false,
+				}),
+			},
+		);
+		expect(await plugin.onRequest?.(unchangedUser)).toBeUndefined();
+
+		const group = new Request("https://example.com/api/auth/scim/v2/Groups", {
+			method: "POST",
+			headers: { "content-type": SCIM_MEDIA_TYPE },
+			body: JSON.stringify({
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+				displayName: "False",
+				active: "False",
+			}),
+		});
+		expect(await plugin.onRequest?.(group)).toBeUndefined();
+	});
+});
+
+describe("SCIM User multi-valued primary ingress helper", () => {
+	it.each([
+		["true", true],
+		["True", true],
+		["TRUE", true],
+		["tRuE", true],
+		["false", false],
+		["False", false],
+		["FALSE", false],
+		["fAlSe", false],
+	] as const)("normalizes the exact case-insensitive string %s for every multi-valued primary at POST and PUT boundaries", (value, expected) => {
+		for (const method of ["POST", "PUT"] as const) {
+			const body = {
+				schemas: [SCIM_USER_SCHEMA],
+				userName: "primary-boundary@example.com",
+				emails: [
+					{
+						value: "primary-boundary@example.com",
+						type: "work",
+						primary: value,
+					},
+				],
+				phoneNumbers: [{ value: "+1-555-0100", primary: value }],
+				addresses: [{ formatted: "1 Infinite Loop", primary: value }],
+				roles: [{ value: "engineer", primary: value }],
+				entitlements: [{ value: "license", primary: value }],
+			};
+			const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
+				method,
+				body,
+			) as typeof body;
+
+			expect(normalized).not.toBe(body);
+			expect(normalized.emails[0]?.primary).toBe(expected);
+			expect(normalized.phoneNumbers[0]?.primary).toBe(expected);
+			expect(normalized.addresses[0]?.primary).toBe(expected);
+			expect(normalized.roles[0]?.primary).toBe(expected);
+			expect(normalized.entitlements[0]?.primary).toBe(expected);
+			expect(body.emails[0]?.primary).toBe(value);
+		}
+	});
+
+	it.each([
+		true,
+		false,
+		" true",
+		"true ",
+		" false ",
+		"",
+		"yes",
+		"1",
+		"0",
+		1,
+		0,
+		null,
+		[],
+		{},
+	] as const)("leaves the rejected near-miss primary value unchanged at POST and PUT boundaries", (value) => {
+		for (const method of ["POST", "PUT"] as const) {
+			const body = {
+				schemas: [SCIM_USER_SCHEMA],
+				userName: "primary-near-miss@example.com",
+				emails: [{ value: "primary-near-miss@example.com", primary: value }],
+			};
+
+			expect(normalizeSCIMUserEntraCompatibilityRequestBody(method, body)).toBe(
+				body,
+			);
+		}
+	});
+
+	it("copies only the multi-valued entries whose primary value changes", () => {
+		const untouchedEmail = {
+			value: "untouched@example.com",
+			type: "home",
+			primary: true,
+		};
+		const body = {
+			schemas: [SCIM_USER_SCHEMA],
+			userName: "copy-on-write@example.com",
+			emails: [
+				{ value: "changed@example.com", type: "work", primary: "True" },
+				untouchedEmail,
+			],
+		};
+		const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
+			"POST",
+			body,
+		) as typeof body;
+
+		expect(normalized).not.toBe(body);
+		expect(normalized.emails[0]).toEqual({ ...body.emails[0], primary: true });
+		expect(normalized.emails[1]).toBe(untouchedEmail);
+		expect(body.emails[0]?.primary).toBe("True");
+	});
+
+	it("normalizes a filtered-path value targeting the primary sub-attribute directly", () => {
+		const body = {
+			schemas: [SCIM_PATCH_SCHEMA],
+			Operations: [
+				{
+					op: "replace",
+					path: 'emails[type eq "work"].primary',
+					value: "true",
+				},
+			],
+		};
+
+		expect(
+			normalizeSCIMUserEntraCompatibilityRequestBody("PATCH", body),
+		).toEqual({
+			...body,
+			Operations: [
+				{
+					op: "replace",
+					path: 'emails[type eq "work"].primary',
+					value: true,
+				},
+			],
+		});
+	});
+
+	it("normalizes a filtered-path value with whitespace around the filter and dot", () => {
+		const body = {
+			schemas: [SCIM_PATCH_SCHEMA],
+			Operations: [
+				{
+					op: "replace",
+					path: 'roles [ type eq "engineer" ] . primary',
+					value: "true",
+				},
+			],
+		};
+
+		expect(
+			normalizeSCIMUserEntraCompatibilityRequestBody("PATCH", body),
+		).toEqual({
+			...body,
+			Operations: [
+				{
+					op: "replace",
+					path: 'roles [ type eq "engineer" ] . primary',
+					value: true,
+				},
+			],
+		});
+	});
+
+	it("normalizes primary inside a filtered-path element replace value", () => {
+		const body = {
+			schemas: [SCIM_PATCH_SCHEMA],
+			Operations: [
+				{
+					op: "replace",
+					path: 'addresses[type eq "work"]',
+					value: { formatted: "1 Infinite Loop", primary: "true" },
+				},
+			],
+		};
+
+		expect(
+			normalizeSCIMUserEntraCompatibilityRequestBody("PATCH", body),
+		).toEqual({
+			...body,
+			Operations: [
+				{
+					op: "replace",
+					path: 'addresses[type eq "work"]',
+					value: { formatted: "1 Infinite Loop", primary: true },
+				},
+			],
+		});
+	});
+
+	it("normalizes primary inside an unfiltered attribute-path array replace value", () => {
+		const body = {
+			schemas: [SCIM_PATCH_SCHEMA],
+			Operations: [
+				{
+					op: "replace",
+					path: "roles",
+					value: [{ value: "engineer", primary: "true" }],
+				},
+			],
+		};
+
+		expect(
+			normalizeSCIMUserEntraCompatibilityRequestBody("PATCH", body),
+		).toEqual({
+			...body,
+			Operations: [
+				{
+					op: "replace",
+					path: "roles",
+					value: [{ value: "engineer", primary: true }],
+				},
+			],
+		});
+	});
+
+	it("normalizes a direct unfiltered primary sub-attribute path target", () => {
+		const body = {
+			schemas: [SCIM_PATCH_SCHEMA],
+			Operations: [{ op: "replace", path: "emails.primary", value: "false" }],
+		};
+
+		expect(
+			normalizeSCIMUserEntraCompatibilityRequestBody("PATCH", body),
+		).toEqual({
+			...body,
+			Operations: [{ op: "replace", path: "emails.primary", value: false }],
+		});
+	});
+
+	it("normalizes active and multi-valued primary fields inside a pathless full-resource PATCH value", () => {
+		const body = {
+			schemas: [SCIM_PATCH_SCHEMA],
+			Operations: [
+				{
+					op: "replace",
+					value: {
+						active: "true",
+						emails: [{ value: "a@example.com", primary: "true" }],
+						addresses: [{ formatted: "1 Infinite Loop", primary: "TRUE" }],
+					},
+				},
+			],
+		};
+
+		expect(
+			normalizeSCIMUserEntraCompatibilityRequestBody("PATCH", body),
+		).toEqual({
+			...body,
+			Operations: [
+				{
+					op: "replace",
+					value: {
+						active: true,
+						emails: [{ value: "a@example.com", primary: true }],
+						addresses: [{ formatted: "1 Infinite Loop", primary: true }],
+					},
+				},
+			],
+		});
+	});
+
+	it("leaves an untouched PATCH operation unchanged", () => {
+		const untouchedOperation = {
+			op: "replace",
+			path: "displayName",
+			value: "False",
+		};
+		const body = {
+			schemas: [SCIM_PATCH_SCHEMA],
+			Operations: [untouchedOperation],
+		};
+
+		expect(
+			normalizeSCIMUserEntraCompatibilityRequestBody("PATCH", body),
+		).toEqual(body);
+	});
+});
+
+function createSCIMHeaders(): HeadersInit {
+	return {
+		accept: SCIM_MEDIA_TYPE,
+		authorization: `Bearer ${SCIM_TOKEN}`,
+		"content-type": SCIM_MEDIA_TYPE,
+	};
+}
+
+async function readJSON<T>(response: Response): Promise<T> {
+	return (await response.json()) as T;
+}
+
+async function expectSCIMMutationError(
+	response: Response,
+	scimType: string,
+): Promise<void> {
+	expect(response.status).toBe(400);
+	expect(response.headers.get("content-type")).toBe(SCIM_MEDIA_TYPE);
+	expect(await readJSON<SCIMErrorResponse>(response)).toMatchObject({
+		schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+		status: "400",
+		scimType,
+	});
+}
+
+async function createTestInstance(
+	onProjected?: (state: SCIMProjectedUserState) => void,
+) {
+	const sqlite = new DatabaseSync(":memory:");
+	const instance = await getHttpTestInstance(
+		{
+			database: {
+				dialect: new NodeSqliteDialect({ database: sqlite }),
+				type: "sqlite",
+				transaction: true,
+			},
+			plugins: [
+				scim({
+					connections: [
+						{
+							id: "active-normalization",
+							credentials: [
+								{
+									type: "bearer",
+									id: "active-normalization-token",
+									token: SCIM_TOKEN,
+								},
+							],
+						},
+					],
+					...(onProjected
+						? {
+								projection: {
+									reconcileUser(state) {
+										onProjected(state);
+									},
+								},
+							}
+						: {}),
+				}),
+			],
+		},
+		{ disableTestUser: true, testWith: "sqlite" },
+	);
+	await (await getMigrations(instance.auth.options)).runMigrations();
+	return { instance, sqlite };
+}
+
+async function readPersistentMutationState(
+	instance: Awaited<ReturnType<typeof createTestInstance>>["instance"],
+) {
+	const [
+		users,
+		sessions,
+		bindings,
+		subjects,
+		scimUsers,
+		groups,
+		memberships,
+		grants,
+		tombstones,
+	] = await Promise.all([
+		instance.db.findMany({ model: "user", where: [] }),
+		instance.db.findMany({ model: "session", where: [] }),
+		instance.db.findMany({ model: "scimConnectionBinding", where: [] }),
+		instance.db.findMany({ model: "scimSubject", where: [] }),
+		instance.db.findMany({ model: "scimUser", where: [] }),
+		instance.db.findMany({ model: "scimGroup", where: [] }),
+		instance.db.findMany({ model: "scimGroupMember", where: [] }),
+		instance.db.findMany({ model: "scimProjectionGrant", where: [] }),
+		instance.db.findMany({ model: "scimIdentityTombstone", where: [] }),
+	]);
+	return {
+		users,
+		sessions,
+		bindings,
+		subjects,
+		scimUsers,
+		groups,
+		memberships,
+		grants,
+		tombstones,
+	};
+}
+
+async function createUser(
+	baseURL: string,
+	active: boolean,
+	userName: string,
+): Promise<SCIMUserResponse> {
+	const response = await fetch(`${baseURL}/api/auth/scim/v2/Users`, {
+		method: "POST",
+		headers: createSCIMHeaders(),
+		body: JSON.stringify({
+			schemas: [SCIM_USER_SCHEMA],
+			externalId: `directory-${userName}`,
+			userName,
+			displayName: "Provisioned User",
+			emails: [
+				{
+					value: userName,
+					type: "work",
+					primary: true,
+				},
+			],
+			active,
+		}),
+	});
+	expect(response.status).toBe(201);
+	return readJSON<SCIMUserResponse>(response);
+}
+
+describe("SCIM User active HTTP normalization", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/10390
+	 */
+	it.each([
+		{
+			scenario: "create",
+			active: "False",
+			expected: false,
+			expectedStatus: 201,
+		},
+		{
+			scenario: "replace",
+			active: "True",
+			expected: true,
+			expectedStatus: 200,
+		},
+		{
+			scenario: "path-patch",
+			active: "false",
+			expected: false,
+			expectedStatus: 204,
+		},
+		{
+			scenario: "pathless-patch",
+			active: "TRUE",
+			expected: true,
+			expectedStatus: 204,
+		},
+		{
+			scenario: "schema-qualified-patch",
+			active: "FaLsE",
+			expected: false,
+			expectedStatus: 204,
+		},
+	] satisfies {
+		scenario: StringActiveScenario;
+		active: string;
+		expected: boolean;
+		expectedStatus: number;
+	}[])("normalizes $scenario string active values at the real HTTP ingress", async ({
+		scenario,
+		active,
+		expected,
+		expectedStatus,
+	}) => {
+		const { instance, sqlite } = await createTestInstance();
+		try {
+			const userName = `${scenario}@example.com`;
+			let userId: string;
+			let response: Response;
+
+			if (scenario === "create") {
+				response = await fetch(`${instance.baseURL}/api/auth/scim/v2/Users`, {
+					method: "POST",
+					headers: createSCIMHeaders(),
+					body: JSON.stringify({
+						schemas: [SCIM_USER_SCHEMA],
+						externalId: `entra-${scenario}`,
+						userName,
+						displayName: "Entra Active User",
+						emails: [
+							{
+								value: userName,
+								type: "work",
+								primary: true,
+							},
+						],
+						active,
+					}),
+				});
+				userId = (await readJSON<SCIMUserResponse>(response.clone())).id;
+			} else {
+				const user = await createUser(instance.baseURL, !expected, userName);
+				userId = user.id;
+				const userURL = `${instance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(user.id)}`;
+				if (scenario === "replace") {
+					response = await fetch(userURL, {
+						method: "PUT",
+						headers: createSCIMHeaders(),
+						body: JSON.stringify({
+							schemas: [SCIM_USER_SCHEMA],
+							externalId: `entra-${scenario}`,
+							userName,
+							displayName: "Entra Active User",
+							emails: [
+								{
+									value: userName,
+									type: "work",
+									primary: true,
+								},
+							],
+							active,
+						}),
+					});
+				} else {
+					const path =
+						scenario === "pathless-patch"
+							? undefined
+							: scenario === "schema-qualified-patch"
+								? `${SCIM_USER_SCHEMA}:active`
+								: "active";
+					response = await fetch(userURL, {
+						method: "PATCH",
+						headers: createSCIMHeaders(),
+						body: JSON.stringify({
+							schemas: [SCIM_PATCH_SCHEMA],
+							Operations: [
+								path
+									? { op: "replace", path, value: active }
+									: { op: "replace", value: { active } },
+							],
+						}),
+					});
+				}
+			}
+
+			expect(response.status).toBe(expectedStatus);
+			const resourceResponse = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(userId)}`,
+				{ headers: createSCIMHeaders() },
+			);
+			expect(resourceResponse.status).toBe(200);
+			const resource = await readJSON<SCIMUserResponse>(resourceResponse);
+			expect(resource.active).toBe(expected);
+			expect(typeof resource.active).toBe("boolean");
+			const persisted = await instance.db.findOne<{ active: boolean }>({
+				model: "scimUser",
+				where: [{ field: "id", value: userId }],
+			});
+			expect(persisted?.active).toBe(expected);
+			expect(typeof persisted?.active).toBe("boolean");
+		} finally {
+			await instance.server.close();
+			sqlite.close();
+		}
+	});
+
+	it("preserves native Boolean provider requests and Boolean schema discovery", async () => {
+		const { instance, sqlite } = await createTestInstance();
+		try {
+			const response = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Users`,
+				{
+					method: "POST",
+					headers: createSCIMHeaders(),
+					body: JSON.stringify({
+						schemas: [SCIM_USER_SCHEMA],
+						externalId: "00u-okta-directory-user",
+						userName: "okta.user@example.com",
+						name: {
+							givenName: "Okta",
+							familyName: "User",
+						},
+						displayName: "Okta User",
+						emails: [
+							{
+								value: "okta.user@example.com",
+								type: "work",
+								primary: true,
+							},
+						],
+						active: true,
+					}),
+				},
+			);
+			expect(response.status).toBe(201);
+			const resource = await readJSON<SCIMUserResponse>(response);
+			expect(resource.active).toBe(true);
+			expect(typeof resource.active).toBe("boolean");
+			const persisted = await instance.db.findOne<{ active: boolean }>({
+				model: "scimUser",
+				where: [{ field: "id", value: resource.id }],
+			});
+			expect(persisted?.active).toBe(true);
+			expect(typeof persisted?.active).toBe("boolean");
+
+			const schemasResponse = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Schemas`,
+				{ headers: { accept: SCIM_MEDIA_TYPE } },
+			);
+			expect(schemasResponse.status).toBe(200);
+			const schemas = await readJSON<SCIMSchemaResponse>(schemasResponse);
+			const userSchema = schemas.Resources.find(
+				(schema) => schema.id === SCIM_USER_SCHEMA,
+			);
+			expect(
+				userSchema?.attributes.find((attribute) => attribute.name === "active"),
+			).toMatchObject({ name: "active", type: "boolean" });
+		} finally {
+			await instance.server.close();
+			sqlite.close();
+		}
+	});
+
+	it("rejects invalid active values across every User mutation shape without persistence", async () => {
+		const { instance, sqlite } = await createTestInstance();
+		try {
+			const usersURL = `${instance.baseURL}/api/auth/scim/v2/Users`;
+			const establishBinding = await fetch(usersURL, {
+				headers: createSCIMHeaders(),
+			});
+			expect(establishBinding.status).toBe(200);
+			const rejectedCreateBefore = await readPersistentMutationState(instance);
+			const rejectedCreate = await fetch(usersURL, {
+				method: "POST",
+				headers: createSCIMHeaders(),
+				body: JSON.stringify({
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "invalid-create@example.com",
+					active: " false",
+				}),
+			});
+			await expectSCIMMutationError(rejectedCreate, "invalidValue");
+			expect(await readPersistentMutationState(instance)).toEqual(
+				rejectedCreateBefore,
+			);
+
+			const created = await createUser(
+				instance.baseURL,
+				true,
+				"invalid-mutations@example.com",
+			);
+			const userURL = `${usersURL}/${encodeURIComponent(created.id)}`;
+			const invalidRequests = [
+				{
+					method: "PUT",
+					body: {
+						schemas: [SCIM_USER_SCHEMA],
+						userName: "invalid-mutations@example.com",
+						active: 1,
+					},
+				},
+				{
+					method: "PATCH",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [{ op: "replace", path: "active", value: null }],
+					},
+				},
+				{
+					method: "PATCH",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{ op: "replace", value: { active: { value: false } } },
+						],
+					},
+				},
+			] as const;
+			for (const request of invalidRequests) {
+				const before = await readPersistentMutationState(instance);
+				const response = await fetch(userURL, {
+					method: request.method,
+					headers: createSCIMHeaders(),
+					body: JSON.stringify(request.body),
+				});
+				await expectSCIMMutationError(response, "invalidValue");
+				expect(await readPersistentMutationState(instance)).toEqual(before);
+			}
+		} finally {
+			await instance.server.close();
+			sqlite.close();
+		}
+	});
+
+	it("rolls back an earlier normalized active operation when a later PATCH operation fails", async () => {
+		const projectedStates: SCIMProjectedUserState[] = [];
+		const { instance, sqlite } = await createTestInstance((state) => {
+			projectedStates.push({
+				...state,
+				sources: [...state.sources],
+				grants: [...state.grants],
+			});
+		});
+		try {
+			const created = await createUser(
+				instance.baseURL,
+				true,
+				"atomic-active@example.com",
+			);
+			const persistedUser = await instance.db.findOne<{
+				id: string;
+				userId: string;
+			}>({
+				model: "scimUser",
+				where: [{ field: "id", value: created.id }],
+			});
+			if (!persistedUser) throw new Error("Expected persisted SCIM User");
+			const sessionAt = new Date("2030-01-01T00:00:00.000Z");
+			await instance.db.create({
+				model: "session",
+				data: {
+					token: "active-normalization-session-token",
+					userId: persistedUser.userId,
+					expiresAt: new Date("2030-02-01T00:00:00.000Z"),
+					createdAt: sessionAt,
+					updatedAt: sessionAt,
+				},
+			});
+			const before = await readPersistentMutationState(instance);
+			const projectedBefore = structuredClone(projectedStates);
+			const resourceBefore = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(created.id)}`,
+				{ headers: createSCIMHeaders() },
+			).then(readJSON<SCIMUserResponse>);
+
+			const response = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(created.id)}`,
+				{
+					method: "PATCH",
+					headers: createSCIMHeaders(),
+					body: JSON.stringify({
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{ op: "replace", path: "active", value: "False" },
+							{
+								op: "replace",
+								path: "id",
+								value: "must-not-be-applied",
+							},
+						],
+					}),
+				},
+			);
+			await expectSCIMMutationError(response, "mutability");
+			expect(await readPersistentMutationState(instance)).toEqual(before);
+			expect(projectedStates).toEqual(projectedBefore);
+			const resourceAfter = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(created.id)}`,
+				{ headers: createSCIMHeaders() },
+			).then(readJSON<SCIMUserResponse>);
+			expect(resourceAfter).toEqual(resourceBefore);
+			expect(resourceAfter.active).toBe(true);
+		} finally {
+			await instance.server.close();
+			sqlite.close();
+		}
+	});
+});
+
+const SCIM_ENTERPRISE_USER_SCHEMA =
+	"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+
+interface SCIMPrimaryNormalizationUserResponse {
+	id: string;
+	active: boolean;
+	emails: { value: string; type?: string; primary?: boolean }[];
+	addresses: { formatted?: string; type?: string; primary?: boolean }[];
+	roles: { value: string; primary?: boolean }[];
+	[SCIM_ENTERPRISE_USER_SCHEMA]?: { manager?: { value: string } };
+}
+
+describe("SCIM User multi-valued primary HTTP normalization", () => {
+	it.each([
+		{
+			attribute: "emails",
+			entry: {
+				value: "primary-http@example.com",
+				type: "work",
+				primary: "true",
+			},
+		},
+		{
+			attribute: "addresses",
+			entry: { formatted: "1 Infinite Loop", type: "work", primary: "true" },
+		},
+		{ attribute: "roles", entry: { value: "engineer", primary: "true" } },
+		{
+			attribute: "phoneNumbers",
+			entry: { value: "+1-555-0100", type: "work", primary: "true" },
+		},
+		{ attribute: "entitlements", entry: { value: "license", primary: "true" } },
+	])("normalizes a string primary for $attribute at the real HTTP create ingress", async ({
+		attribute,
+		entry,
+	}) => {
+		const { instance, sqlite } = await createTestInstance();
+		try {
+			const response = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Users`,
+				{
+					method: "POST",
+					headers: createSCIMHeaders(),
+					body: JSON.stringify({
+						schemas: [SCIM_USER_SCHEMA],
+						userName: `${attribute}-primary@example.com`,
+						displayName: "Entra Primary User",
+						emails: [
+							{
+								value: `${attribute}-primary@example.com`,
+								type: "work",
+								primary: true,
+							},
+						],
+						[attribute]: [entry],
+					}),
+				},
+			);
+
+			expect(response.status).toBe(201);
+			const resource = await readJSON<Record<string, unknown>>(response);
+			const normalizedEntry = (
+				resource[attribute] as { primary?: unknown }[]
+			)[0];
+			expect(normalizedEntry?.primary).toBe(true);
+			expect(typeof normalizedEntry?.primary).toBe("boolean");
+		} finally {
+			await instance.server.close();
+			sqlite.close();
+		}
+	});
+
+	/**
+	 * Mirrors the exact payload shape sent by Microsoft's SCIM Validator,
+	 * which encodes every multi-valued `primary` sub-attribute as a string
+	 * Boolean and the Enterprise User `manager` as a bare string.
+	 */
+	it("creates a user from the Microsoft SCIM Validator's exact string-primary payload", async () => {
+		const { instance, sqlite } = await createTestInstance();
+		try {
+			const response = await fetch(
+				`${instance.baseURL}/api/auth/scim/v2/Users`,
+				{
+					method: "POST",
+					headers: createSCIMHeaders(),
+					body: JSON.stringify({
+						schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+						userName: "validator-primary@example.com",
+						displayName: "Validator Primary User",
+						active: "true",
+						emails: [
+							{
+								value: "validator-primary@example.com",
+								type: "work",
+								primary: "true",
+							},
+						],
+						addresses: [
+							{
+								formatted: "1 Infinite Loop, Cupertino, CA",
+								type: "work",
+								primary: "true",
+							},
+						],
+						roles: [{ value: "engineer", primary: "true" }],
+						[SCIM_ENTERPRISE_USER_SCHEMA]: {
+							manager: "validator-manager-id",
+						},
+					}),
+				},
+			);
+
+			expect(response.status).toBe(201);
+			const resource =
+				await readJSON<SCIMPrimaryNormalizationUserResponse>(response);
+			expect(resource.active).toBe(true);
+			expect(typeof resource.active).toBe("boolean");
+			expect(resource.emails[0]?.primary).toBe(true);
+			expect(typeof resource.emails[0]?.primary).toBe("boolean");
+			expect(resource.addresses[0]?.primary).toBe(true);
+			expect(typeof resource.addresses[0]?.primary).toBe("boolean");
+			expect(resource.roles[0]?.primary).toBe(true);
+			expect(typeof resource.roles[0]?.primary).toBe("boolean");
+			expect(resource[SCIM_ENTERPRISE_USER_SCHEMA]?.manager).toEqual({
+				value: "validator-manager-id",
+			});
+
+			const persisted = await instance.db.findOne<{ active: boolean }>({
+				model: "scimUser",
+				where: [{ field: "id", value: resource.id }],
+			});
+			expect(persisted?.active).toBe(true);
+			expect(typeof persisted?.active).toBe("boolean");
+		} finally {
+			await instance.server.close();
+			sqlite.close();
+		}
+	});
+
+	it("normalizes a string primary through a filtered PATCH path at the real HTTP ingress", async () => {
+		const { instance, sqlite } = await createTestInstance();
+		try {
+			const created = await createUser(
+				instance.baseURL,
+				true,
+				"patch-primary@example.com",
+			);
+			const userURL = `${instance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(created.id)}`;
+			const addRole = await fetch(userURL, {
+				method: "PATCH",
+				headers: createSCIMHeaders(),
+				body: JSON.stringify({
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [
+						{
+							op: "add",
+							path: "roles",
+							value: [
+								{ value: "engineer", type: "primary-role", primary: false },
+							],
+						},
+					],
+				}),
+			});
+			expect(addRole.status).toBe(204);
+
+			const response = await fetch(userURL, {
+				method: "PATCH",
+				headers: createSCIMHeaders(),
+				body: JSON.stringify({
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [
+						{
+							op: "replace",
+							path: 'roles[type eq "primary-role"].primary',
+							value: "true",
+						},
+					],
+				}),
+			});
+
+			expect(response.status).toBe(204);
+			const resourceResponse = await fetch(userURL, {
+				headers: createSCIMHeaders(),
+			});
+			const resource =
+				await readJSON<SCIMPrimaryNormalizationUserResponse>(resourceResponse);
+			const primaryRole = (
+				resource.roles as { value: string; type?: string; primary?: boolean }[]
+			).find((role) => role.type === "primary-role");
+			expect(primaryRole?.primary).toBe(true);
+			expect(typeof primaryRole?.primary).toBe("boolean");
+		} finally {
+			await instance.server.close();
+			sqlite.close();
+		}
+	});
+
+	it("normalizes a string primary through a whitespace-padded filtered PATCH path", async () => {
+		const { instance, sqlite } = await createTestInstance();
+		try {
+			const created = await createUser(
+				instance.baseURL,
+				true,
+				"patch-primary-whitespace@example.com",
+			);
+			const userURL = `${instance.baseURL}/api/auth/scim/v2/Users/${encodeURIComponent(created.id)}`;
+			const addRole = await fetch(userURL, {
+				method: "PATCH",
+				headers: createSCIMHeaders(),
+				body: JSON.stringify({
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [
+						{
+							op: "add",
+							path: "roles",
+							value: [
+								{ value: "engineer", type: "primary-role", primary: false },
+							],
+						},
+					],
+				}),
+			});
+			expect(addRole.status).toBe(200);
+
+			const response = await fetch(userURL, {
+				method: "PATCH",
+				headers: createSCIMHeaders(),
+				body: JSON.stringify({
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [
+						{
+							op: "replace",
+							path: 'roles [ type eq "primary-role" ] . primary',
+							value: "true",
+						},
+					],
+				}),
+			});
+
+			expect(response.status).toBe(200);
+			const resourceResponse = await fetch(userURL, {
+				headers: createSCIMHeaders(),
+			});
+			const resource =
+				await readJSON<SCIMPrimaryNormalizationUserResponse>(resourceResponse);
+			const primaryRole = (
+				resource.roles as { value: string; type?: string; primary?: boolean }[]
+			).find((role) => role.type === "primary-role");
+			expect(primaryRole?.primary).toBe(true);
+			expect(typeof primaryRole?.primary).toBe("boolean");
+		} finally {
+			await instance.server.close();
+			sqlite.close();
+		}
+	});
+});

--- a/packages/scim/src/scim-create-uniqueness.test.ts
+++ b/packages/scim/src/scim-create-uniqueness.test.ts
@@ -171,7 +171,14 @@ describe("SCIM resource create uniqueness races", () => {
 					emailValueIndex: "|ada@example.com|",
 					displayName: "Concurrent User",
 					formattedName: "Concurrent User",
-					serializedEmails: "[]",
+					serializedEmails: JSON.stringify([
+						{ value: "ada@example.com", primary: true },
+					]),
+					serializedAttributes: JSON.stringify({
+						schemas: [USER_SCHEMA],
+						name: { formatted: "Concurrent User" },
+						emails: [{ value: "ada@example.com", primary: true }],
+					}),
 					active: true,
 					orderKey: "concurrent-user-order",
 					createdAt: now,

--- a/packages/scim/src/scim-enterprise-user.test.ts
+++ b/packages/scim/src/scim-enterprise-user.test.ts
@@ -1,0 +1,1827 @@
+import type { User } from "better-auth";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type {
+	SCIMCanonicalManager,
+	SCIMCanonicalUser,
+	SCIMEnterpriseUser,
+} from ".";
+import { scim } from ".";
+
+const BASE_URL = "http://localhost:3000";
+const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_ENTERPRISE_USER_SCHEMA =
+	"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+const SCIM_MICROSOFT_GRAPH_USER_SCHEMA =
+	"urn:ietf:params:scim:schemas:extension:Microsoft:Entra:2.0:User";
+const SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA =
+	"http://schemas.microsoft.com/2006/11/ResourceManagement/ADSCIM/2.0/Group";
+const SCIM_MEDIA_TYPE = "application/scim+json";
+
+interface PersistedSCIMUser {
+	id: string;
+	connectionId: string;
+	userId: string;
+	externalId?: string;
+	formattedName: string;
+	givenName?: string | null;
+	familyName?: string | null;
+	serializedEmails: string;
+	serializedAttributes: string;
+}
+
+interface SCIMUserResponse {
+	schemas: string[];
+	id: string;
+	externalId?: string;
+	userName: string;
+	displayName: string;
+	name: {
+		formatted: string;
+		givenName?: string;
+		familyName?: string;
+		middleName?: string;
+		honorificPrefix?: string;
+		honorificSuffix?: string;
+	};
+	title?: string;
+	userType?: string;
+	preferredLanguage?: string;
+	locale?: string;
+	timezone?: string;
+	phoneNumbers?: Array<{
+		value: string;
+		type?: string;
+		primary?: boolean;
+	}>;
+	addresses?: Array<{
+		formatted?: string;
+		streetAddress?: string;
+		locality?: string;
+		region?: string;
+		postalCode?: string;
+		country?: string;
+		type?: string;
+		primary?: boolean;
+	}>;
+	roles?: Array<{
+		value: string;
+		display?: string;
+		type?: string;
+		primary?: boolean;
+	}>;
+	entitlements?: Array<{
+		value: string;
+		display?: string;
+		type?: string;
+		primary?: boolean;
+	}>;
+	[SCIM_ENTERPRISE_USER_SCHEMA]?: SCIMEnterpriseUser;
+}
+
+function createEnterpriseFixture() {
+	const data = {
+		user: [] as User[],
+		session: [] as { id: string }[],
+		verification: [] as { id: string }[],
+		account: [] as { id: string }[],
+		scimConnectionBinding: [] as { id: string }[],
+		scimIdentityTombstone: [] as { id: string }[],
+		scimSubject: [] as { id: string; userId: string }[],
+		scimUser: [] as PersistedSCIMUser[],
+		scimGroup: [] as { id: string }[],
+		scimGroupMember: [] as { id: string }[],
+		scimProjectionGrant: [] as { id: string }[],
+	};
+	const resolvedUsers: SCIMCanonicalUser[] = [];
+	const auth = betterAuth({
+		baseURL: BASE_URL,
+		database: memoryAdapter(data),
+		plugins: [
+			scim({
+				connections: [
+					{
+						id: "workforce",
+						credentials: [
+							{
+								type: "bearer",
+								id: "workforce-token",
+								token: "workforce-token",
+							},
+						],
+					},
+					{
+						id: "partners",
+						credentials: [
+							{
+								type: "bearer",
+								id: "partners-token",
+								token: "partners-token",
+							},
+						],
+					},
+				],
+				identity: {
+					resolveUser({ resource }) {
+						resolvedUsers.push(resource);
+						return { action: "create" };
+					},
+				},
+			}),
+		],
+	});
+	return { auth, data, resolvedUsers };
+}
+
+function createSCIMRequest(
+	path: string,
+	options: {
+		method?: "GET" | "PATCH" | "POST" | "PUT";
+		token?: "partners-token" | "workforce-token";
+		body?: unknown;
+	} = {},
+): Request {
+	const headers = new Headers({ accept: SCIM_MEDIA_TYPE });
+	if (options.token) {
+		headers.set("authorization", `Bearer ${options.token}`);
+	}
+	if (options.body !== undefined) {
+		headers.set("content-type", SCIM_MEDIA_TYPE);
+	}
+	return new Request(`${BASE_URL}/api/auth${path}`, {
+		method: options.method ?? "GET",
+		headers,
+		...(options.body === undefined
+			? {}
+			: { body: JSON.stringify(options.body) }),
+	});
+}
+
+async function readJSON<T>(response: Response): Promise<T> {
+	return (await response.json()) as T;
+}
+
+describe("SCIM classic Enterprise User provisioning", () => {
+	it("discovers, persists, replaces, and tenant-scopes a Microsoft-style User through HTTP", async () => {
+		const { auth, data, resolvedUsers } = createEnterpriseFixture();
+		const [schemasResponse, enterpriseSchemaResponse, resourceTypeResponse] =
+			await Promise.all([
+				auth.handler(createSCIMRequest("/scim/v2/Schemas")),
+				auth.handler(
+					createSCIMRequest(
+						`/scim/v2/Schemas/${encodeURIComponent(SCIM_ENTERPRISE_USER_SCHEMA)}`,
+					),
+				),
+				auth.handler(createSCIMRequest("/scim/v2/ResourceTypes/User")),
+			]);
+		expect(schemasResponse.status).toBe(200);
+		expect(enterpriseSchemaResponse.status).toBe(200);
+		expect(resourceTypeResponse.status).toBe(200);
+		const schemas = await readJSON<{
+			totalResults: number;
+			Resources: Array<{ id: string }>;
+		}>(schemasResponse);
+		expect(schemas).toMatchObject({ totalResults: 3 });
+		expect(schemas.Resources.map((schema) => schema.id)).toContain(
+			SCIM_ENTERPRISE_USER_SCHEMA,
+		);
+		expect(await readJSON(enterpriseSchemaResponse)).toMatchObject({
+			id: SCIM_ENTERPRISE_USER_SCHEMA,
+			attributes: expect.arrayContaining([
+				expect.objectContaining({ name: "employeeNumber" }),
+				expect.objectContaining({ name: "manager" }),
+			]),
+		});
+		expect(await readJSON(resourceTypeResponse)).toMatchObject({
+			id: "User",
+			schema: SCIM_USER_SCHEMA,
+			schemaExtensions: [
+				{ schema: SCIM_ENTERPRISE_USER_SCHEMA, required: false },
+			],
+		});
+
+		const enterpriseBody = {
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			userName: "bjensen@example.com",
+			externalId: "701984",
+			name: {
+				formatted: "Ms. Barbara Jane Jensen III",
+				familyName: "Jensen",
+				givenName: "Barbara",
+				middleName: "Jane",
+				honorificPrefix: "Ms.",
+				honorificSuffix: "III",
+			},
+			displayName: "Babs Jensen",
+			title: "Tour Guide",
+			userType: "Employee",
+			preferredLanguage: "en-US",
+			locale: "en-US",
+			timezone: "America/Los_Angeles",
+			active: true,
+			emails: [{ value: "bjensen@example.com", type: "work", primary: true }],
+			phoneNumbers: [{ value: "+1-555-555-8377", type: "work", primary: true }],
+			addresses: [
+				{
+					formatted: "100 Universal City Plaza\nHollywood, CA 91608 USA",
+					streetAddress: "100 Universal City Plaza",
+					locality: "Hollywood",
+					region: "CA",
+					postalCode: "91608",
+					country: "USA",
+					type: "work",
+					primary: true,
+				},
+			],
+			roles: [{ value: "Tour Guide", primary: true }],
+			entitlements: [{ value: "Universal Studios", primary: true }],
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				employeeNumber: "701984",
+				costCenter: "4130",
+				organization: "Universal Studios",
+				division: "Theme Park",
+				department: "Tour Operations",
+				manager: [
+					{
+						value: "26118915",
+						$ref: `${BASE_URL}/api/auth/scim/v2/Users/26118915`,
+						displayName: "John Smith",
+					},
+				],
+			},
+		};
+		const createResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: enterpriseBody,
+			}),
+		);
+		expect(createResponse.status).toBe(201);
+		const created = await readJSON<SCIMUserResponse>(createResponse);
+		expect(created).toMatchObject({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			externalId: "701984",
+			userName: "bjensen@example.com",
+			name: enterpriseBody.name,
+			title: "Tour Guide",
+			userType: "Employee",
+			preferredLanguage: "en-US",
+			locale: "en-US",
+			timezone: "America/Los_Angeles",
+			phoneNumbers: enterpriseBody.phoneNumbers,
+			addresses: enterpriseBody.addresses,
+			roles: enterpriseBody.roles,
+			entitlements: enterpriseBody.entitlements,
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				employeeNumber: "701984",
+				costCenter: "4130",
+				organization: "Universal Studios",
+				division: "Theme Park",
+				department: "Tour Operations",
+				manager: {
+					value: "26118915",
+					$ref: `${BASE_URL}/api/auth/scim/v2/Users/26118915`,
+				},
+			},
+		});
+		expect(created[SCIM_ENTERPRISE_USER_SCHEMA]?.manager).not.toHaveProperty(
+			"displayName",
+		);
+		expect(resolvedUsers).toHaveLength(1);
+		expect(resolvedUsers[0]).toMatchObject({
+			title: "Tour Guide",
+			phoneNumbers: enterpriseBody.phoneNumbers,
+			enterprise: {
+				employeeNumber: "701984",
+				manager: { value: "26118915" },
+			},
+		});
+
+		const getResponse = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(created.id)}`, {
+				token: "workforce-token",
+			}),
+		);
+		expect(getResponse.status).toBe(200);
+		expect(await readJSON(getResponse)).toMatchObject(created);
+
+		const entireExtensionResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(created.id)}?attributes=${encodeURIComponent(
+					SCIM_ENTERPRISE_USER_SCHEMA,
+				)}`,
+				{ token: "workforce-token" },
+			),
+		);
+		expect(entireExtensionResponse.status).toBe(200);
+		const entireExtension = await readJSON<Record<string, unknown>>(
+			entireExtensionResponse,
+		);
+		expect(Object.keys(entireExtension).sort()).toEqual(
+			[SCIM_ENTERPRISE_USER_SCHEMA, "id", "schemas"].sort(),
+		);
+		expect(entireExtension[SCIM_ENTERPRISE_USER_SCHEMA]).toMatchObject({
+			department: "Tour Operations",
+			manager: {
+				value: "26118915",
+				$ref: `${BASE_URL}/api/auth/scim/v2/Users/26118915`,
+			},
+		});
+
+		const departmentResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(created.id)}?attributes=${encodeURIComponent(
+					`${SCIM_ENTERPRISE_USER_SCHEMA.toUpperCase()}:department`,
+				)}`,
+				{ token: "workforce-token" },
+			),
+		);
+		expect(departmentResponse.status).toBe(200);
+		expect(await readJSON(departmentResponse)).toEqual({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			id: created.id,
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				department: "Tour Operations",
+			},
+		});
+
+		const managerListResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users?attributes=${encodeURIComponent(
+					`${SCIM_ENTERPRISE_USER_SCHEMA}:manager.value`,
+				)}`,
+				{ token: "workforce-token" },
+			),
+		);
+		expect(managerListResponse.status).toBe(200);
+		expect(await readJSON(managerListResponse)).toMatchObject({
+			totalResults: 1,
+			Resources: [
+				{
+					schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+					id: created.id,
+					[SCIM_ENTERPRISE_USER_SCHEMA]: {
+						manager: { value: "26118915" },
+					},
+				},
+			],
+		});
+
+		const excludedManagerValueResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					created.id,
+				)}?excludedAttributes=${encodeURIComponent(
+					`${SCIM_ENTERPRISE_USER_SCHEMA}:manager.value`,
+				)}`,
+				{ token: "workforce-token" },
+			),
+		);
+		expect(excludedManagerValueResponse.status).toBe(200);
+		const excludedManagerValue = await readJSON<SCIMUserResponse>(
+			excludedManagerValueResponse,
+		);
+		expect(excludedManagerValue[SCIM_ENTERPRISE_USER_SCHEMA]?.manager).toEqual({
+			$ref: `${BASE_URL}/api/auth/scim/v2/Users/26118915`,
+		});
+
+		const workforceRow = data.scimUser.find(
+			(user) => user.connectionId === "workforce",
+		);
+		if (!workforceRow) throw new Error("Expected workforce SCIM User");
+		expect(JSON.parse(workforceRow.serializedAttributes)).toMatchObject({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			name: enterpriseBody.name,
+			phoneNumbers: enterpriseBody.phoneNumbers,
+			enterprise: {
+				employeeNumber: "701984",
+				manager: { value: "26118915" },
+			},
+		});
+		expect(workforceRow).toMatchObject({
+			formattedName: "Ms. Barbara Jane Jensen III",
+			givenName: "Barbara",
+			familyName: "Jensen",
+		});
+		expect(JSON.parse(workforceRow.serializedEmails)).toEqual(
+			enterpriseBody.emails,
+		);
+		expect(data.account).toEqual([]);
+		expect(data.user).toHaveLength(1);
+		expect(data.user[0]).toMatchObject({
+			id: workforceRow.userId,
+			email: "bjensen@example.com",
+			name: "Babs Jensen",
+		});
+		expect(JSON.stringify(data.user)).not.toContain("employeeNumber");
+		expect(JSON.stringify(data.account)).not.toContain("employeeNumber");
+
+		workforceRow.formattedName = "corrupt mirror";
+		workforceRow.givenName = "corrupt mirror";
+		workforceRow.familyName = null;
+		workforceRow.serializedEmails = "[]";
+		const canonicalAfterMirrorCorruption = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(created.id)}`, {
+				token: "workforce-token",
+			}),
+		);
+		expect(canonicalAfterMirrorCorruption.status).toBe(200);
+		expect(await readJSON(canonicalAfterMirrorCorruption)).toMatchObject({
+			name: enterpriseBody.name,
+			emails: enterpriseBody.emails,
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				department: "Tour Operations",
+			},
+		});
+
+		const patchResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					created.id,
+				)}?attributes=${encodeURIComponent(
+					`${SCIM_ENTERPRISE_USER_SCHEMA}:department`,
+				)}`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{
+								op: "replace",
+								path: "displayName",
+								value: "Barbara J. Jensen",
+							},
+						],
+					},
+				},
+			),
+		);
+		const patchBody = await readJSON(patchResponse);
+		expect(patchResponse.status, JSON.stringify(patchBody)).toBe(200);
+		expect(patchBody).toEqual({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			id: created.id,
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				department: "Tour Operations",
+			},
+		});
+		const patchedWorkforceRow = data.scimUser.find(
+			(user) => user.id === workforceRow.id,
+		);
+		if (!patchedWorkforceRow) {
+			throw new Error("Expected patched workforce SCIM User");
+		}
+		expect(patchedWorkforceRow).toMatchObject({
+			formattedName: "Ms. Barbara Jane Jensen III",
+			givenName: "Barbara",
+			familyName: "Jensen",
+		});
+		expect(JSON.parse(patchedWorkforceRow.serializedEmails)).toEqual(
+			enterpriseBody.emails,
+		);
+		expect(JSON.parse(patchedWorkforceRow.serializedAttributes)).toMatchObject({
+			enterprise: {
+				department: "Tour Operations",
+				manager: {
+					value: "26118915",
+					$ref: `${BASE_URL}/api/auth/scim/v2/Users/26118915`,
+				},
+			},
+		});
+
+		const wrongTenantResponse = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(created.id)}`, {
+				token: "partners-token",
+			}),
+		);
+		expect(wrongTenantResponse.status).toBe(404);
+
+		const partnerResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "partners-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+					userName: "partner-bjensen@example.com",
+					externalId: "701984",
+				},
+			}),
+		);
+		expect(partnerResponse.status).toBe(201);
+		const partner = await readJSON<SCIMUserResponse>(partnerResponse);
+		expect(partner).toMatchObject({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			externalId: "701984",
+		});
+		expect(partner).not.toHaveProperty(SCIM_ENTERPRISE_USER_SCHEMA);
+		const partnerGetResponse = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(partner.id)}`, {
+				token: "partners-token",
+			}),
+		);
+		expect(partnerGetResponse.status).toBe(200);
+		const declaredOnlyPartner =
+			await readJSON<SCIMUserResponse>(partnerGetResponse);
+		expect(declaredOnlyPartner.schemas).toEqual([
+			SCIM_USER_SCHEMA,
+			SCIM_ENTERPRISE_USER_SCHEMA,
+		]);
+		expect(declaredOnlyPartner).not.toHaveProperty(SCIM_ENTERPRISE_USER_SCHEMA);
+		expect(data.scimUser).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					connectionId: "workforce",
+					externalId: "701984",
+				}),
+				expect.objectContaining({
+					connectionId: "partners",
+					externalId: "701984",
+				}),
+			]),
+		);
+
+		const replaceResponse = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(created.id)}`, {
+				method: "PUT",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "bjensen@example.com",
+					externalId: "701984",
+					displayName: "Barbara Jensen",
+					name: {
+						formatted: "Barbara Jensen",
+						givenName: "Barbara",
+						familyName: "Jensen",
+					},
+					emails: [
+						{
+							value: "bjensen@example.com",
+							type: "work",
+							primary: true,
+						},
+					],
+					active: true,
+				},
+			}),
+		);
+		expect(replaceResponse.status).toBe(200);
+		const replaced = await readJSON<SCIMUserResponse>(replaceResponse);
+		expect(replaced).toMatchObject({
+			schemas: [SCIM_USER_SCHEMA],
+			displayName: "Barbara Jensen",
+			name: {
+				formatted: "Barbara Jensen",
+				givenName: "Barbara",
+				familyName: "Jensen",
+			},
+		});
+		expect(replaced).not.toHaveProperty(SCIM_ENTERPRISE_USER_SCHEMA);
+		expect(replaced).not.toHaveProperty("title");
+		expect(replaced).not.toHaveProperty("phoneNumbers");
+		const replacedRow = data.scimUser.find(
+			(user) => user.id === workforceRow.id,
+		);
+		if (!replacedRow) throw new Error("Expected replaced workforce SCIM User");
+		expect(JSON.parse(replacedRow.serializedAttributes)).toEqual({
+			schemas: [SCIM_USER_SCHEMA],
+			name: {
+				formatted: "Barbara Jensen",
+				givenName: "Barbara",
+				familyName: "Jensen",
+			},
+			emails: [
+				{
+					value: "bjensen@example.com",
+					type: "work",
+					primary: true,
+				},
+			],
+		});
+	});
+
+	it("accepts an RFC manager reference while discarding client readOnly displayName data", async () => {
+		const { auth, data, resolvedUsers } = createEnterpriseFixture();
+		const response = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+					userName: "reference-only-manager@example.com",
+					[SCIM_ENTERPRISE_USER_SCHEMA]: {
+						manager: {
+							$ref: `${BASE_URL}/api/auth/scim/v2/Users/manager`,
+							displayName: "Client supplied display value",
+						},
+					},
+				},
+			}),
+		);
+
+		expect(response.status).toBe(201);
+		const created = await readJSON<SCIMUserResponse>(response);
+		expect(created[SCIM_ENTERPRISE_USER_SCHEMA]?.manager).toEqual({
+			$ref: `${BASE_URL}/api/auth/scim/v2/Users/manager`,
+		});
+		expect(resolvedUsers[0]?.enterprise?.manager).toEqual({
+			$ref: `${BASE_URL}/api/auth/scim/v2/Users/manager`,
+		});
+		expect(
+			JSON.parse(data.scimUser[0]?.serializedAttributes ?? "{}"),
+		).toMatchObject({
+			enterprise: {
+				manager: {
+					$ref: `${BASE_URL}/api/auth/scim/v2/Users/manager`,
+				},
+			},
+		});
+		expect(data.scimUser[0]?.serializedAttributes).not.toContain("displayName");
+	});
+
+	it("patches core and Enterprise User attributes through Entra and RFC path shapes", async () => {
+		const { auth, data } = createEnterpriseFixture();
+		const managerResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "manager@example.com",
+					displayName: "Priya Shah",
+				},
+			}),
+		);
+		expect(managerResponse.status).toBe(201);
+		const manager = await readJSON<SCIMUserResponse>(managerResponse);
+
+		const reportResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "report@example.com",
+					displayName: "Jordan Lee",
+					name: {
+						formatted: "Jordan Quinn Lee",
+						givenName: "Jordan",
+						middleName: "Quinn",
+						familyName: "Lee",
+					},
+					title: "Analyst",
+					phoneNumbers: [{ value: "+1-555-0100", type: "work", primary: true }],
+				},
+			}),
+		);
+		expect(reportResponse.status).toBe(201);
+		const report = await readJSON<SCIMUserResponse>(reportResponse);
+
+		const patchResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					report.id,
+				)}?attributes=${encodeURIComponent(
+					[
+						"title",
+						"name",
+						"phoneNumbers",
+						"addresses",
+						`${SCIM_ENTERPRISE_USER_SCHEMA}:department`,
+						`${SCIM_ENTERPRISE_USER_SCHEMA}:costCenter`,
+						`${SCIM_ENTERPRISE_USER_SCHEMA}:division`,
+						`${SCIM_ENTERPRISE_USER_SCHEMA}:manager`,
+					].join(","),
+				)}`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{
+								op: "Replace",
+								path: `${SCIM_ENTERPRISE_USER_SCHEMA}:manager`,
+								value: manager.id,
+							},
+							{
+								op: "Replace",
+								value: {
+									title: "Senior Analyst",
+									[`${SCIM_ENTERPRISE_USER_SCHEMA}:department`]: "Finance",
+								},
+							},
+							{
+								op: "Add",
+								path: "addresses",
+								value: [
+									{
+										streetAddress: "1 Finance Way",
+										locality: "Seattle",
+										region: "WA",
+										postalCode: "98101",
+										country: "US",
+										type: "work",
+										primary: true,
+									},
+								],
+							},
+							{
+								op: "Replace",
+								path: 'phoneNumbers[type eq "work"].value',
+								value: "+1-555-0199",
+							},
+							{
+								op: "Add",
+								path: "phoneNumbers",
+								value: [
+									{
+										value: "+1-555-0177",
+										type: "mobile",
+										primary: true,
+									},
+								],
+							},
+							{
+								op: "Replace",
+								path: "name",
+								value: {
+									givenName: "Jordana",
+								},
+							},
+							{
+								op: "Replace",
+								path: `${SCIM_ENTERPRISE_USER_SCHEMA}:costCenter`,
+								value: "CC-204",
+							},
+							{
+								op: "Replace",
+								path: SCIM_ENTERPRISE_USER_SCHEMA,
+								value: {
+									division: "Financial Planning",
+								},
+							},
+							{
+								op: "Add",
+								path: "manager",
+								value: [
+									{
+										value: manager.id,
+										$ref: `${BASE_URL}/api/auth/scim/v2/Users/${manager.id}`,
+										displayName: "Client supplied manager name",
+									},
+								],
+							},
+						],
+					},
+				},
+			),
+		);
+
+		const patchedReport = await readJSON(patchResponse);
+		expect(patchResponse.status, JSON.stringify(patchedReport)).toBe(200);
+		expect(patchedReport).toEqual({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			id: report.id,
+			title: "Senior Analyst",
+			name: {
+				formatted: "Jordan Quinn Lee",
+				givenName: "Jordana",
+				middleName: "Quinn",
+				familyName: "Lee",
+			},
+			phoneNumbers: [
+				{ value: "+1-555-0199", type: "work", primary: false },
+				{ value: "+1-555-0177", type: "mobile", primary: true },
+			],
+			addresses: [
+				{
+					streetAddress: "1 Finance Way",
+					locality: "Seattle",
+					region: "WA",
+					postalCode: "98101",
+					country: "US",
+					type: "work",
+					primary: true,
+				},
+			],
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				department: "Finance",
+				costCenter: "CC-204",
+				division: "Financial Planning",
+				manager: {
+					value: manager.id,
+					$ref: `${BASE_URL}/api/auth/scim/v2/Users/${manager.id}`,
+				},
+			},
+		});
+
+		const persisted = data.scimUser.find((user) => user.id === report.id);
+		if (!persisted) throw new Error("Expected patched report");
+		expect(JSON.parse(persisted.serializedAttributes)).toMatchObject({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			title: "Senior Analyst",
+			phoneNumbers: [
+				{ value: "+1-555-0199", type: "work", primary: false },
+				{ value: "+1-555-0177", type: "mobile", primary: true },
+			],
+			addresses: [
+				{
+					streetAddress: "1 Finance Way",
+					locality: "Seattle",
+					type: "work",
+				},
+			],
+			enterprise: {
+				department: "Finance",
+				costCenter: "CC-204",
+				division: "Financial Planning",
+				manager: {
+					value: manager.id,
+					$ref: `${BASE_URL}/api/auth/scim/v2/Users/${manager.id}`,
+				},
+			},
+			name: {
+				formatted: "Jordan Quinn Lee",
+				givenName: "Jordana",
+				middleName: "Quinn",
+				familyName: "Lee",
+			},
+		});
+		expect(persisted.serializedAttributes).not.toContain("displayName");
+
+		const managerValueResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					report.id,
+				)}?attributes=${encodeURIComponent(
+					`${SCIM_ENTERPRISE_USER_SCHEMA}:manager`,
+				)}`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{
+								op: "Replace",
+								path: "manager.value",
+								value: manager.id,
+							},
+							{
+								op: "Replace",
+								path: "manager.$ref",
+								value: `${BASE_URL}/api/auth/scim/v2/Users/${manager.id}`,
+							},
+						],
+					},
+				},
+			),
+		);
+		expect(managerValueResponse.status).toBe(200);
+		expect(await readJSON(managerValueResponse)).toEqual({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			id: report.id,
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				manager: {
+					value: manager.id,
+					$ref: `${BASE_URL}/api/auth/scim/v2/Users/${manager.id}`,
+				},
+			},
+		});
+
+		const readOnlyManagerResponse = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(report.id)}`, {
+				method: "PATCH",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [
+						{
+							op: "Replace",
+							path: "manager.displayName",
+							value: "Must not persist",
+						},
+					],
+				},
+			}),
+		);
+		expect(readOnlyManagerResponse.status).toBe(400);
+		expect(await readJSON(readOnlyManagerResponse)).toMatchObject({
+			scimType: "mutability",
+		});
+		expect(persisted.serializedAttributes).not.toContain("Must not persist");
+
+		const removeResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					report.id,
+				)}?attributes=${encodeURIComponent(
+					[
+						"title",
+						"phoneNumbers",
+						"addresses",
+						SCIM_ENTERPRISE_USER_SCHEMA,
+					].join(","),
+				)}`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{ op: "Remove", path: "title" },
+							{
+								op: "Remove",
+								path: 'addresses[type eq "work"]',
+							},
+							{
+								op: "Remove",
+								path: `${SCIM_ENTERPRISE_USER_SCHEMA}:department`,
+							},
+							{ op: "Remove", path: "manager" },
+						],
+					},
+				},
+			),
+		);
+		expect(removeResponse.status).toBe(200);
+		expect(await readJSON(removeResponse)).toEqual({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			id: report.id,
+			phoneNumbers: [
+				{ value: "+1-555-0199", type: "work", primary: false },
+				{ value: "+1-555-0177", type: "mobile", primary: true },
+			],
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				costCenter: "CC-204",
+				division: "Financial Planning",
+			},
+		});
+
+		const missingManagerValueResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					report.id,
+				)}?attributes=${encodeURIComponent(
+					`${SCIM_ENTERPRISE_USER_SCHEMA}:manager`,
+				)}`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{
+								op: "Replace",
+								path: "manager.value",
+								value: manager.id,
+							},
+						],
+					},
+				},
+			),
+		);
+		expect(missingManagerValueResponse.status).toBe(200);
+		expect(await readJSON(missingManagerValueResponse)).toEqual({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			id: report.id,
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				manager: { value: manager.id },
+			},
+		});
+
+		const missingUnfilteredSubattributeResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					report.id,
+				)}?attributes=phoneNumbers`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{ op: "Remove", path: "phoneNumbers" },
+							{
+								op: "Replace",
+								path: "phoneNumbers.value",
+								value: "+1-555-0188",
+							},
+						],
+					},
+				},
+			),
+		);
+		expect(missingUnfilteredSubattributeResponse.status).toBe(200);
+		expect(await readJSON(missingUnfilteredSubattributeResponse)).toEqual({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			id: report.id,
+			phoneNumbers: [{ value: "+1-555-0188" }],
+		});
+
+		const beforeRejectedPatch =
+			data.scimUser.find((user) => user.id === report.id)
+				?.serializedAttributes ?? "";
+		const rejectedResponse = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(report.id)}`, {
+				method: "PATCH",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [
+						{
+							op: "Replace",
+							path: "title",
+							value: "Must not persist",
+						},
+						{
+							op: "Replace",
+							path: "urn:ietf:params:scim:schemas:extension:Microsoft:Entra:2.0:User:department",
+							value: "Unsupported",
+						},
+					],
+				},
+			}),
+		);
+		expect(rejectedResponse.status).toBe(400);
+		expect(await readJSON(rejectedResponse)).toMatchObject({
+			scimType: "invalidPath",
+		});
+		expect(
+			data.scimUser.find((user) => user.id === report.id)?.serializedAttributes,
+		).toBe(beforeRejectedPatch);
+	});
+
+	/**
+	 * @see https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups#update-user-multi-valued-properties
+	 */
+	it("applies Microsoft Entra's full multi-op Replace Attributes PATCH shape", async () => {
+		const { auth } = createEnterpriseFixture();
+		const createResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+					userName: "replace-attributes@example.com",
+					displayName: "Replace Attributes",
+					name: { givenName: "Replace", familyName: "Attributes" },
+					emails: [
+						{
+							value: "replace-attributes@example.com",
+							type: "work",
+							primary: true,
+						},
+					],
+					phoneNumbers: [{ value: "+1-555-0100", type: "work", primary: true }],
+					addresses: [
+						{
+							formatted: "1 Old Way",
+							streetAddress: "1 Old Way",
+							locality: "Redmond",
+							region: "WA",
+							postalCode: "98052",
+							country: "US",
+							type: "work",
+							primary: true,
+						},
+					],
+					roles: [{ value: "engineer", display: "Engineer", primary: true }],
+					[SCIM_ENTERPRISE_USER_SCHEMA]: { employeeNumber: "1" },
+				},
+			}),
+		);
+		expect(createResponse.status).toBe(201);
+		const user = await readJSON<SCIMUserResponse>(createResponse);
+
+		const patchResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					user.id,
+				)}?attributes=${encodeURIComponent(
+					[
+						"displayName",
+						"title",
+						"userType",
+						"preferredLanguage",
+						"locale",
+						"timezone",
+						"emails",
+						"phoneNumbers",
+						"addresses",
+						"roles",
+						`${SCIM_ENTERPRISE_USER_SCHEMA}:employeeNumber`,
+					].join(","),
+				)}`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{
+								op: "Replace",
+								path: "emails[primary eq true].value",
+								value: "replaced@example.com",
+							},
+							{
+								op: "Replace",
+								path: "phoneNumbers[primary eq true].value",
+								value: "+1-555-0199",
+							},
+							{
+								op: "Replace",
+								path: "addresses[primary eq true].formatted",
+								value: "2 New Way",
+							},
+							{
+								op: "Replace",
+								path: "addresses[primary eq true].streetAddress",
+								value: "2 New Way",
+							},
+							{
+								op: "Replace",
+								path: "addresses[primary eq true].locality",
+								value: "Bellevue",
+							},
+							{
+								op: "Replace",
+								path: "addresses[primary eq true].region",
+								value: "WA",
+							},
+							{
+								op: "Replace",
+								path: "addresses[primary eq true].postalCode",
+								value: "98004",
+							},
+							{
+								op: "Replace",
+								path: "addresses[primary eq true].country",
+								value: "US",
+							},
+							{
+								op: "Replace",
+								path: "roles[primary eq true].value",
+								value: "senior-engineer",
+							},
+							{
+								op: "Replace",
+								path: "roles[primary eq true].display",
+								value: "Senior Engineer",
+							},
+							{
+								op: "Replace",
+								path: "displayName",
+								value: ["Replaced Attributes"],
+							},
+							{ op: "Replace", path: "title", value: ["Senior Engineer"] },
+							{ op: "Replace", path: "userType", value: ["Employee"] },
+							{ op: "Replace", path: "preferredLanguage", value: ["en-US"] },
+							{ op: "Replace", path: "locale", value: ["en-US"] },
+							{
+								op: "Replace",
+								path: "timezone",
+								value: ["America/Los_Angeles"],
+							},
+							{
+								op: "Replace",
+								path: `${SCIM_ENTERPRISE_USER_SCHEMA}:employeeNumber`,
+								value: ["99999"],
+							},
+						],
+					},
+				},
+			),
+		);
+		const patched = await readJSON<SCIMUserResponse>(patchResponse);
+		expect(patchResponse.status, JSON.stringify(patched)).toBe(200);
+		expect(patched).toMatchObject({
+			displayName: "Replaced Attributes",
+			title: "Senior Engineer",
+			userType: "Employee",
+			preferredLanguage: "en-US",
+			locale: "en-US",
+			timezone: "America/Los_Angeles",
+			emails: [{ value: "replaced@example.com", primary: true }],
+			phoneNumbers: [{ value: "+1-555-0199", primary: true }],
+			addresses: [
+				{
+					formatted: "2 New Way",
+					streetAddress: "2 New Way",
+					locality: "Bellevue",
+					region: "WA",
+					postalCode: "98004",
+					country: "US",
+					primary: true,
+				},
+			],
+			roles: [
+				{ value: "senior-engineer", display: "Senior Engineer", primary: true },
+			],
+			[SCIM_ENTERPRISE_USER_SCHEMA]: { employeeNumber: "99999" },
+		});
+	});
+
+	/**
+	 * Mirrors the exact wire shape captured from Microsoft's SCIM Validator: a
+	 * multi-op PATCH combining `[primary eq true]` filtered replaces with a
+	 * single pathless replace whose value uses flat, dot- and schema-qualified
+	 * keys (`"name.formatted"`, `"urn:...:User:employeeNumber"`) rather than
+	 * nested objects, followed by a filtered-list fetch (not a direct GET by
+	 * ID) to verify every attribute round-trips.
+	 * @see https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups
+	 */
+	it("applies Entra's captured flat-key pathless replace alongside primary filters", async () => {
+		const { auth } = createEnterpriseFixture();
+		const createResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+					userName: "flat-key-replace@example.com",
+					name: { formatted: "Original" },
+					emails: [{ value: "flat-key-replace@example.com", primary: true }],
+					phoneNumbers: [{ value: "+1-555-0100", primary: true }],
+					addresses: [{ formatted: "1 Old Way", primary: true }],
+					roles: [{ value: "engineer", display: "Engineer", primary: true }],
+					entitlements: [{ value: "vpn", display: "VPN", primary: true }],
+					[SCIM_ENTERPRISE_USER_SCHEMA]: { manager: "manager-id" },
+				},
+			}),
+		);
+		const user = await readJSON<SCIMUserResponse>(createResponse);
+
+		const patchResponse = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(user.id)}`, {
+				method: "PATCH",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [
+						{
+							op: "replace",
+							path: "emails[primary eq true].value",
+							value: "flat-key-replaced@example.com",
+						},
+						{
+							op: "replace",
+							path: "phoneNumbers[primary eq true].value",
+							value: "+1-555-0199",
+						},
+						{
+							op: "replace",
+							path: "roles[primary eq true].value",
+							value: "senior-engineer",
+						},
+						{
+							op: "replace",
+							path: "entitlements[primary eq true].value",
+							value: "vpn-admin",
+						},
+						{
+							op: "replace",
+							value: {
+								displayName: "Flat Key Replace",
+								"name.formatted": "Replaced",
+								"name.givenName": "First",
+								[`${SCIM_ENTERPRISE_USER_SCHEMA}:employeeNumber`]: "99999",
+							},
+						},
+					],
+				},
+			}),
+		);
+		const patched = await readJSON<SCIMUserResponse>(patchResponse);
+		expect(patchResponse.status, JSON.stringify(patched)).toBe(200);
+		expect(patched).toMatchObject({
+			displayName: "Flat Key Replace",
+			name: { formatted: "Replaced", givenName: "First" },
+			emails: [{ value: "flat-key-replaced@example.com", primary: true }],
+			phoneNumbers: [{ value: "+1-555-0199", primary: true }],
+			roles: [{ value: "senior-engineer", primary: true }],
+			entitlements: [{ value: "vpn-admin", primary: true }],
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				employeeNumber: "99999",
+				manager: { value: "manager-id" },
+			},
+		});
+
+		const listResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users?filter=${encodeURIComponent(
+					`userName eq "flat-key-replace@example.com"`,
+				)}`,
+				{ token: "workforce-token" },
+			),
+		);
+		const list = await readJSON<{ Resources: SCIMUserResponse[] }>(
+			listResponse,
+		);
+		expect(list.Resources).toHaveLength(1);
+		expect(list.Resources[0]).toMatchObject({
+			displayName: "Flat Key Replace",
+			name: { formatted: "Replaced", givenName: "First" },
+			emails: [{ value: "flat-key-replaced@example.com", primary: true }],
+			phoneNumbers: [{ value: "+1-555-0199", primary: true }],
+			roles: [{ value: "senior-engineer", primary: true }],
+			entitlements: [{ value: "vpn-admin", primary: true }],
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				employeeNumber: "99999",
+				manager: { value: "manager-id" },
+			},
+		});
+	});
+
+	it("resolves the quoted string-literal primary filter variant", async () => {
+		const { auth } = createEnterpriseFixture();
+		const createResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "quoted-primary-filter@example.com",
+					roles: [{ value: "engineer", primary: true }],
+				},
+			}),
+		);
+		const user = await readJSON<SCIMUserResponse>(createResponse);
+
+		const patchResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(user.id)}?attributes=roles`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{
+								op: "Replace",
+								path: 'roles[primary eq "true"].value',
+								value: "senior-engineer",
+							},
+						],
+					},
+				},
+			),
+		);
+		const patched = await readJSON<SCIMUserResponse>(patchResponse);
+		expect(patchResponse.status, JSON.stringify(patched)).toBe(200);
+		expect(patched.roles).toEqual([
+			{ value: "senior-engineer", primary: true },
+		]);
+	});
+
+	it("rejects a primary-filtered replace when no value is currently primary", async () => {
+		const { auth } = createEnterpriseFixture();
+		const createResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "no-primary-match@example.com",
+					roles: [{ value: "engineer", primary: false }],
+				},
+			}),
+		);
+		const user = await readJSON<SCIMUserResponse>(createResponse);
+
+		const patchResponse = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(user.id)}`, {
+				method: "PATCH",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [
+						{
+							op: "Replace",
+							path: "roles[primary eq true].value",
+							value: "senior-engineer",
+						},
+					],
+				},
+			}),
+		);
+		expect(patchResponse.status).toBe(400);
+		expect(await readJSON(patchResponse)).toMatchObject({
+			scimType: "noTarget",
+		});
+	});
+
+	it("cascades an emptied manager object out of the Enterprise extension on subattribute removal", async () => {
+		const { auth, data } = createEnterpriseFixture();
+		const createResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+					userName: "manager-value-remove@example.com",
+					[SCIM_ENTERPRISE_USER_SCHEMA]: { manager: "manager-id" },
+				},
+			}),
+		);
+		const user = await readJSON<SCIMUserResponse>(createResponse);
+
+		const patchResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(user.id)}?attributes=userName`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{
+								op: "Remove",
+								path: `${SCIM_ENTERPRISE_USER_SCHEMA}:manager.value`,
+							},
+						],
+					},
+				},
+			),
+		);
+		const patched = await readJSON<SCIMUserResponse>(patchResponse);
+		expect(patchResponse.status, JSON.stringify(patched)).toBe(200);
+		expect(patched.schemas).toEqual([SCIM_USER_SCHEMA]);
+		expect(patched).not.toHaveProperty(SCIM_ENTERPRISE_USER_SCHEMA);
+
+		const resource = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(user.id)}`, {
+				token: "workforce-token",
+			}),
+		);
+		expect(await readJSON(resource)).not.toHaveProperty(
+			SCIM_ENTERPRISE_USER_SCHEMA,
+		);
+		expect(
+			JSON.parse(
+				data.scimUser.find((candidate) => candidate.id === user.id)
+					?.serializedAttributes ?? "{}",
+			),
+		).not.toHaveProperty("enterprise");
+	});
+
+	/**
+	 * @see https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups
+	 */
+	it("clears manager on Microsoft Entra's replace-with-empty-string PATCH", async () => {
+		const { auth } = createEnterpriseFixture();
+		const createResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+					userName: "manager-empty-string-remove@example.com",
+					[SCIM_ENTERPRISE_USER_SCHEMA]: { manager: "manager-id" },
+				},
+			}),
+		);
+		const user = await readJSON<SCIMUserResponse>(createResponse);
+
+		const patchResponse = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(user.id)}`, {
+				method: "PATCH",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [
+						{
+							op: "replace",
+							path: `${SCIM_ENTERPRISE_USER_SCHEMA}:manager`,
+							value: "",
+						},
+					],
+				},
+			}),
+		);
+		const patched = await readJSON<SCIMUserResponse>(patchResponse);
+		expect(patchResponse.status, JSON.stringify(patched)).toBe(200);
+		expect(patched.schemas).toEqual([SCIM_USER_SCHEMA]);
+		expect(patched).not.toHaveProperty(SCIM_ENTERPRISE_USER_SCHEMA);
+
+		const resource = await auth.handler(
+			createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(user.id)}`, {
+				token: "workforce-token",
+			}),
+		);
+		const fetched = await readJSON<SCIMUserResponse>(resource);
+		expect(fetched.schemas).toEqual([SCIM_USER_SCHEMA]);
+		expect(fetched).not.toHaveProperty(SCIM_ENTERPRISE_USER_SCHEMA);
+	});
+
+	it("resolves a bare Enterprise User sub-attribute name in the attributes projection", async () => {
+		const { auth } = createEnterpriseFixture();
+		const createResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+					userName: "bare-attribute-projection@example.com",
+					roles: [{ value: "engineer", primary: true }],
+					[SCIM_ENTERPRISE_USER_SCHEMA]: { manager: "manager-id" },
+				},
+			}),
+		);
+		const user = await readJSON<SCIMUserResponse>(createResponse);
+
+		const projected = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					user.id,
+				)}?attributes=${encodeURIComponent("userName,roles,manager")}`,
+				{ token: "workforce-token" },
+			),
+		);
+		expect(await readJSON(projected)).toEqual({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			id: user.id,
+			userName: "bare-attribute-projection@example.com",
+			roles: [{ value: "engineer", primary: true }],
+			[SCIM_ENTERPRISE_USER_SCHEMA]: { manager: { value: "manager-id" } },
+		});
+	});
+
+	it("applies a pathless Enterprise User root object with canonical persistence and response", async () => {
+		const { auth, data } = createEnterpriseFixture();
+		const managerResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "pathless-manager@example.com",
+					displayName: "Pathless Manager",
+				},
+			}),
+		);
+		expect(managerResponse.status).toBe(201);
+		const manager = await readJSON<SCIMUserResponse>(managerResponse);
+		const reportResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "pathless-report@example.com",
+					displayName: "Pathless Report",
+				},
+			}),
+		);
+		expect(reportResponse.status).toBe(201);
+		const report = await readJSON<SCIMUserResponse>(reportResponse);
+
+		const patchResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					report.id,
+				)}?attributes=${encodeURIComponent(SCIM_ENTERPRISE_USER_SCHEMA)}`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{
+								op: "Replace",
+								value: {
+									[SCIM_ENTERPRISE_USER_SCHEMA]: {
+										employeeNumber: "E-204",
+										department: "Finance",
+										manager: {
+											value: manager.id,
+										},
+									},
+								},
+							},
+						],
+					},
+				},
+			),
+		);
+		const patched = await readJSON<SCIMUserResponse>(patchResponse);
+
+		expect(patchResponse.status, JSON.stringify(patched)).toBe(200);
+		expect(patched).toMatchObject({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			id: report.id,
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				employeeNumber: "E-204",
+				department: "Finance",
+				manager: {
+					value: manager.id,
+				},
+			},
+		});
+		const persisted = data.scimUser.find((user) => user.id === report.id);
+		if (!persisted) throw new Error("Expected pathless-patched SCIM User");
+		expect(JSON.parse(persisted.serializedAttributes)).toMatchObject({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			enterprise: {
+				employeeNumber: "E-204",
+				department: "Finance",
+				manager: {
+					value: manager.id,
+				},
+			},
+		});
+	});
+
+	it("requires exactly the PatchOp schema on User PATCH without mutating rejected resources", async () => {
+		const { auth, data } = createEnterpriseFixture();
+		const createResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "patch-message-schema@example.com",
+					title: "Original title",
+				},
+			}),
+		);
+		expect(createResponse.status).toBe(201);
+		const created = await readJSON<SCIMUserResponse>(createResponse);
+		const readPersistedAttributes = () => {
+			const persisted = data.scimUser.find((user) => user.id === created.id);
+			if (!persisted) throw new Error("Expected persisted PATCH schema User");
+			return persisted.serializedAttributes;
+		};
+		const beforeRejectedPatches = readPersistedAttributes();
+
+		for (const unsupportedSchema of [
+			SCIM_MICROSOFT_GRAPH_USER_SCHEMA,
+			SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+		]) {
+			const response = await auth.handler(
+				createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(created.id)}`, {
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA, unsupportedSchema],
+						Operations: [
+							{
+								op: "Replace",
+								path: "title",
+								value: "Must not persist",
+							},
+						],
+					},
+				}),
+			);
+			expect(response.status).toBe(400);
+			expect(await readJSON(response)).toMatchObject({
+				scimType: "invalidValue",
+			});
+			expect(readPersistedAttributes()).toBe(beforeRejectedPatches);
+		}
+
+		const acceptedResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(created.id)}?attributes=title`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{
+								op: "Replace",
+								path: "title",
+								value: "Accepted title",
+							},
+						],
+					},
+				},
+			),
+		);
+		expect(acceptedResponse.status).toBe(200);
+		expect(await readJSON(acceptedResponse)).toMatchObject({
+			schemas: [SCIM_USER_SCHEMA],
+			id: created.id,
+			title: "Accepted title",
+		});
+		expect(JSON.parse(readPersistedAttributes())).toMatchObject({
+			title: "Accepted title",
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/10411
+	 */
+	it("demotes existing primary values for every structured core attribute over HTTP", async () => {
+		const { auth } = createEnterpriseFixture();
+		const createResponse = await auth.handler(
+			createSCIMRequest("/scim/v2/Users", {
+				method: "POST",
+				token: "workforce-token",
+				body: {
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "primary-values@example.com",
+					phoneNumbers: [{ value: "+1-555-0100", type: "work", primary: true }],
+					addresses: [{ locality: "Seattle", type: "work", primary: true }],
+					roles: [{ value: "analyst", type: "work", primary: true }],
+					entitlements: [{ value: "standard", type: "work", primary: true }],
+				},
+			}),
+		);
+		expect(createResponse.status).toBe(201);
+		const created = await readJSON<SCIMUserResponse>(createResponse);
+
+		const patchResponse = await auth.handler(
+			createSCIMRequest(
+				`/scim/v2/Users/${encodeURIComponent(
+					created.id,
+				)}?attributes=phoneNumbers,addresses,roles,entitlements`,
+				{
+					method: "PATCH",
+					token: "workforce-token",
+					body: {
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [
+							{
+								op: "Add",
+								value: {
+									phoneNumbers: [
+										{
+											value: "+1-555-0199",
+											type: "mobile",
+											primary: true,
+										},
+									],
+									addresses: [
+										{
+											locality: "Vancouver",
+											type: "home",
+											primary: true,
+										},
+									],
+									roles: [
+										{
+											value: "manager",
+											type: "project",
+											primary: true,
+										},
+									],
+									entitlements: [
+										{
+											value: "premium",
+											type: "license",
+											primary: true,
+										},
+									],
+								},
+							},
+						],
+					},
+				},
+			),
+		);
+		expect(patchResponse.status).toBe(200);
+		expect(await readJSON(patchResponse)).toMatchObject({
+			phoneNumbers: [
+				{ value: "+1-555-0100", type: "work", primary: false },
+				{ value: "+1-555-0199", type: "mobile", primary: true },
+			],
+			addresses: [
+				{ locality: "Seattle", type: "work", primary: false },
+				{ locality: "Vancouver", type: "home", primary: true },
+			],
+			roles: [
+				{ value: "analyst", type: "work", primary: false },
+				{ value: "manager", type: "project", primary: true },
+			],
+			entitlements: [
+				{ value: "standard", type: "work", primary: false },
+				{ value: "premium", type: "license", primary: true },
+			],
+		});
+	});
+
+	it("exposes typed Enterprise User and manager callback data", () => {
+		expectTypeOf<{ value: string }>().toMatchTypeOf<SCIMCanonicalManager>();
+		expectTypeOf<{ $ref: string }>().toMatchTypeOf<SCIMCanonicalManager>();
+		expectTypeOf<SCIMCanonicalManager>().not.toHaveProperty("displayName");
+		expectTypeOf<SCIMEnterpriseUser>().toMatchTypeOf<{
+			employeeNumber?: string;
+			costCenter?: string;
+			organization?: string;
+			division?: string;
+			department?: string;
+			manager?: SCIMCanonicalManager;
+		}>();
+		expectTypeOf<SCIMCanonicalUser["enterprise"]>().toEqualTypeOf<
+			SCIMEnterpriseUser | undefined
+		>();
+	});
+});

--- a/packages/scim/src/scim-filter-interoperability.test.ts
+++ b/packages/scim/src/scim-filter-interoperability.test.ts
@@ -6,6 +6,7 @@ import { scim } from ".";
 
 const BASE_URL = "http://localhost:3000";
 const SCIM_USERS_URL = `${BASE_URL}/api/auth/scim/v2/Users`;
+const SCIM_GROUPS_URL = `${BASE_URL}/api/auth/scim/v2/Groups`;
 
 async function createFilterFixture() {
 	const data = {
@@ -17,6 +18,7 @@ async function createFilterFixture() {
 		scimIdentityTombstone: [] as { id: string }[],
 		scimSubject: [] as { id: string; userId: string }[],
 		scimUser: [] as { id: string }[],
+		scimGroup: [] as { id: string }[],
 		scimGroupMember: [] as { id: string }[],
 		scimProjectionGrant: [] as { id: string }[],
 	};
@@ -36,11 +38,22 @@ async function createFilterFixture() {
 							},
 						],
 					},
+					{
+						id: "partner-workforce",
+						credentials: [
+							{
+								type: "bearer",
+								id: "partner-scim-token",
+								token: "partner-scim-token",
+							},
+						],
+					},
 				],
 			}),
 		],
 	});
 	const headers = { authorization: "Bearer test-scim-token" };
+	const partnerHeaders = { authorization: "Bearer partner-scim-token" };
 	const ada = await auth.api.createSCIMUser({
 		body: {
 			schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
@@ -52,7 +65,7 @@ async function createFilterFixture() {
 					type: "home",
 					primary: true,
 				},
-				{ value: "ada.work@example.com", type: "work" },
+				{ value: "ada.work@example.com", type: "other" },
 				{ value: "ada.alias@example.com", type: "work" },
 			],
 		},
@@ -73,10 +86,37 @@ async function createFilterFixture() {
 		},
 		headers,
 	});
+	const platformGroup = await auth.api.createSCIMGroup({
+		body: {
+			schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+			displayName: "MyPlatform BA SCIM - Admins",
+		},
+		headers,
+	});
+	const partnerPlatformGroup = await auth.api.createSCIMGroup({
+		body: {
+			schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+			displayName: "MyPlatform BA SCIM - Admins",
+		},
+		headers: partnerHeaders,
+	});
+	const quotedGroupName = 'Research and Development - "Admins"';
+	const quotedGroup = await auth.api.createSCIMGroup({
+		body: {
+			schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+			externalId: "research-and-development-admins",
+			displayName: quotedGroupName,
+		},
+		headers,
+	});
 
 	return {
 		ada,
 		grace,
+		partnerPlatformGroup,
+		platformGroup,
+		quotedGroup,
+		quotedGroupName,
 		async listUsers(filter: string) {
 			const url = new URL(SCIM_USERS_URL);
 			url.searchParams.set("filter", filter);
@@ -85,6 +125,23 @@ async function createFilterFixture() {
 					headers: {
 						accept: "application/scim+json",
 						authorization: "Bearer test-scim-token",
+					},
+				}),
+			);
+			const body: unknown = await response.json();
+			return { status: response.status, body };
+		},
+		async listGroups(
+			filter: string,
+			token: "partner-scim-token" | "test-scim-token" = "test-scim-token",
+		) {
+			const url = new URL(SCIM_GROUPS_URL);
+			url.searchParams.set("filter", filter);
+			const response = await auth.handler(
+				new Request(url, {
+					headers: {
+						accept: "application/scim+json",
+						authorization: `Bearer ${token}`,
 					},
 				}),
 			);
@@ -147,6 +204,68 @@ describe("SCIM provider filter interoperability", () => {
 				totalResults: 1,
 				Resources: [{ id: ada.id }],
 			},
+		});
+	});
+
+	it("filters quoted Group display names through the bearer-authenticated HTTP endpoint", async () => {
+		const {
+			listGroups,
+			partnerPlatformGroup,
+			platformGroup,
+			quotedGroup,
+			quotedGroupName,
+		} = await createFilterFixture();
+		const filter = 'displayName eq "MyPlatform BA SCIM - Admins"';
+		const [workforce, partner, quoted, unsupported, invalid] =
+			await Promise.all([
+				listGroups(filter),
+				listGroups(filter, "partner-scim-token"),
+				listGroups(
+					`displayName eq ${JSON.stringify(quotedGroupName)} and externalId eq "research-and-development-admins"`,
+				),
+				listGroups('displayName ne "MyPlatform BA SCIM - Admins"'),
+				listGroups("displayName eq MyPlatform"),
+			]);
+
+		expect(workforce).toMatchObject({
+			status: 200,
+			body: {
+				totalResults: 1,
+				Resources: [{ id: platformGroup.id }],
+			},
+		});
+		expect(partner).toMatchObject({
+			status: 200,
+			body: {
+				totalResults: 1,
+				Resources: [{ id: partnerPlatformGroup.id }],
+			},
+		});
+		expect(workforce.body).not.toMatchObject({
+			Resources: expect.arrayContaining([{ id: partnerPlatformGroup.id }]),
+		});
+		expect(partner.body).not.toMatchObject({
+			Resources: expect.arrayContaining([{ id: platformGroup.id }]),
+		});
+		expect(quoted).toMatchObject({
+			status: 200,
+			body: {
+				totalResults: 1,
+				Resources: [
+					{
+						id: quotedGroup.id,
+						displayName: quotedGroupName,
+					},
+				],
+			},
+		});
+		expect(unsupported).toMatchObject({
+			status: 400,
+			body: { scimType: "invalidFilter" },
+		});
+		expect(invalid).toMatchObject({
+			status: 400,
+			body: { scimType: "invalidFilter" },
 		});
 	});
 });

--- a/packages/scim/src/scim-google-conformance.test.ts
+++ b/packages/scim/src/scim-google-conformance.test.ts
@@ -1,0 +1,300 @@
+import { DatabaseSync } from "node:sqlite";
+import { NodeSqliteDialect } from "@better-auth/kysely-adapter/node-sqlite-dialect";
+import { getMigrations } from "better-auth/db/migration";
+import { getHttpTestInstance } from "better-auth/test";
+import { describe, expect, it } from "vitest";
+import { scim } from ".";
+
+const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+const SCIM_MEDIA_TYPE = "application/scim+json";
+const SCIM_TOKEN = "google-conformance-token";
+
+interface SCIMUserResponse {
+	id: string;
+	userName: string;
+	active: boolean;
+}
+
+interface SCIMGroupResponse {
+	id: string;
+	displayName: string;
+	members?: { value: string }[];
+}
+
+interface SCIMErrorResponse {
+	schemas: string[];
+	status: string;
+}
+
+interface SCIMSchemaAttribute {
+	name: string;
+	type: string;
+	multiValued: boolean;
+	required: boolean;
+	mutability?: string;
+	subAttributes?: SCIMSchemaAttribute[];
+}
+
+interface SCIMSchemaResponse {
+	id: string;
+	attributes: SCIMSchemaAttribute[];
+}
+
+async function readJSON<T>(response: Response): Promise<T> {
+	return (await response.json()) as T;
+}
+
+function createSCIMHeaders(
+	authorization = `Bearer ${SCIM_TOKEN}`,
+): HeadersInit {
+	return {
+		accept: SCIM_MEDIA_TYPE,
+		authorization,
+		"content-type": SCIM_MEDIA_TYPE,
+	};
+}
+
+async function createTestInstance() {
+	const sqlite = new DatabaseSync(":memory:");
+	const instance = await getHttpTestInstance(
+		{
+			database: {
+				dialect: new NodeSqliteDialect({ database: sqlite }),
+				type: "sqlite",
+				transaction: true,
+			},
+			plugins: [
+				scim({
+					connections: [
+						{
+							id: "google-conformance",
+							credentials: [
+								{
+									type: "bearer",
+									id: "google-conformance-token",
+									token: SCIM_TOKEN,
+								},
+							],
+						},
+					],
+				}),
+			],
+		},
+		{ disableTestUser: true, testWith: "sqlite" },
+	);
+	await (await getMigrations(instance.auth.options)).runMigrations();
+	return { instance, sqlite };
+}
+
+/**
+ * Google Workspace/Cloud Identity is the SCIM client for its "automated user
+ * provisioning" feature, calling out to a third-party app's SCIM server the
+ * same way Okta does. Unlike Okta, Google does not publish a developer-facing
+ * wire-level SCIM specification for the receiving server; every test here
+ * encodes only the high-confidence requirements extracted from Google
+ * Workspace's admin-facing documentation, each with its own citation. Filter,
+ * pagination, and PATCH wire shapes are not documented by Google for this
+ * surface and are intentionally left untested here (the RFC 7644 baseline
+ * other conformance suites already exercise is the only defensible
+ * assumption).
+ */
+describe("Google Workspace/Cloud Identity automated provisioning client", () => {
+	/**
+	 * @see https://knowledge.workspace.google.com/admin/users/advanced/configure-amazon-web-services-user-provisioning
+	 * @see https://support.google.com/a/answer/9291789
+	 */
+	describe("R1 — bearer/access token auth, admin-pasted, no OAuth flow", () => {
+		it("accepts the connection's bearer token", async () => {
+			const { instance, sqlite } = await createTestInstance();
+			try {
+				const response = await fetch(
+					`${instance.baseURL}/api/auth/scim/v2/Users`,
+					{ headers: createSCIMHeaders() },
+				);
+
+				expect(response.status).toBe(200);
+			} finally {
+				await instance.server.close();
+				sqlite.close();
+			}
+		});
+
+		it("rejects a missing or invalid token with 401", async () => {
+			const { instance, sqlite } = await createTestInstance();
+			try {
+				const missing = await fetch(
+					`${instance.baseURL}/api/auth/scim/v2/Users`,
+					{ headers: createSCIMHeaders("") },
+				);
+				const stale = await fetch(
+					`${instance.baseURL}/api/auth/scim/v2/Users`,
+					{
+						headers: createSCIMHeaders("Bearer revoked-or-unknown-token"),
+					},
+				);
+
+				expect(missing.status).toBe(401);
+				expect(stale.status).toBe(401);
+				expect((await readJSON<SCIMErrorResponse>(stale)).status).toBe("401");
+			} finally {
+				await instance.server.close();
+				sqlite.close();
+			}
+		});
+	});
+
+	/**
+	 * @see https://knowledge.workspace.google.com/admin/users/advanced/configure-amazon-web-services-user-provisioning
+	 */
+	describe("R3 — deprovisioning: suspend and hard-delete are independent paths", () => {
+		it("hard-deletes a still-active user with no prior deactivation call", async () => {
+			const { instance, sqlite } = await createTestInstance();
+			try {
+				const usersURL = `${instance.baseURL}/api/auth/scim/v2/Users`;
+				const created = await readJSON<SCIMUserResponse>(
+					await fetch(usersURL, {
+						method: "POST",
+						headers: createSCIMHeaders(),
+						body: JSON.stringify({
+							schemas: [SCIM_USER_SCHEMA],
+							userName: "deleted-from-google@example.com",
+							active: true,
+						}),
+					}),
+				);
+				expect(created.active).toBe(true);
+
+				const deleteResponse = await fetch(`${usersURL}/${created.id}`, {
+					method: "DELETE",
+					headers: createSCIMHeaders(),
+				});
+				expect(deleteResponse.status).toBe(204);
+
+				const afterDelete = await fetch(`${usersURL}/${created.id}`, {
+					headers: createSCIMHeaders(),
+				});
+				expect(afterDelete.status).toBe(404);
+			} finally {
+				await instance.server.close();
+				sqlite.close();
+			}
+		});
+
+		it("cleans up group membership on a DELETE arriving long after an earlier suspend", async () => {
+			const { instance, sqlite } = await createTestInstance();
+			try {
+				const usersURL = `${instance.baseURL}/api/auth/scim/v2/Users`;
+				const groupsURL = `${instance.baseURL}/api/auth/scim/v2/Groups`;
+				const created = await readJSON<SCIMUserResponse>(
+					await fetch(usersURL, {
+						method: "POST",
+						headers: createSCIMHeaders(),
+						body: JSON.stringify({
+							schemas: [SCIM_USER_SCHEMA],
+							userName: "delayed-deprovision@example.com",
+							active: true,
+						}),
+					}),
+				);
+				const group = await readJSON<SCIMGroupResponse>(
+					await fetch(groupsURL, {
+						method: "POST",
+						headers: createSCIMHeaders(),
+						body: JSON.stringify({
+							schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+							displayName: "Suspended then deleted",
+							members: [{ value: created.id }],
+						}),
+					}),
+				);
+
+				// "When a user is suspended from Google" — independent trigger #1.
+				const suspendResponse = await fetch(`${usersURL}/${created.id}`, {
+					method: "PATCH",
+					headers: createSCIMHeaders(),
+					body: JSON.stringify({
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [{ op: "replace", value: { active: false } }],
+					}),
+				});
+				expect(suspendResponse.status).toBe(200);
+
+				// "When a user is deleted from Google" — a decoupled, independently
+				// configurable trigger that Google's own docs say can arrive up to
+				// 21 days later; nothing about it depends on the earlier suspend.
+				const deleteResponse = await fetch(`${usersURL}/${created.id}`, {
+					method: "DELETE",
+					headers: createSCIMHeaders(),
+				});
+				expect(deleteResponse.status).toBe(204);
+
+				const afterDelete = await fetch(`${usersURL}/${created.id}`, {
+					headers: createSCIMHeaders(),
+				});
+				expect(afterDelete.status).toBe(404);
+
+				const groupAfterDelete = await readJSON<SCIMGroupResponse>(
+					await fetch(`${groupsURL}/${group.id}`, {
+						headers: createSCIMHeaders(),
+					}),
+				);
+				expect(groupAfterDelete.members).toEqual([]);
+			} finally {
+				await instance.server.close();
+				sqlite.close();
+			}
+		});
+	});
+
+	/**
+	 * @see https://knowledge.workspace.google.com/admin/users/advanced/configure-amazon-web-services-user-provisioning
+	 */
+	describe("R5 — attribute mapping is built live from the receiving app's discovered schema", () => {
+		it("discovers a complete, accurately-flagged User attribute list", async () => {
+			const { instance, sqlite } = await createTestInstance();
+			try {
+				const response = await fetch(
+					`${instance.baseURL}/api/auth/scim/v2/Schemas/${encodeURIComponent(
+						SCIM_USER_SCHEMA,
+					)}`,
+					{ headers: createSCIMHeaders() },
+				);
+				expect(response.status).toBe(200);
+				const schema = await readJSON<SCIMSchemaResponse>(response);
+				const byName = new Map(
+					schema.attributes.map((attribute) => [attribute.name, attribute]),
+				);
+
+				const userName = byName.get("userName");
+				expect(userName?.required).toBe(true);
+				expect(userName?.type).toBe("string");
+
+				const active = byName.get("active");
+				expect(active?.type).toBe("boolean");
+				expect(active?.mutability).toBe("readWrite");
+
+				const emails = byName.get("emails");
+				expect(emails?.multiValued).toBe(true);
+				expect(emails?.subAttributes?.some((sub) => sub.name === "value")).toBe(
+					true,
+				);
+				expect(
+					emails?.subAttributes?.some((sub) => sub.name === "primary"),
+				).toBe(true);
+
+				const name = byName.get("name");
+				expect(name?.type).toBe("complex");
+				expect(
+					name?.subAttributes?.some((sub) => sub.name === "givenName"),
+				).toBe(true);
+				expect(
+					name?.subAttributes?.some((sub) => sub.name === "familyName"),
+				).toBe(true);
+			} finally {
+				await instance.server.close();
+				sqlite.close();
+			}
+		});
+	});
+});

--- a/packages/scim/src/scim-group-patch-delta.test.ts
+++ b/packages/scim/src/scim-group-patch-delta.test.ts
@@ -147,7 +147,7 @@ function createMutationOrderMemoryAdapter(
 }
 
 describe("SCIM incremental Group PATCH", () => {
-	it("returns 204 and reconciles only the membership delta", async () => {
+	it("returns the updated resource and reconciles only the membership delta", async () => {
 		const data = {
 			user: [] as User[],
 			session: [] as { id: string }[],
@@ -241,9 +241,14 @@ describe("SCIM incremental Group PATCH", () => {
 		const addedSource = data.scimUser.find((source) => source.id === added.id);
 		if (!addedSource) throw new Error("Expected the added SCIM User");
 
-		expect(response.status).toBe(204);
+		expect(response.status).toBe(200);
 		expect(response.headers.get("location")).toContain(`/Groups/${group.id}`);
-		expect(await response.text()).toBe("");
+		expect(await response.json()).toMatchObject({
+			id: group.id,
+			members: expect.arrayContaining([
+				expect.objectContaining({ value: added.id }),
+			]),
+		});
 		expect(reconciledUserIds).toEqual([addedSource.userId]);
 		expect(
 			data.scimGroupMember.filter(

--- a/packages/scim/src/scim-groups-v2.test.ts
+++ b/packages/scim/src/scim-groups-v2.test.ts
@@ -286,6 +286,147 @@ describe("SCIM connection-owned Groups", () => {
 		);
 	});
 
+	it("rejects a cross-connection Group member add atomically", async () => {
+		const data = {
+			user: [] as User[],
+			session: [] as { id: string }[],
+			verification: [] as { id: string }[],
+			account: [] as { id: string }[],
+			scimConnectionBinding: [] as { id: string }[],
+			organization: [] as { id: string }[],
+			member: [] as { id: string }[],
+			scimConnection: [] as { id: string }[],
+			scimCredential: [] as { id: string }[],
+			scimIdentityTombstone: [] as { id: string }[],
+			scimSubject: [] as { id: string; userId: string }[],
+			scimUser: [] as SCIMUserRow[],
+			scimGroup: [] as SCIMGroupRow[],
+			scimGroupMember: [] as SCIMGroupMemberRow[],
+			scimProjectionGrant: [] as { id: string }[],
+		};
+		const auth = betterAuth({
+			baseURL: "http://localhost:3000",
+			database: memoryAdapter(data),
+			plugins: [
+				scim({
+					connections: [
+						{
+							id: "workforce-a",
+							credentials: [
+								{
+									type: "bearer",
+									id: "connection-a-token",
+									token: "connection-a-token",
+								},
+							],
+						},
+						{
+							id: "workforce-b",
+							credentials: [
+								{
+									type: "bearer",
+									id: "connection-b-token",
+									token: "connection-b-token",
+								},
+							],
+						},
+					],
+				}),
+			],
+		});
+		const connectionAHeaders = {
+			authorization: "Bearer connection-a-token",
+		};
+		const connectionBHeaders = {
+			authorization: "Bearer connection-b-token",
+		};
+		const connectionAMember = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "member-a@example.com",
+			},
+			headers: connectionAHeaders,
+		});
+		const connectionBMember = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "member-b@example.com",
+			},
+			headers: connectionBHeaders,
+		});
+		const connectionAGroup = await auth.api.createSCIMGroup({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+				displayName: "Engineering A",
+				members: [{ value: connectionAMember.id }],
+			},
+			headers: connectionAHeaders,
+		});
+		const membershipsBefore = data.scimGroupMember
+			.filter((membership) => membership.groupId === connectionAGroup.id)
+			.map((membership) => ({ ...membership }));
+		const groupBefore = data.scimGroup.find(
+			(group) => group.id === connectionAGroup.id,
+		);
+		if (!groupBefore) throw new Error("Expected connection A Group");
+		const groupStateBefore = {
+			displayName: groupBefore.displayName,
+			revision: groupBefore.revision,
+			updatedAt: groupBefore.updatedAt.getTime(),
+		};
+
+		const response = await auth.handler(
+			new Request(
+				`http://localhost:3000/api/auth/scim/v2/Groups/${encodeURIComponent(
+					connectionAGroup.id,
+				)}`,
+				{
+					method: "PATCH",
+					headers: {
+						...connectionAHeaders,
+						"content-type": "application/scim+json",
+					},
+					body: JSON.stringify({
+						schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+						Operations: [
+							{
+								op: "replace",
+								path: "displayName",
+								value: "Must not persist",
+							},
+							{
+								op: "add",
+								path: "members",
+								value: [{ value: connectionBMember.id }],
+							},
+						],
+					}),
+				},
+			),
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+			status: "400",
+			scimType: "invalidValue",
+		});
+		expect(
+			data.scimGroupMember
+				.filter((membership) => membership.groupId === connectionAGroup.id)
+				.map((membership) => ({ ...membership })),
+		).toEqual(membershipsBefore);
+		const groupAfter = data.scimGroup.find(
+			(group) => group.id === connectionAGroup.id,
+		);
+		if (!groupAfter) throw new Error("Expected connection A Group after PATCH");
+		expect({
+			displayName: groupAfter.displayName,
+			revision: groupAfter.revision,
+			updatedAt: groupAfter.updatedAt.getTime(),
+		}).toEqual(groupStateBefore);
+	});
+
 	it("replaces a Group and its connection-owned membership set", async () => {
 		const data = {
 			user: [] as User[],
@@ -779,6 +920,143 @@ describe("SCIM connection-owned Groups", () => {
 		expect(groupRow).toMatchObject({ displayName: "Platform" });
 		expect(groupRow?.externalId).toBeNull();
 		expect(data.scimProjectionGrant).toEqual([]);
+	});
+
+	/**
+	 * @see https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups
+	 */
+	it("applies Microsoft Entra's array-wrapped Group Replace Attributes PATCH", async () => {
+		const data = {
+			user: [] as User[],
+			session: [] as { id: string }[],
+			verification: [] as { id: string }[],
+			account: [] as { id: string }[],
+			scimConnectionBinding: [] as { id: string }[],
+			scimIdentityTombstone: [] as { id: string }[],
+			scimSubject: [] as { id: string; userId: string }[],
+			scimUser: [] as SCIMUserRow[],
+			scimGroup: [] as SCIMGroupRow[],
+			scimGroupMember: [] as SCIMGroupMemberRow[],
+			scimProjectionGrant: [] as { id: string }[],
+		};
+		const auth = betterAuth({
+			baseURL: "http://localhost:3000",
+			database: memoryAdapter(data),
+			plugins: [
+				scim({
+					connections: [
+						{
+							id: "workforce",
+							credentials: [
+								{
+									type: "bearer",
+									id: "test-scim-token",
+									token: "test-scim-token",
+								},
+							],
+						},
+					],
+				}),
+			],
+		});
+		const authorization = { authorization: "Bearer test-scim-token" };
+		const group = await auth.api.createSCIMGroup({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+				externalId: "directory-engineering",
+				displayName: "Engineering",
+			},
+			headers: authorization,
+		});
+
+		await auth.api.patchSCIMGroup({
+			params: { groupId: group.id },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [
+					{ op: "Replace", path: "displayName", value: ["Platform"] },
+					{
+						op: "Replace",
+						path: "externalId",
+						value: ["directory-platform"],
+					},
+				],
+			},
+			headers: authorization,
+		});
+		const patched = await auth.api.getSCIMGroup({
+			params: { groupId: group.id },
+			headers: authorization,
+		});
+
+		expect(patched).toMatchObject({
+			id: group.id,
+			displayName: "Platform",
+			externalId: "directory-platform",
+		});
+	});
+
+	/**
+	 * @see https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups
+	 */
+	it("accepts an empty Operations array as a no-op Group PATCH", async () => {
+		const data = {
+			user: [] as User[],
+			session: [] as { id: string }[],
+			verification: [] as { id: string }[],
+			account: [] as { id: string }[],
+			scimConnectionBinding: [] as { id: string }[],
+			scimIdentityTombstone: [] as { id: string }[],
+			scimSubject: [] as { id: string; userId: string }[],
+			scimUser: [] as SCIMUserRow[],
+			scimGroup: [] as SCIMGroupRow[],
+			scimGroupMember: [] as SCIMGroupMemberRow[],
+			scimProjectionGrant: [] as { id: string }[],
+		};
+		const auth = betterAuth({
+			baseURL: "http://localhost:3000",
+			database: memoryAdapter(data),
+			plugins: [
+				scim({
+					connections: [
+						{
+							id: "workforce",
+							credentials: [
+								{
+									type: "bearer",
+									id: "test-scim-token",
+									token: "test-scim-token",
+								},
+							],
+						},
+					],
+				}),
+			],
+		});
+		const authorization = { authorization: "Bearer test-scim-token" };
+		const group = await auth.api.createSCIMGroup({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+				displayName: "No Op Group",
+			},
+			headers: authorization,
+		});
+
+		await auth.api.patchSCIMGroup({
+			params: { groupId: group.id },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [],
+			},
+			headers: authorization,
+		});
+
+		await expect(
+			auth.api.getSCIMGroup({
+				params: { groupId: group.id },
+				headers: authorization,
+			}),
+		).resolves.toMatchObject({ displayName: "No Op Group" });
 	});
 
 	it("enforces connection-scoped, case-insensitive Group displayName uniqueness", async () => {

--- a/packages/scim/src/scim-http-contract.test.ts
+++ b/packages/scim/src/scim-http-contract.test.ts
@@ -3,7 +3,7 @@ import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { describe, expect, it } from "vitest";
 import { scim } from ".";
-import type { SCIMBearerCredentialOptions } from "./configuration";
+import type { SCIMBearerCredentialOptions, SCIMOptions } from "./configuration";
 
 const BASE_URL = "http://localhost:3000";
 const SCIM_ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
@@ -15,6 +15,10 @@ const SCIM_GROUP_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:Group";
 const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
 const SCIM_ENTERPRISE_USER_SCHEMA =
 	"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+const SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA =
+	"http://schemas.microsoft.com/2006/11/ResourceManagement/ADSCIM/2.0/Group";
+const SCIM_MICROSOFT_GRAPH_GROUP_SCHEMA =
+	"urn:ietf:params:scim:schemas:extension:Microsoft:Entra:2.0:Group";
 
 interface SCIMUserResponse {
 	id: string;
@@ -34,6 +38,7 @@ function createSCIMAuth(
 	credentials: readonly SCIMBearerCredentialOptions[] = [
 		{ type: "bearer", id: "active-scim-token", token: "active-scim-token" },
 	],
+	compatibility?: SCIMOptions["compatibility"],
 ) {
 	const data = {
 		user: [] as User[],
@@ -55,6 +60,7 @@ function createSCIMAuth(
 		plugins: [
 			scim({
 				connections: [{ id: "workforce", credentials }],
+				...(compatibility ? { compatibility } : {}),
 			}),
 		],
 	});
@@ -136,6 +142,68 @@ describe("SCIM HTTP contract", () => {
 		await expectSCIMError(response, 400, "invalidValue");
 	});
 
+	it("rejects case-insensitive duplicate email types over HTTP POST", async () => {
+		const auth = createSCIMAuth();
+		const response = await auth.handler(
+			createUserRequest({
+				userName: "duplicate-types@example.com",
+				emails: [
+					{
+						value: "first@example.com",
+						type: "Work",
+						primary: true,
+					},
+					{ value: "second@example.com", type: "work" },
+				],
+			}),
+		);
+
+		await expectSCIMError(response, 400, "invalidValue");
+	});
+
+	it("rejects case-insensitive duplicate complex types over HTTP PUT without replacing the User", async () => {
+		const auth = createSCIMAuth();
+		const createResponse = await auth.handler(
+			createUserRequest({
+				userName: "replace-types@example.com",
+				displayName: "Original User",
+			}),
+		);
+		const created = await readJson<SCIMUserResponse>(createResponse);
+		const resourceURL = `${SCIM_USERS_URL}/${encodeURIComponent(created.id)}`;
+		const headers = {
+			accept: SCIM_MEDIA_TYPE,
+			authorization: "Bearer active-scim-token",
+			"content-type": SCIM_MEDIA_TYPE,
+		};
+		const beforeResponse = await auth.handler(
+			new Request(resourceURL, { headers }),
+		);
+		const before = await readJson(beforeResponse);
+
+		const response = await auth.handler(
+			new Request(resourceURL, {
+				method: "PUT",
+				headers,
+				body: JSON.stringify({
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "replace-types@example.com",
+					displayName: "Rejected Replacement",
+					phoneNumbers: [
+						{ value: "+1-555-0100", type: "Work" },
+						{ value: "+1-555-0101", type: "work" },
+					],
+				}),
+			}),
+		);
+
+		await expectSCIMError(response, 400, "invalidValue");
+		const afterResponse = await auth.handler(
+			new Request(resourceURL, { headers }),
+		);
+		expect(await readJson(afterResponse)).toEqual(before);
+	});
+
 	it("returns invalidSyntax for malformed JSON before endpoint dispatch", async () => {
 		const auth = createSCIMAuth();
 		const response = await auth.handler(
@@ -166,7 +234,7 @@ describe("SCIM HTTP contract", () => {
 		await expectSCIMError(response, 400, "invalidValue");
 	});
 
-	it("rejects an unsupported User extension schema", async () => {
+	it("accepts the standard Enterprise User extension schema", async () => {
 		const auth = createSCIMAuth();
 		const response = await auth.handler(
 			new Request(SCIM_USERS_URL, {
@@ -179,6 +247,54 @@ describe("SCIM HTTP contract", () => {
 				body: JSON.stringify({
 					schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
 					userName: "enterprise@example.com",
+					[SCIM_ENTERPRISE_USER_SCHEMA]: { employeeNumber: "42" },
+				}),
+			}),
+		);
+
+		expect(response.status).toBe(201);
+		expect(await readJson(response)).toMatchObject({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			[SCIM_ENTERPRISE_USER_SCHEMA]: { employeeNumber: "42" },
+		});
+	});
+
+	it("rejects unknown User schema URIs", async () => {
+		const auth = createSCIMAuth();
+		const unsupportedUserSchema =
+			"urn:example:params:scim:schemas:extension:2.0:User";
+		const response = await auth.handler(
+			new Request(SCIM_USERS_URL, {
+				method: "POST",
+				headers: {
+					accept: SCIM_MEDIA_TYPE,
+					authorization: "Bearer active-scim-token",
+					"content-type": SCIM_MEDIA_TYPE,
+				},
+				body: JSON.stringify({
+					schemas: [SCIM_USER_SCHEMA, unsupportedUserSchema],
+					userName: "unsupported@example.com",
+					[unsupportedUserSchema]: { employeeNumber: "42" },
+				}),
+			}),
+		);
+
+		await expectSCIMError(response, 400, "invalidValue");
+	});
+
+	it("rejects Enterprise User data without its schema URI", async () => {
+		const auth = createSCIMAuth();
+		const response = await auth.handler(
+			new Request(SCIM_USERS_URL, {
+				method: "POST",
+				headers: {
+					accept: SCIM_MEDIA_TYPE,
+					authorization: "Bearer active-scim-token",
+					"content-type": SCIM_MEDIA_TYPE,
+				},
+				body: JSON.stringify({
+					schemas: [SCIM_USER_SCHEMA],
+					userName: "undeclared-enterprise@example.com",
 					[SCIM_ENTERPRISE_USER_SCHEMA]: { employeeNumber: "42" },
 				}),
 			}),
@@ -223,6 +339,231 @@ describe("SCIM HTTP contract", () => {
 					schemas: [SCIM_GROUP_SCHEMA, unsupportedGroupSchema],
 					displayName: "Engineering",
 					[unsupportedGroupSchema]: { code: "engineering" },
+				}),
+			}),
+		);
+
+		await expectSCIMError(response, 400, "invalidValue");
+	});
+
+	/**
+	 * @see https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups
+	 */
+	it("accepts the exact classic Entra Group marker only on enabled POST ingress", async () => {
+		const auth = createSCIMAuth(undefined, {
+			microsoftEntra: { acceptLegacyGroupSchema: true },
+		});
+		const headers = {
+			accept: SCIM_MEDIA_TYPE,
+			authorization: "Bearer active-scim-token",
+			"content-type": SCIM_MEDIA_TYPE,
+		};
+		const createResponse = await auth.handler(
+			new Request(SCIM_GROUPS_URL, {
+				method: "POST",
+				headers,
+				body: JSON.stringify({
+					schemas: [
+						SCIM_GROUP_SCHEMA,
+						SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+					],
+					externalId: "73f7f508-4e50-4b7f-ba50-0cdbf0638d95",
+					displayName: "Marketing",
+					members: [],
+					meta: { resourceType: "Group" },
+				}),
+			}),
+		);
+
+		expect(createResponse.status).toBe(201);
+		const created = await readJson<Record<string, unknown>>(createResponse);
+		expect(created.schemas).toEqual([SCIM_GROUP_SCHEMA]);
+		expect(created.meta).toMatchObject({
+			resourceType: "Group",
+			location: expect.stringMatching(/\/scim\/v2\/Groups\/[^/]+$/u),
+		});
+		expect(created).not.toHaveProperty(
+			SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+		);
+		expect(JSON.stringify(created)).not.toContain(
+			SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+		);
+		if (typeof created.id !== "string") {
+			throw new Error("Expected the classic Entra Group to have an id");
+		}
+
+		const getResponse = await auth.handler(
+			new Request(`${SCIM_GROUPS_URL}/${encodeURIComponent(created.id)}`, {
+				headers,
+			}),
+		);
+		expect(getResponse.status).toBe(200);
+		expect(JSON.stringify(await readJson(getResponse))).not.toContain(
+			SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+		);
+
+		const schemasResponse = await auth.handler(
+			new Request(`${BASE_URL}/api/auth/scim/v2/Schemas`, { headers }),
+		);
+		expect(schemasResponse.status).toBe(200);
+		expect(JSON.stringify(await readJson(schemasResponse))).not.toContain(
+			SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+		);
+
+		const replaceResponse = await auth.handler(
+			new Request(`${SCIM_GROUPS_URL}/${encodeURIComponent(created.id)}`, {
+				method: "PUT",
+				headers,
+				body: JSON.stringify({
+					schemas: [
+						SCIM_GROUP_SCHEMA,
+						SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+					],
+					displayName: "Marketing",
+				}),
+			}),
+		);
+		await expectSCIMError(replaceResponse, 400, "invalidValue");
+
+		const patchResponse = await auth.handler(
+			new Request(`${SCIM_GROUPS_URL}/${encodeURIComponent(created.id)}`, {
+				method: "PATCH",
+				headers,
+				body: JSON.stringify({
+					schemas: [
+						SCIM_PATCH_SCHEMA,
+						SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+					],
+					Operations: [
+						{
+							op: "Replace",
+							path: "displayName",
+							value: "Marketing leaders",
+						},
+					],
+				}),
+			}),
+		);
+		await expectSCIMError(patchResponse, 400, "invalidValue");
+
+		const attributedReplaceResponse = await auth.handler(
+			new Request(`${SCIM_GROUPS_URL}/${encodeURIComponent(created.id)}`, {
+				method: "PUT",
+				headers,
+				body: JSON.stringify({
+					schemas: [SCIM_GROUP_SCHEMA],
+					displayName: "Marketing",
+					[SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA]: {},
+				}),
+			}),
+		);
+		await expectSCIMError(attributedReplaceResponse, 400, "invalidValue");
+
+		const attributedPatchResponse = await auth.handler(
+			new Request(`${SCIM_GROUPS_URL}/${encodeURIComponent(created.id)}`, {
+				method: "PATCH",
+				headers,
+				body: JSON.stringify({
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [
+						{
+							op: "Replace",
+							path: "displayName",
+							value: "Marketing leaders",
+						},
+					],
+					[SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA]: {},
+				}),
+			}),
+		);
+		await expectSCIMError(attributedPatchResponse, 400, "invalidValue");
+	});
+
+	it("rejects disabled, attributed, duplicate, unknown, and Graph Group schema markers", async () => {
+		const disabledAuth = createSCIMAuth();
+		const enabledAuth = createSCIMAuth(undefined, {
+			microsoftEntra: { acceptLegacyGroupSchema: true },
+		});
+		const headers = {
+			accept: SCIM_MEDIA_TYPE,
+			authorization: "Bearer active-scim-token",
+			"content-type": SCIM_MEDIA_TYPE,
+		};
+		const create = (auth: ReturnType<typeof createSCIMAuth>, body: unknown) =>
+			auth.handler(
+				new Request(SCIM_GROUPS_URL, {
+					method: "POST",
+					headers,
+					body: JSON.stringify(body),
+				}),
+			);
+
+		await expectSCIMError(
+			await create(disabledAuth, {
+				schemas: [SCIM_GROUP_SCHEMA, SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA],
+				displayName: "Disabled compatibility",
+			}),
+			400,
+			"invalidValue",
+		);
+		await expectSCIMError(
+			await create(enabledAuth, {
+				schemas: [SCIM_GROUP_SCHEMA, SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA],
+				displayName: "Attributed marker",
+				[SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA]: {
+					department: "Marketing",
+				},
+			}),
+			400,
+			"invalidValue",
+		);
+		await expectSCIMError(
+			await create(enabledAuth, {
+				schemas: [
+					SCIM_GROUP_SCHEMA,
+					SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+					SCIM_MICROSOFT_ENTRA_LEGACY_GROUP_SCHEMA,
+				],
+				displayName: "Duplicate marker",
+			}),
+			400,
+			"invalidValue",
+		);
+		await expectSCIMError(
+			await create(enabledAuth, {
+				schemas: [
+					SCIM_GROUP_SCHEMA,
+					"urn:example:params:scim:schemas:extension:2.0:Group",
+				],
+				displayName: "Unknown extension",
+			}),
+			400,
+			"invalidValue",
+		);
+		await expectSCIMError(
+			await create(enabledAuth, {
+				schemas: [SCIM_GROUP_SCHEMA, SCIM_MICROSOFT_GRAPH_GROUP_SCHEMA],
+				displayName: "Graph extension",
+			}),
+			400,
+			"invalidValue",
+		);
+	});
+
+	it("rejects the User-only Enterprise schema on a Group resource", async () => {
+		const auth = createSCIMAuth();
+		const response = await auth.handler(
+			new Request(SCIM_GROUPS_URL, {
+				method: "POST",
+				headers: {
+					accept: SCIM_MEDIA_TYPE,
+					authorization: "Bearer active-scim-token",
+					"content-type": SCIM_MEDIA_TYPE,
+				},
+				body: JSON.stringify({
+					schemas: [SCIM_GROUP_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+					displayName: "Engineering",
+					[SCIM_ENTERPRISE_USER_SCHEMA]: { department: "Engineering" },
 				}),
 			}),
 		);

--- a/packages/scim/src/scim-okta-conformance.test.ts
+++ b/packages/scim/src/scim-okta-conformance.test.ts
@@ -1,0 +1,497 @@
+import { DatabaseSync } from "node:sqlite";
+import { NodeSqliteDialect } from "@better-auth/kysely-adapter/node-sqlite-dialect";
+import { getMigrations } from "better-auth/db/migration";
+import { getHttpTestInstance } from "better-auth/test";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { scim } from ".";
+
+const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+const SCIM_LIST_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
+const SCIM_ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
+const SCIM_MEDIA_TYPE = "application/scim+json";
+const SCIM_TOKEN = "okta-conformance-token";
+
+interface SCIMName {
+	givenName?: string;
+	familyName?: string;
+}
+
+interface SCIMEmail {
+	value: string;
+	type?: string;
+	primary?: boolean;
+}
+
+interface SCIMUserResponse {
+	schemas: string[];
+	id: string;
+	userName: string;
+	name?: SCIMName;
+	displayName?: string;
+	active: boolean;
+	emails?: SCIMEmail[];
+}
+
+interface SCIMListResponse<Resource> {
+	schemas: string[];
+	totalResults: number;
+	startIndex: number;
+	itemsPerPage: number;
+	Resources: Resource[];
+}
+
+interface SCIMErrorResponse {
+	schemas: string[];
+	status: string;
+	detail?: string;
+}
+
+async function readJSON<T>(response: Response): Promise<T> {
+	return (await response.json()) as T;
+}
+
+function createSCIMHeaders(
+	authorization = `Bearer ${SCIM_TOKEN}`,
+): HeadersInit {
+	return {
+		accept: SCIM_MEDIA_TYPE,
+		authorization,
+		"content-type": SCIM_MEDIA_TYPE,
+	};
+}
+
+async function createTestInstance() {
+	const sqlite = new DatabaseSync(":memory:");
+	const instance = await getHttpTestInstance(
+		{
+			database: {
+				dialect: new NodeSqliteDialect({ database: sqlite }),
+				type: "sqlite",
+				transaction: true,
+			},
+			plugins: [
+				scim({
+					connections: [
+						{
+							id: "okta-conformance",
+							credentials: [
+								{
+									type: "bearer",
+									id: "okta-conformance-token",
+									token: SCIM_TOKEN,
+								},
+							],
+						},
+					],
+				}),
+			],
+		},
+		{ disableTestUser: true, testWith: "sqlite" },
+	);
+	await (await getMigrations(instance.auth.options)).runMigrations();
+	return { instance, sqlite };
+}
+
+/**
+ * Translates Okta's own SCIM 2.0 conformance fixtures, step for step, against
+ * a real HTTP listener. Both suites are distributed from
+ * `https://developer.okta.com/docs/guides/scim-provisioning-integration-test/main/`
+ * ("Configure and run tests" → "Step 1 — Download test files").
+ */
+describe("Okta SCIM 2.0 SPEC test", () => {
+	// @see https://developer.okta.com/standards/SCIM/SCIMFiles/Okta-SCIM-20-SPEC-Test.json
+	let instance: Awaited<ReturnType<typeof createTestInstance>>["instance"];
+	let sqlite: Awaited<ReturnType<typeof createTestInstance>>["sqlite"];
+	let usersURL: string;
+
+	// Okta's own onboarding docs call this "profile sourcing": R1/R2 require the
+	// store to already contain at least one User before the suite runs.
+	let seededUserId: string;
+	const seededUserName = "morgan.chen@example.com";
+	const seededGivenName = "Morgan";
+	const seededFamilyName = "Chen";
+
+	// Populated by R6, consumed by R7-R9.
+	const randomUsername = "jordan.rivera@example.com";
+	const randomUsernameCaps = randomUsername.toUpperCase();
+	const randomGivenName = "Jordan";
+	const randomFamilyName = "Rivera";
+	const randomEmail = "jordan.rivera.primary@example.com";
+	let idUserOne: string;
+
+	beforeAll(async () => {
+		const created = await createTestInstance();
+		instance = created.instance;
+		sqlite = created.sqlite;
+		usersURL = `${instance.baseURL}/api/auth/scim/v2/Users`;
+
+		const seedResponse = await fetch(usersURL, {
+			method: "POST",
+			headers: createSCIMHeaders(),
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName: seededUserName,
+				name: { givenName: seededGivenName, familyName: seededFamilyName },
+				emails: [{ value: seededUserName, type: "work", primary: true }],
+				displayName: `${seededGivenName} ${seededFamilyName}`,
+				active: true,
+			}),
+		});
+		expect(seedResponse.status).toBe(201);
+		seededUserId = (await readJSON<SCIMUserResponse>(seedResponse)).id;
+	});
+
+	afterAll(async () => {
+		await instance.server.close();
+		sqlite.close();
+	});
+
+	it("R1 — Required Test: Test Users endpoint", async () => {
+		const response = await fetch(`${usersURL}?count=1&startIndex=1`, {
+			headers: createSCIMHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await readJSON<SCIMListResponse<SCIMUserResponse>>(response);
+		expect(body.schemas).toContain(SCIM_LIST_SCHEMA);
+		expect(typeof body.itemsPerPage).toBe("number");
+		expect(typeof body.startIndex).toBe("number");
+		expect(typeof body.totalResults).toBe("number");
+		expect(body.Resources.length).toBeGreaterThan(0);
+		const [resource] = body.Resources;
+		expect(resource?.id).toBeTruthy();
+		expect(resource?.name?.familyName).toBeTruthy();
+		expect(resource?.name?.givenName).toBeTruthy();
+		expect(resource?.userName).toBeTruthy();
+		expect(resource?.active).toBe(true);
+		expect(resource?.emails?.[0]?.value).toBeTruthy();
+	});
+
+	it("R2 — Required Test: Get Users/{id}", async () => {
+		const response = await fetch(`${usersURL}/${seededUserId}`, {
+			headers: createSCIMHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await readJSON<SCIMUserResponse>(response);
+		expect(body.id).toBe(seededUserId);
+		expect(body.name?.familyName).toBeTruthy();
+		expect(body.name?.givenName).toBeTruthy();
+		expect(body.userName).toBeTruthy();
+		expect(body.active).toBe(true);
+		expect(body.emails?.[0]?.value).toBeTruthy();
+	});
+
+	it("R3 — Required Test: Test invalid User by username", async () => {
+		const response = await fetch(
+			`${usersURL}?${new URLSearchParams({
+				filter: 'userName eq "nonexistent-user@example.invalid"',
+			})}`,
+			{ headers: createSCIMHeaders() },
+		);
+
+		expect(response.status).toBe(200);
+		const body = await readJSON<SCIMListResponse<SCIMUserResponse>>(response);
+		expect(body.schemas).toContain(SCIM_LIST_SCHEMA);
+		expect(body.totalResults).toBe(0);
+	});
+
+	it("R4 — Required Test: Test invalid User by ID", async () => {
+		const response = await fetch(`${usersURL}/00000000000000000000`, {
+			headers: createSCIMHeaders(),
+		});
+
+		expect(response.status).toBe(404);
+		const body = await readJSON<SCIMErrorResponse>(response);
+		expect(body.detail).toBeTruthy();
+		expect(body.schemas).toContain(SCIM_ERROR_SCHEMA);
+	});
+
+	it("R5 — Required Test: Make sure random user doesn't exist", async () => {
+		const response = await fetch(
+			`${usersURL}?${new URLSearchParams({
+				filter: `userName eq "${randomUsername}"`,
+			})}`,
+			{ headers: createSCIMHeaders() },
+		);
+
+		expect(response.status).toBe(200);
+		const body = await readJSON<SCIMListResponse<SCIMUserResponse>>(response);
+		expect(body.totalResults).toBe(0);
+		expect(body.schemas).toContain(SCIM_LIST_SCHEMA);
+	});
+
+	it("R6 — Required Test: Create Okta user with realistic values", async () => {
+		const response = await fetch(usersURL, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: `Bearer ${SCIM_TOKEN}`,
+				accept: "application/scim+json; charset=utf-8",
+			},
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName: randomUsername,
+				name: { givenName: randomGivenName, familyName: randomFamilyName },
+				emails: [{ primary: true, value: randomEmail, type: "work" }],
+				displayName: `${randomGivenName} ${randomFamilyName}`,
+				active: true,
+			}),
+		});
+
+		expect(response.status).toBe(201);
+		const body = await readJSON<SCIMUserResponse>(response);
+		expect(body.active).toBe(true);
+		expect(body.id).toBeTruthy();
+		expect(body.name?.familyName).toBe(randomFamilyName);
+		expect(body.name?.givenName).toBe(randomGivenName);
+		expect(body.schemas).toContain(SCIM_USER_SCHEMA);
+		expect(body.userName).toBe(randomUsername);
+		idUserOne = body.id;
+	});
+
+	it("R7 — Required Test: Verify that user was created", async () => {
+		const response = await fetch(`${usersURL}/${idUserOne}`, {
+			headers: createSCIMHeaders(),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await readJSON<SCIMUserResponse>(response);
+		expect(body.userName).toBe(randomUsername);
+		expect(body.name?.familyName).toBe(randomFamilyName);
+		expect(body.name?.givenName).toBe(randomGivenName);
+	});
+
+	it("R8 — Required Test: Expect failure when recreating user with same values", async () => {
+		// Verbatim Okta quirk: the duplicate-check body reuses `randomUsername`
+		// (not `randomEmail`) as the email value; the conflict this must trigger
+		// is on `userName`, which is identical to R6.
+		const response = await fetch(usersURL, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: `Bearer ${SCIM_TOKEN}`,
+				accept: "application/scim+json; charset=utf-8",
+			},
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName: randomUsername,
+				name: { givenName: randomGivenName, familyName: randomFamilyName },
+				emails: [{ primary: true, value: randomUsername, type: "work" }],
+				displayName: `${randomGivenName} ${randomFamilyName}`,
+				active: true,
+			}),
+		});
+
+		expect(response.status).toBe(409);
+	});
+
+	it("R9 — Required Test: Username Case Sensitivity Check", async () => {
+		const response = await fetch(
+			`${usersURL}?${new URLSearchParams({
+				filter: `userName eq "${randomUsernameCaps}"`,
+			})}`,
+			{ headers: createSCIMHeaders() },
+		);
+
+		// Okta's own suite only requires 200 here; it does not assert match
+		// semantics either way. This server additionally documents its own
+		// choice: `userNameKey` lookups normalize case, so a differently-cased
+		// query still resolves to the same account.
+		expect(response.status).toBe(200);
+		const body = await readJSON<SCIMListResponse<SCIMUserResponse>>(response);
+		expect(body.totalResults).toBe(1);
+		expect(body.Resources[0]?.userName).toBe(randomUsername);
+	});
+
+	it("R10 — Optional Test: Verify Groups endpoint", async () => {
+		const response = await fetch(
+			`${instance.baseURL}/api/auth/scim/v2/Groups`,
+			{
+				headers: createSCIMHeaders(),
+			},
+		);
+
+		expect(response.status).toBe(200);
+		const body = await readJSON<SCIMListResponse<unknown>>(response);
+		if (body.totalResults === 0) {
+			expect(body.Resources).toEqual([]);
+		} else {
+			expect(Array.isArray(body.Resources)).toBe(true);
+		}
+	});
+
+	it("R11 — Required Test: Check status 401", async () => {
+		const response = await fetch(
+			`${usersURL}?${new URLSearchParams({
+				filter: `userName eq "${randomUsernameCaps}"`,
+			})}`,
+			{ headers: createSCIMHeaders("non-token") },
+		);
+
+		expect(response.status).toBe(401);
+		const body = await readJSON<SCIMErrorResponse>(response);
+		expect(body.detail).toBeTruthy();
+		expect(body.status).toBe("401");
+		expect(body.schemas).toContain(SCIM_ERROR_SCHEMA);
+	});
+
+	it("R12 — Required Test: Check status 404", async () => {
+		const response = await fetch(`${usersURL}/00919288221112222`, {
+			headers: createSCIMHeaders(),
+		});
+
+		expect(response.status).toBe(404);
+		const body = await readJSON<SCIMErrorResponse>(response);
+		expect(body.detail).toBeTruthy();
+		expect(body.status).toBe("404");
+		expect(body.schemas).toContain(SCIM_ERROR_SCHEMA);
+	});
+
+	// The SPEC test file lists three supported client auth methods (OAuth 2.0
+	// Authorization Code, HTTP Basic, and a bearer token), but neither Runscope
+	// suite exercises Basic Auth directly. This server deliberately supports
+	// only a bearer token in the `Authorization` header (see
+	// `ServiceProviderConfig`'s single `oauthbearertoken` scheme); an Okta
+	// customer configured for Basic Auth gets a 401 on every call, documented
+	// here rather than left implicit.
+	// @see https://developer.okta.com/docs/api/openapi/okta-scim/guides/scim-20/
+	it("rejects HTTP Basic credentials (Basic Auth is not a supported scheme)", async () => {
+		const response = await fetch(usersURL, {
+			headers: createSCIMHeaders(
+				`Basic ${Buffer.from("okta:okta-conformance-token").toString("base64")}`,
+			),
+		});
+
+		expect(response.status).toBe(401);
+		const body = await readJSON<SCIMErrorResponse>(response);
+		expect(body.status).toBe("401");
+		expect(body.schemas).toContain(SCIM_ERROR_SCHEMA);
+	});
+});
+
+/**
+ * Translates the CRUD suite's net effect on the SCIM server. The Runscope
+ * fixture drives a live Okta org and only polls the SCIM server indirectly
+ * (Okta Users/Apps management API calls are out of scope here); this encodes
+ * the fixed wire-level sequence those actions are documented to trigger.
+ * @see https://developer.okta.com/standards/SCIM/SCIMFiles/Okta-SCIM-20-CRUD-Test.json
+ */
+describe("Okta SCIM 2.0 CRUD test net wire sequence", () => {
+	it("creates, reads, replaces, deactivates, reactivates, and deactivates a user", async () => {
+		const { instance, sqlite } = await createTestInstance();
+		try {
+			const usersURL = `${instance.baseURL}/api/auth/scim/v2/Users`;
+			const userName = "riley.okta.test@atko.com";
+
+			// 1. POST /Users — Okta always includes an unsolicited `password`
+			// placeholder on create, even when password sync is disabled; the
+			// server must accept and may ignore it.
+			const createResponse = await fetch(usersURL, {
+				method: "POST",
+				headers: createSCIMHeaders(),
+				body: JSON.stringify({
+					schemas: [SCIM_USER_SCHEMA],
+					userName,
+					name: { givenName: "Riley", familyName: "Okta" },
+					emails: [{ value: userName, type: "work", primary: true }],
+					displayName: "Riley Okta",
+					title: "Engineer",
+					phoneNumbers: [{ value: "415.123.4567" }],
+					password: "N3verSt0red!",
+					active: true,
+				}),
+			});
+			expect(createResponse.status).toBe(201);
+			const created = await readJSON<SCIMUserResponse>(createResponse);
+			expect(created).not.toHaveProperty("password");
+
+			// 2. GET /Users?filter=userName eq "<email>" — existence check.
+			const filterResponse = await fetch(
+				`${usersURL}?${new URLSearchParams({
+					filter: `userName eq "${userName}"`,
+				})}`,
+				{ headers: createSCIMHeaders() },
+			);
+			expect(filterResponse.status).toBe(200);
+			const filtered =
+				await readJSON<SCIMListResponse<SCIMUserResponse>>(filterResponse);
+			expect(filtered.Resources).toHaveLength(1);
+			expect(filtered.Resources[0]?.id).toBe(created.id);
+
+			// 3. PUT /Users/{id} — a full-resource read-modify-write: Okta fetches
+			// the current resource, changes only `givenName`, and PUTs the entire
+			// object back, including fields it never intended to change.
+			const beforePut = await readJSON<SCIMUserResponse>(
+				await fetch(`${usersURL}/${created.id}`, {
+					headers: createSCIMHeaders(),
+				}),
+			);
+			const putResponse = await fetch(`${usersURL}/${created.id}`, {
+				method: "PUT",
+				headers: createSCIMHeaders(),
+				body: JSON.stringify({
+					...beforePut,
+					name: { ...beforePut.name, givenName: "Rileyupdate" },
+				}),
+			});
+			expect(putResponse.status).toBe(200);
+			expect(
+				(await readJSON<SCIMUserResponse>(putResponse)).name?.givenName,
+			).toBe("Rileyupdate");
+
+			// 4. PATCH /Users/{id} — deactivate (pathless value shape; Okta's
+			// documented `{"Operations":[{"op":"replace","value":{"active":false}}]}`).
+			const deactivateResponse = await fetch(`${usersURL}/${created.id}`, {
+				method: "PATCH",
+				headers: createSCIMHeaders(),
+				body: JSON.stringify({
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [{ op: "replace", value: { active: false } }],
+				}),
+			});
+			// Okta's guide documents both 200 (full resource) and 204 (no body)
+			// as acceptable PATCH responses; this server always returns 200.
+			expect(deactivateResponse.status).toBe(200);
+			expect(
+				(await readJSON<SCIMUserResponse>(deactivateResponse)).active,
+			).toBe(false);
+
+			// 5. PATCH /Users/{id} — reactivate (symmetric shape).
+			const reactivateResponse = await fetch(`${usersURL}/${created.id}`, {
+				method: "PATCH",
+				headers: createSCIMHeaders(),
+				body: JSON.stringify({
+					schemas: [SCIM_PATCH_SCHEMA],
+					Operations: [{ op: "replace", value: { active: true } }],
+				}),
+			});
+			expect(reactivateResponse.status).toBe(200);
+			expect(
+				(await readJSON<SCIMUserResponse>(reactivateResponse)).active,
+			).toBe(true);
+
+			// 6. A second deactivate PATCH — Okta never sends `DELETE /Users/{id}`;
+			// unassigning the integration triggers another deactivation instead.
+			const secondDeactivateResponse = await fetch(
+				`${usersURL}/${created.id}`,
+				{
+					method: "PATCH",
+					headers: createSCIMHeaders(),
+					body: JSON.stringify({
+						schemas: [SCIM_PATCH_SCHEMA],
+						Operations: [{ op: "replace", value: { active: false } }],
+					}),
+				},
+			);
+			expect(secondDeactivateResponse.status).toBe(200);
+			expect(
+				(await readJSON<SCIMUserResponse>(secondDeactivateResponse)).active,
+			).toBe(false);
+		} finally {
+			await instance.server.close();
+			sqlite.close();
+		}
+	});
+});

--- a/packages/scim/src/scim-profile.test.ts
+++ b/packages/scim/src/scim-profile.test.ts
@@ -16,7 +16,7 @@ describe("SCIM canonical User profiles", () => {
 			scimConnectionBinding: [] as { id: string }[],
 			scimIdentityTombstone: [] as { id: string }[],
 			scimSubject: [] as { id: string; userId: string }[],
-			scimUser: [] as { id: string; serializedEmails: string }[],
+			scimUser: [] as { id: string; serializedAttributes: string }[],
 			scimGroupMember: [] as { id: string }[],
 			scimProjectionGrant: [] as { id: string }[],
 		};
@@ -59,7 +59,7 @@ describe("SCIM canonical User profiles", () => {
 						primary: true,
 					},
 					{ value: "ada.shared@example.com", type: "work" },
-					{ value: "ada.alias@example.com", type: "work" },
+					{ value: "ada.alias@example.com", type: "other" },
 				],
 			},
 			headers,
@@ -92,14 +92,14 @@ describe("SCIM canonical User profiles", () => {
 				},
 				{
 					value: "ada.alias@example.com",
-					type: "work",
+					type: "other",
 					primary: false,
 				},
 			],
 		});
-		expect(JSON.parse(data.scimUser[0]?.serializedEmails ?? "[]")).toEqual(
-			retrieved.emails,
-		);
+		expect(
+			JSON.parse(data.scimUser[0]?.serializedAttributes ?? "{}"),
+		).toMatchObject({ emails: retrieved.emails });
 		expect(data.user[0]).toMatchObject({
 			email: "ada.shared@example.com",
 			name: "Countess of Lovelace",
@@ -107,7 +107,7 @@ describe("SCIM canonical User profiles", () => {
 
 		const persisted = data.scimUser[0];
 		if (!persisted) throw new Error("Expected the persisted SCIM User");
-		persisted.serializedEmails = "corrupt";
+		persisted.serializedAttributes = "corrupt";
 		await expect(
 			auth.api.getSCIMUser({
 				params: { userId: created.id },
@@ -117,7 +117,7 @@ describe("SCIM canonical User profiles", () => {
 			expect.objectContaining({
 				statusCode: 500,
 				body: expect.objectContaining({
-					detail: "Stored SCIM User email state is invalid",
+					detail: "Stored SCIM User attribute state is invalid",
 				}),
 			}),
 		);

--- a/packages/scim/src/scim-sqlite.test.ts
+++ b/packages/scim/src/scim-sqlite.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 import { NodeSqliteDialect } from "@better-auth/kysely-adapter/node-sqlite-dialect";
+import { betterAuth } from "better-auth";
 import { getMigrations } from "better-auth/db/migration";
 import { getTestInstance } from "better-auth/test";
 import { describe, expect, it } from "vitest";
@@ -7,8 +8,212 @@ import { scim } from ".";
 
 const USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
 const GROUP_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:Group";
+const SCIM_MEDIA_TYPE = "application/scim+json";
+
+function createLegacySCIMUserTable(sqlite: DatabaseSync) {
+	sqlite.exec(`
+		CREATE TABLE "scimUser" (
+			"id" text PRIMARY KEY NOT NULL,
+			"connectionId" text NOT NULL,
+			"provisioningDomainId" text NOT NULL,
+			"userId" text NOT NULL,
+			"connectionUserKey" text NOT NULL,
+			"userName" text NOT NULL,
+			"userNameKey" text NOT NULL,
+			"primaryEmail" text NOT NULL,
+			"workEmailValueIndex" text NOT NULL,
+			"emailValueIndex" text NOT NULL,
+			"displayName" text NOT NULL,
+			"formattedName" text NOT NULL,
+			"givenName" text,
+			"familyName" text,
+			"serializedEmails" text NOT NULL,
+			"externalId" text,
+			"externalIdKey" text,
+			"active" integer NOT NULL,
+			"orderKey" text NOT NULL,
+			"createdAt" integer NOT NULL,
+			"updatedAt" integer NOT NULL
+		);
+		INSERT INTO "scimUser" (
+			"id", "connectionId", "provisioningDomainId", "userId",
+			"connectionUserKey", "userName", "userNameKey", "primaryEmail",
+			"workEmailValueIndex", "emailValueIndex", "displayName",
+			"formattedName", "givenName", "familyName", "serializedEmails",
+			"active", "orderKey", "createdAt", "updatedAt"
+		) VALUES (
+			'legacy-scim-user', 'legacy', 'legacy', 'legacy-user',
+			'legacy:user', 'legacy@example.com', 'legacy:username',
+			'legacy@example.com', '|legacy|', '|legacy|', 'Legacy User',
+			'Legacy User', 'Legacy', 'User',
+			'[{"value":"legacy@example.com","primary":true}]',
+			1, 'legacy-order', 0, 0
+		);
+	`);
+}
+
+function createLegacySCIMAuth(sqlite: DatabaseSync) {
+	return betterAuth({
+		baseURL: "http://localhost:3000",
+		database: {
+			dialect: new NodeSqliteDialect({ database: sqlite }),
+			type: "sqlite",
+			transaction: true,
+		},
+		plugins: [
+			scim({
+				connections: [
+					{
+						id: "legacy",
+						credentials: [
+							{
+								type: "bearer",
+								id: "legacy-token",
+								token: "legacy-token",
+							},
+						],
+					},
+				],
+			}),
+		],
+	});
+}
 
 describe("SCIM SQLite integration", () => {
+	it("adds serializedAttributes as a nullable column that migrates populated legacy rows", async ({
+		onTestFinished,
+	}) => {
+		const sqlite = new DatabaseSync(":memory:");
+		onTestFinished(() => sqlite.close());
+		createLegacySCIMUserTable(sqlite);
+		const auth = createLegacySCIMAuth(sqlite);
+
+		const migrations = await getMigrations(auth.options);
+		const scimUserAdditions = migrations.toBeAdded.find(
+			(table) => table.table === "scimUser",
+		);
+		expect(Object.keys(scimUserAdditions?.fields ?? {})).toEqual([
+			"serializedAttributes",
+		]);
+		expect(scimUserAdditions?.fields.serializedAttributes).toMatchObject({
+			type: "string",
+			required: false,
+		});
+		const sql = (await migrations.compileMigrations()).toLowerCase();
+		expect(sql).toContain('add column "serializedattributes" text');
+		expect(sql).not.toMatch(/add column "serializedattributes"[^;]*not null/);
+
+		await expect(migrations.runMigrations()).resolves.not.toThrow();
+
+		const response = await auth.handler(
+			new Request(
+				"http://localhost:3000/api/auth/scim/v2/Users/legacy-scim-user",
+				{
+					headers: {
+						accept: SCIM_MEDIA_TYPE,
+						authorization: "Bearer legacy-token",
+					},
+				},
+			),
+		);
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({
+			userName: "legacy@example.com",
+			name: {
+				formatted: "Legacy User",
+				givenName: "Legacy",
+				familyName: "User",
+			},
+			emails: [{ value: "legacy@example.com", primary: true }],
+		});
+	});
+
+	it("upgrades a populated legacy table and provisions a new user through the real HTTP endpoint", async ({
+		onTestFinished,
+	}) => {
+		const sqlite = new DatabaseSync(":memory:");
+		onTestFinished(() => sqlite.close());
+		createLegacySCIMUserTable(sqlite);
+		const auth = createLegacySCIMAuth(sqlite);
+		const migrations = await getMigrations(auth.options);
+
+		await migrations.runMigrations();
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/api/auth/scim/v2/Users", {
+				method: "POST",
+				headers: {
+					accept: SCIM_MEDIA_TYPE,
+					authorization: "Bearer legacy-token",
+					"content-type": SCIM_MEDIA_TYPE,
+				},
+				body: JSON.stringify({
+					schemas: [USER_SCHEMA],
+					userName: "upgraded@example.com",
+					displayName: "Upgraded User",
+					name: {
+						formatted: "Ms. Upgraded User",
+						givenName: "Upgraded",
+						familyName: "User",
+					},
+					emails: [
+						{
+							value: "upgraded@example.com",
+							type: "work",
+							primary: true,
+						},
+					],
+					active: true,
+				}),
+			}),
+		);
+
+		expect(response.status).toBe(201);
+		const persisted = sqlite
+			.prepare(
+				`SELECT "formattedName", "givenName", "familyName",
+					"serializedEmails", "serializedAttributes"
+				FROM "scimUser"
+				WHERE "userName" = 'upgraded@example.com'`,
+			)
+			.get() as
+			| {
+					formattedName: string;
+					givenName: string | null;
+					familyName: string | null;
+					serializedEmails: string;
+					serializedAttributes: string;
+			  }
+			| undefined;
+		expect(persisted).toMatchObject({
+			formattedName: "Ms. Upgraded User",
+			givenName: "Upgraded",
+			familyName: "User",
+		});
+		expect(JSON.parse(persisted?.serializedEmails ?? "[]")).toEqual([
+			{
+				value: "upgraded@example.com",
+				type: "work",
+				primary: true,
+			},
+		]);
+		expect(JSON.parse(persisted?.serializedAttributes ?? "{}")).toMatchObject({
+			schemas: [USER_SCHEMA],
+			name: {
+				formatted: "Ms. Upgraded User",
+				givenName: "Upgraded",
+				familyName: "User",
+			},
+			emails: [
+				{
+					value: "upgraded@example.com",
+					type: "work",
+					primary: true,
+				},
+			],
+		});
+	});
+
 	it("persists and queries canonical resources through a native transaction adapter", async ({
 		onTestFinished,
 	}) => {
@@ -54,7 +259,7 @@ describe("SCIM SQLite integration", () => {
 						type: "home",
 						primary: true,
 					},
-					{ value: "first-work@example.com", type: "work" },
+					{ value: "first-work@example.com", type: "other" },
 					{ value: "second-work@example.com", type: "work" },
 				],
 			},

--- a/packages/scim/src/scim-sso-http-e2e.test.ts
+++ b/packages/scim/src/scim-sso-http-e2e.test.ts
@@ -273,7 +273,7 @@ describe("SCIM-provisioned SSO authentication over HTTP", () => {
 					}),
 				},
 			);
-			expect(response.status).toBe(204);
+			expect(response.status).toBe(200);
 		}
 
 		async function deleteSCIMUser(userId: string): Promise<void> {

--- a/packages/scim/src/scim-user-patch.test.ts
+++ b/packages/scim/src/scim-user-patch.test.ts
@@ -7,6 +7,7 @@ import type { SCIMUser } from "./persistence";
 
 const PATCH_OP_SCHEMA =
 	"urn:ietf:params:scim:api:messages:2.0:PatchOp" as const;
+const SCIM_MEDIA_TYPE = "application/scim+json";
 
 function createTestContext() {
 	const data = {
@@ -21,6 +22,7 @@ function createTestContext() {
 		scimGroupMember: [] as { id: string }[],
 		scimProjectionGrant: [] as { id: string }[],
 	};
+	let identityResolutionCount = 0;
 	const auth = betterAuth({
 		baseURL: "http://localhost:3000",
 		database: memoryAdapter(data),
@@ -38,6 +40,12 @@ function createTestContext() {
 						],
 					},
 				],
+				identity: {
+					resolveUser() {
+						identityResolutionCount += 1;
+						return { action: "create" };
+					},
+				},
 			}),
 		],
 	});
@@ -46,6 +54,7 @@ function createTestContext() {
 		auth,
 		data,
 		headers: { authorization: "Bearer test-scim-token" },
+		getIdentityResolutionCount: () => identityResolutionCount,
 	};
 }
 
@@ -271,6 +280,86 @@ describe("SCIM User PATCH provider compatibility", () => {
 		);
 	});
 
+	it("adds, replaces, and removes a non-work typed email through the filtered path", async () => {
+		const { auth, headers } = createTestContext();
+		const created = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "home-email@example.com",
+				emails: [
+					{
+						value: "work@example.com",
+						type: "work",
+						primary: true,
+					},
+				],
+			},
+			headers,
+		});
+
+		await auth.api.patchSCIMUser({
+			params: { userId: created.id },
+			body: {
+				schemas: [PATCH_OP_SCHEMA],
+				Operations: [
+					{
+						op: "add",
+						path: 'emails[type eq "home"].value',
+						value: "home@example.com",
+					},
+				],
+			},
+			headers,
+		});
+		const withHomeEmail = await auth.api.getSCIMUser({
+			params: { userId: created.id },
+			headers,
+		});
+		expect(withHomeEmail.emails).toEqual([
+			{ value: "work@example.com", type: "work", primary: true },
+			{ value: "home@example.com", type: "home", primary: false },
+		]);
+
+		await auth.api.patchSCIMUser({
+			params: { userId: created.id },
+			body: {
+				schemas: [PATCH_OP_SCHEMA],
+				Operations: [
+					{
+						op: "replace",
+						path: 'emails[type eq "home"].value',
+						value: "home-updated@example.com",
+					},
+				],
+			},
+			headers,
+		});
+		const withReplacedHomeEmail = await auth.api.getSCIMUser({
+			params: { userId: created.id },
+			headers,
+		});
+		expect(withReplacedHomeEmail.emails).toEqual([
+			{ value: "work@example.com", type: "work", primary: true },
+			{ value: "home-updated@example.com", type: "home", primary: false },
+		]);
+
+		await auth.api.patchSCIMUser({
+			params: { userId: created.id },
+			body: {
+				schemas: [PATCH_OP_SCHEMA],
+				Operations: [{ op: "remove", path: 'emails[type eq "home"].value' }],
+			},
+			headers,
+		});
+		const finalResource = await auth.api.getSCIMUser({
+			params: { userId: created.id },
+			headers,
+		});
+		expect(finalResource.emails).toEqual([
+			{ value: "work@example.com", type: "work", primary: true },
+		]);
+	});
+
 	it("appends email tuples and treats duplicate additions as a no-op", async () => {
 		const { auth, data, headers } = createTestContext();
 		const created = await auth.api.createSCIMUser({
@@ -390,6 +479,104 @@ describe("SCIM User PATCH provider compatibility", () => {
 		);
 	});
 
+	it("rejects duplicate email types atomically across HTTP PATCH shapes", async () => {
+		const { auth, data, getIdentityResolutionCount, headers } =
+			createTestContext();
+		const created = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "patch-type-collision@example.com",
+				emails: [
+					{
+						value: "home@example.com",
+						type: "home",
+						primary: true,
+					},
+					{ value: "work@example.com", type: "work" },
+				],
+			},
+			headers,
+		});
+		const resourceURL = `http://localhost:3000/api/auth/scim/v2/Users/${encodeURIComponent(
+			created.id,
+		)}`;
+		const resourceBefore = await auth.api.getSCIMUser({
+			params: { userId: created.id },
+			headers,
+		});
+		const persistedBefore = getPersistedUser(data, created.id);
+		const serializedAttributesBefore =
+			persistedBefore.scimUser.serializedAttributes;
+		const backingUserBefore = { ...persistedBefore.user };
+		const callbackCountBefore = getIdentityResolutionCount();
+		const operationSets = [
+			[
+				{
+					op: "add",
+					path: "emails",
+					value: [{ value: "second-work@example.com", type: "Work" }],
+				},
+			],
+			[
+				{
+					op: "replace",
+					path: "emails",
+					value: [
+						{
+							value: "home@example.com",
+							type: "home",
+							primary: true,
+						},
+						{ value: "first-work@example.com", type: "Work" },
+						{ value: "second-work@example.com", type: "work" },
+					],
+				},
+			],
+			[
+				{
+					op: "add",
+					value: {
+						emails: [{ value: "pathless-work@example.com", type: "Work" }],
+					},
+				},
+			],
+		] as const;
+
+		for (const Operations of operationSets) {
+			const response = await auth.handler(
+				new Request(resourceURL, {
+					method: "PATCH",
+					headers: {
+						...headers,
+						accept: SCIM_MEDIA_TYPE,
+						"content-type": SCIM_MEDIA_TYPE,
+					},
+					body: JSON.stringify({
+						schemas: [PATCH_OP_SCHEMA],
+						Operations,
+					}),
+				}),
+			);
+
+			expect(response.status).toBe(400);
+			expect(await response.json()).toMatchObject({
+				scimType: "invalidValue",
+			});
+			expect(
+				await auth.api.getSCIMUser({
+					params: { userId: created.id },
+					headers,
+				}),
+			).toEqual(resourceBefore);
+			const persistedAfter = getPersistedUser(data, created.id);
+			expect(persistedAfter.scimUser.serializedAttributes).toBe(
+				serializedAttributesBefore,
+			);
+			expect(persistedAfter.user).toEqual(backingUserBefore);
+			expect(getIdentityResolutionCount()).toBe(callbackCountBefore);
+		}
+	});
+
 	it("rejects an email replacement with a duplicate type and value tuple", async () => {
 		const { auth, data, headers } = createTestContext();
 		const created = await auth.api.createSCIMUser({
@@ -404,10 +591,6 @@ describe("SCIM User PATCH provider compatibility", () => {
 					},
 					{
 						value: "work@example.com",
-						type: "work",
-					},
-					{
-						value: "other-work@example.com",
 						type: "work",
 					},
 				],
@@ -435,8 +618,8 @@ describe("SCIM User PATCH provider compatibility", () => {
 									type: "home",
 									primary: true,
 								},
-								{ value: "duplicate@example.com", type: "work" },
-								{ value: "duplicate@example.com", type: "work" },
+								{ value: "duplicate@example.com" },
+								{ value: "duplicate@example.com" },
 							],
 						},
 					],
@@ -456,16 +639,13 @@ describe("SCIM User PATCH provider compatibility", () => {
 		});
 		const persistedAfter = getPersistedUser(data, created.id);
 		expect(resourceAfter).toEqual(resourceBefore);
-		expect(persistedAfter.scimUser.serializedEmails).toBe(
-			persistedBefore.scimUser.serializedEmails,
+		expect(persistedAfter.scimUser.serializedAttributes).toBe(
+			persistedBefore.scimUser.serializedAttributes,
 		);
 		expect(persistedAfter.user.email).toBe(persistedBefore.user.email);
 	});
 
-	it.each([
-		"emails.value",
-		'emails[type eq "work"].value',
-	])("rejects %s replacements that collapse distinct email tuples", async (path) => {
+	it("rejects emails.value replacements that collapse distinct email tuples", async () => {
 		const { auth, headers } = createTestContext();
 		const created = await auth.api.createSCIMUser({
 			body: {
@@ -474,10 +654,9 @@ describe("SCIM User PATCH provider compatibility", () => {
 				emails: [
 					{
 						value: "primary-work@example.com",
-						type: "work",
 						primary: true,
 					},
-					{ value: "secondary-work@example.com", type: "work" },
+					{ value: "secondary-work@example.com" },
 				],
 			},
 			headers,
@@ -495,7 +674,7 @@ describe("SCIM User PATCH provider compatibility", () => {
 					Operations: [
 						{
 							op: "replace",
-							path,
+							path: "emails.value",
 							value: "collision@example.com",
 						},
 					],
@@ -590,6 +769,44 @@ describe("SCIM User PATCH provider compatibility", () => {
 			statusCode: 400,
 			body: expect.objectContaining({ scimType: "invalidPath" }),
 		});
+	});
+
+	it("rejects a PATCH attribute path with a trailing empty segment", async () => {
+		const { auth, headers } = createTestContext();
+		const created = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "path-trailing-dot@example.com",
+				name: { formatted: "Original Name" },
+			},
+			headers,
+		});
+
+		await expect(
+			auth.api.patchSCIMUser({
+				params: { userId: created.id },
+				body: {
+					schemas: [PATCH_OP_SCHEMA],
+					Operations: [
+						{
+							op: "replace",
+							path: "name.",
+							value: { formatted: "Unexpected Name" },
+						},
+					],
+				},
+				headers,
+			}),
+		).rejects.toMatchObject({
+			statusCode: 400,
+			body: expect.objectContaining({ scimType: "invalidPath" }),
+		});
+
+		const resource = await auth.api.getSCIMUser({
+			params: { userId: created.id },
+			headers,
+		});
+		expect(resource.name).toMatchObject({ formatted: "Original Name" });
 	});
 
 	it("atomically applies pathless object updates and removes externalId", async () => {
@@ -804,5 +1021,112 @@ describe("SCIM User PATCH provider compatibility", () => {
 				scimType: "mutability",
 			}),
 		});
+	});
+});
+
+describe("SCIM User compatibility with pre-serializedAttributes rows", () => {
+	it("serves GET, PUT, and PATCH for a scimUser row persisted before serializedAttributes existed", async () => {
+		const { auth, data, headers } = createTestContext();
+		const created = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "legacy.login@example.com",
+				name: {
+					formatted: "Legacy Employee",
+					givenName: "Legacy",
+					familyName: "Employee",
+				},
+				emails: [{ value: "legacy.primary@example.com", primary: true }],
+			},
+			headers,
+		});
+
+		function forgetSerializedAttributes() {
+			getPersistedUser(data, created.id).scimUser.serializedAttributes =
+				undefined;
+		}
+
+		forgetSerializedAttributes();
+		const retrieved = await auth.api.getSCIMUser({
+			params: { userId: created.id },
+			headers,
+		});
+		expect(retrieved).toMatchObject({
+			userName: "legacy.login@example.com",
+			name: {
+				formatted: "Legacy Employee",
+				givenName: "Legacy",
+				familyName: "Employee",
+			},
+			emails: [{ value: "legacy.primary@example.com", primary: true }],
+		});
+		expect(
+			getPersistedUser(data, created.id).scimUser.serializedAttributes,
+		).toBeFalsy();
+
+		forgetSerializedAttributes();
+		const replaced = await auth.api.replaceSCIMUser({
+			params: { userId: created.id },
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "legacy.login@example.com",
+				name: {
+					formatted: "Legacy Employee Renewed",
+					givenName: "Legacy",
+					familyName: "Employee",
+				},
+				emails: [{ value: "legacy.primary@example.com", primary: true }],
+			},
+			headers,
+		});
+		expect(replaced.name).toMatchObject({
+			formatted: "Legacy Employee Renewed",
+		});
+		expect(
+			getPersistedUser(data, created.id).scimUser.serializedAttributes,
+		).toBeTruthy();
+
+		forgetSerializedAttributes();
+		await auth.api.patchSCIMUser({
+			params: { userId: created.id },
+			body: {
+				schemas: [PATCH_OP_SCHEMA],
+				Operations: [{ op: "replace", path: "title", value: "Archivist" }],
+			},
+			headers,
+		});
+		const patchedResource = await auth.api.getSCIMUser({
+			params: { userId: created.id },
+			headers,
+		});
+		expect(patchedResource.title).toBe("Archivist");
+		expect(
+			getPersistedUser(data, created.id).scimUser.serializedAttributes,
+		).toBeTruthy();
+	});
+
+	/**
+	 * @see https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups
+	 */
+	it("accepts an empty Operations array as a no-op PATCH", async () => {
+		const { auth, headers } = createTestContext();
+		const created = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "no-op-patch@example.com",
+				displayName: "No Op",
+			},
+			headers,
+		});
+
+		await auth.api.patchSCIMUser({
+			params: { userId: created.id },
+			body: { schemas: [PATCH_OP_SCHEMA], Operations: [] },
+			headers,
+		});
+
+		await expect(
+			auth.api.getSCIMUser({ params: { userId: created.id }, headers }),
+		).resolves.toMatchObject({ displayName: "No Op" });
 	});
 });

--- a/packages/scim/src/user-attributes.ts
+++ b/packages/scim/src/user-attributes.ts
@@ -1,0 +1,89 @@
+import type { SCIMUser } from "./persistence";
+import { createSCIMError } from "./scim-error";
+import type { SCIMCanonicalUserAttributes } from "./user-schemas";
+import {
+	SCIM_MAX_SERIALIZED_USER_ATTRIBUTES_LENGTH,
+	SCIM_USER_SCHEMA,
+	SCIMCanonicalUserAttributesSchema,
+} from "./user-schemas";
+
+function invalidStoredUserAttributes(): never {
+	throw createSCIMError("INTERNAL_SERVER_ERROR", {
+		detail: "Stored SCIM User attribute state is invalid",
+	});
+}
+
+/** Serialize one validated, bounded canonical User attribute payload. */
+export function serializeSCIMUserAttributes(
+	attributes: SCIMCanonicalUserAttributes,
+): string {
+	const parsed = SCIMCanonicalUserAttributesSchema.safeParse(attributes);
+	if (!parsed.success) return invalidStoredUserAttributes();
+	const serialized = JSON.stringify(parsed.data);
+	if (serialized.length > SCIM_MAX_SERIALIZED_USER_ATTRIBUTES_LENGTH) {
+		return invalidStoredUserAttributes();
+	}
+	return serialized;
+}
+
+/**
+ * Derive canonical User attributes for a row persisted before
+ * `serializedAttributes` existed, from its compatibility mirror columns.
+ * These rows predate Enterprise User support, so only the core schema and
+ * the mirrored name/email fields can be reconstructed.
+ */
+function deriveSCIMUserAttributesFromMirrors(
+	user: Pick<
+		SCIMUser,
+		"formattedName" | "givenName" | "familyName" | "serializedEmails"
+	>,
+): SCIMCanonicalUserAttributes {
+	let emails: unknown;
+	try {
+		emails = JSON.parse(user.serializedEmails);
+	} catch {
+		return invalidStoredUserAttributes();
+	}
+	const attributes = SCIMCanonicalUserAttributesSchema.safeParse({
+		schemas: [SCIM_USER_SCHEMA],
+		name: {
+			formatted: user.formattedName,
+			...(user.givenName ? { givenName: user.givenName } : {}),
+			...(user.familyName ? { familyName: user.familyName } : {}),
+		},
+		emails,
+	});
+	if (!attributes.success) return invalidStoredUserAttributes();
+	return attributes.data;
+}
+
+/** Read and validate one complete canonical User attribute payload. */
+export function readSCIMUserAttributes(
+	user: Pick<
+		SCIMUser,
+		| "serializedAttributes"
+		| "formattedName"
+		| "givenName"
+		| "familyName"
+		| "serializedEmails"
+	>,
+): SCIMCanonicalUserAttributes {
+	if (!user.serializedAttributes) {
+		return deriveSCIMUserAttributesFromMirrors(user);
+	}
+	if (
+		user.serializedAttributes.length >
+		SCIM_MAX_SERIALIZED_USER_ATTRIBUTES_LENGTH
+	) {
+		return invalidStoredUserAttributes();
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(user.serializedAttributes);
+	} catch {
+		return invalidStoredUserAttributes();
+	}
+	const attributes = SCIMCanonicalUserAttributesSchema.safeParse(parsed);
+	if (!attributes.success) return invalidStoredUserAttributes();
+	return attributes.data;
+}

--- a/packages/scim/src/user-email.ts
+++ b/packages/scim/src/user-email.ts
@@ -1,0 +1,16 @@
+import type { SCIMEmail } from "./configuration";
+
+/** Create a case-insensitive identity for one complex email value. */
+export function createSCIMEmailTupleKey(
+	email: Pick<SCIMEmail, "type" | "value">,
+): string {
+	return JSON.stringify([
+		email.type?.trim().toLowerCase() ?? null,
+		email.value.trim().toLowerCase(),
+	]);
+}
+
+/** Serialize the 1.7 compatibility mirror for canonical email values. */
+export function serializeSCIMEmails(emails: readonly SCIMEmail[]): string {
+	return JSON.stringify(emails);
+}

--- a/packages/scim/src/user-patch.ts
+++ b/packages/scim/src/user-patch.ts
@@ -1,39 +1,51 @@
 import * as z from "zod";
-import type { SCIMEmail, SCIMName } from "./configuration";
+import type { SCIMCanonicalEmail, SCIMEmail, SCIMName } from "./configuration";
 import type { SCIMUser } from "./persistence";
-import { stripSCIMCoreAttributePrefix } from "./resource-schema-registry";
-import { createSCIMError } from "./scim-error";
 import {
-	createSCIMEmailTupleKey,
+	resolveSCIMCanonicalAttributePath,
+	stripSCIMCoreAttributePrefix,
+} from "./resource-schema-registry";
+import { createSCIMError } from "./scim-error";
+import { readSCIMUserAttributes } from "./user-attributes";
+import { createSCIMEmailTupleKey } from "./user-email";
+import {
+	createCanonicalSCIMUserProfile,
 	normalizeSCIMEmails,
-	readSCIMEmails,
-	serializeSCIMEmails,
 } from "./user-profile";
+import type { SCIMCanonicalUserAttributes } from "./user-schemas";
+import {
+	APIUserSchema,
+	hasUniqueSCIMDefinedTypes,
+	SCIM_ENTERPRISE_USER_SCHEMA,
+	SCIMEnterpriseUserInputSchema,
+	SCIMEnterpriseUserResourceSchema,
+	SCIMUserResourceSchema,
+} from "./user-schemas";
 
 const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
-const WORK_EMAIL_VALUE_PATH =
-	/^emails\s*\[\s*type\s+eq\s+"work"\s*\]\s*\.\s*value$/i;
+const EMAIL_TYPE_VALUE_PATH =
+	/^emails\s*\[\s*type\s+eq\s+"([^"]+)"\s*\]\s*\.\s*value$/i;
+/** Matches Microsoft Entra's `emails[primary eq true].value` PATCH path. */
+const EMAIL_PRIMARY_VALUE_PATH =
+	/^emails\s*\[\s*primary\s+eq\s+"?true"?\s*\]\s*\.\s*value$/i;
 const scimEmailValueSchema = z.email().max(254);
 
 export const patchSCIMUserBodySchema = z.object({
 	schemas: z
-		.array(z.string())
-		.refine((schemas) => schemas.includes(SCIM_PATCH_SCHEMA), {
-			message: "Invalid schemas for PatchOp",
+		.array(z.literal(SCIM_PATCH_SCHEMA))
+		.length(1, "schemas must contain only the PatchOp schema"),
+	// An empty array is a valid no-op PATCH (Microsoft Entra sends one).
+	Operations: z.array(
+		z.object({
+			op: z
+				.string()
+				.toLowerCase()
+				.default("replace")
+				.pipe(z.enum(["replace", "add", "remove"])),
+			path: z.string().optional(),
+			value: z.unknown().optional(),
 		}),
-	Operations: z
-		.array(
-			z.object({
-				op: z
-					.string()
-					.toLowerCase()
-					.default("replace")
-					.pipe(z.enum(["replace", "add", "remove"])),
-				path: z.string().optional(),
-				value: z.unknown().optional(),
-			}),
-		)
-		.min(1),
+	),
 });
 
 const patchEmailSchema = z.object({
@@ -46,13 +58,28 @@ const patchEmailSchema = z.object({
 export interface SCIMUserPatchState {
 	userName: string;
 	primaryEmail: string;
-	emails: SCIMEmail[];
+	emails: SCIMCanonicalEmail[];
 	displayName: string;
 	formattedName: string;
 	givenName: string | undefined;
 	familyName: string | undefined;
+	middleName: string | undefined;
+	honorificPrefix: string | undefined;
+	honorificSuffix: string | undefined;
 	externalId: string | undefined;
 	active: boolean;
+	attributes: SCIMCanonicalUserAttributes;
+}
+
+function createComparableSCIMPatchValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(createComparableSCIMPatchValue);
+	if (!isRecord(value)) return value;
+	return Object.fromEntries(
+		Object.entries(value)
+			.filter(([, item]) => item !== undefined)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([key, item]) => [key, createComparableSCIMPatchValue(item)]),
+	);
 }
 
 /** Whether an applied PATCH changes the canonical persisted User resource. */
@@ -60,16 +87,23 @@ export function scimUserPatchChangesState(
 	user: SCIMUser,
 	state: SCIMUserPatchState,
 ): boolean {
+	const attributes = readSCIMUserAttributes(user);
 	return (
 		user.userName !== state.userName ||
 		user.primaryEmail !== state.primaryEmail ||
-		user.serializedEmails !== serializeSCIMEmails(state.emails) ||
+		JSON.stringify(createComparableSCIMPatchValue(attributes.emails)) !==
+			JSON.stringify(createComparableSCIMPatchValue(state.emails)) ||
 		user.displayName !== state.displayName ||
-		user.formattedName !== state.formattedName ||
-		(user.givenName ?? undefined) !== state.givenName ||
-		(user.familyName ?? undefined) !== state.familyName ||
+		attributes.name.formatted !== state.formattedName ||
+		attributes.name.givenName !== state.givenName ||
+		attributes.name.familyName !== state.familyName ||
+		attributes.name.middleName !== state.middleName ||
+		attributes.name.honorificPrefix !== state.honorificPrefix ||
+		attributes.name.honorificSuffix !== state.honorificSuffix ||
 		(user.externalId ?? undefined) !== state.externalId ||
-		user.active !== state.active
+		user.active !== state.active ||
+		JSON.stringify(createComparableSCIMPatchValue(attributes)) !==
+			JSON.stringify(createComparableSCIMPatchValue(state.attributes))
 	);
 }
 
@@ -84,11 +118,20 @@ function invalidPatchValue(detail: string): never {
 	});
 }
 
+/**
+ * Unwrap a PATCH operation value Microsoft Entra sent as a single-element
+ * array for what is actually a single-valued attribute.
+ */
+function unwrapSinglePatchValue(value: unknown): unknown {
+	return Array.isArray(value) && value.length === 1 ? value[0] : value;
+}
+
 function readNonEmptyString(value: unknown, attribute: string): string {
-	if (typeof value !== "string" || !value.trim()) {
+	const scalar = unwrapSinglePatchValue(value);
+	if (typeof scalar !== "string" || !scalar.trim()) {
 		return invalidPatchValue(`${attribute} must be a non-empty string`);
 	}
-	return value.trim();
+	return scalar.trim();
 }
 
 function readEmail(value: unknown): string {
@@ -108,7 +151,7 @@ function readEmailValues(value: unknown): SCIMEmail[] {
 	return parsed.data;
 }
 
-function readEmailSet(value: unknown, userName: string): SCIMEmail[] {
+function readEmailSet(value: unknown, userName: string): SCIMCanonicalEmail[] {
 	const emails = readEmailValues(value);
 	if (emails.filter((email) => email.primary).length > 1) {
 		return invalidPatchValue("emails cannot contain multiple primary values");
@@ -117,6 +160,9 @@ function readEmailSet(value: unknown, userName: string): SCIMEmail[] {
 		return invalidPatchValue(
 			"emails cannot contain duplicate type and value pairs",
 		);
+	}
+	if (!hasUniqueSCIMDefinedTypes(emails)) {
+		return invalidPatchValue("emails cannot contain duplicate defined types");
 	}
 	return normalizeSCIMEmails(userName, emails);
 }
@@ -134,6 +180,21 @@ function readName(value: unknown): Partial<SCIMName> {
 				break;
 			case "familyname":
 				name.familyName = readNonEmptyString(attributeValue, "name.familyName");
+				break;
+			case "middlename":
+				name.middleName = readNonEmptyString(attributeValue, "name.middleName");
+				break;
+			case "honorificprefix":
+				name.honorificPrefix = readNonEmptyString(
+					attributeValue,
+					"name.honorificPrefix",
+				);
+				break;
+			case "honorificsuffix":
+				name.honorificSuffix = readNonEmptyString(
+					attributeValue,
+					"name.honorificSuffix",
+				);
 				break;
 			default:
 				throw createSCIMError("BAD_REQUEST", {
@@ -167,7 +228,12 @@ function composeName(state: SCIMUserPatchState): string {
 
 function setNamePart(
 	state: SCIMUserPatchState,
-	attribute: "givenName" | "familyName",
+	attribute:
+		| "familyName"
+		| "givenName"
+		| "honorificPrefix"
+		| "honorificSuffix"
+		| "middleName",
 	value: string | undefined,
 ): void {
 	state[attribute] = value;
@@ -236,17 +302,17 @@ function replaceAllEmailValues(
 
 function replaceSelectedEmail(
 	state: SCIMUserPatchState,
-	selector: "work",
+	selector: string,
 	op: "add" | "replace",
 	value: unknown,
 ): void {
 	const replacement = readEmail(value);
-	const matches = (email: SCIMEmail) => email.type === "work";
+	const matches = (email: SCIMEmail) => email.type === selector;
 	const hasSelection = state.emails.some(matches);
 	if (!hasSelection && op === "add") {
 		setEmails(state, [
 			...state.emails,
-			{ value: replacement, type: "work", primary: false },
+			{ value: replacement, type: selector, primary: false },
 		]);
 		return;
 	}
@@ -262,8 +328,648 @@ function replaceSelectedEmail(
 	setEmails(state, emails);
 }
 
+/** Replace the currently primary email's value, keeping `primary` on it. */
+function replacePrimaryEmail(state: SCIMUserPatchState, value: unknown): void {
+	const replacement = readEmail(value);
+	if (!state.emails.some((email) => email.primary)) {
+		throw createSCIMError("BAD_REQUEST", {
+			detail: "No primary email matches the PATCH path",
+			scimType: "noTarget",
+		});
+	}
+	setEmails(
+		state,
+		state.emails.map((email) =>
+			email.primary ? { ...email, value: replacement } : email,
+		),
+	);
+}
+
 function normalizePatchPath(path: string): string {
-	return stripSCIMCoreAttributePrefix("User", path.trim()).toLowerCase();
+	return resolveSCIMCanonicalAttributePath("User", path.trim()).toLowerCase();
+}
+
+interface SCIMPatchAttributeDescriptor {
+	name: string;
+	type: string;
+	multiValued: boolean;
+	mutability?: string;
+	subAttributes?: readonly SCIMPatchAttributeDescriptor[];
+}
+
+interface ResolvedSCIMPatchPath {
+	attribute: SCIMPatchAttributeDescriptor;
+	attributeName: string;
+	enterprise: boolean;
+	selectorType?: string;
+	selectorPrimary?: boolean;
+	subAttribute?: SCIMPatchAttributeDescriptor;
+	subAttributeName?: string;
+}
+
+const SCIM_VALUE_PATH =
+	/^([A-Za-z$][\w$-]*)\s*\[\s*type\s+eq\s+"([^"]+)"\s*\](?:\s*\.\s*([A-Za-z$][\w$-]*))?$/i;
+/** Matches Microsoft Entra's `attr[primary eq true]` and `attr[primary eq "true"]` filters. */
+const SCIM_PRIMARY_VALUE_PATH =
+	/^([A-Za-z$][\w$-]*)\s*\[\s*primary\s+eq\s+"?(true|false)"?\s*\](?:\s*\.\s*([A-Za-z$][\w$-]*))?$/i;
+
+function clonePatchValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(clonePatchValue);
+	if (!isRecord(value)) return value;
+	return clonePatchRecord(value);
+}
+
+function clonePatchRecord(
+	value: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(value).map(([key, item]) => [key, clonePatchValue(item)]),
+	);
+}
+
+function findPatchAttribute(
+	attributes: readonly SCIMPatchAttributeDescriptor[],
+	name: string,
+): SCIMPatchAttributeDescriptor | undefined {
+	return attributes.find(
+		(attribute) => attribute.name.toLowerCase() === name.toLowerCase(),
+	);
+}
+
+function resolveMutableSCIMUserPatchPath(
+	path: string,
+): ResolvedSCIMPatchPath | { enterpriseRoot: true } {
+	const canonicalPath = resolveSCIMCanonicalAttributePath("User", path.trim());
+	const enterprisePrefix = "enterprise.";
+	const enterprise =
+		canonicalPath.toLowerCase() === "enterprise" ||
+		canonicalPath.toLowerCase().startsWith(enterprisePrefix);
+	if (canonicalPath.toLowerCase() === "enterprise") {
+		return { enterpriseRoot: true };
+	}
+	const relativePath = enterprise
+		? canonicalPath.slice(enterprisePrefix.length)
+		: canonicalPath;
+	const attributes = (
+		enterprise
+			? SCIMEnterpriseUserResourceSchema.attributes
+			: SCIMUserResourceSchema.attributes
+	) as readonly SCIMPatchAttributeDescriptor[];
+	const valuePathMatch = SCIM_VALUE_PATH.exec(relativePath);
+	const primaryValuePathMatch = valuePathMatch
+		? null
+		: SCIM_PRIMARY_VALUE_PATH.exec(relativePath);
+	const filterMatch = valuePathMatch ?? primaryValuePathMatch;
+	const pathSegments = relativePath.split(".");
+	const [attributePath, subAttributePath] = filterMatch
+		? [filterMatch[1], filterMatch[3]]
+		: pathSegments;
+	if (
+		!attributePath ||
+		(!filterMatch &&
+			(pathSegments.length > 2 ||
+				pathSegments.some((segment) => segment.length === 0)))
+	) {
+		throw createSCIMError("BAD_REQUEST", {
+			detail: `User PATCH path ${path} is not supported`,
+			scimType: "invalidPath",
+		});
+	}
+	const attribute = findPatchAttribute(attributes, attributePath);
+	if (!attribute) {
+		throw createSCIMError("BAD_REQUEST", {
+			detail: `User PATCH path ${path} is not supported`,
+			scimType: "invalidPath",
+		});
+	}
+	if (attribute.mutability === "readOnly") rejectReadOnlyAttribute(path);
+
+	const subAttribute = subAttributePath
+		? findPatchAttribute(attribute.subAttributes ?? [], subAttributePath)
+		: undefined;
+	if (subAttributePath && !subAttribute) {
+		throw createSCIMError("BAD_REQUEST", {
+			detail: `User PATCH path ${path} is not supported`,
+			scimType: "invalidPath",
+		});
+	}
+	if (subAttribute?.mutability === "readOnly") rejectReadOnlyAttribute(path);
+	if (filterMatch && !attribute.multiValued) {
+		throw createSCIMError("BAD_REQUEST", {
+			detail: `User PATCH path ${path} is not a multi-valued attribute`,
+			scimType: "invalidPath",
+		});
+	}
+
+	return {
+		attribute,
+		attributeName: attribute.name,
+		enterprise,
+		...(valuePathMatch?.[2]
+			? { selectorType: valuePathMatch[2].trim().toLowerCase() }
+			: {}),
+		...(primaryValuePathMatch
+			? { selectorPrimary: primaryValuePathMatch[2]?.toLowerCase() === "true" }
+			: {}),
+		...(subAttribute
+			? {
+					subAttribute,
+					subAttributeName: subAttribute.name,
+				}
+			: {}),
+	};
+}
+
+function getSCIMPatchContainer(
+	document: Record<string, unknown>,
+	enterprise: boolean,
+	create: boolean,
+): Record<string, unknown> | undefined {
+	if (!enterprise) return document;
+	const current = document[SCIM_ENTERPRISE_USER_SCHEMA];
+	if (isRecord(current)) return current;
+	if (!create) return undefined;
+	const extension: Record<string, unknown> = {};
+	document[SCIM_ENTERPRISE_USER_SCHEMA] = extension;
+	return extension;
+}
+
+function setEnterpriseSchemaDeclaration(
+	document: Record<string, unknown>,
+	declared: boolean,
+): void {
+	const schemas = Array.isArray(document.schemas)
+		? document.schemas.filter(
+				(schema): schema is string => typeof schema === "string",
+			)
+		: [];
+	const withoutEnterprise = schemas.filter(
+		(schema) => schema !== SCIM_ENTERPRISE_USER_SCHEMA,
+	);
+	document.schemas = declared
+		? [...withoutEnterprise, SCIM_ENTERPRISE_USER_SCHEMA]
+		: withoutEnterprise;
+}
+
+function removeEmptyEnterpriseExtension(
+	document: Record<string, unknown>,
+): void {
+	const extension = document[SCIM_ENTERPRISE_USER_SCHEMA];
+	if (!isRecord(extension) || Object.keys(extension).length > 0) return;
+	delete document[SCIM_ENTERPRISE_USER_SCHEMA];
+	setEnterpriseSchemaDeclaration(document, false);
+}
+
+function mergePatchObject(
+	current: unknown,
+	value: unknown,
+	attribute: string,
+): Record<string, unknown> {
+	if (!isRecord(value)) {
+		return invalidPatchValue(`${attribute} must be an object`);
+	}
+	return {
+		...(isRecord(current) ? current : {}),
+		...clonePatchRecord(value),
+	};
+}
+
+function parseEnterprisePatchObject(
+	value: unknown,
+	attribute: string,
+): Record<string, unknown> {
+	if (!isRecord(value)) {
+		return invalidPatchValue(`${attribute} must be an object`);
+	}
+	for (const key of Object.keys(value)) {
+		if (
+			!findPatchAttribute(
+				SCIMEnterpriseUserResourceSchema.attributes as readonly SCIMPatchAttributeDescriptor[],
+				key,
+			)
+		) {
+			throw createSCIMError("BAD_REQUEST", {
+				detail: `User PATCH path ${SCIM_ENTERPRISE_USER_SCHEMA}:${key} is not supported`,
+				scimType: "invalidPath",
+			});
+		}
+	}
+	const parsed = SCIMEnterpriseUserInputSchema.safeParse(value);
+	if (!parsed.success) {
+		const issue = parsed.error.issues[0];
+		return invalidPatchValue(
+			issue
+				? `${attribute}.${issue.path.join(".")}: ${issue.message}`
+				: `${attribute} is invalid`,
+		);
+	}
+	return clonePatchRecord(parsed.data);
+}
+
+function mergeEnterprisePatchObject(
+	current: unknown,
+	value: unknown,
+	attribute: string,
+): Record<string, unknown> {
+	const currentEnterprise = isRecord(current) ? current : {};
+	const patch = parseEnterprisePatchObject(value, attribute);
+	const currentManager = currentEnterprise.manager;
+	const patchManager = patch.manager;
+	return {
+		...currentEnterprise,
+		...patch,
+		...(isRecord(patchManager)
+			? {
+					manager: {
+						...(isRecord(currentManager) ? currentManager : {}),
+						...patchManager,
+					},
+				}
+			: {}),
+	};
+}
+
+function normalizeManagerPatchValue(value: unknown): Record<string, unknown> {
+	const manager = parseEnterprisePatchObject(
+		{ manager: value },
+		`${SCIM_ENTERPRISE_USER_SCHEMA}:manager`,
+	).manager;
+	return isRecord(manager)
+		? manager
+		: invalidPatchValue("manager must contain value or $ref");
+}
+
+function normalizeMultiValueAdditions(value: unknown): unknown[] {
+	return (Array.isArray(value) ? value : [value]).map(clonePatchValue);
+}
+
+function valueSetsPrimary(value: unknown): boolean {
+	return Array.isArray(value)
+		? value.some(valueSetsPrimary)
+		: isRecord(value) && value.primary === true;
+}
+
+function enforceSinglePatchedPrimary(
+	values: unknown[],
+	preferredIndex: number | undefined,
+): unknown[] {
+	if (preferredIndex === undefined) return values;
+	return values.map((item, index) =>
+		isRecord(item) && item.primary === true && index !== preferredIndex
+			? { ...item, primary: false }
+			: item,
+	);
+}
+
+function matchesSCIMType(value: unknown, selectorType: string): boolean {
+	return (
+		isRecord(value) &&
+		typeof value.type === "string" &&
+		value.type.trim().toLowerCase() === selectorType
+	);
+}
+
+function matchesSCIMPrimary(value: unknown, selectorPrimary: boolean): boolean {
+	return isRecord(value) && value.primary === selectorPrimary;
+}
+
+function applySCIMMultiValuePatch(
+	container: Record<string, unknown>,
+	resolved: ResolvedSCIMPatchPath,
+	op: "add" | "remove" | "replace",
+	value: unknown,
+	path: string,
+): void {
+	const current = container[resolved.attributeName];
+	const currentValues = Array.isArray(current)
+		? current.map(clonePatchValue)
+		: [];
+
+	if (
+		!resolved.selectorType &&
+		resolved.selectorPrimary === undefined &&
+		!resolved.subAttributeName
+	) {
+		if (op === "remove") {
+			delete container[resolved.attributeName];
+			return;
+		}
+		const additions = normalizeMultiValueAdditions(value);
+		const nextValues =
+			op === "add" ? [...currentValues, ...additions] : additions;
+		const firstAddedPrimary = additions.findIndex(
+			(item) => isRecord(item) && item.primary === true,
+		);
+		const preferredPrimary =
+			firstAddedPrimary < 0
+				? undefined
+				: (op === "add" ? currentValues.length : 0) + firstAddedPrimary;
+		container[resolved.attributeName] = enforceSinglePatchedPrimary(
+			nextValues,
+			preferredPrimary,
+		);
+		return;
+	}
+
+	const matches = currentValues.map((item) => {
+		if (resolved.selectorPrimary !== undefined) {
+			return matchesSCIMPrimary(item, resolved.selectorPrimary);
+		}
+		return resolved.selectorType
+			? matchesSCIMType(item, resolved.selectorType)
+			: true;
+	});
+	const hasTarget = matches.some(Boolean);
+	if (!hasTarget) {
+		if (op === "remove") return;
+		if (
+			op === "replace" &&
+			(resolved.selectorType || resolved.selectorPrimary !== undefined)
+		) {
+			throw createSCIMError("BAD_REQUEST", {
+				detail: `No value matches the User PATCH path ${path}`,
+				scimType: "noTarget",
+			});
+		}
+		if (!resolved.subAttributeName) {
+			const additions = normalizeMultiValueAdditions(value).map((item) =>
+				isRecord(item)
+					? {
+							...item,
+							...(resolved.selectorType ? { type: resolved.selectorType } : {}),
+							...(resolved.selectorPrimary === undefined
+								? {}
+								: { primary: resolved.selectorPrimary }),
+						}
+					: item,
+			);
+			const nextValues = [...currentValues, ...additions];
+			const firstAddedPrimary = additions.findIndex(
+				(item) => isRecord(item) && item.primary === true,
+			);
+			container[resolved.attributeName] = enforceSinglePatchedPrimary(
+				nextValues,
+				firstAddedPrimary < 0
+					? undefined
+					: currentValues.length + firstAddedPrimary,
+			);
+			return;
+		}
+		const nextValues = [
+			...currentValues,
+			{
+				...(resolved.selectorType ? { type: resolved.selectorType } : {}),
+				...(resolved.selectorPrimary === undefined
+					? {}
+					: { primary: resolved.selectorPrimary }),
+				[resolved.subAttributeName]: clonePatchValue(value),
+			},
+		];
+		container[resolved.attributeName] = enforceSinglePatchedPrimary(
+			nextValues,
+			resolved.subAttributeName.toLowerCase() === "primary" && value === true
+				? nextValues.length - 1
+				: undefined,
+		);
+		return;
+	}
+
+	if (!resolved.subAttributeName) {
+		if (op === "remove") {
+			const remainingValues = currentValues.filter(
+				(_, index) => !matches[index],
+			);
+			if (remainingValues.length === 0) {
+				delete container[resolved.attributeName];
+			} else {
+				container[resolved.attributeName] = remainingValues;
+			}
+			return;
+		}
+		const replacements = normalizeMultiValueAdditions(value);
+		if (replacements.length !== 1 || !isRecord(replacements[0])) {
+			return invalidPatchValue(
+				`User PATCH path ${path} requires one complex value`,
+			);
+		}
+		const replacement = replacements[0];
+		const nextValues = currentValues.map((item, index) => {
+			if (!matches[index]) return item;
+			if (!isRecord(item)) {
+				return invalidPatchValue(
+					`${resolved.attributeName} must contain objects`,
+				);
+			}
+			return { ...item, ...replacement };
+		});
+		const firstReplacedIndex = matches.findIndex(Boolean);
+		container[resolved.attributeName] = enforceSinglePatchedPrimary(
+			nextValues,
+			replacement.primary === true && firstReplacedIndex >= 0
+				? firstReplacedIndex
+				: undefined,
+		);
+		return;
+	}
+
+	const subAttributeName = resolved.subAttributeName;
+	const nextValues = currentValues.map((item, index) => {
+		if (!matches[index]) return item;
+		if (!isRecord(item)) {
+			return invalidPatchValue(
+				`${resolved.attributeName} must contain objects`,
+			);
+		}
+		if (op === "remove") {
+			const { [resolved.subAttributeName as string]: _removed, ...remaining } =
+				item;
+			return remaining;
+		}
+		return {
+			...item,
+			[subAttributeName]: clonePatchValue(value),
+		};
+	});
+	const selectedIndex = matches.findIndex(Boolean);
+	container[resolved.attributeName] = enforceSinglePatchedPrimary(
+		nextValues,
+		subAttributeName.toLowerCase() === "primary" &&
+			value === true &&
+			selectedIndex >= 0
+			? selectedIndex
+			: valueSetsPrimary(value)
+				? selectedIndex
+				: undefined,
+	);
+}
+
+function applyGenericSCIMUserAttributePatch(
+	document: Record<string, unknown>,
+	op: "add" | "remove" | "replace",
+	path: string,
+	value: unknown,
+): void {
+	const resolved = resolveMutableSCIMUserPatchPath(path);
+	if ("enterpriseRoot" in resolved) {
+		if (op === "remove") {
+			delete document[SCIM_ENTERPRISE_USER_SCHEMA];
+			setEnterpriseSchemaDeclaration(document, false);
+			return;
+		}
+		document[SCIM_ENTERPRISE_USER_SCHEMA] = mergeEnterprisePatchObject(
+			document[SCIM_ENTERPRISE_USER_SCHEMA],
+			value,
+			SCIM_ENTERPRISE_USER_SCHEMA,
+		);
+		setEnterpriseSchemaDeclaration(document, true);
+		return;
+	}
+	if (
+		!resolved.enterprise &&
+		(resolved.attributeName === "emails" || resolved.attributeName === "name")
+	) {
+		throw createSCIMError("BAD_REQUEST", {
+			detail: `User PATCH path ${path} is not supported`,
+			scimType: "invalidPath",
+		});
+	}
+
+	const container = getSCIMPatchContainer(
+		document,
+		resolved.enterprise,
+		op !== "remove",
+	);
+	if (!container) return;
+	if (resolved.enterprise && op !== "remove") {
+		setEnterpriseSchemaDeclaration(document, true);
+	}
+
+	if (resolved.attribute.multiValued) {
+		applySCIMMultiValuePatch(container, resolved, op, value, path);
+		removeEmptyEnterpriseExtension(document);
+		return;
+	}
+
+	if (resolved.subAttributeName) {
+		const current = container[resolved.attributeName];
+		if (!isRecord(current)) {
+			if (op === "remove") return;
+			container[resolved.attributeName] = {
+				[resolved.subAttributeName]: clonePatchValue(value),
+			};
+			return;
+		}
+		if (op === "remove") {
+			delete current[resolved.subAttributeName];
+			if (Object.keys(current).length === 0) {
+				delete container[resolved.attributeName];
+			}
+		} else {
+			current[resolved.subAttributeName] = clonePatchValue(value);
+		}
+		removeEmptyEnterpriseExtension(document);
+		return;
+	}
+
+	if (op === "remove") {
+		delete container[resolved.attributeName];
+		removeEmptyEnterpriseExtension(document);
+		return;
+	}
+	if (
+		resolved.enterprise &&
+		resolved.attributeName === "manager" &&
+		resolved.attribute.type === "complex"
+	) {
+		// Microsoft Entra clears manager with a replace to "" instead of a remove op.
+		if (value === "") {
+			delete container[resolved.attributeName];
+			removeEmptyEnterpriseExtension(document);
+			return;
+		}
+		const currentManager = container[resolved.attributeName];
+		container[resolved.attributeName] = {
+			...(isRecord(currentManager) ? currentManager : {}),
+			...normalizeManagerPatchValue(value),
+		};
+		return;
+	}
+	container[resolved.attributeName] =
+		resolved.attribute.type === "complex" && isRecord(value)
+			? mergePatchObject(
+					container[resolved.attributeName],
+					value,
+					resolved.attributeName,
+				)
+			: clonePatchValue(value);
+}
+
+function createSCIMUserPatchDocument(
+	user: SCIMUser,
+	attributes: SCIMCanonicalUserAttributes,
+): Record<string, unknown> {
+	const { enterprise, ...coreAttributes } = attributes;
+	return {
+		...clonePatchRecord(coreAttributes),
+		userName: user.userName,
+		...(user.externalId === null ? {} : { externalId: user.externalId }),
+		displayName: user.displayName,
+		active: user.active,
+		...(enterprise
+			? {
+					[SCIM_ENTERPRISE_USER_SCHEMA]: clonePatchValue(enterprise),
+				}
+			: {}),
+	};
+}
+
+function finalizeSCIMUserPatch(
+	state: SCIMUserPatchState,
+	document: Record<string, unknown>,
+): SCIMUserPatchState {
+	document.userName = state.userName;
+	document.externalId = state.externalId;
+	document.displayName = state.displayName;
+	document.active = state.active;
+	document.name = {
+		formatted: state.formattedName,
+		...(state.givenName ? { givenName: state.givenName } : {}),
+		...(state.familyName ? { familyName: state.familyName } : {}),
+		...(state.middleName ? { middleName: state.middleName } : {}),
+		...(state.honorificPrefix
+			? { honorificPrefix: state.honorificPrefix }
+			: {}),
+		...(state.honorificSuffix
+			? { honorificSuffix: state.honorificSuffix }
+			: {}),
+	};
+	document.emails = clonePatchValue(state.emails);
+
+	const parsed = APIUserSchema.safeParse(document);
+	if (!parsed.success) {
+		const issue = parsed.error.issues[0];
+		return invalidPatchValue(
+			issue
+				? `${issue.path.join(".") || "User"}: ${issue.message}`
+				: "The patched User resource is invalid",
+		);
+	}
+	const profile = createCanonicalSCIMUserProfile(parsed.data);
+	return {
+		userName: profile.userName,
+		primaryEmail: profile.primaryEmail,
+		emails: profile.emails,
+		displayName: profile.displayName,
+		formattedName: profile.formattedName,
+		givenName: profile.name.givenName,
+		familyName: profile.name.familyName,
+		middleName: profile.name.middleName,
+		honorificPrefix: profile.name.honorificPrefix,
+		honorificSuffix: profile.name.honorificSuffix,
+		externalId: parsed.data.externalId,
+		active: parsed.data.active !== false,
+		attributes: profile.attributes,
+	};
 }
 
 /** Apply ordered User PatchOp operations without mutating persisted state. */
@@ -271,16 +977,22 @@ export function applySCIMUserPatch(
 	user: SCIMUser,
 	operations: z.infer<typeof patchSCIMUserBodySchema>["Operations"],
 ): SCIMUserPatchState {
+	const attributes = readSCIMUserAttributes(user);
+	const document = createSCIMUserPatchDocument(user, attributes);
 	const state: SCIMUserPatchState = {
 		userName: user.userName,
 		primaryEmail: user.primaryEmail,
-		emails: readSCIMEmails(user),
+		emails: attributes.emails,
 		displayName: user.displayName,
-		formattedName: user.formattedName,
-		givenName: user.givenName ?? undefined,
-		familyName: user.familyName ?? undefined,
+		formattedName: attributes.name.formatted,
+		givenName: attributes.name.givenName,
+		familyName: attributes.name.familyName,
+		middleName: attributes.name.middleName,
+		honorificPrefix: attributes.name.honorificPrefix,
+		honorificSuffix: attributes.name.honorificSuffix,
 		externalId: user.externalId ?? undefined,
 		active: user.active,
+		attributes,
 	};
 
 	function applyAttribute(
@@ -311,16 +1023,18 @@ export function applySCIMUserPatch(
 				state.externalId =
 					op === "remove" ? undefined : readNonEmptyString(value, "externalId");
 				return;
-			case "active":
+			case "active": {
 				if (op === "remove") {
 					state.active = true;
 					return;
 				}
-				if (typeof value !== "boolean") {
+				const scalar = unwrapSinglePatchValue(value);
+				if (typeof scalar !== "boolean") {
 					invalidPatchValue("active must be a boolean");
 				}
-				state.active = value;
+				state.active = scalar;
 				return;
+			}
 			case "displayname":
 				state.displayName =
 					op === "remove"
@@ -331,24 +1045,27 @@ export function applySCIMUserPatch(
 				if (op === "remove") {
 					state.givenName = undefined;
 					state.familyName = undefined;
+					state.middleName = undefined;
+					state.honorificPrefix = undefined;
+					state.honorificSuffix = undefined;
 					setFormattedName(state, state.displayName || state.primaryEmail);
 					return;
 				}
 				const name = readName(value);
-				if (op === "replace") {
-					state.givenName = name.givenName;
-					state.familyName = name.familyName;
-					setFormattedName(
-						state,
-						(name.formatted ?? composeName(state)) || state.displayName,
-					);
-					return;
-				}
 				if (name.givenName !== undefined) {
 					setNamePart(state, "givenName", name.givenName);
 				}
 				if (name.familyName !== undefined) {
 					setNamePart(state, "familyName", name.familyName);
+				}
+				if (name.middleName !== undefined) {
+					setNamePart(state, "middleName", name.middleName);
+				}
+				if (name.honorificPrefix !== undefined) {
+					setNamePart(state, "honorificPrefix", name.honorificPrefix);
+				}
+				if (name.honorificSuffix !== undefined) {
+					setNamePart(state, "honorificSuffix", name.honorificSuffix);
 				}
 				if (name.formatted !== undefined) {
 					setFormattedName(state, name.formatted);
@@ -381,6 +1098,33 @@ export function applySCIMUserPatch(
 						: readNonEmptyString(value, "name.familyName"),
 				);
 				return;
+			case "name.middlename":
+				setNamePart(
+					state,
+					"middleName",
+					op === "remove"
+						? undefined
+						: readNonEmptyString(value, "name.middleName"),
+				);
+				return;
+			case "name.honorificprefix":
+				setNamePart(
+					state,
+					"honorificPrefix",
+					op === "remove"
+						? undefined
+						: readNonEmptyString(value, "name.honorificPrefix"),
+				);
+				return;
+			case "name.honorificsuffix":
+				setNamePart(
+					state,
+					"honorificSuffix",
+					op === "remove"
+						? undefined
+						: readNonEmptyString(value, "name.honorificSuffix"),
+				);
+				return;
 			case "emails":
 				if (op === "remove") {
 					invalidPatchValue("emails cannot be removed");
@@ -397,23 +1141,31 @@ export function applySCIMUserPatch(
 				}
 				replaceAllEmailValues(state, value);
 				return;
-			default:
-				if (WORK_EMAIL_VALUE_PATH.test(schemaRelativePath)) {
+			default: {
+				const emailTypeMatch = EMAIL_TYPE_VALUE_PATH.exec(schemaRelativePath);
+				if (emailTypeMatch?.[1]) {
+					const selectorType = emailTypeMatch[1].trim().toLowerCase();
 					if (op === "remove") {
 						const remaining = state.emails.filter(
-							(email) => email.type !== "work",
+							(email) => email.type !== selectorType,
 						);
 						if (remaining.length === state.emails.length) return;
 						setEmails(state, remaining);
 						return;
 					}
-					replaceSelectedEmail(state, "work", op, value);
+					replaceSelectedEmail(state, selectorType, op, value);
 					return;
 				}
-				throw createSCIMError("BAD_REQUEST", {
-					detail: `User PATCH path ${path} is not supported`,
-					scimType: "invalidPath",
-				});
+				if (EMAIL_PRIMARY_VALUE_PATH.test(schemaRelativePath)) {
+					if (op === "remove") {
+						invalidPatchValue("emails.value cannot be removed");
+					}
+					replacePrimaryEmail(state, value);
+					return;
+				}
+				applyGenericSCIMUserAttributePatch(document, op, path, value);
+				return;
+			}
 		}
 	}
 
@@ -437,5 +1189,5 @@ export function applySCIMUserPatch(
 		}
 	}
 
-	return state;
+	return finalizeSCIMUserPatch(state, document);
 }

--- a/packages/scim/src/user-profile.ts
+++ b/packages/scim/src/user-profile.ts
@@ -1,34 +1,21 @@
-import type { SCIMCanonicalEmail, SCIMEmail, SCIMName } from "./configuration";
-import type { SCIMUser } from "./persistence";
+import type {
+	SCIMCanonicalEmail,
+	SCIMCanonicalName,
+	SCIMEmail,
+} from "./configuration";
 import { createScopedKey } from "./resource-key";
-import { createSCIMError } from "./scim-error";
-
-interface SCIMProfileInput {
-	userName: string;
-	displayName?: string;
-	name?: SCIMName;
-	emails?: readonly SCIMEmail[];
-}
+import type { APIUser, SCIMCanonicalUserAttributes } from "./user-schemas";
+import { SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR } from "./user-schemas";
 
 /** Canonical provider-owned profile fields stored on a SCIM User. */
 export interface CanonicalSCIMUserProfile {
 	userName: string;
 	displayName: string;
 	formattedName: string;
-	givenName: string | undefined;
-	familyName: string | undefined;
+	name: SCIMCanonicalName;
 	emails: SCIMCanonicalEmail[];
 	primaryEmail: string;
-}
-
-/** Create a case-insensitive identity for one complex email value. */
-export function createSCIMEmailTupleKey(
-	email: Pick<SCIMEmail, "type" | "value">,
-): string {
-	return JSON.stringify([
-		email.type?.trim().toLowerCase() ?? null,
-		email.value.trim().toLowerCase(),
-	]);
+	attributes: SCIMCanonicalUserAttributes;
 }
 
 function normalizeOptionalString(value?: string): string | undefined {
@@ -66,7 +53,7 @@ export function normalizeSCIMEmails(
 
 /** Resolve the provider profile independently from the Better Auth User row. */
 export function createCanonicalSCIMUserProfile(
-	input: SCIMProfileInput,
+	input: APIUser,
 ): CanonicalSCIMUserProfile {
 	const userName = input.userName.trim();
 	const emails = normalizeSCIMEmails(userName, input.emails);
@@ -76,6 +63,9 @@ export function createCanonicalSCIMUserProfile(
 		userName;
 	const givenName = normalizeOptionalString(input.name?.givenName);
 	const familyName = normalizeOptionalString(input.name?.familyName);
+	const middleName = normalizeOptionalString(input.name?.middleName);
+	const honorificPrefix = normalizeOptionalString(input.name?.honorificPrefix);
+	const honorificSuffix = normalizeOptionalString(input.name?.honorificSuffix);
 	const composedName = [givenName, familyName].filter(Boolean).join(" ");
 	const formattedName =
 		normalizeOptionalString(input.name?.formatted) ??
@@ -83,21 +73,46 @@ export function createCanonicalSCIMUserProfile(
 		(composedName || primaryEmail);
 	const displayName =
 		normalizeOptionalString(input.displayName) ?? formattedName;
+	const name = {
+		formatted: formattedName,
+		...(givenName ? { givenName } : {}),
+		...(familyName ? { familyName } : {}),
+		...(middleName ? { middleName } : {}),
+		...(honorificPrefix ? { honorificPrefix } : {}),
+		...(honorificSuffix ? { honorificSuffix } : {}),
+	};
+	const attributes: SCIMCanonicalUserAttributes = {
+		schemas: input.schemas,
+		name,
+		emails,
+		...(input.title ? { title: input.title } : {}),
+		...(input.userType ? { userType: input.userType } : {}),
+		...(input.preferredLanguage
+			? { preferredLanguage: input.preferredLanguage }
+			: {}),
+		...(input.locale ? { locale: input.locale } : {}),
+		...(input.timezone ? { timezone: input.timezone } : {}),
+		...(input.phoneNumbers ? { phoneNumbers: input.phoneNumbers } : {}),
+		...(input.addresses ? { addresses: input.addresses } : {}),
+		...(input.roles ? { roles: input.roles } : {}),
+		...(input.entitlements ? { entitlements: input.entitlements } : {}),
+		...(input[SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.id]
+			? {
+					[SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.canonicalAttribute]:
+						input[SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.id],
+				}
+			: {}),
+	};
 
 	return {
 		userName,
 		displayName,
 		formattedName,
-		givenName,
-		familyName,
+		name,
 		emails,
 		primaryEmail,
+		attributes,
 	};
-}
-
-/** Serialize a bounded canonical email set for adapter-portable storage. */
-export function serializeSCIMEmails(emails: readonly SCIMEmail[]): string {
-	return JSON.stringify(emails);
 }
 
 /** Build an adapter-portable exact-membership index for email equality filters. */
@@ -122,53 +137,4 @@ export function createSCIMEmailValueIndex(
 /** Create one delimiter-safe token used by an email equality query. */
 export function createSCIMEmailValueToken(email: string): string {
 	return createScopedKey(["scim-email-value", email.trim().toLowerCase()]);
-}
-
-function invalidStoredEmailState(): never {
-	throw createSCIMError("INTERNAL_SERVER_ERROR", {
-		detail: "Stored SCIM User email state is invalid",
-	});
-}
-
-/** Read and validate the complete canonical email set from storage. */
-export function readSCIMEmails(user: SCIMUser): SCIMCanonicalEmail[] {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(user.serializedEmails);
-	} catch {
-		return invalidStoredEmailState();
-	}
-	if (!Array.isArray(parsed) || parsed.length < 1 || parsed.length > 20) {
-		return invalidStoredEmailState();
-	}
-
-	const emails: SCIMCanonicalEmail[] = [];
-	for (const candidate of parsed) {
-		if (
-			typeof candidate !== "object" ||
-			candidate === null ||
-			!("value" in candidate) ||
-			typeof candidate.value !== "string" ||
-			candidate.value.trim().toLowerCase() !== candidate.value ||
-			("type" in candidate &&
-				(typeof candidate.type !== "string" ||
-					candidate.type.trim().toLowerCase() !== candidate.type)) ||
-			("primary" in candidate && typeof candidate.primary !== "boolean")
-		) {
-			return invalidStoredEmailState();
-		}
-		const type = "type" in candidate ? candidate.type : undefined;
-		emails.push({
-			value: candidate.value,
-			...(type ? { type } : {}),
-			primary: "primary" in candidate && candidate.primary === true,
-		});
-	}
-	if (
-		emails.filter((email) => email.primary).length !== 1 ||
-		new Set(emails.map(createSCIMEmailTupleKey)).size !== emails.length
-	) {
-		return invalidStoredEmailState();
-	}
-	return emails;
 }

--- a/packages/scim/src/user-provisioning.ts
+++ b/packages/scim/src/user-provisioning.ts
@@ -37,7 +37,10 @@ import {
 	createSCIMUserExternalIdKey,
 	createScopedKey,
 } from "./resource-key";
-import { SCIM_RESOURCE_SCHEMA_REGISTRY } from "./resource-schema-registry";
+import {
+	SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR,
+	SCIM_RESOURCE_SCHEMA_REGISTRY,
+} from "./resource-schema-registry";
 import { runSCIMCreateWithUniquenessCheck } from "./resource-uniqueness";
 import { createSCIMError, SCIMErrorOpenAPISchemas } from "./scim-error";
 import {
@@ -47,6 +50,11 @@ import {
 	SCIM_REQUEST_MEDIA_TYPES,
 } from "./scim-metadata";
 import {
+	readSCIMUserAttributes,
+	serializeSCIMUserAttributes,
+} from "./user-attributes";
+import { serializeSCIMEmails } from "./user-email";
+import {
 	applySCIMUserPatch,
 	patchSCIMUserBodySchema,
 	scimUserPatchChangesState,
@@ -55,15 +63,10 @@ import {
 	createCanonicalSCIMUserProfile,
 	createSCIMEmailValueIndex,
 	createSCIMEmailValueToken,
-	readSCIMEmails,
-	serializeSCIMEmails,
 } from "./user-profile";
 
-const {
-	inputSchema: APIUserSchema,
-	openAPISchema: OpenAPIUserResourceSchema,
-	schemaId: SCIM_USER_SCHEMA,
-} = SCIM_RESOURCE_SCHEMA_REGISTRY.User;
+const { inputSchema: APIUserSchema, openAPISchema: OpenAPIUserResourceSchema } =
+	SCIM_RESOURCE_SCHEMA_REGISTRY.User;
 
 function requireUserAttributeProjection(
 	input: SCIMCollectionQueryInput,
@@ -76,14 +79,6 @@ function requireUserAttributeProjection(
 		});
 	}
 	return projection.value;
-}
-
-function requestsProjectedMutationResponse(
-	input: SCIMCollectionQueryInput,
-): boolean {
-	return (
-		input.attributes !== undefined || input.excludedAttributes !== undefined
-	);
 }
 
 function createUserNameKey(connectionId: string, userName: string): string {
@@ -158,19 +153,23 @@ function createUserCollectionWhere(
 }
 
 function createUserResource(baseURL: string, scimUser: SCIMUser) {
+	const {
+		[SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.canonicalAttribute]: enterprise,
+		...attributes
+	} = readSCIMUserAttributes(scimUser);
 	return {
-		schemas: [SCIM_USER_SCHEMA],
+		...attributes,
 		id: scimUser.id,
 		...(scimUser.externalId ? { externalId: scimUser.externalId } : {}),
 		userName: scimUser.userName,
-		name: {
-			formatted: scimUser.formattedName,
-			...(scimUser.givenName ? { givenName: scimUser.givenName } : {}),
-			...(scimUser.familyName ? { familyName: scimUser.familyName } : {}),
-		},
 		displayName: scimUser.displayName,
 		active: scimUser.active,
-		emails: readSCIMEmails(scimUser),
+		...(enterprise
+			? {
+					[SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.responseAttribute]:
+						enterprise,
+				}
+			: {}),
 		meta: {
 			resourceType: "User",
 			created: scimUser.createdAt,
@@ -414,16 +413,11 @@ export function createSCIMUser(
 					connectionId: connection.id,
 					provisioningDomainId: connection.provisioningDomainId,
 					resource: {
+						...profile.attributes,
 						...(ctx.body.externalId ? { externalId: ctx.body.externalId } : {}),
 						userName: profile.userName,
 						primaryEmail: profile.primaryEmail,
 						displayName: profile.displayName,
-						name: {
-							formatted: profile.formattedName,
-							...(profile.givenName ? { givenName: profile.givenName } : {}),
-							...(profile.familyName ? { familyName: profile.familyName } : {}),
-						},
-						emails: profile.emails,
 						active,
 					},
 				},
@@ -488,9 +482,12 @@ export function createSCIMUser(
 									emailValueIndex: createSCIMEmailValueIndex(profile.emails),
 									displayName: profile.displayName,
 									formattedName: profile.formattedName,
-									givenName: profile.givenName,
-									familyName: profile.familyName,
+									givenName: profile.name.givenName,
+									familyName: profile.name.familyName,
 									serializedEmails: serializeSCIMEmails(profile.emails),
+									serializedAttributes: serializeSCIMUserAttributes(
+										profile.attributes,
+									),
 									externalId: ctx.body.externalId,
 									externalIdKey,
 									active,
@@ -833,9 +830,12 @@ export function replaceSCIMUser(
 							emailValueIndex: createSCIMEmailValueIndex(profile.emails),
 							displayName: profile.displayName,
 							formattedName: profile.formattedName,
-							givenName: profile.givenName ?? null,
-							familyName: profile.familyName ?? null,
+							givenName: profile.name.givenName ?? null,
+							familyName: profile.name.familyName ?? null,
 							serializedEmails: serializeSCIMEmails(profile.emails),
+							serializedAttributes: serializeSCIMUserAttributes(
+								profile.attributes,
+							),
 							externalId: ctx.body.externalId ?? null,
 							externalIdKey: externalIdKey ?? null,
 							active,
@@ -892,11 +892,8 @@ export function patchSCIMUser(
 				openapi: {
 					summary: "Patch SCIM User",
 					responses: {
-						"204": {
-							description: "SCIM User updated",
-						},
 						"200": {
-							description: "Projected SCIM User resource",
+							description: "Updated SCIM User resource",
 							content: createSCIMOpenAPIContent(OpenAPIUserResourceSchema),
 						},
 						...SCIMErrorOpenAPISchemas,
@@ -909,7 +906,6 @@ export function patchSCIMUser(
 			const adapter: DBAdapter = ctx.context.adapter;
 			const query = ctx.query ?? {};
 			const attributeProjection = requireUserAttributeProjection(query);
-			const returnResource = requestsProjectedMutationResponse(query);
 			const scimUser = await findSCIMUser(
 				adapter,
 				ctx.context.scimConnection,
@@ -1011,6 +1007,9 @@ export function patchSCIMUser(
 							givenName: patch.givenName ?? null,
 							familyName: patch.familyName ?? null,
 							serializedEmails: serializeSCIMEmails(patch.emails),
+							serializedAttributes: serializeSCIMUserAttributes(
+								patch.attributes,
+							),
 							externalId: patch.externalId ?? null,
 							externalIdKey: externalIdKey ?? null,
 							active: patch.active,
@@ -1043,13 +1042,9 @@ export function patchSCIMUser(
 				updatedSCIMUser,
 			);
 			ctx.setHeader("location", completeResource.meta.location);
-			if (returnResource) {
-				return ctx.json(
-					projectSCIMResourceAttributes(completeResource, attributeProjection),
-				);
-			}
-			ctx.setStatus(204);
-			return;
+			return ctx.json(
+				projectSCIMResourceAttributes(completeResource, attributeProjection),
+			);
 		},
 	);
 }

--- a/packages/scim/src/user-schemas.ts
+++ b/packages/scim/src/user-schemas.ts
@@ -1,132 +1,269 @@
 import * as z from "zod";
-import { createSCIMEmailTupleKey } from "./user-profile";
+import { createSCIMEmailTupleKey } from "./user-email";
 
-const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_SCHEMA_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:Schema";
+const SCIM_RESOURCE_TYPE_SCHEMA =
+	"urn:ietf:params:scim:schemas:core:2.0:ResourceType";
+
+/** Standard SCIM core User schema URI. */
+export const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+
+/** Standard SCIM Enterprise User extension schema URI. */
+export const SCIM_ENTERPRISE_USER_SCHEMA =
+	"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+
+/** Maximum serialized size of one canonical SCIM User attribute payload. */
+export const SCIM_MAX_SERIALIZED_USER_ATTRIBUTES_LENGTH = 65_535;
+
+const SCIM_MAX_MULTI_VALUE_COUNT = 20;
+const SCIM_MAX_STRUCTURED_VALUE_COUNT = 10;
+const scimStringSchema = z.string().trim().min(1).max(256);
+const scimLongStringSchema = z.string().trim().min(1).max(1_024);
+const scimReferenceSchema = z.string().trim().min(1).max(2_048);
 const scimEmailValueSchema = z.email().max(254);
 
-export const APIUserSchema = z
+/**
+ * Unwrap a single-element array before validation. Microsoft Entra sometimes
+ * wraps a single-valued attribute's PATCH replace value in an array.
+ */
+function scimSingleValueScalar<Schema extends z.ZodType>(schema: Schema) {
+	return z.preprocess(
+		(value) => (Array.isArray(value) && value.length === 1 ? value[0] : value),
+		schema,
+	);
+}
+
+function atMostOnePrimary<T extends { primary?: boolean }>(
+	values: readonly T[],
+): boolean {
+	return values.filter((value) => value.primary).length <= 1;
+}
+
+function primaryRefinement<T extends { primary?: boolean }>() {
+	return (values: readonly T[]) => atMostOnePrimary(values);
+}
+
+/**
+ * Whether every defined complex-value type occurs at most once,
+ * case-insensitively. Untyped values do not participate in this constraint.
+ */
+export function hasUniqueSCIMDefinedTypes(
+	values: readonly { type?: string }[],
+): boolean {
+	const definedTypes = values.flatMap((value) =>
+		value.type === undefined ? [] : [value.type.trim().toLowerCase()],
+	);
+	return new Set(definedTypes).size === definedTypes.length;
+}
+
+export interface SCIMDiscoveryAttribute {
+	name: string;
+	subAttributes?: readonly SCIMDiscoveryAttribute[];
+	[key: string]: unknown;
+}
+
+const scimNameSchema = z.object({
+	formatted: scimLongStringSchema.optional(),
+	givenName: scimStringSchema.optional(),
+	familyName: scimStringSchema.optional(),
+	middleName: scimStringSchema.optional(),
+	honorificPrefix: scimStringSchema.optional(),
+	honorificSuffix: scimStringSchema.optional(),
+});
+
+const scimCanonicalNameSchema = scimNameSchema.extend({
+	formatted: scimLongStringSchema,
+});
+
+const scimEmailSchema = z.object({
+	value: scimEmailValueSchema,
+	primary: z.boolean().optional(),
+	type: scimStringSchema.transform((type) => type.toLowerCase()).optional(),
+});
+
+const scimCanonicalEmailSchema = scimEmailSchema.extend({
+	primary: z.boolean(),
+});
+
+const scimPhoneNumberSchema = z.object({
+	value: scimLongStringSchema,
+	type: scimStringSchema.transform((type) => type.toLowerCase()).optional(),
+	primary: z.boolean().optional(),
+});
+
+const scimAddressSchema = z
 	.object({
-		schemas: z
-			.array(z.literal(SCIM_USER_SCHEMA))
-			.length(1, "schemas must contain only the core SCIM User schema"),
-		userName: z.string().trim().min(1),
-		externalId: z.string().min(1).optional(),
-		displayName: z.string().trim().min(1).optional(),
-		name: z
-			.object({
-				formatted: z.string().trim().min(1).optional(),
-				givenName: z.string().trim().min(1).optional(),
-				familyName: z.string().trim().min(1).optional(),
-			})
-			.optional(),
-		emails: z
-			.array(
-				z.object({
-					value: scimEmailValueSchema,
-					primary: z.boolean().optional(),
-					type: z.string().trim().min(1).optional(),
-				}),
-			)
-			.max(20)
-			.refine((emails) => emails.filter((email) => email.primary).length <= 1, {
-				message: "emails cannot contain multiple primary values",
-			})
-			.refine(
-				(emails) =>
-					new Set(emails.map(createSCIMEmailTupleKey)).size === emails.length,
-				{ message: "emails cannot contain duplicate type and value pairs" },
-			)
-			.optional(),
-		active: z.boolean().optional(),
+		formatted: scimLongStringSchema.optional(),
+		streetAddress: scimLongStringSchema.optional(),
+		locality: scimStringSchema.optional(),
+		region: scimStringSchema.optional(),
+		postalCode: scimStringSchema.optional(),
+		country: scimStringSchema.optional(),
+		type: scimStringSchema.transform((type) => type.toLowerCase()).optional(),
+		primary: z.boolean().optional(),
 	})
-	.superRefine((user, context) => {
-		if (
-			(user.emails === undefined || user.emails.length === 0) &&
-			!scimEmailValueSchema.safeParse(user.userName).success
-		) {
-			context.addIssue({
-				code: "custom",
-				path: ["emails"],
-				message:
-					"emails must contain an email when userName is not an email address",
-			});
+	.refine(
+		(address) =>
+			Object.entries(address).some(
+				([attribute, value]) =>
+					attribute !== "primary" &&
+					attribute !== "type" &&
+					value !== undefined,
+			),
+		{ message: "addresses must contain at least one address value" },
+	);
+
+const scimRoleSchema = z.object({
+	value: scimLongStringSchema,
+	display: scimLongStringSchema.optional(),
+	type: scimStringSchema.transform((type) => type.toLowerCase()).optional(),
+	primary: z.boolean().optional(),
+});
+
+const scimEntitlementSchema = scimRoleSchema;
+
+const scimCanonicalManagerSchema = z
+	.object({
+		value: scimStringSchema.optional(),
+		$ref: scimReferenceSchema.optional(),
+	})
+	.refine(
+		(manager) => manager.value !== undefined || manager.$ref !== undefined,
+		{
+			message: "manager must contain value or $ref",
+		},
+	)
+	.transform((manager) => {
+		if (manager.value !== undefined) {
+			return {
+				value: manager.value,
+				...(manager.$ref === undefined ? {} : { $ref: manager.$ref }),
+			};
 		}
+		if (manager.$ref !== undefined) return { $ref: manager.$ref };
+		throw new Error("Validated manager is missing value and $ref");
 	});
 
-export const OpenAPIUserResourceSchema = {
-	type: "object",
-	properties: {
-		id: { type: "string" },
-		externalId: { type: "string" },
-		meta: {
-			type: "object",
-			properties: {
-				resourceType: { type: "string" },
-				created: { type: "string", format: "date-time" },
-				lastModified: { type: "string", format: "date-time" },
-				location: { type: "string" },
-			},
-		},
-		userName: { type: "string" },
-		name: {
-			type: "object",
-			properties: {
-				formatted: { type: "string" },
-				givenName: { type: "string" },
-				familyName: { type: "string" },
-			},
-		},
-		displayName: { type: "string" },
-		active: { type: "boolean" },
-		emails: {
-			type: "array",
-			items: {
-				type: "object",
-				properties: {
-					value: { type: "string" },
-					primary: { type: "boolean" },
-					type: { type: "string" },
-				},
-			},
-		},
-		schemas: {
-			type: "array",
-			items: { type: "string" },
-		},
-	},
-	required: ["schemas", "id"] as string[],
-} as const;
+const scimManagerInputObjectSchema = z.object({
+	value: scimStringSchema.optional(),
+	$ref: scimReferenceSchema.optional(),
+	displayName: scimLongStringSchema.optional(),
+});
+
+const scimManagerInputSchema = z
+	.union([
+		scimStringSchema,
+		scimManagerInputObjectSchema,
+		z.array(scimManagerInputObjectSchema).length(1),
+	])
+	.transform((manager) => {
+		if (typeof manager === "string") return { value: manager };
+		const candidate = Array.isArray(manager) ? manager[0] : manager;
+		if (!candidate) return undefined;
+		const { value, $ref } = candidate;
+		if (value !== undefined) {
+			return { value, ...($ref === undefined ? {} : { $ref }) };
+		}
+		if ($ref !== undefined) return { $ref };
+		return undefined;
+	});
+
+const scimEnterpriseUserAttributeShape = {
+	employeeNumber: scimSingleValueScalar(scimStringSchema).optional(),
+	costCenter: scimSingleValueScalar(scimStringSchema).optional(),
+	organization: scimSingleValueScalar(scimLongStringSchema).optional(),
+	division: scimSingleValueScalar(scimLongStringSchema).optional(),
+	department: scimSingleValueScalar(scimLongStringSchema).optional(),
+};
+
+export const SCIMEnterpriseUserInputSchema = z
+	.object({
+		...scimEnterpriseUserAttributeShape,
+		manager: scimManagerInputSchema.optional(),
+	})
+	.transform(({ manager, ...enterprise }) => ({
+		...enterprise,
+		...(manager === undefined ? {} : { manager }),
+	}));
+
+const SCIMEnterpriseUserCanonicalSchema = z.object({
+	...scimEnterpriseUserAttributeShape,
+	manager: scimCanonicalManagerSchema.optional(),
+});
+
+function stringAttribute(
+	name: string,
+	description: string,
+	options: {
+		required?: boolean;
+		mutability?: "readOnly" | "readWrite";
+		uniqueness?: "none" | "server";
+	} = {},
+) {
+	return {
+		name,
+		type: "string",
+		multiValued: false,
+		description,
+		required: options.required ?? false,
+		caseExact: false,
+		mutability: options.mutability ?? "readWrite",
+		returned: "default",
+		uniqueness: options.uniqueness ?? "none",
+	};
+}
+
+function typeSubAttribute() {
+	return {
+		...stringAttribute("type", "A label indicating the attribute's function."),
+	};
+}
+
+function primarySubAttribute() {
+	return {
+		name: "primary",
+		type: "boolean",
+		multiValued: false,
+		description: "Whether this is the primary value for the attribute.",
+		required: false,
+		mutability: "readWrite",
+		returned: "default",
+	};
+}
+
+function multiValuedAttribute(
+	name: string,
+	description: string,
+	subAttributes: readonly SCIMDiscoveryAttribute[],
+) {
+	return {
+		name,
+		type: "complex",
+		multiValued: true,
+		description,
+		required: false,
+		subAttributes,
+		mutability: "readWrite",
+		returned: "default",
+		uniqueness: "none",
+	};
+}
 
 export const SCIMUserResourceSchema = {
-	id: "urn:ietf:params:scim:schemas:core:2.0:User",
-	schemas: ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
+	id: SCIM_USER_SCHEMA,
+	schemas: [SCIM_SCHEMA_SCHEMA],
 	name: "User",
 	description: "User Account",
 	attributes: [
-		{
-			name: "userName",
-			type: "string",
-			multiValued: false,
-			description:
-				"Unique identifier for the User within its provisioning connection.",
-			required: true,
-			caseExact: false,
-			mutability: "readWrite",
-			returned: "default",
-			uniqueness: "server",
-		},
-		{
-			name: "displayName",
-			type: "string",
-			multiValued: false,
-			description:
-				"The name of the User, suitable for display to end-users.  The name SHOULD be the full name of the User being described, if known.",
-			required: false,
-			caseExact: false,
-			mutability: "readWrite",
-			returned: "default",
-			uniqueness: "none",
-		},
+		stringAttribute(
+			"userName",
+			"Unique identifier for the User within its provisioning connection.",
+			{ required: true, uniqueness: "server" },
+		),
+		stringAttribute(
+			"displayName",
+			"The name of the User, suitable for display to end-users.",
+		),
 		{
 			name: "active",
 			type: "boolean",
@@ -141,90 +278,107 @@ export const SCIMUserResourceSchema = {
 			name: "name",
 			type: "complex",
 			multiValued: false,
-			description: "The components of the user's real name.",
+			description: "The components of the User's real name.",
 			required: false,
 			subAttributes: [
-				{
-					name: "formatted",
-					type: "string",
-					multiValued: false,
-					description:
-						"The full name, including all middlenames, titles, and suffixes as appropriate, formatted for display(e.g., 'Ms. Barbara J Jensen, III').",
-					required: false,
-					caseExact: false,
-					mutability: "readWrite",
-					returned: "default",
-					uniqueness: "none",
-				},
-				{
-					name: "givenName",
-					type: "string",
-					multiValued: false,
-					description: "The given name of the User.",
-					required: false,
-					caseExact: false,
-					mutability: "readWrite",
-					returned: "default",
-					uniqueness: "none",
-				},
-				{
-					name: "familyName",
-					type: "string",
-					multiValued: false,
-					description: "The family name of the User.",
-					required: false,
-					caseExact: false,
-					mutability: "readWrite",
-					returned: "default",
-					uniqueness: "none",
-				},
+				stringAttribute("formatted", "The complete formatted name."),
+				stringAttribute("givenName", "The given name of the User."),
+				stringAttribute("familyName", "The family name of the User."),
+				stringAttribute("middleName", "The middle name of the User."),
+				stringAttribute("honorificPrefix", "The honorific prefix of the User."),
+				stringAttribute("honorificSuffix", "The honorific suffix of the User."),
 			],
 			mutability: "readWrite",
 			returned: "default",
 			uniqueness: "none",
 		},
+		multiValuedAttribute("emails", "Email addresses for the User.", [
+			stringAttribute("value", "Email address for the User.", {
+				required: true,
+			}),
+			typeSubAttribute(),
+			primarySubAttribute(),
+		]),
+		stringAttribute("title", "The User's title."),
+		stringAttribute("userType", "The User's relationship to the organization."),
+		stringAttribute(
+			"preferredLanguage",
+			"The User's preferred written or spoken language.",
+		),
+		stringAttribute("locale", "The User's default location."),
+		stringAttribute("timezone", "The User's time zone."),
+		multiValuedAttribute("phoneNumbers", "Phone numbers for the User.", [
+			stringAttribute("value", "Phone number for the User.", {
+				required: true,
+			}),
+			typeSubAttribute(),
+			primarySubAttribute(),
+		]),
+		multiValuedAttribute("addresses", "Postal addresses for the User.", [
+			stringAttribute("formatted", "The complete formatted address."),
+			stringAttribute("streetAddress", "The full street address."),
+			stringAttribute("locality", "The city or locality."),
+			stringAttribute("region", "The state or region."),
+			stringAttribute("postalCode", "The postal code."),
+			stringAttribute("country", "The country."),
+			typeSubAttribute(),
+			primarySubAttribute(),
+		]),
+		multiValuedAttribute("roles", "Roles for the User.", [
+			stringAttribute("value", "The role value.", { required: true }),
+			stringAttribute("display", "A human-readable role name."),
+			typeSubAttribute(),
+			primarySubAttribute(),
+		]),
+		multiValuedAttribute("entitlements", "Entitlements for the User.", [
+			stringAttribute("value", "The entitlement value.", { required: true }),
+			stringAttribute("display", "A human-readable entitlement name."),
+			typeSubAttribute(),
+			primarySubAttribute(),
+		]),
+	],
+	meta: {
+		resourceType: "Schema",
+		location: `/scim/v2/Schemas/${SCIM_USER_SCHEMA}`,
+	},
+};
+
+export const SCIMEnterpriseUserResourceSchema = {
+	id: SCIM_ENTERPRISE_USER_SCHEMA,
+	schemas: [SCIM_SCHEMA_SCHEMA],
+	name: "EnterpriseUser",
+	description: "Enterprise User",
+	attributes: [
+		stringAttribute("employeeNumber", "A number assigned to the User."),
+		stringAttribute("costCenter", "The User's cost center."),
+		stringAttribute("organization", "The User's organization."),
+		stringAttribute("division", "The User's division."),
+		stringAttribute("department", "The User's department."),
 		{
-			name: "emails",
+			name: "manager",
 			type: "complex",
-			multiValued: true,
-			description:
-				"Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'. Canonical type values of 'work', 'home', and 'other'.",
+			multiValued: false,
+			description: "The User's manager.",
 			required: false,
 			subAttributes: [
+				stringAttribute("value", "The manager's identifier.", {
+					required: false,
+				}),
 				{
-					name: "value",
-					type: "string",
+					name: "$ref",
+					type: "reference",
+					referenceTypes: ["User"],
 					multiValued: false,
-					description:
-						"Email addresses for the user.  The value SHOULD be canonicalized by the service provider, e.g., 'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'. Canonical type values of 'work', 'home', and 'other'.",
-					required: true,
-					caseExact: false,
-					mutability: "readWrite",
-					returned: "default",
-					uniqueness: "none",
-				},
-				{
-					name: "type",
-					type: "string",
-					multiValued: false,
-					description:
-						"A label indicating the attribute's function, such as work or home.",
+					description: "The URI of the manager's SCIM User resource.",
 					required: false,
 					caseExact: false,
 					mutability: "readWrite",
 					returned: "default",
 					uniqueness: "none",
 				},
-				{
-					name: "primary",
-					type: "boolean",
-					multiValued: false,
-					description:
-						"A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred mailing address or primary email address.  The primary attribute value 'true' MUST appear no more than once.",
-					required: false,
-					mutability: "readWrite",
-					returned: "default",
-				},
+				stringAttribute("displayName", "The manager's display name.", {
+					mutability: "readOnly",
+				}),
 			],
 			mutability: "readWrite",
 			returned: "default",
@@ -233,17 +387,413 @@ export const SCIMUserResourceSchema = {
 	],
 	meta: {
 		resourceType: "Schema",
-		location: "/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
+		location: `/scim/v2/Schemas/${SCIM_ENTERPRISE_USER_SCHEMA}`,
 	},
 };
 
+const OpenAPIEnterpriseUserSchema = {
+	type: "object",
+	properties: {
+		employeeNumber: { type: "string", maxLength: 256 },
+		costCenter: { type: "string", maxLength: 256 },
+		organization: { type: "string", maxLength: 1_024 },
+		division: { type: "string", maxLength: 1_024 },
+		department: { type: "string", maxLength: 1_024 },
+		manager: {
+			type: "object",
+			properties: {
+				value: { type: "string", maxLength: 256 },
+				$ref: { type: "string", maxLength: 2_048 },
+			},
+		},
+	},
+} as const;
+
+/**
+ * Complete protocol and storage behavior for the standard Enterprise User
+ * extension.
+ */
+export const SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR = {
+	kind: "extension",
+	id: SCIM_ENTERPRISE_USER_SCHEMA,
+	required: false,
+	inputPathAliases: [
+		{
+			path: "manager",
+			relativePath: "manager",
+		},
+	],
+	inputSchema: SCIMEnterpriseUserInputSchema,
+	canonicalSchema: SCIMEnterpriseUserCanonicalSchema,
+	canonicalAttribute: "enterprise",
+	responseAttribute: SCIM_ENTERPRISE_USER_SCHEMA,
+	discoverySchema: SCIMEnterpriseUserResourceSchema,
+	openAPISchema: OpenAPIEnterpriseUserSchema,
+} as const;
+
+const SCIM_CORE_USER_SCHEMA_DESCRIPTOR = {
+	kind: "core",
+	id: SCIM_USER_SCHEMA,
+	required: true,
+	discoverySchema: SCIMUserResourceSchema,
+} as const;
+
+/**
+ * Ordered built-in schema descriptors for the SCIM User resource.
+ *
+ * Validation, discovery, ResourceType metadata, OpenAPI, persistence, and
+ * response serialization consume these descriptors.
+ */
+export const SCIM_USER_SCHEMA_DESCRIPTORS = [
+	SCIM_CORE_USER_SCHEMA_DESCRIPTOR,
+	SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR,
+] as const;
+
+const supportedUserSchemaIds: ReadonlySet<string> = new Set(
+	SCIM_USER_SCHEMA_DESCRIPTORS.map((descriptor) => descriptor.id),
+);
+
+const scimUserSchemasSchema = z
+	.array(z.string())
+	.min(1)
+	.max(SCIM_USER_SCHEMA_DESCRIPTORS.length)
+	.superRefine((schemas, context) => {
+		for (const schema of schemas) {
+			if (!supportedUserSchemaIds.has(schema)) {
+				context.addIssue({
+					code: "custom",
+					message: `Unsupported SCIM User schema ${schema}`,
+				});
+			}
+			if (schemas.indexOf(schema) !== schemas.lastIndexOf(schema)) {
+				context.addIssue({
+					code: "custom",
+					message: `SCIM User schema ${schema} must not be duplicated`,
+				});
+			}
+		}
+		for (const descriptor of SCIM_USER_SCHEMA_DESCRIPTORS) {
+			if (descriptor.required && !schemas.includes(descriptor.id)) {
+				context.addIssue({
+					code: "custom",
+					message: `schemas must contain ${descriptor.id}`,
+				});
+			}
+		}
+	})
+	.transform((schemas) =>
+		SCIM_USER_SCHEMA_DESCRIPTORS.filter((descriptor) =>
+			schemas.includes(descriptor.id),
+		).map((descriptor) => descriptor.id),
+	);
+
+function validateEnterpriseDeclaration(
+	user: {
+		schemas: readonly string[];
+		enterprise?: unknown;
+	},
+	context: z.RefinementCtx,
+): void {
+	if (
+		user.enterprise !== undefined &&
+		!user.schemas.includes(SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.id)
+	) {
+		context.addIssue({
+			code: "custom",
+			path: ["schemas"],
+			message: `The Enterprise User extension requires ${SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.id} in schemas`,
+		});
+	}
+}
+
+export const APIUserSchema = z
+	.object({
+		schemas: scimUserSchemasSchema,
+		userName: z.string().trim().min(1).max(512),
+		externalId: scimLongStringSchema.optional(),
+		displayName: scimLongStringSchema.optional(),
+		name: scimNameSchema.optional(),
+		emails: z
+			.array(scimEmailSchema)
+			.max(SCIM_MAX_MULTI_VALUE_COUNT)
+			.refine(primaryRefinement(), {
+				message: "emails cannot contain multiple primary values",
+			})
+			.refine(
+				(emails) =>
+					new Set(emails.map(createSCIMEmailTupleKey)).size === emails.length,
+				{ message: "emails cannot contain duplicate type and value pairs" },
+			)
+			.refine(hasUniqueSCIMDefinedTypes, {
+				message: "emails cannot contain duplicate defined types",
+			})
+			.optional(),
+		title: scimSingleValueScalar(scimLongStringSchema).optional(),
+		userType: scimSingleValueScalar(scimStringSchema).optional(),
+		preferredLanguage: scimSingleValueScalar(scimStringSchema).optional(),
+		locale: scimSingleValueScalar(scimStringSchema).optional(),
+		timezone: scimSingleValueScalar(scimStringSchema).optional(),
+		phoneNumbers: z
+			.array(scimPhoneNumberSchema)
+			.max(SCIM_MAX_STRUCTURED_VALUE_COUNT)
+			.refine(primaryRefinement(), {
+				message: "phoneNumbers cannot contain multiple primary values",
+			})
+			.refine(hasUniqueSCIMDefinedTypes, {
+				message: "phoneNumbers cannot contain duplicate defined types",
+			})
+			.optional(),
+		addresses: z
+			.array(scimAddressSchema)
+			.max(SCIM_MAX_STRUCTURED_VALUE_COUNT)
+			.refine(primaryRefinement(), {
+				message: "addresses cannot contain multiple primary values",
+			})
+			.refine(hasUniqueSCIMDefinedTypes, {
+				message: "addresses cannot contain duplicate defined types",
+			})
+			.optional(),
+		roles: z
+			.array(scimRoleSchema)
+			.max(SCIM_MAX_STRUCTURED_VALUE_COUNT)
+			.refine(primaryRefinement(), {
+				message: "roles cannot contain multiple primary values",
+			})
+			.refine(hasUniqueSCIMDefinedTypes, {
+				message: "roles cannot contain duplicate defined types",
+			})
+			.optional(),
+		entitlements: z
+			.array(scimEntitlementSchema)
+			.max(SCIM_MAX_STRUCTURED_VALUE_COUNT)
+			.refine(primaryRefinement(), {
+				message: "entitlements cannot contain multiple primary values",
+			})
+			.refine(hasUniqueSCIMDefinedTypes, {
+				message: "entitlements cannot contain duplicate defined types",
+			})
+			.optional(),
+		active: z.boolean().optional(),
+		[SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.id]:
+			SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.inputSchema.optional(),
+	})
+	.superRefine((user, context) => {
+		if (
+			(user.emails === undefined || user.emails.length === 0) &&
+			!scimEmailValueSchema.safeParse(user.userName).success
+		) {
+			context.addIssue({
+				code: "custom",
+				path: ["emails"],
+				message:
+					"emails must contain an email when userName is not an email address",
+			});
+		}
+		validateEnterpriseDeclaration(
+			{
+				schemas: user.schemas,
+				enterprise: user[SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.id],
+			},
+			context,
+		);
+		if (
+			JSON.stringify(user).length > SCIM_MAX_SERIALIZED_USER_ATTRIBUTES_LENGTH
+		) {
+			context.addIssue({
+				code: "custom",
+				message: "SCIM User attributes exceed the supported serialized size",
+			});
+		}
+	});
+
+export type APIUser = z.infer<typeof APIUserSchema>;
+
+export const SCIMCanonicalUserAttributesSchema = z
+	.object({
+		schemas: scimUserSchemasSchema,
+		name: scimCanonicalNameSchema,
+		emails: z
+			.array(scimCanonicalEmailSchema)
+			.min(1)
+			.max(SCIM_MAX_MULTI_VALUE_COUNT)
+			.refine(
+				(emails) => emails.filter((email) => email.primary).length === 1,
+				{ message: "stored emails must contain exactly one primary value" },
+			)
+			.refine(
+				(emails) =>
+					new Set(emails.map(createSCIMEmailTupleKey)).size === emails.length,
+				{ message: "stored emails must contain unique type and value pairs" },
+			)
+			.refine(hasUniqueSCIMDefinedTypes, {
+				message: "stored emails must contain unique defined types",
+			}),
+		title: scimLongStringSchema.optional(),
+		userType: scimStringSchema.optional(),
+		preferredLanguage: scimStringSchema.optional(),
+		locale: scimStringSchema.optional(),
+		timezone: scimStringSchema.optional(),
+		phoneNumbers: z
+			.array(scimPhoneNumberSchema)
+			.max(SCIM_MAX_STRUCTURED_VALUE_COUNT)
+			.refine(primaryRefinement())
+			.refine(hasUniqueSCIMDefinedTypes)
+			.optional(),
+		addresses: z
+			.array(scimAddressSchema)
+			.max(SCIM_MAX_STRUCTURED_VALUE_COUNT)
+			.refine(primaryRefinement())
+			.refine(hasUniqueSCIMDefinedTypes)
+			.optional(),
+		roles: z
+			.array(scimRoleSchema)
+			.max(SCIM_MAX_STRUCTURED_VALUE_COUNT)
+			.refine(primaryRefinement())
+			.refine(hasUniqueSCIMDefinedTypes)
+			.optional(),
+		entitlements: z
+			.array(scimEntitlementSchema)
+			.max(SCIM_MAX_STRUCTURED_VALUE_COUNT)
+			.refine(primaryRefinement())
+			.refine(hasUniqueSCIMDefinedTypes)
+			.optional(),
+		[SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.canonicalAttribute]:
+			SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.canonicalSchema.optional(),
+	})
+	.superRefine(validateEnterpriseDeclaration);
+
+export type SCIMCanonicalUserAttributes = z.infer<
+	typeof SCIMCanonicalUserAttributesSchema
+>;
+
+const complexMultiValueOpenAPISchema = {
+	type: "array",
+	maxItems: SCIM_MAX_STRUCTURED_VALUE_COUNT,
+};
+
+const commonMultiValueProperties = {
+	type: { type: "string", maxLength: 256 },
+	primary: { type: "boolean" },
+};
+
+export const OpenAPIUserResourceSchema = {
+	type: "object",
+	properties: {
+		id: { type: "string" },
+		externalId: { type: "string", maxLength: 1_024 },
+		meta: {
+			type: "object",
+			properties: {
+				resourceType: { type: "string" },
+				created: { type: "string", format: "date-time" },
+				lastModified: { type: "string", format: "date-time" },
+				location: { type: "string" },
+			},
+		},
+		userName: { type: "string", maxLength: 512 },
+		name: {
+			type: "object",
+			properties: {
+				formatted: { type: "string", maxLength: 1_024 },
+				givenName: { type: "string", maxLength: 256 },
+				familyName: { type: "string", maxLength: 256 },
+				middleName: { type: "string", maxLength: 256 },
+				honorificPrefix: { type: "string", maxLength: 256 },
+				honorificSuffix: { type: "string", maxLength: 256 },
+			},
+		},
+		displayName: { type: "string", maxLength: 1_024 },
+		title: { type: "string", maxLength: 1_024 },
+		userType: { type: "string", maxLength: 256 },
+		preferredLanguage: { type: "string", maxLength: 256 },
+		locale: { type: "string", maxLength: 256 },
+		timezone: { type: "string", maxLength: 256 },
+		active: { type: "boolean" },
+		emails: {
+			type: "array",
+			maxItems: SCIM_MAX_MULTI_VALUE_COUNT,
+			items: {
+				type: "object",
+				properties: {
+					value: { type: "string", format: "email", maxLength: 254 },
+					...commonMultiValueProperties,
+				},
+			},
+		},
+		phoneNumbers: {
+			...complexMultiValueOpenAPISchema,
+			items: {
+				type: "object",
+				properties: {
+					value: { type: "string", maxLength: 1_024 },
+					...commonMultiValueProperties,
+				},
+			},
+		},
+		addresses: {
+			...complexMultiValueOpenAPISchema,
+			items: {
+				type: "object",
+				properties: {
+					formatted: { type: "string", maxLength: 1_024 },
+					streetAddress: { type: "string", maxLength: 1_024 },
+					locality: { type: "string", maxLength: 256 },
+					region: { type: "string", maxLength: 256 },
+					postalCode: { type: "string", maxLength: 256 },
+					country: { type: "string", maxLength: 256 },
+					...commonMultiValueProperties,
+				},
+			},
+		},
+		roles: {
+			...complexMultiValueOpenAPISchema,
+			items: {
+				type: "object",
+				properties: {
+					value: { type: "string", maxLength: 1_024 },
+					display: { type: "string", maxLength: 1_024 },
+					...commonMultiValueProperties,
+				},
+			},
+		},
+		entitlements: {
+			...complexMultiValueOpenAPISchema,
+			items: {
+				type: "object",
+				properties: {
+					value: { type: "string", maxLength: 1_024 },
+					display: { type: "string", maxLength: 1_024 },
+					...commonMultiValueProperties,
+				},
+			},
+		},
+		[SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.responseAttribute]:
+			SCIM_ENTERPRISE_USER_SCHEMA_DESCRIPTOR.openAPISchema,
+		schemas: {
+			type: "array",
+			maxItems: SCIM_USER_SCHEMA_DESCRIPTORS.length,
+			items: {
+				type: "string",
+				enum: SCIM_USER_SCHEMA_DESCRIPTORS.map((descriptor) => descriptor.id),
+			},
+		},
+	},
+	required: ["schemas", "id"] as string[],
+} as const;
+
 export const SCIMUserResourceType = {
-	schemas: ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+	schemas: [SCIM_RESOURCE_TYPE_SCHEMA],
 	id: "User",
 	name: "User",
 	endpoint: "/Users",
 	description: "User Account",
-	schema: "urn:ietf:params:scim:schemas:core:2.0:User",
+	schema: SCIM_CORE_USER_SCHEMA_DESCRIPTOR.id,
+	schemaExtensions: SCIM_USER_SCHEMA_DESCRIPTORS.filter(
+		(descriptor) => !descriptor.required,
+	).map((descriptor) => ({
+		schema: descriptor.id,
+		required: descriptor.required,
+	})),
 	meta: {
 		resourceType: "ResourceType",
 		location: "/scim/v2/ResourceTypes/User",

--- a/packages/test-utils/src/scim-lifecycle.ts
+++ b/packages/test-utils/src/scim-lifecycle.ts
@@ -308,7 +308,10 @@ export async function runSCIMLifecycle(
 			},
 		},
 	);
-	await expectSCIMNoContent(unchangedUserPatchResponse);
+	expectSCIMResponse(unchangedUserPatchResponse, 200);
+	expect(
+		await readJson<SCIMUserResource>(unchangedUserPatchResponse),
+	).toMatchObject({ id: createdUser.id, displayName: "Ada Byron" });
 	const unchangedUserResponse = await request(
 		`/Users/${encodeURIComponent(createdUser.id)}`,
 	);
@@ -377,7 +380,10 @@ export async function runSCIMLifecycle(
 	}
 
 	const addMemberResponse = await addMember();
-	await expectSCIMNoContent(addMemberResponse);
+	expectSCIMResponse(addMemberResponse, 200);
+	expect(
+		(await readJson<SCIMGroupResource>(addMemberResponse)).members,
+	).toEqual([expect.objectContaining({ value: createdUser.id })]);
 
 	const groupWithMemberResponse = await request(
 		`/Groups/${encodeURIComponent(createdGroup.id)}`,
@@ -410,7 +416,10 @@ export async function runSCIMLifecycle(
 			},
 		},
 	);
-	await expectSCIMNoContent(oktaRemovalResponse);
+	expectSCIMResponse(oktaRemovalResponse, 200);
+	expect(
+		(await readJson<SCIMGroupResource>(oktaRemovalResponse)).members,
+	).toEqual([]);
 	const groupAfterOktaRemovalResponse = await request(
 		`/Groups/${encodeURIComponent(createdGroup.id)}`,
 	);
@@ -436,7 +445,10 @@ export async function runSCIMLifecycle(
 			},
 		},
 	);
-	await expectSCIMNoContent(secondAddResponse);
+	expectSCIMResponse(secondAddResponse, 200);
+	expect(
+		(await readJson<SCIMGroupResource>(secondAddResponse)).members,
+	).toEqual([expect.objectContaining({ value: createdUser.id })]);
 	const entraRemovalResponse = await request(
 		`/Groups/${encodeURIComponent(createdGroup.id)}`,
 		{
@@ -453,7 +465,10 @@ export async function runSCIMLifecycle(
 			},
 		},
 	);
-	await expectSCIMNoContent(entraRemovalResponse);
+	expectSCIMResponse(entraRemovalResponse, 200);
+	expect(
+		(await readJson<SCIMGroupResource>(entraRemovalResponse)).members,
+	).toEqual([]);
 	const groupAfterEntraRemovalResponse = await request(
 		`/Groups/${encodeURIComponent(createdGroup.id)}`,
 	);
@@ -464,7 +479,7 @@ export async function runSCIMLifecycle(
 	await checkpoint("entra-member-removed");
 
 	const restoreMemberResponse = await addMember();
-	await expectSCIMNoContent(restoreMemberResponse);
+	expectSCIMResponse(restoreMemberResponse, 200);
 	const restoredGroupResponse = await request(
 		`/Groups/${encodeURIComponent(createdGroup.id)}`,
 	);
@@ -486,7 +501,10 @@ export async function runSCIMLifecycle(
 			},
 		},
 	);
-	await expectSCIMNoContent(deactivateUserResponse);
+	expectSCIMResponse(deactivateUserResponse, 200);
+	expect(
+		await readJson<SCIMUserResource>(deactivateUserResponse),
+	).toMatchObject({ id: createdUser.id, active: false });
 	const inactiveUserResponse = await request(
 		`/Users/${encodeURIComponent(createdUser.id)}`,
 	);
@@ -515,7 +533,10 @@ export async function runSCIMLifecycle(
 			},
 		},
 	);
-	await expectSCIMNoContent(reactivateUserResponse);
+	expectSCIMResponse(reactivateUserResponse, 200);
+	expect(
+		await readJson<SCIMUserResource>(reactivateUserResponse),
+	).toMatchObject({ id: createdUser.id, active: true });
 	const activeUserResponse = await request(
 		`/Users/${encodeURIComponent(createdUser.id)}`,
 	);
@@ -588,7 +609,7 @@ export async function runSCIMLifecycle(
 			},
 		},
 	);
-	await expectSCIMNoContent(addReprovisionedMemberResponse);
+	expectSCIMResponse(addReprovisionedMemberResponse, 200);
 	const groupWithReprovisionedMemberResponse = await request(
 		`/Groups/${encodeURIComponent(createdGroup.id)}`,
 	);


### PR DESCRIPTION
Real-world IdPs provision more than the core name and email attributes the SCIM plugin accepted so far. Microsoft Entra and Okta send the Enterprise User extension and the classic profile attributes; Entra additionally PATCHes `manager` through legacy path aliases, posts Groups carrying its legacy attribute-less schema marker, and sends `active` as a string boolean. Connections to those IdPs either rejected valid payloads or silently dropped the data.

Two approach notes for review. Canonical attributes persist in a single `serializedAttributes` field on `scimUser` rather than one column per attribute, with the existing name and email columns kept as compatibility mirrors; rows created before the field existed derive their canonical attributes from the mirrors on read. Attribute paths resolve through a schema descriptor registry shared by discovery, PATCH, and filtering, so schema-qualified paths behave identically in all three; the filter parser had to become bracket- and quote-aware for that.

Successful `PATCH` responses now return `200 OK` with the updated resource: provisioning clients assert on the mutation response without re-fetching, and a body-less `204` hid normalization side effects from them. The PR also adds executable provider conformance suites: Microsoft's SCIM Validator test set (everything passes except two Preview-tool assertions documented in the reference docs), Okta's published SCIM 2.0 spec test translated step-for-step, and Google's documented provisioning-client requirements, so conformance is re-verified on every CI run.
