### PR TITLE
fix(oauth-provider): infer user additionalFields in customUserInfoClaims and callbacks (#10652)

### DIFF
--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -1908,7 +1908,7 @@ describe("oauth - prompt", async () => {
 		);
 
 		let selectAccountRedirectUri = "";
-		await serverClient.$fetch(data.url, {
+		await serverClient.$fetch(data.url!, {
 			method: "GET",
 			headers,
 			onError(ctx) {

--- a/packages/oauth-provider/src/public-types.test.ts
+++ b/packages/oauth-provider/src/public-types.test.ts
@@ -18,4 +18,30 @@ describe("public oauth-provider types", () => {
 			AuthMethod | "none"
 		>();
 	});
+
+	it("infers user additionalFields in customUserInfoClaims and claim callbacks", () => {
+		const options: OAuthOptions = {
+			loginPage: "/login",
+			consentPage: "/consent",
+			customUserInfoClaims: ({ user }) => {
+				const role: string = user.role;
+				const customField: unknown = user.customField;
+				return { role, customField };
+			},
+			customIdTokenClaims: ({ user }) => {
+				const role: string = user.role;
+				return { role };
+			},
+			customAccessTokenClaims: ({ user }) => {
+				const role: string = user?.role;
+				return { role };
+			},
+			customTokenResponseFields: ({ user }) => {
+				const role: string = user?.role;
+				return { role };
+			},
+		};
+		expectTypeOf(options.customUserInfoClaims).not.toBeUndefined();
+	});
 });
+

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -201,8 +201,8 @@ export interface OAuthOptions<
 	 * }
 	 */
 	clientReference?: (context: {
-		user?: User & Record<string, unknown>;
-		session?: Session & Record<string, unknown>;
+		user?: User & Record<string, any>;
+		session?: Session & Record<string, any>;
 	}) => Awaitable<string | undefined>;
 	/**
 	 * RBAC on OAuth Clients.
@@ -213,8 +213,8 @@ export interface OAuthOptions<
 	clientPrivileges?: (context: {
 		headers: Headers;
 		action: "create" | "read" | "update" | "delete" | "list" | "rotate";
-		user?: User & Record<string, unknown>;
-		session?: Session & Record<string, unknown>;
+		user?: User & Record<string, any>;
+		session?: Session & Record<string, any>;
 	}) => Awaitable<boolean | undefined>;
 	/**
 	 * List default scopes when using the token endpoint's
@@ -291,8 +291,8 @@ export interface OAuthOptions<
 		 */
 		shouldRedirect?: (context: {
 			headers: Headers;
-			user: User & Record<string, unknown>;
-			session: Session & Record<string, unknown>;
+			user: User & Record<string, any>;
+			session: Session & Record<string, any>;
 			scopes: Scopes;
 		}) => Awaitable<boolean | string>;
 	};
@@ -320,8 +320,8 @@ export interface OAuthOptions<
 		 */
 		shouldRedirect: (context: {
 			headers: Headers;
-			user: User & Record<string, unknown>;
-			session: Session & Record<string, unknown>;
+			user: User & Record<string, any>;
+			session: Session & Record<string, any>;
 			scopes: Scopes;
 		}) => Awaitable<boolean>;
 	};
@@ -340,8 +340,8 @@ export interface OAuthOptions<
 		 * scope doesn't have a reference id and it should.
 		 */
 		consentReferenceId: (context: {
-			user: User & Record<string, unknown>;
-			session: Session & Record<string, unknown>;
+			user: User & Record<string, any>;
+			session: Session & Record<string, any>;
 			scopes: Scopes;
 		}) => Awaitable<string | undefined>;
 		/**
@@ -358,8 +358,8 @@ export interface OAuthOptions<
 		 */
 		shouldRedirect: (context: {
 			headers: Headers;
-			user: User & Record<string, unknown>;
-			session: Session & Record<string, unknown>;
+			user: User & Record<string, any>;
+			session: Session & Record<string, any>;
 			scopes: Scopes;
 		}) => Awaitable<boolean>;
 	};
@@ -449,7 +449,7 @@ export interface OAuthOptions<
 	 */
 	customUserInfoClaims?: (info: {
 		/** The user object */
-		user: User & Record<string, unknown>;
+		user: User & Record<string, any>;
 		/** The scopes from the access token used
 		 * in the /userinfo request (matches jwt.scopes) */
 		scopes: Scopes;
@@ -468,7 +468,7 @@ export interface OAuthOptions<
 	 */
 	customIdTokenClaims?: (info: {
 		/** The user object if token is associated to a user. */
-		user: User & Record<string, unknown>;
+		user: User & Record<string, any>;
 		/** Scopes granted for this token */
 		scopes: Scopes;
 		/** oAuthClient metadata */
@@ -489,7 +489,7 @@ export interface OAuthOptions<
 	 */
 	customAccessTokenClaims?: (info: {
 		/** The user object if token is associated to a user. Null if user doesn't exist. Undefined if user not applicable. */
-		user?: (User & Record<string, unknown>) | null;
+		user?: (User & Record<string, any>) | null;
 		/** reference of the consent/authorization */
 		referenceId?: string;
 		/** Scopes granted for this token */
@@ -518,7 +518,7 @@ export interface OAuthOptions<
 		 * Undefined for `client_credentials` (M2M, no user).
 		 * Always present for `authorization_code` and `refresh_token`.
 		 */
-		user?: (User & Record<string, unknown>) | null;
+		user?: (User & Record<string, any>) | null;
 		/** Scopes granted for this token */
 		scopes: Scopes;
 		/** oAuthClient metadata */


### PR DESCRIPTION
Fixes #10652

### Summary
Refine `user` and `session` callback parameter types in `@better-auth/oauth-provider` from `Record<string, unknown>` to `Record<string, any>`. This allows accessing dynamic `additionalFields` on `user` (e.g. `user.role`, `user.customField`) in `customUserInfoClaims`, `customIdTokenClaims`, `customAccessTokenClaims`, `customTokenResponseFields`, and other provider callbacks without TypeScript compilation errors.

This aligns `@better-auth/oauth-provider` with the established pattern used across Better Auth core and plugins (`jwt`, `sso`, `stripe`, `electron`).

### Changes
- `packages/oauth-provider/src/types/index.ts`: Refine callback context parameter definitions (`user`, `session`) from `Record<string, unknown>` to `Record<string, any>`.
- `packages/oauth-provider/src/public-types.test.ts`: Add type inference unit test asserting dynamic `additionalFields` property access in claim callbacks.
- `packages/oauth-provider/src/oauth.test.ts`: Fix non-null assertion on prompt redirect URL fetch call (`data.url!`).

### Testing
- `npx tsc --noEmit` passed cleanly (0 errors).
- `pnpm test` passed 84/84 tests in `packages/oauth-provider`.
