### PR TITLE
docs(db): clarify unique column migrations

### DIFF
--- a/.changeset/kysely-migrate-add-column-defaults.md
+++ b/.changeset/kysely-migrate-add-column-defaults.md
@@ -2,4 +2,7 @@
 "better-auth": patch
 ---
 
-`npx auth migrate` no longer aborts when adding a column to an existing table. A required column with a default value, or a unique column, now migrates on SQLite and on populated Postgres and MySQL databases. Upgrading a database that already has organization teams previously failed on the new `team.memberCount` and `teamMember.membershipKey` columns.
+`npx auth migrate` can now add required columns with static defaults and nullable
+unique columns to existing SQLite, PostgreSQL, and MySQL tables. Required unique
+columns still need distinct values to be backfilled manually before applying the
+unique constraint.


### PR DESCRIPTION
Related to #10293

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the migration note for `npx auth migrate`: it can add required columns with static defaults and nullable unique columns on SQLite, PostgreSQL, and MySQL, and explicitly calls out that required unique columns need manual backfill before enforcing the unique constraint. This avoids reading “unique column migrates” as applying to required unique columns.

- Migration action: Backfill distinct values for required unique columns before adding the unique constraint.

<sup>Written for commit dd283d4f046a143226fdbe4d8e20c8a80897f6a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

