### PR TITLE
fix(mcp): export MCPOptions and add a resolvable ./plugins/mcp entry

### DIFF
--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -485,6 +485,9 @@
       "plugins/device-authorization": [
         "./dist/plugins/device-authorization/index.d.mts"
       ],
+      "plugins/mcp": [
+        "./dist/plugins/mcp/index.d.mts"
+      ],
       "plugins/mcp/client": [
         "./dist/plugins/mcp/client/index.d.mts"
       ],

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -311,6 +311,11 @@
       "types": "./dist/plugins/device-authorization/index.d.mts",
       "default": "./dist/plugins/device-authorization/index.mjs"
     },
+    "./plugins/mcp": {
+      "dev-source": "./src/plugins/mcp/index.ts",
+      "types": "./dist/plugins/mcp/index.d.mts",
+      "default": "./dist/plugins/mcp/index.mjs"
+    },
     "./plugins/mcp/client": {
       "dev-source": "./src/plugins/mcp/client/index.ts",
       "types": "./dist/plugins/mcp/client/index.d.mts",

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -46,7 +46,7 @@ declare module "@better-auth/core" {
 	}
 }
 
-interface MCPOptions {
+export interface MCPOptions {
 	loginPage: string;
 	resource?: string | undefined;
 	oidcConfig?: OIDCOptions | undefined;

--- a/packages/better-auth/src/plugins/mcp/mcp.test.ts
+++ b/packages/better-auth/src/plugins/mcp/mcp.test.ts
@@ -5,8 +5,10 @@ import { toNodeHandler } from "../../integrations/node";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { genericOAuth } from "../generic-oauth";
 import { genericOAuthClient } from "../generic-oauth/client";
+import type { MCPOptions as MCPOptionsFromPluginsBarrel } from "../index";
 import { jwt } from "../jwt";
 import type { Client } from "../oidc-provider/types";
+import type { MCPOptions } from ".";
 import { mcp, withMcpAuth } from ".";
 
 // Pre-verifies any user the RP creates via OAuth signup so the existing-user
@@ -1327,5 +1329,23 @@ describe("mcp session freshness (security)", () => {
 		expect(response.status).toBe(401);
 		expect(body?.error).toBe("invalid_grant");
 		expect(body?.access_token).toBeUndefined();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10532
+	 *
+	 * `MCPOptions` was declared without `export`, so it had no importable
+	 * specifier anywhere reachable. TypeScript's declaration emitter could
+	 * therefore not name it, and any consumer building with `declaration: true`
+	 * hit `TS4023: ... but cannot be named` on any exported value typed by
+	 * `mcp()`. These are type-only imports: they fail to compile (not just fail
+	 * at runtime) if the export is ever dropped again, from either the plugin's
+	 * own module or the `plugins` barrel every sibling options type goes
+	 * through.
+	 */
+	it("exports MCPOptions from its own module and the plugins barrel", () => {
+		const fromOwnModule: MCPOptions = { loginPage: "/login" };
+		const fromBarrel: MCPOptionsFromPluginsBarrel = { loginPage: "/login" };
+		expect(fromOwnModule).toEqual(fromBarrel);
 	});
 });

--- a/packages/better-auth/tsdown.config.ts
+++ b/packages/better-auth/tsdown.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
 		"./src/plugins/haveibeenpwned/index.ts",
 		"./src/plugins/one-time-token/index.ts",
 		"./src/plugins/siwe/index.ts",
+		"./src/plugins/mcp/index.ts",
 		"./src/plugins/mcp/client/index.ts",
 		"./src/plugins/mcp/client/adapters.ts",
 		"./src/test-utils/index.ts",


### PR DESCRIPTION
Fixes #10532

## What's broken

`MCPOptions` is declared in the mcp plugin but never actually exported anywhere reachable. If your project compiles with `declaration: true` (composite builds, or anything that lints its own exported API surface) and you export a value built with `mcp()`, you get:

```
error TS4023: Exported variable 'auth' has or is using name 'MCPOptions' from external module ".../better-auth/dist/plugins/mcp/index" but cannot be named.
```

There's no workaround on the consumer side either — you can't re-export a type that was never exported in the first place.

## Why it happens

Three small gaps, all in the same direction:

1. `interface MCPOptions` in `plugins/mcp/index.ts` was missing the `export` keyword.
2. The `plugins/mcp/index.ts` module itself wasn't in `tsdown.config.ts`'s entry list, so there was no standalone `dist/plugins/mcp/index.mjs`/`.d.mts` to point at (only its `client` subfolder was built).
3. The package's `exports` map had `./plugins/mcp/client` and `./plugins/mcp/client/adapters`, but no `./plugins/mcp` — every sibling plugin's options type (`AdminOptions`, `OIDCOptions`, `MagicLinkOptions`, ...) has this entry, mcp's didn't.

## The fix

Just those three things, matching the existing pattern for every other plugin:

- `export interface MCPOptions` — the `plugins` barrel already does `export * from "./mcp"`, so this alone makes it flow through to `better-auth/plugins`.
- Added `./src/plugins/mcp/index.ts` to the tsdown entry list.
- Added the `./plugins/mcp` exports map entry, same shape as its neighbors.

## How I checked it

Built a throwaway consumer package against `dist` with `declaration: true`, importing `mcp` and exporting an `auth` instance built with it — same shape as the issue's repro:

```
# before this change
error TS4023: Exported variable 'auth' has or is using name 'MCPOptions' ... but cannot be named.

# with this change
(clean build; auth.d.ts includes `options: import("better-auth/plugins").MCPOptions`)
```

`attw --profile esm-only --pack .` and `publint run --strict --pack false` both pass on the built package. `pnpm typecheck` is clean.

Added a regression test in `mcp.test.ts` that type-only imports `MCPOptions` from both the plugin's own module and the `plugins` barrel. Worth flagging honestly: this test does *not* fail under `vitest run` if the export regresses, since Vitest transpiles TypeScript without type-checking it — type-only imports just get erased. What it does catch is `tsc --noEmit`: on `main` it fails with `TS2459`/`TS2724`, and passes with this change. I left the test in because it documents the contract and will fail loudly the moment CI runs a real typecheck, but the `tsc --noEmit` result is the actual proof this is fixed, not the vitest run.

## Type

🐛 Bug Fix (type-only change, no runtime behavior touched)

*An AI coding agent helped me write this. I reviewed the diff, reproduced the TS4023 error on `main` and confirmed it's gone with this change, and ran the checks above myself.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports `MCPOptions` and makes `./plugins/mcp` a resolvable subpath. The type now resolves under modern and classic module resolution, fixing TS4023 for `declaration: true` builds.

- **Bug Fixes**
  - Exported `MCPOptions` from `src/plugins/mcp/index.ts` (picked up by the `better-auth/plugins` barrel).
  - Added `./plugins/mcp` to `package.json` `exports` and `typesVersions`, and to `tsdown.config.ts` so `dist/plugins/mcp` is built and resolves correctly.
  - Added a type-only regression test importing `MCPOptions` from both the plugin module and the `plugins` barrel.

<sup>Written for commit f2fffdf1a8792ef6470f3642efb75049dbd314f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

