### PR TITLE
docs: clarify remaining 1.7 migration details

### DIFF
--- a/docs/content/blogs/1-7-rc.mdx
+++ b/docs/content/blogs/1-7-rc.mdx
@@ -80,14 +80,14 @@ These setups were impossible, broken, or unsafe before, and work now.
 
 **Other apps logging in through you**
 
-| Setup                                          | What was blocked                        | How it works now                                                             |
-| ---------------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------- |
-| **APIs needing theft-resistant tokens**        | Only plain bearer tokens.               | Use DPoP tokens bound to the client's key.                                   |
-| **Several APIs behind one login server**       | One token could be used on any API.     | Use per-API resources, so tokens are locked to the API they were issued for. |
-| **Machine clients registering themselves**     | Registration required a logged-in user. | Use pre-shared registration tokens.                                          |
-| **MCP clients (Claude, Codex, Factory Droid)** | Their registration was rejected.        | They are accepted automatically, with Client ID Metadata Document support.   |
-| **Single sign-out across apps**                | Sign-out did not notify other apps.     | Use OIDC Back-Channel Logout.                                                |
-| **Forced re-login**                            | The request was ignored.                | `max_age` is enforced.                                                       |
+| Setup                                      | What was blocked                                               | How it works now                                                                            |
+| ------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **APIs needing theft-resistant tokens**    | Only plain bearer tokens.                                      | Use DPoP tokens bound to the client's key.                                                  |
+| **Several APIs behind one login server**   | One token could be used on any API.                            | Use per-API resources, so tokens are locked to the API they were issued for.                |
+| **Machine clients registering themselves** | Registration required a logged-in user.                        | Use pre-shared registration tokens.                                                         |
+| **URL-identified MCP clients**             | Only endpoint-based Dynamic Client Registration was available. | Compose `mcp()` with `cimd()` for Client ID Metadata Documents, or explicitly opt into DCR. |
+| **Single sign-out across apps**            | Sign-out did not notify other apps.                            | Use OIDC Back-Channel Logout.                                                               |
+| **Forced re-login**                        | The request was ignored.                                       | `max_age` is enforced.                                                                      |
 
 **Enterprise SSO**
 

--- a/docs/content/docs/authentication/microsoft.mdx
+++ b/docs/content/docs/authentication/microsoft.mdx
@@ -84,23 +84,13 @@ Enabling OAuth with Microsoft Azure Entra ID (formerly Active Directory) allows 
   </Step>
 </Steps>
 
-## Account Identifier Migration
+## Account identifiers
 
-Better Auth stores the Microsoft Entra `oid` claim as the account identifier for the built-in `microsoft` provider and the Generic OAuth `microsoftEntraId` helper. Microsoft documents `sub` as a pairwise, app-specific identifier, so changing or recreating an app registration can change `sub` for the same user.
+Better Auth uses the verified Microsoft Entra `oid` claim as the provider-owned account identifier. `mapProfileToUser` can map local user fields but cannot replace this identifier.
 
-If you already have Microsoft accounts created with an older Better Auth version, migrate their account rows before upgrading production traffic:
-
-* Built-in provider rows use `providerId: "microsoft"`.
-* Generic OAuth helper rows use `providerId: "microsoft-entra-id"`.
-* Preserve the row's trusted `issuer` and update `accountId` from the old `sub` value to the user's `oid` value.
-
-When stored Microsoft ID tokens are available, verify each token and copy its `oid` claim into that row's `accountId`. `mapProfileToUser` only maps local user fields and cannot override this provider-owned account identifier.
-
-If stored Microsoft ID tokens are not available, Better Auth's account row only has the old `sub` value and cannot derive `oid` from Better Auth data alone. Run this as a controlled migration: pause Microsoft sign-in and account linking during the cutover, or migrate from an external Microsoft Entra export before accepting production traffic on the new identifier. Otherwise, users who were not migrated can create duplicate Microsoft account rows.
-
-If you are also upgrading from a schema that still uses `accountId` or does not have `issuer`, complete the [1.7 account identity backfill](/docs/guides/1-7-upgrade-guide#account-identity-is-scoped-by-issuer) as part of the same maintenance window.
-
-If you use the Generic OAuth `microsoftEntraId` helper with custom scopes or a custom `getToken`, make sure the token exchange still returns Microsoft's `id_token`; the helper reads `oid` from that token. The helper also requires Microsoft discovery to provide the issuer and JWKS metadata used to verify ID tokens, and provider initialization fails when that metadata is unavailable.
+<Callout type="warn">
+  Upgrading from Better Auth 1.6 requires a one-time migration of existing Microsoft account rows from `sub` to `oid`. Follow [Migrate Microsoft account identifiers](/docs/guides/1-7-upgrade-guide#migrate-microsoft-account-identifiers) before accepting production traffic on 1.7.
+</Callout>
 
 ## Large Profile Images ⚠️
 

--- a/docs/content/docs/guides/1-7-upgrade-guide.mdx
+++ b/docs/content/docs/guides/1-7-upgrade-guide.mdx
@@ -113,7 +113,16 @@ Deploy only after the collision query returns no rows and the required unique in
 
 Review every custom OAuth provider's account subject. OpenID Connect discovery providers now use verified `sub`; plain OAuth providers use `id`; the previous runtime fallback between those fields is removed. Set `accountSubject` when either default is not the provider's immutable identifier. `getUserInfo().user` now contains only mutable local-user fields; keep the provider identifier in `getUserInfo().data`. `mapProfileToUser` can no longer return `id`. The `accountInfo` response exposes the selected identity as `account.accountId` instead of `user.id`.
 
-Microsoft accounts now use the stable `oid` claim instead of `sub`. Before adding the compound index, replace each existing Microsoft account's `accountId` with the verified `oid` for that directory user. The generic `microsoftEntraId` helper also requires a concrete tenant GUID. Replace `common`, `organizations`, or `consumers` configurations with the built-in Microsoft social provider, which validates tenant claims and derives the token's actual issuer.
+#### Migrate Microsoft account identifiers
+
+Microsoft accounts now use the stable directory `oid` claim instead of the pairwise, app-specific `sub` claim. Complete this during step 3 of the account identity backfill, before checking for collisions or adding the compound account index:
+
+1. Inventory rows with `providerId: "microsoft"` for the built-in provider and `providerId: "microsoft-entra-id"` for the Generic OAuth helper.
+2. Assign each row its trusted issuer as part of the account identity backfill, and replace its old `sub`-based `accountId` with the verified `oid` for that directory user.
+3. When stored Microsoft ID tokens are available, verify each token and copy its `oid` claim. `mapProfileToUser` cannot override this provider-owned account identifier.
+4. When stored ID tokens are unavailable, pause Microsoft sign-in and account linking during the cutover and obtain the mapping from a trusted Microsoft Entra export. Better Auth cannot derive `oid` from the old account row alone; accepting traffic before the migration can create duplicate accounts.
+
+If you use the Generic OAuth `microsoftEntraId` helper with custom scopes or `getToken`, ensure the token exchange still returns Microsoft's `id_token` and discovery provides the issuer and JWKS metadata needed to verify it. The helper also requires a concrete tenant GUID. Replace `common`, `organizations`, or `consumers` configurations with the built-in Microsoft social provider, which validates tenant claims and derives the token's actual issuer.
 
 ### Generic OAuth is rebuilt on the social-provider path
 

--- a/docs/content/docs/guides/1-7-upgrade-guide.mdx
+++ b/docs/content/docs/guides/1-7-upgrade-guide.mdx
@@ -529,7 +529,7 @@ betterAuth({
 
 Setups where the proxy rewrites the host for you, such as nginx, Vercel, Cloudflare, and Netlify, need no change.
 
-Dynamic base URLs also fail closed when a request has no usable host or its host does not match `allowedHosts`. Direct server API calls must therefore include request URL or header data that resolves to an allowed public origin. Better Auth rebuilds the base URL, trusted origins, provider URLs, and cookies for that resolved host on each request; OAuth issuer, discovery, protected-resource, and JWKS URLs follow the same request origin.
+Without `baseURL.fallback`, dynamic base URLs fail closed when a request has no usable host or its host does not match `allowedHosts`. Direct server API calls must therefore include request URL or header data that resolves to an allowed public origin, or configure a trusted fallback. Better Auth rebuilds the base URL, trusted origins, provider URLs, and cookies for the resolved origin on each request; OAuth issuer, discovery, protected-resource, and JWKS URLs follow the same request origin.
 
 ### IdP redirects and DPoP need your canonical origin
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies remaining 1.7 migration docs by centralizing Microsoft account-ID migration in the upgrade guide (with a callout in provider docs), documenting dynamic base URL fallback, and updating the 1.7 RC blog for URL-identified MCP clients via `mcp()` + `cimd()` or explicit DCR. Also notes `microsoftEntraId` helper requirements (ID token verification and a concrete tenant GUID).

- **Migration**
  - Before adding the compound account index, migrate Microsoft accounts from `sub` to `oid` using verified ID tokens; if tokens are missing, pause sign-in and backfill from a trusted Entra export.
  - For server calls without a resolvable host, include URL/headers or set `baseURL.fallback` to avoid fail-closed behavior.

<sup>Written for commit c36db1271d1b6780ed21e5ab2c354f8bd00c4b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

