### PR TITLE
fix(api-key): prevent continuous traffic from extending rate-limit windows

### DIFF
--- a/.changeset/fixed-api-key-rate-limit-window.md
+++ b/.changeset/fixed-api-key-rate-limit-window.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/api-key": minor
+---
+
+API key rate limits now reset on a fixed window even when requests continue throughout the window. This adds the nullable `rateLimitResetAt` field.

--- a/docs/content/blogs/1-7-rc.mdx
+++ b/docs/content/blogs/1-7-rc.mdx
@@ -219,6 +219,7 @@ export const auth = betterAuth({
 | OAuth token-redemption errors use standard codes                | Authorization-code redemption failures return `400 invalid_grant` instead of `401 invalid_client` or `invalid_request`.             |
 | Sign-out runs session-delete hooks with external session stores | `session.delete` hooks now run on sign-out even with `secondaryStorage` and `preserveSessionInDatabase`.                            |
 | Two-factor invalidation failure has its own error code          | A failed two-factor challenge cleanup now returns `FAILED_TO_INVALIDATE_TWO_FACTOR_CHALLENGE`.                                      |
+| API key rate limits use fixed windows                           | Continuous traffic no longer postpones a key's rate-limit reset.                                                                    |
 
 ### New additions
 

--- a/docs/content/docs/guides/1-7-upgrade-guide.mdx
+++ b/docs/content/docs/guides/1-7-upgrade-guide.mdx
@@ -49,6 +49,7 @@ These features change the schema:
 | Organization team counters | `team.memberCount` and `teamMember.membershipKey` columns                                                               | No                        |
 | Provider client store      | `oauthApplication` becomes `oauthClient`, plus new token tables                                                         | **Yes, move client data** |
 | Device Authorization       | An optional `resource` column, plus indexes on `deviceCode` and `userCode`                                              | **Yes, MySQL/SQL Server** |
+| API key fixed windows      | A nullable `rateLimitResetAt` column on API keys                                                                        | No                        |
 
 <Callout type="warn">
   Prepare account identities, OAuth clients, and SCIM data before applying the generated 1.7 schema. The CLI adds tables, columns, and indexes, but it does not choose issuers, copy OAuth clients, or convert legacy SCIM data.

--- a/docs/content/docs/plugins/api-key/advanced.mdx
+++ b/docs/content/docs/plugins/api-key/advanced.mdx
@@ -607,15 +607,17 @@ const apiKey = await auth.api.createApiKey({
 
 ### How does it work?
 
-The rate limiting system uses a sliding window approach:
+The rate limiting system uses a per-key, first-request-anchored fixed window:
 
-1. **First Request**: When an API key is used for the first time (no previous `lastRequest`), the request is allowed and `requestCount` is set to 1.
+1. **First Request**: The first accepted request starts a window, sets `requestCount` to 1, and sets `rateLimitResetAt` to `timeWindow` milliseconds in the future.
 
-2. **Within Window**: For subsequent requests within the `timeWindow`, the `requestCount` is incremented. If `requestCount` reaches `rateLimitMax`, the request is rejected with a `RATE_LIMITED` error code.
+2. **Within Window**: Subsequent requests before `rateLimitResetAt` increment `requestCount`. Once `requestCount` reaches `rateLimitMax`, requests are rejected with a `RATE_LIMITED` error code.
 
-3. **Window Reset**: If the time since the last request exceeds the `timeWindow`, the window resets: `requestCount` is reset to 1 and `lastRequest` is updated to the current time.
+3. **Window Reset**: At or after `rateLimitResetAt`, the next accepted request starts a new window and resets `requestCount` to 1. Continuous traffic does not extend the current window.
 
-4. **Rate Limit Exceeded**: When a request is rejected due to rate limiting, the error response includes a `tryAgainIn` value (in milliseconds) indicating how long to wait before the window resets.
+4. **Rate Limit Exceeded**: A rejected response includes `tryAgainIn` in milliseconds, calculated from `rateLimitResetAt`. `lastRequest` is only the timestamp of the most recent accepted request and does not control window expiration.
+
+Fixed windows can allow bursts around a boundary, and changing `rateLimitEnabled`, `rateLimitTimeWindow`, or `rateLimitMax` clears the current window so the next accepted request starts a new one when rate limiting is enabled.
 
 **Disabling Rate Limiting**:
 

--- a/docs/content/docs/plugins/api-key/reference.mdx
+++ b/docs/content/docs/plugins/api-key/reference.mdx
@@ -128,13 +128,13 @@ Customize the rate-limiting.
 
     `timeWindow` <span className="opacity-70">`number`</span>
 
-    The duration in milliseconds where each request is counted.
-    Once the `maxRequests` is reached, the request will be rejected until the `timeWindow` has passed, at which point the `timeWindow` will be reset.
+    The duration of each first-request-anchored fixed window in milliseconds. A window starts with the first accepted request.
+    Once `maxRequests` is reached, requests are rejected until that window ends.
 
     `maxRequests` <span className="opacity-70">`number`</span>
 
-    Maximum amount of requests allowed within a window.
-    Once the `maxRequests` is reached, the request will be rejected until the `timeWindow` has passed, at which point the `timeWindow` will be reset.
+    Maximum amount of requests allowed within a fixed window.
+    Once `maxRequests` is reached, requests are rejected until the current window ends.
   </Accordion>
 </Accordions>
 
@@ -525,6 +525,12 @@ export const apiKeyTableFields = [
 		type: "number",
 		description:
 			"The number of requests made within the rate limit time window.",
+		isOptional: true,
+	},
+	{
+		name: "rateLimitResetAt",
+		type: "Date",
+		description: "The date and time when the current rate limit window resets.",
 		isOptional: true,
 	},
 	{

--- a/packages/api-key/src/adapter.ts
+++ b/packages/api-key/src/adapter.ts
@@ -152,6 +152,7 @@ function serializeApiKey(apiKey: ApiKey): string {
 		expiresAt: apiKey.expiresAt?.toISOString() ?? null,
 		lastRefillAt: apiKey.lastRefillAt?.toISOString() ?? null,
 		lastRequest: apiKey.lastRequest?.toISOString() ?? null,
+		rateLimitResetAt: apiKey.rateLimitResetAt?.toISOString() ?? null,
 	});
 }
 
@@ -172,6 +173,9 @@ function deserializeApiKey(data: unknown): ApiKey | null {
 			expiresAt: parsed.expiresAt ? new Date(parsed.expiresAt) : null,
 			lastRefillAt: parsed.lastRefillAt ? new Date(parsed.lastRefillAt) : null,
 			lastRequest: parsed.lastRequest ? new Date(parsed.lastRequest) : null,
+			rateLimitResetAt: parsed.rateLimitResetAt
+				? new Date(parsed.rateLimitResetAt)
+				: null,
 		} as ApiKey;
 	} catch {
 		return null;

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -5332,6 +5332,47 @@ describe("concurrent verification enforces atomic counters", async () => {
 			expect(stored.requestCount).toBe(2);
 		});
 
+		it("preserves a legacy counter while initializing its fixed window", async () => {
+			const { headers, user } = await signInWithTestUser();
+			const created = await auth.api.createApiKey({
+				body: {
+					rateLimitEnabled: true,
+					rateLimitMax: 2,
+					rateLimitTimeWindow: 60_000,
+					userId: user.id,
+				},
+			});
+			await auth.api.verifyApiKey({ body: { key: created.key } });
+
+			const primed = await auth.api.getApiKey({
+				query: { id: created.id },
+				headers,
+			});
+			const context = await auth.$context;
+			await context.adapter.update({
+				model: "apikey",
+				where: [{ field: "id", value: created.id }],
+				update: { rateLimitResetAt: null },
+			});
+
+			gate = createArrivalGate(concurrency);
+			const results = await Promise.all(
+				Array.from({ length: concurrency }, () =>
+					auth.api.verifyApiKey({ body: { key: created.key } }),
+				),
+			);
+
+			expect(results.filter((result) => result.valid)).toHaveLength(1);
+			const stored = await auth.api.getApiKey({
+				query: { id: created.id },
+				headers,
+			});
+			expect(stored.requestCount).toBe(2);
+			expect(stored.rateLimitResetAt).toEqual(
+				new Date(primed.lastRequest!.getTime() + 60_000),
+			);
+		});
+
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/6035
 		 */

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -69,6 +69,7 @@ describe("api-key", async () => {
 		expect(apiKey.data?.rateLimitTimeWindow).toEqual(86400000);
 		expect(apiKey.data?.rateLimitMax).toEqual(10);
 		expect(apiKey.data?.requestCount).toEqual(0);
+		expect(apiKey.data?.rateLimitResetAt).toBeNull();
 		expect(apiKey.data?.remaining).toBeNull();
 		expect(apiKey.data?.lastRequest).toBeNull();
 		expect(apiKey.data?.expiresAt).toBeNull();
@@ -151,6 +152,7 @@ describe("api-key", async () => {
 		expect(apiKey.rateLimitTimeWindow).toEqual(86400000);
 		expect(apiKey.rateLimitMax).toEqual(10);
 		expect(apiKey.requestCount).toEqual(0);
+		expect(apiKey.rateLimitResetAt).toBeNull();
 		expect(apiKey.remaining).toBeNull();
 		expect(apiKey.lastRequest).toBeNull();
 		expect(apiKey.rateLimitEnabled).toBe(true);
@@ -1018,6 +1020,53 @@ describe("api-key", async () => {
 	});
 
 	/**
+	 * @see https://github.com/better-auth/better-auth/issues/6035
+	 */
+	it("resets the rate limit window during continuous traffic", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+		const { auth: fixedWindowAuth, signInWithTestUser: signIn } =
+			await getTestInstance({
+				plugins: [
+					apiKey({
+						rateLimit: {
+							enabled: true,
+							maxRequests: 5,
+							timeWindow: 2_000,
+						},
+					}),
+				],
+			});
+		const { headers: fixedWindowHeaders, user: fixedWindowUser } =
+			await signIn();
+		const created = await fixedWindowAuth.api.createApiKey({
+			body: { userId: fixedWindowUser.id },
+		});
+
+		for (let request = 0; request < 5; request++) {
+			const response = await fixedWindowAuth.api.verifyApiKey({
+				body: { key: created.key },
+			});
+			expect(response.valid).toBe(true);
+			await vi.advanceTimersByTimeAsync(400);
+		}
+
+		const responseAfterReset = await fixedWindowAuth.api.verifyApiKey({
+			body: { key: created.key },
+		});
+		expect(responseAfterReset.valid).toBe(true);
+
+		const stored = await fixedWindowAuth.api.getApiKey({
+			query: { id: created.id },
+			headers: fixedWindowHeaders,
+		});
+		expect(stored.requestCount).toBe(1);
+		expect(stored.rateLimitResetAt).toEqual(
+			new Date("2026-01-01T00:00:04.000Z"),
+		);
+	});
+
+	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9504
 	 */
 	it("should return 429 when API key rate limit is exceeded via before hook", async () => {
@@ -1580,6 +1629,32 @@ describe("api-key", async () => {
 		});
 
 		expect(updated.lastRequest).toBeNull();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/6035
+	 */
+	it("should start a fresh window after updating rate limit configuration", async () => {
+		const key = await auth.api.createApiKey({
+			body: {
+				rateLimitMax: 2,
+				rateLimitTimeWindow: 60_000,
+				userId: user.id,
+			},
+		});
+		await auth.api.verifyApiKey({ body: { key: key.key } });
+
+		const updated = await auth.api.updateApiKey({
+			body: {
+				keyId: key.id,
+				rateLimitMax: 3,
+				userId: user.id,
+			},
+		});
+
+		expect(updated.requestCount).toBe(0);
+		expect(updated.rateLimitResetAt).toBeNull();
+		expect(updated.lastRequest).not.toBeNull();
 	});
 
 	it("should not auto-decrement remaining when updating API key", async () => {
@@ -3086,6 +3161,7 @@ describe("api-key", async () => {
 					referenceId: user.id,
 					lastRefillAt: null,
 					lastRequest: null,
+					rateLimitResetAt: null,
 					metadata: null,
 					rateLimitMax: null,
 					rateLimitTimeWindow: null,
@@ -3141,6 +3217,7 @@ describe("api-key", async () => {
 					referenceId: user.id,
 					lastRefillAt: null,
 					lastRequest: null,
+					rateLimitResetAt: null,
 					metadata: null,
 					rateLimitMax: null,
 					rateLimitTimeWindow: null,
@@ -3168,6 +3245,7 @@ describe("api-key", async () => {
 					referenceId: user.id,
 					lastRefillAt: null,
 					lastRequest: null,
+					rateLimitResetAt: null,
 					metadata: null,
 					rateLimitMax: null,
 					rateLimitTimeWindow: null,
@@ -3226,6 +3304,7 @@ describe("api-key", async () => {
 						referenceId: user.id,
 						lastRefillAt: null,
 						lastRequest: null,
+						rateLimitResetAt: null,
 						metadata: null,
 						rateLimitMax: null,
 						rateLimitTimeWindow: null,
@@ -3284,6 +3363,7 @@ describe("api-key", async () => {
 						referenceId: user.id,
 						lastRefillAt: null,
 						lastRequest: null,
+						rateLimitResetAt: null,
 						metadata: null,
 						rateLimitMax: null,
 						rateLimitTimeWindow: null,
@@ -4977,6 +5057,10 @@ describe("verify should not write back stale state", async () => {
 		return true;
 	};
 
+	afterEach(() => {
+		onValidate = null;
+	});
+
 	describe("database storage", async () => {
 		const { auth, signInWithTestUser } = await getTestInstance(
 			{
@@ -5012,6 +5096,44 @@ describe("verify should not write back stale state", async () => {
 				headers,
 			});
 			expect(stored.enabled).toBe(false);
+		});
+
+		it("should open a window with a rate limit policy updated during verification", async () => {
+			const { headers, user } = await signInWithTestUser();
+			const created = await auth.api.createApiKey({
+				body: {
+					rateLimitMax: 5,
+					rateLimitTimeWindow: 60_000,
+					userId: user.id,
+				},
+			});
+
+			onValidate = async () => {
+				await auth.api.updateApiKey({
+					body: {
+						keyId: created.id,
+						rateLimitMax: 2,
+						rateLimitTimeWindow: 120_000,
+						userId: user.id,
+					},
+				});
+			};
+
+			const result = await auth.api.verifyApiKey({
+				body: { key: created.key },
+			});
+			expect(result.valid).toBe(true);
+
+			const stored = await auth.api.getApiKey({
+				query: { id: created.id },
+				headers,
+			});
+			expect(stored.rateLimitMax).toBe(2);
+			expect(stored.rateLimitTimeWindow).toBe(120_000);
+			expect(stored.requestCount).toBe(1);
+			expect(
+				stored.rateLimitResetAt!.getTime() - stored.lastRequest!.getTime(),
+			).toBe(120_000);
 		});
 	});
 
@@ -5141,6 +5263,7 @@ describe("concurrent verification enforces atomic counters", async () => {
 
 		afterEach(() => {
 			gate = null;
+			vi.useRealTimers();
 		});
 
 		it("does not let concurrent verifications drop remaining below zero", async () => {
@@ -5207,6 +5330,42 @@ describe("concurrent verification enforces atomic counters", async () => {
 				headers,
 			});
 			expect(stored.requestCount).toBe(2);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/6035
+		 */
+		it("opens only one fixed window during a concurrent reset", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+			const { headers, user } = await signInWithTestUser();
+			const created = await auth.api.createApiKey({
+				body: {
+					rateLimitEnabled: true,
+					rateLimitMax: 2,
+					rateLimitTimeWindow: 60_000,
+					userId: user.id,
+				},
+			});
+			await auth.api.verifyApiKey({ body: { key: created.key } });
+			await vi.advanceTimersByTimeAsync(60_000);
+
+			gate = createArrivalGate(concurrency);
+			const results = await Promise.all(
+				Array.from({ length: concurrency }, () =>
+					auth.api.verifyApiKey({ body: { key: created.key } }),
+				),
+			);
+
+			expect(results.filter((result) => result.valid)).toHaveLength(2);
+			const stored = await auth.api.getApiKey({
+				query: { id: created.id },
+				headers,
+			});
+			expect(stored.requestCount).toBe(2);
+			expect(stored.rateLimitResetAt).toEqual(
+				new Date("2026-01-01T00:02:00.000Z"),
+			);
 		});
 	});
 

--- a/packages/api-key/src/rate-limit.test.ts
+++ b/packages/api-key/src/rate-limit.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { evaluateRateLimit } from "./rate-limit";
+import type { ApiKey } from "./types";
+
+const options = {
+	rateLimit: { enabled: true },
+};
+const policy = {
+	maxRequests: 5,
+	windowMs: 2_000,
+};
+
+function createApiKey(overrides: Partial<ApiKey> = {}): ApiKey {
+	const createdAt = new Date("2026-01-01T00:00:00.000Z");
+	return {
+		id: "api-key-id",
+		configId: "default",
+		name: null,
+		start: null,
+		prefix: null,
+		key: "hashed-key",
+		referenceId: "user-id",
+		refillInterval: null,
+		refillAmount: null,
+		lastRefillAt: null,
+		enabled: true,
+		rateLimitEnabled: true,
+		rateLimitTimeWindow: policy.windowMs,
+		rateLimitMax: policy.maxRequests,
+		requestCount: policy.maxRequests,
+		remaining: null,
+		lastRequest: new Date("2026-01-01T00:00:01.800Z"),
+		rateLimitResetAt: new Date("2026-01-01T00:00:02.000Z"),
+		expiresAt: null,
+		createdAt,
+		updatedAt: createdAt,
+		metadata: null,
+		permissions: null,
+		...overrides,
+	};
+}
+
+describe("evaluateRateLimit", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/6035
+	 */
+	it("opens a new fixed window after the deadline despite continuous traffic", () => {
+		const now = new Date("2026-01-01T00:00:02.400Z");
+		const observedResetAt = new Date("2026-01-01T00:00:02.000Z");
+
+		const decision = evaluateRateLimit(createApiKey(), options, now);
+
+		expect(decision).toEqual({
+			type: "open",
+			now,
+			observedResetAt,
+			resetAt: new Date("2026-01-01T00:00:04.400Z"),
+			policy,
+		});
+	});
+
+	it("opens the first window when no deadline exists", () => {
+		const now = new Date("2026-01-01T00:00:00.000Z");
+
+		const decision = evaluateRateLimit(
+			createApiKey({ rateLimitResetAt: null, requestCount: 0 }),
+			options,
+			now,
+		);
+
+		expect(decision).toEqual({
+			type: "open",
+			now,
+			observedResetAt: null,
+			resetAt: new Date("2026-01-01T00:00:02.000Z"),
+			policy,
+		});
+	});
+
+	it("treats the reset deadline as the exclusive end of the window", () => {
+		const now = new Date("2026-01-01T00:00:02.000Z");
+		const observedResetAt = new Date("2026-01-01T00:00:02.000Z");
+
+		const decision = evaluateRateLimit(createApiKey(), options, now);
+
+		expect(decision).toEqual({
+			type: "open",
+			now,
+			observedResetAt,
+			resetAt: new Date("2026-01-01T00:00:04.000Z"),
+			policy,
+		});
+	});
+
+	it("increments within a window without moving its deadline", () => {
+		const now = new Date("2026-01-01T00:00:01.900Z");
+		const resetAt = new Date("2026-01-01T00:00:02.000Z");
+
+		const decision = evaluateRateLimit(
+			createApiKey({ requestCount: 4 }),
+			options,
+			now,
+		);
+
+		expect(decision).toEqual({
+			type: "increment",
+			now,
+			resetAt,
+			policy,
+		});
+	});
+
+	it("reports retry time from the stable window deadline", () => {
+		const now = new Date("2026-01-01T00:00:01.500Z");
+
+		const decision = evaluateRateLimit(
+			createApiKey({
+				lastRequest: new Date("2026-01-01T00:00:01.400Z"),
+			}),
+			options,
+			now,
+		);
+
+		expect(decision).toMatchObject({
+			type: "deny",
+			tryAgainIn: 500,
+		});
+	});
+
+	it("stamps the accepted request without consuming a slot when disabled", () => {
+		const now = new Date("2026-01-01T00:00:01.500Z");
+
+		expect(
+			evaluateRateLimit(createApiKey(), { rateLimit: { enabled: false } }, now),
+		).toEqual({ type: "skip", lastRequest: now });
+		expect(
+			evaluateRateLimit(
+				createApiKey({ rateLimitEnabled: false }),
+				options,
+				now,
+			),
+		).toEqual({ type: "skip", lastRequest: now });
+	});
+
+	it("leaves the request timestamp untouched when the key has no policy", () => {
+		const now = new Date("2026-01-01T00:00:01.500Z");
+
+		const decision = evaluateRateLimit(
+			createApiKey({ rateLimitMax: null }),
+			options,
+			now,
+		);
+
+		expect(decision).toEqual({ type: "skip", lastRequest: null });
+	});
+});

--- a/packages/api-key/src/rate-limit.test.ts
+++ b/packages/api-key/src/rate-limit.test.ts
@@ -77,6 +77,68 @@ describe("evaluateRateLimit", () => {
 		});
 	});
 
+	it("preserves a saturated legacy counter until its window ends", () => {
+		const now = new Date("2026-01-01T00:00:01.500Z");
+
+		const decision = evaluateRateLimit(
+			createApiKey({
+				lastRequest: new Date("2026-01-01T00:00:01.000Z"),
+				rateLimitResetAt: null,
+			}),
+			options,
+			now,
+		);
+
+		expect(decision).toMatchObject({
+			type: "deny",
+			tryAgainIn: 1_500,
+		});
+	});
+
+	it("initializes a fixed deadline without resetting a legacy counter", () => {
+		const now = new Date("2026-01-01T00:00:01.500Z");
+		const observedLastRequest = new Date("2026-01-01T00:00:01.000Z");
+
+		const decision = evaluateRateLimit(
+			createApiKey({
+				lastRequest: observedLastRequest,
+				rateLimitResetAt: null,
+				requestCount: 4,
+			}),
+			options,
+			now,
+		);
+
+		expect(decision).toEqual({
+			type: "initialize",
+			now,
+			observedLastRequest,
+			resetAt: new Date("2026-01-01T00:00:03.000Z"),
+			policy,
+		});
+	});
+
+	it("opens a new window after a legacy counter expires", () => {
+		const now = new Date("2026-01-01T00:00:03.000Z");
+
+		const decision = evaluateRateLimit(
+			createApiKey({
+				lastRequest: new Date("2026-01-01T00:00:01.000Z"),
+				rateLimitResetAt: null,
+			}),
+			options,
+			now,
+		);
+
+		expect(decision).toEqual({
+			type: "open",
+			now,
+			observedResetAt: null,
+			resetAt: new Date("2026-01-01T00:00:05.000Z"),
+			policy,
+		});
+	});
+
 	it("treats the reset deadline as the exclusive end of the window", () => {
 		const now = new Date("2026-01-01T00:00:02.000Z");
 		const observedResetAt = new Date("2026-01-01T00:00:02.000Z");

--- a/packages/api-key/src/rate-limit.ts
+++ b/packages/api-key/src/rate-limit.ts
@@ -1,6 +1,10 @@
 import { API_KEY_ERROR_CODES as ERROR_CODES } from ".";
-import type { PredefinedApiKeyOptions } from "./routes";
 import type { ApiKey } from "./types";
+
+type FixedWindowPolicy = {
+	maxRequests: number;
+	windowMs: number;
+};
 
 /**
  * The atomic action the verify route must apply for the current request, derived
@@ -14,23 +18,20 @@ export type RateLimitDecision =
 			lastRequest: Date | null;
 	  }
 	| {
-			/** First request in a fresh window: set `requestCount` to 1. */
-			type: "start";
+			/** Open a window and consume its first request. */
+			type: "open";
 			now: Date;
-	  }
-	| {
-			/** Window elapsed: reset `requestCount` to 1, guarded on the window. */
-			type: "reset";
-			now: Date;
-			/** `lastRequest` must still predate this instant for the reset to apply. */
-			windowStart: Date;
+			/** The deadline observed when this decision was made; used as a CAS token. */
+			observedResetAt: Date | null;
+			resetAt: Date;
+			policy: FixedWindowPolicy;
 	  }
 	| {
 			/** Within the window and under the max: increment `requestCount` by 1. */
 			type: "increment";
 			now: Date;
-			max: number;
-			windowStart: Date;
+			resetAt: Date;
+			policy: FixedWindowPolicy;
 	  }
 	| {
 			/** Within the window and at the max: reject. */
@@ -46,10 +47,9 @@ export type RateLimitDecision =
  */
 export function evaluateRateLimit(
 	apiKey: ApiKey,
-	opts: PredefinedApiKeyOptions,
+	opts: { rateLimit: { enabled: boolean } },
+	now: Date,
 ): RateLimitDecision {
-	const now = new Date();
-	const lastRequest = apiKey.lastRequest;
 	const rateLimitTimeWindow = apiKey.rateLimitTimeWindow;
 	const rateLimitMax = apiKey.rateLimitMax;
 
@@ -66,17 +66,21 @@ export function evaluateRateLimit(
 		return { type: "skip", lastRequest: null };
 	}
 
-	if (lastRequest === null) {
-		return { type: "start", now };
-	}
+	const policy = {
+		maxRequests: rateLimitMax,
+		windowMs: rateLimitTimeWindow,
+	};
+	const observedResetAt = apiKey.rateLimitResetAt
+		? new Date(apiKey.rateLimitResetAt)
+		: null;
 
-	const timeSinceLastRequest = now.getTime() - new Date(lastRequest).getTime();
-
-	if (timeSinceLastRequest > rateLimitTimeWindow) {
+	if (observedResetAt === null || now.getTime() >= observedResetAt.getTime()) {
 		return {
-			type: "reset",
+			type: "open",
 			now,
-			windowStart: new Date(now.getTime() - rateLimitTimeWindow),
+			observedResetAt,
+			resetAt: new Date(now.getTime() + rateLimitTimeWindow),
+			policy,
 		};
 	}
 
@@ -84,14 +88,14 @@ export function evaluateRateLimit(
 		return {
 			type: "deny",
 			message: ERROR_CODES.RATE_LIMIT_EXCEEDED.message,
-			tryAgainIn: Math.ceil(rateLimitTimeWindow - timeSinceLastRequest),
+			tryAgainIn: observedResetAt.getTime() - now.getTime(),
 		};
 	}
 
 	return {
 		type: "increment",
 		now,
-		max: rateLimitMax,
-		windowStart: new Date(now.getTime() - rateLimitTimeWindow),
+		resetAt: observedResetAt,
+		policy,
 	};
 }

--- a/packages/api-key/src/rate-limit.ts
+++ b/packages/api-key/src/rate-limit.ts
@@ -27,6 +27,15 @@ export type RateLimitDecision =
 			policy: FixedWindowPolicy;
 	  }
 	| {
+			/** Lazily migrates an active legacy window without resetting its counter. */
+			type: "initialize";
+			now: Date;
+			/** The legacy timestamp observed when deriving the first fixed deadline. */
+			observedLastRequest: Date;
+			resetAt: Date;
+			policy: FixedWindowPolicy;
+	  }
+	| {
 			/** Within the window and under the max: increment `requestCount` by 1. */
 			type: "increment";
 			now: Date;
@@ -74,7 +83,45 @@ export function evaluateRateLimit(
 		? new Date(apiKey.rateLimitResetAt)
 		: null;
 
-	if (observedResetAt === null || now.getTime() >= observedResetAt.getTime()) {
+	if (observedResetAt === null) {
+		const observedLastRequest = apiKey.lastRequest
+			? new Date(apiKey.lastRequest)
+			: null;
+
+		if (apiKey.requestCount > 0 && observedLastRequest) {
+			const resetAt = new Date(
+				observedLastRequest.getTime() + rateLimitTimeWindow,
+			);
+
+			if (now.getTime() < resetAt.getTime()) {
+				if (apiKey.requestCount >= rateLimitMax) {
+					return {
+						type: "deny",
+						message: ERROR_CODES.RATE_LIMIT_EXCEEDED.message,
+						tryAgainIn: resetAt.getTime() - now.getTime(),
+					};
+				}
+
+				return {
+					type: "initialize",
+					now,
+					observedLastRequest,
+					resetAt,
+					policy,
+				};
+			}
+		}
+
+		return {
+			type: "open",
+			now,
+			observedResetAt,
+			resetAt: new Date(now.getTime() + rateLimitTimeWindow),
+			policy,
+		};
+	}
+
+	if (now.getTime() >= observedResetAt.getTime()) {
 		return {
 			type: "open",
 			now,

--- a/packages/api-key/src/routes/create-api-key.ts
+++ b/packages/api-key/src/routes/create-api-key.ts
@@ -242,6 +242,13 @@ export function createApiKey({
 												type: "number",
 												description: "Current request count in window",
 											},
+											rateLimitResetAt: {
+												type: "string",
+												format: "date-time",
+												nullable: true,
+												description:
+													"Current rate limit window reset timestamp",
+											},
 											permissions: {
 												type: "object",
 												nullable: true,
@@ -475,6 +482,7 @@ export function createApiKey({
 				referenceId: referenceId,
 				lastRefillAt: null,
 				lastRequest: null,
+				rateLimitResetAt: null,
 				metadata: null,
 				rateLimitMax: rateLimitMax ?? opts.rateLimit.maxRequests ?? null,
 				rateLimitTimeWindow:

--- a/packages/api-key/src/routes/get-api-key.ts
+++ b/packages/api-key/src/routes/get-api-key.ts
@@ -122,6 +122,13 @@ export function getApiKey({
 												description:
 													"The number of requests made within the rate limit time window",
 											},
+											rateLimitResetAt: {
+												type: "string",
+												format: "date-time",
+												nullable: true,
+												description:
+													"When the current rate limit window resets",
+											},
 											remaining: {
 												type: "number",
 												nullable: true,

--- a/packages/api-key/src/routes/list-api-keys.ts
+++ b/packages/api-key/src/routes/list-api-keys.ts
@@ -180,6 +180,13 @@ export function listApiKeys({
 															description:
 																"The number of requests made within the rate limit time window",
 														},
+														rateLimitResetAt: {
+															type: "string",
+															format: "date-time",
+															nullable: true,
+															description:
+																"When the current rate limit window resets",
+														},
 														remaining: {
 															type: "number",
 															nullable: true,

--- a/packages/api-key/src/routes/update-api-key.ts
+++ b/packages/api-key/src/routes/update-api-key.ts
@@ -200,6 +200,13 @@ export function updateApiKey({
 												description:
 													"The number of requests made within the rate limit time window",
 											},
+											rateLimitResetAt: {
+												type: "string",
+												format: "date-time",
+												nullable: true,
+												description:
+													"When the current rate limit window resets",
+											},
 											remaining: {
 												type: "number",
 												nullable: true,
@@ -426,6 +433,14 @@ export function updateApiKey({
 			}
 			if (rateLimitMax !== undefined) {
 				newValues.rateLimitMax = rateLimitMax;
+			}
+			if (
+				rateLimitEnabled !== undefined ||
+				rateLimitTimeWindow !== undefined ||
+				rateLimitMax !== undefined
+			) {
+				newValues.requestCount = 0;
+				newValues.rateLimitResetAt = null;
 			}
 
 			if (permissions !== undefined) {

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -311,6 +311,47 @@ async function consumeRateLimit(
 				});
 				return updated ?? snapshot;
 			}
+			case "initialize": {
+				const initialized = await ctx.context.adapter.incrementOne<ApiKey>({
+					model: API_KEY_TABLE_NAME,
+					where: [
+						{ field: "id", value: snapshot.id },
+						{ field: "rateLimitEnabled", value: true },
+						{
+							field: "rateLimitTimeWindow",
+							value: decision.policy.windowMs,
+						},
+						{
+							field: "rateLimitMax",
+							value: decision.policy.maxRequests,
+						},
+						{ field: "rateLimitResetAt", value: null },
+						{
+							field: "lastRequest",
+							value: decision.observedLastRequest,
+						},
+						{
+							field: "requestCount",
+							operator: "gt",
+							value: 0,
+						},
+						{
+							field: "requestCount",
+							operator: "lt",
+							value: decision.policy.maxRequests,
+						},
+					],
+					increment: { requestCount: 1 },
+					set: {
+						lastRequest: decision.now,
+						rateLimitResetAt: decision.resetAt,
+					},
+				});
+				if (initialized) {
+					return initialized;
+				}
+				break;
+			}
 			case "increment": {
 				const incremented = await ctx.context.adapter.incrementOne<ApiKey>({
 					model: API_KEY_TABLE_NAME,
@@ -504,6 +545,12 @@ function applyRateLimitToSnapshot(
 				lastRequest: decision.now,
 				rateLimitResetAt: decision.resetAt,
 				requestCount: 1,
+			};
+		case "initialize":
+			return {
+				lastRequest: decision.now,
+				rateLimitResetAt: decision.resetAt,
+				requestCount: apiKey.requestCount + 1,
 			};
 		case "increment":
 			return {

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -277,102 +277,132 @@ async function consumeRemaining(
 /**
  * Guarded rate-limit consumption. The common in-window path increments
  * `requestCount` only while it is below the max (compare-and-swap), so a burst
- * of concurrent verifications can never exceed the limit. Window resets and the
- * first request in a window are guarded conditional sets; a request that loses
- * every guard within an active window is rejected. Returns the updated row, or
- * the unchanged row when rate limiting does not apply.
+ * of concurrent verifications can never exceed the limit. Opening a window is
+ * guarded by the observed deadline and policy; a request that loses a guard
+ * reloads the row and evaluates the new state. Returns the updated row, or the
+ * unchanged row when rate limiting does not apply.
  */
 async function consumeRateLimit(
 	ctx: GenericEndpointContext,
 	apiKey: ApiKey,
 	opts: PredefinedApiKeyOptions,
 ): Promise<ApiKey> {
-	const decision = evaluateRateLimit(apiKey, opts);
+	let snapshot = apiKey;
 
-	if (decision.type === "deny") {
-		throw new APIError("TOO_MANY_REQUESTS", {
-			message: decision.message,
-			code: "RATE_LIMITED" as const,
-			details: { tryAgainIn: decision.tryAgainIn },
-		});
-	}
+	// Retry with the latest row when a concurrent write invalidates the CAS guards.
+	while (true) {
+		const decision = evaluateRateLimit(snapshot, opts, new Date());
 
-	if (decision.type === "skip") {
-		if (decision.lastRequest === null) {
-			return apiKey;
+		switch (decision.type) {
+			case "deny":
+				throw new APIError("TOO_MANY_REQUESTS", {
+					message: decision.message,
+					code: "RATE_LIMITED" as const,
+					details: { tryAgainIn: decision.tryAgainIn },
+				});
+			case "skip": {
+				if (decision.lastRequest === null) {
+					return snapshot;
+				}
+				const updated = await ctx.context.adapter.update<ApiKey>({
+					model: API_KEY_TABLE_NAME,
+					where: [{ field: "id", value: snapshot.id }],
+					update: { lastRequest: decision.lastRequest },
+				});
+				return updated ?? snapshot;
+			}
+			case "increment": {
+				const incremented = await ctx.context.adapter.incrementOne<ApiKey>({
+					model: API_KEY_TABLE_NAME,
+					where: [
+						{ field: "id", value: snapshot.id },
+						{ field: "rateLimitEnabled", value: true },
+						{
+							field: "rateLimitTimeWindow",
+							value: decision.policy.windowMs,
+						},
+						{
+							field: "rateLimitMax",
+							value: decision.policy.maxRequests,
+						},
+						{
+							field: "rateLimitResetAt",
+							value: decision.resetAt,
+						},
+						{
+							field: "requestCount",
+							operator: "lt",
+							value: decision.policy.maxRequests,
+						},
+					],
+					increment: { requestCount: 1 },
+					set: { lastRequest: decision.now },
+				});
+				if (incremented) {
+					return incremented;
+				}
+				break;
+			}
+			case "open": {
+				const windowGuards = decision.observedResetAt
+					? [
+							{
+								field: "rateLimitResetAt",
+								operator: "eq" as const,
+								value: decision.observedResetAt,
+							},
+							{
+								field: "rateLimitResetAt",
+								operator: "lte" as const,
+								value: decision.now,
+							},
+						]
+					: [
+							{
+								field: "rateLimitResetAt",
+								operator: "eq" as const,
+								value: null,
+							},
+						];
+
+				const opened = await ctx.context.adapter.incrementOne<ApiKey>({
+					model: API_KEY_TABLE_NAME,
+					where: [
+						{ field: "id", value: snapshot.id },
+						{ field: "rateLimitEnabled", value: true },
+						{
+							field: "rateLimitTimeWindow",
+							value: decision.policy.windowMs,
+						},
+						{
+							field: "rateLimitMax",
+							value: decision.policy.maxRequests,
+						},
+						...windowGuards,
+					],
+					increment: {},
+					set: {
+						requestCount: 1,
+						lastRequest: decision.now,
+						rateLimitResetAt: decision.resetAt,
+					},
+				});
+				if (opened) {
+					return opened;
+				}
+				break;
+			}
 		}
-		const updated = await ctx.context.adapter.update<ApiKey>({
-			model: API_KEY_TABLE_NAME,
-			where: [{ field: "id", value: apiKey.id }],
-			update: { lastRequest: decision.lastRequest },
-		});
-		return updated ?? apiKey;
-	}
 
-	if (decision.type === "increment") {
-		const incremented = await ctx.context.adapter.incrementOne<ApiKey>({
-			model: API_KEY_TABLE_NAME,
-			where: [
-				{ field: "id", value: apiKey.id },
-				{
-					field: "lastRequest",
-					operator: "gt",
-					value: decision.windowStart,
-				},
-				{
-					field: "requestCount",
-					operator: "lt",
-					value: decision.max,
-				},
-			],
-			increment: { requestCount: 1 },
-			set: { lastRequest: decision.now },
-		});
-		if (incremented) {
-			return incremented;
-		}
-		// The window rolled or the max was reached between the read and the
-		// write. Re-evaluate against the freshest row to apply the right guard.
 		const fresh = await ctx.context.adapter.findOne<ApiKey>({
 			model: API_KEY_TABLE_NAME,
-			where: [{ field: "id", value: apiKey.id }],
+			where: [{ field: "id", value: snapshot.id }],
 		});
 		if (!fresh) {
 			throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
 		}
-		return consumeRateLimit(ctx, fresh, opts);
+		snapshot = fresh;
 	}
-
-	// "start" and "reset": set the count to 1 for a fresh window, guarded so a
-	// concurrent increment in the same window cannot be silently overwritten.
-	const windowGuard =
-		decision.type === "reset"
-			? {
-					field: "lastRequest",
-					operator: "lte" as const,
-					value: decision.windowStart,
-				}
-			: { field: "lastRequest", operator: "eq" as const, value: null };
-
-	const started = await ctx.context.adapter.incrementOne<ApiKey>({
-		model: API_KEY_TABLE_NAME,
-		where: [{ field: "id", value: apiKey.id }, windowGuard],
-		increment: {},
-		set: { requestCount: 1, lastRequest: decision.now },
-	});
-	if (started) {
-		return started;
-	}
-	// Another verification already opened the window. Re-evaluate so this
-	// request consumes an increment slot instead of resetting the count.
-	const fresh = await ctx.context.adapter.findOne<ApiKey>({
-		model: API_KEY_TABLE_NAME,
-		where: [{ field: "id", value: apiKey.id }],
-	});
-	if (!fresh) {
-		throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
-	}
-	return consumeRateLimit(ctx, fresh, opts);
 }
 
 /**
@@ -457,7 +487,7 @@ function applyRateLimitToSnapshot(
 	apiKey: ApiKey,
 	opts: PredefinedApiKeyOptions,
 ): Partial<ApiKey> {
-	const decision = evaluateRateLimit(apiKey, opts);
+	const decision = evaluateRateLimit(apiKey, opts, new Date());
 	switch (decision.type) {
 		case "deny":
 			throw new APIError("TOO_MANY_REQUESTS", {
@@ -469,9 +499,12 @@ function applyRateLimitToSnapshot(
 			return decision.lastRequest === null
 				? {}
 				: { lastRequest: decision.lastRequest };
-		case "start":
-		case "reset":
-			return { lastRequest: decision.now, requestCount: 1 };
+		case "open":
+			return {
+				lastRequest: decision.now,
+				rateLimitResetAt: decision.resetAt,
+				requestCount: 1,
+			};
 		case "increment":
 			return {
 				lastRequest: decision.now,

--- a/packages/api-key/src/schema.ts
+++ b/packages/api-key/src/schema.ts
@@ -131,6 +131,14 @@ export const apiKeySchema = ({
 					defaultValue: 0,
 				},
 				/**
+				 * The date and time when the current rate limit window resets.
+				 */
+				rateLimitResetAt: {
+					type: "date",
+					required: false,
+					input: false,
+				},
+				/**
 				 * The remaining number of requests before the key is revoked.
 				 *
 				 * If this is null, then the key is not revoked.

--- a/packages/api-key/src/types.ts
+++ b/packages/api-key/src/types.ts
@@ -177,17 +177,20 @@ export interface ApiKeyConfigurationOptions {
 				 */
 				enabled?: boolean;
 				/**
-				 * The duration in milliseconds where each request is counted.
+				 * The duration of each first-request-anchored fixed window in
+				 * milliseconds. A window starts with the first accepted request.
 				 *
-				 * Once the `maxRequests` is reached, the request will be rejected until the `timeWindow` has passed, at which point the `timeWindow` will be reset.
+				 * Once `maxRequests` is reached, requests are rejected until the
+				 * current window ends.
 				 *
 				 * @default 1000 * 60 * 60 * 24 // 1 day
 				 */
 				timeWindow?: number;
 				/**
-				 * Maximum amount of requests allowed within a window
+				 * Maximum amount of requests allowed within a fixed window.
 				 *
-				 * Once the `maxRequests` is reached, the request will be rejected until the `timeWindow` has passed, at which point the `timeWindow` will be reset.
+				 * Once `maxRequests` is reached, requests are rejected until the
+				 * current window ends.
 				 *
 				 * @default 10 // 10 requests per day
 				 */
@@ -333,6 +336,10 @@ export type ApiKey = {
 	 * The number of requests made within the rate limit time window
 	 */
 	requestCount: number;
+	/**
+	 * When the current rate limit window resets
+	 */
+	rateLimitResetAt: Date | null;
 	/**
 	 * Remaining requests (every time API key is used this should updated and should be updated on refill as well)
 	 */


### PR DESCRIPTION
> [!IMPORTANT]
> This adds the nullable `rateLimitResetAt` field. It requires a database schema migration but does not introduce a breaking API change.

Replaces https://github.com/better-auth/better-auth/pull/8803
Closes https://github.com/better-auth/better-auth/issues/6035

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API key rate limiting by switching to first-request-anchored fixed windows in `@better-auth/api-key`. Continuous traffic no longer delays resets, and a nullable rateLimitResetAt tracks the window deadline.

- **Bug Fixes**
  - Use fixed windows; the first accepted request opens a window and sets the reset deadline.
  - Denials report tryAgainIn from the stable deadline; lastRequest no longer controls resets.
  - Concurrency-safe guards ensure only one window opens and increments don’t exceed the max.
  - Changing rate-limit config (enabled/max/window) clears the current window and count.
  - Added rateLimitResetAt across adapter, schema, API responses, and docs.
  - Preserve legacy counters by initializing resetAt from lastRequest without resetting count; after expiry, open a fresh fixed window.

- **Migration**
  - Add a nullable rateLimitResetAt column to the API keys table.
  - No breaking API changes; run your schema migration.

<sup>Written for commit ef3d1c638c59d4ef2e1b3efe298b597aa9ad68a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

