### PR TITLE
fix(oauth): set account cookie after implicit account linking

### DIFF
--- a/.changeset/honest-readers-shake.md
+++ b/.changeset/honest-readers-shake.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Fix account cookie creation after implicit OAuth account linking when storeAccountCookie is enabled.

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -38,6 +38,7 @@ export async function handleOAuthUserInfo(
 		});
 	let user = dbUser?.user;
 	const isRegister = !user;
+	let newLinkedAccount: Account;
 
 	if (dbUser) {
 		const linkedAccount =
@@ -73,7 +74,7 @@ export async function handleOAuthUserInfo(
 				};
 			}
 			try {
-				await c.context.internalAdapter.linkAccount({
+				newLinkedAccount = await c.context.internalAdapter.linkAccount({
 					providerId: account.providerId,
 					accountId: userInfo.id.toString(),
 					userId: dbUser.user.id,
@@ -90,6 +91,9 @@ export async function handleOAuthUserInfo(
 					error: "unable to link account",
 					data: null,
 				};
+			}
+			if (c.context.options.account?.storeAccountCookie) {
+				await setAccountCookie(c, newLinkedAccount);
 			}
 
 			// Reachable only when `requireLocalEmailVerified: false` lets the link

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -318,6 +318,124 @@ describe("oauth2", async () => {
 		expect(accessTokenRes.data?.accessToken).toBeTruthy();
 	});
 
+	it("should resolve getAccessToken after implicit account linking (storeAccountCookie)", async () => {
+		const { customFetchImpl, auth } = await getTestInstance({
+			account: {
+				storeAccountCookie: true,
+			},
+			plugins: [
+				genericOAuth({
+					config: [
+						{
+							providerId: "test-implicit-link-a",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId,
+							clientSecret,
+							pkce: true,
+						},
+						{
+							providerId: "test-implicit-link-b",
+							discoveryUrl: `http://localhost:${port}/.well-known/openid-configuration`,
+							clientId,
+							clientSecret,
+							pkce: true,
+						},
+					],
+				}),
+			],
+		});
+
+		const ctx = await auth.$context;
+		const accountDataCookieName = ctx.authCookies.accountData.name;
+
+		const newAuthClient = createAuthClient({
+			plugins: [genericOAuthClient()],
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl,
+			},
+		});
+
+		const sharedEmail = "implicit-link-cookie@test.com";
+
+		// First sign-in with provider A creates the user.
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				email: sharedEmail,
+				name: "Implicit Link Cookie",
+				sub: "implicit-link-cookie-a",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const firstHeaders = new Headers();
+		const firstSignInRes = await newAuthClient.signIn.oauth2({
+			providerId: "test-implicit-link-a",
+			callbackURL: "http://localhost:3000/dashboard",
+			fetchOptions: {
+				onSuccess: cookieSetter(firstHeaders),
+			},
+		});
+
+		await simulateOAuthFlow(
+			firstSignInRes.data?.url || "",
+			firstHeaders,
+			customFetchImpl,
+		);
+
+		// Sign in with provider B using the same email.
+		server.service.once("beforeUserinfo", (userInfoResponse) => {
+			userInfoResponse.body = {
+				email: sharedEmail,
+				name: "Implicit Link Cookie",
+				sub: "implicit-link-cookie-b",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+
+		const secondHeaders = new Headers();
+		const secondSignInRes = await newAuthClient.signIn.oauth2({
+			providerId: "test-implicit-link-b",
+			callbackURL: "http://localhost:3000/dashboard",
+			fetchOptions: {
+				onSuccess: cookieSetter(secondHeaders),
+			},
+		});
+
+		const { headers: postCallbackHeaders, setCookieHeader } =
+			await simulateOAuthFlow(
+				secondSignInRes.data?.url || "",
+				secondHeaders,
+				customFetchImpl,
+			);
+
+		const cookies = parseSetCookieHeader(setCookieHeader);
+		const accountDataCookie = cookies.get(accountDataCookieName);
+
+		expect(accountDataCookie).toBeDefined();
+		expect(accountDataCookie?.value).toBeTruthy();
+
+		await expect(
+			symmetricDecodeJWT(
+				accountDataCookie!.value!,
+				ctx.secret,
+				"better-auth-account",
+			),
+		).resolves.toMatchObject({
+			providerId: "test-implicit-link-b",
+		});
+
+		const accessTokenRes = await newAuthClient.getAccessToken(
+			{ providerId: "test-implicit-link-b" },
+			{ headers: postCallbackHeaders },
+		);
+
+		expect(accessTokenRes.error).toBeNull();
+		expect(accessTokenRes.data?.accessToken).toBeTruthy();
+	});
+
 	it("should redirect to the provider and handle the response after linked", async () => {
 		const headers = new Headers();
 		const res = await authClient.signIn.oauth2({


### PR DESCRIPTION
## Summary

This PR fixes a bug where `storeAccountCookie` was not honored after implicit OAuth account linking.

When an existing user signs in with a new OAuth provider using the same email address, Better Auth correctly links the provider to the existing account. However, unlike the new-user and already-linked flows, the implicit linking path did not call `setAccountCookie()`.

As a result, `getAccessToken()` could not resolve the newly linked provider in stateless (`storeAccountCookie`) deployments.

This PR:
- Stores the `linkAccount()` result.
- Sets the account cookie after successful implicit account linking when `storeAccountCookie` is enabled.
- Adds a regression test covering this flow.

## Fixes

Closes #10690

## Testing

- Added a regression test covering:
  - First sign-in with Provider A.
  - Implicit account linking with Provider B using the same email.
  - Account cookie creation.
  - Successful `getAccessToken()` for the newly linked provider.

## Breaking Changes

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing account cookie after implicit OAuth account linking when `storeAccountCookie` is enabled. Ensures `getAccessToken()` works for newly linked providers in stateless setups in `better-auth`.

- **Bug Fixes**
  - Save `linkAccount()` result and call `setAccountCookie()` after implicit linking when `storeAccountCookie` is true.
  - Add regression test covering provider A sign-in, implicit linking with provider B (same email), cookie creation, and successful `getAccessToken()` for provider B.

<sup>Written for commit af1e7f75fe94e313ff9201bd7c3bdd1285b50f52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

