### PR TITLE
fix(oauth-provider): allow localhost redirect port variance

### DIFF
--- a/.changeset/tidy-pans-smile.md
+++ b/.changeset/tidy-pans-smile.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Allow native OAuth clients registered with an exact `localhost` redirect URI to use an ephemeral callback port.

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -363,6 +363,83 @@ describe("oauth authorize - unauthenticated", async () => {
 	});
 });
 
+describe("oauth authorize - localhost redirect port", async () => {
+	const authServerBaseUrl = "http://localhost:3000";
+	const registeredLocalhostRedirect = "http://localhost/callback?source=cli";
+	const registeredPublicRedirect = "https://client.example.com/callback";
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: authServerBaseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const unauthenticatedClient = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: authServerBaseUrl,
+		fetchOptions: { customFetchImpl },
+	});
+
+	let clientId: string | undefined;
+	beforeAll(async () => {
+		const client = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				application_type: "native",
+				redirect_uris: [registeredLocalhostRedirect, registeredPublicRedirect],
+			},
+		});
+		clientId = client?.client_id;
+		expect(clientId).toBeDefined();
+	});
+
+	async function authorizeRedirect(redirectUri: string) {
+		if (!clientId) throw new Error("beforeAll not run properly");
+		const url = new URL(`${authServerBaseUrl}/api/auth/oauth2/authorize`);
+		url.searchParams.set("client_id", clientId);
+		url.searchParams.set("redirect_uri", redirectUri);
+		url.searchParams.set("response_type", "code");
+		url.searchParams.set("scope", "openid");
+		url.searchParams.set("code_challenge", generateRandomString(43));
+		url.searchParams.set("code_challenge_method", "S256");
+
+		let location = "";
+		await unauthenticatedClient.$fetch(url.toString(), {
+			onError(context) {
+				location = context.response.headers.get("Location") ?? "";
+			},
+		});
+		return location;
+	}
+
+	it("allows an ephemeral port for the exact localhost hostname", async () => {
+		const location = await authorizeRedirect(
+			"http://localhost:56053/callback?source=cli",
+		);
+		expect(location).toContain("/login");
+	});
+
+	it.each([
+		["path", "http://localhost:56053/other?source=cli"],
+		["query", "http://localhost:56053/callback?source=other"],
+		["protocol", "https://localhost:56053/callback?source=cli"],
+		["hostname", "http://tenant.localhost:56053/callback?source=cli"],
+		["non-loopback host port", "https://client.example.com:56053/callback"],
+	])("rejects a changed %s", async (_component, requestedRedirect) => {
+		const location = await authorizeRedirect(requestedRedirect);
+		expect(location).toContain("/error");
+		expect(location).not.toContain("/login");
+	});
+});
+
 describe("oauth authorize - max_age (OIDC Core 1.0 §3.1.2.1)", async () => {
 	const authServerBaseUrl = "http://localhost:3000";
 	const rpBaseUrl = "http://localhost:5000";

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -266,8 +266,12 @@ function findRegisteredRedirectUri(
 		if (!req) return false;
 		try {
 			const reg = new URL(url);
+			// RFC 8252 requires variable ports for loopback IP literals. Exact
+			// `localhost` is a narrow compatibility extension for native clients.
+			const allowsVariablePort =
+				isLoopbackIP(reg.hostname) || reg.hostname === "localhost";
 			return (
-				isLoopbackIP(reg.hostname) &&
+				allowsVariablePort &&
 				reg.hostname === req.hostname &&
 				reg.pathname === req.pathname &&
 				reg.protocol === req.protocol &&


### PR DESCRIPTION
## Summary

Allow native OAuth clients registered with an exact `http://localhost/...` redirect URI to request the same redirect URI with an ephemeral callback port.

This aligns authorization-time matching with the OAuth provider's existing registration contract and documentation, which already permit exact `localhost` as a native HTTP loopback host with any port.

## Root cause

`findRegisteredRedirectUri` already ignored the port for registered loopback IP literals, but gated that behavior exclusively with `isLoopbackIP(reg.hostname)`. That helper intentionally excludes DNS names, so a registered `http://localhost/callback` matched itself but rejected `http://localhost:56053/callback` with `invalid_redirect`.

The matcher now grants port variance to either a strict loopback IP literal or the exact normalized hostname `localhost`.

## Security boundary

Only the port may vary. The matcher still requires exact equality for:

- protocol
- hostname
- pathname
- query

The compatibility case is deliberately limited to exact `localhost`; it does not use the broader loopback-host helper and therefore does not admit `tenant.localhost` or other DNS names. Non-loopback hosts still require the fully registered URI, including the port.

Regression coverage verifies the positive ephemeral-port case and rejects changes to path, query, protocol, hostname, `tenant.localhost`, and the port of a non-loopback host.

## Standards context

[RFC 8252 section 7.3](https://www.rfc-editor.org/rfc/rfc8252.html#section-7.3) requires authorization servers to allow an arbitrary request-time port for loopback IP literal redirect URIs so native clients can bind an available ephemeral port.

[RFC 8252 section 8.3](https://www.rfc-editor.org/rfc/rfc8252.html#section-8.3) says `localhost` functions similarly, but does not recommend it because hostname resolution can be misconfigured or attacked. Accordingly, this PR treats exact `localhost` support as a narrow Better Auth compatibility extension; it does not claim RFC 8252 requires DNS `localhost` port variance.

## Checks

- `pnpm vitest packages/oauth-provider/src/authorize.test.ts --run` — 49 passed
- `pnpm typecheck` — passed
- `pnpm --filter @better-auth/oauth-provider lint:package` — passed
- `pnpm --filter @better-auth/oauth-provider lint:types` — passed (expected ignored CommonJS-to-ESM warning only)
- commit hooks: Biome and spellcheck passed

## Breaking changes

None.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows native OAuth clients registered with `http://localhost/...` in `@better-auth/oauth-provider` to use the same redirect URI with any ephemeral port. Fixes invalid_redirect errors and aligns with loopback behavior while keeping strict matching for protocol, hostname, path, and query.

- **Bug Fixes**
  - Allow variable ports when the registered redirect uses exact `localhost`; still require exact protocol, hostname, path, and query. Rejects `tenant.localhost` and non-loopback hosts with mismatched ports.
  - Adds tests for the accepted localhost ephemeral port and for rejections on path, query, protocol, hostname, and non-loopback host ports.

<sup>Written for commit 15c51f2ec7401d2edeeb04ee21583e4474c4570f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

