### PR TITLE
docs(mcp): note the RFC 9207 `iss` gap in the deprecation callout

### DIFF
--- a/docs/content/docs/plugins/mcp.mdx
+++ b/docs/content/docs/plugins/mcp.mdx
@@ -7,6 +7,16 @@ description: MCP provider plugin for Better Auth
 
 <Callout type="warn">
   This plugin will soon be deprecated in favor of the [OAuth Provider Plugin](/docs/plugins/oauth-provider).
+
+  One difference worth knowing before you choose: this plugin does not emit the
+  [RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207) `iss` parameter on
+  authorization responses, and does not advertise
+  `authorization_response_iss_parameter_supported` in its metadata. MCP
+  specification revision
+  [2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+  asks MCP authorization servers to include `iss` (a `SHOULD`, and a `MUST` to
+  advertise it once you do). The
+  [OAuth Provider Plugin](/docs/plugins/oauth-provider) implements both.
 </Callout>
 
 The **MCP** plugin lets your app act as an OAuth provider for MCP clients. It handles authentication and makes it easy to issue and manage access tokens for MCP applications.


### PR DESCRIPTION
## What

Adds one paragraph to the `mcp()` deprecation callout noting that this plugin does not emit the RFC 9207 `iss` authorization-response parameter, and that `@better-auth/oauth-provider` does.

Docs only — no code change.

## Why

MCP specification revision [2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization) asks MCP authorization servers to include `iss` on authorization responses:

> MCP authorization servers **SHOULD** include the `iss` parameter in authorization responses, including error responses, as defined in RFC 9207 Section 2. Authorization servers that include the `iss` parameter **MUST** advertise this by setting `authorization_response_iss_parameter_supported` to `true` in their metadata.

`@better-auth/oauth-provider` implements this (#7669) — including on error responses, which is the part most implementations skip. The older `mcp()` plugin does not, which is a perfectly reasonable consequence of the deprecation. The gap just isn't written down anywhere, so someone following the documented `mcp()` path today ships a non-conformant authorization server without knowing.

Verified against `better-auth@1.6.9`, a `mcp()` server with a dynamically registered client, authorization-code flow:

```
success   302 Location: http://localhost:9999/cb?code=…&state=st1
error     302 Location: http://localhost:9999/cb?error=invalid_scope&error_description=…
```

No `iss` on either, and `GET /.well-known/oauth-authorization-server` has no `authorization_response_iss_parameter_supported` key. For contrast, `@better-auth/oauth-provider` has had both since v1.4.19 (v1.4.18 does not) — i.e. it is already correct at the same version users are pinned to.

To head off a likely confusion: `getMCPProviderMetadata` does already list `"iss"`, but that is inside `claims_supported` — the ID-token/JWT `iss` *claim*, which works fine. RFC 9207 defines a different thing: an `iss` **query parameter on the authorization response redirect**.

## Framing

I deliberately wrote this as a reason to migrate rather than as a defect report, since [the policy note in `oidc-provider`](https://github.com/better-auth/better-auth/blob/main/packages/better-auth/src/plugins/oidc-provider/index.ts) is explicit that the deprecated plugins won't be tightened further and that migrating is the path to parity. Happy to reword if you'd rather it read differently, or to move it into its own callout instead of extending the deprecation one.

Context and the reasoning behind it: #ISSUE_PLACEHOLDER


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the MCP plugin docs to note a spec gap: it does not include the RFC 9207 `iss` parameter on authorization responses or advertise `authorization_response_iss_parameter_supported`. Point users to `@better-auth/oauth-provider`, which implements both and aligns with the 2026-07-28 MCP spec revision.

<sup>Written for commit db32bd7c213bbbabdcac833a3a9cc74b8cf251c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

