### PR TITLE
fix(cli): include column names for enum fields in generated drizzle schema

### DIFF
--- a/.changeset/drizzle-enum-column-name.md
+++ b/.changeset/drizzle-enum-column-name.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+Include the column name for enum fields in generated Drizzle schemas on SQLite and MySQL, so multi-word fields map to their snake_case columns.

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -87,9 +87,9 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 			if (typeof type !== "string") {
 				if (Array.isArray(type) && type.every((x) => typeof x === "string")) {
 					return {
-						sqlite: `text({ enum: [${type.map((x) => `'${x}'`).join(", ")}] })`,
+						sqlite: `text('${name}', { enum: [${type.map((x) => `'${x}'`).join(", ")}] })`,
 						pg: `text('${name}', { enum: [${type.map((x) => `'${x}'`).join(", ")}] })`,
-						mysql: `mysqlEnum([${type.map((x) => `'${x}'`).join(", ")}])`,
+						mysql: `mysqlEnum('${name}', [${type.map((x) => `'${x}'`).join(", ")}])`,
 					}[databaseType];
 				} else {
 					throw new TypeError(

--- a/packages/cli/test/__snapshots__/auth-schema-mysql-enum.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql-enum.txt
@@ -20,7 +20,7 @@ export const user = mysqlTable("user", {
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
-  status: mysqlEnum(["active", "inactive", "pending"]),
+  status: mysqlEnum("status", ["active", "inactive", "pending"]),
 });
 
 export const session = mysqlTable(

--- a/packages/cli/test/__snapshots__/auth-schema-sqlite-enum.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-sqlite-enum.txt
@@ -16,7 +16,7 @@ export const user = sqliteTable("user", {
     .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
-  priority: text({ enum: ["high", "medium", "low"] }).notNull(),
+  priority: text("priority", { enum: ["high", "medium", "low"] }).notNull(),
 });
 
 export const session = sqliteTable(

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -1060,7 +1060,7 @@ describe("Enum field support in Drizzle schemas", () => {
 		});
 		expect(schema.code).toContain("mysqlEnum");
 		expect(schema.code).toContain(
-			'status: mysqlEnum(["active", "inactive", "pending"])',
+			'status: mysqlEnum("status", ["active", "inactive", "pending"])',
 		);
 		await expect(schema.code).toMatchFileSnapshot(
 			"./__snapshots__/auth-schema-mysql-enum.txt",
@@ -1088,12 +1088,60 @@ describe("Enum field support in Drizzle schemas", () => {
 				},
 			} as BetterAuthOptions,
 		});
-		expect(schema.code).toContain("text({ enum: [");
 		expect(schema.code).toContain(
-			'priority: text({ enum: ["high", "medium", "low"] })',
+			'priority: text("priority", { enum: ["high", "medium", "low"] })',
 		);
 		await expect(schema.code).toMatchFileSnapshot(
 			"./__snapshots__/auth-schema-sqlite-enum.txt",
+		);
+	});
+
+	it("should generate snake_case column names for multi-word enum fields", async () => {
+		const sqliteSchema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: {
+				id: "drizzle",
+				options: {
+					provider: "sqlite",
+					schema: {},
+				},
+			} as any,
+			options: {
+				database: {} as any,
+				user: {
+					additionalFields: {
+						userRole: {
+							type: ["admin", "user"],
+						},
+					},
+				},
+			} as BetterAuthOptions,
+		});
+		expect(sqliteSchema.code).toContain(
+			'userRole: text("user_role", { enum: ["admin", "user"] })',
+		);
+		const mysqlSchema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: {
+				id: "drizzle",
+				options: {
+					provider: "mysql",
+					schema: {},
+				},
+			} as any,
+			options: {
+				database: {} as any,
+				user: {
+					additionalFields: {
+						userRole: {
+							type: ["admin", "user"],
+						},
+					},
+				},
+			} as BetterAuthOptions,
+		});
+		expect(mysqlSchema.code).toContain(
+			'userRole: mysqlEnum("user_role", ["admin", "user"])',
 		);
 	});
 


### PR DESCRIPTION
## What

`generate` now emits an explicit column name for enum fields in Drizzle schemas on SQLite and MySQL:

```ts
// before
subscriptionStatus: text({ enum: ["active", "canceled"] })
subscriptionStatus: mysqlEnum(["active", "canceled"])

// after
subscriptionStatus: text("subscription_status", { enum: ["active", "canceled"] })
subscriptionStatus: mysqlEnum("subscription_status", ["active", "canceled"])
```

## Why

Every other column type passes an explicit snake_case name, and so does the Postgres enum branch. The SQLite and MySQL enum branches did not, so Drizzle fell back to the TypeScript key and multi-word fields got camelCase columns in an otherwise snake_case schema. Single-word fields and the `camelCase` adapter option are unaffected.

## Tests

Updated the existing enum assertions and snapshots, and added a regression test covering a multi-word enum field on both providers. Changeset included (`auth` patch). `pnpm typecheck` passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes enum fields in generated Drizzle schemas for SQLite and MySQL to include explicit column names. Multi-word enums now map to snake_case columns, matching Postgres and other field types.

- **Bug Fixes**
  - Pass the snake_case column name for SQLite (`text('<name>', { enum: [...] })`) and MySQL (`mysqlEnum('<name>', [...])`).
  - No change to single-word enums or the `camelCase` adapter option.

- **Migration**
  - If you generated schemas with multi-word enum fields before this fix, rename existing DB columns from camelCase to snake_case after regenerating.

<sup>Written for commit 82590a3babb3d5227a747296a78685c9ceebed14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->