### PR TITLE
fix: encrypt idToken when encryptOAuthTokens is enabled

### DIFF
--- a/.changeset/mean-eels-shave.md
+++ b/.changeset/mean-eels-shave.md
@@ -4,5 +4,5 @@
 
 `account.encryptOAuthTokens` now covers the ID token as well. Previously only
 the access token and refresh token were encrypted, so the ID token was still
-written to the account table in plain text. Tokens stored before this change
-are still readable.
+written to the account table in plain text. ID tokens stored before this change
+are still readable, and get encrypted the next time the account is written.

--- a/.changeset/mean-eels-shave.md
+++ b/.changeset/mean-eels-shave.md
@@ -1,0 +1,8 @@
+---
+"better-auth": patch
+---
+
+`account.encryptOAuthTokens` now covers the ID token as well. Previously only
+the access token and refresh token were encrypted, so the ID token was still
+written to the account table in plain text. Tokens stored before this change
+are still readable.

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -490,7 +490,8 @@ export const auth = betterAuth({
 
 ### `encryptOAuthTokens`
 
-Encrypt OAuth tokens before storing them in the database. Default: `false`.
+Encrypt OAuth tokens (access token, refresh token and ID token) before storing
+them in the database. Default: `false`.
 
 ### `updateAccountOnSignIn`
 

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -1320,6 +1320,69 @@ describe("account", async () => {
 		expect(account?.idToken).toBe(newIdToken);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10757
+	 */
+	it("should encrypt a stored plaintext idToken on refresh when the provider returns no id_token", async () => {
+		const { auth, client, signInWithTestUser } = await getTestInstance({
+			socialProviders: {
+				google: {
+					clientId: "test",
+					clientSecret: "test",
+					enabled: true,
+				},
+			},
+			account: {
+				encryptOAuthTokens: true,
+				storeAccountCookie: false,
+			},
+		});
+		const ctx = await auth.$context;
+
+		server.use(
+			http.post("https://oauth2.googleapis.com/token", async () => {
+				// the provider rotates the access token but issues no new id_token
+				return HttpResponse.json({
+					access_token: "rotated-access-token",
+					expires_in: 3600,
+				});
+			}),
+		);
+
+		const { runWithUser, user } = await signInWithTestUser();
+		// an account row written before `encryptOAuthTokens` covered idToken
+		const legacyIdToken = await signJWT(
+			{ sub: "legacy", email: "legacy@test.com" },
+			DEFAULT_SECRET,
+		);
+		await ctx.internalAdapter.createAccount({
+			userId: user.id,
+			providerId: "google",
+			accountId: "legacy-plaintext-id-token",
+			accessToken: "legacy-access-token",
+			refreshToken: "legacy-refresh-token",
+			idToken: legacyIdToken,
+			accessTokenExpiresAt: new Date(Date.now() - 1000),
+		});
+
+		await runWithUser(async () => {
+			const res = await client.getAccessToken({ providerId: "google" });
+			expect(res.error).toBeFalsy();
+			expect(res.data?.accessToken).toBe("rotated-access-token");
+			// the caller still gets the readable token back
+			expect(res.data?.idToken).toBe(legacyIdToken);
+		});
+
+		const account = await ctx.adapter.findOne<Account>({
+			model: "account",
+			where: [{ field: "accountId", value: "legacy-plaintext-id-token" }],
+		});
+		expect(account?.idToken).not.toBe(legacyIdToken);
+		await expect(
+			symmetricDecrypt({ key: ctx.secretConfig, data: account!.idToken! }),
+		).resolves.toBe(legacyIdToken);
+	});
+
 	it("should persist refreshed idToken in account cookie during getAccessToken auto-refresh in stateless mode", async () => {
 		const { auth, client, cookieSetter } = await getTestInstance({
 			database: undefined,

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -19,7 +19,7 @@ import {
 } from "vitest";
 import { betterAuth } from "../../auth/minimal";
 import { parseSetCookieHeader } from "../../cookies";
-import { signJWT, symmetricDecodeJWT } from "../../crypto";
+import { signJWT, symmetricDecodeJWT, symmetricDecrypt } from "../../crypto";
 import { genericOAuth } from "../../plugins/generic-oauth";
 import { getTestInstance } from "../../test-utils/test-instance";
 import type { Account } from "../../types";
@@ -176,6 +176,32 @@ describe("account", async () => {
 				providerId: "google",
 			});
 			expect(accessToken.data?.accessToken).toBe("test");
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10757
+	 */
+	it("should encrypt id token", async () => {
+		const { runWithUser: runWithClient2 } = await signInWithTestUser();
+		const account = await ctx.adapter.findOne<Account>({
+			model: "account",
+			where: [{ field: "providerId", value: "google" }],
+		});
+		expect(account?.idToken).toBeTruthy();
+		// the stored value must not be the raw JWT the provider issued
+		expect(account?.idToken).not.toContain(".");
+		const decrypted = await symmetricDecrypt({
+			key: ctx.secretConfig,
+			data: account!.idToken!,
+		});
+		expect(decrypted.split(".")).toHaveLength(3);
+		await runWithClient2(async () => {
+			const accessToken = await client.getAccessToken({
+				providerId: "google",
+			});
+			// callers still get the usable token back
+			expect(accessToken.data?.idToken).toBe(decrypted);
 		});
 	});
 

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -16,7 +16,11 @@ import { parseAccountOutput } from "../../db/schema";
 import { missingEmailLogMessage } from "../../oauth2/errors";
 import { applyUpdateUserInfoOnLink } from "../../oauth2/link-account";
 import { generateState } from "../../oauth2/state";
-import { decryptOAuthToken, setTokenUtil } from "../../oauth2/utils";
+import {
+	decryptOAuthToken,
+	reencryptOAuthToken,
+	setTokenUtil,
+} from "../../oauth2/utils";
 import {
 	freshSessionMiddleware,
 	getSessionFromCtx,
@@ -589,7 +593,7 @@ async function getValidAccessToken(
 					newTokens?.refreshTokenExpiresAt ?? account.refreshTokenExpiresAt,
 				idToken: newTokens?.idToken
 					? await setTokenUtil(newTokens.idToken, ctx.context)
-					: account.idToken,
+					: await reencryptOAuthToken(account.idToken, ctx.context),
 			};
 			let updatedAccount: Record<string, any> | null = null;
 			if (account.id) {
@@ -853,7 +857,7 @@ export const refreshToken = createAuthEndpoint(
 					scope: tokens.scopes?.join(",") || account.scope,
 					idToken: tokens.idToken
 						? await setTokenUtil(tokens.idToken, ctx.context)
-						: account.idToken,
+						: await reencryptOAuthToken(account.idToken, ctx.context),
 				};
 				await ctx.context.internalAdapter.updateAccount(account.id, updateData);
 			}
@@ -871,7 +875,7 @@ export const refreshToken = createAuthEndpoint(
 					scope: tokens.scopes?.join(",") || accountData.scope,
 					idToken: tokens.idToken
 						? await setTokenUtil(tokens.idToken, ctx.context)
-						: accountData.idToken,
+						: await reencryptOAuthToken(accountData.idToken, ctx.context),
 				};
 				await setAccountCookie(ctx, updateData);
 			}

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -329,9 +329,15 @@ export const linkSocialAccount = createAuthEndpoint(
 					userId: session.user.id,
 					providerId: provider.id,
 					accountId: linkingUserId,
-					accessToken: c.body.idToken.accessToken,
-					idToken: token,
-					refreshToken: c.body.idToken.refreshToken,
+					accessToken: await setTokenUtil(
+						c.body.idToken.accessToken,
+						c.context,
+					),
+					idToken: await setTokenUtil(token, c.context),
+					refreshToken: await setTokenUtil(
+						c.body.idToken.refreshToken,
+						c.context,
+					),
 					scope: c.body.idToken.scopes?.join(","),
 				});
 			} catch (_e: any) {
@@ -581,7 +587,9 @@ async function getValidAccessToken(
 					: account.refreshToken,
 				refreshTokenExpiresAt:
 					newTokens?.refreshTokenExpiresAt ?? account.refreshTokenExpiresAt,
-				idToken: newTokens?.idToken || account.idToken,
+				idToken: newTokens?.idToken
+					? await setTokenUtil(newTokens.idToken, ctx.context)
+					: account.idToken,
 			};
 			let updatedAccount: Record<string, any> | null = null;
 			if (account.id) {
@@ -620,7 +628,11 @@ async function getValidAccessToken(
 				(await decryptOAuthToken(account.accessToken ?? "", ctx.context)),
 			accessTokenExpiresAt,
 			scopes: account.scope?.split(",") ?? [],
-			idToken: newTokens?.idToken ?? account.idToken ?? undefined,
+			idToken:
+				newTokens?.idToken ??
+				(account.idToken
+					? await decryptOAuthToken(account.idToken, ctx.context)
+					: undefined),
 		};
 	} catch (_error) {
 		throw APIError.from("BAD_REQUEST", {
@@ -839,7 +851,9 @@ export const refreshToken = createAuthEndpoint(
 					accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 					refreshTokenExpiresAt: resolvedRefreshTokenExpiresAt,
 					scope: tokens.scopes?.join(",") || account.scope,
-					idToken: tokens.idToken || account.idToken,
+					idToken: tokens.idToken
+						? await setTokenUtil(tokens.idToken, ctx.context)
+						: account.idToken,
 				};
 				await ctx.context.internalAdapter.updateAccount(account.id, updateData);
 			}
@@ -855,7 +869,9 @@ export const refreshToken = createAuthEndpoint(
 					accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 					refreshTokenExpiresAt: resolvedRefreshTokenExpiresAt,
 					scope: tokens.scopes?.join(",") || accountData.scope,
-					idToken: tokens.idToken || accountData.idToken,
+					idToken: tokens.idToken
+						? await setTokenUtil(tokens.idToken, ctx.context)
+						: accountData.idToken,
 				};
 				await setAccountCookie(ctx, updateData);
 			}
@@ -865,7 +881,11 @@ export const refreshToken = createAuthEndpoint(
 				accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 				refreshTokenExpiresAt: resolvedRefreshTokenExpiresAt,
 				scope: tokens.scopes?.join(",") || account.scope,
-				idToken: tokens.idToken || account.idToken,
+				idToken:
+					tokens.idToken ||
+					(account.idToken
+						? await decryptOAuthToken(account.idToken, ctx.context)
+						: account.idToken),
 				providerId: account.providerId,
 				accountId: account.accountId,
 			});

--- a/packages/better-auth/src/api/routes/callback.ts
+++ b/packages/better-auth/src/api/routes/callback.ts
@@ -202,7 +202,7 @@ export const callbackOAuth = createAuthEndpoint(
 					Object.entries({
 						accessToken: await setTokenUtil(tokens.accessToken, c.context),
 						refreshToken: await setTokenUtil(tokens.refreshToken, c.context),
-						idToken: tokens.idToken,
+						idToken: await setTokenUtil(tokens.idToken, c.context),
 						accessTokenExpiresAt: tokens.accessTokenExpiresAt,
 						refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
 						scope: tokens.scopes?.join(","),
@@ -220,6 +220,7 @@ export const callbackOAuth = createAuthEndpoint(
 					...tokens,
 					accessToken: await setTokenUtil(tokens.accessToken, c.context),
 					refreshToken: await setTokenUtil(tokens.refreshToken, c.context),
+					idToken: await setTokenUtil(tokens.idToken, c.context),
 					scope: tokens.scopes?.join(","),
 				});
 				if (!newAccount) {

--- a/packages/better-auth/src/oauth2/link-account.ts
+++ b/packages/better-auth/src/oauth2/link-account.ts
@@ -95,7 +95,7 @@ export async function handleOAuthUserInfo(
 					userId: dbUser.user.id,
 					accessToken: await setTokenUtil(account.accessToken, c.context),
 					refreshToken: await setTokenUtil(account.refreshToken, c.context),
-					idToken: account.idToken,
+					idToken: await setTokenUtil(account.idToken, c.context),
 					accessTokenExpiresAt: account.accessTokenExpiresAt,
 					refreshTokenExpiresAt: account.refreshTokenExpiresAt,
 					scope: account.scope,
@@ -129,7 +129,7 @@ export async function handleOAuthUserInfo(
 				c.context.options.account?.updateAccountOnSignIn !== false
 					? Object.fromEntries(
 							Object.entries({
-								idToken: account.idToken,
+								idToken: await setTokenUtil(account.idToken, c.context),
 								accessToken: await setTokenUtil(account.accessToken, c.context),
 								refreshToken: await setTokenUtil(
 									account.refreshToken,
@@ -217,7 +217,7 @@ export async function handleOAuthUserInfo(
 			const accountData = {
 				accessToken: await setTokenUtil(account.accessToken, c.context),
 				refreshToken: await setTokenUtil(account.refreshToken, c.context),
-				idToken: account.idToken,
+				idToken: await setTokenUtil(account.idToken, c.context),
 				accessTokenExpiresAt: account.accessTokenExpiresAt,
 				refreshTokenExpiresAt: account.refreshTokenExpiresAt,
 				scope: account.scope,

--- a/packages/better-auth/src/oauth2/utils.ts
+++ b/packages/better-auth/src/oauth2/utils.ts
@@ -35,3 +35,18 @@ export function setTokenUtil(
 	}
 	return token;
 }
+
+/**
+ * Encrypt a token that was read back from the account table.
+ *
+ * Rows written before `encryptOAuthTokens` was turned on hold plaintext, so
+ * decrypting first normalizes both cases instead of double-encrypting the ones
+ * that are already ciphertext.
+ */
+export async function reencryptOAuthToken(
+	token: string | null | undefined,
+	ctx: AuthContext,
+) {
+	if (!token) return token;
+	return setTokenUtil(await decryptOAuthToken(token, ctx), ctx);
+}

--- a/packages/better-auth/src/plugins/generic-oauth/routes.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/routes.ts
@@ -512,7 +512,7 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 					const updateData = Object.fromEntries(
 						Object.entries({
 							accessToken: await setTokenUtil(tokens.accessToken, ctx.context),
-							idToken: tokens.idToken,
+							idToken: await setTokenUtil(tokens.idToken, ctx.context),
 							refreshToken: await setTokenUtil(
 								tokens.refreshToken,
 								ctx.context,
@@ -536,7 +536,7 @@ export const oAuth2Callback = (options: GenericOAuthOptions) =>
 						refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
 						scope: tokens.scopes?.join(","),
 						refreshToken: await setTokenUtil(tokens.refreshToken, ctx.context),
-						idToken: tokens.idToken,
+						idToken: await setTokenUtil(tokens.idToken, ctx.context),
 					});
 					if (!newAccount) {
 						redirectOnError(ctx, resolvedErrorURL, "unable_to_link_account");


### PR DESCRIPTION
Fixes #10757

`account.encryptOAuthTokens` only covered `accessToken` and `refreshToken`. `idToken` was written to the account table in plain text on every write path, even though it sits in the same row and is just as sensitive.

**Writes** now go through `setTokenUtil`, same as the other two:
- `oauth2/link-account.ts` (link, update-on-sign-in, create paths)
- `api/routes/callback.ts` (update + create)
- `api/routes/account.ts` (`getValidAccessToken` refresh, `refreshToken` route)
- `plugins/generic-oauth/routes.ts` (update + create)

**Reads** decrypt before returning, so callers still get a usable token: `get-access-token` and `refresh-token`.

While in there: the `linkSocialAccount` id-token flow was writing `accessToken`, `refreshToken` and `idToken` all unencrypted. Those three now use `setTokenUtil` too.

### Existing rows

No migration needed. `decryptOAuthToken` already skips values that don't look encrypted, and a raw JWT has dots in it, so previously stored plain tokens keep being returned as-is.

They also get encrypted the next time the account row is written, including the case where the provider refreshes without issuing a new `id_token`. That fallback used to write the old value straight back, so a legacy row would have stayed in plain text forever. It now goes through a small `reencryptOAuthToken` helper (decrypt, then encrypt) so already-encrypted values aren't double-encrypted.

### Verification

Added a regression test in `account.test.ts` that reads the account row straight from the adapter:

```
✓ src/api/routes/account.test.ts (39 tests)
  Tests  39 passed (39)
```

Without the source change it fails as expected:

```
FAIL  account > should encrypt id token
AssertionError: expected 'eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRl…' not to contain '.'
```

Rest of the suite:

- `packages/better-auth`: 2341 passed, 2 failed (both `connect ECONNREFUSED ::1:5432`, no local Postgres, unrelated)
- `packages/sso`: 464 passed
- `tsc --project tsconfig.json`: clean
- `biome check` on the touched files: clean

The second commit adds a regression test for it: an account row seeded with a plaintext `idToken`, refreshed against a provider that returns no `id_token`, ends up encrypted at rest while the endpoint still returns the readable JWT. It fails on the first commit alone:

```
FAIL  account > should encrypt a stored plaintext idToken on refresh when the provider returns no id_token
AssertionError: expected 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsZWdh…' not to be 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsZWdh…'
```

Changeset included (patch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypts OAuth ID tokens when `account.encryptOAuthTokens` is enabled, matching `accessToken` and `refreshToken`. Also normalizes legacy plaintext `idToken` during refresh so stored values are encrypted, while responses still return the raw JWT.

- **Bug Fixes**
  - Encrypt `idToken` on create/update/link/refresh paths in `better-auth` and generic OAuth routes; all writes go through `setTokenUtil`.
  - Decrypt `idToken` in `get-access-token` and `refresh-token` responses; if a refresh returns no `id_token`, re-encrypt the stored value after decrypting to normalize legacy plaintext.
  - Fix `linkSocialAccount` to encrypt all three tokens; update docs; add regression tests; no migration needed—existing plain tokens are readable and get encrypted on the next write.

<sup>Written for commit 07b4b7b044899fc5423379612c6c1a03ac687d69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



### AI usage disclosure

I used Claude Code as an assistant on this change. I reviewed every line and verified the behaviour myself. Not a requirement here as far as I can find, noting it anyway.
