### PR TITLE
fix(client): deduplicate settled session requests on Suspense retry

### DIFF
--- a/packages/better-auth/src/client/query.test.ts
+++ b/packages/better-auth/src/client/query.test.ts
@@ -541,6 +541,76 @@ describe("useAuthQuery - error handling", () => {
 		expect(observedRequests).toEqual([{ aborted: false }]);
 	});
 
+	it("should not refetch a settled session request on a Suspense retry", async () => {
+		vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+		let requestCount = 0;
+		let resolveSessionRequest: ((response: Response) => void) | undefined;
+		let resumeRender: (() => void) | undefined;
+		let suspended = true;
+		const suspendedRender = new Promise<void>((resolve) => {
+			resumeRender = () => {
+				suspended = false;
+				resolve();
+			};
+		});
+		const client = createReactAuthClient({
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl: async () => {
+					requestCount++;
+					if (requestCount > 1) {
+						return new Response(JSON.stringify({ session: null, user: null }));
+					}
+					return new Promise<Response>((resolve) => {
+						resolveSessionRequest = resolve;
+					});
+				},
+			},
+		});
+		const SessionWatcher = () => {
+			client.useSession();
+			if (suspended) throw suspendedRender;
+			return null;
+		};
+		const root = createRoot(document.createElement("div"));
+
+		await act(async () => {
+			root.render(
+				createElement(
+					Suspense,
+					{ fallback: null },
+					createElement(SessionWatcher),
+				),
+			);
+			await vi.advanceTimersByTimeAsync(0);
+		});
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(STORE_UNMOUNT_DELAY);
+		});
+
+		const settleSessionRequest = resolveSessionRequest;
+		if (!settleSessionRequest) throw new Error("Session request did not start");
+		await act(async () =>
+			settleSessionRequest(
+				new Response(JSON.stringify({ session: null, user: null })),
+			),
+		);
+		expect(client.$store.atoms.session!.value.isPending).toBe(false);
+
+		const retrySuspendedRender = resumeRender;
+		if (!retrySuspendedRender) {
+			throw new Error("Suspense retry was not scheduled");
+		}
+		await act(async () => retrySuspendedRender());
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(0);
+		});
+
+		expect(requestCount).toBe(1);
+
+		await act(async () => root.unmount());
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9613
 	 */

--- a/packages/better-auth/src/client/session-atom.ts
+++ b/packages/better-auth/src/client/session-atom.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthClientOptions } from "@better-auth/core";
 import type { BetterFetch, BetterFetchError } from "@better-fetch/fetch";
-import { atom, onMount } from "nanostores";
+import { atom, onMount, STORE_UNMOUNT_DELAY } from "nanostores";
 import type { Session, User } from "../types";
 import { isJsonEqual, withEquality } from "./equality";
 import type { AuthQueryAtom, AuthQueryState } from "./query";
@@ -77,7 +77,7 @@ export function getSessionAtom(
 ) {
 	const $signal = atom<boolean>(false);
 
-	let activeRequest: SessionRequest | undefined;
+	let sessionRequest: SessionRequest | undefined;
 
 	const refetch = (
 		queryParams?: { query?: SessionQueryParams } | undefined,
@@ -181,7 +181,7 @@ export function getSessionAtom(
 	const fetchSession = (
 		queryParams?: { query?: SessionQueryParams } | undefined,
 	): Promise<void> => {
-		activeRequest?.cancel();
+		sessionRequest?.cancel();
 		const controller = new AbortController();
 		const promise = Promise.resolve().then(() => {
 			if (controller.signal.aborted) return;
@@ -191,16 +191,18 @@ export function getSessionAtom(
 			cancel: () => controller.abort(),
 			promise,
 		};
-		activeRequest = request;
-		const clearActiveRequest = () => {
-			if (activeRequest === request) activeRequest = undefined;
+		sessionRequest = request;
+		const releaseSessionRequest = () => {
+			setTimeout(() => {
+				if (sessionRequest === request) sessionRequest = undefined;
+			}, STORE_UNMOUNT_DELAY);
 		};
-		void request.promise.then(clearActiveRequest, clearActiveRequest);
+		void request.promise.then(releaseSessionRequest, releaseSessionRequest);
 		return request.promise;
 	};
 
 	const fetchSessionOnMount = (): Promise<void> =>
-		activeRequest?.promise ?? fetchSession();
+		sessionRequest?.promise ?? fetchSession();
 
 	let broadcastSessionUpdate: (
 		trigger: "signout" | "getSession" | "updateUser",


### PR DESCRIPTION
Keep settled session requests reusable during the nanostores unmount window to prevent duplicate fetches on Suspense retries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates session fetches on React Suspense retries by reusing a settled session request during the `nanostores` unmount window. Prevents extra network calls and flicker in `useSession`.

- Bug Fixes
  - Keep the last settled session request for `STORE_UNMOUNT_DELAY` before clearing, so Suspense retries reuse it.
  - Cancel any in-flight request before starting a new one; delay release of the internal `sessionRequest` reference.
  - Add a React test to ensure a Suspense retry does not trigger a second session fetch (request count stays 1).

<sup>Written for commit 3c4ff6bd721b5be8468a506e718dd40eb0a04c56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

