### PR TITLE
fix(scim): create filtered PATCH values when no target matches

### DIFF
--- a/.changeset/scim-filtered-patch-upsert.md
+++ b/.changeset/scim-filtered-patch-upsert.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": minor
+---
+
+SCIM PATCH operations that target filtered multi-valued attributes (`phoneNumbers`, `addresses`, `roles`, `entitlements`, `emails`) now create the value when the filter matches nothing instead of rejecting the request with a `noTarget` error. Microsoft Entra ID sends these operations for attributes that are not populated yet, and the rejection also discarded every other operation bundled in the same PATCH request.

--- a/docs/content/docs/plugins/scim/reference.mdx
+++ b/docs/content/docs/plugins/scim/reference.mdx
@@ -367,7 +367,9 @@ Operations run in array order and accept case-insensitive `add`, `replace`, and 
 
 In this table, `enterpriseUrn` is `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`.
 
-User paths may include the core User schema prefix. An `add` or `replace` operation may omit `path` and provide an object of writable attributes, including flat Enterprise URI keys. Unfiltered `replace` adds a missing target, while a filtered value path with no match returns `noTarget`. `id`, `schemas`, `meta`, and `manager.displayName` are read-only.
+User paths may include the core User schema prefix. An `add` or `replace` operation may omit `path` and provide an object of writable attributes, including flat Enterprise URI keys. Unfiltered `replace` adds a missing target. `id`, `schemas`, `meta`, and `manager.displayName` are read-only.
+
+When a filtered value path such as `phoneNumbers[type eq "work"].value` matches no stored value, Better Auth creates the value with the filtered `type` or `primary` stamped on it instead of returning the [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2.3) `noTarget` error. [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups) sends these operations for attributes that are not populated yet, and because PATCH is atomic, rejecting one of them would also discard every other operation in the same request. A created email is never primary, so a filter miss cannot move the sign-in address. A `remove` on a filtered path that matches nothing stays a no-op, and a `remove` without a path still returns `noTarget`.
 
 ### Group PATCH paths
 

--- a/packages/scim/src/scim-enterprise-user.test.ts
+++ b/packages/scim/src/scim-enterprise-user.test.ts
@@ -1379,7 +1379,7 @@ describe("SCIM classic Enterprise User provisioning", () => {
 		]);
 	});
 
-	it("rejects a primary-filtered replace when no value is currently primary", async () => {
+	it("creates a primary-filtered replace target when no value is currently primary", async () => {
 		const { auth } = createEnterpriseFixture();
 		const createResponse = await auth.handler(
 			createSCIMRequest("/scim/v2/Users", {
@@ -1410,10 +1410,12 @@ describe("SCIM classic Enterprise User provisioning", () => {
 				},
 			}),
 		);
-		expect(patchResponse.status).toBe(400);
-		expect(await readJSON(patchResponse)).toMatchObject({
-			scimType: "noTarget",
-		});
+		const patched = await readJSON<SCIMUserResponse>(patchResponse);
+		expect(patchResponse.status, JSON.stringify(patched)).toBe(200);
+		expect(patched.roles).toEqual([
+			{ value: "engineer", primary: false },
+			{ value: "senior-engineer", primary: true },
+		]);
 	});
 
 	it("cascades an emptied manager object out of the Enterprise extension on subattribute removal", async () => {

--- a/packages/scim/src/scim-entra-conformance.test.ts
+++ b/packages/scim/src/scim-entra-conformance.test.ts
@@ -1,0 +1,288 @@
+import type { User } from "better-auth";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { describe, expect, it } from "vitest";
+import { scim } from ".";
+import type { SCIMUser } from "./persistence";
+
+const BASE_URL = "http://localhost:3000";
+const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+const SCIM_MEDIA_TYPE = "application/scim+json";
+const SCIM_TOKEN = "entra-token";
+
+interface SCIMMultiValue {
+	value: string;
+	display?: string;
+	type?: string;
+	primary?: boolean;
+}
+
+interface SCIMAddress {
+	formatted?: string;
+	streetAddress?: string;
+	locality?: string;
+	region?: string;
+	postalCode?: string;
+	country?: string;
+	type?: string;
+	primary?: boolean;
+}
+
+interface SCIMUserResponse {
+	schemas: string[];
+	id: string;
+	userName: string;
+	name: {
+		formatted: string;
+		givenName?: string;
+		familyName?: string;
+	};
+	emails?: SCIMMultiValue[];
+	phoneNumbers?: SCIMMultiValue[];
+	addresses?: SCIMAddress[];
+	roles?: SCIMMultiValue[];
+	entitlements?: SCIMMultiValue[];
+}
+
+function createEntraFixture() {
+	const data = {
+		user: [] as User[],
+		session: [] as { id: string }[],
+		verification: [] as { id: string }[],
+		account: [] as { id: string }[],
+		scimConnectionBinding: [] as { id: string }[],
+		scimIdentityTombstone: [] as { id: string }[],
+		scimSubject: [] as { id: string; userId: string }[],
+		scimUser: [] as SCIMUser[],
+		scimGroup: [] as { id: string }[],
+		scimGroupMember: [] as { id: string }[],
+		scimProjectionGrant: [] as { id: string }[],
+	};
+	const auth = betterAuth({
+		baseURL: BASE_URL,
+		database: memoryAdapter(data),
+		plugins: [
+			scim({
+				connections: [
+					{
+						id: "workforce",
+						credentials: [
+							{ type: "bearer", id: SCIM_TOKEN, token: SCIM_TOKEN },
+						],
+					},
+				],
+				identity: {
+					resolveUser() {
+						return { action: "create" };
+					},
+				},
+			}),
+		],
+	});
+	return { auth, data };
+}
+
+function createSCIMRequest(
+	path: string,
+	options: {
+		method?: "GET" | "PATCH" | "POST";
+		body?: unknown;
+	} = {},
+): Request {
+	const headers = new Headers({
+		accept: SCIM_MEDIA_TYPE,
+		authorization: `Bearer ${SCIM_TOKEN}`,
+	});
+	if (options.body !== undefined) {
+		headers.set("content-type", SCIM_MEDIA_TYPE);
+	}
+	return new Request(`${BASE_URL}/api/auth${path}`, {
+		method: options.method ?? "GET",
+		headers,
+		...(options.body === undefined
+			? {}
+			: { body: JSON.stringify(options.body) }),
+	});
+}
+
+async function readJSON<T>(response: Response): Promise<T> {
+	return (await response.json()) as T;
+}
+
+async function createUser(
+	auth: ReturnType<typeof createEntraFixture>["auth"],
+	body: Record<string, unknown>,
+): Promise<SCIMUserResponse> {
+	const response = await auth.handler(
+		createSCIMRequest("/scim/v2/Users", {
+			method: "POST",
+			body: { schemas: [SCIM_USER_SCHEMA], ...body },
+		}),
+	);
+	const created = await readJSON<SCIMUserResponse>(response);
+	expect(response.status, JSON.stringify(created)).toBe(201);
+	return created;
+}
+
+async function patchUser(
+	auth: ReturnType<typeof createEntraFixture>["auth"],
+	userId: string,
+	operations: unknown[],
+): Promise<Response> {
+	return auth.handler(
+		createSCIMRequest(`/scim/v2/Users/${encodeURIComponent(userId)}`, {
+			method: "PATCH",
+			body: { schemas: [SCIM_PATCH_SCHEMA], Operations: operations },
+		}),
+	);
+}
+
+describe("SCIM User PATCH against Microsoft Entra ID attribute mappings", () => {
+	it("creates a filtered phone number and keeps the operations bundled with it", async () => {
+		const { auth } = createEntraFixture();
+		const user = await createUser(auth, {
+			userName: "bundled-phone@example.com",
+			name: { givenName: "Ada", familyName: "Lovelace" },
+		});
+
+		const response = await patchUser(auth, user.id, [
+			{
+				op: "Replace",
+				path: 'phoneNumbers[type eq "work"].value',
+				value: "+1-555-0100",
+			},
+			{ op: "Replace", path: "name.familyName", value: "King" },
+		]);
+		const patched = await readJSON<SCIMUserResponse>(response);
+		expect(response.status, JSON.stringify(patched)).toBe(200);
+		expect(patched.phoneNumbers).toEqual([
+			{ value: "+1-555-0100", type: "work" },
+		]);
+		expect(patched.name.familyName).toBe("King");
+	});
+
+	it("creates a filtered address sub-attribute", async () => {
+		const { auth } = createEntraFixture();
+		const user = await createUser(auth, {
+			userName: "missing-address@example.com",
+		});
+
+		const response = await patchUser(auth, user.id, [
+			{
+				op: "Replace",
+				path: 'addresses[type eq "work"].postalCode',
+				value: "94105",
+			},
+		]);
+		const patched = await readJSON<SCIMUserResponse>(response);
+		expect(response.status, JSON.stringify(patched)).toBe(200);
+		expect(patched.addresses).toEqual([{ type: "work", postalCode: "94105" }]);
+	});
+
+	it("creates filtered roles and entitlements", async () => {
+		const { auth } = createEntraFixture();
+		const user = await createUser(auth, {
+			userName: "missing-role@example.com",
+		});
+
+		const response = await patchUser(auth, user.id, [
+			{
+				op: "Replace",
+				path: 'roles[type eq "work"].value',
+				value: "engineer",
+			},
+			{
+				op: "Replace",
+				path: 'entitlements[type eq "work"].value',
+				value: "vpn",
+			},
+		]);
+		const patched = await readJSON<SCIMUserResponse>(response);
+		expect(response.status, JSON.stringify(patched)).toBe(200);
+		expect(patched.roles).toEqual([{ value: "engineer", type: "work" }]);
+		expect(patched.entitlements).toEqual([{ value: "vpn", type: "work" }]);
+	});
+
+	it("creates a filtered email without moving the primary address", async () => {
+		const { auth } = createEntraFixture();
+		const user = await createUser(auth, {
+			userName: "primary-email@example.com",
+			emails: [
+				{ value: "primary-email@example.com", type: "work", primary: true },
+			],
+		});
+
+		const response = await patchUser(auth, user.id, [
+			{
+				op: "Replace",
+				path: 'emails[type eq "other"].value',
+				value: "other-email@example.com",
+			},
+		]);
+		const patched = await readJSON<SCIMUserResponse>(response);
+		expect(response.status, JSON.stringify(patched)).toBe(200);
+		expect(patched.emails).toEqual([
+			{ value: "primary-email@example.com", type: "work", primary: true },
+			{ value: "other-email@example.com", type: "other", primary: false },
+		]);
+	});
+
+	it("creates a single primary value for a quoted primary filter", async () => {
+		const { auth } = createEntraFixture();
+		const user = await createUser(auth, {
+			userName: "quoted-primary@example.com",
+			roles: [{ value: "engineer", primary: false }],
+		});
+
+		const response = await patchUser(auth, user.id, [
+			{
+				op: "Replace",
+				path: 'roles[primary eq "true"].value',
+				value: "senior-engineer",
+			},
+		]);
+		const patched = await readJSON<SCIMUserResponse>(response);
+		expect(response.status, JSON.stringify(patched)).toBe(200);
+		expect(patched.roles).toEqual([
+			{ value: "engineer", primary: false },
+			{ value: "senior-engineer", primary: true },
+		]);
+		expect(patched.roles?.filter((role) => role.primary)).toHaveLength(1);
+	});
+
+	it("updates a populated filtered phone number in place", async () => {
+		const { auth } = createEntraFixture();
+		const user = await createUser(auth, {
+			userName: "populated-phone@example.com",
+			phoneNumbers: [{ value: "+1-555-0100", type: "work" }],
+		});
+
+		const response = await patchUser(auth, user.id, [
+			{
+				op: "Replace",
+				path: 'phoneNumbers[type eq "work"].value',
+				value: "+1-555-0199",
+			},
+		]);
+		const patched = await readJSON<SCIMUserResponse>(response);
+		expect(response.status, JSON.stringify(patched)).toBe(200);
+		expect(patched.phoneNumbers).toEqual([
+			{ value: "+1-555-0199", type: "work" },
+		]);
+	});
+
+	it("rejects a remove operation without a path", async () => {
+		const { auth } = createEntraFixture();
+		const user = await createUser(auth, {
+			userName: "pathless-remove@example.com",
+		});
+
+		const response = await patchUser(auth, user.id, [
+			{ op: "Remove", value: { displayName: "Ada" } },
+		]);
+		const error = await readJSON<{ scimType?: string }>(response);
+		expect(response.status, JSON.stringify(error)).toBe(400);
+		expect(error.scimType).toBe("noTarget");
+	});
+});

--- a/packages/scim/src/scim-user-patch.test.ts
+++ b/packages/scim/src/scim-user-patch.test.ts
@@ -196,7 +196,7 @@ describe("SCIM User PATCH provider compatibility", () => {
 		expect(persisted.user.email).toBe("shared@example.com");
 	});
 
-	it("adds a missing work email and treats a missing filtered removal as a no-op", async () => {
+	it("creates a missing work email for add and replace and treats a missing filtered removal as a no-op", async () => {
 		const { auth, data, headers } = createTestContext();
 		const created = await auth.api.createSCIMUser({
 			body: {
@@ -244,29 +244,39 @@ describe("SCIM User PATCH provider compatibility", () => {
 			},
 			headers,
 		});
+		await auth.api.patchSCIMUser({
+			params: { userId: created.id },
+			body: {
+				schemas: [PATCH_OP_SCHEMA],
+				Operations: [
+					{
+						op: "replace",
+						path: 'emails[type eq "work"].value',
+						value: "replacement@example.com",
+					},
+				],
+			},
+			headers,
+		});
+		const withReplacedWorkEmail = await auth.api.getSCIMUser({
+			params: { userId: created.id },
+			headers,
+		});
+		expect(withReplacedWorkEmail.emails).toEqual([
+			{ value: "home@example.com", type: "home", primary: true },
+			{ value: "replacement@example.com", type: "work", primary: false },
+		]);
+
+		await auth.api.patchSCIMUser({
+			params: { userId: created.id },
+			body: {
+				schemas: [PATCH_OP_SCHEMA],
+				Operations: [{ op: "remove", path: 'emails[type eq "work"].value' }],
+			},
+			headers,
+		});
 		const updatedAtAfterRemoval = getPersistedUser(data, created.id).scimUser
 			.updatedAt;
-		await expect(
-			auth.api.patchSCIMUser({
-				params: { userId: created.id },
-				body: {
-					schemas: [PATCH_OP_SCHEMA],
-					Operations: [
-						{
-							op: "replace",
-							path: 'emails[type eq "work"].value',
-							value: "replacement@example.com",
-						},
-					],
-				},
-				headers,
-			}),
-		).rejects.toThrowError(
-			expect.objectContaining({
-				statusCode: 400,
-				body: expect.objectContaining({ scimType: "noTarget" }),
-			}),
-		);
 		await auth.api.patchSCIMUser({
 			params: { userId: created.id },
 			body: {

--- a/packages/scim/src/user-patch.ts
+++ b/packages/scim/src/user-patch.ts
@@ -303,24 +303,18 @@ function replaceAllEmailValues(
 function replaceSelectedEmail(
 	state: SCIMUserPatchState,
 	selector: string,
-	op: "add" | "replace",
 	value: unknown,
 ): void {
 	const replacement = readEmail(value);
 	const matches = (email: SCIMEmail) => email.type === selector;
 	const hasSelection = state.emails.some(matches);
-	if (!hasSelection && op === "add") {
+	// A selector miss appends the email: Entra replaces addresses it has not created yet.
+	if (!hasSelection) {
 		setEmails(state, [
 			...state.emails,
 			{ value: replacement, type: selector, primary: false },
 		]);
 		return;
-	}
-	if (!hasSelection) {
-		throw createSCIMError("BAD_REQUEST", {
-			detail: `No ${selector} email matches the PATCH path`,
-			scimType: "noTarget",
-		});
 	}
 	const emails = state.emails.map((email) =>
 		matches(email) ? { ...email, value: replacement } : email,
@@ -680,17 +674,9 @@ function applySCIMMultiValuePatch(
 			: true;
 	});
 	const hasTarget = matches.some(Boolean);
+	// A selector miss creates the value instead of returning RFC 7644 noTarget: Entra replaces values that do not exist yet, and rejecting would void the whole PATCH.
 	if (!hasTarget) {
 		if (op === "remove") return;
-		if (
-			op === "replace" &&
-			(resolved.selectorType || resolved.selectorPrimary !== undefined)
-		) {
-			throw createSCIMError("BAD_REQUEST", {
-				detail: `No value matches the User PATCH path ${path}`,
-				scimType: "noTarget",
-			});
-		}
 		if (!resolved.subAttributeName) {
 			const additions = normalizeMultiValueAdditions(value).map((item) =>
 				isRecord(item)
@@ -1153,7 +1139,7 @@ export function applySCIMUserPatch(
 						setEmails(state, remaining);
 						return;
 					}
-					replaceSelectedEmail(state, selectorType, op, value);
+					replaceSelectedEmail(state, selectorType, value);
 					return;
 				}
 				if (EMAIL_PRIMARY_VALUE_PATH.test(schemaRelativePath)) {


### PR DESCRIPTION
Microsoft Entra ID provisions multi-valued attributes with filtered replace operations even when nothing matches the filter: a delta sync for a user with no stored phone number sends `Replace phoneNumbers[type eq "work"].value`. The plugin rejected these with the RFC 7644 `noTarget` error, and PATCH atomicity turned that one miss into a failure of the whole request, so unrelated updates bundled alongside (a name change, an `active` flip) never applied. These paths are [Entra's default attribute mappings](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups), so provisioning stalls on any tenant where an attribute gets populated after the first sync.

The engine already resolves this tension for the sibling operations: a filtered `remove` that matches nothing no-ops, and a filtered `add` that matches nothing creates the value with the selector's `type` or `primary` stamped on it. This change extends the same policy to `replace`; the fix is deleting the throw, and the existing create paths handle the rest. The deviation from [RFC 7644 section 3.5.2.3](https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2.3) is deliberate and documented inline and in the reference docs. Two safety properties hold by construction: a created email is never primary, so a miss cannot move a user's sign-in address, and a `[primary eq true]` miss implies no existing primary, so the created entry becomes the only primary.

Pathless `remove` operations keep returning `noTarget`; that boundary rejects malformed requests rather than unpopulated state. A new Entra conformance suite covers the documented mapping paths alongside the existing Okta and Google suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SCIM PATCH filtered replaces act as upserts for multi-valued attributes to match Microsoft Entra ID, preventing `noTarget` from voiding bundled operations. Unblocks provisioning when attributes like `phoneNumbers` or `roles` are first set.

- **Bug Fixes**
  - Filtered `replace` on multi-valued paths (`phoneNumbers`, `addresses`, `roles`, `entitlements`, `emails`) now creates the value when no match exists (e.g., `phoneNumbers[type eq "work"].value`), instead of returning `noTarget` (RFC deviation documented).
  - Safety: created emails are never primary; a `[primary eq true]` miss creates a single primary only if none exists. Filtered `remove` with no match stays a no-op; `remove` without a path still returns `noTarget`.
  - Added Entra conformance tests for default mappings; updated SCIM reference docs; minor release for `@better-auth/scim`.

<sup>Written for commit 4000b2bf1807f981465497acc9c13d03e67b33c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

