### PR TITLE
docs: fix validator JSDoc to mention Standard Schema

### DIFF
--- a/packages/core/src/db/type.ts
+++ b/packages/core/src/db/type.ts
@@ -251,7 +251,8 @@ export type DBFieldAttributeConfig = {
 	 */
 	bigint?: boolean | undefined;
 	/**
-	 * A zod schema to validate the value.
+	 * A Standard Schema to validate the value. Works with any Standard Schema
+	 * library, such as Zod, Valibot or ArkType.
 	 */
 	validator?:
 		| {


### PR DESCRIPTION
The `validator` field accepts any Standard Schema object, but the JSDoc still says it takes a Zod schema. This updates the comment so users know that libraries like Valibot and ArkType work as well. I'm the author of Valibot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the JSDoc for the `validator` field to state it accepts any Standard Schema. Clarifies support for `zod`, `valibot`, and `arktype`.

<sup>Written for commit d88f3bca6807679f070e162258a30b29fa35cb6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

