### PR TITLE
test(electron): wait for session refresh after sign-out

### DIFF
--- a/packages/electron/test/electron.test.ts
+++ b/packages/electron/test/electron.test.ts
@@ -1415,15 +1415,16 @@ describe("Electron", () => {
 			password: "password",
 		});
 
-		const before = client.$store.atoms.session!.get();
+		const { refetch } = client.$store.atoms.session!.get();
 		await client.signOut();
-		const after = client.$store.atoms.session!.get();
-
-		expect(after).toMatchObject({
-			...before,
-			data: null,
-			error: null,
-			isPending: false,
+		await vi.waitFor(() => {
+			expect(client.$store.atoms.session!.get()).toEqual({
+				data: null,
+				error: null,
+				isPending: false,
+				isRefetching: false,
+				refetch,
+			});
 		});
 	});
 


### PR DESCRIPTION
Allow the asynchronous session refresh triggered by sign-out to settle before asserting the final store state.

This removes the test's dependency on transient scheduling while preserving an exact assertion, including the `refetch` function identity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Electron sign-out test wait for the async session refresh before asserting store state using `vi.waitFor`. It now asserts the exact final snapshot (`data: null`, `error: null`, `isPending: false`, `isRefetching: false`) while preserving the original `refetch` function identity to avoid timing flakiness.

<sup>Written for commit 47d442baf82b5bae1a94913c1f1d81062d355275. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

