### PR TITLE
fix(cimd): answer the socket's all-addresses lookup in the Node transport

### DIFF
--- a/.changeset/fix-cimd-node-lookup.md
+++ b/.changeset/fix-cimd-node-lookup.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/cimd": patch
+---
+
+Fix CIMD client metadata discovery failing with `ERR_INVALID_IP_ADDRESS` on supported Node.js versions.

--- a/packages/cimd/src/node.test.ts
+++ b/packages/cimd/src/node.test.ts
@@ -150,6 +150,38 @@ describe("Node CIMD metadata transport", () => {
 		expect(pinnedAddress).toBe("93.184.216.34");
 	});
 
+	it("answers an all-addresses lookup with the pinned address list", async () => {
+		// Since Node 20, `net.autoSelectFamily` defaults to true and the socket
+		// asks the lookup override with `all: true`, expecting an address list.
+		// The legacy three-argument answer fails every connection with
+		// ERR_INVALID_IP_ADDRESS before it opens.
+		mocks.lookup.mockResolvedValue([
+			{ address: "93.184.216.34", family: 4 },
+			{ address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+		]);
+		mockHttpsResponse({ body: "ok" });
+
+		await fetchClientMetadataResource(
+			"https://client.example.com/client.json",
+		);
+
+		const options = mocks.request.mock.calls[0]?.[1] as {
+			lookup: (
+				hostname: string,
+				options: { all?: boolean },
+				callback: (
+					error: Error | null,
+					addresses: { address: string; family: number }[],
+				) => void,
+			) => void;
+		};
+		const answered = vi.fn();
+		options.lookup("client.example.com", { all: true }, answered);
+		expect(answered).toHaveBeenCalledWith(null, [
+			{ address: "93.184.216.34", family: 4 },
+		]);
+	});
+
 	it("returns redirect responses without following them", async () => {
 		mocks.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 		mockHttpsResponse({

--- a/packages/cimd/src/node.test.ts
+++ b/packages/cimd/src/node.test.ts
@@ -1,20 +1,26 @@
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
 	lookup: vi.fn(),
 	request: vi.fn(),
 }));
 
-vi.mock("node:dns/promises", () => ({ lookup: mocks.lookup }));
-vi.mock("node:https", () => ({ request: mocks.request }));
+vi.mock(import("node:dns/promises"), () => ({ lookup: mocks.lookup }));
+vi.mock(import("node:https"), () => ({ request: mocks.request }));
 
 import { fetchClientMetadataResource } from "./node";
+
+interface MockLookupAddress {
+	address: string;
+	family: number;
+}
 
 interface MockResponseOptions {
 	body?: string;
 	headers?: Record<string, string>;
+	lookupOptions?: { all?: boolean };
 	status?: number;
 }
 
@@ -25,11 +31,11 @@ function mockHttpsResponse(options: MockResponseOptions = {}) {
 			requestOptions: {
 				lookup: (
 					hostname: string,
-					options: object,
+					lookupOptions: { all?: boolean },
 					callback: (
 						error: Error | null,
-						address: string,
-						family: number,
+						result: string | MockLookupAddress[],
+						family?: number,
 					) => void,
 				) => void;
 			},
@@ -40,25 +46,35 @@ function mockHttpsResponse(options: MockResponseOptions = {}) {
 				destroy: (error?: Error) => void;
 			};
 			request.end = () => {
-				requestOptions.lookup("client.example.com", {}, (error) => {
-					if (error) {
-						request.emit("error", error);
-						return;
-					}
-					const response = Readable.from([
-						Buffer.from(options.body ?? "metadata"),
-					]) as Readable & {
-						headers: Record<string, string>;
-						statusCode: number;
-						statusMessage: string;
-					};
-					response.headers = options.headers ?? {
-						"content-type": "application/json",
-					};
-					response.statusCode = options.status ?? 200;
-					response.statusMessage = "OK";
-					onResponse(response);
-				});
+				requestOptions.lookup(
+					"client.example.com",
+					options.lookupOptions ?? {},
+					(error, result) => {
+						if (error) {
+							request.emit("error", error);
+							return;
+						}
+
+						if (options.lookupOptions?.all && !Array.isArray(result)) {
+							request.emit("error", new TypeError("Invalid IP address"));
+							return;
+						}
+
+						const response = Readable.from([
+							Buffer.from(options.body ?? "metadata"),
+						]) as Readable & {
+							headers: Record<string, string>;
+							statusCode: number;
+							statusMessage: string;
+						};
+						response.headers = options.headers ?? {
+							"content-type": "application/json",
+						};
+						response.statusCode = options.status ?? 200;
+						response.statusMessage = "OK";
+						onResponse(response);
+					},
+				);
 			};
 			request.destroy = (error) => {
 				if (error) request.emit("error", error);
@@ -67,11 +83,6 @@ function mockHttpsResponse(options: MockResponseOptions = {}) {
 		},
 	);
 }
-
-beforeEach(() => {
-	mocks.lookup.mockReset();
-	mocks.request.mockReset();
-});
 
 describe("Node CIMD metadata transport", () => {
 	it("rejects private DNS answers before opening a connection", async () => {
@@ -150,36 +161,24 @@ describe("Node CIMD metadata transport", () => {
 		expect(pinnedAddress).toBe("93.184.216.34");
 	});
 
-	it("answers an all-addresses lookup with the pinned address list", async () => {
-		// Since Node 20, `net.autoSelectFamily` defaults to true and the socket
-		// asks the lookup override with `all: true`, expecting an address list.
-		// The legacy three-argument answer fails every connection with
-		// ERR_INVALID_IP_ADDRESS before it opens.
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10810
+	 */
+	it("fetches metadata when Node requests all addresses", async () => {
 		mocks.lookup.mockResolvedValue([
 			{ address: "93.184.216.34", family: 4 },
 			{ address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
 		]);
-		mockHttpsResponse({ body: "ok" });
+		mockHttpsResponse({
+			body: "ok",
+			lookupOptions: { all: true },
+		});
 
-		await fetchClientMetadataResource(
+		const response = await fetchClientMetadataResource(
 			"https://client.example.com/client.json",
 		);
 
-		const options = mocks.request.mock.calls[0]?.[1] as {
-			lookup: (
-				hostname: string,
-				options: { all?: boolean },
-				callback: (
-					error: Error | null,
-					addresses: { address: string; family: number }[],
-				) => void,
-			) => void;
-		};
-		const answered = vi.fn();
-		options.lookup("client.example.com", { all: true }, answered);
-		expect(answered).toHaveBeenCalledWith(null, [
-			{ address: "93.184.216.34", family: 4 },
-		]);
+		expect(await response.text()).toBe("ok");
 	});
 
 	it("returns redirect responses without following them", async () => {

--- a/packages/cimd/src/node.ts
+++ b/packages/cimd/src/node.ts
@@ -77,11 +77,16 @@ export const fetchClientMetadataResource: ClientMetadataResourceFetch = async (
 						? url.hostname
 						: undefined,
 				signal,
-				// Since Node 20, `net.autoSelectFamily` defaults to true and the
-				// socket asks `lookup` with `all: true`, expecting an address
-				// list back. The legacy three-argument answer to that question
-				// fails the connection with ERR_INVALID_IP_ADDRESS before it
-				// opens.
+				/**
+				 * Node requests all lookup results when automatic address-family
+				 * selection is enabled. The callback must receive an address array for
+				 * `all: true`, and the legacy address and family arguments otherwise.
+				 * Both forms return only the previously validated address to preserve
+				 * connection pinning.
+				 *
+				 * @see https://nodejs.org/api/net.html#socketconnectoptions-connectlistener
+				 * @see https://nodejs.org/api/dns.html#dnslookuphostname-options-callback
+				 */
 				lookup: (_hostname, options, callback) => {
 					if (options.all) {
 						callback(null, [pinnedAddress]);

--- a/packages/cimd/src/node.ts
+++ b/packages/cimd/src/node.ts
@@ -77,8 +77,17 @@ export const fetchClientMetadataResource: ClientMetadataResourceFetch = async (
 						? url.hostname
 						: undefined,
 				signal,
-				lookup: (_hostname, _options, callback) => {
-					callback(null, pinnedAddress.address, pinnedAddress.family);
+				// Since Node 20, `net.autoSelectFamily` defaults to true and the
+				// socket asks `lookup` with `all: true`, expecting an address
+				// list back. The legacy three-argument answer to that question
+				// fails the connection with ERR_INVALID_IP_ADDRESS before it
+				// opens.
+				lookup: (_hostname, options, callback) => {
+					if (options.all) {
+						callback(null, [pinnedAddress]);
+					} else {
+						callback(null, pinnedAddress.address, pinnedAddress.family);
+					}
 				},
 			},
 			(response) => {


### PR DESCRIPTION
Closes #10810

## The bug

`fetchClientMetadataResource` from `@better-auth/cimd/node` fails on every call on Node >= 20. The transport pins the resolved DNS answer through a custom `lookup` override on `https.request`, and the override always answers in the legacy three-argument form:

```ts
lookup: (_hostname, _options, callback) => {
  callback(null, pinnedAddress.address, pinnedAddress.family);
},
```

Since Node 20, `net.autoSelectFamily` defaults to `true`, so the socket calls the override with `{ all: true }` and expects an address **list** back. The legacy answer fails the connection with `ERR_INVALID_IP_ADDRESS: Invalid IP address: undefined` before it opens. The CIMD plugin catches the transport error and rewrites it, so every authorization against a server wired with this transport answers:

```
{"error":"invalid_client","error_description":"Failed to fetch metadata document (network error or redirect blocked)"}
```

No CIMD client can ever register — observed in production on Vercel (Node 22) with Claude as the client, and reproducible with ten lines: any `https.request` with a three-argument custom `lookup` on stock Node >= 20 fails the same way, and succeeds with `autoSelectFamily: false`.

## The fix

The override answers the `all: true` question with the pinned address as a one-entry list, and keeps the legacy answer for the legacy question. The pin, Host header, TLS SNI, `agent: false`, and no-redirect behavior are unchanged.

The new test drives the captured override with `{ all: true }` and asserts the list answer — it fails on the old transport with the exact production symptom. All 8 transport tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DNS lookup handling in the Node transport for `@better-auth/cimd/node` so `fetchClientMetadataResource` works on Node 20+ (where `net.autoSelectFamily` defaults to true), preventing connection failures and restoring client registration.

- **Bug Fixes**
  - The `lookup` override returns a one-item address list when called with `{ all: true }` and keeps the legacy three-arg response otherwise; pinning, `Host`, SNI, `agent: false`, and no-redirect behavior are unchanged.
  - Adds a test that reproduces the failure and updates the test mocks to exercise the all-addresses callback path.

<sup>Written for commit 8547bf8994d96f086e509454e8b664a969a58195. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

