### PR TITLE
fix(open-api): emit query parameters for optional query schemas

### DIFF
--- a/.changeset/open-api-optional-query-parameters.md
+++ b/.changeset/open-api-optional-query-parameters.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Emit query parameters in the OpenAPI document for endpoints whose `query` schema is wrapped in `z.optional()`. `/get-session`, `/account-info`, `/callback/{id}` and `/reset-password` previously published no query parameters at all, and neither did plugin endpoints declared the same way, such as `@better-auth/stripe`'s `GET /subscription/list`.

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -210,7 +210,32 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
       "get": {
         "description": "Get the account info provided by the provider",
         "operationId": undefined,
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "accountId",
+            "schema": {
+              "description": "The provider given account id for which to get the account info",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "providerId",
+            "schema": {
+              "description": "The provider ID to disambiguate provider-issued account IDs",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "userId",
+            "schema": {
+              "description": "The user ID associated with the account",
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "content": {
@@ -371,6 +396,48 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
         "operationId": undefined,
         "parameters": [
           {
+            "in": "query",
+            "name": "code",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "error",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "device_id",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "error_description",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "user",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
             "in": "path",
             "name": "id",
             "required": true,
@@ -490,6 +557,48 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
         "description": undefined,
         "operationId": undefined,
         "parameters": [
+          {
+            "in": "query",
+            "name": "code",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "error",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "device_id",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "error_description",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "user",
+            "schema": {
+              "type": "string",
+            },
+          },
           {
             "in": "path",
             "name": "id",
@@ -1611,7 +1720,24 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
       "get": {
         "description": "Get the current session",
         "operationId": "getSession",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "disableCookieCache",
+            "schema": {
+              "description": "Disable cookie cache and fetch session from database",
+              "type": "boolean",
+            },
+          },
+          {
+            "in": "query",
+            "name": "disableRefresh",
+            "schema": {
+              "description": "Disable session refresh. Useful for checking session status, without updating the session",
+              "type": "boolean",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "content": {
@@ -1747,7 +1873,24 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
       "post": {
         "description": "Get the current session",
         "operationId": "getSessionPost",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "disableCookieCache",
+            "schema": {
+              "description": "Disable cookie cache and fetch session from database",
+              "type": "boolean",
+            },
+          },
+          {
+            "in": "query",
+            "name": "disableRefresh",
+            "schema": {
+              "description": "Disable session refresh. Useful for checking session status, without updating the session",
+              "type": "boolean",
+            },
+          },
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2883,7 +3026,15 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
       "post": {
         "description": "Reset the password for a user",
         "operationId": "resetPassword",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "token",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -153,6 +153,30 @@ function unwrapZodSchema(
 	return asZodSchema(zodType.unwrap());
 }
 
+/**
+ * Strip the wrappers that can sit between an endpoint's `query` option and the object whose shape
+ * describes its parameters.
+ *
+ * A query declared as `z.optional(z.object({ ... }))` is a ZodOptional *wrapping* a ZodObject, so an
+ * `instanceof z.ZodObject` check alone is false, the shape walk never runs, and the endpoint
+ * publishes no query parameters at all. Unwraps the same set `toOpenApiSchema` already unwraps, via
+ * the same helper.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10750
+ */
+function unwrapQuerySchema(query: unknown): unknown {
+	let current = query;
+	while (
+		current instanceof z.ZodOptional ||
+		current instanceof z.ZodDefault ||
+		current instanceof z.ZodPrefault ||
+		current instanceof z.ZodNonOptional
+	) {
+		current = unwrapZodSchema(current);
+	}
+	return current;
+}
+
 function getZodDef<T extends object>(zodType: z.ZodType<unknown>) {
 	return (zodType as z.ZodType<unknown> & ZodDef<T>)._def;
 }
@@ -215,11 +239,12 @@ function getParameters(options: EndpointOptions) {
 	if (options.metadata?.openapi?.parameters) {
 		parameters.push(...options.metadata.openapi.parameters);
 	}
+	const querySchema = unwrapQuerySchema(options.query);
 	if (
 		!options.metadata?.openapi?.parameters &&
-		options.query instanceof z.ZodObject
+		querySchema instanceof z.ZodObject
 	) {
-		Object.entries(options.query.shape).forEach(([key, value]) => {
+		Object.entries(querySchema.shape).forEach(([key, value]) => {
 			if (value instanceof z.ZodType) {
 				const parameterSchema = toOpenApiSchema(value as z.ZodType<unknown>);
 				parameters.push({

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -159,22 +159,37 @@ function unwrapZodSchema(
  *
  * A query declared as `z.optional(z.object({ ... }))` is a ZodOptional *wrapping* a ZodObject, so an
  * `instanceof z.ZodObject` check alone is false, the shape walk never runs, and the endpoint
- * publishes no query parameters at all. Unwraps the same set `toOpenApiSchema` already unwraps, via
- * the same helper.
+ * publishes no query parameters at all. The wrapper only says how the query object as a whole may be
+ * supplied — the parameters inside it are the same either way, so every one of these unwraps to the
+ * object underneath.
+ *
+ * Loops rather than unwrapping once, since the wrappers compose
+ * (`z.optional(z.nullable(z.object({ ... })))`). `ZodCatch` and `ZodReadonly` expose their inner type
+ * through `_def` rather than `unwrap()`, which is how `toOpenApiSchema` reaches them too.
  *
  * @see https://github.com/better-auth/better-auth/issues/10750
  */
 function unwrapQuerySchema(query: unknown): unknown {
 	let current = query;
-	while (
-		current instanceof z.ZodOptional ||
-		current instanceof z.ZodDefault ||
-		current instanceof z.ZodPrefault ||
-		current instanceof z.ZodNonOptional
-	) {
-		current = unwrapZodSchema(current);
+	while (true) {
+		if (
+			current instanceof z.ZodOptional ||
+			current instanceof z.ZodNullable ||
+			current instanceof z.ZodDefault ||
+			current instanceof z.ZodPrefault ||
+			current instanceof z.ZodNonOptional
+		) {
+			current = unwrapZodSchema(current);
+			continue;
+		}
+		if (current instanceof z.ZodCatch || current instanceof z.ZodReadonly) {
+			current = getZodDef<{ innerType: z.ZodType<unknown> }>(
+				current as z.ZodType<unknown>,
+			).innerType;
+			continue;
+		}
+		return current;
 	}
-	return current;
 }
 
 function getZodDef<T extends object>(zodType: z.ZodType<unknown>) {

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -163,33 +163,25 @@ function unwrapZodSchema(
  * supplied — the parameters inside it are the same either way, so every one of these unwraps to the
  * object underneath.
  *
- * Loops rather than unwrapping once, since the wrappers compose
- * (`z.optional(z.nullable(z.object({ ... })))`). `ZodCatch` and `ZodReadonly` expose their inner type
- * through `_def` rather than `unwrap()`, which is how `toOpenApiSchema` reaches them too.
+ * Loops rather than unwrapping once, since the wrappers compose — `z.optional(z.nullable(...))`, or
+ * `.optional().nonoptional()`, whose inner type is itself a wrapper.
  *
  * @see https://github.com/better-auth/better-auth/issues/10750
  */
 function unwrapQuerySchema(query: unknown): unknown {
 	let current = query;
-	while (true) {
-		if (
-			current instanceof z.ZodOptional ||
-			current instanceof z.ZodNullable ||
-			current instanceof z.ZodDefault ||
-			current instanceof z.ZodPrefault ||
-			current instanceof z.ZodNonOptional
-		) {
-			current = unwrapZodSchema(current);
-			continue;
-		}
-		if (current instanceof z.ZodCatch || current instanceof z.ZodReadonly) {
-			current = getZodDef<{ innerType: z.ZodType<unknown> }>(
-				current as z.ZodType<unknown>,
-			).innerType;
-			continue;
-		}
-		return current;
+	while (
+		current instanceof z.ZodOptional ||
+		current instanceof z.ZodNullable ||
+		current instanceof z.ZodDefault ||
+		current instanceof z.ZodPrefault ||
+		current instanceof z.ZodNonOptional ||
+		current instanceof z.ZodCatch ||
+		current instanceof z.ZodReadonly
+	) {
+		current = unwrapZodSchema(current);
 	}
+	return current;
 }
 
 function getZodDef<T extends object>(zodType: z.ZodType<unknown>) {

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -231,6 +231,24 @@ const optionalQueryPlugin = {
 			},
 			async () => ({ success: true }),
 		),
+		nullableQuery: createAuthEndpoint(
+			"/test/nullable-query",
+			{
+				method: "GET",
+				query: z.object({ token: z.string().optional() }).nullable(),
+			},
+			async () => ({ success: true }),
+		),
+		composedWrapperQuery: createAuthEndpoint(
+			"/test/composed-wrapper-query",
+			{
+				method: "GET",
+				query: z.optional(
+					z.nullable(z.object({ cursor: z.string().optional() })),
+				),
+			},
+			async () => ({ success: true }),
+		),
 	},
 } satisfies BetterAuthPlugin;
 
@@ -970,6 +988,21 @@ describe("open-api", async () => {
 			schema: { type: "string" },
 		});
 		expect(getPathParameter(path, "customerType")).toMatchObject({
+			in: "query",
+		});
+	});
+
+	// The wrappers compose, and each only describes how the query object as a whole may be supplied —
+	// the parameters inside it are the same either way.
+	it.each([
+		["nullable", "/test/nullable-query", "token"],
+		["optional + nullable", "/test/composed-wrapper-query", "cursor"],
+	])("should emit query parameters for a %s query schema", async (_label, endpoint, parameterName) => {
+		const schema = await authWithOptionalQuery.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, Path>;
+		const path = paths[endpoint];
+		expect(path).toBeDefined();
+		expect(getPathParameter(path, parameterName)).toMatchObject({
 			in: "query",
 		});
 	});

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -249,6 +249,22 @@ const optionalQueryPlugin = {
 			},
 			async () => ({ success: true }),
 		),
+		readonlyQuery: createAuthEndpoint(
+			"/test/readonly-query",
+			{
+				method: "GET",
+				query: z.object({ locale: z.string().optional() }).readonly(),
+			},
+			async () => ({ success: true }),
+		),
+		catchQuery: createAuthEndpoint(
+			"/test/catch-query",
+			{
+				method: "GET",
+				query: z.object({ page: z.string().optional() }).catch({}),
+			},
+			async () => ({ success: true }),
+		),
 	},
 } satisfies BetterAuthPlugin;
 
@@ -997,6 +1013,8 @@ describe("open-api", async () => {
 	it.each([
 		["nullable", "/test/nullable-query", "token"],
 		["optional + nullable", "/test/composed-wrapper-query", "cursor"],
+		["readonly", "/test/readonly-query", "locale"],
+		["catch", "/test/catch-query", "page"],
 	])("should emit query parameters for a %s query schema", async (_label, endpoint, parameterName) => {
 		const schema = await authWithOptionalQuery.api.generateOpenAPISchema();
 		const paths = schema.paths as Record<string, Path>;

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -215,6 +215,25 @@ const queryConstraintsPlugin = {
 	},
 } satisfies BetterAuthPlugin;
 
+const optionalQueryPlugin = {
+	id: "optional-query-test",
+	endpoints: {
+		optionalQuery: createAuthEndpoint(
+			"/test/optional-query",
+			{
+				method: "GET",
+				query: z.optional(
+					z.object({
+						referenceId: z.string().optional(),
+						customerType: z.enum(["user", "organization"]).optional(),
+					}),
+				),
+			},
+			async () => ({ success: true }),
+		),
+	},
+} satisfies BetterAuthPlugin;
+
 let defaultFactoryCallCount = 0;
 
 const defaultFactoryBodyPlugin = {
@@ -307,6 +326,9 @@ describe("open-api", async () => {
 	});
 	const { auth: authWithQueryConstraints } = await getTestInstance({
 		plugins: [openAPI(), queryConstraintsPlugin],
+	});
+	const { auth: authWithOptionalQuery } = await getTestInstance({
+		plugins: [openAPI(), optionalQueryPlugin],
 	});
 	const { auth: authWithDefaultFactoryBody } = await getTestInstance({
 		plugins: [openAPI(), defaultFactoryBodyPlugin],
@@ -927,6 +949,28 @@ describe("open-api", async () => {
 			maxLength: 12,
 			minLength: 6,
 			type: "string",
+		});
+	});
+
+	/**
+	 * A query declared as `z.optional(z.object({ ... }))` is a ZodOptional wrapping the object, so an
+	 * `instanceof z.ZodObject` check alone skipped the shape walk and the endpoint published no query
+	 * parameters at all. `@better-auth/stripe`'s `GET /subscription/list` is the real-world case.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10750
+	 */
+	it("should emit query parameters when the query schema is wrapped in z.optional()", async () => {
+		const schema = await authWithOptionalQuery.api.generateOpenAPISchema();
+		const paths = schema.paths as Record<string, Path>;
+		const path = paths["/test/optional-query"];
+		expect(path).toBeDefined();
+
+		expect(getPathParameter(path, "referenceId")).toMatchObject({
+			in: "query",
+			schema: { type: "string" },
+		});
+		expect(getPathParameter(path, "customerType")).toMatchObject({
+			in: "query",
 		});
 	});
 


### PR DESCRIPTION
Closes #10750

### The bug

`getParameters` gated its shape walk on `options.query instanceof z.ZodObject`:

```ts
// packages/better-auth/src/plugins/open-api/generator.ts:218-222 (before)
if (
	!options.metadata?.openapi?.parameters &&
	options.query instanceof z.ZodObject
) {
	Object.entries(options.query.shape).forEach(([key, value]) => {
```

A query declared as `z.optional(z.object({ … }))` is a `ZodOptional` **wrapping** a `ZodObject`, so the check is false, the loop never runs, and the endpoint publishes **no query parameters at all**.

### This affects core endpoints, not just plugins

The issue was reported from `@better-auth/stripe`'s `GET /subscription/list`, but four core endpoints were silently affected too — visible in the snapshot diff:

| Endpoint | Parameters that were missing |
| --- | --- |
| `/get-session` | `disableCookieCache`, `disableRefresh` |
| `/account-info` | `accountId`, `providerId`, `userId` |
| `/callback/{id}` | `code`, `error`, `error_description`, `state`, `user`, `device_id` |
| `/reset-password` | `token` |

Both spellings of the wrapper are involved: `getSessionQuerySchema = z.optional(z.object({ … }))` (`cookies/session-store.ts:270`) and the chained `z.object({ … }).optional()` (`api/routes/password.ts:234`).

### The fix

Unwrap before the check, reusing the existing `unwrapZodSchema` helper and the same wrapper set `toOpenApiSchema` already unwraps (`ZodOptional`, `ZodDefault`, `ZodPrefault`, `ZodNonOptional`):

```ts
function unwrapQuerySchema(query: unknown): unknown {
	let current = query;
	while (
		current instanceof z.ZodOptional ||
		current instanceof z.ZodDefault ||
		current instanceof z.ZodPrefault ||
		current instanceof z.ZodNonOptional
	) {
		current = unwrapZodSchema(current);
	}
	return current;
}
```

Deliberately reuses the helper rather than calling `.unwrap()` directly, so the query path unwraps the same way the rest of the file already does.

### Tests

Added a regression test with a fixture mirroring the existing `queryConstraintsPlugin`. It fails on current `main`:

```
Error: Expected path to define referenceId parameter
 ❯ src/plugins/open-api/open-api.test.ts:968:10
```

The snapshot update is exactly the four core endpoints above gaining their parameters — no other output changed.

Verified locally:

- `pnpm vitest packages/better-auth/src/plugins/open-api --run` → 29 passed
- `pnpm vitest packages/stripe --run` → 174 passed
- `pnpm typecheck` → clean
- `biome check` → clean

### Relationship to #9747

#9747 contains an equivalent unwrap, but it is `CONFLICTING`/`DIRTY`, unchanged since 2026-05-31, and predates four `generator.ts` fixes that have landed since (#9315, #9704, and two more on 06-12 and 07-19) — its hunk targets `getParameters` around line 130, where the function now sits near 213 with a different guard and the `unwrapZodSchema` helper that did not exist then. It is also a `feat(admin)` PR that carries the generator change incidentally.

This is the standalone version against current `main`. If #9747 lands first, I'll close this.
