### PR TITLE
docs(username): fix displayUsername release notes

### DIFF
--- a/.changeset/curly-plants-exist.md
+++ b/.changeset/curly-plants-exist.md
@@ -2,4 +2,5 @@
 "better-auth": minor
 ---
 
-Introduces the functionality to disable `displayName` from the username plugin.
+Allow the username plugin's separate `displayUsername` field to be omitted by
+setting `displayUsername: false` on both the server and client plugins.

--- a/packages/better-auth/CHANGELOG.md
+++ b/packages/better-auth/CHANGELOG.md
@@ -8,7 +8,7 @@
 
   The OAuth integration replaces the optional `resource` column with `oauthClientId` and `resources`. Regenerate and apply the schema when using it. Before upgrading from an earlier 1.7 prerelease, let pending OAuth device codes expire or delete them because they cannot be exchanged through the new integration.
 
-- [#10330](https://github.com/better-auth/better-auth/pull/10330) [`081d3c3`](https://github.com/better-auth/better-auth/commit/081d3c379c720926295067d878c421b5e8684c78) Thanks [@ping-maxwell](https://github.com/ping-maxwell)! - Introduces the functionality to disable `displayName` from the username plugin.
+- [#10330](https://github.com/better-auth/better-auth/pull/10330) [`081d3c3`](https://github.com/better-auth/better-auth/commit/081d3c379c720926295067d878c421b5e8684c78) Thanks [@ping-maxwell](https://github.com/ping-maxwell)! - Allow the username plugin's separate `displayUsername` field to be omitted by setting `displayUsername: false` on both the server and client plugins.
 
 ### Patch Changes
 


### PR DESCRIPTION
Related to #10330

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the username plugin release notes to reflect the actual behavior. Previously said you could disable “displayName”; now clarifies you can omit the separate “displayUsername” field by setting `displayUsername: false` on both the server and client plugins.

- Changes only `.changeset/curly-plants-exist.md` and `packages/better-auth/CHANGELOG.md`; no runtime or API changes.
- No migration required; this is a wording fix.

<sup>Written for commit 62ab25794d70c7bd3ee9248ef4f1e46e5d088f6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

