### PR TITLE
fix(oauth-provider): infer additional user fields in claim callbacks

### DIFF
--- a/.changeset/oauth-provider-claim-types.md
+++ b/.changeset/oauth-provider-claim-types.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+`customUserInfoClaims`, `customIdTokenClaims` and `customAccessTokenClaims` report the auth instance's user type, so configured `additionalFields` arrive with their declared types instead of `unknown`.

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -13,7 +13,7 @@ import {
 } from "better-auth/api";
 import { parseSetCookieHeader } from "better-auth/cookies";
 import { mergeSchema } from "better-auth/db";
-import type { BetterAuthPlugin } from "better-auth/types";
+import type { BetterAuthOptions, BetterAuthPlugin } from "better-auth/types";
 import * as z from "zod";
 import type { AuthorizeEndpointSettings } from "./authorize";
 import { authorizeEndpoint } from "./authorize";
@@ -68,7 +68,21 @@ export const getOAuthProviderState = oAuthState.get;
  * @param options - The options for the oAuth Provider plugin.
  * @returns A Better Auth plugin.
  */
-export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
+export const oauthProvider = <
+	AuthOptions extends BetterAuthOptions = BetterAuthOptions,
+	O extends OAuthOptions<Scope[], AuthOptions> = OAuthOptions<
+		Scope[],
+		AuthOptions
+	>,
+>(
+	options: O,
+	/**
+	 * The auth options this provider is installed into. Passing them is optional
+	 * and changes nothing at runtime — it lets the claim callbacks type the user
+	 * with its configured `additionalFields` instead of `unknown`.
+	 */
+	_authOptions?: AuthOptions | undefined,
+) => {
 	let clientRegistrationAllowedScopes = options.clientRegistrationAllowedScopes;
 	if (options.clientRegistrationDefaultScopes) {
 		const _allowedScopes = clientRegistrationAllowedScopes

--- a/packages/oauth-provider/src/public-types.test.ts
+++ b/packages/oauth-provider/src/public-types.test.ts
@@ -2,8 +2,10 @@ import type {
 	AuthMethod,
 	GrantType,
 	OAuthOptions,
+	Scope,
 	TokenEndpointAuthMethod,
 } from "@better-auth/oauth-provider";
+import type { BetterAuthOptions } from "better-auth";
 import { describe, expectTypeOf, it } from "vitest";
 
 describe("public oauth-provider types", () => {
@@ -17,5 +19,54 @@ describe("public oauth-provider types", () => {
 		expectTypeOf<TokenEndpointAuthMethod>().toEqualTypeOf<
 			AuthMethod | "none"
 		>();
+	});
+});
+
+/**
+ * The claim callbacks receive the user, so a deployment's configured
+ * `additionalFields` must arrive with their declared types rather than as
+ * `unknown` — otherwise every custom claim needs a cast.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10652
+ */
+describe("claim callbacks infer configured additional user fields", () => {
+	const authOptions = {
+		user: {
+			additionalFields: {
+				phoneNumber: { type: "string", required: true },
+				loyaltyPoints: { type: "number", required: false },
+			},
+		},
+	} satisfies BetterAuthOptions;
+
+	type Options = OAuthOptions<Scope[], typeof authOptions>;
+
+	it("types additional fields on customUserInfoClaims", () => {
+		type Info = Parameters<NonNullable<Options["customUserInfoClaims"]>>[0];
+
+		expectTypeOf<Info["user"]["phoneNumber"]>().toEqualTypeOf<string>();
+		expectTypeOf<Info["user"]["email"]>().toEqualTypeOf<string>();
+	});
+
+	it("types additional fields on customIdTokenClaims", () => {
+		type Info = Parameters<NonNullable<Options["customIdTokenClaims"]>>[0];
+
+		expectTypeOf<Info["user"]["phoneNumber"]>().toEqualTypeOf<string>();
+	});
+
+	it("types additional fields on customAccessTokenClaims", () => {
+		type Info = Parameters<NonNullable<Options["customAccessTokenClaims"]>>[0];
+
+		expectTypeOf<
+			NonNullable<Info["user"]>["phoneNumber"]
+		>().toEqualTypeOf<string>();
+	});
+
+	it("leaves the user type intact when no options are supplied", () => {
+		type Info = Parameters<
+			NonNullable<OAuthOptions["customUserInfoClaims"]>
+		>[0];
+
+		expectTypeOf<Info["user"]["email"]>().toEqualTypeOf<string>();
 	});
 });

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1,5 +1,10 @@
 import type { GenericEndpointContext, LiteralString } from "@better-auth/core";
-import type { InferOptionSchema, Session, User } from "better-auth/types";
+import type {
+	BetterAuthOptions,
+	InferOptionSchema,
+	Session,
+	User,
+} from "better-auth/types";
 import type { JWTPayload } from "jose";
 import type { schema } from "../schema";
 import type { Awaitable } from "./helpers";
@@ -35,6 +40,12 @@ export type AuthorizePrompt =
 
 export interface OAuthOptions<
 	Scopes extends readonly Scope[] = InternallySupportedScopes[],
+	/**
+	 * The auth options this provider is installed into. Supply them as the second
+	 * argument to `oauthProvider` and the claim callbacks receive the user with
+	 * its configured `additionalFields` typed, instead of as `unknown`.
+	 */
+	AuthOptions extends BetterAuthOptions = BetterAuthOptions,
 > {
 	/**
 	 * Custom schema definitions
@@ -449,7 +460,7 @@ export interface OAuthOptions<
 	 */
 	customUserInfoClaims?: (info: {
 		/** The user object */
-		user: User & Record<string, unknown>;
+		user: User<AuthOptions["user"], AuthOptions["plugins"]>;
 		/** The scopes from the access token used
 		 * in the /userinfo request (matches jwt.scopes) */
 		scopes: Scopes;
@@ -468,7 +479,7 @@ export interface OAuthOptions<
 	 */
 	customIdTokenClaims?: (info: {
 		/** The user object if token is associated to a user. */
-		user: User & Record<string, unknown>;
+		user: User<AuthOptions["user"], AuthOptions["plugins"]>;
 		/** Scopes granted for this token */
 		scopes: Scopes;
 		/** oAuthClient metadata */
@@ -489,7 +500,7 @@ export interface OAuthOptions<
 	 */
 	customAccessTokenClaims?: (info: {
 		/** The user object if token is associated to a user. Null if user doesn't exist. Undefined if user not applicable. */
-		user?: (User & Record<string, unknown>) | null;
+		user?: User<AuthOptions["user"], AuthOptions["plugins"]> | null;
 		/** reference of the consent/authorization */
 		referenceId?: string;
 		/** Scopes granted for this token */

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -458,7 +458,7 @@ export interface OAuthOptions<
 	 * @param info - context that may be useful when creating custom claims
 	 * @returns Additional claims for userinfo request
 	 */
-	customUserInfoClaims?: (info: {
+	customUserInfoClaims?(info: {
 		/** The user object */
 		user: User<AuthOptions["user"], AuthOptions["plugins"]>;
 		/** The scopes from the access token used
@@ -466,7 +466,7 @@ export interface OAuthOptions<
 		scopes: Scopes;
 		/** The access token payload used in the /userinfo request */
 		jwt: JWTPayload;
-	}) => Awaitable<Record<string, any>>;
+	}): Awaitable<Record<string, any>>;
 	/**
 	 * Custom claims attached to OIDC id tokens.
 	 *
@@ -477,14 +477,14 @@ export interface OAuthOptions<
 	 *
 	 * @param info - context that may be useful when creating custom claims
 	 */
-	customIdTokenClaims?: (info: {
+	customIdTokenClaims?(info: {
 		/** The user object if token is associated to a user. */
 		user: User<AuthOptions["user"], AuthOptions["plugins"]>;
 		/** Scopes granted for this token */
 		scopes: Scopes;
 		/** oAuthClient metadata */
 		metadata?: Record<string, any>;
-	}) => Awaitable<Record<string, any>>;
+	}): Awaitable<Record<string, any>>;
 	/**
 	 * Custom claims attached to access tokens.
 	 *
@@ -498,7 +498,7 @@ export interface OAuthOptions<
 	 *
 	 * @param info - context that may be useful when creating custom claims
 	 */
-	customAccessTokenClaims?: (info: {
+	customAccessTokenClaims?(info: {
 		/** The user object if token is associated to a user. Null if user doesn't exist. Undefined if user not applicable. */
 		user?: User<AuthOptions["user"], AuthOptions["plugins"]> | null;
 		/** reference of the consent/authorization */
@@ -509,7 +509,7 @@ export interface OAuthOptions<
 		resource?: string;
 		/** oAuthClient metadata */
 		metadata?: Record<string, any>;
-	}) => Awaitable<Record<string, any>>;
+	}): Awaitable<Record<string, any>>;
 	/**
 	 * Custom fields to include in the token response body.
 	 *


### PR DESCRIPTION
## Summary

`customUserInfoClaims`, `customIdTokenClaims` and `customAccessTokenClaims` typed the user as `User & Record<string, unknown>`, so every configured `additionalFields` entry arrived as `unknown` and had to be cast at the call site. The callbacks now report the auth instance's own user type.

Closes #10652

## Testing

- `pnpm vitest packages/oauth-provider --run` — 341 pass
- `pnpm typecheck`, `pnpm typecheck:dist`, `pnpm lint`

Type-level regressions in the style of #9466.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes user typing in OAuth claim callbacks so `additionalFields` are inferred instead of `unknown`, removing casts in custom claim code. No runtime changes.

- **Bug Fixes**
  - Claim callbacks now derive the user type from auth options, so additional fields are strongly typed.
  - `oauthProvider` accepts an optional second argument with auth options for better inference; types-only, no behavior change.
  - Kept callbacks assignable across auth option variants by using method syntax; added type tests in `@better-auth/oauth-provider`.

<sup>Written for commit 3767b3805b9a15e71e05f6229ec8987c37b5da8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

