### PR TITLE
docs(two-factor): align enrollment guidance with current behavior

### DIFF
--- a/.changeset/two-factor-otp-enable.md
+++ b/.changeset/two-factor-otp-enable.md
@@ -2,7 +2,7 @@
 "better-auth": minor
 ---
 
-feat(two-factor)!: add OTP-only enablement and remove `skipVerificationOnEnable`
+feat(two-factor)!: add OTP-only enablement and a discriminated response
 
 `enableTwoFactor` now accepts a `method` parameter (`"otp" | "totp"`, default `"totp"`) and returns a discriminated response with a `method` field.
 
@@ -17,7 +17,8 @@ feat(two-factor)!: add OTP-only enablement and remove `skipVerificationOnEnable`
 - Returns `{ method: "totp", totpURI, backupCodes }`.
 - Rejects with `TOTP_NOT_CONFIGURED` if `totpOptions.disable` is set.
 
+The existing `skipVerificationOnEnable` option remains supported for TOTP enrollment.
+
 ### Breaking changes
 
-- **Removed `skipVerificationOnEnable`**: use `method: "otp"` for immediate activation, or the standard TOTP verification flow.
 - **Response shape changed**: `enableTwoFactor` includes a `method` field in the response (`"otp"` or `"totp"`).

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -115,7 +115,7 @@ To enable two-factor authentication, call `twoFactor.enable`. The user must prov
 When `method` is `"totp"` (default):
 
 * Returns `{ method: "totp", totpURI, backupCodes }`. Use `totpURI` to display a QR code.
-* `twoFactorEnabled` won’t be set to `true` until the user verifies their TOTP code. See [verifying TOTP](#totp).
+* By default, `twoFactorEnabled` remains `false` until the user verifies a TOTP code. When the server plugin is configured with `skipVerificationOnEnable: true`, TOTP is enabled without enrollment-code verification. See [verifying TOTP](#totp).
 
 When `method` is `"otp"`:
 
@@ -538,6 +538,8 @@ export const twoFactorTableFields = [
 **twoFactorTable**: The name of the table that stores the two factor authentication data. Default: `twoFactor`.
 
 **issuer**: Custom issuer name for the TOTP URI. Defaults to your `appName`.
+
+**skipVerificationOnEnable**: Activate TOTP immediately without verifying an enrollment code. Defaults to `false`.
 
 **allowPasswordless**: Allow enabling and managing 2FA without a password for users that do not have a credential account. Password is still required if a credential account exists. This option does not change which sign-in methods are challenged for 2FA.
 


### PR DESCRIPTION
Related to #9057 and #9115 (https://github.com/better-auth/better-auth/commit/3fbab440684e3d8114bec2e18db931c2b6e1312a)

<img width="400" alt="1" src="https://github.com/user-attachments/assets/ccf0bdc7-d6eb-4928-82f8-1c9f1583e9c3" />


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update 2FA docs to match current enrollment behavior. Clarifies that `skipVerificationOnEnable` is still supported for TOTP (immediate activation), when `twoFactorEnabled` flips to true, and corrects the changeset to note a discriminated `enableTwoFactor` response instead of removing the option.

<sup>Written for commit 1f84c311c8760d89794179645481fb3dee0e2b45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

