### PR TITLE
fix(i18n): annotate i18n return type as BetterAuthPlugin

### DIFF
--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -66,7 +66,7 @@ function parseAcceptLanguage(header: string | null): string[] {
  */
 export const i18n = <Locales extends string[]>(
 	options: I18nOptions<Locales>,
-) => {
+): BetterAuthPlugin => {
 	const availableLocales = Object.keys(options.translations);
 
 	let defaultLocale: Locales[number];


### PR DESCRIPTION
## Summary
Explicitly annotates the return type of the `i18n` plugin creator function as `: BetterAuthPlugin`.

## Problem
When `@better-auth/i18n` is built with `tsdown` without a return type annotation, `tsdown` infers the return type down to its internal middleware implementation details:
```ts
handler: (inputContext: MiddlewareInputContext<MiddlewareOptions>) => Promise<void>;
```
This causes `tsdown` to generate an internal chunk file (`dist/index-CMj6OYMa.d.mts`) containing an unexported `interface MiddlewareOptions`.

## Solution
Annotating `export const i18n = <...>(...): BetterAuthPlugin => { ... }` ensures `tsdown` emits the high-level public contract directly in `dist/index.d.mts`:
```ts
declare const i18n: <Locales extends string[]>(options: I18nOptions<Locales>) => BetterAuthPlugin;
```

## Observed Build Changes
1. **Declaration File**: `dist/index.d.mts` cleanly exports `declare const i18n: <Locales extends string[]>(options: I18nOptions<Locales>) => BetterAuthPlugin;`.
2. **Chunk Output**: The internal `.d.mts` chunk file (`index-CMj6OYMa.d.mts`) is no longer generated by `tsdown` (reducing declaration output from 11 files to 10).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Annotates the `i18n` plugin’s return type as BetterAuthPlugin to stabilize public typings and stop internal middleware types from leaking into the build. This fixes `@better-auth/i18n` type emission when built with `tsdown`.

- **Bug Fixes**
  - Force return type to `BetterAuthPlugin` to prevent `tsdown` inferring internal handler types.
  - `dist/index.d.mts` now exports the plugin type directly; the extra internal `.d.mts` chunk is no longer generated.

<sup>Written for commit 537e5556f4b2a9f417f61787e863fc7d2cbd42ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

