### PR TITLE
feat(oauth-provider): allow access-token lifetime per grant

### DIFF
--- a/.changeset/per-grant-access-token-lifetime.md
+++ b/.changeset/per-grant-access-token-lifetime.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+Allow `accessTokenExpiresIn` to be a function, evaluated per user grant, so applications with per-connection consent policies can issue different access-token lifetimes. Numeric configuration is unchanged.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1059,7 +1059,7 @@ The callback receives the grant type, user (undefined for `client_credentials`),
 
 Each token type and grant type can independently can set a default expiration.
 
-* `accessTokenExpiresIn` defaults 1 hour
+* `accessTokenExpiresIn` defaults 1 hour (also accepts a function, see [Per-grant access token expiration](#per-grant-access-token-expiration))
 * `m2mAccessTokenExpiresIn` defaults 1 hour
 * `idTokenExpiresIn` defaults 10 hours
 * `refreshTokenExpiresIn` defaults 30 days
@@ -1075,6 +1075,25 @@ oauthProvider({
   },
 })
 ```
+
+#### Per-grant access token expiration
+
+`accessTokenExpiresIn` also accepts a function, evaluated each time a user grant is issued. Use this when the lifetime is a property of the individual connection rather than of the whole process — for example when a consent screen lets the approver choose how long the connection's access token should live.
+
+```ts title="auth.ts"
+oauthProvider({
+  accessTokenExpiresIn: async ({ user, client, scopes, grantType }) => {
+    const choice = await getConsentedLifetime(user.id, client.clientId);
+    return choice ?? 3600;
+  },
+})
+```
+
+The function receives only values the provider has already validated — the authenticated `user`, the authenticated `client`, the granted `scopes`, the `grantType`, and the endpoint `ctx`. Nothing from the token request body is passed, so a client cannot obtain a longer token by asking for one.
+
+It must return a finite, positive number of seconds. Any other result falls back to the 1 hour default rather than to a longer lifetime, so a faulty resolver cannot widen the window. Throwing propagates and denies the token.
+
+Client credentials grants are unaffected and continue to use `m2mAccessTokenExpiresIn`. `scopeExpirations` still applies on top, so the earliest expiration wins.
 
 ### Registration
 

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -2010,6 +2010,146 @@ describe("oauth token - config", async () => {
 		expect(tokens.error?.status).toBeUndefined();
 		expect(tokens.data?.access_token).toBeDefined();
 	});
+
+	/**
+	 * Run one authorization_code grant and return the issued tokens.
+	 */
+	async function authorizationCodeTokens(
+		oauthProviderConfig?: Omit<
+			OAuthOptions<Scope[]>,
+			"loginPage" | "consentPage"
+		>,
+	) {
+		const { client, oauthClient } = await createTestInstance({
+			oauthProviderConfig,
+		});
+		const { url: authUrl, codeVerifier } = await createAuthUrl({
+			clientId: oauthClient?.client_id!,
+			clientSecret: oauthClient?.client_secret,
+		});
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const url = new URL(callbackRedirectUrl);
+		const tokens = await client.oauth2.token(
+			{
+				code: url.searchParams.get("code")!,
+				code_verifier: codeVerifier,
+				grant_type: "authorization_code",
+				// Requesting the audience yields a JWT access token, so the tests below
+				// can read `exp`/`iat` back off the token itself and not only trust
+				// `expires_in` in the response body.
+				resource: validAudience,
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				redirect_uri: redirectUri,
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		return { client, oauthClient, tokens };
+	}
+
+	it("accessTokenExpiresIn - a number keeps its existing behaviour", async () => {
+		const { tokens } = await authorizationCodeTokens({
+			accessTokenExpiresIn: 7200,
+		});
+		expect(tokens.data?.expires_in).toBe(7200);
+		const accessToken = decodeJwt(tokens.data?.access_token ?? "");
+		expect((accessToken.exp ?? 0) - (accessToken.iat ?? 0)).toBe(7200);
+	});
+
+	it("accessTokenExpiresIn - a function decides the lifetime per grant", async () => {
+		const { tokens } = await authorizationCodeTokens({
+			accessTokenExpiresIn: () => 1800,
+		});
+		expect(tokens.data?.expires_in).toBe(1800);
+		const accessToken = decodeJwt(tokens.data?.access_token ?? "");
+		expect((accessToken.exp ?? 0) - (accessToken.iat ?? 0)).toBe(1800);
+	});
+
+	it("accessTokenExpiresIn - an async function is awaited", async () => {
+		const { tokens } = await authorizationCodeTokens({
+			accessTokenExpiresIn: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 1));
+				return 900;
+			},
+		});
+		expect(tokens.data?.expires_in).toBe(900);
+	});
+
+	it("accessTokenExpiresIn - the resolver receives the validated grant", async () => {
+		let seen: {
+			userId?: string;
+			clientId?: string;
+			scopes?: string[];
+			grantType?: string;
+		} = {};
+		const { oauthClient } = await authorizationCodeTokens({
+			accessTokenExpiresIn: ({ user, client, scopes, grantType }) => {
+				seen = {
+					userId: user?.id,
+					clientId: client?.clientId,
+					scopes,
+					grantType,
+				};
+				return 1200;
+			},
+		});
+		expect(seen.userId).toBeDefined();
+		expect(seen.clientId).toBe(oauthClient?.client_id);
+		expect(seen.scopes).toContain("openid");
+		expect(seen.grantType).toBe("authorization_code");
+	});
+
+	// A resolver is trusted to throw, but never trusted to return a sane number:
+	// anything that is not finite and positive falls back to the 1 hour default
+	// rather than to a longer lifetime.
+	it.for([
+		{ label: "zero", value: 0 },
+		{ label: "negative", value: -60 },
+		{ label: "NaN", value: Number.NaN },
+		{ label: "Infinity", value: Number.POSITIVE_INFINITY },
+	])(
+		"accessTokenExpiresIn - $label result falls back to the default",
+		async ({ value }) => {
+			const { tokens } = await authorizationCodeTokens({
+				accessTokenExpiresIn: () => value,
+			});
+			expect(tokens.data?.expires_in).toBe(3600);
+		},
+	);
+
+	it("accessTokenExpiresIn - a function does not affect client_credentials", async () => {
+		const { client, oauthClient } = await createTestInstance({
+			oauthProviderConfig: {
+				accessTokenExpiresIn: () => 60,
+				m2mAccessTokenExpiresIn: 7200,
+			},
+		});
+		const tokens = await client.oauth2.token(
+			{
+				grant_type: "client_credentials",
+				client_id: oauthClient?.client_id,
+				client_secret: oauthClient?.client_secret,
+				scope: "read:profile",
+			},
+			{
+				headers: {
+					accept: "application/json",
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+		expect(tokens.data?.expires_in).toBe(7200);
+	});
 });
 
 describe("oauth token - client secret validation", async () => {

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -85,7 +85,7 @@ async function createJwtAccessToken(
 	},
 ) {
 	const iat = overrides?.iat ?? Math.floor(Date.now() / 1000);
-	const exp = overrides?.exp ?? iat + (opts.accessTokenExpiresIn ?? 3600);
+	const exp = overrides?.exp ?? iat + staticAccessTokenExpiresIn(opts);
 	const customClaims = opts.customAccessTokenClaims
 		? await opts.customAccessTokenClaims({
 				user,
@@ -247,7 +247,7 @@ async function createOpaqueAccessToken(
 	refreshId?: string,
 ) {
 	const iat = payload.iat ?? Math.floor(Date.now() / 1000);
-	const exp = payload?.exp ?? iat + (opts.accessTokenExpiresIn ?? 3600);
+	const exp = payload?.exp ?? iat + staticAccessTokenExpiresIn(opts);
 	const token = opts.generateOpaqueAccessToken
 		? await opts.generateOpaqueAccessToken()
 		: generateRandomString(32, "A-Z", "a-z");
@@ -471,6 +471,62 @@ interface CreateUserTokensParams {
 	verificationValue?: VerificationValue;
 }
 
+const DEFAULT_ACCESS_TOKEN_EXPIRES_IN = 3600;
+
+/**
+ * The configured lifetime where no grant is in scope to resolve one against.
+ *
+ * A resolver can only be evaluated with a grant, so on these paths a configured
+ * function is treated as "not a static value" and the default applies. Both callers
+ * are reached with an already-computed `exp` during a normal grant, so this is the
+ * fallback for direct callers rather than the usual path.
+ */
+function staticAccessTokenExpiresIn(opts: OAuthOptions<Scope[]>): number {
+	return typeof opts.accessTokenExpiresIn === "number"
+		? opts.accessTokenExpiresIn
+		: DEFAULT_ACCESS_TOKEN_EXPIRES_IN;
+}
+
+/**
+ * Resolve the user access-token lifetime for a single grant.
+ *
+ * A number behaves exactly as before. A function is evaluated with the grant context
+ * the provider has already validated, never with anything taken from the request body,
+ * so a client cannot lengthen its own token by asking.
+ *
+ * The resolver is trusted to throw — a throw propagates and denies the token, which is
+ * the fail-closed outcome — but it is not trusted to return a sane number. A
+ * non-finite or non-positive result falls back to the default rather than to a longer
+ * lifetime, so a buggy resolver can never widen the window it was added to narrow.
+ */
+async function resolveUserAccessTokenExpiresIn(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	params: {
+		user: User;
+		client: SchemaClient<Scope[]>;
+		scopes: string[];
+		grantType: GrantType | undefined;
+	},
+): Promise<number> {
+	const configured = opts.accessTokenExpiresIn;
+	if (typeof configured !== "function") {
+		return configured ?? DEFAULT_ACCESS_TOKEN_EXPIRES_IN;
+	}
+	const resolved = await configured({
+		ctx,
+		user: params.user,
+		client: params.client,
+		scopes: params.scopes,
+		grantType: params.grantType,
+	});
+	return typeof resolved === "number" &&
+		Number.isFinite(resolved) &&
+		resolved > 0
+		? Math.floor(resolved)
+		: DEFAULT_ACCESS_TOKEN_EXPIRES_IN;
+}
+
 async function createUserTokens(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
@@ -491,7 +547,12 @@ async function createUserTokens(
 
 	const iat = Math.floor(Date.now() / 1000);
 	const baseExpiry = user
-		? (opts.accessTokenExpiresIn ?? 3600)
+		? await resolveUserAccessTokenExpiresIn(ctx, opts, {
+				user,
+				client,
+				scopes,
+				grantType,
+			})
 		: (opts.m2mAccessTokenExpiresIn ?? 3600);
 	const defaultExp = iat + baseExpiry;
 	const exp = opts.scopeExpirations

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -33,6 +33,31 @@ export type AuthorizePrompt =
 	| "login consent"
 	| "select_account consent";
 
+/**
+ * Context handed to an {@link OAuthOptions.accessTokenExpiresIn} resolver when a user
+ * grant is issued. Every field has already been validated by the provider.
+ */
+export interface AccessTokenExpiresInContext<
+	Scopes extends readonly Scope[] = InternallySupportedScopes[],
+> {
+	ctx: GenericEndpointContext;
+	/** The authenticated user the grant is being issued for. */
+	user: User;
+	/** The authenticated client the grant is being issued to. */
+	client: SchemaClient<Scopes>;
+	/** The scopes granted, after validation. */
+	scopes: Scopes[number][];
+	/** The grant type in play, when the flow provides one. */
+	grantType: GrantType | undefined;
+}
+
+/**
+ * Resolves the user access-token lifetime, in seconds, for a single grant.
+ */
+export type AccessTokenExpiresInResolver<
+	Scopes extends readonly Scope[] = InternallySupportedScopes[],
+> = (params: AccessTokenExpiresInContext<Scopes>) => Awaitable<number>;
+
 export interface OAuthOptions<
 	Scopes extends readonly Scope[] = InternallySupportedScopes[],
 > {
@@ -73,9 +98,29 @@ export interface OAuthOptions<
 	/**
 	 * The amount of time in seconds that the access token is valid for.
 	 *
+	 * May also be a function, evaluated each time a user grant is issued, so the
+	 * lifetime can be decided per grant rather than once per process. It receives
+	 * the grant context the provider has already validated — never anything read
+	 * from the token request body — so a client cannot obtain a longer token by
+	 * asking for one.
+	 *
+	 * The resolver must return a finite, positive number of seconds. Any other
+	 * result (including a rejected promise being avoided by returning `NaN`) falls
+	 * back to the default below rather than to a longer lifetime. Throwing is
+	 * propagated and denies the token, which is the fail-closed outcome.
+	 *
+	 * Client-credentials (machine-to-machine) grants are unaffected and continue to
+	 * use {@link OAuthOptions.m2mAccessTokenExpiresIn}.
+	 *
 	 * @default 3600 (1 hour) - Industry standard
+	 *
+	 * @example
+	 * ```ts
+	 * accessTokenExpiresIn: async ({ user, client }) =>
+	 * 	(await lookupConsentedLifetime(user.id, client.clientId)) ?? 3600,
+	 * ```
 	 */
-	accessTokenExpiresIn?: number;
+	accessTokenExpiresIn?: number | AccessTokenExpiresInResolver<Scopes>;
 	/**
 	 * The amount of time in seconds that a client
 	 * credentials grant access token is valid for.


### PR DESCRIPTION
### Summary

`accessTokenExpiresIn` may now be a function, evaluated when a user grant is issued, so the access-token lifetime can be decided per grant instead of once per process. A number behaves exactly as before.

```ts
oauthProvider({
  accessTokenExpiresIn: async ({ user, client, scopes, grantType }) => {
    const choice = await getConsentedLifetime(user.id, client.clientId);
    return choice ?? 3600;
  },
})
```

### Why

Applications whose consent screen lets the approver choose how long a connection's access token should live cannot express that with a single process-wide number — two connections to the same server legitimately want different lifetimes.

The obvious workaround is to read something off the token request, which is exactly what you do not want: it would let a client lengthen its own token by asking. Evaluating a resolver at issuance keeps the decision tied to the grant the provider has already validated.

### Design notes

Two things were deliberate, both on the safe side:

- **The resolver only ever sees validated input** — the authenticated `user`, the authenticated `client`, the granted `scopes`, the `grantType`, and the endpoint `ctx`. Nothing from the request body is passed through.
- **It is trusted to throw, but not trusted to return a sane number.** A throw propagates and denies the token, which is the fail-closed outcome. A non-finite or non-positive return falls back to the existing 1 hour default rather than to a longer lifetime, so a faulty resolver can never widen the window it was configured to narrow.

`createJwtAccessToken` and `createOpaqueAccessToken` can be reached without a grant in scope, so a configured *function* is treated there as "no static value" and the default applies. On the normal grant path both already receive a computed `exp`, so this only affects direct callers.

### Backward compatibility

None broken. Existing numeric `accessTokenExpiresIn` configurations keep their exact behaviour, including the `?? 3600` fallback. Client-credentials grants are untouched and continue to use `m2mAccessTokenExpiresIn`. `scopeExpirations` still applies on top, so the earliest expiration still wins.

### Tests

Added to `packages/oauth-provider/src/token.test.ts`, in the existing `oauth token - config` block:

- a numeric value keeps its existing behaviour (asserted on `expires_in` and on the JWT `exp`/`iat`)
- a function decides the lifetime per grant
- an async function is awaited
- the resolver receives the validated user, client, scopes and grant type
- `0`, negative, `NaN` and `Infinity` results each fall back to the 1 hour default
- a configured function does not affect `client_credentials`, which still uses `m2mAccessTokenExpiresIn`

Verification run locally:

- `pnpm exec vitest run src/token.test.ts` — 62 passed
- full `@better-auth/oauth-provider` suite — 22 files, 346 passed
- `pnpm typecheck` — clean

Changeset and documentation for the public option are included, per CONTRIBUTING.

### Related

Happy to adjust the resolver's parameter shape or naming if you'd prefer it to match another callback in the plugin — `customAccessTokenClaims` was the closest existing precedent I could find and the shape here follows it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per‑grant access‑token lifetimes to `@better-auth/oauth-provider` by allowing `accessTokenExpiresIn` to be a function evaluated when a user grant is issued. Numeric configs are unchanged and still default to 1 hour.

- **New Features**
  - `accessTokenExpiresIn` may be an async function; it receives validated `user`, `client`, `scopes`, `grantType`, and `ctx`.
  - Non‑finite or non‑positive returns fall back to 1h; thrown errors deny the token.
  - `client_credentials` is unchanged and uses `m2mAccessTokenExpiresIn`; `scopeExpirations` still caps the earliest expiry.
  - Direct calls to `createJwtAccessToken`/`createOpaqueAccessToken` use the default when a function is configured.
  - Docs updated and tests added.

<sup>Written for commit b0786f5ded7dd4fd84fdd74dba161e1249debf08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

