### PR TITLE
fix(jwt): resolve the transaction-scoped adapter when signing

### DIFF
--- a/.changeset/jwt-cookie-cache-transaction-scoped-adapter.md
+++ b/.changeset/jwt-cookie-cache-transaction-scoped-adapter.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Sign-up no longer deadlocks when session cookie caching uses the JWT strategy on a single-connection SQLite database with native transactions enabled. JWKS key lookups and creation now resolve the transaction-scoped adapter instead of always querying the root connection, so minting a signing key during sign-up joins the surrounding transaction instead of racing it for the only available connection. On multi-connection databases (Postgres, MySQL) this also fixes a silent atomicity gap where a JWKS key created mid-transaction could commit independently of the transaction it was minted in.

--- a/packages/better-auth/src/plugins/jwt/adapter.ts
+++ b/packages/better-auth/src/plugins/jwt/adapter.ts
@@ -2,11 +2,12 @@ import type {
 	BetterAuthOptions,
 	GenericEndpointContext,
 } from "@better-auth/core";
+import { getCurrentAdapter } from "@better-auth/core/context";
 import type { DBAdapter } from "@better-auth/core/db/adapter";
 import type { Jwk, JwtOptions } from "./types";
 
 export const getJwksAdapter = (
-	adapter: DBAdapter<BetterAuthOptions>,
+	baseAdapter: DBAdapter<BetterAuthOptions>,
 	options?: JwtOptions,
 ) => {
 	return {
@@ -14,6 +15,7 @@ export const getJwksAdapter = (
 			if (options?.adapter?.getJwks) {
 				return await options.adapter.getJwks(ctx);
 			}
+			const adapter = await getCurrentAdapter(baseAdapter);
 			return await adapter.findMany<Jwk>({
 				model: "jwks",
 			});
@@ -25,6 +27,7 @@ export const getJwksAdapter = (
 					(a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
 				)[0];
 			}
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const keys = await adapter.findMany<Jwk>({
 				model: "jwks",
 			});
@@ -36,6 +39,7 @@ export const getJwksAdapter = (
 			if (options?.adapter?.createJwk) {
 				return await options.adapter.createJwk(webKey, ctx);
 			}
+			const adapter = await getCurrentAdapter(baseAdapter);
 			const jwk = await adapter.create<Omit<Jwk, "id">, Jwk>({
 				model: "jwks",
 				data: {

--- a/packages/better-auth/src/plugins/jwt/jwt.test.ts
+++ b/packages/better-auth/src/plugins/jwt/jwt.test.ts
@@ -1,8 +1,13 @@
+import { DatabaseSync } from "node:sqlite";
 import type { BetterAuthClientPlugin } from "@better-auth/core";
+import { runWithTransaction } from "@better-auth/core/context";
+import { NodeSqliteDialect } from "@better-auth/kysely-adapter/node-sqlite-dialect";
 import type { JSONWebKeySet } from "jose";
 import { createLocalJWKSet, jwtVerify } from "jose";
 import { describe, expect, expectTypeOf, it } from "vitest";
+import { betterAuth } from "../../auth/full";
 import { createAuthClient } from "../../client";
+import { getMigrations } from "../../db/get-migration";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { inferAdditionalFields } from "../additional-fields/client";
 import { jwt } from ".";
@@ -780,6 +785,47 @@ describe("jwt - custom jwksPath", async () => {
 		// Verify old /jwks endpoint is not found
 		const oldJwks = await client.$fetch<JSONWebKeySet>("/jwks");
 		expect(oldJwks.error?.status).toBe(404);
+	});
+});
+
+describe("jwt - JWKS minting inside an active transaction", async () => {
+	it("mints the first signing key through the transaction-scoped adapter instead of deadlocking on the connection", async () => {
+		const auth = betterAuth({
+			baseURL: "http://localhost:3000",
+			secret: "better-auth.secret",
+			database: {
+				dialect: new NodeSqliteDialect({
+					database: new DatabaseSync(":memory:"),
+				}),
+				type: "sqlite",
+				transaction: true,
+			},
+			emailAndPassword: {
+				enabled: true,
+			},
+			plugins: [jwt()],
+		});
+
+		const { runMigrations } = await getMigrations(auth.options);
+		await runMigrations();
+
+		const signUpResult = await auth.api.signUpEmail({
+			body: {
+				email: "transactional-jwks@example.com",
+				password: "password123",
+				name: "Transactional JWKS User",
+			},
+			returnHeaders: true,
+		});
+		const headers = new Headers();
+		headers.set("cookie", signUpResult.headers.getSetCookie()[0]!);
+
+		const ctx = await auth.$context;
+		const token = await runWithTransaction(ctx.adapter, () =>
+			auth.api.getToken({ headers }),
+		);
+
+		expect(token.token).toEqual(expect.any(String));
 	});
 });
 


### PR DESCRIPTION
Minting or reading a JWKS signing key inside an active database transaction always queried through the root connection. On a single-connection SQLite database configured with `transaction: true` that deadlocks: the transaction holds the pool's only connection while the key lookup waits for it forever. On Postgres and MySQL pools it is quieter but still wrong: the key commits independently of the transaction it was minted in.

The JWKS adapter now resolves the transaction-scoped adapter per query, the same pattern the organization plugin uses. Behavior is unchanged when no transaction is active.
