### PR TITLE
fix(oauth-provider): allow client_credentials-only clients to register without redirect_uris

### DIFF
--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -1275,7 +1275,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				{
 					method: "POST",
 					body: z.object({
-						redirect_uris: z.array(SafeUrlSchema).min(1).min(1),
+						redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 						scope: z.string().optional(),
 						client_name: z.string().optional(),
 						client_uri: z.string().optional(),

--- a/packages/oauth-provider/src/oauthClient/index.ts
+++ b/packages/oauth-provider/src/oauthClient/index.ts
@@ -232,7 +232,7 @@ export const createOAuthClient = (opts: OAuthOptions<Scope[]>) =>
 			method: "POST",
 			use: [sessionMiddleware],
 			body: z.object({
-				redirect_uris: z.array(SafeUrlSchema).min(1),
+				redirect_uris: z.array(SafeUrlSchema).min(1).optional(),
 				scope: z.string().optional(),
 				client_name: z.string().optional(),
 				client_uri: z.string().optional(),

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -83,6 +83,57 @@ describe("oauth register", async () => {
 		expect(response.data?.client_secret).toBeDefined();
 	});
 
+	// RFC 7591 §2 makes `redirect_uris` REQUIRED only for "clients using
+	// flows with redirection" — a client_credentials-only client has no
+	// redirection leg and so has no redirect URI to register.
+	// checkOAuthClient already states that rule correctly; the request
+	// schema must not contradict it.
+	it("should register a client_credentials-only client without redirect_uris", async () => {
+		const response = await serverClient.oauth2.register({
+			grant_types: ["client_credentials"],
+		});
+		expect(response.data?.client_id).toBeDefined();
+		expect(response.data?.client_secret).toBeDefined();
+		expect(response.data?.redirect_uris).toEqual([]);
+	});
+
+	it("should still fail without redirect_uris when grant_types defaults to authorization_code", async () => {
+		const response = await serverClient.oauth2.register({
+			client_name: "no grant_types, no redirect_uris",
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	it("should still fail without redirect_uris when grant_types includes authorization_code", async () => {
+		const response = await serverClient.oauth2.register({
+			grant_types: ["authorization_code", "client_credentials"],
+		});
+		expect(response.error?.status).toBe(400);
+	});
+
+	// Same defect, same fix, on the session-gated sibling endpoint. This one
+	// matters more in practice: a first-party machine client is created
+	// through /oauth2/create-client, not through public dynamic registration,
+	// because only that path leaves the client secret non-expiring.
+	it("should create a client_credentials-only client without redirect_uris via /oauth2/create-client", async () => {
+		const response = await auth.api.createOAuthClient({
+			headers,
+			body: { grant_types: ["client_credentials"] },
+		});
+		expect(response?.client_id).toBeDefined();
+		expect(response?.client_secret).toBeDefined();
+		expect(response?.redirect_uris).toEqual([]);
+	});
+
+	it("should still fail without redirect_uris via /oauth2/create-client for authorization_code", async () => {
+		await expect(
+			auth.api.createOAuthClient({
+				headers,
+				body: { grant_types: ["authorization_code"] },
+			}),
+		).rejects.toThrow();
+	});
+
 	it("should fail authorization_code without response type code", async () => {
 		const response = await serverClient.oauth2.register({
 			// @ts-expect-error testing with a different response type even though unsupported

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -271,6 +271,12 @@ export async function createOAuthClientEndpoint(
 		model: "oauthClient",
 		data: {
 			...schema,
+			// `redirectUris` is a required column, but a client registering
+			// only non-redirect grants (e.g. client_credentials) legitimately
+			// has none — checkOAuthClient above already rejected every client
+			// that DOES need them. Normalize to the empty list, matching what
+			// schemaToOAuth already reports on the way back out.
+			redirectUris: schema.redirectUris ?? [],
 			createdAt: new Date(iat * 1000),
 			updatedAt: new Date(iat * 1000),
 		},


### PR DESCRIPTION
### The bug

`checkOAuthClient` already states RFC 7591 §2's rule correctly — redirect URIs are required only for redirect-based flows:

```ts
if (
    (!client.grant_types || client.grant_types.includes("authorization_code")) &&
    (!client.redirect_uris || client.redirect_uris.length === 0)
) {
    throw new APIError("BAD_REQUEST", { error: "invalid_redirect_uri", ... });
}
```

But the request schemas for `/oauth2/register` and `/oauth2/create-client` declare `redirect_uris: z.array(SafeUrlSchema).min(1)` **unconditionally**, and zod runs first. So a pure `client_credentials` client — which has no redirection leg and therefore no redirect URI — is rejected before that correct check ever runs.

The only way through today is to invent a callback URL the client will never use, which then sits in the client registry as a false record.

> RFC 7591 §2: "This metadata member is REQUIRED for clients using flows with redirection."

### The fix

1. `redirect_uris` becomes `.optional()` on both endpoints. `.min(1)` is kept, so an explicitly **empty array** is still rejected — only omission is now allowed, and `checkOAuthClient` is left as the sole decider of whether omitting it is legal.

   A pleasant side effect: a redirect-flow client that omits its URIs now gets the RFC 7591 §3.2.2 error code `invalid_redirect_uri`, instead of a generic schema-validation failure.

2. `createOAuthClientEndpoint` normalizes the omitted value to `[]` on insert. `redirectUris` is a `required: true` column, and `schemaToOAuth` already reports `redirect_uris: redirectUris ?? []` on the way back out — this only makes the write side agree with the read side. Without it, the request now passes validation and then fails on a NOT NULL violation.

### Not changed

`/admin/oauth2/create-client` carries the same schema. It is admin-gated and I have no test for it, so I left it rather than ship an unverified change — happy to include it if you'd prefer.

### Tests

Added to `packages/oauth-provider/src/register.test.ts`:

| test | without the fix | with the fix |
|---|---|---|
| register a `client_credentials`-only client without `redirect_uris` | ❌ 400 | ✅ |
| same via `/oauth2/create-client` | ❌ 400 | ✅ |
| still fails when `grant_types` defaults to `authorization_code` | ✅ | ✅ |
| still fails when `grant_types` includes `authorization_code` | ✅ | ✅ |
| same, via `/oauth2/create-client` | ✅ | ✅ |

The negative cases passing both before and after is deliberate — they prove the rule is still **enforced**, not deleted.

Full `packages/oauth-provider` suite: **342 passing**.

### Context

Found while registering the first machine-to-machine client against a self-hosted IdP built on this plugin. It has also been verified end-to-end there — real Postgres, real HTTP handler — as a `pnpm` patch carrying exactly this diff.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `client_credentials`-only OAuth clients to register without `redirect_uris`, matching RFC 7591 and removing the need for fake callback URLs. Applies to `/oauth2/register` and `/oauth2/create-client`; redirect flows still require URIs and now return `invalid_redirect_uri` when missing.

- **Bug Fixes**
  - Made `redirect_uris` optional in request schemas; still reject explicitly empty arrays.
  - Normalized omitted `redirect_uris` to `[]` on insert to satisfy the required `redirectUris` column and match read behavior.
  - Left `/admin/oauth2/create-client` unchanged (no tests).

<sup>Written for commit b1a2239557e450daee55a532c2311be34d8ffe64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

