### PR TITLE
fix(db): recognize postgres int8 as a number type in migration diffs

### DIFF
--- a/.changeset/postgres-int8-migration-diff.md
+++ b/.changeset/postgres-int8-migration-diff.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Recognize PostgreSQL `int8` as a valid number type in migration diffs. Kysely's introspector reports `pg_type.typname`, so Better Auth's own `bigint` columns (such as the database-backed rate limiter's `lastRequest`) came back as `int8` and were reported as a type mismatch on every run.

--- a/packages/better-auth/src/db/get-migration-schema.test.ts
+++ b/packages/better-auth/src/db/get-migration-schema.test.ts
@@ -4,7 +4,7 @@ import { CamelCasePlugin, Kysely, PostgresDialect } from "kysely";
 import { Pool } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { betterAuth } from "../auth/full";
-import { getMigrations } from "./get-migration";
+import { getMigrations, matchType } from "./get-migration";
 
 const CONNECTION_STRING = "postgres://user:password@localhost:5433/better_auth";
 // Check if PostgreSQL is available
@@ -757,5 +757,63 @@ describe("index generation for columns added to existing tables", () => {
 
 		const sql = await second.compileMigrations();
 		expect(sql).toBe(";");
+	});
+});
+
+describe("matchType", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10718
+	 *
+	 * Kysely's PostgreSQL introspector reports `pg_type.typname`, so a
+	 * `bigint` column comes back as `int8` — the name the acceptable-types
+	 * map has to carry for the diff to recognize Better Auth's own
+	 * `rateLimit.lastRequest` column.
+	 */
+	it("should accept the pg_type name Kysely reports for a bigint column", () => {
+		expect(matchType("int8", "number", "postgres")).toBe(true);
+	});
+
+	it("should still accept the spelled-out bigint name", () => {
+		expect(matchType("bigint", "number", "postgres")).toBe(true);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10718
+ */
+describe.runIf(isPostgresAvailable)("PostgreSQL rate limit schema diff", () => {
+	const pool = new Pool({ connectionString: CONNECTION_STRING });
+	const dropTables = `DROP TABLE IF EXISTS public."rateLimit" CASCADE; DROP TABLE IF EXISTS public.session CASCADE; DROP TABLE IF EXISTS public.account CASCADE; DROP TABLE IF EXISTS public.verification CASCADE; DROP TABLE IF EXISTS public."user" CASCADE;`;
+
+	beforeAll(async () => {
+		await pool.query(dropTables);
+	});
+
+	afterAll(async () => {
+		await pool.query(dropTables);
+		await pool.end();
+	});
+
+	it("should not warn about its own bigint lastRequest column on a subsequent run", async () => {
+		const warnings: string[] = [];
+		const config: BetterAuthOptions = {
+			database: pool,
+			rateLimit: {
+				storage: "database",
+			},
+			logger: {
+				log: (level, message) => {
+					if (level === "warn") warnings.push(message);
+				},
+			},
+		};
+
+		const initial = await getMigrations(config);
+		await initial.runMigrations();
+
+		const second = await getMigrations(config);
+		expect(second.toBeCreated.length).toBe(0);
+		expect(second.toBeAdded.length).toBe(0);
+		expect(warnings.filter((w) => w.includes("lastRequest"))).toEqual([]);
 	});
 });

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -23,6 +23,7 @@ const postgresMap = {
 	string: ["character varying", "varchar", "text", "uuid"],
 	number: [
 		"int4",
+		"int8",
 		"integer",
 		"bigint",
 		"smallint",


### PR DESCRIPTION
Closes #10718.

The PostgreSQL twin of #10306 / #10316: Better Auth generates the rate limiter's `lastRequest` column as `bigint`, then its own schema diff reports that column as a type mismatch on every `getMigrations` call.

```
WARN [Better Auth]: Field lastRequest in table rateLimit has a different type in the database. Expected number but got int8.
```

**Why.** `matchType` compares Kysely's `column.dataType`, and Kysely's PostgreSQL introspector selects `pg_type.typname` (`typ.typname as type`), not the spelled-out SQL name — so a `bigint` column arrives as `int8`. `postgresMap.number` carried `"bigint"`, and `"int4"` alongside `"integer"`, but never `"int8"`.

**Fix.** One entry added to `postgresMap.number`, mirroring #10316.

**Tests.** Two, both failing before the change:
* a `matchType` unit test — `matchType("int8", "number", "postgres")`, no database needed;
* a Postgres integration test (`describe.runIf(isPostgresAvailable)`) that migrates, re-runs `getMigrations`, and asserts no warning mentions `lastRequest` — this is what actually reproduces the reported symptom, since a type mismatch only warns and never lands in `toBeCreated`/`toBeAdded`.

`pnpm vitest packages/better-auth/src/db --run` → 87 passed, with both `docker compose` Postgres services up.

**Not changed here:** `smallint`, `real` and `double precision` are unreachable through Kysely for the same reason (it reports `int2`, `float4`, `float8`). No Better Auth field generates those today — `getType` only ever emits `integer` or `bigint` for a `number` — so they affect user-defined columns only, and I kept this PR to the reported bug. Happy to fold them in if you'd prefer the whole class fixed at once.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognize PostgreSQL `int8` as a valid number type in migration diffs to stop false type mismatch warnings for `rateLimit.lastRequest` and other `bigint` columns when using `getMigrations`.

- **Bug Fixes**
  - Map Postgres `int8` to number in the diff logic to match `Kysely`’s `pg_type.typname`.
  - Added a unit test for `matchType("int8", "number", "postgres")` and a Postgres integration test to ensure no warnings on subsequent `getMigrations` runs.

<sup>Written for commit 1d999888685e4ab1052795fe5ce28adc9d305957. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

