### PR TITLE
fix: correctness and security fixes across mcp, oauth-provider, sso, email-otp and organization

### DIFF
--- a/.changeset/verifiable-id-tokens-and-redirect-safety.md
+++ b/.changeset/verifiable-id-tokens-and-redirect-safety.md
@@ -1,0 +1,13 @@
+---
+"better-auth": patch
+"@better-auth/oauth-provider": patch
+"@better-auth/sso": patch
+---
+
+MCP id tokens are signed with the jwt plugin's published key and discovery points at the JWKS that serves it, so a client can verify the token it receives; a public client, which holds no secret to verify with, now receives no id token instead of an unverifiable one. MCP also requires PKCE for public clients regardless of `requirePKCE`, and exports `MCPOptions`.
+
+The signed OAuth query carries a url-safe signature, so an intermediary decoding the URL once can no longer invalidate it, and the oauth-provider claim callbacks report configured `additionalFields` with their declared types.
+
+SAML logins read `InResponseTo` where the login extractor places it, so InResponseTo replay validation runs and `allowIdpInitiated: false` accepts genuine SP-initiated logins. SSO error redirects merge their parameters into the target URL instead of concatenating them, preserving any query the URL already carried and encoding values.
+
+`customSession` propagates session lookup failures rather than reporting them as `null`, which callers read as "not signed in". Verification reservations stay unique under `advanced.database.generateId: "uuid"`, so replay markers work. The generic email-OTP endpoints refuse `change-email`, which they could never read or write correctly. Deleting an organization clears the session's active organization only once the delete succeeds.

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1967,5 +1967,74 @@ describe("internal adapter test", async () => {
 			expect(first).toBe(true);
 			expect(second).toBe(true);
 		});
+
+		/**
+		 * The reservation is a replay guard, so it has to hold under every id
+		 * strategy — a deployment that silently always reserves is worse than one
+		 * that never does, because callers believe they hold the marker.
+		 *
+		 * @see https://github.com/better-auth/better-auth/issues/10624
+		 */
+		describe("under advanced.database.generateId: uuid", () => {
+			const uuidOptions = {
+				advanced: { database: { generateId: "uuid" } },
+			} satisfies Partial<BetterAuthOptions>;
+
+			it("returns false the second time for the same identifier", async () => {
+				const adapter = await makeAdapter(uuidOptions);
+
+				const first = await adapter.reserveVerificationValue({
+					identifier: "reserve:uuid-once",
+					value: "jti-uuid",
+					expiresAt: new Date(Date.now() + 60_000),
+				});
+				const second = await adapter.reserveVerificationValue({
+					identifier: "reserve:uuid-once",
+					value: "jti-uuid-replay",
+					expiresAt: new Date(Date.now() + 60_000),
+				});
+
+				expect(first).toBe(true);
+				expect(second).toBe(false);
+			});
+
+			it("yields exactly one winner under concurrent reserve", async () => {
+				const adapter = await makeAdapter(uuidOptions);
+
+				const results = await Promise.all([
+					adapter.reserveVerificationValue({
+						identifier: "reserve:uuid-race",
+						value: "jti-uuid-race",
+						expiresAt: new Date(Date.now() + 60_000),
+					}),
+					adapter.reserveVerificationValue({
+						identifier: "reserve:uuid-race",
+						value: "jti-uuid-race",
+						expiresAt: new Date(Date.now() + 60_000),
+					}),
+				]);
+
+				expect(results.filter((r) => r === true)).toHaveLength(1);
+				expect(results.filter((r) => r === false)).toHaveLength(1);
+			});
+
+			it("still reserves independently across different identifiers", async () => {
+				const adapter = await makeAdapter(uuidOptions);
+
+				const first = await adapter.reserveVerificationValue({
+					identifier: "reserve:uuid-a",
+					value: "jti-uuid-a",
+					expiresAt: new Date(Date.now() + 60_000),
+				});
+				const second = await adapter.reserveVerificationValue({
+					identifier: "reserve:uuid-b",
+					value: "jti-uuid-b",
+					expiresAt: new Date(Date.now() + 60_000),
+				});
+
+				expect(first).toBe(true);
+				expect(second).toBe(true);
+			});
+		});
 	});
 });

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -13,7 +13,6 @@ import type { InternalLogger } from "@better-auth/core/env";
 import { generateId } from "@better-auth/core/utils/id";
 import { getIp } from "@better-auth/core/utils/ip";
 import { safeJSONParse } from "@better-auth/core/utils/json";
-import { base64Url } from "@better-auth/utils/base64";
 import { createHash } from "@better-auth/utils/hash";
 import type { Account, Session, User, Verification } from "../types";
 import { getDate } from "../utils/date";
@@ -1400,14 +1399,32 @@ export const createInternalAdapter = (
 			value: string;
 			expiresAt: Date;
 		}): Promise<boolean> => {
-			const reservationId = base64Url.encode(
-				new Uint8Array(
-					await createHash("SHA-256").digest(
-						new TextEncoder().encode("reserve:" + data.identifier),
-					),
+			/**
+			 * The reservation's uniqueness is the primary key: the same identifier
+			 * must derive the same id so a second caller collides and loses. Shape
+			 * it as a UUID, because adapters configured for UUID ids validate the
+			 * value passed with `forceAllowId` and discard anything else — which
+			 * would hand every caller a different id and turn the guard into a
+			 * silent no-op (or a NOT NULL failure, depending on the dialect).
+			 */
+			const digest = new Uint8Array(
+				await createHash("SHA-256").digest(
+					new TextEncoder().encode("reserve:" + data.identifier),
 				),
-				{ padding: false },
 			);
+			const uuidBytes = digest.slice(0, 16);
+			uuidBytes[6] = (uuidBytes[6]! & 0x0f) | 0x50; // version 5: name-derived
+			uuidBytes[8] = (uuidBytes[8]! & 0x3f) | 0x80; // RFC 4122 variant
+			const hex = Array.from(uuidBytes, (b) =>
+				b.toString(16).padStart(2, "0"),
+			).join("");
+			const reservationId = [
+				hex.slice(0, 8),
+				hex.slice(8, 12),
+				hex.slice(12, 16),
+				hex.slice(16, 20),
+				hex.slice(20),
+			].join("-");
 			const storageOption = getStorageOption(
 				data.identifier,
 				options.verification?.storeIdentifier,

--- a/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
+++ b/packages/better-auth/src/plugins/custom-session/custom-session.test.ts
@@ -1,3 +1,4 @@
+import { memoryAdapter } from "@better-auth/memory-adapter";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { createAuthClient } from "../../client";
 import { parseSetCookieHeader } from "../../cookies";
@@ -448,5 +449,69 @@ describe("Custom Session Plugin Tests", async () => {
 		expectTypeOf<CustomData>().toMatchObjectType<{
 			message: string;
 		}>();
+	});
+});
+
+/**
+ * `null` is the "not authenticated" signal, so callers redirect to login and
+ * clear cookies on it. A lookup failure must not be reported that way, or a few
+ * seconds of database trouble signs out users whose sessions are valid.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10566
+ */
+describe("Custom Session error semantics", async () => {
+	let failSessionLookup = false;
+	const db = {
+		user: [],
+		session: [],
+		account: [],
+		verification: [],
+	};
+
+	const failingAdapter: BetterAuthOptions["database"] = (options) => {
+		const adapter = memoryAdapter(db)(options);
+		const findOne: typeof adapter.findOne = async (data) => {
+			if (failSessionLookup && data.model === "session") {
+				throw new Error("database unavailable");
+			}
+			return adapter.findOne(data);
+		};
+		return { ...adapter, findOne };
+	};
+
+	const { auth, signInWithTestUser } = await getTestInstance({
+		database: failingAdapter,
+		// The DB must actually be consulted, so no cookie cache.
+		session: { cookieCache: { enabled: false } },
+		plugins: [customSession(async ({ user, session }) => ({ user, session }))],
+	});
+
+	it("should propagate a session lookup failure instead of returning null", async () => {
+		const { headers } = await signInWithTestUser();
+
+		// Sanity: the same call succeeds while the store is healthy, so a null
+		// below could only come from the failure, never from a bad fixture.
+		await expect(auth.api.getSession({ headers })).resolves.not.toBeNull();
+
+		failSessionLookup = true;
+		try {
+			await expect(auth.api.getSession({ headers })).rejects.toThrow();
+		} finally {
+			failSessionLookup = false;
+		}
+	});
+
+	it("should still return null when there is genuinely no session", async () => {
+		await expect(
+			auth.api.getSession({ headers: new Headers() }),
+		).resolves.toBeNull();
+	});
+
+	it("should still return the custom shape when healthy", async () => {
+		const { headers } = await signInWithTestUser();
+		const session = await auth.api.getSession({ headers });
+
+		expect(session?.user).toBeDefined();
+		expect(session?.session).toBeDefined();
 	});
 });

--- a/packages/better-auth/src/plugins/custom-session/index.ts
+++ b/packages/better-auth/src/plugins/custom-session/index.ts
@@ -98,14 +98,19 @@ export const customSession = <
 					requireHeaders: true,
 				},
 				async (ctx): Promise<Returns | null> => {
+					/**
+					 * Deliberately uncaught: `/get-session` already rethrows APIErrors
+					 * and normalizes anything else to INTERNAL_SERVER_ERROR, returning
+					 * null only when there is genuinely no session. Swallowing that here
+					 * reported a failed lookup as "not signed in", so callers that gate
+					 * on null signed out users whose sessions were valid.
+					 */
 					const session = await getSession()({
 						...ctx,
 						method: "GET",
 						asResponse: false,
 						headers: ctx.headers,
 						returnHeaders: true,
-					}).catch((e) => {
-						return null;
 					});
 					if (!session?.response) {
 						return ctx.json(null);

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -2655,3 +2655,90 @@ describe("email-otp send origin/CSRF protection", async () => {
 		expect(sendVerificationOTP).toHaveBeenCalledTimes(1);
 	});
 });
+
+/**
+ * A change-email OTP is stored against both the current and the new address,
+ * because that pairing is what binds the code to one target mailbox. The
+ * generic endpoints build the identifier from the current address alone, so
+ * they can neither read nor write a real change-email code — and the one they
+ * do write carries no target at all. `sendVerificationOTP` already refuses the
+ * type for this reason; the rest must too.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10612
+ */
+describe("email-otp generic endpoints reject change-email", async () => {
+	let sentOtp = "";
+	const { auth, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			emailOTP({
+				generateOTP: () => "123456",
+				changeEmail: { enabled: true },
+				async sendVerificationOTP({ otp }) {
+					sentOtp = otp;
+				},
+			}),
+		],
+	});
+
+	it("should reject change-email in createVerificationOTP", async () => {
+		await expect(
+			auth.api.createVerificationOTP({
+				body: { email: "test@test.com", type: "change-email" },
+			}),
+		).rejects.toThrow();
+	});
+
+	it("should reject change-email in getVerificationOTP", async () => {
+		await expect(
+			auth.api.getVerificationOTP({
+				query: { email: "test@test.com", type: "change-email" },
+			}),
+		).rejects.toThrow();
+	});
+
+	it("should reject change-email in checkVerificationOTP", async () => {
+		await expect(
+			auth.api.checkVerificationOTP({
+				body: {
+					email: "test@test.com",
+					type: "change-email",
+					otp: "123456",
+				},
+			}),
+		).rejects.toThrow();
+	});
+
+	it("should leave the other otp types working", async () => {
+		const created = await auth.api.createVerificationOTP({
+			body: { email: "test@test.com", type: "email-verification" },
+		});
+		expect(created).toBeTruthy();
+
+		await expect(
+			auth.api.checkVerificationOTP({
+				body: {
+					email: "test@test.com",
+					type: "email-verification",
+					otp: created,
+				},
+			}),
+		).resolves.toMatchObject({ success: true });
+	});
+
+	it("should leave the dedicated change-email flow working", async () => {
+		const { headers } = await signInWithTestUser();
+
+		await auth.api.requestEmailChangeEmailOTP({
+			body: { newEmail: "changed@test.com" },
+			headers,
+		});
+		expect(sentOtp).toBeTruthy();
+
+		await expect(
+			auth.api.changeEmailEmailOTP({
+				body: { newEmail: "changed@test.com", otp: sentOtp },
+				headers,
+			}),
+		).resolves.toBeTruthy();
+	});
+});

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -200,6 +200,17 @@ export const createVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 			},
 		},
 		async (ctx) => {
+			// A change-email OTP is keyed by both the current and the new address,
+			// so this endpoint can neither read nor write a real one. Refuse the
+			// type rather than act on an identifier that binds no target mailbox.
+			if (ctx.body.type === "change-email") {
+				ctx.context.logger.error(
+					"Use the /email-otp/request-email-change and /email-otp/change-email endpoints for changing email",
+				);
+				throw APIError.fromStatus("BAD_REQUEST", {
+					message: "Invalid OTP type",
+				});
+			}
 			const email = ctx.body.email.toLowerCase();
 			const otp =
 				opts.generateOTP({ email, type: ctx.body.type }, ctx) ||
@@ -270,6 +281,17 @@ export const getVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 			},
 		},
 		async (ctx) => {
+			// A change-email OTP is keyed by both the current and the new address,
+			// so this endpoint can neither read nor write a real one. Refuse the
+			// type rather than act on an identifier that binds no target mailbox.
+			if (ctx.query.type === "change-email") {
+				ctx.context.logger.error(
+					"Use the /email-otp/request-email-change and /email-otp/change-email endpoints for changing email",
+				);
+				throw APIError.fromStatus("BAD_REQUEST", {
+					message: "Invalid OTP type",
+				});
+			}
 			const email = ctx.query.email.toLowerCase();
 			const verificationValue =
 				await ctx.context.internalAdapter.findVerificationValue(
@@ -365,6 +387,17 @@ export const checkVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 			},
 		},
 		async (ctx) => {
+			// A change-email OTP is keyed by both the current and the new address,
+			// so this endpoint can neither read nor write a real one. Refuse the
+			// type rather than act on an identifier that binds no target mailbox.
+			if (ctx.body.type === "change-email") {
+				ctx.context.logger.error(
+					"Use the /email-otp/request-email-change and /email-otp/change-email endpoints for changing email",
+				);
+				throw APIError.fromStatus("BAD_REQUEST", {
+					message: "Invalid OTP type",
+				});
+			}
 			const email = ctx.body.email.toLowerCase();
 			const isValidEmail = z.email().safeParse(email);
 			if (!isValidEmail.success) {

--- a/packages/better-auth/src/plugins/mcp/authorize.ts
+++ b/packages/better-auth/src/plugins/mcp/authorize.ts
@@ -136,9 +136,19 @@ export async function authorizeMCPOAuth(
 		);
 	}
 
+	/**
+	 * A public client proves nothing at the token endpoint — it has no secret —
+	 * so the PKCE challenge is the only thing binding an authorization code to
+	 * the client that asked for it. Require it for public clients whatever
+	 * `requirePKCE` says; without a stored challenge the token endpoint has
+	 * nothing to check a verifier against, and an intercepted code is redeemable
+	 * by anyone. Confidential clients authenticate with their secret, so for them
+	 * PKCE stays opt-in.
+	 */
+	const isPublicClient = client.type === "public";
 	if (
 		(!query.code_challenge || !query.code_challenge_method) &&
-		options.requirePKCE
+		(options.requirePKCE || isPublicClient)
 	) {
 		throw ctx.redirect(
 			redirectErrorURL(

--- a/packages/better-auth/src/plugins/mcp/authorize.ts
+++ b/packages/better-auth/src/plugins/mcp/authorize.ts
@@ -146,10 +146,22 @@ export async function authorizeMCPOAuth(
 	 * PKCE stays opt-in.
 	 */
 	const isPublicClient = client.type === "public";
-	if (
-		(!query.code_challenge || !query.code_challenge_method) &&
-		(options.requirePKCE || isPublicClient)
-	) {
+	const missingChallenge = !query.code_challenge;
+	const missingMethod = !query.code_challenge_method;
+
+	// `requirePKCE` keeps the strictness it always had: both parts or nothing.
+	const failsExplicitRequirement =
+		options.requirePKCE && (missingChallenge || missingMethod);
+
+	// A public client must always send the challenge. The method may still be
+	// omitted by a caller who opted into the legacy plain fallback below, which
+	// is a documented compatibility path and not ours to withdraw here.
+	const failsPublicClientRequirement =
+		isPublicClient &&
+		(missingChallenge ||
+			(missingMethod && !options.allowPlainCodeChallengeMethod));
+
+	if (failsExplicitRequirement || failsPublicClientRequirement) {
 		throw ctx.redirect(
 			redirectErrorURL(
 				query.redirect_uri,

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -10,7 +10,6 @@ import {
 import { isProduction, logger } from "@better-auth/core/env";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { isSafeUrlScheme } from "@better-auth/core/utils/url";
-import { getWebcryptoSubtle } from "@better-auth/utils";
 import { base64 } from "@better-auth/utils/base64";
 import { createHash } from "@better-auth/utils/hash";
 import { SignJWT } from "jose";
@@ -26,6 +25,7 @@ import {
 	resolveBaseURL,
 } from "../../utils/url";
 import { PACKAGE_VERSION } from "../../version";
+import { getJwtToken } from "../jwt";
 import type {
 	Client,
 	CodeVerificationValue,
@@ -68,12 +68,19 @@ export const getMCPProviderMetadata = (
 				"issuer or baseURL is not set. If you're the app developer, please make sure to set the `baseURL` in your auth config.",
 		});
 	}
+	/**
+	 * Advertise what the token endpoint actually signs with: the jwt plugin's
+	 * published keys when it is installed, otherwise the client secret.
+	 */
+	const supportedAlgs = ctx.context.getPlugin("jwt")
+		? ["RS256", "EdDSA"]
+		: ["HS256"];
 	return {
 		issuer,
 		authorization_endpoint: `${baseURL}/mcp/authorize`,
 		token_endpoint: `${baseURL}/mcp/token`,
 		userinfo_endpoint: `${baseURL}/mcp/userinfo`,
-		jwks_uri: `${baseURL}/mcp/jwks`,
+		jwks_uri: `${baseURL}/jwks`,
 		registration_endpoint: `${baseURL}/mcp/register`,
 		scopes_supported: ["openid", "profile", "email", "offline_access"],
 		response_types_supported: ["code"],
@@ -84,7 +91,7 @@ export const getMCPProviderMetadata = (
 			"urn:mace:incommon:iap:bronze",
 		],
 		subject_types_supported: ["public"],
-		id_token_signing_alg_values_supported: ["RS256"],
+		id_token_signing_alg_values_supported: supportedAlgs,
 		token_endpoint_auth_methods_supported: [
 			"client_secret_basic",
 			"client_secret_post",
@@ -117,7 +124,7 @@ export const getMCPProtectedResourceMetadata = (
 	return {
 		resource: options?.resource ?? origin,
 		authorization_servers: [origin],
-		jwks_uri: options?.oidcConfig?.metadata?.jwks_uri ?? `${baseURL}/mcp/jwks`,
+		jwks_uri: options?.oidcConfig?.metadata?.jwks_uri ?? `${baseURL}/jwks`,
 		scopes_supported: options?.oidcConfig?.metadata?.scopes_supported ?? [
 			"openid",
 			"profile",
@@ -724,17 +731,6 @@ export const mcp = (options: MCPOptions) => {
 							error: "invalid_grant",
 						});
 					}
-					const secretKey = {
-						alg: "HS256",
-						key: await getWebcryptoSubtle().generateKey(
-							{
-								name: "HMAC",
-								hash: "SHA-256",
-							},
-							true,
-							["sign", "verify"],
-						),
-					};
 					const profile = {
 						given_name: user.name.split(" ")[0]!,
 						family_name: user.name.split(" ")[1]!,
@@ -759,7 +755,7 @@ export const mcp = (options: MCPOptions) => {
 							)
 						: {};
 
-					const idToken = await new SignJWT({
+					const idTokenPayload = {
 						sub: user.id,
 						aud: client_id.toString(),
 						iat: Date.now(),
@@ -770,13 +766,43 @@ export const mcp = (options: MCPOptions) => {
 						acr: "urn:mace:incommon:iap:silver", // default to silver - ⚠︎ this should be configurable and should be validated against the client's metadata
 						...userClaims,
 						...additionalUserClaims,
-					})
-						.setProtectedHeader({ alg: secretKey.alg })
-						.setIssuedAt()
-						.setExpirationTime(
-							Math.floor(Date.now() / 1000) + opts.accessTokenExpiresIn,
-						)
-						.sign(secretKey.key);
+					};
+					const idTokenExpiresAt =
+						Math.floor(Date.now() / 1000) + opts.accessTokenExpiresIn;
+
+					/**
+					 * The discovery document advertises RS256 id tokens and a JWKS, so sign
+					 * with the jwt plugin's published key whenever it is installed — that is
+					 * the key clients fetch to verify. Without it, fall back to the client
+					 * secret so a confidential client can still verify with something it
+					 * holds; a public client has no such secret and gets no id token rather
+					 * than one nothing can check.
+					 */
+					const jwtPlugin = ctx.context.getPlugin("jwt");
+					let idToken: string | undefined;
+					if (jwtPlugin) {
+						idToken = await getJwtToken(ctx, {
+							...jwtPlugin.options,
+							jwt: {
+								...jwtPlugin.options?.jwt,
+								getSubject: () => user.id,
+								audience: client_id.toString(),
+								issuer:
+									jwtPlugin.options?.jwt?.issuer ??
+									(typeof ctx.context.options.baseURL === "string"
+										? ctx.context.options.baseURL
+										: undefined),
+								expirationTime: idTokenExpiresAt,
+								definePayload: () => idTokenPayload,
+							},
+						});
+					} else if (client.clientSecret) {
+						idToken = await new SignJWT(idTokenPayload)
+							.setProtectedHeader({ alg: "HS256" })
+							.setIssuedAt()
+							.setExpirationTime(idTokenExpiresAt)
+							.sign(new TextEncoder().encode(client.clientSecret));
+					}
 					return ctx.json(
 						{
 							access_token: accessToken,

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -65,6 +65,12 @@ export interface MCPOptions {
  *
  * Declared as a complete record so adding a member to `JWSAlgorithms` fails the
  * build here until discovery advertises it too.
+ *
+ * A deployment that supplies `jwt.sign` signs outside this set entirely — that
+ * callback owns every header, `alg` included, so no value here can describe it.
+ * Such a deployment declares its own algorithms through
+ * `oidcConfig.metadata.id_token_signing_alg_values_supported`, which is merged
+ * over this default.
  */
 const JWT_PLUGIN_ALGORITHMS: Record<JWSAlgorithms, true> = {
 	EdDSA: true,
@@ -321,7 +327,9 @@ export const mcp = (options: MCPOptions) => {
 				},
 				async (c) => {
 					try {
-						const metadata = getMCPProviderMetadata(c, options);
+						// `opts` carries the resolved oidc config; `options` is MCPOptions and
+						// has no `metadata`, so passing it silently dropped every override.
+						const metadata = getMCPProviderMetadata(c, opts);
 						return c.json(metadata);
 					} catch (e) {
 						console.log(e);

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -46,7 +46,7 @@ declare module "@better-auth/core" {
 	}
 }
 
-interface MCPOptions {
+export interface MCPOptions {
 	loginPage: string;
 	resource?: string | undefined;
 	oidcConfig?: OIDCOptions | undefined;

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -26,6 +26,7 @@ import {
 } from "../../utils/url";
 import { PACKAGE_VERSION } from "../../version";
 import { getJwtToken } from "../jwt";
+import type { JWSAlgorithms } from "../jwt/types";
 import type {
 	Client,
 	CodeVerificationValue,
@@ -53,14 +54,42 @@ export interface MCPOptions {
 }
 
 /**
+ * Every algorithm the jwt plugin can be configured to sign with.
+ *
+ * Discovery cannot know which one a given token used: the signer prefers the
+ * algorithm recorded on the active persisted key over the configured one, and
+ * reading that key is asynchronous. `id_token_signing_alg_values_supported` is
+ * the set the server supports rather than the one currently in use, so listing
+ * all of them is both accurate and safe — a client never meets an algorithm it
+ * was not told about.
+ *
+ * Declared as a complete record so adding a member to `JWSAlgorithms` fails the
+ * build here until discovery advertises it too.
+ */
+const JWT_PLUGIN_ALGORITHMS: Record<JWSAlgorithms, true> = {
+	EdDSA: true,
+	ES256: true,
+	ES512: true,
+	PS256: true,
+	RS256: true,
+};
+
+/**
  * The URL discovery should name for the keys that verify an issued id token.
  *
  * The jwt plugin owns the JWKS and may serve it from a custom path or host it
  * remotely, so neither is safe to assume. Without that plugin an id token is
- * signed with the client secret and there is no key set to fetch.
+ * signed with the client secret: there is no key set to publish, and naming one
+ * would send clients to an endpoint that does not exist. Mirrors how
+ * `@better-auth/oauth-provider` builds the same field.
  */
-function resolveJwksUri(ctx: GenericEndpointContext, baseURL: string) {
-	const jwks = ctx.context.getPlugin("jwt")?.options?.jwks;
+function resolveJwksUri(
+	ctx: GenericEndpointContext,
+	baseURL: string,
+): string | undefined {
+	const jwtPlugin = ctx.context.getPlugin("jwt");
+	if (!jwtPlugin) return undefined;
+	const jwks = jwtPlugin.options?.jwks;
 	return jwks?.remoteUrl ?? `${baseURL}${jwks?.jwksPath ?? "/jwks"}`;
 }
 
@@ -80,17 +109,11 @@ export const getMCPProviderMetadata = (
 				"issuer or baseURL is not set. If you're the app developer, please make sure to set the `baseURL` in your auth config.",
 		});
 	}
-	/**
-	 * Advertise the algorithm the id token is really signed with. The jwt
-	 * plugin's key pair may be any supported algorithm, and a client that is
-	 * handed one it was never told about rejects the token. Without that plugin
-	 * the id token is signed with the client secret, which is HS256.
-	 */
 	// Presence of the plugin decides, not presence of its options: `jwt()` takes
-	// none, and then signs with the default EdDSA key pair.
-	const jwtPlugin = ctx.context.getPlugin("jwt");
-	const supportedAlgs = jwtPlugin
-		? [jwtPlugin.options?.jwks?.keyPairConfig?.alg ?? "EdDSA"]
+	// none and still signs. Without it the id token is signed with the client
+	// secret, which is HS256.
+	const supportedAlgs = ctx.context.getPlugin("jwt")
+		? Object.keys(JWT_PLUGIN_ALGORITHMS)
 		: ["HS256"];
 	return {
 		issuer,

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -52,6 +52,18 @@ export interface MCPOptions {
 	oidcConfig?: OIDCOptions | undefined;
 }
 
+/**
+ * The URL discovery should name for the keys that verify an issued id token.
+ *
+ * The jwt plugin owns the JWKS and may serve it from a custom path or host it
+ * remotely, so neither is safe to assume. Without that plugin an id token is
+ * signed with the client secret and there is no key set to fetch.
+ */
+function resolveJwksUri(ctx: GenericEndpointContext, baseURL: string) {
+	const jwks = ctx.context.getPlugin("jwt")?.options?.jwks;
+	return jwks?.remoteUrl ?? `${baseURL}${jwks?.jwksPath ?? "/jwks"}`;
+}
+
 export const getMCPProviderMetadata = (
 	ctx: GenericEndpointContext,
 	options?: OIDCOptions | undefined,
@@ -69,18 +81,23 @@ export const getMCPProviderMetadata = (
 		});
 	}
 	/**
-	 * Advertise what the token endpoint actually signs with: the jwt plugin's
-	 * published keys when it is installed, otherwise the client secret.
+	 * Advertise the algorithm the id token is really signed with. The jwt
+	 * plugin's key pair may be any supported algorithm, and a client that is
+	 * handed one it was never told about rejects the token. Without that plugin
+	 * the id token is signed with the client secret, which is HS256.
 	 */
-	const supportedAlgs = ctx.context.getPlugin("jwt")
-		? ["RS256", "EdDSA"]
+	// Presence of the plugin decides, not presence of its options: `jwt()` takes
+	// none, and then signs with the default EdDSA key pair.
+	const jwtPlugin = ctx.context.getPlugin("jwt");
+	const supportedAlgs = jwtPlugin
+		? [jwtPlugin.options?.jwks?.keyPairConfig?.alg ?? "EdDSA"]
 		: ["HS256"];
 	return {
 		issuer,
 		authorization_endpoint: `${baseURL}/mcp/authorize`,
 		token_endpoint: `${baseURL}/mcp/token`,
 		userinfo_endpoint: `${baseURL}/mcp/userinfo`,
-		jwks_uri: `${baseURL}/jwks`,
+		jwks_uri: resolveJwksUri(ctx, baseURL),
 		registration_endpoint: `${baseURL}/mcp/register`,
 		scopes_supported: ["openid", "profile", "email", "offline_access"],
 		response_types_supported: ["code"],
@@ -124,7 +141,8 @@ export const getMCPProtectedResourceMetadata = (
 	return {
 		resource: options?.resource ?? origin,
 		authorization_servers: [origin],
-		jwks_uri: options?.oidcConfig?.metadata?.jwks_uri ?? `${baseURL}/jwks`,
+		jwks_uri:
+			options?.oidcConfig?.metadata?.jwks_uri ?? resolveJwksUri(ctx, baseURL),
 		scopes_supported: options?.oidcConfig?.metadata?.scopes_supported ?? [
 			"openid",
 			"profile",

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -443,8 +443,13 @@ describe("mcp", async () => {
 			response_modes_supported: ["query"],
 			grant_types_supported: ["authorization_code", "refresh_token"],
 			subject_types_supported: ["public"],
-			// This instance installs jwt() with its default key pair.
-			id_token_signing_alg_values_supported: ["EdDSA"],
+			id_token_signing_alg_values_supported: [
+				"EdDSA",
+				"ES256",
+				"ES512",
+				"PS256",
+				"RS256",
+			],
 			token_endpoint_auth_methods_supported: [
 				"client_secret_basic",
 				"client_secret_post",
@@ -1899,24 +1904,35 @@ describe("mcp discovery follows the jwt plugin's configuration", async () => {
 		});
 
 		expect(metadata.jwks_uri).toBe("https://cdn.example.com/keys.json");
-		expect(metadata.id_token_signing_alg_values_supported).toEqual(["RS256"]);
 	});
 
-	it("should advertise the configured signing algorithm", async ({
+	it("should advertise every algorithm the plugin can sign with", async ({
 		expect,
 	}) => {
-		const metadata = await metadataFor({
+		// The signer prefers the algorithm on the active persisted key over the
+		// configured one, so discovery cannot name a single value. Advertising the
+		// whole supported set means a client never meets an unadvertised one.
+		const configured = await metadataFor({
 			jwks: { keyPairConfig: { alg: "ES256" } },
 		});
+		const defaulted = await metadataFor({});
 
-		expect(metadata.id_token_signing_alg_values_supported).toEqual(["ES256"]);
+		for (const algs of [
+			configured.id_token_signing_alg_values_supported,
+			defaulted.id_token_signing_alg_values_supported,
+		]) {
+			expect(algs).toEqual(
+				expect.arrayContaining(["EdDSA", "ES256", "ES512", "PS256", "RS256"]),
+			);
+		}
 	});
 
-	it("should advertise EdDSA when the jwt plugin uses its default key", async ({
+	it("should publish no jwks_uri when there is no jwt plugin to serve one", async ({
 		expect,
 	}) => {
-		const metadata = await metadataFor({});
+		const metadata = await metadataFor();
 
-		expect(metadata.id_token_signing_alg_values_supported).toEqual(["EdDSA"]);
+		expect(metadata.jwks_uri).toBeUndefined();
+		expect(metadata.id_token_signing_alg_values_supported).toEqual(["HS256"]);
 	});
 });

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -443,7 +443,8 @@ describe("mcp", async () => {
 			response_modes_supported: ["query"],
 			grant_types_supported: ["authorization_code", "refresh_token"],
 			subject_types_supported: ["public"],
-			id_token_signing_alg_values_supported: ["RS256", "EdDSA"],
+			// This instance installs jwt() with its default key pair.
+			id_token_signing_alg_values_supported: ["EdDSA"],
 			token_endpoint_auth_methods_supported: [
 				"client_secret_basic",
 				"client_secret_post",
@@ -1766,5 +1767,81 @@ describe("mcp public types", () => {
 	it("exports MCPOptions from the plugins entrypoint", () => {
 		expectTypeOf<MCPOptions["loginPage"]>().toEqualTypeOf<string>();
 		expectTypeOf<MCPOptions["resource"]>().toEqualTypeOf<string | undefined>();
+	});
+});
+
+/**
+ * Discovery has to name the key location and algorithm the signer actually
+ * uses. The jwt plugin can move its JWKS and can be configured for any
+ * supported algorithm, so neither may be assumed.
+ */
+describe("mcp discovery follows the jwt plugin's configuration", async () => {
+	async function metadataFor(jwtOptions?: Parameters<typeof jwt>[0]) {
+		const tempServer = await listen(
+			toNodeHandler(async () => new Response("temp")),
+			{ port: 0 },
+		);
+		const port = tempServer.address?.port || 3005;
+		const baseURL = `http://localhost:${port}`;
+		await tempServer.close();
+
+		const { auth, customFetchImpl } = await getTestInstance({
+			baseURL,
+			plugins: jwtOptions
+				? [mcp({ loginPage: "/login" }), jwt(jwtOptions)]
+				: [mcp({ loginPage: "/login" })],
+		});
+		const server = await listen(toNodeHandler(auth.handler), { port });
+
+		const client = createAuthClient({
+			baseURL,
+			fetchOptions: { customFetchImpl },
+		});
+		const metadata = await client.$fetch<Record<string, any>>(
+			"/.well-known/oauth-authorization-server",
+		);
+		await server.close();
+		return metadata.data!;
+	}
+
+	it("should advertise a custom jwks path", async ({ expect }) => {
+		const metadata = await metadataFor({
+			jwks: { jwksPath: "/.well-known/jwks.json" },
+		});
+
+		expect(metadata.jwks_uri).toContain("/.well-known/jwks.json");
+		expect(metadata.jwks_uri).not.toMatch(/\/jwks$/);
+	});
+
+	it("should advertise a remotely hosted jwks", async ({ expect }) => {
+		// The library requires an explicit alg alongside remoteUrl, since it can no
+		// longer read one off a locally generated key pair.
+		const metadata = await metadataFor({
+			jwks: {
+				remoteUrl: "https://cdn.example.com/keys.json",
+				keyPairConfig: { alg: "RS256" },
+			},
+		});
+
+		expect(metadata.jwks_uri).toBe("https://cdn.example.com/keys.json");
+		expect(metadata.id_token_signing_alg_values_supported).toEqual(["RS256"]);
+	});
+
+	it("should advertise the configured signing algorithm", async ({
+		expect,
+	}) => {
+		const metadata = await metadataFor({
+			jwks: { keyPairConfig: { alg: "ES256" } },
+		});
+
+		expect(metadata.id_token_signing_alg_values_supported).toEqual(["ES256"]);
+	});
+
+	it("should advertise EdDSA when the jwt plugin uses its default key", async ({
+		expect,
+	}) => {
+		const metadata = await metadataFor({});
+
+		expect(metadata.id_token_signing_alg_values_supported).toEqual(["EdDSA"]);
 	});
 });

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -1488,3 +1488,122 @@ describe("mcp id token verifiability (security)", async () => {
 		);
 	});
 });
+
+/**
+ * A public client cannot keep a secret, so PKCE is the only thing binding an
+ * authorization code to the client that requested it. It must not be optional.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10637
+ */
+describe("mcp pkce enforcement for public clients (security)", async () => {
+	const tempServer = await listen(
+		toNodeHandler(async () => new Response("temp")),
+		{ port: 0 },
+	);
+	const port = tempServer.address?.port || 3003;
+	const baseURL = `http://localhost:${port}`;
+	await tempServer.close();
+
+	// No requirePKCE here on purpose: the default must already be safe.
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL,
+		plugins: [mcp({ loginPage: "/login" })],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const serverClient = createAuthClient({
+		baseURL,
+		fetchOptions: { customFetchImpl, headers },
+	});
+
+	const server = await listen(toNodeHandler(auth.handler), { port });
+	afterAll(async () => {
+		await server.close();
+	});
+
+	async function register(authMethod: "none" | "client_secret_basic") {
+		const created = await serverClient.$fetch("/mcp/register", {
+			method: "POST",
+			body: {
+				client_name: `pkce-${authMethod}`,
+				redirect_uris: ["http://localhost:3000/callback"],
+				token_endpoint_auth_method: authMethod,
+			},
+		});
+		return created.data as any;
+	}
+
+	/** Authorizes without any code_challenge and returns the resulting redirect. */
+	async function authorizeWithoutPKCE(client: any) {
+		const url =
+			`${baseURL}/api/auth/mcp/authorize?` +
+			new URLSearchParams({
+				client_id: client.client_id,
+				redirect_uri: client.redirect_uris[0],
+				response_type: "code",
+				scope: "openid profile email",
+			}).toString();
+
+		let location = "";
+		await serverClient.$fetch(url, {
+			method: "GET",
+			onError(context: any) {
+				location = context.response.headers.get("Location") || "";
+			},
+			onSuccess(context: any) {
+				location = context.response.headers.get("Location") || location;
+			},
+		});
+		return new URL(location);
+	}
+
+	it("should reject a public client that omits PKCE, by default", async ({
+		expect,
+	}) => {
+		const redirect = await authorizeWithoutPKCE(await register("none"));
+
+		expect(redirect.searchParams.get("code")).toBeNull();
+		expect(redirect.searchParams.get("error")).toBe("invalid_request");
+	});
+
+	it("should still issue a code to a public client that uses PKCE", async ({
+		expect,
+	}) => {
+		const client = await register("none");
+		const challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"; // S256 of a known verifier
+
+		const url =
+			`${baseURL}/api/auth/mcp/authorize?` +
+			new URLSearchParams({
+				client_id: client.client_id,
+				redirect_uri: client.redirect_uris[0],
+				response_type: "code",
+				scope: "openid profile email",
+				code_challenge: challenge,
+				code_challenge_method: "S256",
+			}).toString();
+
+		let location = "";
+		await serverClient.$fetch(url, {
+			method: "GET",
+			onError(context: any) {
+				location = context.response.headers.get("Location") || "";
+			},
+			onSuccess(context: any) {
+				location = context.response.headers.get("Location") || location;
+			},
+		});
+		expect(new URL(location).searchParams.get("code")).toBeTruthy();
+	});
+
+	it("should leave confidential clients free to skip PKCE", async ({
+		expect,
+	}) => {
+		const redirect = await authorizeWithoutPKCE(
+			await register("client_secret_basic"),
+		);
+
+		expect(redirect.searchParams.get("code")).toBeTruthy();
+		expect(redirect.searchParams.get("error")).toBeNull();
+	});
+});

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -1,9 +1,10 @@
 import { jwtVerify } from "jose";
 import { listen } from "listhen";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, expectTypeOf, it } from "vitest";
 import { createAuthClient } from "../../client";
 import { toNodeHandler } from "../../integrations/node";
 import { getTestInstance } from "../../test-utils/test-instance";
+import type { MCPOptions } from "..";
 import { genericOAuth } from "../generic-oauth";
 import { genericOAuthClient } from "../generic-oauth/client";
 import { jwt } from "../jwt";
@@ -1752,5 +1753,18 @@ describe("mcp id token without the jwt plugin (security)", async () => {
 		expect(metadata.data?.id_token_signing_alg_values_supported).toEqual([
 			"HS256",
 		]);
+	});
+});
+
+/**
+ * A consumer whose exported value is typed by this plugin needs to name the
+ * options type, or declaration emit fails with TS4023.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10532
+ */
+describe("mcp public types", () => {
+	it("exports MCPOptions from the plugins entrypoint", () => {
+		expectTypeOf<MCPOptions["loginPage"]>().toEqualTypeOf<string>();
+		expectTypeOf<MCPOptions["resource"]>().toEqualTypeOf<string | undefined>();
 	});
 });

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -1599,6 +1599,81 @@ describe("mcp pkce enforcement for public clients (security)", async () => {
 		expect(new URL(location).searchParams.get("code")).toBeTruthy();
 	});
 
+	it("should honour the plain-method opt-in for public clients", async ({
+		expect,
+	}) => {
+		// `allowPlainCodeChallengeMethod` is a documented compatibility path: a
+		// caller who opts in may omit `code_challenge_method` and have it default
+		// to "plain". Requiring PKCE for public clients must not withdraw it.
+		const tempServer = await listen(
+			toNodeHandler(async () => new Response("temp")),
+			{ port: 0 },
+		);
+		const plainPort = tempServer.address?.port || 3006;
+		const plainBaseURL = `http://localhost:${plainPort}`;
+		await tempServer.close();
+
+		const {
+			auth: plainAuth,
+			signInWithTestUser: plainSignIn,
+			customFetchImpl: plainFetch,
+		} = await getTestInstance({
+			baseURL: plainBaseURL,
+			plugins: [
+				mcp({
+					loginPage: "/login",
+					oidcConfig: {
+						loginPage: "/login",
+						allowPlainCodeChallengeMethod: true,
+					},
+				}),
+			],
+		});
+		const { headers: plainHeaders } = await plainSignIn();
+		const plainClient = createAuthClient({
+			baseURL: plainBaseURL,
+			fetchOptions: { customFetchImpl: plainFetch, headers: plainHeaders },
+		});
+		const plainServer = await listen(toNodeHandler(plainAuth.handler), {
+			port: plainPort,
+		});
+
+		const registered = await plainClient.$fetch("/mcp/register", {
+			method: "POST",
+			body: {
+				client_name: "plain-pkce-public",
+				redirect_uris: ["http://localhost:3000/callback"],
+				token_endpoint_auth_method: "none",
+			},
+		});
+		const client = registered.data as { client_id: string };
+
+		let location = "";
+		await plainClient.$fetch(
+			`${plainBaseURL}/api/auth/mcp/authorize?` +
+				new URLSearchParams({
+					client_id: client.client_id,
+					redirect_uri: "http://localhost:3000/callback",
+					response_type: "code",
+					scope: "openid",
+					// A challenge, but deliberately no method.
+					code_challenge: "a-plain-challenge-value",
+				}).toString(),
+			{
+				method: "GET",
+				onError(context: { response: Response }) {
+					location = context.response.headers.get("Location") || "";
+				},
+				onSuccess(context: { response: Response }) {
+					location = context.response.headers.get("Location") || location;
+				},
+			},
+		);
+		await plainServer.close();
+
+		expect(new URL(location).searchParams.get("code")).toBeTruthy();
+	});
+
 	it("should leave confidential clients free to skip PKCE", async ({
 		expect,
 	}) => {

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -434,14 +434,14 @@ describe("mcp", async () => {
 			authorization_endpoint: `${baseURL}/api/auth/mcp/authorize`,
 			token_endpoint: `${baseURL}/api/auth/mcp/token`,
 			userinfo_endpoint: `${baseURL}/api/auth/mcp/userinfo`,
-			jwks_uri: `${baseURL}/api/auth/mcp/jwks`,
+			jwks_uri: `${baseURL}/api/auth/jwks`,
 			registration_endpoint: `${baseURL}/api/auth/mcp/register`,
 			scopes_supported: ["openid", "profile", "email", "offline_access"],
 			response_types_supported: ["code"],
 			response_modes_supported: ["query"],
 			grant_types_supported: ["authorization_code", "refresh_token"],
 			subject_types_supported: ["public"],
-			id_token_signing_alg_values_supported: ["RS256"],
+			id_token_signing_alg_values_supported: ["RS256", "EdDSA"],
 			token_endpoint_auth_methods_supported: [
 				"client_secret_basic",
 				"client_secret_post",
@@ -472,7 +472,7 @@ describe("mcp", async () => {
 		expect(metadata.data).toMatchObject({
 			resource: origin,
 			authorization_servers: [origin],
-			jwks_uri: `${baseURL}/api/auth/mcp/jwks`,
+			jwks_uri: `${baseURL}/api/auth/jwks`,
 			scopes_supported: ["openid", "profile", "email", "offline_access"],
 			bearer_methods_supported: ["header"],
 			resource_signing_alg_values_supported: ["RS256"],
@@ -1327,5 +1327,164 @@ describe("mcp session freshness (security)", () => {
 		expect(response.status).toBe(401);
 		expect(body?.error).toBe("invalid_grant");
 		expect(body?.access_token).toBeUndefined();
+	});
+});
+
+/**
+ * The discovery document advertises RS256 id tokens verifiable through a JWKS.
+ * These assert the issued token actually matches that contract.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10638
+ */
+describe("mcp id token verifiability (security)", async () => {
+	const tempServer = await listen(
+		toNodeHandler(async () => new Response("temp")),
+		{ port: 0 },
+	);
+	const port = tempServer.address?.port || 3002;
+	const baseURL = `http://localhost:${port}`;
+	await tempServer.close();
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL,
+		plugins: [mcp({ loginPage: "/login" }), jwt()],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const serverClient = createAuthClient({
+		baseURL,
+		fetchOptions: { customFetchImpl, headers },
+	});
+
+	const server = await listen(toNodeHandler(auth.handler), { port });
+	afterAll(async () => {
+		await server.close();
+	});
+
+	const base64url = (bytes: Uint8Array) =>
+		btoa(String.fromCharCode(...bytes))
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/=+$/, "");
+
+	/** Decodes a JWT's protected header the way a verifying client would. */
+	function decodeJwtHeader(token: string): { alg?: string; kid?: string } {
+		const [encodedHeader] = token.split(".");
+		if (!encodedHeader) {
+			throw new Error(`not a JWT: ${token}`);
+		}
+		return JSON.parse(
+			new TextDecoder().decode(
+				Uint8Array.from(
+					atob(encodedHeader.replace(/-/g, "+").replace(/_/g, "/")),
+					(c) => c.charCodeAt(0),
+				),
+			),
+		);
+	}
+
+	/** Runs a full authorization-code exchange and returns the raw token response. */
+	async function getTokenResponse() {
+		const registered = await serverClient.$fetch("/mcp/register", {
+			method: "POST",
+			body: {
+				client_name: "idtoken-verifiability-client",
+				redirect_uris: ["http://localhost:3000/callback"],
+				token_endpoint_auth_method: "client_secret_basic",
+			},
+		});
+		const client = registered.data as any;
+
+		const verifier = base64url(crypto.getRandomValues(new Uint8Array(32)));
+		const challenge = base64url(
+			new Uint8Array(
+				await crypto.subtle.digest(
+					"SHA-256",
+					new TextEncoder().encode(verifier),
+				),
+			),
+		);
+
+		const authorizeURL =
+			`${baseURL}/api/auth/mcp/authorize?` +
+			new URLSearchParams({
+				client_id: client.client_id,
+				redirect_uri: client.redirect_uris[0],
+				response_type: "code",
+				scope: "openid profile email",
+				code_challenge: challenge,
+				code_challenge_method: "S256",
+			}).toString();
+
+		let redirectURI = "";
+		await serverClient.$fetch(authorizeURL, {
+			method: "GET",
+			onError(context: any) {
+				redirectURI = context.response.headers.get("Location") || "";
+			},
+			onSuccess(context: any) {
+				redirectURI = context.response.headers.get("Location") || redirectURI;
+			},
+		});
+		const code = new URL(redirectURI).searchParams.get("code");
+
+		const response = await customFetchImpl(`${baseURL}/api/auth/mcp/token`, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "authorization_code",
+				code: code!,
+				client_id: client.client_id,
+				client_secret: client.client_secret,
+				redirect_uri: client.redirect_uris[0],
+				code_verifier: verifier,
+			}).toString(),
+		});
+		return { body: await response.json(), client };
+	}
+
+	it("should issue an id token a client can actually verify", async ({
+		expect,
+	}) => {
+		const { body } = await getTokenResponse();
+		expect(body.id_token).toBeTruthy();
+
+		const metadata = await serverClient.$fetch<Record<string, any>>(
+			"/.well-known/oauth-authorization-server",
+		);
+		const advertisedAlgs =
+			metadata.data?.id_token_signing_alg_values_supported ?? [];
+
+		expect(advertisedAlgs).toContain(decodeJwtHeader(body.id_token).alg);
+	});
+
+	it("should sign successive id tokens with the same, published key", async ({
+		expect,
+	}) => {
+		const first = await getTokenResponse();
+		const second = await getTokenResponse();
+
+		const kidOf = (token: string) => decodeJwtHeader(token).kid;
+
+		expect(kidOf(first.body.id_token)).toBeDefined();
+		expect(kidOf(first.body.id_token)).toBe(kidOf(second.body.id_token));
+	});
+
+	it("should publish the signing key at the advertised jwks_uri", async ({
+		expect,
+	}) => {
+		const { body } = await getTokenResponse();
+		const metadata = await serverClient.$fetch<Record<string, any>>(
+			"/.well-known/oauth-authorization-server",
+		);
+
+		// Follow the advertised URL exactly as a client would, rather than a
+		// path this test happens to know.
+		const jwks = await (await customFetchImpl(metadata.data!.jwks_uri)).json();
+		expect(jwks.keys?.length).toBeGreaterThan(0);
+
+		expect(jwks.keys.map((k: { kid: string }) => k.kid)).toContain(
+			decodeJwtHeader(body.id_token).kid,
+		);
 	});
 });

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -1,3 +1,4 @@
+import { jwtVerify } from "jose";
 import { listen } from "listhen";
 import { afterAll, describe, expect, it } from "vitest";
 import { createAuthClient } from "../../client";
@@ -1605,5 +1606,151 @@ describe("mcp pkce enforcement for public clients (security)", async () => {
 
 		expect(redirect.searchParams.get("code")).toBeTruthy();
 		expect(redirect.searchParams.get("error")).toBeNull();
+	});
+});
+
+/**
+ * Without the jwt plugin there are no published keys, so an id token can only
+ * be verified by something the client already holds — its own secret. A public
+ * client holds nothing, and must get no id token rather than an unverifiable
+ * one.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10638
+ */
+describe("mcp id token without the jwt plugin (security)", async () => {
+	const tempServer = await listen(
+		toNodeHandler(async () => new Response("temp")),
+		{ port: 0 },
+	);
+	const port = tempServer.address?.port || 3004;
+	const baseURL = `http://localhost:${port}`;
+	await tempServer.close();
+
+	// Deliberately no jwt() here.
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL,
+		plugins: [mcp({ loginPage: "/login" })],
+	});
+
+	const { headers } = await signInWithTestUser();
+	const serverClient = createAuthClient({
+		baseURL,
+		fetchOptions: { customFetchImpl, headers },
+	});
+
+	const server = await listen(toNodeHandler(auth.handler), { port });
+	afterAll(async () => {
+		await server.close();
+	});
+
+	const b64url = (bytes: Uint8Array) =>
+		btoa(String.fromCharCode(...bytes))
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/=+$/, "");
+
+	async function tokenFor(authMethod: "none" | "client_secret_basic") {
+		const registered = await serverClient.$fetch("/mcp/register", {
+			method: "POST",
+			body: {
+				client_name: `no-jwt-${authMethod}`,
+				redirect_uris: ["http://localhost:3000/callback"],
+				token_endpoint_auth_method: authMethod,
+			},
+		});
+		const client = registered.data as any;
+
+		const verifier = b64url(crypto.getRandomValues(new Uint8Array(32)));
+		const challenge = b64url(
+			new Uint8Array(
+				await crypto.subtle.digest(
+					"SHA-256",
+					new TextEncoder().encode(verifier),
+				),
+			),
+		);
+
+		let redirect = "";
+		await serverClient.$fetch(
+			`${baseURL}/api/auth/mcp/authorize?` +
+				new URLSearchParams({
+					client_id: client.client_id,
+					redirect_uri: client.redirect_uris[0],
+					response_type: "code",
+					scope: "openid profile email",
+					code_challenge: challenge,
+					code_challenge_method: "S256",
+				}).toString(),
+			{
+				method: "GET",
+				onError(context: any) {
+					redirect = context.response.headers.get("Location") || "";
+				},
+				onSuccess(context: any) {
+					redirect = context.response.headers.get("Location") || redirect;
+				},
+			},
+		);
+		const code = new URL(redirect).searchParams.get("code");
+
+		const body = new URLSearchParams({
+			grant_type: "authorization_code",
+			code: code!,
+			client_id: client.client_id,
+			redirect_uri: client.redirect_uris[0],
+			code_verifier: verifier,
+		});
+		if (client.client_secret) {
+			body.set("client_secret", client.client_secret);
+		}
+
+		const response = await customFetchImpl(`${baseURL}/api/auth/mcp/token`, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: body.toString(),
+		});
+		return { body: await response.json(), client };
+	}
+
+	it("should sign a confidential client's id token with its client secret", async ({
+		expect,
+	}) => {
+		const { body, client } = await tokenFor("client_secret_basic");
+
+		expect(body.id_token).toBeTruthy();
+		await expect(
+			jwtVerify(body.id_token, new TextEncoder().encode(client.client_secret)),
+		).resolves.toBeTruthy();
+	});
+
+	it("should reject an id token verified with the wrong secret", async ({
+		expect,
+	}) => {
+		const { body } = await tokenFor("client_secret_basic");
+
+		await expect(
+			jwtVerify(body.id_token, new TextEncoder().encode("not-the-secret")),
+		).rejects.toThrow();
+	});
+
+	it("should issue no id token to a public client, which holds no secret", async ({
+		expect,
+	}) => {
+		const { body } = await tokenFor("none");
+
+		expect(body.access_token).toBeTruthy();
+		expect(body.id_token).toBeUndefined();
+	});
+
+	it("should advertise HS256 when there are no published keys", async ({
+		expect,
+	}) => {
+		const metadata = await serverClient.$fetch<Record<string, any>>(
+			"/.well-known/oauth-authorization-server",
+		);
+
+		expect(metadata.data?.id_token_signing_alg_values_supported).toEqual([
+			"HS256",
+		]);
 	});
 });

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -1927,6 +1927,49 @@ describe("mcp discovery follows the jwt plugin's configuration", async () => {
 		}
 	});
 
+	it("should let a deployment declare the algorithms of its own signer", async ({
+		expect,
+	}) => {
+		// `jwt.sign` owns every header including `alg`, so the built-in set cannot
+		// describe it. The deployment says what it signs with, and that wins.
+		const tempServer = await listen(
+			toNodeHandler(async () => new Response("temp")),
+			{ port: 0 },
+		);
+		const port = tempServer.address?.port || 3007;
+		const baseURL = `http://localhost:${port}`;
+		await tempServer.close();
+
+		const { auth, customFetchImpl } = await getTestInstance({
+			baseURL,
+			plugins: [
+				mcp({
+					loginPage: "/login",
+					oidcConfig: {
+						loginPage: "/login",
+						metadata: {
+							id_token_signing_alg_values_supported: ["HS512"],
+						},
+					},
+				}),
+				jwt(),
+			],
+		});
+		const server = await listen(toNodeHandler(auth.handler), { port });
+		const client = createAuthClient({
+			baseURL,
+			fetchOptions: { customFetchImpl },
+		});
+		const metadata = await client.$fetch<Record<string, any>>(
+			"/.well-known/oauth-authorization-server",
+		);
+		await server.close();
+
+		expect(metadata.data!.id_token_signing_alg_values_supported).toEqual([
+			"HS512",
+		]);
+	});
+
 	it("should publish no jwks_uri when there is no jwt plugin to serve one", async ({
 		expect,
 	}) => {

--- a/packages/better-auth/src/plugins/oidc-provider/types.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/types.ts
@@ -447,7 +447,7 @@ export interface OIDCMetadata {
 	 *
 	 * @default `/jwks`
 	 */
-	jwks_uri: string;
+	jwks_uri?: string;
 	/**
 	 * The URL of the dynamic client registration endpoint.
 	 *

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -4,6 +4,7 @@ import * as z from "zod";
 import { createAuthEndpoint } from "../../api";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { emailOTP } from "../email-otp";
+import { phoneNumber } from "../phone-number";
 import { username } from "../username";
 import { openAPI } from ".";
 import type { OpenAPISchema, Path } from "./generator";
@@ -976,6 +977,37 @@ describe("open-api", async () => {
 		);
 		expect(getSchemaProperty(requestBodySchema, "unionOptional").type).toBe(
 			"string",
+		);
+	});
+});
+
+/**
+ * This endpoint accepts arbitrary extra fields, expressed as
+ * `z.object({...}).and(z.record(...))`. That makes the schema an intersection
+ * rather than an object, and the generated spec must still describe the fields
+ * a caller has to send.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/8122
+ */
+describe("open-api request bodies for intersection schemas", () => {
+	it("documents the phone-number verify body", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [
+				phoneNumber({
+					sendOTP() {},
+				}),
+				openAPI(),
+			],
+		});
+
+		const schema = await auth.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, Path>;
+		const body = getPostRequestBody(paths, "/phone-number/verify");
+		const properties =
+			body.content["application/json"]?.schema?.properties ?? {};
+
+		expect(Object.keys(properties)).toEqual(
+			expect.arrayContaining(["phoneNumber", "code"]),
 		);
 	});
 });

--- a/packages/better-auth/src/plugins/organization/organization-hook.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization-hook.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { APIError } from "../../api";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { organization } from ".";
 
@@ -314,5 +315,106 @@ describe("organization creation in database hooks", async () => {
 		});
 		expect(org).toBeDefined();
 		expect((org as any)?.name).toBe("Before-After Org");
+	});
+});
+
+/**
+ * A rejected delete must leave no trace: the organization survives, so the
+ * session's pointer to it has to survive too.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10590
+ */
+describe("organization delete rejected by a before hook", async () => {
+	let rejectDelete = false;
+
+	const { auth, signInWithTestUser, db } = await getTestInstance({
+		plugins: [
+			organization({
+				organizationHooks: {
+					beforeDeleteOrganization: async () => {
+						if (rejectDelete) {
+							throw new APIError("BAD_REQUEST", {
+								message: "org still has other members",
+							});
+						}
+					},
+				},
+			}),
+		],
+	});
+
+	async function setup() {
+		const { headers } = await signInWithTestUser();
+		const org = await auth.api.createOrganization({
+			body: { name: `Acme ${Math.random()}`, slug: `acme-${Date.now()}` },
+			headers,
+		});
+		await auth.api.setActiveOrganization({
+			body: { organizationId: org!.id },
+			headers,
+		});
+		return { headers, org: org! };
+	}
+
+	const activeOrgOf = async (headers: Headers) =>
+		(await auth.api.getSession({ headers }))?.session.activeOrganizationId ??
+		null;
+
+	it("should keep the active organization when the delete is rejected", async () => {
+		const { headers, org } = await setup();
+		expect(await activeOrgOf(headers)).toBe(org.id);
+
+		rejectDelete = true;
+		try {
+			await expect(
+				auth.api.deleteOrganization({
+					body: { organizationId: org.id },
+					headers,
+				}),
+			).rejects.toThrow();
+		} finally {
+			rejectDelete = false;
+		}
+
+		// The organization is still there, so the session must still point at it.
+		expect(
+			await db.findOne({
+				model: "organization",
+				where: [{ field: "id", value: org.id }],
+			}),
+		).not.toBeNull();
+		expect(await activeOrgOf(headers)).toBe(org.id);
+	});
+
+	it("should clear the active organization when the delete succeeds", async () => {
+		const { headers, org } = await setup();
+
+		await auth.api.deleteOrganization({
+			body: { organizationId: org.id },
+			headers,
+		});
+
+		expect(await activeOrgOf(headers)).toBeNull();
+	});
+
+	it("should leave a non-active organization's pointer alone", async () => {
+		const { headers, org: active } = await setup();
+		// Creating an organization makes it active unless told otherwise, and this
+		// case needs the active one to stay put.
+		const other = await auth.api.createOrganization({
+			body: {
+				name: "Other",
+				slug: `other-${Date.now()}`,
+				keepCurrentActiveOrganization: true,
+			},
+			headers,
+		});
+
+		await auth.api.deleteOrganization({
+			body: { organizationId: other!.id },
+			headers,
+		});
+
+		expect(await activeOrgOf(headers)).toBe(active.id);
 	});
 });

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -593,13 +593,6 @@ export const deleteOrganization = <O extends OrganizationOptions>(
 					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_ORGANIZATION,
 				);
 			}
-			if (organizationId === session.session.activeOrganizationId) {
-				/**
-				 * If the organization is deleted, we set the active organization to null
-				 */
-				await adapter.setActiveOrganization(session.session.token, null, ctx);
-			}
-
 			const org = await adapter.findOrganizationById(organizationId);
 			if (!org) {
 				throw APIError.fromStatus("BAD_REQUEST");
@@ -614,6 +607,17 @@ export const deleteOrganization = <O extends OrganizationOptions>(
 				);
 			}
 			await adapter.deleteOrganization(organizationId);
+
+			/**
+			 * Only once the organization is actually gone. Clearing beforehand meant a
+			 * `beforeDeleteOrganization` hook that rejected the delete — or a failing
+			 * delete — left the organization intact but the session pointing at
+			 * nothing, with no way back.
+			 */
+			if (organizationId === session.session.activeOrganizationId) {
+				await adapter.setActiveOrganization(session.session.token, null, ctx);
+			}
+
 			if (options?.organizationHooks?.afterDeleteOrganization) {
 				await options.organizationHooks.afterDeleteOrganization(
 					{

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -692,3 +692,72 @@ describe("oauth authorize - authenticated", async () => {
 		expect(callbackRedirectUrl).not.toContain("/consent");
 	});
 });
+
+/**
+ * The signed query travels in a URL. A standard-base64 signature carries `+`
+ * and `/`, so one stray decode by an intermediary (SSR hosts rebuilding request
+ * URLs, link rewriters, deep-link handoffs) turns `+` into a space and
+ * verification can never succeed again.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10427
+ */
+describe("signed query URL safety", () => {
+	const secret = "url-safety-test-secret";
+
+	/**
+	 * Builds signed params whose standard-base64 signature contains a character
+	 * that URL decoding would mangle. Deterministic: the same state is found on
+	 * every run.
+	 */
+	async function signedParamsWithUnsafeChars() {
+		for (let i = 0; i < 500; i++) {
+			const params = new URLSearchParams();
+			params.set("client_id", "demo");
+			params.set("state", `s${i}`);
+			params.set("exp", "9999999999");
+			params.set(signedQueryIssuedAtParam, "1");
+			setSignedOAuthQueryParameterNames(params);
+			const sig = await makeSignature(
+				canonicalizeOAuthQueryParams(params).toString(),
+				secret,
+			);
+			if (sig.includes("+") || sig.includes("/")) {
+				return { params, sig };
+			}
+		}
+		throw new Error("no signature with url-unsafe characters found");
+	}
+
+	const toUrlSafe = (sig: string) =>
+		sig.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+	it("should accept a url-safe signature", async () => {
+		const { params, sig } = await signedParamsWithUnsafeChars();
+		params.set("sig", toUrlSafe(sig));
+
+		expect(await verifyOAuthQueryParams(params.toString(), secret)).toBe(true);
+	});
+
+	it("should still accept a standard-base64 signature", async () => {
+		const { params, sig } = await signedParamsWithUnsafeChars();
+		params.set("sig", sig);
+
+		expect(await verifyOAuthQueryParams(params.toString(), secret)).toBe(true);
+	});
+
+	it("should survive an intermediary decoding the query one extra time", async () => {
+		const { params, sig } = await signedParamsWithUnsafeChars();
+		params.set("sig", toUrlSafe(sig));
+
+		const mangled = decodeURIComponent(params.toString());
+
+		expect(await verifyOAuthQueryParams(mangled, secret)).toBe(true);
+	});
+
+	it("should still reject a tampered signature", async () => {
+		const { params, sig } = await signedParamsWithUnsafeChars();
+		params.set("sig", toUrlSafe(sig).slice(0, -1) + "X");
+
+		expect(await verifyOAuthQueryParams(params.toString(), secret)).toBe(false);
+	});
+});

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -747,11 +747,19 @@ describe("signed query URL safety", () => {
 
 	it("should survive an intermediary decoding the query one extra time", async () => {
 		const { params, sig } = await signedParamsWithUnsafeChars();
+
+		// The defect: standard base64 percent-encodes `+` as `%2B`, and one extra
+		// decode turns it back into a space, which is what #10427 reports.
+		params.set("sig", sig);
+		const mangledStandard = decodeURIComponent(params.toString());
+		expect(new URLSearchParams(mangledStandard).get("sig")).toContain(" ");
+		expect(await verifyOAuthQueryParams(mangledStandard, secret)).toBe(false);
+
+		// The url-safe form has nothing for that decode to corrupt.
 		params.set("sig", toUrlSafe(sig));
-
-		const mangled = decodeURIComponent(params.toString());
-
-		expect(await verifyOAuthQueryParams(mangled, secret)).toBe(true);
+		const mangledUrlSafe = decodeURIComponent(params.toString());
+		expect(new URLSearchParams(mangledUrlSafe).get("sig")).not.toContain(" ");
+		expect(await verifyOAuthQueryParams(mangledUrlSafe, secret)).toBe(true);
 	});
 
 	it("should still reject a tampered signature", async () => {

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -27,6 +27,7 @@ import {
 	isPKCERequired,
 	parsePrompt,
 	storeToken,
+	toUrlSafeSignature,
 } from "./utils";
 
 /**
@@ -671,6 +672,6 @@ async function signParams(
 		canonicalizeOAuthQueryParams(params).toString(),
 		ctx.context.secret,
 	);
-	params.set("sig", signature);
+	params.set("sig", toUrlSafeSignature(signature));
 	return params.toString();
 }

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -13,7 +13,7 @@ import {
 } from "better-auth/api";
 import { parseSetCookieHeader } from "better-auth/cookies";
 import { mergeSchema } from "better-auth/db";
-import type { BetterAuthPlugin } from "better-auth/types";
+import type { BetterAuthOptions, BetterAuthPlugin } from "better-auth/types";
 import * as z from "zod";
 import type { AuthorizeEndpointSettings } from "./authorize";
 import { authorizeEndpoint } from "./authorize";
@@ -68,7 +68,21 @@ export const getOAuthProviderState = oAuthState.get;
  * @param options - The options for the oAuth Provider plugin.
  * @returns A Better Auth plugin.
  */
-export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
+export const oauthProvider = <
+	AuthOptions extends BetterAuthOptions = BetterAuthOptions,
+	O extends OAuthOptions<Scope[], AuthOptions> = OAuthOptions<
+		Scope[],
+		AuthOptions
+	>,
+>(
+	options: O,
+	/**
+	 * The auth options this provider is installed into. Passing them is optional
+	 * and changes nothing at runtime — it lets the claim callbacks type the user
+	 * with its configured `additionalFields` instead of `unknown`.
+	 */
+	_authOptions?: AuthOptions | undefined,
+) => {
 	let clientRegistrationAllowedScopes = options.clientRegistrationAllowedScopes;
 	if (options.clientRegistrationDefaultScopes) {
 		const _allowedScopes = clientRegistrationAllowedScopes

--- a/packages/oauth-provider/src/public-types.test.ts
+++ b/packages/oauth-provider/src/public-types.test.ts
@@ -2,8 +2,10 @@ import type {
 	AuthMethod,
 	GrantType,
 	OAuthOptions,
+	Scope,
 	TokenEndpointAuthMethod,
 } from "@better-auth/oauth-provider";
+import type { BetterAuthOptions } from "better-auth";
 import { describe, expectTypeOf, it } from "vitest";
 
 describe("public oauth-provider types", () => {
@@ -17,5 +19,54 @@ describe("public oauth-provider types", () => {
 		expectTypeOf<TokenEndpointAuthMethod>().toEqualTypeOf<
 			AuthMethod | "none"
 		>();
+	});
+});
+
+/**
+ * The claim callbacks receive the user, so a deployment's configured
+ * `additionalFields` must arrive with their declared types rather than as
+ * `unknown` — otherwise every custom claim needs a cast.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10652
+ */
+describe("claim callbacks infer configured additional user fields", () => {
+	const authOptions = {
+		user: {
+			additionalFields: {
+				phoneNumber: { type: "string", required: true },
+				loyaltyPoints: { type: "number", required: false },
+			},
+		},
+	} satisfies BetterAuthOptions;
+
+	type Options = OAuthOptions<Scope[], typeof authOptions>;
+
+	it("types additional fields on customUserInfoClaims", () => {
+		type Info = Parameters<NonNullable<Options["customUserInfoClaims"]>>[0];
+
+		expectTypeOf<Info["user"]["phoneNumber"]>().toEqualTypeOf<string>();
+		expectTypeOf<Info["user"]["email"]>().toEqualTypeOf<string>();
+	});
+
+	it("types additional fields on customIdTokenClaims", () => {
+		type Info = Parameters<NonNullable<Options["customIdTokenClaims"]>>[0];
+
+		expectTypeOf<Info["user"]["phoneNumber"]>().toEqualTypeOf<string>();
+	});
+
+	it("types additional fields on customAccessTokenClaims", () => {
+		type Info = Parameters<NonNullable<Options["customAccessTokenClaims"]>>[0];
+
+		expectTypeOf<
+			NonNullable<Info["user"]>["phoneNumber"]
+		>().toEqualTypeOf<string>();
+	});
+
+	it("leaves the user type intact when no options are supplied", () => {
+		type Info = Parameters<
+			NonNullable<OAuthOptions["customUserInfoClaims"]>
+		>[0];
+
+		expectTypeOf<Info["user"]["email"]>().toEqualTypeOf<string>();
 	});
 });

--- a/packages/oauth-provider/src/public-types.test.ts
+++ b/packages/oauth-provider/src/public-types.test.ts
@@ -62,6 +62,19 @@ describe("claim callbacks infer configured additional user fields", () => {
 		>().toEqualTypeOf<string>();
 	});
 
+	it("does not widen the user into an index signature", () => {
+		type Info = Parameters<NonNullable<Options["customUserInfoClaims"]>>[0];
+
+		// A field nobody configured must not resolve to something usable — that is
+		// what distinguishes real inference from `any` or a catch-all record.
+		// @ts-expect-error `notConfigured` is not a field on this user
+		type _NotAField = Info["user"]["notConfigured"];
+
+		expectTypeOf<Info["user"]["loyaltyPoints"]>().toEqualTypeOf<
+			number | undefined | null
+		>();
+	});
+
 	it("leaves the user type intact when no options are supplied", () => {
 		type Info = Parameters<
 			NonNullable<OAuthOptions["customUserInfoClaims"]>

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1,5 +1,10 @@
 import type { GenericEndpointContext, LiteralString } from "@better-auth/core";
-import type { InferOptionSchema, Session, User } from "better-auth/types";
+import type {
+	BetterAuthOptions,
+	InferOptionSchema,
+	Session,
+	User,
+} from "better-auth/types";
 import type { JWTPayload } from "jose";
 import type { schema } from "../schema";
 import type { Awaitable } from "./helpers";
@@ -35,6 +40,12 @@ export type AuthorizePrompt =
 
 export interface OAuthOptions<
 	Scopes extends readonly Scope[] = InternallySupportedScopes[],
+	/**
+	 * The auth options this provider is installed into. Supply them as the second
+	 * argument to `oauthProvider` and the claim callbacks receive the user with
+	 * its configured `additionalFields` typed, instead of as `unknown`.
+	 */
+	AuthOptions extends BetterAuthOptions = BetterAuthOptions,
 > {
 	/**
 	 * Custom schema definitions
@@ -449,7 +460,7 @@ export interface OAuthOptions<
 	 */
 	customUserInfoClaims?: (info: {
 		/** The user object */
-		user: User & Record<string, unknown>;
+		user: User<AuthOptions["user"], AuthOptions["plugins"]>;
 		/** The scopes from the access token used
 		 * in the /userinfo request (matches jwt.scopes) */
 		scopes: Scopes;
@@ -468,7 +479,7 @@ export interface OAuthOptions<
 	 */
 	customIdTokenClaims?: (info: {
 		/** The user object if token is associated to a user. */
-		user: User & Record<string, unknown>;
+		user: User<AuthOptions["user"], AuthOptions["plugins"]>;
 		/** Scopes granted for this token */
 		scopes: Scopes;
 		/** oAuthClient metadata */
@@ -489,7 +500,7 @@ export interface OAuthOptions<
 	 */
 	customAccessTokenClaims?: (info: {
 		/** The user object if token is associated to a user. Null if user doesn't exist. Undefined if user not applicable. */
-		user?: (User & Record<string, unknown>) | null;
+		user?: User<AuthOptions["user"], AuthOptions["plugins"]> | null;
 		/** reference of the consent/authorization */
 		referenceId?: string;
 		/** Scopes granted for this token */

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -458,7 +458,7 @@ export interface OAuthOptions<
 	 * @param info - context that may be useful when creating custom claims
 	 * @returns Additional claims for userinfo request
 	 */
-	customUserInfoClaims?: (info: {
+	customUserInfoClaims?(info: {
 		/** The user object */
 		user: User<AuthOptions["user"], AuthOptions["plugins"]>;
 		/** The scopes from the access token used
@@ -466,7 +466,7 @@ export interface OAuthOptions<
 		scopes: Scopes;
 		/** The access token payload used in the /userinfo request */
 		jwt: JWTPayload;
-	}) => Awaitable<Record<string, any>>;
+	}): Awaitable<Record<string, any>>;
 	/**
 	 * Custom claims attached to OIDC id tokens.
 	 *
@@ -477,14 +477,14 @@ export interface OAuthOptions<
 	 *
 	 * @param info - context that may be useful when creating custom claims
 	 */
-	customIdTokenClaims?: (info: {
+	customIdTokenClaims?(info: {
 		/** The user object if token is associated to a user. */
 		user: User<AuthOptions["user"], AuthOptions["plugins"]>;
 		/** Scopes granted for this token */
 		scopes: Scopes;
 		/** oAuthClient metadata */
 		metadata?: Record<string, any>;
-	}) => Awaitable<Record<string, any>>;
+	}): Awaitable<Record<string, any>>;
 	/**
 	 * Custom claims attached to access tokens.
 	 *
@@ -498,7 +498,7 @@ export interface OAuthOptions<
 	 *
 	 * @param info - context that may be useful when creating custom claims
 	 */
-	customAccessTokenClaims?: (info: {
+	customAccessTokenClaims?(info: {
 		/** The user object if token is associated to a user. Null if user doesn't exist. Undefined if user not applicable. */
 		user?: User<AuthOptions["user"], AuthOptions["plugins"]> | null;
 		/** reference of the consent/authorization */
@@ -509,7 +509,7 @@ export interface OAuthOptions<
 		resource?: string;
 		/** oAuthClient metadata */
 		metadata?: Record<string, any>;
-	}) => Awaitable<Record<string, any>>;
+	}): Awaitable<Record<string, any>>;
 	/**
 	 * Custom fields to include in the token response body.
 	 *

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -144,6 +144,20 @@ export function resolveSessionAuthTime(value: unknown): Date | undefined {
 
 const cachedTrustedClients = new TTLCache<string, SchemaClient<Scope[]>>();
 
+/**
+ * Re-encodes a standard-base64 signature with the url-safe alphabet.
+ *
+ * `makeSignature` returns standard base64, whose `+` and `/` survive correct
+ * percent-encoding but not a second decode by an intermediary — `+` comes back
+ * as a space and the signature is unverifiable. Anything travelling in a URL
+ * uses this form instead. `makeSignature` itself is left alone: it also derives
+ * pairwise subject identifiers, which are stable values relying parties have
+ * already seen.
+ */
+export function toUrlSafeSignature(signature: string) {
+	return signature.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
 export async function verifyOAuthQueryParams(
 	oauth_query: string,
 	secret: string,
@@ -157,10 +171,15 @@ export async function verifyOAuthQueryParams(
 		canonicalizeOAuthQueryParams(queryParams).toString(),
 		secret,
 	);
+	// Signatures are emitted url-safe so a stray decode cannot mangle them, but
+	// standard base64 is still accepted: a URL signed before this change is
+	// typically still in flight when it is redeemed.
+	const verifySigUrlSafe = toUrlSafeSignature(verifySig);
 	return (
 		sigs.length === 1 &&
 		!!sig &&
-		constantTimeEqual(sig, verifySig) &&
+		(constantTimeEqual(sig, verifySigUrlSafe) ||
+			constantTimeEqual(sig, verifySig)) &&
 		new Date(exp * 1000) >= new Date()
 	);
 }

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -215,6 +215,49 @@ describe("SSO", async () => {
 		expect(callbackURL).toContain("/dashboard");
 	});
 
+	/**
+	 * The SAML path in this plugin merges error params through
+	 * `buildSAMLRedirectUrl`. The OIDC callback concatenated `?error=` instead, so
+	 * an error URL that already carried a query got a second `?`, and values went
+	 * out unencoded.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/3875
+	 */
+	it("should merge encoded error params into an error URL that already has a query", async () => {
+		const headers = new Headers();
+		const res = await authClient.signIn.sso({
+			providerId: "test",
+			callbackURL: "/dashboard",
+			errorCallbackURL: "/error?title=Invalid%20invite",
+			fetchOptions: { throw: true, onSuccess: cookieSetter(headers) },
+		});
+
+		const state = new URL(res.url).searchParams.get("state");
+		expect(state).toBeTruthy();
+
+		// The IdP declines: the `!code || error` branch of the callback.
+		const response = await auth.handler(
+			new Request(
+				`http://localhost:3000/api/auth/sso/callback/test?state=${state}&error=access_denied&error_description=${encodeURIComponent(
+					"user said no",
+				)}`,
+				{ headers },
+			),
+		);
+		const location = response.headers.get("location") || "";
+
+		// A second `?` is not a query separator: everything after it is swallowed
+		// into the previous parameter's value, so the app sees neither.
+		expect(location.split("?").length - 1).toBe(1);
+		// Values must be encoded — a raw space is not legal in a URL.
+		expect(location).not.toContain(" ");
+
+		const parsed = new URL(location, "http://localhost:3000");
+		expect(parsed.searchParams.get("title")).toBe("Invalid invite");
+		expect(parsed.searchParams.get("error")).toBe("access_denied");
+		expect(parsed.searchParams.get("error_description")).toBe("user said no");
+	});
+
 	it("should sign in with SSO provider with domain", async () => {
 		const headers = new Headers();
 		const res = await authClient.signIn.sso({

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -258,6 +258,33 @@ describe("SSO", async () => {
 		expect(parsed.searchParams.get("error_description")).toBe("user said no");
 	});
 
+	it("should name a concrete error when the callback carries neither code nor error", async () => {
+		const headers = new Headers();
+		const res = await authClient.signIn.sso({
+			providerId: "test",
+			callbackURL: "/dashboard",
+			errorCallbackURL: "/error?title=Invalid%20invite",
+			fetchOptions: { throw: true, onSuccess: cookieSetter(headers) },
+		});
+		const state = new URL(res.url).searchParams.get("state");
+
+		// An aborted or malformed IdP redirection: state comes back, nothing else.
+		const response = await auth.handler(
+			new Request(
+				`http://localhost:3000/api/auth/sso/callback/test?state=${state}`,
+				{ headers },
+			),
+		);
+		const parsed = new URL(
+			response.headers.get("location") || "",
+			"http://localhost:3000",
+		);
+
+		expect(parsed.searchParams.get("error")).toBeTruthy();
+		expect(parsed.searchParams.get("error")).not.toBe("undefined");
+		expect(parsed.searchParams.get("error_description")).not.toBe("undefined");
+	});
+
 	it("should sign in with SSO provider with domain", async () => {
 		const headers = new Headers();
 		const res = await authClient.signIn.sso({

--- a/packages/sso/src/routes/saml-pipeline.ts
+++ b/packages/sso/src/routes/saml-pipeline.ts
@@ -431,9 +431,17 @@ export async function processSAMLResponse(
 	}
 
 	// 12. InResponseTo validation
-	const inResponseTo = (extract as SAMLAssertionExtract).inResponseTo as
-		| string
-		| undefined;
+	/**
+	 * samlify's login extractor puts the Response element's attributes under
+	 * `response`, so that is where a login carries `InResponseTo`; the logout
+	 * pipeline already reads it there. Reading only the top level made every
+	 * SP-initiated login look unsolicited — which silently skipped the replay
+	 * check by default, and rejected every real login under
+	 * `allowIdpInitiated: false`.
+	 */
+	const samlExtract = extract as SAMLAssertionExtract;
+	const inResponseTo =
+		samlExtract.inResponseTo ?? samlExtract.response?.inResponseTo;
 	const shouldValidateInResponseTo =
 		options?.saml?.enableInResponseToValidation !== false;
 

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1482,8 +1482,13 @@ async function handleOIDCCallback(
 	if (!code || error) {
 		throw ctx.redirect(
 			buildSAMLRedirectUrl(errorURL || callbackURL, {
-				error: String(error),
-				error_description: String(error_description ?? ""),
+				// This branch also covers a callback carrying neither a code nor an
+				// error — an aborted or malformed redirection — where the provider
+				// named nothing to report.
+				error: error ? String(error) : "invalid_request",
+				error_description: error_description
+					? String(error_description)
+					: "missing_authorization_code",
 			}),
 		);
 	}

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1474,14 +1474,17 @@ async function handleOIDCCallback(
 		const errorURL =
 			ctx.context.options.onAPIError?.errorURL ||
 			`${ctx.context.baseURL}/error`;
-		throw ctx.redirect(`${errorURL}?error=invalid_state`);
+		throw ctx.redirect(
+			buildSAMLRedirectUrl(errorURL, { error: "invalid_state" }),
+		);
 	}
 	const { callbackURL, errorURL, newUserURL, requestSignUp } = stateData;
 	if (!code || error) {
 		throw ctx.redirect(
-			`${
-				errorURL || callbackURL
-			}?error=${error}&error_description=${error_description}`,
+			buildSAMLRedirectUrl(errorURL || callbackURL, {
+				error: String(error),
+				error_description: String(error_description ?? ""),
+			}),
 		);
 	}
 	let provider: SSOProvider<SSOOptions> | null = null;
@@ -1523,9 +1526,10 @@ async function handleOIDCCallback(
 	}
 	if (!provider) {
 		throw ctx.redirect(
-			`${
-				errorURL || callbackURL
-			}?error=invalid_provider&error_description=provider not found`,
+			buildSAMLRedirectUrl(errorURL || callbackURL, {
+				error: "invalid_provider",
+				error_description: "provider not found",
+			}),
 		);
 	}
 
@@ -1542,9 +1546,10 @@ async function handleOIDCCallback(
 
 	if (!config) {
 		throw ctx.redirect(
-			`${
-				errorURL || callbackURL
-			}?error=invalid_provider&error_description=provider not found`,
+			buildSAMLRedirectUrl(errorURL || callbackURL, {
+				error: "invalid_provider",
+				error_description: "provider not found",
+			}),
 		);
 	}
 
@@ -1555,15 +1560,17 @@ async function handleOIDCCallback(
 	} catch (error) {
 		if (error instanceof DiscoveryError) {
 			throw ctx.redirect(
-				`${
-					errorURL || callbackURL
-				}?error=discovery_failed&error_description=${encodeURIComponent(error.message)}`,
+				buildSAMLRedirectUrl(errorURL || callbackURL, {
+					error: "discovery_failed",
+					error_description: error.message,
+				}),
 			);
 		}
 		throw ctx.redirect(
-			`${
-				errorURL || callbackURL
-			}?error=discovery_failed&error_description=unexpected_discovery_error`,
+			buildSAMLRedirectUrl(errorURL || callbackURL, {
+				error: "discovery_failed",
+				error_description: "unexpected_discovery_error",
+			}),
 		);
 	}
 	if (!config.scopes) {
@@ -1575,9 +1582,10 @@ async function handleOIDCCallback(
 
 	if (!config.tokenEndpoint) {
 		throw ctx.redirect(
-			`${
-				errorURL || callbackURL
-			}?error=invalid_provider&error_description=token_endpoint_not_found`,
+			buildSAMLRedirectUrl(errorURL || callbackURL, {
+				error: "invalid_provider",
+				error_description: "token_endpoint_not_found",
+			}),
 		);
 	}
 
@@ -1602,18 +1610,20 @@ async function handleOIDCCallback(
 		ctx.context.logger.error("Error validating authorization code", e);
 		if (e instanceof BetterFetchError) {
 			throw ctx.redirect(
-				`${
-					errorURL || callbackURL
-				}?error=invalid_provider&error_description=${e.message}`,
+				buildSAMLRedirectUrl(errorURL || callbackURL, {
+					error: "invalid_provider",
+					error_description: e.message,
+				}),
 			);
 		}
 		return null;
 	});
 	if (!tokenResponse) {
 		throw ctx.redirect(
-			`${
-				errorURL || callbackURL
-			}?error=invalid_provider&error_description=token_response_not_found`,
+			buildSAMLRedirectUrl(errorURL || callbackURL, {
+				error: "invalid_provider",
+				error_description: "token_response_not_found",
+			}),
 		);
 	}
 	let userInfo: {
@@ -1638,9 +1648,13 @@ async function handleOIDCCallback(
 		);
 		if (userInfoResponse.error) {
 			throw ctx.redirect(
-				`${errorURL || callbackURL}?error=invalid_provider&error_description=${
-					userInfoResponse.error.message
-				}`,
+				buildSAMLRedirectUrl(errorURL || callbackURL, {
+					error: "invalid_provider",
+					// The fetch error carries no message on some failures; the previous
+					// template interpolated that as the literal string "undefined".
+					error_description:
+						userInfoResponse.error.message ?? "user_info_request_failed",
+				}),
 			);
 		}
 		const rawUserInfo = userInfoResponse.data;
@@ -1665,9 +1679,10 @@ async function handleOIDCCallback(
 		const idToken = decodeJwt(tokenResponse.idToken);
 		if (!config.jwksEndpoint) {
 			throw ctx.redirect(
-				`${
-					errorURL || callbackURL
-				}?error=invalid_provider&error_description=jwks_endpoint_not_found`,
+				buildSAMLRedirectUrl(errorURL || callbackURL, {
+					error: "invalid_provider",
+					error_description: "jwks_endpoint_not_found",
+				}),
 			);
 		}
 		const verified = await validateToken(
@@ -1683,9 +1698,10 @@ async function handleOIDCCallback(
 		});
 		if (!verified) {
 			throw ctx.redirect(
-				`${
-					errorURL || callbackURL
-				}?error=invalid_provider&error_description=token_not_verified`,
+				buildSAMLRedirectUrl(errorURL || callbackURL, {
+					error: "invalid_provider",
+					error_description: "token_not_verified",
+				}),
 			);
 		}
 
@@ -1714,17 +1730,19 @@ async function handleOIDCCallback(
 		};
 	} else {
 		throw ctx.redirect(
-			`${
-				errorURL || callbackURL
-			}?error=invalid_provider&error_description=user_info_endpoint_not_found`,
+			buildSAMLRedirectUrl(errorURL || callbackURL, {
+				error: "invalid_provider",
+				error_description: "user_info_endpoint_not_found",
+			}),
 		);
 	}
 
 	if (!userInfo.email || !userInfo.id) {
 		throw ctx.redirect(
-			`${
-				errorURL || callbackURL
-			}?error=invalid_provider&error_description=missing_user_info`,
+			buildSAMLRedirectUrl(errorURL || callbackURL, {
+				error: "invalid_provider",
+				error_description: "missing_user_info",
+			}),
 		);
 	}
 	const isTrustedProvider =
@@ -1883,14 +1901,19 @@ export const callbackSSOShared = (options?: SSOOptions) => {
 				const errorURL =
 					ctx.context.options.onAPIError?.errorURL ||
 					`${ctx.context.baseURL}/error`;
-				throw ctx.redirect(`${errorURL}?error=invalid_state`);
+				throw ctx.redirect(
+					buildSAMLRedirectUrl(errorURL, { error: "invalid_state" }),
+				);
 			}
 
 			const providerId = stateData.ssoProviderId as string | undefined;
 			if (!providerId) {
 				const errorURL = stateData.errorURL || stateData.callbackURL;
 				throw ctx.redirect(
-					`${errorURL}?error=invalid_state&error_description=missing_provider_id`,
+					buildSAMLRedirectUrl(errorURL, {
+						error: "invalid_state",
+						error_description: "missing_provider_id",
+					}),
 				);
 			}
 
@@ -1955,7 +1978,9 @@ export const callbackSSOSAML = (options?: SSOOptions) => {
 				const session = await getSessionFromCtx(ctx);
 
 				if (!session?.session) {
-					throw ctx.redirect(`${errorURL}?error=invalid_request`);
+					throw ctx.redirect(
+						buildSAMLRedirectUrl(errorURL, { error: "invalid_request" }),
+					);
 				}
 
 				const relayState = ctx.query?.RelayState as string | undefined;
@@ -2155,7 +2180,10 @@ export const sloEndpoint = (options?: SSOOptions) => {
 
 			if (!samlRequest && !samlResponse) {
 				throw ctx.redirect(
-					`${safeErrorURL}?error=invalid_request&error_description=missing_logout_data`,
+					buildSAMLRedirectUrl(safeErrorURL, {
+						error: "invalid_request",
+						error_description: "missing_logout_data",
+					}),
 				);
 			}
 

--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -336,6 +336,8 @@ interface MockSAMLTemplateOverrides {
 	audience?: string;
 	destination?: string;
 	subjectRecipient?: string;
+	/** Echo an AuthnRequest id back, the way a real IdP answers an SP-initiated login. */
+	inResponseTo?: string;
 }
 
 const createTemplateCallback =
@@ -376,7 +378,9 @@ const createTemplateCallback =
 			SubjectConfirmationDataNotOnOrAfter: fiveMinutesLater.toISOString(),
 			NameIDFormat: selectedNameIDFormat,
 			NameID: email,
-			InResponseTo: "null",
+			// An IdP-initiated response carries no InResponseTo. The literal string
+			// "null" would be indistinguishable from a real request id once parsed.
+			InResponseTo: overrides.inResponseTo ?? "",
 			AuthnStatement: "",
 			attrFirstName: "Test",
 			attrLastName: "User",
@@ -534,6 +538,7 @@ const createMockSAMLIdP = (port: number, options: MockIdPOptions = {}) => {
 				audience: queryValue(req.query.audience),
 				destination: queryValue(req.query.destination),
 				subjectRecipient: queryValue(req.query.recipient),
+				inResponseTo: queryValue(req.query.inResponseTo),
 			};
 			const { context, entityEndpoint } = (await idp.createLoginResponse(
 				sp,
@@ -4775,6 +4780,104 @@ describe("SAML SSO - Assertion Replay Protection", () => {
 
 		expect(succeeded).toHaveLength(1);
 		expect(failed).toHaveLength(1);
+	});
+
+	/**
+	 * The login extractor puts InResponseTo under `response`, so reading only the
+	 * top level made every solicited login look unsolicited: the replay check
+	 * silently never ran, and `allowIdpInitiated: false` refused real logins.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10504
+	 */
+	it("should validate InResponseTo on a solicited login instead of calling it unsolicited", async () => {
+		const { auth, signInWithTestUser, db } = await getTestInstance({
+			plugins: [sso({ saml: { allowIdpInitiated: false } })],
+		});
+
+		const { headers } = await signInWithTestUser();
+
+		await auth.api.registerSSOProvider({
+			body: {
+				providerId: "sp-initiated-only-provider",
+				issuer: "http://localhost:8081",
+				domain: "http://localhost:8081",
+				samlConfig: {
+					entryPoint: "http://localhost:8081/api/sso/saml2/idp/post",
+					cert: certificate,
+					callbackUrl: "http://localhost:3000/dashboard",
+					wantAssertionsSigned: false,
+					signatureAlgorithm: "sha256",
+					digestAlgorithm: "sha256",
+					idpMetadata: { metadata: idpMetadata },
+					spMetadata: { metadata: spMetadata },
+					identifierFormat:
+						"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+				},
+			},
+			headers,
+		});
+
+		const signInRes = await auth.api.signInSSO({
+			body: {
+				providerId: "sp-initiated-only-provider",
+				callbackURL: "http://localhost:3000/dashboard",
+			},
+			returnHeaders: true,
+		});
+		const signInUrl = signInRes.response?.url;
+		const relayState = new URL(signInUrl!).searchParams.get("RelayState");
+
+		// A real IdP echoes the AuthnRequest id back on the Response element.
+		// Read the id better-auth stored, and have the mock IdP answer with it.
+		const stored = await db.findMany<{ identifier: string; value: string }>({
+			model: "verification",
+		});
+		const authnRequest = stored.find((row) =>
+			row.identifier.startsWith("saml-authn-request:"),
+		);
+		expect(authnRequest).toBeDefined();
+		const requestId = authnRequest!.identifier.replace(
+			"saml-authn-request:",
+			"",
+		);
+
+		let samlResponse: any;
+		await betterFetch(`${signInUrl}&inResponseTo=${requestId}`, {
+			onSuccess: async (context) => {
+				samlResponse = await context.data;
+			},
+		});
+
+		const submit = () =>
+			auth.handler(
+				new Request(
+					"http://localhost:3000/api/auth/sso/saml2/sp/acs/sp-initiated-only-provider",
+					{
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+							Cookie: signInRes.headers.get("set-cookie") ?? "",
+						},
+						body: new URLSearchParams({
+							SAMLResponse: samlResponse.samlResponse,
+							RelayState: relayState!,
+						}),
+					},
+				),
+			);
+
+		const first = await submit();
+		const firstLocation = first.headers.get("location") || "";
+
+		// The response carries an InResponseTo, so this login is solicited and
+		// must not be refused as IdP-initiated.
+		expect(firstLocation).not.toContain("unsolicited");
+		expect(firstLocation).toContain("dashboard");
+
+		// The AuthnRequest is one-shot: the same signed response cannot be
+		// redeemed twice.
+		const second = await submit();
+		expect(second.headers.get("location") || "").toContain("error");
 	});
 
 	it("should issue only one session when the same IdP-initiated assertion is submitted concurrently", async () => {

--- a/packages/sso/src/types.ts
+++ b/packages/sso/src/types.ts
@@ -117,6 +117,13 @@ export interface SAMLAssertionExtract {
 	nameID?: string;
 	sessionIndex?: string;
 	inResponseTo?: string;
+	/**
+	 * samlify's `loginResponseFields` extractor puts the Response element's own
+	 * attributes here, which is where a login response carries `InResponseTo`.
+	 */
+	response?: {
+		inResponseTo?: string;
+	};
 	conditions?: {
 		notBefore?: string;
 		notOnOrAfter?: string;


### PR DESCRIPTION
## Summary

Eleven independent fixes, one commit each, plus a `patch` changeset. Every fix carries a
regression test that was run against the unfixed code first and confirmed to fail there.

**mcp**
- Id tokens were signed with a per-request HMAC key that was never stored, so no client could
  verify one; discovery advertised RS256 and a `jwks_uri` the plugin does not serve. Now signs
  with the jwt plugin's published key, falls back to the client secret for confidential clients,
  and issues no id token to a public client rather than one nothing can check. Closes #10638
- PKCE was gated on `requirePKCE`, which the plugin never defaults, so a public client could
  authorize with no `code_challenge`; the token endpoint only compares a verifier when a
  challenge was stored, leaving an intercepted code redeemable with any verifier. Closes #10637
- `MCPOptions` was declared without `export`, so consumers using declaration emit hit TS4023.
  Closes #10532

**oauth-provider**
- The signed query used standard base64, so the signature usually carried `+` or `/` and one
  extra URL-decode en route made it unverifiable. Emits url-safe now and still accepts the old
  form; `makeSignature` is unchanged, since it also derives pairwise subject identifiers.
  Closes #10427
- The claim callbacks typed the user as `User & Record<string, unknown>`, so every configured
  `additionalFields` entry arrived as `unknown`. Closes #10652

**sso**
- The SAML login pipeline read `InResponseTo` from the top level of the extract; samlify places
  it under `response`, as the logout pipeline here already accounts for. Every SP-initiated
  login therefore looked unsolicited: the replay check never ran despite defaulting on, and
  `allowIdpInitiated: false` rejected genuine logins. Closes #10504
- Eighteen error redirects concatenated `?error=` onto a target that may already carry a query,
  producing a second `?` — everything after it is swallowed into the previous value — and sent
  values unencoded. All eighteen now use the URL builder the SAML path already uses. Closes #3875

**core**
- `customSession` caught everything from the inner `getSession` and returned `null`, which is
  the not-authenticated signal, so a database outage signed out users whose sessions were valid.
  Closes #10566
- `reserveVerificationValue` relies on a deterministic primary key to make a second caller lose,
  but adapters configured for uuid ids replace any id that is not a UUID, so every caller won and
  the replay guard did nothing. Closes #10624

**email-otp**
- A change-email OTP is keyed by both the current and new address, which binds it to one target
  mailbox. `createVerificationOTP`, `getVerificationOTP` and `checkVerificationOTP` build the
  identifier from the current address alone, so they wrote, returned and validated a code the
  real change-email flow can never read. They now refuse the type, matching the guard
  `sendVerificationOTP` already carries. Closes #10612

**organization**
- `deleteOrganization` cleared the session's `activeOrganizationId` before looking the
  organization up, before `beforeDeleteOrganization` ran and before the delete, so a hook that
  refused the delete left the organization intact and the session pointing at nothing.
  Closes #10590

Three supporting commits: coverage for the id-token fallback path, a variance fix for the
oauth-provider generic that `tsc --build` accepted but `typecheck:dist` rejected, and a
regression guard for OpenAPI request bodies built from intersection schemas.

## Testing

- `pnpm vitest packages/better-auth/src/plugins/mcp packages/better-auth/src/plugins/custom-session packages/better-auth/src/plugins/email-otp packages/better-auth/src/plugins/organization packages/better-auth/src/db packages/oauth-provider packages/sso --run` — 1267 pass
- `pnpm typecheck`, `pnpm typecheck:dist`
- `pnpm lint`, `pnpm format:check`, `pnpm lint:spell`, `pnpm lint:types`, `pnpm lint:packages`, `pnpm lint:dependencies`

Where a test harness changed alongside a fix, the test was re-checked with only the source change
reverted, so it pins the fix and not the harness. `saml.test.ts`'s mock IdP emitted a literal
`InResponseTo="null"`, which is why the SAML defect went unnoticed; it now omits the value by
default and can echo a supplied request id, so the suite exercises solicited and unsolicited
logins as a real IdP produces them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens OIDC/SAML flows and fixes correctness across `mcp`, `@better-auth/oauth-provider`, `@better-auth/sso`, `email-otp`, `organization`, and core. ID tokens are verifiable via the `jwt` plugin’s JWKS; discovery now honors `oidcConfig.metadata` overrides, lists supported algs, resolves custom/remote JWKS, and omits `jwks_uri` when none is served; PKCE is enforced for public clients; error redirects are safe; and session/verification edge cases behave correctly.

- **Bug Fixes**
  - `mcp`
    - ID tokens: sign with the `jwt` plugin’s published key; otherwise fall back to `HS256` with the client secret for confidential clients; public clients receive no ID token without the plugin. Discovery resolves `jwks_uri` from the `jwt` plugin (custom path or remote URL), advertises all supported signing algs when the plugin is present, omits `jwks_uri` when it isn’t, and honors `oidcConfig.metadata` overrides (e.g., custom alg lists when using `jwt.sign`); without the plugin, it advertises `HS256`. Enforce PKCE for public clients regardless of `requirePKCE` (still honors `allowPlainCodeChallengeMethod`); confidential clients remain opt‑in. Exported `MCPOptions`.
  - `@better-auth/oauth-provider`
    - Signed OAuth queries use URL-safe signatures; verification accepts old signatures too. Claim callbacks infer `additionalFields` types when auth options are supplied (see Migration).
  - `@better-auth/sso`
    - Validate SAML `InResponseTo` from the correct nested field to run replay checks and accept solicited logins when `allowIdpInitiated: false`. All error redirects (including OIDC) now merge and encode params into target URLs and avoid “undefined” messages.
  - Core
    - `customSession` propagates session lookup errors instead of returning `null`. `reserveVerificationValue` derives a deterministic UUID key so uniqueness holds under `advanced.database.generateId: "uuid"`.
  - `email-otp`
    - Generic OTP endpoints reject `change-email`; use the dedicated change-email endpoints.
  - `organization`
    - Clear `activeOrganizationId` only after a successful delete.

- **Migration**
  - No breaking changes. Optional: pass your auth options as the second arg to `oauthProvider(options, authOptions)` to get typed `additionalFields` in claim callbacks.

<sup>Written for commit 4b4d99ed50ebd5c2d2f9ede2a3fdd0226051c333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

