### PR TITLE
docs: make AI chat failures recoverable

### DIFF
--- a/docs/components/ai-chat.tsx
+++ b/docs/components/ai-chat.tsx
@@ -15,6 +15,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { getChatErrorMessage } from "@/lib/ai-chat/error";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./markdown";
 import { MessageFeedback } from "./message-feedback";
@@ -396,11 +397,20 @@ function PanelMessages({ className, ...props }: ComponentProps<"div">) {
 // ─── Panel Input ─────────────────────────────────────────────────────────────
 
 function PanelInput({ autoFocus = false }: { autoFocus?: boolean }) {
-	const { status, sendMessage, stop, setMessages, messages, regenerate } =
-		useChatContext();
+	const {
+		status,
+		error,
+		sendMessage,
+		stop,
+		setMessages,
+		messages,
+		regenerate,
+		clearError,
+	} = useChatContext();
 	const [input, setInput] = useState("");
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const isLoading = status === "streaming" || status === "submitted";
+	const hasError = error != null;
 	const inputDragRef = useRef<{ startY: number; startHeight: number } | null>(
 		null,
 	);
@@ -420,7 +430,7 @@ function PanelInput({ autoFocus = false }: { autoFocus?: boolean }) {
 
 	const onSubmit = (e?: SyntheticEvent) => {
 		e?.preventDefault();
-		if (!input.trim() || isLoading) return;
+		if (!input.trim() || isLoading || hasError) return;
 		void sendMessage({ text: input });
 		setInput("");
 		requestAnimationFrame(adjustHeight);
@@ -487,8 +497,14 @@ function PanelInput({ autoFocus = false }: { autoFocus?: boolean }) {
 									onSubmit();
 								}
 							}}
-							disabled={isLoading}
-							placeholder={isLoading ? "AI is answering..." : "Ask a question"}
+							disabled={isLoading || hasError}
+							placeholder={
+								isLoading
+									? "AI is answering..."
+									: hasError
+										? "Retry or clear the chat to continue"
+										: "Ask a question"
+							}
 							autoFocus={autoFocus}
 							rows={1}
 							style={{
@@ -525,8 +541,25 @@ function PanelInput({ autoFocus = false }: { autoFocus?: boolean }) {
 					</div>
 				</form>
 			</div>
-			<div className="flex items-center gap-1.5 p-1 empty:hidden">
-				{!isLoading &&
+			<div className="flex flex-wrap items-center gap-1.5 p-1 empty:hidden">
+				{hasError && (
+					<div
+						role="alert"
+						className="flex w-full items-center justify-between gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-2.5 py-2 text-xs text-destructive"
+					>
+						<span>{getChatErrorMessage(error)}</span>
+						<button
+							type="button"
+							className="flex shrink-0 items-center gap-1 font-medium hover:underline"
+							onClick={() => void regenerate()}
+						>
+							<RefreshCw className="size-3" />
+							Retry
+						</button>
+					</div>
+				)}
+				{!hasError &&
+					!isLoading &&
 					messages.length > 0 &&
 					messages.at(-1)?.role === "assistant" && (
 						<button
@@ -542,7 +575,10 @@ function PanelInput({ autoFocus = false }: { autoFocus?: boolean }) {
 					<button
 						type="button"
 						className="flex items-center gap-1.5 px-2.5 py-1 text-xs border rounded-full text-muted-foreground hover:text-foreground transition-colors"
-						onClick={() => setMessages([])}
+						onClick={() => {
+							setMessages([]);
+							clearError();
+						}}
 					>
 						Clear Chat
 					</button>

--- a/docs/lib/ai-chat/error.test.ts
+++ b/docs/lib/ai-chat/error.test.ts
@@ -13,7 +13,27 @@ describe("getChatErrorMessage", () => {
 	});
 
 	it("explains when the request was rate limited", () => {
-		expect(getChatErrorMessage(new Error("Rate limit exceeded"))).toBe(
+		const errors = [
+			"Rate limit exceeded",
+			"rate_limit_error",
+			"Too Many Requests",
+			"RESOURCE_EXCEEDED",
+			"Quota exceeded",
+			"Request failed with status 429",
+		];
+
+		for (const error of errors) {
+			expect(getChatErrorMessage(new Error(error))).toBe(
+				CHAT_RATE_LIMIT_MESSAGE,
+			);
+		}
+	});
+
+	it("preserves sanitized errors received from the stream", () => {
+		expect(getChatErrorMessage(new Error(CHAT_ERROR_MESSAGE))).toBe(
+			CHAT_ERROR_MESSAGE,
+		);
+		expect(getChatErrorMessage(new Error(CHAT_RATE_LIMIT_MESSAGE))).toBe(
 			CHAT_RATE_LIMIT_MESSAGE,
 		);
 	});

--- a/docs/lib/ai-chat/error.test.ts
+++ b/docs/lib/ai-chat/error.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+	CHAT_ERROR_MESSAGE,
+	CHAT_RATE_LIMIT_MESSAGE,
+	getChatErrorMessage,
+} from "./error";
+
+describe("getChatErrorMessage", () => {
+	it("returns a recoverable message without exposing internal errors", () => {
+		expect(
+			getChatErrorMessage(new Error("Gateway request failed: secret")),
+		).toBe(CHAT_ERROR_MESSAGE);
+	});
+
+	it("explains when the request was rate limited", () => {
+		expect(getChatErrorMessage(new Error("Rate limit exceeded"))).toBe(
+			CHAT_RATE_LIMIT_MESSAGE,
+		);
+	});
+
+	it("handles non-Error values", () => {
+		expect(getChatErrorMessage(undefined)).toBe(CHAT_ERROR_MESSAGE);
+	});
+});

--- a/docs/lib/ai-chat/error.test.ts
+++ b/docs/lib/ai-chat/error.test.ts
@@ -18,14 +18,28 @@ describe("getChatErrorMessage", () => {
 			"rate_limit_error",
 			"Too Many Requests",
 			"RESOURCE_EXCEEDED",
+			"RESOURCE_EXHAUSTED",
 			"Quota exceeded",
+			"quota_exhausted",
 			"Request failed with status 429",
+			"HTTP 429",
 		];
 
 		for (const error of errors) {
 			expect(getChatErrorMessage(new Error(error))).toBe(
 				CHAT_RATE_LIMIT_MESSAGE,
 			);
+		}
+	});
+
+	it("does not mistake unrelated quota or numeric details for rate limits", () => {
+		const errors = [
+			"Moderation blocked due to output quota policy",
+			"Unexpected value 429 in response",
+		];
+
+		for (const error of errors) {
+			expect(getChatErrorMessage(new Error(error))).toBe(CHAT_ERROR_MESSAGE);
 		}
 	});
 

--- a/docs/lib/ai-chat/error.ts
+++ b/docs/lib/ai-chat/error.ts
@@ -5,7 +5,7 @@ export const CHAT_RATE_LIMIT_MESSAGE =
 	"Too many requests. Please wait a moment and try again.";
 
 const RATE_LIMIT_PATTERN =
-	/rate[_ -]?limit|too many requests|resource_exceeded|quota|\b429\b/i;
+	/rate[_ -]?limit|too many requests|resource_(?:exceeded|exhausted)|quota[_ -]?(?:exceeded|exhausted)|(?:http(?: status)?|status(?: code)?)\s*:?\s*429/i;
 
 export function getChatErrorMessage(error: unknown): string {
 	const message = error instanceof Error ? error.message : String(error);

--- a/docs/lib/ai-chat/error.ts
+++ b/docs/lib/ai-chat/error.ts
@@ -1,0 +1,15 @@
+export const CHAT_ERROR_MESSAGE =
+	"The response was interrupted. Please try again.";
+
+export const CHAT_RATE_LIMIT_MESSAGE =
+	"Too many requests. Please wait a moment and try again.";
+
+export function getChatErrorMessage(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+
+	if (message.toLowerCase().includes("rate limit")) {
+		return CHAT_RATE_LIMIT_MESSAGE;
+	}
+
+	return CHAT_ERROR_MESSAGE;
+}

--- a/docs/lib/ai-chat/error.ts
+++ b/docs/lib/ai-chat/error.ts
@@ -4,10 +4,17 @@ export const CHAT_ERROR_MESSAGE =
 export const CHAT_RATE_LIMIT_MESSAGE =
 	"Too many requests. Please wait a moment and try again.";
 
+const RATE_LIMIT_PATTERN =
+	/rate[_ -]?limit|too many requests|resource_exceeded|quota|\b429\b/i;
+
 export function getChatErrorMessage(error: unknown): string {
 	const message = error instanceof Error ? error.message : String(error);
 
-	if (message.toLowerCase().includes("rate limit")) {
+	if (message === CHAT_ERROR_MESSAGE || message === CHAT_RATE_LIMIT_MESSAGE) {
+		return message;
+	}
+
+	if (RATE_LIMIT_PATTERN.test(message)) {
 		return CHAT_RATE_LIMIT_MESSAGE;
 	}
 

--- a/docs/lib/ai-chat/route.ts
+++ b/docs/lib/ai-chat/route.ts
@@ -1,5 +1,7 @@
 import { convertToModelMessages, stepCountIs, streamText, tool } from "ai";
 import * as z from "zod";
+import { getChatErrorMessage } from "@/lib/ai-chat/error";
+import { prepareChatStep } from "@/lib/ai-chat/step";
 import { getLLMText } from "@/lib/llm-text";
 import { source } from "@/lib/source";
 import { checkRateLimit, getClientIP } from "./rate-limit";
@@ -400,10 +402,16 @@ export async function POST(req: Request) {
 					},
 				}),
 			},
+			prepareStep: prepareChatStep,
 			stopWhen: stepCountIs(8),
 		});
 
-		return result.toUIMessageStreamResponse();
+		return result.toUIMessageStreamResponse({
+			onError: (error) => {
+				console.error(`[ai-chat] stream error (${errorId})`, error);
+				return getChatErrorMessage(error);
+			},
+		});
 	} catch (err) {
 		console.error(`[ai-chat] unhandled error (${errorId})`, err);
 		return new Response(

--- a/docs/lib/ai-chat/step.test.ts
+++ b/docs/lib/ai-chat/step.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { prepareChatStep } from "./step";
+
+describe("prepareChatStep", () => {
+	it("requires a tool call before the assistant can answer", () => {
+		expect(prepareChatStep({ stepNumber: 0 })).toEqual({
+			toolChoice: "required",
+		});
+	});
+
+	it("lets the assistant answer after using a tool", () => {
+		expect(prepareChatStep({ stepNumber: 1 })).toEqual({});
+	});
+});

--- a/docs/lib/ai-chat/step.ts
+++ b/docs/lib/ai-chat/step.ts
@@ -1,0 +1,7 @@
+export function prepareChatStep({ stepNumber }: { stepNumber: number }) {
+	if (stepNumber === 0) {
+		return { toolChoice: "required" as const };
+	}
+
+	return {};
+}

--- a/docs/vitest.config.ts
+++ b/docs/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+	},
+});


### PR DESCRIPTION
## Summary

- require the docs assistant to perform an initial tool lookup before answering
- propagate streaming failures to the client with safe, rate-limit-aware messages
- provide a visible retry flow instead of leaving interrupted responses in a silent terminal state
