### PR TITLE
fix(auth): auth init crashing on empty dependency installs and blank install error messages.

### DIFF
--- a/.changeset/real-loops-sort.md
+++ b/.changeset/real-loops-sort.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+Fix `auth init` crashing on empty dependency installs and blank install error messages.

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1481,6 +1481,7 @@ export const auth = betterAuth({
 		}
 
 		for (const [type, dependencies] of Object.entries(deps)) {
+			if (dependencies.size === 0) continue;
 			await installDependencies({
 				cwd,
 				dependencies: [...dependencies],

--- a/packages/cli/src/utils/install-dependencies.ts
+++ b/packages/cli/src/utils/install-dependencies.ts
@@ -89,7 +89,8 @@ export function installDependencies({
 		exec(command, { cwd }, (error, stdout, stderr) => {
 			if (error) {
 				const message =
-					[stderr, stdout].filter(Boolean).join("\n").trim() ||
+					(stderr || "").trim() ||
+					(stdout || "").trim() ||
 					error.message ||
 					"Failed to install dependencies";
 				reject(new Error(message));

--- a/packages/cli/src/utils/install-dependencies.ts
+++ b/packages/cli/src/utils/install-dependencies.ts
@@ -42,6 +42,13 @@ export function installDependencies({
 	type?: "prod" | "peer" | "optional" | "dev" | "catalog" | undefined;
 	catalogName?: string;
 }): Promise<boolean> {
+	const dependencyList = Array.isArray(dependencies)
+		? dependencies
+		: [dependencies];
+	if (dependencyList.length === 0 || dependencyList.every((dep) => !dep)) {
+		return Promise.resolve(true);
+	}
+
 	let installCommand: string;
 	const flags: string[] = [];
 	switch (packageManager) {
@@ -76,12 +83,16 @@ export function installDependencies({
 			flags.push(flag);
 		}
 	}
-	const command = `${installCommand}${flags.length > 0 ? ` ${flags.join(" ")}` : ""} ${Array.isArray(dependencies) ? dependencies.join(" ") : dependencies}`;
+	const command = `${installCommand}${flags.length > 0 ? ` ${flags.join(" ")}` : ""} ${dependencyList.join(" ")}`;
 
 	return new Promise((resolve, reject) => {
 		exec(command, { cwd }, (error, stdout, stderr) => {
 			if (error) {
-				reject(new Error(stderr));
+				const message =
+					[stderr, stdout].filter(Boolean).join("\n").trim() ||
+					error.message ||
+					"Failed to install dependencies";
+				reject(new Error(message));
 				return;
 			}
 			resolve(true);

--- a/packages/cli/test/install-dependencies.test.ts
+++ b/packages/cli/test/install-dependencies.test.ts
@@ -296,6 +296,47 @@ describe("installDependencies", () => {
 	});
 
 	testWithTmpDir(
+		"should skip exec when dependencies array is empty",
+		async ({ tmp }) => {
+			const result = await installDependencies({
+				dependencies: [],
+				packageManager: "pnpm",
+				cwd: tmp,
+				type: "dev",
+			});
+
+			expect(result).toBe(true);
+			expect(mockExec).not.toHaveBeenCalled();
+		},
+	);
+
+	testWithTmpDir(
+		"should reject with stdout when stderr is empty",
+		async ({ tmp }) => {
+			const execError = Object.assign(new Error("Command failed"), { code: 1 });
+			mockExec.mockImplementation((_cmd, _opts, callback) => {
+				if (callback) {
+					callback(
+						execError,
+						"ERR_PNPM_MISSING_PACKAGE_NAME  `pnpm add` requires the package name",
+						"",
+					);
+				}
+				return {} as ReturnType<typeof exec>;
+			});
+
+			const promise = installDependencies({
+				dependencies: "nonexistent-package",
+				packageManager: "pnpm",
+				cwd: tmp,
+			});
+			await expect(promise).rejects.toThrow(
+				"ERR_PNPM_MISSING_PACKAGE_NAME  `pnpm add` requires the package name",
+			);
+		},
+	);
+
+	testWithTmpDir(
 		"should reject with stderr message on exec error",
 		async ({ tmp }) => {
 			const execError = Object.assign(new Error("Command failed"), { code: 1 });

--- a/packages/cli/test/install-dependencies.test.ts
+++ b/packages/cli/test/install-dependencies.test.ts
@@ -337,6 +337,26 @@ describe("installDependencies", () => {
 	);
 
 	testWithTmpDir(
+		"should prefer stderr over stdout on exec error",
+		async ({ tmp }) => {
+			const execError = Object.assign(new Error("Command failed"), { code: 1 });
+			mockExec.mockImplementation((_cmd, _opts, callback) => {
+				if (callback) {
+					callback(execError, "progress output", "actual error");
+				}
+				return {} as ReturnType<typeof exec>;
+			});
+
+			const promise = installDependencies({
+				dependencies: "nonexistent-package",
+				packageManager: "npm",
+				cwd: tmp,
+			});
+			await expect(promise).rejects.toThrow("actual error");
+		},
+	);
+
+	testWithTmpDir(
 		"should reject with stderr message on exec error",
 		async ({ tmp }) => {
 			const execError = Object.assign(new Error("Command failed"), { code: 1 });


### PR DESCRIPTION
`auth init` crashed during dependency install when only prod (or only dev) packages were needed, because it still ran an empty `pnpm add`/`pnpm add -D`. Install failures also showed a blank error when the package manager wrote to stdout.

The fix is to skip empty dependency sets; no-op on empty installs; surface stdout when stderr is empty.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `auth init` crashing on empty dependency installs and improves install error messages by preferring stderr and falling back to stdout.

- **Bug Fixes**
  - Skip empty dependency sets in `auth init` and `installDependencies` to avoid running empty `pnpm add` commands.
  - Prefer stderr for install errors; use stdout if stderr is empty.
  - Added tests for empty installs, stdout-only failures, and stderr precedence.

<sup>Written for commit 5f56a844f317839302afcb96b2ed1a4bbbfcdec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

