### PR TITLE
test(drizzle-adapter): add drizzle-orm 1.x join integration test

### DIFF
--- a/.changeset/drizzle-v1-integration-test.md
+++ b/.changeset/drizzle-v1-integration-test.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a drizzle-orm 1.x join integration test (dev-only: new devDependencies and a separate vitest project; no change to the published package).

--- a/.changeset/drizzle-v1-joins.md
+++ b/.changeset/drizzle-v1-joins.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/drizzle-adapter": patch
+---
+
+Fix the Drizzle adapter throwing `Unknown relational filter field: "decoder"` when `experimental.joins` is enabled on drizzle-orm 1.x. Join-enabled reads such as session resolution now work on both drizzle 0.x and 1.x.

--- a/packages/drizzle-adapter/package.json
+++ b/packages/drizzle-adapter/package.json
@@ -31,6 +31,7 @@
     "lint:types": "attw --profile esm-only --pack .",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
+    "test:v1": "vitest run --config vitest.v1.config.ts",
     "coverage": "vitest run --coverage --coverage.provider=istanbul"
   },
   "files": [
@@ -59,7 +60,9 @@
   "devDependencies": {
     "@better-auth/core": "workspace:*",
     "@better-auth/utils": "catalog:",
+    "@electric-sql/pglite": "0.3.15",
     "drizzle-orm": "^0.45.2",
+    "drizzle-orm-v1": "npm:drizzle-orm@1.0.0-rc.4",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -1,4 +1,5 @@
 import { is, SQL } from "drizzle-orm";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { describe, expect, it, vi } from "vitest";
 import { drizzleAdapter } from "./drizzle-adapter";
 
@@ -509,6 +510,87 @@ describe("drizzle-adapter", () => {
 			});
 
 			expect(result).toBeNull();
+		});
+	});
+
+	describe("relational join where (experimental joins)", () => {
+		const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
+		const userTable = sqliteTable("user", {
+			id: text("id").primaryKey(),
+			name: text("name"),
+			email: text("email"),
+			emailVerified: integer("emailVerified", { mode: "boolean" }),
+			image: text("image"),
+			createdAt: integer("createdAt", { mode: "timestamp" }),
+			updatedAt: integer("updatedAt", { mode: "timestamp" }),
+		});
+		const userRow = {
+			id: "123",
+			name: "Test",
+			email: "test@example.com",
+			emailVerified: false,
+			image: null,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+
+		function createJoinDb(marker: "v0" | "v1") {
+			const findFirst = vi.fn().mockResolvedValue(userRow);
+			const db = {
+				// Duck-typed drizzle major: 1.x exposes `_.relations`, 0.x exposes
+				// `_.fullSchema`. buildRelationalWhere branches on this.
+				_:
+					marker === "v1"
+						? { relations: {} }
+						: { fullSchema: { user: userTable } },
+				query: { user: { findFirst } },
+			} as any;
+			const adapter = drizzleAdapter(db, {
+				provider: "sqlite",
+				schema: { user: userTable },
+			})({
+				secret: defaultSecret,
+				experimental: { joins: true },
+			});
+			return { adapter, findFirst };
+		}
+
+		/**
+		 * drizzle 1.x changed the relational (`db.query`) `where` from a raw `SQL`
+		 * (0.x) to an object filter DSL, so passing the clause built for the query
+		 * builder throws `Unknown relational filter field: "decoder"` and every
+		 * join-enabled read (e.g. `getSession`) fails. On 1.x the clause must go
+		 * through the `RAW` escape hatch, remapped onto the aliased root table.
+		 */
+		it("wraps the where in RAW on drizzle 1.x", async () => {
+			const { adapter, findFirst } = createJoinDb("v1");
+
+			await adapter.findOne({
+				model: "user",
+				where: [{ field: "id", value: "123" }],
+			});
+
+			expect(findFirst).toHaveBeenCalledTimes(1);
+			const arg = findFirst.mock.calls[0]![0];
+			expect(is(arg.where, SQL)).toBe(false);
+			expect(typeof arg.where.RAW).toBe("function");
+			// The callback receives the aliased root table and must return a SQL
+			// with its columns remapped onto that alias (no throw).
+			const remapped = arg.where.RAW(userTable);
+			expect(is(remapped, SQL)).toBe(true);
+		});
+
+		it("passes a raw SQL where on drizzle 0.x", async () => {
+			const { adapter, findFirst } = createJoinDb("v0");
+
+			await adapter.findOne({
+				model: "user",
+				where: [{ field: "id", value: "123" }],
+			});
+
+			expect(findFirst).toHaveBeenCalledTimes(1);
+			const arg = findFirst.mock.calls[0]![0];
+			expect(is(arg.where, SQL)).toBe(true);
 		});
 	});
 });

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -16,6 +16,7 @@ import {
 	count,
 	desc,
 	eq,
+	getTableName,
 	gt,
 	gte,
 	inArray,
@@ -24,6 +25,7 @@ import {
 	like,
 	lt,
 	lte,
+	mapColumnsInSQLToAlias,
 	ne,
 	notInArray,
 	or,
@@ -110,6 +112,37 @@ function readDriverRowCount(result: unknown): unknown {
 
 function hasDriverRowCount(result: unknown): boolean {
 	return readDriverRowCount(result) !== undefined;
+}
+
+/**
+ * Build the `where` for a relational (`db.query`) join from the raw `SQL`
+ * clause produced by `convertWhereClause`.
+ *
+ * Drizzle changed the relational `where` contract between majors: drizzle 0.x
+ * accepts a raw `SQL` filter, while drizzle 1.x expects an object filter DSL and
+ * rejects a raw `SQL` with `Unknown relational filter field: "decoder"` (it
+ * enumerates the `SQL` instance's own keys, the first of which is `decoder`).
+ * The non-join query builder consumes the same raw `SQL` on both majors, so on
+ * 1.x we hand the clause to the `RAW` escape hatch instead of rebuilding it.
+ *
+ * drizzle 1.x also aliases the root table inside a relational query (e.g. `d0`),
+ * so the clause — whose columns still point at the physical table — is remapped
+ * onto the aliased table that the `RAW` callback receives, otherwise Postgres
+ * reports `relation "<table>" does not exist`.
+ *
+ * The major is duck-typed from `db._` rather than a version string, matching how
+ * this adapter already distinguishes drivers (see `getAffectedRowCount`):
+ * drizzle 1.x exposes `db._.relations`, drizzle 0.x exposes `db._.fullSchema`.
+ */
+function buildRelationalWhere(db: DB, clause: (SQL | undefined)[]) {
+	const filter = clause[0];
+	if (!filter) return undefined;
+	const isDrizzleV1 = !!db._ && "relations" in db._;
+	if (!isDrizzleV1) return filter;
+	return {
+		RAW: (table: unknown) =>
+			mapColumnsInSQLToAlias(filter, getTableName(table as any)),
+	};
 }
 
 export interface DrizzleAdapterConfig {
@@ -771,7 +804,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								}
 							}
 							const query = db.query[queryModel].findFirst({
-								where: clause[0],
+								where: buildRelationalWhere(db, clause),
 								columns:
 									select?.length && select.length > 0
 										? select.reduce(
@@ -865,7 +898,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								];
 							}
 							const query = db.query[queryModel].findMany({
-								where: clause[0],
+								where: buildRelationalWhere(db, clause),
 								with: includes,
 								columns:
 									select?.length && select.length > 0

--- a/packages/drizzle-adapter/src/drizzle-joins-v1.integration.ts
+++ b/packages/drizzle-adapter/src/drizzle-joins-v1.integration.ts
@@ -1,0 +1,90 @@
+import { PGlite } from "@electric-sql/pglite";
+import { defineRelations } from "drizzle-orm-v1";
+import { pgTable, text, timestamp } from "drizzle-orm-v1/pg-core";
+import { drizzle } from "drizzle-orm-v1/pglite";
+import { beforeAll, describe, expect, it } from "vitest";
+import { drizzleAdapter } from "./drizzle-adapter";
+
+/**
+ * Integration coverage for `experimental.joins` on drizzle-orm 1.x.
+ *
+ * drizzle 1.x changed the relational (`db.query`) `where` from a raw `SQL` (0.x)
+ * to an object filter DSL, so the clause the adapter builds throws
+ * `Unknown relational filter field: "decoder"` and every join-enabled read
+ * (e.g. `getSession`) 500s. The adapter now routes 1.x through the `RAW` escape
+ * hatch, remapping columns onto the aliased root table.
+ *
+ * This runs against a real in-memory Postgres (pglite) and real drizzle 1.x
+ * (installed as `drizzle-orm-v1`, aliased to `drizzle-orm` for this project — see
+ * vitest.v1.config.ts). Without the fix, every query here throws the error above.
+ */
+const user = pgTable("user", {
+	id: text("id").primaryKey(),
+	name: text("name").notNull(),
+	email: text("email").notNull(),
+	emailVerified: text("email_verified"),
+	image: text("image"),
+	createdAt: timestamp("created_at").notNull(),
+	updatedAt: timestamp("updated_at").notNull(),
+});
+const session = pgTable("session", {
+	id: text("id").primaryKey(),
+	token: text("token").notNull(),
+	userId: text("user_id").notNull(),
+	expiresAt: timestamp("expires_at").notNull(),
+	createdAt: timestamp("created_at").notNull(),
+	updatedAt: timestamp("updated_at").notNull(),
+});
+
+const schema = { user, session };
+const relations = defineRelations(schema, (r) => ({
+	session: { user: r.one.user({ from: r.session.userId, to: r.user.id }) },
+	user: { sessions: r.many.session() },
+}));
+
+const secret = "test-secret-that-is-at-least-32-chars-long!!";
+let db: ReturnType<typeof drizzle>;
+
+function createAdapter() {
+	return drizzleAdapter(db as never, { provider: "pg", schema })({
+		secret,
+		experimental: { joins: true },
+	});
+}
+
+describe("drizzle 1.x relational joins (pglite)", () => {
+	beforeAll(async () => {
+		const client = new PGlite();
+		db = drizzle({ client, relations });
+		await client.exec(`
+			CREATE TABLE "user" (id text primary key, name text not null, email text not null, email_verified text, image text, created_at timestamp not null, updated_at timestamp not null);
+			CREATE TABLE "session" (id text primary key, token text not null, user_id text not null, expires_at timestamp not null, created_at timestamp not null, updated_at timestamp not null);
+			INSERT INTO "user" values ('u1','Alice','alice@example.com', null, null, now(), now());
+			INSERT INTO "session" values ('s1','tok_abc','u1', now(), now(), now());
+		`);
+	});
+
+	it("findOne resolves the relational where instead of throwing 'decoder'", async () => {
+		const adapter = createAdapter();
+
+		const found = await adapter.findOne<{ id: string; email: string }>({
+			model: "user",
+			where: [{ field: "email", value: "alice@example.com" }],
+		});
+
+		expect(found?.id).toBe("u1");
+		expect(found?.email).toBe("alice@example.com");
+	});
+
+	it("findMany resolves the relational where", async () => {
+		const adapter = createAdapter();
+
+		const rows = await adapter.findMany<{ id: string }>({
+			model: "session",
+			where: [{ field: "token", value: "tok_abc" }],
+		});
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.id).toBe("s1");
+	});
+});

--- a/packages/drizzle-adapter/vitest.v1.config.ts
+++ b/packages/drizzle-adapter/vitest.v1.config.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+/**
+ * Dedicated project for exercising the adapter against drizzle-orm 1.x.
+ *
+ * The rest of the repo pins drizzle 0.x, so 1.x is installed under the
+ * `drizzle-orm-v1` alias (see package.json devDependencies). Here we alias the
+ * bare `drizzle-orm` specifier to that 1.x copy so the *adapter source* resolves
+ * a single, consistent 1.x instance — matching how a real 1.x consumer app is
+ * wired, and ensuring drizzle's `is(Column)` / `SQL` identity checks line up.
+ */
+const aliasDrizzleToV1 = [
+	{ find: /^drizzle-orm$/, replacement: "drizzle-orm-v1" },
+];
+
+export default defineConfig({
+	resolve: {
+		alias: aliasDrizzleToV1,
+		conditions: ["dev-source"],
+	},
+	ssr: {
+		resolve: {
+			alias: aliasDrizzleToV1,
+			conditions: ["dev-source"],
+		},
+	},
+	test: {
+		name: "drizzle-adapter-v1",
+		root: fileURLToPath(new URL(".", import.meta.url)),
+		include: ["src/**/*.integration.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1185,9 +1185,15 @@ importers:
       '@better-auth/utils':
         specifier: 'catalog:'
         version: 0.4.2
+      '@electric-sql/pglite':
+        specifier: 0.3.15
+        version: 0.3.15
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260226.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.1(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))(typescript@6.0.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@upstash/redis@1.36.4)(better-sqlite3@12.6.2)(bun-types@1.3.9)(kysely@0.29.2)(mysql2@3.18.2(@types/node@25.9.5))(pg@8.19.0)(postgres@3.4.8)(prisma@7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3))
+      drizzle-orm-v1:
+        specifier: npm:drizzle-orm@1.0.0-rc.4
+        version: drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260226.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@upstash/redis@1.36.4)(better-sqlite3@12.6.2)(bun-types@1.3.9)(mysql2@3.18.2(@types/node@25.9.5))(pg@8.19.0)(postgres@3.4.8)(valibot@1.4.2(typescript@6.0.3))(zod@4.3.6)
       tsdown:
         specifier: 'catalog:'
         version: 0.22.7(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.19.0)(publint@0.3.17)(tsx@4.22.4)(typescript@6.0.3)
@@ -8515,6 +8521,152 @@ packages:
       sql.js:
         optional: true
       sqlite3:
+        optional: true
+
+  drizzle-orm@1.0.0-rc.4:
+    resolution: {integrity: sha512-BT+pf+qoiYHqltoA88Jmf6ilGMXPlpfE0hEJKc2adRtMCAl25Swk/t5gXcWxZNAwdtf3F5gCd2FpeOyP/pT0Hw==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@effect/sql-d1': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-libsql': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-mysql2': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-pg': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-pglite': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-sqlite-bun': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-sqlite-do': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-sqlite-node': '>=4.0.0-beta.83 || >=4.0.0'
+      '@effect/sql-sqlite-wasm': '>=4.0.0-beta.83 || >=4.0.0'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@sinclair/typebox': '>=0.34.8'
+      '@sqlitecloud/drivers': '>=1.0.653'
+      '@tidbcloud/serverless': '*'
+      '@tursodatabase/database': '>=0.6.0-pre.28 || >=0.6.0'
+      '@tursodatabase/database-common': '>=0.6.0-pre.28 || >=0.6.0'
+      '@tursodatabase/database-wasm': '>=0.6.0-pre.28 || >=0.6.0'
+      '@tursodatabase/serverless': '>=1.1.3'
+      '@tursodatabase/sync': '>=0.6.0-pre.28 || >=0.6.0'
+      '@types/better-sqlite3': '*'
+      '@types/mssql': ^9.1.4
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      arktype: '>=2.0.0'
+      better-sqlite3: '>=9.3.0'
+      bun-types: '*'
+      effect: '>=4.0.0-beta.83 || >=4.0.0'
+      expo-sqlite: '>=14.0.0'
+      mssql: ^11.0.1
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+      typebox: '>=1.0.0'
+      valibot: '>=1.4.2 <2'
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@effect/sql-d1':
+        optional: true
+      '@effect/sql-libsql':
+        optional: true
+      '@effect/sql-mysql2':
+        optional: true
+      '@effect/sql-pg':
+        optional: true
+      '@effect/sql-pglite':
+        optional: true
+      '@effect/sql-sqlite-bun':
+        optional: true
+      '@effect/sql-sqlite-do':
+        optional: true
+      '@effect/sql-sqlite-node':
+        optional: true
+      '@effect/sql-sqlite-wasm':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@sinclair/typebox':
+        optional: true
+      '@sqlitecloud/drivers':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@tursodatabase/database':
+        optional: true
+      '@tursodatabase/database-common':
+        optional: true
+      '@tursodatabase/database-wasm':
+        optional: true
+      '@tursodatabase/serverless':
+        optional: true
+      '@tursodatabase/sync':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/mssql':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      arktype:
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      effect:
+        optional: true
+      expo-sqlite:
+        optional: true
+      mssql:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+      typebox:
+        optional: true
+      valibot:
+        optional: true
+      zod:
         optional: true
 
   dts-resolver@3.0.0:
@@ -21960,6 +22112,22 @@ snapshots:
       pg: 8.19.0
       postgres: 3.4.8
       prisma: 7.4.1(@types/react@19.2.14)(better-sqlite3@12.6.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.3)
+
+  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@4.20260226.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@upstash/redis@1.36.4)(better-sqlite3@12.6.2)(bun-types@1.3.9)(mysql2@3.18.2(@types/node@25.9.5))(pg@8.19.0)(postgres@3.4.8)(valibot@1.4.2(typescript@6.0.3))(zod@4.3.6):
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260226.1
+      '@electric-sql/pglite': 0.3.15
+      '@opentelemetry/api': 1.9.0
+      '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.16.0
+      '@upstash/redis': 1.36.4
+      better-sqlite3: 12.6.2
+      bun-types: 1.3.9
+      mysql2: 3.18.2(@types/node@25.9.5)
+      pg: 8.19.0
+      postgres: 3.4.8
+      valibot: 1.4.2(typescript@6.0.3)
+      zod: 4.3.6
 
   dts-resolver@3.0.0(oxc-resolver@11.19.0):
     optionalDependencies:


### PR DESCRIPTION
Stacked on #10754 (merge that first). Adds a real in-memory Postgres (pglite) integration test running the adapter against drizzle-orm 1.x. Until #10754 merges this diff also includes the fix commit; I'll rebase so only the test remains once it lands. Dev-only — no published change. Run with `pnpm test:v1`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a real `drizzle-orm` 1.x join integration test using in-memory Postgres and fix the adapter to support relational where on 1.x. This prevents the “Unknown relational filter field: 'decoder'” error and makes join-enabled reads work on both 0.x and 1.x.

- **Bug Fixes**
  - For `drizzle-orm` 1.x, route relational `where` through the `RAW` escape hatch and remap columns to the aliased root table; 0.x continues to use the raw `SQL`. Applies to `findOne` and `findMany`.

- **Dependencies**
  - Dev-only: add `@electric-sql/pglite` and `drizzle-orm-v1` (aliased to `drizzle-orm`).
  - Add a dedicated Vitest project (`vitest.v1.config.ts`) and `pnpm test:v1` script.

<sup>Written for commit d3f96ba565e0f4d9ac31da1c237e079cc2e47f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

