### PR TITLE
fix(oauth-provider): verify id_token_hint with the local key set

### DIFF
--- a/.changeset/logout-verifies-id-token-locally.md
+++ b/.changeset/logout-verifies-id-token-locally.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+RP-initiated logout now verifies `id_token_hint` with the key set the provider already holds, instead of requesting its own public JWKS endpoint over HTTP. `/oauth2/end-session` no longer fails when the auth server cannot reach its own base URL, such as behind an edge that requires a header or an IP allowlist.

--- a/packages/oauth-provider/src/logout.test.ts
+++ b/packages/oauth-provider/src/logout.test.ts
@@ -651,12 +651,13 @@ describe("oauth logout - disableJwtPlugin", async () => {
 
 /**
  * The provider holds the key set that signs its own id tokens, so RP-initiated
- * logout must not depend on its public base URL being reachable from the server
- * itself. Nothing listens on this port: any self-fetch fails the request.
+ * logout must not reach for them over HTTP. A decoy key set is served on the
+ * provider's own base URL: a self-fetch would verify against those keys instead
+ * of the real ones, and the request counter would move.
  *
  * @see https://github.com/better-auth/better-auth/issues/10728
  */
-describe("oauth logout - unreachable base url", async () => {
+describe("oauth logout - no jwks self-fetch", async () => {
 	const port = 3006;
 	const baseUrl = `http://localhost:${port}`;
 	const rpBaseUrl = "http://localhost:5000";
@@ -690,8 +691,19 @@ describe("oauth logout - unreachable base url", async () => {
 	const providerId = "test";
 	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
 	let oauthClient: OAuthClient | null;
+	let decoy: Listener;
+	let decoyRequests = 0;
 
 	beforeAll(async () => {
+		decoy = await listen(
+			(_req, res) => {
+				decoyRequests++;
+				res.setHeader("content-type", "application/json");
+				res.end(JSON.stringify({ keys: [] }));
+			},
+			{ port },
+		);
+
 		oauthClient = await auth.api.adminCreateOAuthClient({
 			headers,
 			body: {
@@ -703,7 +715,13 @@ describe("oauth logout - unreachable base url", async () => {
 		expect(oauthClient?.client_id).toBeDefined();
 	});
 
-	it("should end the session without fetching its own jwks", async () => {
+	afterAll(async () => {
+		if (decoy) {
+			await decoy.close();
+		}
+	});
+
+	it("should end the session with the local key set", async () => {
 		const clientId = oauthClient?.client_id!;
 		const clientSecret = oauthClient?.client_secret!;
 		const codeVerifier = generateRandomString(32);
@@ -753,6 +771,7 @@ describe("oauth logout - unreachable base url", async () => {
 			},
 		});
 		expect(logoutRes.error).toBeNull();
+		expect(decoyRequests).toBe(0);
 
 		const sessionAfter = await client.getSession({
 			fetchOptions: {

--- a/packages/oauth-provider/src/logout.test.ts
+++ b/packages/oauth-provider/src/logout.test.ts
@@ -650,10 +650,9 @@ describe("oauth logout - disableJwtPlugin", async () => {
 });
 
 /**
- * The provider holds the key set that signs its own id tokens, so RP-initiated
- * logout must not reach for them over HTTP. A decoy key set is served on the
- * provider's own base URL: a self-fetch would verify against those keys instead
- * of the real ones, and the request counter would move.
+ * The provider signs its own id tokens, so RP-initiated logout must resolve the
+ * key set in process. The decoy is there to catch a self-fetch: it holds the
+ * port the base URL resolves to, and its keys verify nothing.
  *
  * @see https://github.com/better-auth/better-auth/issues/10728
  */

--- a/packages/oauth-provider/src/logout.test.ts
+++ b/packages/oauth-provider/src/logout.test.ts
@@ -1349,3 +1349,137 @@ describe("oauth logout - disableJwtPlugin", async () => {
 		expect(logoutRes.error?.status).toBe(302);
 	});
 });
+
+/**
+ * The provider signs its own id tokens, so RP-initiated logout must resolve the
+ * key set in process. The decoy is there to catch a self-fetch: it holds the
+ * port the base URL resolves to, and its keys verify nothing.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10728
+ */
+describe("oauth logout - no jwks self-fetch", async () => {
+	const port = 3007;
+	const baseUrl = `http://localhost:${port}`;
+	const rpBaseUrl = "http://localhost:5000";
+	const state = "123";
+	const scopes = ["openid", "email", "profile", "offline_access"];
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: baseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+				scopes,
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: baseUrl,
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	let oauthClient: OAuthClient | null;
+	let decoy: Listener;
+	let decoyRequests = 0;
+
+	beforeAll(async () => {
+		decoy = await listen(
+			(_req, res) => {
+				decoyRequests++;
+				res.setHeader("content-type", "application/json");
+				res.end(JSON.stringify({ keys: [] }));
+			},
+			{ port },
+		);
+
+		oauthClient = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				application_type: "native",
+				token_endpoint_auth_method: "client_secret_post",
+				skip_consent: true,
+				enable_end_session: true,
+			},
+		});
+		expect(oauthClient?.client_id).toBeDefined();
+	});
+
+	afterAll(async () => {
+		if (decoy) {
+			await decoy.close();
+		}
+	});
+
+	it("should end the session with the local key set", async () => {
+		const clientId = oauthClient?.client_id!;
+		const clientSecret = oauthClient?.client_secret!;
+		const codeVerifier = generateRandomString(32);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId,
+				clientSecret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${baseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			headers,
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain("code=");
+
+		const { body, headers: tokenHeaders } = await authorizationCodeRequest({
+			code: new URL(callbackRedirectUrl).searchParams.get("code")!,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId,
+				clientSecret,
+				redirectURI: redirectUri,
+			},
+		});
+		const tokens = await client.$fetch<{ id_token?: string }>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+		expect(tokens.data?.id_token).toBeDefined();
+
+		const logoutRes = await client.oauth2.endSession({
+			query: {
+				id_token_hint: tokens.data?.id_token!,
+			},
+		});
+		expect(logoutRes.error).toBeNull();
+		expect(decoyRequests).toBe(0);
+
+		const sessionAfter = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(sessionAfter.data).toBeNull();
+	});
+});

--- a/packages/oauth-provider/src/logout.test.ts
+++ b/packages/oauth-provider/src/logout.test.ts
@@ -648,3 +648,117 @@ describe("oauth logout - disableJwtPlugin", async () => {
 		expect(logoutRes.error?.status).toBe(302);
 	});
 });
+
+/**
+ * The provider holds the key set that signs its own id tokens, so RP-initiated
+ * logout must not depend on its public base URL being reachable from the server
+ * itself. Nothing listens on this port: any self-fetch fails the request.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10728
+ */
+describe("oauth logout - unreachable base url", async () => {
+	const port = 3006;
+	const baseUrl = `http://localhost:${port}`;
+	const rpBaseUrl = "http://localhost:5000";
+	const state = "123";
+	const scopes = ["openid", "email", "profile", "offline_access"];
+
+	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
+		baseURL: baseUrl,
+		plugins: [
+			oauthProvider({
+				loginPage: "/login",
+				consentPage: "/consent",
+				silenceWarnings: {
+					oauthAuthServerConfig: true,
+					openidConfig: true,
+				},
+				scopes,
+			}),
+			jwt(),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+	const client = createAuthClient({
+		plugins: [oauthProviderClient()],
+		baseURL: baseUrl,
+		fetchOptions: {
+			customFetchImpl,
+		},
+	});
+
+	const providerId = "test";
+	const redirectUri = `${rpBaseUrl}/api/auth/oauth2/callback/${providerId}`;
+	let oauthClient: OAuthClient | null;
+
+	beforeAll(async () => {
+		oauthClient = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				skip_consent: true,
+				enable_end_session: true,
+			},
+		});
+		expect(oauthClient?.client_id).toBeDefined();
+	});
+
+	it("should end the session without fetching its own jwks", async () => {
+		const clientId = oauthClient?.client_id!;
+		const clientSecret = oauthClient?.client_secret!;
+		const codeVerifier = generateRandomString(32);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId,
+				clientSecret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${baseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			headers,
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		expect(callbackRedirectUrl).toContain("code=");
+
+		const { body, headers: tokenHeaders } = createAuthorizationCodeRequest({
+			code: new URL(callbackRedirectUrl).searchParams.get("code")!,
+			codeVerifier,
+			redirectURI: redirectUri,
+			options: {
+				clientId,
+				clientSecret,
+				redirectURI: redirectUri,
+			},
+		});
+		const tokens = await client.$fetch<{ id_token?: string }>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers: tokenHeaders,
+		});
+		expect(tokens.data?.id_token).toBeDefined();
+
+		const logoutRes = await client.oauth2.endSession({
+			query: {
+				id_token_hint: tokens.data?.id_token!,
+			},
+		});
+		expect(logoutRes.error).toBeNull();
+
+		const sessionAfter = await client.getSession({
+			fetchOptions: {
+				headers,
+			},
+		});
+		expect(sessionAfter.data).toBeNull();
+	});
+});

--- a/packages/oauth-provider/src/logout.ts
+++ b/packages/oauth-provider/src/logout.ts
@@ -2,7 +2,7 @@ import type { GenericEndpointContext } from "@better-auth/core";
 import { getJwks } from "better-auth/oauth2";
 import type { Session } from "better-auth/types";
 import { APIError } from "better-call";
-import type { JWTPayload } from "jose";
+import type { JSONWebKeySet, JWTPayload } from "jose";
 import { compactVerify, createLocalJWKSet, decodeJwt } from "jose";
 import { handleRedirect } from "./authorize";
 import type { OAuthOptions, Scope } from "./types";
@@ -31,14 +31,10 @@ export async function rpInitiatedLogoutEndpoint(
 		state?: string;
 	} = ctx.query;
 
-	const baseURL = ctx.context.baseURL;
 	const jwtPlugin = opts.disableJwtPlugin
 		? undefined
 		: getJwtPlugin(ctx.context);
 	const jwtPluginOptions = jwtPlugin?.options;
-	const jwksUrl =
-		jwtPluginOptions?.jwks?.remoteUrl ??
-		`${baseURL}${jwtPluginOptions?.jwks?.jwksPath ?? "/jwks"}`;
 
 	let clientId = client_id;
 	if (!clientId) {
@@ -107,7 +103,16 @@ export async function rpInitiatedLogoutEndpoint(
 		idTokenPayload = JSON.parse(idToken);
 	} else {
 		const jwks = await getJwks(id_token_hint, {
-			jwksFetch: jwksUrl,
+			jwksFetch: jwtPluginOptions?.jwks?.remoteUrl
+				? jwtPluginOptions.jwks.remoteUrl
+				: async () => {
+						const jwksRes = await jwtPlugin?.endpoints.getJwks(ctx);
+						// @ts-expect-error response is a JSONWebKeySet but within the response field
+						return jwksRes?.response as JSONWebKeySet | undefined;
+					},
+			// The plugin instance is stable across requests, so the key set
+			// fetched by the per-request closure above is cached under it.
+			jwksCacheKey: jwtPlugin,
 		});
 
 		// compactVerify only verifies the token, not its claims (perform manually)

--- a/packages/oauth-provider/src/logout.ts
+++ b/packages/oauth-provider/src/logout.ts
@@ -7,7 +7,7 @@ import { getJwks } from "better-auth/oauth2";
 import { resolveSigningKey, signJWT } from "better-auth/plugins";
 import type { Session } from "better-auth/types";
 import { APIError } from "better-call";
-import type { JWTPayload } from "jose";
+import type { JSONWebKeySet, JWTPayload } from "jose";
 import { compactVerify, createLocalJWKSet, decodeJwt } from "jose";
 import type { OAuthRedirectResult } from "./authorize";
 import { getIssuer, handleRedirect } from "./authorize";
@@ -696,11 +696,21 @@ async function verifyLogoutHint(
 				new TextDecoder().decode(verifiedPayload),
 			) as JWTPayload;
 		} else {
-			const jwtPluginOptions = getJwtPlugin(ctx.context).options;
-			const jwksUrl =
-				jwtPluginOptions?.jwks?.remoteUrl ??
-				`${ctx.context.baseURL}${jwtPluginOptions?.jwks?.jwksPath ?? "/jwks"}`;
-			const jwks = await getJwks(hint, { jwksFetch: jwksUrl });
+			const jwtPlugin = getJwtPlugin(ctx.context);
+			const jwtPluginOptions = jwtPlugin?.options;
+			const jwksFetch = jwtPluginOptions?.jwks?.remoteUrl
+				? jwtPluginOptions.jwks.remoteUrl
+				: async (): Promise<JSONWebKeySet | undefined> => {
+						const jwksRes = await jwtPlugin?.endpoints.getJwks(ctx);
+						// @ts-expect-error response is a JSONWebKeySet but within the response field
+						return jwksRes?.response as JSONWebKeySet | undefined;
+					};
+			const jwks = await getJwks(hint, {
+				jwksFetch,
+				// The plugin instance is stable across requests, so the key set
+				// fetched by the per-request closure above is cached under it.
+				jwksCacheKey: jwtPlugin,
+			});
 			const { payload: verifiedPayload } = await compactVerify(
 				hint,
 				createLocalJWKSet(jwks),


### PR DESCRIPTION
Closes #10728.

RP-initiated logout verifies `id_token_hint` by fetching its own JWKS over HTTP from `${baseURL}${jwksPath}`, even though the provider is the issuer and already holds that key set.

`introspect.ts` and `revoke.ts` resolve the same key set in-process through `jwtPlugin.endpoints.getJwks(ctx)`. This aligns `logout.ts` with them, including the `jwksCacheKey: jwtPlugin` cache key added in #9987. Behavior is unchanged when `jwks.remoteUrl` is configured — only the default path stops going over the network.

### Why it matters

When the server cannot reach its own public base URL, RP-initiated logout fails with a 500 while every other endpoint keeps working:

```
ERROR [Better Auth]: Error Error: Jwks failed: Forbidden
    at async fetchJwks (@better-auth/core/dist/oauth2/verify.mjs:47:47)
    at async getJwks (@better-auth/core/dist/oauth2/verify.mjs:80:10)
    at async rpInitiatedLogoutEndpoint (@better-auth/oauth-provider/dist/index.mjs:1122:76)
error GET /api/auth/oauth2/end-session 500
```

That happens whenever the public hostname is gated at the edge — a load balancer requiring a header or an IP allowlist, or split-horizon DNS resolving the host differently inside the network. Regular clients pass; the server's own hairpin request does not. Even where the hairpin succeeds, logout availability ends up depending on the full public path (DNS → CDN/WAF → LB) being reachable from the task itself.

The available options don't help: `jwks.remoteUrl` makes the public `/jwks` endpoint return 404 (breaking resource-server verification), and `disableJwtPlugin` changes token formats entirely.

### History

The divergence dates back to the plugin's introduction in #4163 — `introspect.ts` used the in-process closure from the start, while `logout.ts` used a URL string. #6989 later edited that exact line to add `jwksPath` support, and #9987 added `jwksCacheKey` to introspection and revocation, but neither pass moved logout off the self-fetch.

#10812 rebuilt the logout flow and moved hint verification into `verifyLogoutHint`, carrying the URL string along unchanged, so the self-fetch is still on `main` today. This PR is rebased onto it and now changes `verifyLogoutHint`.

### Testing

Added a regression test that stands a decoy JWKS server on the provider's own base URL: it serves an empty key set and counts requests, so a self-fetch either verifies against the wrong keys or shows up in the count. It fails on `main` (`401 invalid_token`, decoy hit) and passes with this change. `pnpm vitest packages/oauth-provider --run` passes (925 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the provider’s local JWKS to verify `id_token_hint` during RP-initiated logout instead of fetching its own `/jwks` over HTTP. This prevents 500s when the server can’t reach its public base URL; behavior is unchanged when `jwks.remoteUrl` is set.

- **Bug Fixes**
  - `@better-auth/oauth-provider`: `logout.ts` now resolves JWKS via `jwtPlugin.endpoints.getJwks(ctx)` with `jwksCacheKey: jwtPlugin`, aligning with `introspect.ts` and `revoke.ts`.
  - Default JWKS path no longer self-fetches; `jwks.remoteUrl` remains supported.
  - Regression test serves a decoy JWKS on the provider base URL; asserts no self-fetch (request count stays 0), `/oauth2/end-session` succeeds, and the session is cleared.

<sup>Written for commit a6268ffb847b6f811db86c1419691f2950c607a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


