### PR TITLE
fix(client): deduplicate settled session requests during Suspense retries

### DIFF
--- a/.changeset/tasty-dragons-burn.md
+++ b/.changeset/tasty-dragons-burn.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Prevent duplicate session requests during transient remounts while ensuring incomplete refreshes are revalidated.

--- a/packages/better-auth/src/client/query.test.ts
+++ b/packages/better-auth/src/client/query.test.ts
@@ -649,6 +649,54 @@ describe("useAuthQuery - error handling", () => {
 		unsubscribeSecond();
 	});
 
+	it("should retry an incomplete session refresh on remount", async () => {
+		const methods: string[] = [];
+		let resolveSessionRequest: ((response: Response) => void) | undefined;
+		const $fetch = createFetch({
+			baseURL: "http://localhost:3000",
+			customFetchImpl: async (_url, init) => {
+				const method = init?.method ?? "GET";
+				methods.push(method);
+				if (methods.length === 1) {
+					return new Promise<Response>((resolve) => {
+						resolveSessionRequest = resolve;
+					});
+				}
+				if (method === "POST") throw new Error("Session refresh failed");
+				return new Response(JSON.stringify({ session: null, user: null }));
+			},
+		});
+		const { session } = getSessionAtom($fetch);
+
+		const unsubscribeFirst = session.listen(() => {});
+		await vi.advanceTimersByTimeAsync(0);
+		unsubscribeFirst();
+		await vi.advanceTimersByTimeAsync(STORE_UNMOUNT_DELAY);
+
+		const settleSessionRequest = resolveSessionRequest;
+		if (!settleSessionRequest) throw new Error("Session request did not start");
+		settleSessionRequest(
+			new Response(
+				JSON.stringify({
+					needsRefresh: true,
+					session: {
+						id: "session-1",
+						expiresAt: new Date(Date.now() + 60_000),
+					},
+					user: { id: "user-1" },
+				}),
+			),
+		);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(session.value.data?.session.id).toBe("session-1");
+
+		const unsubscribeSecond = session.listen(() => {});
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(methods).toEqual(["GET", "POST", "GET"]);
+		unsubscribeSecond();
+	});
+
 	it("should revalidate after the session signal changes", async () => {
 		let fetchCount = 0;
 		let resolveSessionRequest: ((response: Response) => void) | undefined;

--- a/packages/better-auth/src/client/query.test.ts
+++ b/packages/better-auth/src/client/query.test.ts
@@ -611,6 +611,81 @@ describe("useAuthQuery - error handling", () => {
 		await act(async () => root.unmount());
 	});
 
+	it("should retry a failed session request on remount", async () => {
+		let fetchCount = 0;
+		let resolveSessionRequest: ((response: Response) => void) | undefined;
+		const $fetch = createFetch({
+			baseURL: "http://localhost:3000",
+			customFetchImpl: async () => {
+				fetchCount++;
+				if (fetchCount > 1) {
+					return new Response(JSON.stringify({ session: null, user: null }));
+				}
+				return new Promise<Response>((resolve) => {
+					resolveSessionRequest = resolve;
+				});
+			},
+		});
+		const { session } = getSessionAtom($fetch);
+
+		const unsubscribeFirst = session.listen(() => {});
+		await vi.advanceTimersByTimeAsync(0);
+		unsubscribeFirst();
+		await vi.advanceTimersByTimeAsync(STORE_UNMOUNT_DELAY);
+
+		const settleSessionRequest = resolveSessionRequest;
+		if (!settleSessionRequest) throw new Error("Session request did not start");
+		settleSessionRequest(
+			new Response(JSON.stringify({ message: "Internal Server Error" }), {
+				status: 500,
+			}),
+		);
+		await Promise.resolve();
+
+		const unsubscribeSecond = session.listen(() => {});
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(fetchCount).toBe(2);
+		unsubscribeSecond();
+	});
+
+	it("should revalidate after the session signal changes", async () => {
+		let fetchCount = 0;
+		let resolveSessionRequest: ((response: Response) => void) | undefined;
+		const $fetch = createFetch({
+			baseURL: "http://localhost:3000",
+			customFetchImpl: async () => {
+				fetchCount++;
+				if (fetchCount > 1) {
+					return new Response(JSON.stringify({ session: null, user: null }));
+				}
+				return new Promise<Response>((resolve) => {
+					resolveSessionRequest = resolve;
+				});
+			},
+		});
+		const { $sessionSignal, session } = getSessionAtom($fetch);
+
+		const unsubscribeFirst = session.listen(() => {});
+		await vi.advanceTimersByTimeAsync(0);
+		unsubscribeFirst();
+		await vi.advanceTimersByTimeAsync(STORE_UNMOUNT_DELAY);
+
+		const settleSessionRequest = resolveSessionRequest;
+		if (!settleSessionRequest) throw new Error("Session request did not start");
+		settleSessionRequest(
+			new Response(JSON.stringify({ session: null, user: null })),
+		);
+		await Promise.resolve();
+		$sessionSignal.set(!$sessionSignal.get());
+
+		const unsubscribeSecond = session.listen(() => {});
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(fetchCount).toBe(2);
+		unsubscribeSecond();
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9613
 	 */

--- a/packages/better-auth/src/client/query.test.ts
+++ b/packages/better-auth/src/client/query.test.ts
@@ -541,6 +541,76 @@ describe("useAuthQuery - error handling", () => {
 		expect(observedRequests).toEqual([{ aborted: false }]);
 	});
 
+	it("should not refetch a settled session request on a Suspense retry", async () => {
+		vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+		let requestCount = 0;
+		let resolveSessionRequest: ((response: Response) => void) | undefined;
+		let resumeRender: (() => void) | undefined;
+		let suspended = true;
+		const suspendedRender = new Promise<void>((resolve) => {
+			resumeRender = () => {
+				suspended = false;
+				resolve();
+			};
+		});
+		const client = createReactAuthClient({
+			baseURL: "http://localhost:3000",
+			fetchOptions: {
+				customFetchImpl: async () => {
+					requestCount++;
+					if (requestCount > 1) {
+						return new Response(JSON.stringify({ session: null, user: null }));
+					}
+					return new Promise<Response>((resolve) => {
+						resolveSessionRequest = resolve;
+					});
+				},
+			},
+		});
+		const SessionWatcher = () => {
+			client.useSession();
+			if (suspended) throw suspendedRender;
+			return null;
+		};
+		const root = createRoot(document.createElement("div"));
+
+		await act(async () => {
+			root.render(
+				createElement(
+					Suspense,
+					{ fallback: null },
+					createElement(SessionWatcher),
+				),
+			);
+			await vi.advanceTimersByTimeAsync(0);
+		});
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(STORE_UNMOUNT_DELAY);
+		});
+
+		const settleSessionRequest = resolveSessionRequest;
+		if (!settleSessionRequest) throw new Error("Session request did not start");
+		await act(async () =>
+			settleSessionRequest(
+				new Response(JSON.stringify({ session: null, user: null })),
+			),
+		);
+		expect(client.$store.atoms.session!.value.isPending).toBe(false);
+
+		const retrySuspendedRender = resumeRender;
+		if (!retrySuspendedRender) {
+			throw new Error("Suspense retry was not scheduled");
+		}
+		await act(async () => retrySuspendedRender());
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(0);
+		});
+
+		expect(requestCount).toBe(1);
+
+		await act(async () => root.unmount());
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9613
 	 */

--- a/packages/better-auth/src/client/session-atom.ts
+++ b/packages/better-auth/src/client/session-atom.ts
@@ -29,11 +29,11 @@ type SessionResponse = (
 ) &
 	Record<string, any>;
 
-type SessionFetchResult = "aborted" | "error" | "stale" | "success";
+type SessionFetchOutcome = "aborted" | "failed" | "stale" | "fresh";
 
 type SessionFlight = {
 	cancel: () => void;
-	promise: Promise<SessionFetchResult>;
+	promise: Promise<SessionFetchOutcome>;
 	revision: number;
 };
 
@@ -107,7 +107,7 @@ export function getSessionAtom(
 	const executeSessionFetch = async (
 		signal: AbortSignal,
 		queryParams?: { query?: SessionQueryParams } | undefined,
-	): Promise<SessionFetchResult> => {
+	): Promise<SessionFetchOutcome> => {
 		const current = session.value;
 		session.set({
 			...current,
@@ -129,7 +129,7 @@ export function getSessionAtom(
 			}
 
 			let { data, error } = normalizeSessionResponse(res);
-			let result: SessionFetchResult = "success";
+			let outcome: SessionFetchOutcome = "fresh";
 
 			if (data?.needsRefresh) {
 				try {
@@ -145,7 +145,7 @@ export function getSessionAtom(
 					if (signal.aborted) {
 						return "aborted";
 					}
-					result = "stale";
+					outcome = "stale";
 				}
 			}
 
@@ -159,7 +159,7 @@ export function getSessionAtom(
 					isRefetching: false,
 					refetch,
 				});
-				return "error";
+				return "failed";
 			}
 
 			const sessionData = normalizeSessionData(data);
@@ -177,7 +177,7 @@ export function getSessionAtom(
 				isRefetching: false,
 				refetch,
 			});
-			return result;
+			return outcome;
 		} catch (fetchError) {
 			if (signal.aborted) {
 				return "aborted";
@@ -190,7 +190,7 @@ export function getSessionAtom(
 				isRefetching: false,
 				refetch,
 			});
-			return "error";
+			return "failed";
 		}
 	};
 
@@ -222,14 +222,14 @@ export function getSessionAtom(
 			revision: sessionRevision,
 		};
 		flight = request;
-		const settleFlight = (result: SessionFetchResult) => {
+		const settleFlight = (outcome: SessionFetchOutcome) => {
 			if (flight !== request) return;
 			flight = undefined;
-			if (result === "success" && request.revision === sessionRevision) {
+			if (outcome === "fresh" && request.revision === sessionRevision) {
 				freshUntil = getFreshUntil();
 			}
 		};
-		void request.promise.then(settleFlight, () => settleFlight("error"));
+		void request.promise.then(settleFlight, () => settleFlight("failed"));
 		return request.promise.then(() => undefined);
 	};
 

--- a/packages/better-auth/src/client/session-atom.ts
+++ b/packages/better-auth/src/client/session-atom.ts
@@ -10,6 +10,9 @@ import type { SessionQueryParams } from "./types";
 // SSR detection
 const isServer = () => typeof window === "undefined";
 
+// Align session request reuse with the nanostores's remount lifecycle.
+const SESSION_MOUNT_DEDUPE_INTERVAL = STORE_UNMOUNT_DELAY;
+
 export type SessionAtom = AuthQueryAtom<{
 	user: User;
 	session: Session;
@@ -26,9 +29,12 @@ type SessionResponse = (
 ) &
 	Record<string, any>;
 
-type SessionRequest = {
+type SessionFetchResult = "aborted" | "error" | "success";
+
+type SessionFlight = {
 	cancel: () => void;
-	promise: Promise<void>;
+	promise: Promise<SessionFetchResult>;
+	revision: number;
 };
 
 /**
@@ -77,7 +83,13 @@ export function getSessionAtom(
 ) {
 	const $signal = atom<boolean>(false);
 
-	let sessionRequest: SessionRequest | undefined;
+	let flight: SessionFlight | undefined;
+	let freshUntil = 0;
+	let sessionRevision = 0;
+	$signal.listen(() => {
+		sessionRevision++;
+		freshUntil = 0;
+	});
 
 	const refetch = (
 		queryParams?: { query?: SessionQueryParams } | undefined,
@@ -95,7 +107,7 @@ export function getSessionAtom(
 	const executeSessionFetch = async (
 		signal: AbortSignal,
 		queryParams?: { query?: SessionQueryParams } | undefined,
-	): Promise<void> => {
+	): Promise<SessionFetchResult> => {
 		const current = session.value;
 		session.set({
 			...current,
@@ -104,7 +116,7 @@ export function getSessionAtom(
 			error: null,
 			refetch,
 		});
-		if (signal.aborted) return;
+		if (signal.aborted) return "aborted";
 
 		try {
 			const res = await $fetch<SessionResponse>("/get-session", {
@@ -113,7 +125,7 @@ export function getSessionAtom(
 				signal,
 			});
 			if (signal.aborted) {
-				return;
+				return "aborted";
 			}
 
 			let { data, error } = normalizeSessionResponse(res);
@@ -125,12 +137,12 @@ export function getSessionAtom(
 						signal,
 					});
 					if (signal.aborted) {
-						return;
+						return "aborted";
 					}
 					({ data, error } = normalizeSessionResponse(refreshRes));
 				} catch {
 					if (signal.aborted) {
-						return;
+						return "aborted";
 					}
 				}
 			}
@@ -145,7 +157,7 @@ export function getSessionAtom(
 					isRefetching: false,
 					refetch,
 				});
-				return;
+				return "error";
 			}
 
 			const sessionData = normalizeSessionData(data);
@@ -163,9 +175,10 @@ export function getSessionAtom(
 				isRefetching: false,
 				refetch,
 			});
+			return "success";
 		} catch (fetchError) {
 			if (signal.aborted) {
-				return;
+				return "aborted";
 			}
 			const latest = session.value;
 			session.set({
@@ -175,34 +188,56 @@ export function getSessionAtom(
 				isRefetching: false,
 				refetch,
 			});
+			return "error";
 		}
+	};
+
+	const getFreshUntil = (): number => {
+		const expiresAt = session.value.data?.session?.expiresAt;
+		const sessionExpiresAt =
+			expiresAt instanceof Date
+				? expiresAt.getTime()
+				: Number.POSITIVE_INFINITY;
+		return Math.min(
+			Date.now() + SESSION_MOUNT_DEDUPE_INTERVAL,
+			sessionExpiresAt,
+		);
 	};
 
 	const fetchSession = (
 		queryParams?: { query?: SessionQueryParams } | undefined,
 	): Promise<void> => {
-		sessionRequest?.cancel();
+		freshUntil = 0;
+		flight?.cancel();
 		const controller = new AbortController();
 		const promise = Promise.resolve().then(() => {
-			if (controller.signal.aborted) return;
+			if (controller.signal.aborted) return "aborted" as const;
 			return executeSessionFetch(controller.signal, queryParams);
 		});
-		const request: SessionRequest = {
+		const request: SessionFlight = {
 			cancel: () => controller.abort(),
 			promise,
+			revision: sessionRevision,
 		};
-		sessionRequest = request;
-		const releaseSessionRequest = () => {
-			setTimeout(() => {
-				if (sessionRequest === request) sessionRequest = undefined;
-			}, STORE_UNMOUNT_DELAY);
+		flight = request;
+		const settleFlight = (result: SessionFetchResult) => {
+			if (flight !== request) return;
+			flight = undefined;
+			if (result === "success" && request.revision === sessionRevision) {
+				freshUntil = getFreshUntil();
+			}
 		};
-		void request.promise.then(releaseSessionRequest, releaseSessionRequest);
-		return request.promise;
+		void request.promise.then(settleFlight, () => settleFlight("error"));
+		return request.promise.then(() => undefined);
 	};
 
-	const fetchSessionOnMount = (): Promise<void> =>
-		sessionRequest?.promise ?? fetchSession();
+	const fetchSessionOnMount = (): Promise<void> => {
+		if (flight?.revision === sessionRevision) {
+			return flight.promise.then(() => undefined);
+		}
+		if (Date.now() < freshUntil) return Promise.resolve();
+		return fetchSession();
+	};
 
 	let broadcastSessionUpdate: (
 		trigger: "signout" | "getSession" | "updateUser",

--- a/packages/better-auth/src/client/session-atom.ts
+++ b/packages/better-auth/src/client/session-atom.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthClientOptions } from "@better-auth/core";
 import type { BetterFetch, BetterFetchError } from "@better-fetch/fetch";
-import { atom, onMount } from "nanostores";
+import { atom, onMount, STORE_UNMOUNT_DELAY } from "nanostores";
 import type { Session, User } from "../types";
 import { isJsonEqual, withEquality } from "./equality";
 import type { AuthQueryAtom, AuthQueryState } from "./query";
@@ -77,7 +77,7 @@ export function getSessionAtom(
 ) {
 	const $signal = atom<boolean>(false);
 
-	let activeRequest: SessionRequest | undefined;
+	let sessionRequest: SessionRequest | undefined;
 
 	const refetch = (
 		queryParams?: { query?: SessionQueryParams } | undefined,
@@ -181,7 +181,7 @@ export function getSessionAtom(
 	const fetchSession = (
 		queryParams?: { query?: SessionQueryParams } | undefined,
 	): Promise<void> => {
-		activeRequest?.cancel();
+		sessionRequest?.cancel();
 		const controller = new AbortController();
 		const promise = Promise.resolve().then(() => {
 			if (controller.signal.aborted) return;
@@ -191,16 +191,18 @@ export function getSessionAtom(
 			cancel: () => controller.abort(),
 			promise,
 		};
-		activeRequest = request;
-		const clearActiveRequest = () => {
-			if (activeRequest === request) activeRequest = undefined;
+		sessionRequest = request;
+		const releaseSessionRequest = () => {
+			setTimeout(() => {
+				if (sessionRequest === request) sessionRequest = undefined;
+			}, STORE_UNMOUNT_DELAY);
 		};
-		void request.promise.then(clearActiveRequest, clearActiveRequest);
+		void request.promise.then(releaseSessionRequest, releaseSessionRequest);
 		return request.promise;
 	};
 
 	const fetchSessionOnMount = (): Promise<void> =>
-		activeRequest?.promise ?? fetchSession();
+		sessionRequest?.promise ?? fetchSession();
 
 	let broadcastSessionUpdate: (
 		trigger: "signout" | "getSession" | "updateUser",

--- a/packages/better-auth/src/client/session-atom.ts
+++ b/packages/better-auth/src/client/session-atom.ts
@@ -196,6 +196,7 @@ export function getSessionAtom(
 
 	const getFreshUntil = (): number => {
 		const expiresAt = session.value.data?.session?.expiresAt;
+		// Treat missing expiry as unbounded so Math.min picks the dedupe deadline.
 		const sessionExpiresAt =
 			expiresAt instanceof Date
 				? expiresAt.getTime()

--- a/packages/better-auth/src/client/session-atom.ts
+++ b/packages/better-auth/src/client/session-atom.ts
@@ -29,7 +29,7 @@ type SessionResponse = (
 ) &
 	Record<string, any>;
 
-type SessionFetchResult = "aborted" | "error" | "success";
+type SessionFetchResult = "aborted" | "error" | "stale" | "success";
 
 type SessionFlight = {
 	cancel: () => void;
@@ -129,6 +129,7 @@ export function getSessionAtom(
 			}
 
 			let { data, error } = normalizeSessionResponse(res);
+			let result: SessionFetchResult = "success";
 
 			if (data?.needsRefresh) {
 				try {
@@ -144,6 +145,7 @@ export function getSessionAtom(
 					if (signal.aborted) {
 						return "aborted";
 					}
+					result = "stale";
 				}
 			}
 
@@ -175,7 +177,7 @@ export function getSessionAtom(
 				isRefetching: false,
 				refetch,
 			});
-			return "success";
+			return result;
 		} catch (fetchError) {
 			if (signal.aborted) {
 				return "aborted";


### PR DESCRIPTION
Prevent transient Suspense remounts from reissuing a settled session request.

### Before

Request deduplication ended as soon as the request settled, allowing a transient remount to immediately issue another request.

### Policy

| Condition | Behavior |
| --- | --- |
| Request in flight | Reuse the request |
| Fresh result | Skip remount revalidation during the dedupe interval |
| Stale, failed, or aborted result | Revalidate on the next mount |
| Explicit refetch, session change, or expiration | Revalidate |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates settled session requests during React Suspense retries to prevent duplicate fetches on transient remounts. Previously dedupe ended on settle; now successful results are reused until the smaller of `nanostores` `STORE_UNMOUNT_DELAY` or session expiry, while failed/aborted or incomplete refreshes always retry.

**Details**
- Request policy: reuse in-flight; treat successful results as fresh during the dedupe window; revalidate on explicit refetch, session signal change, or expiry; never mark failed refreshes as fresh.
- Implementation: separate session “flight” from mount freshness with a revisioned flight; set `freshUntil` only for a “fresh” outcome on the current revision; align dedupe with `STORE_UNMOUNT_DELAY`.
- Tests: add coverage for Suspense retry dedupe, remount after failure, retry after incomplete refresh, and revalidation when the session signal flips.

<sup>Written for commit 98b94d2113d6abb0b74213aa42459412bd2eacaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



