### PR TITLE
docs: add SuperSend TX as an email provider example

### DIFF
--- a/docs/content/docs/concepts/email.mdx
+++ b/docs/content/docs/concepts/email.mdx
@@ -12,6 +12,7 @@ Better Auth works with any transactional email provider, giving you full control
 For example, you might consider the following email providers:
 
 * [Resend](https://resend.com/better-auth)
+* [SuperSend TX](https://docs.supersendtx.com/guides/better-auth)
 
 ## Email Verification
 


### PR DESCRIPTION
## Summary

Adds [SuperSend TX](https://docs.supersendtx.com/guides/better-auth) to the **Bring Your Own Email Provider** list in the email docs, next to Resend.

SuperSend TX ships a Better Auth helper (`supersendtx-better-auth` / `createBetterAuthEmail`) that wires verification, password reset, magic link, email OTP, and org invite callbacks.

## Links

- Guide: https://docs.supersendtx.com/guides/better-auth
- Package: https://www.npmjs.com/package/supersendtx-better-auth

## Checklist

- [x] Docs only (one bullet + link)
- [x] Matches existing Resend listing format

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added SuperSend TX to the Bring Your Own Email Provider list in the email docs, next to Resend. Links to its Better Auth guide so users can wire verification, password reset, magic links, OTP, and org invites via `supersendtx-better-auth` (`createBetterAuthEmail`).

<sup>Written for commit 7bb1dc56ad7365ef1768a0f232afbb06ed0750a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

