### PR TITLE
docs(core): clarify dynamic base URL proxy trust

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -42,7 +42,7 @@ If not explicitly set, the system will check for the environment variable `BETTE
 
 ### Dynamic Base URL
 
-Use the object form when your app can be reached through multiple domains, such as preview deployments, branch environments, or multiple production hosts. Better Auth derives the host from the incoming request, validates it against `allowedHosts`, and constructs the request-specific base URL from that match.
+Use the object form when your app can be reached through multiple domains, such as preview deployments, branch environments, or multiple production hosts. Better Auth derives the host from the `Host` header and then the request URL, validates it against `allowedHosts`, and constructs the request-specific base URL from that match. Forwarded host and protocol headers are ignored unless you explicitly set `advanced.trustedProxyHeaders: true`.
 
 ```ts
 import { betterAuth } from "better-auth";
@@ -61,8 +61,8 @@ export const auth = betterAuth({
 ```
 
 * `allowedHosts`: List of accepted host patterns. Supports exact matches (`myapp.com`), wildcards (`*.vercel.app`, `preview-*.myapp.com`), and port wildcards (`localhost:*`). Automatically added to [`trustedOrigins`](#trustedorigins) (localhost entries get both `http` and `https`)
-* `protocol`: Protocol for URL construction. `"http"`, `"https"`, or `"auto"` (default). `"auto"` derives from `x-forwarded-proto`, then request URL, then defaults to HTTPS. Also affects the cookie `Secure` flag: `"https"` → secure, `"http"` → not secure, `"auto"` or unset → `NODE_ENV === "production"`. Override with `advanced.useSecureCookies`
-* `fallback`: URL to use when the incoming host does not match. Without it, unknown hosts throw. Its origin is also added to `trustedOrigins`
+* `protocol`: Protocol for URL construction. `"http"`, `"https"`, or `"auto"` (default). `"auto"` uses `x-forwarded-proto` only when `advanced.trustedProxyHeaders` is `true`, then the request URL, then HTTP for local loopback hosts, and otherwise HTTPS. Also affects the cookie `Secure` flag: `"https"` → secure, `"http"` → not secure, `"auto"` or unset → `NODE_ENV === "production"`. Override with `advanced.useSecureCookies`
+* `fallback`: URL to use when no request host is available or the incoming host does not match. Without it, unresolved or unknown hosts throw. Its origin is also added to `trustedOrigins`
 
 <Callout type="warn">
   Use `fallback` carefully. It can hide deployment or proxy misconfiguration that would otherwise fail loudly.

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -146,7 +146,8 @@ export type DynamicBaseURLConfig = {
 	/**
 	 * List of allowed hostnames. Supports wildcard patterns.
 	 *
-	 * The derived host from the request will be validated against this list.
+	 * `x-forwarded-host` is used only when `advanced.trustedProxyHeaders` is
+	 * enabled.
 	 * Uses the same wildcard matching as `trustedOrigins`.
 	 *
 	 * @example
@@ -161,8 +162,7 @@ export type DynamicBaseURLConfig = {
 	allowedHosts: string[];
 
 	/**
-	 * Fallback URL to use if the derived host doesn't match any allowed host.
-	 * If not set, Better Auth will throw an error when the host doesn't match.
+	 * Fallback URL used when no allowed request host can be resolved.
 	 *
 	 * @example "https://myapp.com"
 	 */
@@ -172,7 +172,7 @@ export type DynamicBaseURLConfig = {
 	 * Protocol to use when constructing the URL.
 	 * - `"https"`: Always use HTTPS (recommended for production)
 	 * - `"http"`: Always use HTTP (for local development)
-	 * - `"auto"`: Derive from `x-forwarded-proto` header or default to HTTPS
+	 * - `"auto"`: Trust `x-forwarded-proto` only when proxy headers are enabled
 	 *
 	 * @default "auto"
 	 */

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -163,6 +163,8 @@ export type DynamicBaseURLConfig = {
 
 	/**
 	 * Fallback URL used when no allowed request host can be resolved.
+	 * If omitted, Better Auth throws when the request host is unavailable or not
+	 * allowed.
 	 *
 	 * @example "https://myapp.com"
 	 */


### PR DESCRIPTION
Related to #9131

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies dynamic base URL host/protocol resolution and fallback error conditions to prevent proxy misconfigurations. No runtime changes; this documents that forwarded headers are ignored unless `advanced.trustedProxyHeaders` is enabled.

- Host is derived from the `Host` header and then the request URL; forwarded host/protocol headers are ignored unless `advanced.trustedProxyHeaders: true`.
- `"auto"` protocol now documented to trust `x-forwarded-proto` only when proxy headers are enabled; otherwise use the request URL, prefer HTTP for loopback hosts, and default to HTTPS. Notes cookie `Secure` flag behavior and `advanced.useSecureCookies` override.
- `fallback` is used when no request host is available or the host is not allowed; without it, unresolved or unknown hosts throw. Its origin is added to `trustedOrigins`.
- Aligns comments in `packages/core/src/types/init-options.ts` with the docs for `allowedHosts`, `fallback`, and `"auto"` protocol.

<sup>Written for commit bb82fcd4f72a369d6dcf13d9bc759f2ce83d776e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

