### PR TITLE
docs: flag indexed fields in the core schema tables

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -399,6 +399,7 @@ export const sessionTableFields = [
 		type: "string",
 		description: "The ID of the user",
 		isForeignKey: true,
+		isIndexed: true,
 		references: { model: "user", field: "id", onDelete: "cascade" },
 	},
 	{
@@ -456,6 +457,7 @@ export const accountTableFields = [
 		type: "string",
 		description: "The ID of the user",
 		isForeignKey: true,
+		isIndexed: true,
 		references: { model: "user", field: "id", onDelete: "cascade" },
 	},
 	{
@@ -548,6 +550,7 @@ export const verificationTableFields = [
 		name: "identifier",
 		type: "string",
 		description: "The identifier for the verification request",
+		isIndexed: true,
 	},
 	{
 		name: "value",


### PR DESCRIPTION
The core schema tables don't mark the fields Better Auth indexes, so `session.userId`, `account.userId` and `verification.identifier` read as unindexed. `DatabaseTable` already supports `isIndexed`; these three rows just never set it. The flag also feeds the SQL, Prisma and Drizzle views, so the copyable snippets gain the index definitions.

Targets `next` rather than `main` because `isIndexed` and the 1.7 account fields only exist there.

No breaking changes, no related issue.

# Screenshots
<details>
<summary><code>IDX</code> badge on the three indexed fields</summary>

`session.userId` — alongside the existing `FK`:

<img width="2744" height="2400" alt="session-table" src="https://github.com/user-attachments/assets/fd9d87b1-1965-4f79-b629-532c4402219b" />

`account.userId`:

<img width="2744" height="4584" alt="account-table" src="https://github.com/user-attachments/assets/0188c7a8-0de8-41c8-8d2b-b366a057b4df" />

`verification.identifier`:

<img width="2744" height="2016" alt="verification-table" src="https://github.com/user-attachments/assets/3004abd4-8325-4220-af5b-5387194eb3f1" />

</details>

<details>
<summary>Index carried into the copyable snippets</summary>

The SQL, Prisma and Drizzle views gain the index definition — `session`, PostgreSQL:

<img width="2744" height="1708" alt="session-sql" src="https://github.com/user-attachments/assets/87d629a0-409e-4265-a97e-11fdb5d93470" />

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked `session.userId`, `account.userId`, and `verification.identifier` as indexed in the core schema docs. This fixes the tables and ensures the SQL, Prisma, and Drizzle snippets include the correct index definitions.

<sup>Written for commit 851127abd8e75c0300fa9670045e1de3d024003b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

