### PR TITLE
fix(oauth-provider): accept CIMD documents with at least one supported grant

### DIFF
--- a/.changeset/cimd-grant-intersection.md
+++ b/.changeset/cimd-grant-intersection.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Client ID Metadata Document clients that declare a grant the server does not offer (such as Claude's enterprise `jwt-bearer` grant) can now register. Only documents sharing no grant with the server are refused.

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -512,81 +512,81 @@ describe("oauth register", async () => {
 		});
 	});
 
-	it("keeps a client metadata document whose grants intersect the supported set", async () => {
-		// One document serves every authorization server the client talks to, so
-		// it declares the union of the client's grants. Claude's hosted document
-		// declares jwt-bearer for its enterprise flow beside authorization_code
-		// and refresh_token, and must register on a server that offers no
-		// jwt-bearer handler.
-		await expect(
-			checkOAuthClient(
-				{
-					client_id: "https://client.example.com/oauth/client-metadata",
-					client_name: "Claude",
-					redirect_uris: ["https://client.example.com/api/auth_callback"],
-					grant_types: [
-						"authorization_code",
-						"refresh_token",
-						"urn:ietf:params:oauth:grant-type:jwt-bearer",
-					],
-					response_types: ["code"],
-					token_endpoint_auth_method: "none",
-				},
-				{
-					loginPage: "/login",
-					consentPage: "/consent",
-				},
-				{ registrationSource: "clientMetadataDocument" },
-			),
-		).resolves.toBeUndefined();
-	});
-
-	it("rejects a client metadata document sharing no grant with the server", async () => {
-		await expect(
-			checkOAuthClient(
-				{
-					client_id: "https://client.example.com/oauth/client-metadata",
-					client_name: "Assertion Only",
-					redirect_uris: [],
-					grant_types: ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
-					response_types: [],
-					token_endpoint_auth_method: "none",
-				},
-				{
-					loginPage: "/login",
-					consentPage: "/consent",
-				},
-				{ registrationSource: "clientMetadataDocument" },
-			),
-		).rejects.toMatchObject({
-			body: {
-				error_description: expect.stringContaining("no mutually supported"),
-			},
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10660
+	 */
+	describe("client metadata document grant intersection", () => {
+		it("keeps a client metadata document whose grants intersect the supported set", async () => {
+			await expect(
+				checkOAuthClient(
+					{
+						client_id: "https://client.example.com/oauth/client-metadata",
+						client_name: "Claude",
+						redirect_uris: ["https://client.example.com/api/auth_callback"],
+						grant_types: [
+							"authorization_code",
+							"refresh_token",
+							"urn:ietf:params:oauth:grant-type:jwt-bearer",
+						],
+						response_types: ["code"],
+						token_endpoint_auth_method: "none",
+					},
+					{
+						loginPage: "/login",
+						consentPage: "/consent",
+					},
+					{ registrationSource: "clientMetadataDocument" },
+				),
+			).resolves.toBeUndefined();
 		});
-	});
 
-	it("still rejects a dynamic registration declaring an unsupported grant", async () => {
-		await expect(
-			checkOAuthClient(
-				{
-					client_id: "dcr-client",
-					redirect_uris: [redirectUri],
-					grant_types: [
-						"authorization_code",
-						"urn:ietf:params:oauth:grant-type:jwt-bearer",
-					],
-					response_types: ["code"],
+		it("rejects a client metadata document sharing no grant with the server", async () => {
+			await expect(
+				checkOAuthClient(
+					{
+						client_id: "https://client.example.com/oauth/client-metadata",
+						client_name: "Assertion Only",
+						redirect_uris: [],
+						grant_types: ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+						response_types: [],
+						token_endpoint_auth_method: "none",
+					},
+					{
+						loginPage: "/login",
+						consentPage: "/consent",
+					},
+					{ registrationSource: "clientMetadataDocument" },
+				),
+			).rejects.toMatchObject({
+				body: {
+					error_description: expect.stringContaining("no mutually supported"),
 				},
-				{
-					loginPage: "/login",
-					consentPage: "/consent",
+			});
+		});
+
+		it("still rejects a dynamic registration declaring an unsupported grant", async () => {
+			await expect(
+				checkOAuthClient(
+					{
+						client_id: "dcr-client",
+						redirect_uris: [redirectUri],
+						grant_types: [
+							"authorization_code",
+							"urn:ietf:params:oauth:grant-type:jwt-bearer",
+						],
+						response_types: ["code"],
+					},
+					{
+						loginPage: "/login",
+						consentPage: "/consent",
+					},
+					{ registrationSource: "dynamic" },
+				),
+			).rejects.toMatchObject({
+				body: {
+					error_description: expect.stringContaining("unsupported grant_type"),
 				},
-				{ registrationSource: "dynamic" },
-			),
-		).rejects.toMatchObject({
-			body: {
-				error_description: expect.stringContaining("unsupported grant_type"),
-			},
+			});
 		});
 	});
 

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -512,6 +512,84 @@ describe("oauth register", async () => {
 		});
 	});
 
+	it("keeps a client metadata document whose grants intersect the supported set", async () => {
+		// One document serves every authorization server the client talks to, so
+		// it declares the union of the client's grants. Claude's hosted document
+		// declares jwt-bearer for its enterprise flow beside authorization_code
+		// and refresh_token, and must register on a server that offers no
+		// jwt-bearer handler.
+		await expect(
+			checkOAuthClient(
+				{
+					client_id: "https://client.example.com/oauth/client-metadata",
+					client_name: "Claude",
+					redirect_uris: ["https://client.example.com/api/auth_callback"],
+					grant_types: [
+						"authorization_code",
+						"refresh_token",
+						"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					],
+					response_types: ["code"],
+					token_endpoint_auth_method: "none",
+				},
+				{
+					loginPage: "/login",
+					consentPage: "/consent",
+				},
+				{ registrationSource: "clientMetadataDocument" },
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects a client metadata document sharing no grant with the server", async () => {
+		await expect(
+			checkOAuthClient(
+				{
+					client_id: "https://client.example.com/oauth/client-metadata",
+					client_name: "Assertion Only",
+					redirect_uris: [],
+					grant_types: ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+					response_types: [],
+					token_endpoint_auth_method: "none",
+				},
+				{
+					loginPage: "/login",
+					consentPage: "/consent",
+				},
+				{ registrationSource: "clientMetadataDocument" },
+			),
+		).rejects.toMatchObject({
+			body: {
+				error_description: expect.stringContaining("no mutually supported"),
+			},
+		});
+	});
+
+	it("still rejects a dynamic registration declaring an unsupported grant", async () => {
+		await expect(
+			checkOAuthClient(
+				{
+					client_id: "dcr-client",
+					redirect_uris: [redirectUri],
+					grant_types: [
+						"authorization_code",
+						"urn:ietf:params:oauth:grant-type:jwt-bearer",
+					],
+					response_types: ["code"],
+				},
+				{
+					loginPage: "/login",
+					consentPage: "/consent",
+				},
+				{ registrationSource: "dynamic" },
+			),
+		).rejects.toMatchObject({
+			body: {
+				error_description: expect.stringContaining("unsupported grant_type"),
+			},
+		});
+	});
+
 	it("rejects a bare JWK array through managed registration", async () => {
 		await expect(
 			auth.api.adminCreateOAuthClient({

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -419,10 +419,7 @@ export async function checkOAuthClient(
 		// beside authorization_code and refresh_token. The document passes when
 		// at least one declared grant is mutually supported; the token endpoint
 		// still refuses any grant it has no handler for.
-		if (
-			grantTypes.length > 0 &&
-			!grantTypes.some((grantType) => supportedGrantTypes.has(grantType))
-		) {
+		if (!grantTypes.some((grantType) => supportedGrantTypes.has(grantType))) {
 			throw new APIError("BAD_REQUEST", {
 				error: "invalid_client_metadata",
 				error_description: `no mutually supported grant_type among ${grantTypes.join(", ")}`,

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -409,12 +409,33 @@ export async function checkOAuthClient(
 
 	// Validate correlation between grant_types and response_types
 	const supportedGrantTypes = new Set(getSupportedGrantTypes(opts));
-	for (const grantType of grantTypes) {
-		if (!supportedGrantTypes.has(grantType)) {
+	if (isClientMetadataDocument) {
+		// One Client ID Metadata Document serves every authorization server the
+		// client talks to, so it declares the union of the client's grants
+		// across all of them. Rejecting the document over a grant this server
+		// does not offer makes any multi-capability client unregistrable —
+		// Claude's hosted document declares
+		// urn:ietf:params:oauth:grant-type:jwt-bearer for its enterprise flow
+		// beside authorization_code and refresh_token. The document passes when
+		// at least one declared grant is mutually supported; the token endpoint
+		// still refuses any grant it has no handler for.
+		if (
+			grantTypes.length > 0 &&
+			!grantTypes.some((grantType) => supportedGrantTypes.has(grantType))
+		) {
 			throw new APIError("BAD_REQUEST", {
 				error: "invalid_client_metadata",
-				error_description: `unsupported grant_type ${grantType}`,
+				error_description: `no mutually supported grant_type among ${grantTypes.join(", ")}`,
 			});
+		}
+	} else {
+		for (const grantType of grantTypes) {
+			if (!supportedGrantTypes.has(grantType)) {
+				throw new APIError("BAD_REQUEST", {
+					error: "invalid_client_metadata",
+					error_description: `unsupported grant_type ${grantType}`,
+				});
+			}
 		}
 	}
 	if (

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -410,15 +410,9 @@ export async function checkOAuthClient(
 	// Validate correlation between grant_types and response_types
 	const supportedGrantTypes = new Set(getSupportedGrantTypes(opts));
 	if (isClientMetadataDocument) {
-		// One Client ID Metadata Document serves every authorization server the
-		// client talks to, so it declares the union of the client's grants
-		// across all of them. Rejecting the document over a grant this server
-		// does not offer makes any multi-capability client unregistrable —
-		// Claude's hosted document declares
-		// urn:ietf:params:oauth:grant-type:jwt-bearer for its enterprise flow
-		// beside authorization_code and refresh_token. The document passes when
-		// at least one declared grant is mutually supported; the token endpoint
-		// still refuses any grant it has no handler for.
+		// One metadata document serves every authorization server the client talks
+		// to, so it declares a grant union; require one mutual grant and let the
+		// token endpoint refuse the rest.
 		if (!grantTypes.some((grantType) => supportedGrantTypes.has(grantType))) {
 			throw new APIError("BAD_REQUEST", {
 				error: "invalid_client_metadata",


### PR DESCRIPTION
## The bug

`checkOAuthClient` validates each grant a client declares against the server's supported set and rejects the whole registration on the first miss. For dynamic registration that is right. For a Client ID Metadata Document it makes any multi-capability client unregistrable: one document serves every authorization server the client talks to, so it declares the union of the client's grants across all of them.

The concrete case is Claude. `https://claude.ai/oauth/mcp-oauth-client-metadata` (Claude web, desktop, mobile, and Cowork) declares:

```json
"grant_types": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"]
```

`jwt-bearer` backs Claude's Enterprise Managed Auth against servers that support it. A server built on `mcp()` + `cimd()` offers no such grant, so every Claude connection dies at `/oauth2/authorize` with:

```
{"error":"invalid_client_metadata","error_description":"unsupported grant_type urn:ietf:params:oauth:grant-type:jwt-bearer"}
```

This is the Claude case of #10660.

## The fix

For `registrationSource === "clientMetadataDocument"`, the document passes when at least one declared grant is mutually supported, and is refused only when nothing is mutual. Dynamic registration keeps the strict per-grant check, unchanged. The token endpoint is untouched: it still refuses any grant it has no handler for, so nothing is granted that was not before.
