### PR TITLE
docs(oauth): qualify transaction rollback guarantee

### DIFF
--- a/.changeset/oauth-signup-transaction.md
+++ b/.changeset/oauth-signup-transaction.md
@@ -2,4 +2,6 @@
 "better-auth": patch
 ---
 
-Create new OAuth accounts in the user creation transaction so failed account writes roll back the user row.
+Create new OAuth accounts in the user creation transaction. Adapters with native
+transaction support roll back the user when the account write fails, while other
+adapters still perform the writes sequentially.


### PR DESCRIPTION
Related to #10125

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies OAuth signup docs to state when user/account writes roll back together. Previously we implied all failed account writes rolled back the user; now we specify this only holds for adapters with native transaction support, while others still write sequentially.

- Updates the `.changeset` note for `better-auth` (patch). No runtime changes.
- Adapter authors: no migration required. To guarantee rollback, add native transaction support to your adapter.

<sup>Written for commit e1c2b21b628d4a2622514c28b4cd99d7886e1a5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

