### PR TITLE
fix(phone-number): use custom verifyOTP when resetting the password

### DIFF
--- a/.changeset/phone-number-reset-verify-otp.md
+++ b/.changeset/phone-number-reset-verify-otp.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Honor the phone number plugin's custom `verifyOTP` option when resetting a password. The reset route always used the internal OTP check, so integrations that delegate verification to an external provider such as Twilio Verify could never complete a phone number password reset.

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1282,4 +1282,40 @@ describe("custom verifyOTP", async () => {
 		expect(user.data?.user.phoneNumber).toBe(updatedPhoneNumber);
 		expect(user.data?.user.phoneNumberVerified).toBe(true);
 	});
+
+	it("should use custom verifyOTP when resetting the password", async () => {
+		const resetPhoneNumber = "+1222333444";
+
+		// Register the phone number so a user exists to reset the password for.
+		await client.phoneNumber.sendOtp({ phoneNumber: resetPhoneNumber });
+		mockVerifyOTP.mockResolvedValueOnce(true);
+		await client.phoneNumber.verify({
+			phoneNumber: resetPhoneNumber,
+			code: "123456",
+		});
+
+		await client.phoneNumber.requestPasswordReset({
+			phoneNumber: resetPhoneNumber,
+		});
+
+		mockVerifyOTP.mockClear();
+		// The provider accepts this code even though it is not the stored one,
+		// which is the point of delegating verification to it.
+		mockVerifyOTP.mockResolvedValueOnce(true);
+
+		const res = await client.phoneNumber.resetPassword({
+			phoneNumber: resetPhoneNumber,
+			otp: "999999",
+			newPassword: "new-password-123",
+		});
+
+		expect(mockVerifyOTP).toHaveBeenCalledWith(
+			expect.objectContaining({
+				phoneNumber: resetPhoneNumber,
+				code: "999999",
+			}),
+			expect.anything(),
+		);
+		expect(res.error).toBe(null);
+	});
 });

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -1283,8 +1283,12 @@ describe("custom verifyOTP", async () => {
 		expect(user.data?.user.phoneNumberVerified).toBe(true);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10697
+	 */
 	it("should use custom verifyOTP when resetting the password", async () => {
 		const resetPhoneNumber = "+1222333444";
+		const newPassword = "new-password-123";
 
 		// Register the phone number so a user exists to reset the password for.
 		await client.phoneNumber.sendOtp({ phoneNumber: resetPhoneNumber });
@@ -1306,7 +1310,7 @@ describe("custom verifyOTP", async () => {
 		const res = await client.phoneNumber.resetPassword({
 			phoneNumber: resetPhoneNumber,
 			otp: "999999",
-			newPassword: "new-password-123",
+			newPassword,
 		});
 
 		expect(mockVerifyOTP).toHaveBeenCalledWith(
@@ -1317,5 +1321,13 @@ describe("custom verifyOTP", async () => {
 			expect.anything(),
 		);
 		expect(res.error).toBe(null);
+
+		// The reset must actually persist, not just return success.
+		const signInRes = await client.signIn.phoneNumber({
+			phoneNumber: resetPhoneNumber,
+			password: newPassword,
+		});
+		expect(signInRes.error).toBe(null);
+		expect(signInRes.data?.user.phoneNumber).toBe(resetPhoneNumber);
 	});
 });

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -787,16 +787,11 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 					);
 				}
 
-				// Clean up verification value
-				const otp =
-					await ctx.context.internalAdapter.findVerificationValue(
-						phoneResetIdentifier,
-					);
-				if (otp) {
-					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
-						phoneResetIdentifier,
-					);
-				}
+				// Drop any stored reset code so it cannot be replayed. This is a
+				// no-op when nothing was stored, so it needs no existence check.
+				await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+					phoneResetIdentifier,
+				);
 			} else {
 				await verifyPhoneNumberOTP(
 					ctx,

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -769,7 +769,42 @@ export const resetPasswordPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 		},
 		async (ctx) => {
 			const phoneResetIdentifier = `${ctx.body.phoneNumber}-request-password-reset`;
-			await verifyPhoneNumberOTP(ctx, opts, phoneResetIdentifier, ctx.body.otp);
+			if (opts?.verifyOTP) {
+				// A custom verifier owns OTP validation for every flow, so the
+				// reset code is checked against it rather than the stored value.
+				const isValid = await opts.verifyOTP(
+					{
+						phoneNumber: ctx.body.phoneNumber,
+						code: ctx.body.otp,
+					},
+					ctx,
+				);
+
+				if (!isValid) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						PHONE_NUMBER_ERROR_CODES.INVALID_OTP,
+					);
+				}
+
+				// Clean up verification value
+				const otp =
+					await ctx.context.internalAdapter.findVerificationValue(
+						phoneResetIdentifier,
+					);
+				if (otp) {
+					await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+						phoneResetIdentifier,
+					);
+				}
+			} else {
+				await verifyPhoneNumberOTP(
+					ctx,
+					opts,
+					phoneResetIdentifier,
+					ctx.body.otp,
+				);
+			}
 			const userRes = await ctx.context.adapter.findOne<
 				UserWithPhoneNumber & { account: Account[] | undefined }
 			>({


### PR DESCRIPTION
## Summary

The phone number plugin's `verifyOTP` option was honored by `/phone-number/verify` but ignored by `/phone-number/reset-password`, which always ran the internal check against the locally stored code.

Closes #10697

## The problem

The verify route branches on the option, the reset route did not:

```ts
// /phone-number/reset-password
const phoneResetIdentifier = `${ctx.body.phoneNumber}-request-password-reset`;
await verifyPhoneNumberOTP(ctx, opts, phoneResetIdentifier, ctx.body.otp);
```

`verifyPhoneNumberOTP` compares against the stored value with `otpValue !== providedCode`, so a custom verifier is never consulted.

For an integration that delegates OTP delivery and verification to an external provider such as Twilio Verify, the user receives a provider generated code while the route compares against the one Better Auth generated locally. The two never match, so phone number password reset cannot be completed at all.

This contradicts the documented contract, which does not qualify which route the option covers:

> A custom function to verify the OTP code. When provided, this function will be used instead of the default internal verification logic.

> When using this option, ensure that proper validation is implemented, as it overrides our internal verification logic.

## The fix

Check `opts.verifyOTP` first in the reset route, mirroring the structure already used by the verify route, and clean up the stored verification value on success:

```diff
 const phoneResetIdentifier = `${ctx.body.phoneNumber}-request-password-reset`;
-await verifyPhoneNumberOTP(ctx, opts, phoneResetIdentifier, ctx.body.otp);
+if (opts?.verifyOTP) {
+	const isValid = await opts.verifyOTP(
+		{ phoneNumber: ctx.body.phoneNumber, code: ctx.body.otp },
+		ctx,
+	);
+	if (!isValid) {
+		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.INVALID_OTP);
+	}
+	// Clean up verification value
+	const otp = await ctx.context.internalAdapter.findVerificationValue(
+		phoneResetIdentifier,
+	);
+	if (otp) {
+		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+			phoneResetIdentifier,
+		);
+	}
+} else {
+	await verifyPhoneNumberOTP(ctx, opts, phoneResetIdentifier, ctx.body.otp);
+}
```

Behaviour is unchanged when `verifyOTP` is not configured, which is the default.

## Tests

Added `should use custom verifyOTP when resetting the password` to the existing `custom verifyOTP` suite. It registers a phone number, requests a reset, then submits a code that the provider accepts but which does not match the stored value, and asserts the verifier is called with that code and the reset succeeds.

Verified it fails on the unpatched code with `Number of calls: 0`, confirming the verifier was never invoked.

The full `phone-number` suite passes 35/35 and `pnpm typecheck` exits 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor custom `verifyOTP` in `/phone-number/reset-password`, matching `/phone-number/verify` and restoring compatibility with external OTP providers (e.g., Twilio Verify). Previously the route only checked the locally stored code; behavior is unchanged when `verifyOTP` isn't set.

- Call `opts.verifyOTP` first; otherwise run the internal OTP check.
- After a successful custom verification, delete the stored reset code to prevent replay (no redundant lookup).
- Tests cover verifier invocation, acceptance of provider-only codes, and that sign-in with the new password succeeds.

<sup>Written for commit 516b2985476c1bd301115bb8eb942495e7ba180f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

