### PR TITLE
docs: clarify express.json() usage with toNodeHandler

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -380,11 +380,9 @@ description: Learn how to configure Better Auth in your project.
         const app = express();
         const port = 8000;
 
-        app.all("/api/auth/*", toNodeHandler(auth));
-
-        // Mount express json middleware after Better Auth handler
-        // or only apply it to routes that don't interact with Better Auth
         app.use(express.json());
+
+        app.all("/api/auth/*", toNodeHandler(auth));
 
         app.listen(port, () => {
             console.log(`Better Auth app listening on port ${port}`);

--- a/docs/content/docs/integrations/express.mdx
+++ b/docs/content/docs/integrations/express.mdx
@@ -15,10 +15,6 @@ Before you start, make sure you have a Better Auth instance configured. If you h
 
 To enable Better Auth to handle requests, we need to mount the handler to an API route. Create a catch-all route to manage all requests to `/api/auth/*` in case of ExpressJS v4 or `/api/auth/*splat` in case of ExpressJS v5 (or any other path specified in your Better Auth options).
 
-<Callout type="warn">
-  Don’t use `express.json()` before the Better Auth handler. Use it only for other routes, or the client API will get stuck on "pending".
-</Callout>
-
 ```ts title="server.ts"
 import express from "express";
 import { toNodeHandler } from "better-auth/node";
@@ -27,12 +23,10 @@ import { auth } from "./auth";
 const app = express();
 const port = 3005;
 
+app.use(express.json());
+
 app.all("/api/auth/*", toNodeHandler(auth)); // For ExpressJS v4
 // app.all("/api/auth/*splat", toNodeHandler(auth)); For ExpressJS v5 
-
-// Mount express json middleware after Better Auth handler
-// or only apply it to routes that don't interact with Better Auth
-app.use(express.json());
 
 app.listen(port, () => {
 	console.log(`Example app listening on port ${port}`);

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -3000,6 +3000,64 @@ describe("oauth - config", () => {
 		expect(tokenPayload.token_type).toBe("Bearer");
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10706
+	 */
+	it("should preserve JSON body when req.body was pre-parsed", async () => {
+		const { auth: authorizationServer } = await getTestInstance({
+			baseURL: authServerBaseUrl,
+			plugins: [
+				jwt(),
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					silenceWarnings: {
+						oauthAuthServerConfig: true,
+						openidConfig: true,
+					},
+				}),
+			],
+		});
+
+		const nodeHandler = toNodeHandler(authorizationServer.handler);
+		server = await listen(
+			async (req, res) => {
+				const chunks: Uint8Array[] = [];
+				for await (const chunk of req) {
+					chunks.push(chunk);
+				}
+				const bodyString = Buffer.concat(chunks).toString("utf-8");
+				const requestWithParsedBody = req as typeof req & {
+					body?: unknown;
+				};
+				requestWithParsedBody.body = JSON.parse(bodyString || "{}");
+
+				await nodeHandler(req, res);
+			},
+			{
+				port,
+			},
+		);
+
+		const response = await fetch(
+			new URL("/api/auth/sign-in/email", server.url),
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					email: "test-nonexistent@email.com",
+					password: "password123",
+				}),
+			},
+		);
+
+		const json = (await response.json()) as { message?: string; code?: string };
+		expect(response.status).toBe(401);
+		expect(json.code).toBe("INVALID_EMAIL_OR_PASSWORD");
+	});
+
 	it.for([
 		{
 			storeClientSecret: undefined,


### PR DESCRIPTION
Fixes #10706

## Context
The Express integration docs contained a warning against using `express.json()` before the Better Auth handler, stating the client API would get stuck on "pending". This predates a fix in `better-call` (better-auth/better-call#36) that added support for handling a pre-consumed/pre-parsed request stream.

An existing regression test (from #8019) already proved this works for `application/x-www-form-urlencoded` bodies, but there was no coverage for `application/json` bodies specifically.

## Changes
- **Added a regression test** (`oauth.test.ts`) that simulates middleware (like `express.json()`) pre-parsing the request body as JSON before it reaches `toNodeHandler`, then verifies the request is still processed correctly (not stuck pending).
- **Updated the Express integration docs** (`express.mdx`) to remove the outdated warning and reorder the example so `express.json()` is mounted before the Better Auth handler.
- **Updated the installation guide** (`installation.mdx`, Express tab) with the same fix for consistency.

## Testing
Ran the affected test file locally — all 128 tests pass, no regressions:

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Express integration: it’s safe to mount `express.json()` before the Better Auth `toNodeHandler`; removes the outdated warning that the client could get stuck on “pending”. Fixes #10706.

- Updates `docs/integrations/express.mdx` and `docs/installation.mdx` to show `app.use(express.json())` before `app.all("/api/auth/*", toNodeHandler(auth))`.
- Adds a regression test in `packages/oauth-provider/src/oauth.test.ts` that pre-parses the JSON body into `req.body` and verifies the request completes (401 with `INVALID_EMAIL_OR_PASSWORD`, not hanging).
- No runtime changes to `better-auth`; no migration required.

<sup>Written for commit 298cdc14f78da77e995faa78e17af715a33368db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

