### PR TITLE
docs: add local email testing section

### DIFF
--- a/docs/content/docs/concepts/email.mdx
+++ b/docs/content/docs/concepts/email.mdx
@@ -15,6 +15,51 @@ For example, you might consider the following email providers:
 * [SuperSend TX](https://docs.supersendtx.com/guides/better-auth)
 * [Mailtrap](https://docs.mailtrap.io/guides/integrations/better-auth)
 
+## Local Email Testing
+
+During development, you rarely want verification links and password reset tokens going out to real inboxes. A local SMTP catcher solves this: it accepts every message your app sends and shows it in a web UI instead of delivering it.
+
+[Mailtrap Local](https://github.com/mailtrap/mailtrap-local) is an MIT-licensed, single-binary catcher. It listens for SMTP on `127.0.0.1:3535` and serves the web UI on `127.0.0.1:3550`.
+
+```bash
+docker run --rm \
+  -p 3535:3535 -p 3550:3550 \
+  -v mailtrap-local:/var/lib/mailtrap-local \
+  mailtrap/mailtrap-local:latest
+```
+
+It's also available via Homebrew (`brew tap mailtrap/local && brew install mailtrap-local`) and as a prebuilt binary.
+
+Since it speaks plain SMTP, any SMTP client can target it. This is one way to implement the `sendEmail` function used throughout the examples on this page:
+
+```ts title="email.ts"
+import nodemailer from 'nodemailer';
+
+const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST ?? '127.0.0.1',
+    port: Number(process.env.SMTP_PORT ?? 3535)
+});
+
+export async function sendEmail(options: {
+    to: string;
+    subject: string;
+    text: string;
+}) {
+    await transporter.sendMail({
+        from: 'no-reply@example.com',
+        to: options.to,
+        subject: options.subject,
+        text: options.text
+    });
+}
+```
+
+Sign up in your app, then open `http://127.0.0.1:3550` to read the captured email and follow its verification link.
+
+<Callout type="warn">
+  A catcher never delivers mail, so keep it to local development. Point `SMTP_HOST` and `SMTP_PORT` at your transactional provider in staging and production.
+</Callout>
+
 ## Email Verification
 
 Email verification is a security feature that ensures users provide a valid email address. It helps prevent spam and abuse by confirming that the email address belongs to the user. In this guide, you'll get a walk through of how to implement token based email verification in your app.

--- a/docs/content/docs/concepts/email.mdx
+++ b/docs/content/docs/concepts/email.mdx
@@ -30,7 +30,11 @@ docker run --rm \
 
 It's also available via Homebrew (`brew tap mailtrap/local && brew install mailtrap-local`) and as a prebuilt binary.
 
-Since it speaks plain SMTP, any SMTP client can target it. This is one way to implement the `sendEmail` function used throughout the examples on this page:
+Since it speaks plain SMTP, any SMTP client can target it. This is one way to implement the `sendEmail` function used throughout the examples on this page, using [Nodemailer](https://nodemailer.com):
+
+```bash
+npm install nodemailer
+```
 
 ```ts title="email.ts"
 import nodemailer from 'nodemailer';
@@ -46,7 +50,7 @@ export async function sendEmail(options: {
     text: string;
 }) {
     await transporter.sendMail({
-        from: 'no-reply@example.com',
+        from: process.env.EMAIL_FROM ?? 'no-reply@example.com',
         to: options.to,
         subject: options.subject,
         text: options.text
@@ -57,7 +61,7 @@ export async function sendEmail(options: {
 Sign up in your app, then open `http://127.0.0.1:3550` to read the captured email and follow its verification link.
 
 <Callout type="warn">
-  A catcher never delivers mail, so keep it to local development. Point `SMTP_HOST` and `SMTP_PORT` at your transactional provider in staging and production.
+  A catcher never delivers mail, so keep it to local development. The transporter above is deliberately minimal: a local catcher needs no credentials or TLS. Real providers do, so in staging and production also pass `auth` with your provider's credentials, enable `secure` for the port you're connecting to, and set `EMAIL_FROM` to a sender address that provider has verified.
 </Callout>
 
 ## Email Verification


### PR DESCRIPTION
## Summary

The email docs currently jump straight from "set up a transactional provider" to implementing `sendVerificationEmail`, with no guidance on where those emails should go while you're developing locally. There are also four pages that import `sendEmail` from `'./email'` — `concepts/email.mdx`, `concepts/users-accounts.mdx`, `authentication/email-password.mdx` and `plugins/organization.mdx` — but the docs never show an implementation of it, so the reader has to supply the one piece that actually sends the mail.

This adds a `## Local Email Testing` section to `docs/content/docs/concepts/email.mdx`, between the provider list and `## Email Verification`, covering both: how to catch auth emails locally, and a concrete `sendEmail` implementation the surrounding examples can reuse.

The section uses [Mailtrap Local](https://github.com/mailtrap/mailtrap-local) as the local SMTP target — MIT licensed, a single self-contained binary, with SMTP on `127.0.0.1:3535` and a web UI on `127.0.0.1:3550`. It speaks plain SMTP, so the `nodemailer` snippet works against a real provider too by pointing `SMTP_HOST` / `SMTP_PORT` elsewhere, which the closing callout notes.

## Notes

- Docs-only, confined to `docs/`. No changeset (nothing under `packages/**`).
- Adds a subsection to an existing page, so no `sidebar-content.tsx` entry is needed.
- `pnpm lint:spell` and `pnpm format:check` both pass; no new cspell dictionary entries required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Local Email Testing section to the email concepts doc to capture auth emails locally with Mailtrap Local and provide a reusable `sendEmail` implemented with `nodemailer`. It includes a Docker command (plus Homebrew/prebuilt options), an explicit `npm install nodemailer` step, localhost defaults with `SMTP_HOST`/`SMTP_PORT`/`EMAIL_FROM` overrides, and a production SMTP callout to use `auth`, `secure`, and a provider-verified `EMAIL_FROM` so the snippet works locally and with real providers.

<sup>Written for commit 80c92843f6e2510d36f4612ef1565bb3f4a97095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

