### PR TITLE
fix(oauth-provider): treat acr_values as voluntary

### DIFF
--- a/.changeset/id-token-claim-authority.md
+++ b/.changeset/id-token-claim-authority.md
@@ -2,6 +2,9 @@
 "@better-auth/oauth-provider": minor
 ---
 
-ID tokens now report `acr: "0"` instead of the InCommon Bronze URI. The default OpenID discovery document no longer advertises `acr_values_supported`, since the provider does not support requestable ACR classes yet.
+ID tokens now use `acr: "0"`, indicating that authentication did not meet
+ISO/IEC 29115 level 1, and OpenID discovery advertises only `"0"`. Because
+`acr_values` is voluntary, requests for other classes continue instead of
+failing.
 
 `customIdTokenClaims`, extension ID-token claims, and per-issuance `idTokenClaims` can no longer set OIDC/JWT protocol claims such as issuer, subject, audience, token lifetime, nonce, session or hash binding, `auth_time`, `acr`, `amr`, or `azp`. Namespaced custom claims still appear in ID tokens.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1721,8 +1721,7 @@ The metadata endpoint can be customized so that the publicized scopes and claims
 
 All scopes inside the advertisedMetadata section MUST be listed in `scopes` otherwise initialization will fail.
 
-Better Auth advertises `acr_values_supported: ["0"]`, which is the unspecified authentication context. Custom ACR policies are not currently supported; authorization requests for other
-`acr_values` are rejected with `invalid_request`.
+Better Auth advertises `acr_values_supported: ["0"]`. In OIDC Core, `"0"` means the authentication did not meet ISO/IEC 29115 level 1. Custom ACR policies are not currently supported. Because `acr_values` is voluntary, requests for other classes continue and the ID token reports `acr: "0"`.
 
 #### Scopes
 

--- a/packages/oauth-provider/src/authentication-context.ts
+++ b/packages/oauth-provider/src/authentication-context.ts
@@ -1,12 +1,13 @@
 import { logger } from "@better-auth/core/env";
 
 /**
- * RFC 6711 "unspecified" Authentication Context Class Reference.
+ * OIDC Core Authentication Context Class Reference for authentication that
+ * does not meet ISO/IEC 29115 level 1.
  *
  * Better Auth does not currently evaluate a stronger ACR policy, so discovery
  * and ID tokens must not claim an assurance profile such as InCommon bronze.
  */
-export const UNSPECIFIED_ACR = "0";
+export const LEVEL_0_ACR = "0";
 
 const RESERVED_ID_TOKEN_CLAIMS = new Set([
 	"iss",

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -556,22 +556,6 @@ describe("oauth authorize - acr_values (OIDC Core 1.0 §3.1.2.1)", async () => {
 		return location;
 	}
 
-	/**
-	 * @see https://github.com/better-auth/better-auth/pull/10152
-	 */
-	it("rejects unsupported acr_values instead of silently downgrading", async () => {
-		const location = await redirectFor("1");
-		const errorRedirect = new URL(location);
-
-		expect(errorRedirect.origin + errorRedirect.pathname).toBe(redirectUri);
-		expect(errorRedirect.searchParams.get("error")).toBe("invalid_request");
-		expect(errorRedirect.searchParams.get("error_description")).toBe(
-			"unsupported acr_values",
-		);
-		expect(errorRedirect.searchParams.get("state")).toBe("acr-state");
-		expect(errorRedirect.searchParams.get("code")).toBeNull();
-	});
-
 	it("accepts the advertised unspecified acr value", async () => {
 		const location = await redirectFor("0");
 		const callbackRedirect = new URL(location);

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -5,7 +5,6 @@ import { getSessionFromCtx } from "better-auth/api";
 import { generateRandomString, makeSignature } from "better-auth/crypto";
 import type { Verification } from "better-auth/db";
 import { APIError } from "better-call";
-import { UNSPECIFIED_ACR } from "./authentication-context";
 import { getRequestedUserInfoClaims } from "./claims-request";
 import { oAuthState } from "./oauth";
 import type { OAuthErrorCode, OAuthRedirectOnError } from "./oauth-endpoint";
@@ -135,12 +134,6 @@ function getAuthorizationRequestParameters(
 			: ctx.query;
 	const parameters = isRecord(source) ? source : {};
 	return { ...parameters } as unknown as OAuthAuthorizationQuery;
-}
-
-function isAcrValuesRequestSupported(acrValues: string | undefined): boolean {
-	if (acrValues === undefined) return true;
-	const requestedAcrValues = acrValues.split(" ").filter(Boolean);
-	return requestedAcrValues.includes(UNSPECIFIED_ACR);
 }
 
 export const handleRedirect = (
@@ -443,13 +436,6 @@ export async function authorizeEndpoint(
 	}
 	query = parsedQuery.data as OAuthAuthorizationQuery;
 	ctx.query = query;
-	if (!isAcrValuesRequestSupported(query.acr_values)) {
-		return authorizeRedirectOnError(opts)({
-			error: "invalid_request",
-			error_description: "unsupported acr_values",
-			ctx,
-		});
-	}
 	await oAuthState.set({
 		query: serializeAuthorizationQuery(query).toString(),
 	});

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -4,7 +4,7 @@ import {
 	PRIVATE_KEY_JWT_SIGNING_ALGORITHMS,
 } from "@better-auth/core/oauth2";
 import type { JWSAlgorithms, JwtOptions } from "better-auth/plugins";
-import { UNSPECIFIED_ACR } from "./authentication-context";
+import { LEVEL_0_ACR } from "./authentication-context";
 import { validateIssuerUrl } from "./authorize";
 import {
 	applyOAuthProviderMetadataExtensions,
@@ -178,7 +178,7 @@ export function oidcServerMetadata(
 		subject_types_supported: opts.pairwiseSecret
 			? ["public", "pairwise"]
 			: ["public"],
-		acr_values_supported: [UNSPECIFIED_ACR],
+		acr_values_supported: [LEVEL_0_ACR],
 		id_token_signing_alg_values_supported: (() => {
 			if (opts.disableJwtPlugin) return ["HS256" as const];
 			// Advertise every algorithm the plugin can sign with: the primary

--- a/packages/oauth-provider/src/oidc-rs256-profile.test.ts
+++ b/packages/oauth-provider/src/oidc-rs256-profile.test.ts
@@ -99,7 +99,7 @@ describe("OpenID Connect RS256 provider profile", async () => {
 		);
 	});
 
-	it("issues an RS256 ID token through the authorization-code flow", async () => {
+	it("issues an RS256 ID token with the current ACR for unsupported acr_values", async () => {
 		if (!oauthClient?.client_id || !oauthClient.client_secret) {
 			throw new Error("beforeAll not run properly");
 		}
@@ -118,6 +118,9 @@ describe("OpenID Connect RS256 provider profile", async () => {
 			scopes,
 			codeVerifier,
 			nonce,
+			additionalParams: {
+				acr_values: "1",
+			},
 		});
 
 		let callbackRedirectUrl = "";

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -17,8 +17,8 @@ import type { Session, User } from "better-auth/types";
 import type { JWTPayload } from "jose";
 import { base64url, decodeProtectedHeader, SignJWT } from "jose";
 import {
+	LEVEL_0_ACR,
 	stripReservedIdTokenClaims,
-	UNSPECIFIED_ACR,
 } from "./authentication-context";
 import { resolveAccessTokenClaims } from "./claims";
 import { getRequestedUserInfoClaims } from "./claims-request";
@@ -374,7 +374,7 @@ async function createIdToken(
 	const payload: JWTPayload = {
 		...ID_TOKEN_SCOPE_CLAIM_GUARDS,
 		auth_time: authTimeSec,
-		acr: UNSPECIFIED_ACR,
+		acr: LEVEL_0_ACR,
 		...customClaims,
 		at_hash: atHash,
 		iss: jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL,


### PR DESCRIPTION
> [!NOTE]
> If the Claim is not Essential and a requested value cannot be provided, the Authorization Server SHOULD return the session's current `acr` as the value of the `acr` Claim.
> 
> https://openid.net/specs/openid-connect-core-1_0.html#acrSemantics

Related to #10152

### Current Limitation

Better Auth currently supports only the `"0"` ACR value. Custom ACR values and authentication context policies are not supported.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats `acr_values` as voluntary in `@better-auth/oauth-provider` per OIDC Core. Previously, unsupported `acr_values` caused `invalid_request`; now the flow continues and ID tokens report `acr: "0"` (authentication did not meet ISO/IEC 29115 level 1). Discovery advertises only `"0"`.

- Removes request-time `acr_values` validation and error path; continues authorization and sets `acr: "0"`.
- Renames `UNSPECIFIED_ACR` to `LEVEL_0_ACR`; uses it in ID token and metadata.
- Keeps `acr_values_supported: ["0"]` in server metadata; updates docs to clarify semantics.
- Updates tests to verify continuation with unsupported `acr_values`.

Migration:
- If clients relied on an authorization error for unsupported `acr_values`, update them to read the `acr` claim from the ID token instead. No server configuration changes required.

<sup>Written for commit 1b4b0ac556e6cdd742ab6fda447e182698346831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

