### PR TITLE
fix(two-factor): log attempt counter failures instead of discarding them

### DIFF
--- a/.changeset/log-two-factor-attempt-counter-errors.md
+++ b/.changeset/log-two-factor-attempt-counter-errors.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Log the underlying error when the two-factor attempt counter cannot be read or written, instead of discarding it. Behaviour is unchanged and these failures still fail closed, but an adapter or schema problem previously surfaced only as a generic "Invalid two factor cookie", giving no indication of the real cause.

--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -147,7 +147,13 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 				// row means a lost race or an expired challenge.
 				const consumed = await ctx.context.internalAdapter
 					.consumeVerificationValue(identifier)
-					.catch(() => null);
+					.catch((error) => {
+						ctx.context.logger.debug(
+							"Two-factor: failed to consume the attempt counter; treating the challenge as invalid.",
+							error,
+						);
+						return null;
+					});
 				if (!consumed) {
 					throw APIError.from(
 						"UNAUTHORIZED",
@@ -163,7 +169,12 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 					// start a new sign-in, and clear the now-dead cookie.
 					await ctx.context.internalAdapter
 						.consumeVerificationValue(signedTwoFactorCookie)
-						.catch(() => {});
+						.catch((error) => {
+							ctx.context.logger.debug(
+								"Two-factor: failed to cancel the challenge after the attempt budget was spent.",
+								error,
+							);
+						});
 					expireCookie(ctx, twoFactorCookie);
 					throw APIError.from(
 						"BAD_REQUEST",
@@ -177,7 +188,12 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 							identifier,
 							expiresAt: verificationToken.expiresAt,
 						})
-						.catch(() => {});
+						.catch((error) => {
+							ctx.context.logger.debug(
+								"Two-factor: failed to rearm the attempt counter.",
+								error,
+							);
+						});
 				return {
 					// recordFailure spends a slot; restore returns it on a server
 					// error. Both swallow write errors (fail closed).


### PR DESCRIPTION
The three `.catch` handlers around the two-factor attempt counter in `verify-two-factor.ts` discard their errors entirely. Any adapter, schema or transaction failure therefore surfaces only as a generic `INVALID_TWO_FACTOR_COOKIE`, with nothing written to any log.

This came out of debugging a passwordless setup (magic-link + OAuth, custom step-up hook per the 2FA docs) where three separate problems — a missing companion `2fa-attempts-*` row, a dropped `Set-Cookie`, and a `twoFactor` table missing `failedVerificationCount` — all presented as that one message. Adding a temporary `console.error` in the first catch turned an open-ended investigation into a ninety-second diagnosis. Context in #10322.

Behaviour is deliberately unchanged: all three still fail closed, as the surrounding comments intend. Only the error is now reported, at `debug` level, matching the existing `ctx.context.logger.debug` usage in `plugins/jwt/verify.ts`.

Verified locally: `tsc --build` clean, and 83/83 passing across the four `src/plugins/two-factor/*.test.ts` files (including the account-lockout and attempt-cap suites). Changeset included as a `patch`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log errors from the two-factor attempt counter (consume, cancel, rearm) instead of discarding them, so adapter/schema/transaction failures no longer appear only as “Invalid two factor cookie.”
Behavior is unchanged: failures still fail closed, and errors are logged at debug level.

<sup>Written for commit dfbc929975f6ec183308940b3b0816eb1ac298f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

