### PR TITLE
fix(one-tap): preserve client plugin inference with oneTapClient

### DIFF
--- a/.changeset/fix-one-tap-client-plugin-inference.md
+++ b/.changeset/fix-one-tap-client-plugin-inference.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix `oneTapClient()` collapsing `createAuthClient` type inference when combined with other client plugins. The `oneTap` action is available on the client again.

--- a/packages/better-auth/src/plugins/one-tap/client.ts
+++ b/packages/better-auth/src/plugins/one-tap/client.ts
@@ -1,9 +1,12 @@
 /// <reference types="@types/google.accounts" />
 import type {
+	BetterAuthClientOptions,
 	BetterAuthClientPlugin,
 	ClientFetchOption,
+	ClientStore,
 } from "@better-auth/core";
 import { isSafeUrlScheme } from "@better-auth/core/utils/url";
+import type { BetterFetch } from "@better-fetch/fetch";
 import { PACKAGE_VERSION } from "../../version";
 
 declare global {
@@ -212,7 +215,11 @@ export const oneTapClient = (options: GoogleOneTapOptions) => {
 				},
 			},
 		],
-		getActions: ($fetch, _) => {
+		getActions: (
+			$fetch: BetterFetch,
+			_$store: ClientStore,
+			_options: BetterAuthClientOptions | undefined,
+		) => {
 			return {
 				oneTap: async (
 					opts?: GoogleOneTapActionOptions | undefined,

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -1,6 +1,9 @@
 // cspell:ignore AQAB
-import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BetterAuthClientPlugin } from "@better-auth/core";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { createAuthClient } from "../../client";
 import { getTestInstance } from "../../test-utils/test-instance";
+import { oneTapClient } from "./client";
 import { oneTap } from "./index";
 
 vi.mock("@better-fetch/fetch", async (importOriginal) => {
@@ -710,5 +713,31 @@ describe("one-tap disableSignUp", () => {
 			status: "UNAUTHORIZED",
 			body: { message: "signup disabled" },
 		});
+	});
+});
+
+/**
+ * Declaration emit previously left `getActions`'s `$fetch` parameter
+ * un-annotated. With no import of `BetterFetch` in the file, emit had no
+ * name to reference and inlined `import("@better-fetch/fetch").BetterFetch`
+ * instead - a form not assignable to `BetterAuthClientPlugin`'s
+ * `getActions`, so `oneTapClient()` failed `createAuthClient`'s check and
+ * the client lost the `oneTap` action.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10583
+ */
+describe("oneTapClient types", () => {
+	it("should be assignable to BetterAuthClientPlugin", () => {
+		const plugin: BetterAuthClientPlugin = oneTapClient({
+			clientId: "test-client",
+		});
+		expect(plugin.id).toBe("one-tap");
+	});
+
+	it("should preserve the oneTap client action", () => {
+		const client = createAuthClient({
+			plugins: [oneTapClient({ clientId: "test-client" })],
+		});
+		expectTypeOf(client.oneTap).toBeFunction();
 	});
 });


### PR DESCRIPTION
## Problem

`oneTapClient`'s `getActions` left `$fetch` (and the remaining parameters) unannotated. With no import of `BetterFetch` in the file, declaration emit had no name to reference, so it emitted an inline `import("@better-fetch/fetch").BetterFetch` type. That inline form is not assignable to `BetterAuthClientPlugin`'s `getActions` signature, so `oneTapClient()` fails `createAuthClient`'s check and the client loses the `oneTap` action.

Same fix shape as `jwtClient` in #10513: annotate `getActions` with the full `BetterAuthClientPlugin` arity. The trigger differs, though - #10513 attributed jwt's break to a generic `$fetch<JSONWebKeySet>()` call in the body narrowing the inferred type. `one-tap/client.ts` has no generic `$fetch<T>()` call anywhere (verified directly in the current source) - `$fetch` was simply never annotated.

## Evidence

1. Reproduced independently: a real Next.js app, `tsc --noEmit` clean on 1.6.23, exit 2 on 1.6.24 with `TS2322` on the plugins array and `TS2339` on `oneTap`. Reproduces with `skipLibCheck: true` and Next's ambient types in scope, so it's not a config artifact.
2. The emitted declarations differ across plugins: `jwt` and `one-tap` (both broken) emit inline `import("@better-fetch/fetch").BetterFetch`; `oauth-popup` (working) emits a named `BetterFetch`.
3. Swapping the inline form for a named reference in the emitted declaration alone clears the error - direct evidence the emit form is causal, not correlated.
4. A build of unmodified current `main` emits a declaration line byte-identical to published 1.6.24, so nothing since the release fixed this. The fixed build takes the same reproduction from exit 2 to exit 0.

## Fix

Annotate `getActions` with the full `BetterAuthClientPlugin` arity (`BetterFetch`, `ClientStore`, `options`), forcing a real import into the file so emit uses the named reference instead.

## Test

Added an `expectTypeOf`/assignability assertion that `oneTapClient()` is assignable to `BetterAuthClientPlugin` and that the client still exposes `oneTap`, mirroring the check added for `jwtClient` in #10513. Note this is source-level and can't reproduce the actual regression: TypeScript checks the inferred type directly here rather than round-tripping it through declaration emit, which is where the bug lives. A build-level test (compiling real declarations and checking a downstream consumer against them) would catch it directly - happy to add one if maintainers want it.

Fixes #10583


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Annotates `oneTapClient` `getActions` to preserve client plugin inference and keep the `oneTap` action available. Restores compatibility with `createAuthClient` and clears TS errors introduced in 1.6.24.

- **Bug Fixes**
  - Annotated `getActions` params (`BetterFetch`, `ClientStore`, `BetterAuthClientOptions`) to match the plugin signature and force a named import, avoiding inline `import("@better-fetch/fetch").BetterFetch` in declaration emit.
  - Added type tests to ensure `oneTapClient` is assignable and `client.oneTap` exists.
  - Added a patch changeset for `better-auth`.

<sup>Written for commit d60483ed1f018fab179c1aed0f1da6b236242da1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

