### PR TITLE
docs: add Mailtrap as an email provider example

### DIFF
--- a/docs/content/docs/concepts/email.mdx
+++ b/docs/content/docs/concepts/email.mdx
@@ -13,6 +13,7 @@ For example, you might consider the following email providers:
 
 * [Resend](https://resend.com/better-auth)
 * [SuperSend TX](https://docs.supersendtx.com/guides/better-auth)
+* [Mailtrap](https://docs.mailtrap.io/guides/integrations/better-auth)
 
 ## Email Verification
 


### PR DESCRIPTION
## Summary

Adds [Mailtrap](https://docs.mailtrap.io/guides/integrations/better-auth) to the **Bring Your Own Email Provider** list in the email docs, alongside Resend and SuperSend TX.

The linked guide implements the `sendEmail` function these docs reference but never define, then wires it into every email surface Better Auth exposes: `sendVerificationEmail`, `sendResetPassword`, and the Magic Link, Email OTP, and Organization plugin callbacks.

## Links

- Guide: https://docs.mailtrap.io/guides/integrations/better-auth
- Package: https://www.npmjs.com/package/mailtrap

## Checklist

- [x] Docs only (one bullet + link)
- [x] Matches the existing Resend and SuperSend TX listing format
- [x] `pnpm format:check` and `pnpm lint:spell` pass
- [x] No changeset (docs are outside `packages/**`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Mailtrap to the “Bring Your Own Email Provider” list in the email docs, alongside Resend and SuperSend TX. This links to Mailtrap’s guide that shows how to implement `sendEmail` for Better Auth email flows.

<sup>Written for commit f1f31fb0ef76e683b43e90c8d066bb327a646c74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

