### PR TITLE
fix(drizzle-adapter): support drizzle-orm 1.x relational where in joins

### DIFF
--- a/.changeset/drizzle-v1-joins.md
+++ b/.changeset/drizzle-v1-joins.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/drizzle-adapter": patch
+---
+
+Fix the Drizzle adapter throwing `Unknown relational filter field: "decoder"` when `experimental.joins` is enabled on drizzle-orm 1.x. Join-enabled reads such as session resolution now work on both drizzle 0.x and 1.x.

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -1,4 +1,5 @@
 import { is, SQL } from "drizzle-orm";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { describe, expect, it, vi } from "vitest";
 import { drizzleAdapter } from "./drizzle-adapter";
 
@@ -509,6 +510,87 @@ describe("drizzle-adapter", () => {
 			});
 
 			expect(result).toBeNull();
+		});
+	});
+
+	describe("relational join where (experimental joins)", () => {
+		const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
+		const userTable = sqliteTable("user", {
+			id: text("id").primaryKey(),
+			name: text("name"),
+			email: text("email"),
+			emailVerified: integer("emailVerified", { mode: "boolean" }),
+			image: text("image"),
+			createdAt: integer("createdAt", { mode: "timestamp" }),
+			updatedAt: integer("updatedAt", { mode: "timestamp" }),
+		});
+		const userRow = {
+			id: "123",
+			name: "Test",
+			email: "test@example.com",
+			emailVerified: false,
+			image: null,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+
+		function createJoinDb(marker: "v0" | "v1") {
+			const findFirst = vi.fn().mockResolvedValue(userRow);
+			const db = {
+				// Duck-typed drizzle major: 1.x exposes `_.relations`, 0.x exposes
+				// `_.fullSchema`. buildRelationalWhere branches on this.
+				_:
+					marker === "v1"
+						? { relations: {} }
+						: { fullSchema: { user: userTable } },
+				query: { user: { findFirst } },
+			} as any;
+			const adapter = drizzleAdapter(db, {
+				provider: "sqlite",
+				schema: { user: userTable },
+			})({
+				secret: defaultSecret,
+				experimental: { joins: true },
+			});
+			return { adapter, findFirst };
+		}
+
+		/**
+		 * drizzle 1.x changed the relational (`db.query`) `where` from a raw `SQL`
+		 * (0.x) to an object filter DSL, so passing the clause built for the query
+		 * builder throws `Unknown relational filter field: "decoder"` and every
+		 * join-enabled read (e.g. `getSession`) fails. On 1.x the clause must go
+		 * through the `RAW` escape hatch, remapped onto the aliased root table.
+		 */
+		it("wraps the where in RAW on drizzle 1.x", async () => {
+			const { adapter, findFirst } = createJoinDb("v1");
+
+			await adapter.findOne({
+				model: "user",
+				where: [{ field: "id", value: "123" }],
+			});
+
+			expect(findFirst).toHaveBeenCalledTimes(1);
+			const arg = findFirst.mock.calls[0]![0];
+			expect(is(arg.where, SQL)).toBe(false);
+			expect(typeof arg.where.RAW).toBe("function");
+			// The callback receives the aliased root table and must return a SQL
+			// with its columns remapped onto that alias (no throw).
+			const remapped = arg.where.RAW(userTable);
+			expect(is(remapped, SQL)).toBe(true);
+		});
+
+		it("passes a raw SQL where on drizzle 0.x", async () => {
+			const { adapter, findFirst } = createJoinDb("v0");
+
+			await adapter.findOne({
+				model: "user",
+				where: [{ field: "id", value: "123" }],
+			});
+
+			expect(findFirst).toHaveBeenCalledTimes(1);
+			const arg = findFirst.mock.calls[0]![0];
+			expect(is(arg.where, SQL)).toBe(true);
 		});
 	});
 });

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -16,6 +16,7 @@ import {
 	count,
 	desc,
 	eq,
+	getTableName,
 	gt,
 	gte,
 	inArray,
@@ -24,6 +25,7 @@ import {
 	like,
 	lt,
 	lte,
+	mapColumnsInSQLToAlias,
 	ne,
 	notInArray,
 	or,
@@ -110,6 +112,37 @@ function readDriverRowCount(result: unknown): unknown {
 
 function hasDriverRowCount(result: unknown): boolean {
 	return readDriverRowCount(result) !== undefined;
+}
+
+/**
+ * Build the `where` for a relational (`db.query`) join from the raw `SQL`
+ * clause produced by `convertWhereClause`.
+ *
+ * Drizzle changed the relational `where` contract between majors: drizzle 0.x
+ * accepts a raw `SQL` filter, while drizzle 1.x expects an object filter DSL and
+ * rejects a raw `SQL` with `Unknown relational filter field: "decoder"` (it
+ * enumerates the `SQL` instance's own keys, the first of which is `decoder`).
+ * The non-join query builder consumes the same raw `SQL` on both majors, so on
+ * 1.x we hand the clause to the `RAW` escape hatch instead of rebuilding it.
+ *
+ * drizzle 1.x also aliases the root table inside a relational query (e.g. `d0`),
+ * so the clause — whose columns still point at the physical table — is remapped
+ * onto the aliased table that the `RAW` callback receives, otherwise Postgres
+ * reports `relation "<table>" does not exist`.
+ *
+ * The major is duck-typed from `db._` rather than a version string, matching how
+ * this adapter already distinguishes drivers (see `getAffectedRowCount`):
+ * drizzle 1.x exposes `db._.relations`, drizzle 0.x exposes `db._.fullSchema`.
+ */
+function buildRelationalWhere(db: DB, clause: (SQL | undefined)[]) {
+	const filter = clause[0];
+	if (!filter) return undefined;
+	const isDrizzleV1 = !!db._ && "relations" in db._;
+	if (!isDrizzleV1) return filter;
+	return {
+		RAW: (table: unknown) =>
+			mapColumnsInSQLToAlias(filter, getTableName(table as any)),
+	};
 }
 
 export interface DrizzleAdapterConfig {
@@ -771,7 +804,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								}
 							}
 							const query = db.query[queryModel].findFirst({
-								where: clause[0],
+								where: buildRelationalWhere(db, clause),
 								columns:
 									select?.length && select.length > 0
 										? select.reduce(
@@ -865,7 +898,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								];
 							}
 							const query = db.query[queryModel].findMany({
-								where: clause[0],
+								where: buildRelationalWhere(db, clause),
 								with: includes,
 								columns:
 									select?.length && select.length > 0


### PR DESCRIPTION
With experimental.joins enabled on drizzle-orm 1.x, every join query threw
DrizzleError: Unknown relational filter field: "decoder", 500ing all
join-enabled reads (e.g. session resolution). drizzle 0.x accepted a raw SQL
relational where; 1.x changed it to an object filter DSL.

findOne/findMany now route the clause through drizzle 1.x's RAW escape hatch and
remap columns onto the aliased root table, detected by duck-typing db._
(relations vs fullSchema) rather than a version string. The 0.x path is
unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Drizzle adapter error “Unknown relational filter field: 'decoder'” when `experimental.joins` is enabled on `drizzle-orm` 1.x. Join-enabled reads like session resolution now work on both 0.x and 1.x without behavior changes to 0.x.

- **Bug Fixes**
  - Detects `drizzle-orm` 1.x by duck-typing `db._` (`relations` vs `fullSchema`).
  - Adds a relational where builder that uses the 1.x `RAW` escape hatch and remaps columns to the aliased root table.
  - Routes `findOne`/`findMany` relational filters through this builder and adds tests for both 0.x and 1.x paths.

<sup>Written for commit 446807a104ed7aeddef28f912ad4d202c77072fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

