### PR TITLE
docs(changeset): describe the jwt transaction fix by its mechanism

### DIFF
--- a/.changeset/jwt-cookie-cache-transaction-scoped-adapter.md
+++ b/.changeset/jwt-cookie-cache-transaction-scoped-adapter.md
@@ -1,5 +1,0 @@
----
-"better-auth": patch
----
-
-Sign-up no longer deadlocks when session cookie caching uses the JWT strategy on a single-connection SQLite database with native transactions enabled. JWKS key lookups and creation now resolve the transaction-scoped adapter instead of always querying the root connection, so minting a signing key during sign-up joins the surrounding transaction instead of racing it for the only available connection. On multi-connection databases (Postgres, MySQL) this also fixes a silent atomicity gap where a JWKS key created mid-transaction could commit independently of the transaction it was minted in.

--- a/.changeset/jwt-transaction-scoped-adapter.md
+++ b/.changeset/jwt-transaction-scoped-adapter.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Minting or reading a JWKS signing key inside an active database transaction now uses the transaction-scoped adapter instead of the root connection. On a single-connection SQLite database with native transactions enabled, this no longer deadlocks, and on Postgres and MySQL the key commits with the surrounding transaction instead of independently of it.


### PR DESCRIPTION
The changelog entry for the JWT transaction-scoped adapter fix described its trigger as session cookie caching with the JWT strategy, a configuration that does not exist on this release line. The entry now describes the mechanism users can actually hit: JWKS key reads and creation inside an active database transaction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the `better-auth` changelog entry for the JWT transaction fix by describing the actual mechanism. Replaces the old changeset and now states that minting or reading a JWKS signing key inside an active DB transaction uses the transaction-scoped adapter, preventing single-connection SQLite deadlocks and ensuring the key commits with the surrounding transaction on Postgres/MySQL; removes the incorrect session cookie caching reference.

<sup>Written for commit 179645abc4b7ef1ed4f3a086515e6ae9d8e85845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

