### PR TITLE
fix(vue): forward headers to useSession useFetch

### DIFF
--- a/.changeset/forward-vue-session-headers.md
+++ b/.changeset/forward-vue-session-headers.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Forward configured headers when using the Vue `useSession` integration with Nuxt `useFetch`.

--- a/packages/better-auth/src/client/client-ssr.test.ts
+++ b/packages/better-auth/src/client/client-ssr.test.ts
@@ -22,3 +22,24 @@ it("should call '/api/auth' for vue client", async () => {
 	await client.getSession();
 	expect(customFetchImpl).toBeCalled();
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10705
+ */
+it("should forward client headers when using Vue useSession with useFetch", async () => {
+	const headers = { cookie: "better-auth.session_token=session" };
+	const useFetch = vi.fn(async () => ({
+		data: null,
+		error: null,
+	}));
+	const client = createVueClient({
+		fetchOptions: { headers },
+	});
+
+	await client.useSession(useFetch);
+
+	expect(useFetch).toHaveBeenCalledWith(
+		expect.any(String),
+		expect.objectContaining({ headers }),
+	);
+});

--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -145,6 +145,7 @@ export function createAuthClient<Option extends BetterAuthClientOptions>(
 			const ref = useStore(pluginsAtoms.$sessionSignal!);
 			return useFetch(`${baseURL}/get-session`, {
 				ref,
+				headers: options?.fetchOptions?.headers,
 			}).then((res: any) => {
 				return {
 					data: res.data,


### PR DESCRIPTION
Closes #10705

## Summary

When the Vue client is used with Nuxt's injected `useFetch`, `useSession(useFetch)` previously passed only its reactive `ref`. Headers configured through `createAuthClient({ fetchOptions })`, including the request cookie needed during SSR, were omitted.

As a result, the server-side `/get-session` request could resolve as unauthenticated even when the incoming request had a valid session cookie. The resulting `null` session was then serialized into the Nuxt payload and could cause a hydration mismatch.

## Changes

- Forward `fetchOptions.headers` to the injected `useFetch` call.
- Preserve the existing reactive session `ref`.
- Add a regression test for the header-forwarding path.
- Add a patch changeset for `better-auth`.

## Validation

- `pnpm vitest packages/better-auth/src/client/client-ssr.test.ts --run --reporter=verbose`
- `pnpm typecheck`
- `pnpm exec biome check packages/better-auth/src/client/vue/index.ts packages/better-auth/src/client/client-ssr.test.ts`
- Pre-commit Biome and spell checks

I also ran the complete client test directory: 103 tests passed. One existing declaration-emission test failed in a temporary-workspace subprocess on this Windows environment; it is unrelated to this Vue header change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Vue `useSession` with Nuxt `useFetch` to forward configured headers (including cookies) so SSR session lookup works and prevents hydration mismatches.

- **Bug Fixes**
  - Forward `fetchOptions.headers` from `createAuthClient` to `useFetch` in the Vue client.
  - Preserve the existing reactive `ref` behavior.
  - Add a regression test for header forwarding.
  - Add a patch changeset for `better-auth`.

<sup>Written for commit 21be0fb075237b6a2c7e343d6d07181b5bbda167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

