### PR TITLE
docs: add better-auth-azure-cosmos to community adapters

### DIFF
--- a/docs/lib/community-adapters-data.ts
+++ b/docs/lib/community-adapters-data.ts
@@ -209,4 +209,15 @@ export const communityAdapters: CommunityAdapter[] = [
 			avatar: "https://github.com/bjorntech.png",
 		},
 	},
+	{
+		name: "better-auth-azure-cosmos",
+		url: "https://github.com/9hsein5/better-auth-azure-cosmos",
+		database: "Azure Cosmos DB",
+		databaseUrl: "https://learn.microsoft.com/azure/cosmos-db/nosql/",
+		author: {
+			name: "9hsein5",
+			url: "https://github.com/9hsein5",
+			avatar: "https://github.com/9hsein5.png",
+		},
+	},
 ];


### PR DESCRIPTION
Adds `better-auth-azure-cosmos` to the community adapters list.

Azure Cosmos DB for NoSQL isn't covered by the built-in adapters, and there's no entry for it in the table today. This is an implementation of the `createAdapterFactory` contract on top of the `@azure/cosmos` SDK.

- Package: https://www.npmjs.com/package/better-auth-azure-cosmos
- Repo: https://github.com/9hsein5/better-auth-azure-cosmos

Notes that may be relevant to reviewers:

- `consumeOne` is implemented natively with an ETag (`If-Match`) conditional delete, rather than relying on the transaction fallback. Cosmos limits a transactional batch to a single logical partition, so the adapter reports `transaction: false` and the conditional delete is what keeps single-use credentials race-safe.
- Two layouts are supported: one shared container partitioned on a hierarchical `(model, id)` key, and one container per model partitioned on `/id`.
- Runs the `normal`, `authFlow`, `caseInsensitive` and `joins` suites from `@better-auth/test-utils` against the Cosmos DB emulator in CI — 236 passing. The `numberId` and `transactions` suites are intentionally not run, since the adapter reports `supportsNumericIds: false` and `transaction: false`.

Thanks for the `createAdapterFactory` guide and the test-utils package — the conformance suites caught three real bugs, including one where query field names weren't being routed through `getFieldName`, which only surfaces once a custom `fieldName` mapping is configured.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `better-auth-azure-cosmos` to the community adapters list so users can find a Cosmos DB (NoSQL) adapter built on `@azure/cosmos`.

<sup>Written for commit 440084654a88afd80b089a4ecc3144cf887d778c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

