### PR TITLE
docs: fix 2FA description in client plugin setup

### DIFF
--- a/docs/content/docs/plugins/multi-session.mdx
+++ b/docs/content/docs/plugins/multi-session.mdx
@@ -26,7 +26,7 @@ The multi-session plugin allows users to maintain multiple active sessions acros
   <Step>
     ### Add the client Plugin
 
-    Add the client plugin and Specify where the user should be redirected if they need to verify 2nd factor
+    Add the multi-session client plugin to enable managing multiple active sessions.
 
     ```ts title="auth-client.ts"
     import { createAuthClient } from "better-auth/client"


### PR DESCRIPTION
The "Add the client Plugin" step in the multi-session docs described redirecting users to verify their 2nd factor, text seems to be copy-pasted from the 2FA plugin docs and has nothing to do with `multiSessionClient()`, which takes no options and has no redirect or 2FA behaviour.

Replaced with an accurate one-line description of what the step actually does.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the “Add the client Plugin” step in the multi-session docs by removing an incorrect 2FA redirect note and replacing it with an accurate one-line description of the plugin’s purpose. Clarifies that `multiSessionClient()` has no 2FA or redirect behavior and takes no options.

<sup>Written for commit 2b06538cb482b0bff2ed402ac6c3de9aabd0aa30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

