### PR TITLE
fix(expo): preserve client plugin inference with expoClient

### DIFF
--- a/.changeset/fix-expo-client-plugin-inference.md
+++ b/.changeset/fix-expo-client-plugin-inference.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/expo": patch
+---
+
+Fix `expoClient()` collapsing `createAuthClient` type inference when combined with other client plugins. The `getCookie` action is available on the client again.

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -1,10 +1,12 @@
 import type {
+	BetterAuthClientOptions,
 	BetterAuthClientPlugin,
 	ClientFetchOption,
 	ClientStore,
 } from "@better-auth/core";
 import type { Session, User } from "@better-auth/core/db";
 import { safeJSONParse } from "@better-auth/core/utils/json";
+import type { BetterFetch } from "@better-fetch/fetch";
 import {
 	parseSetCookieHeader,
 	SECURE_COOKIE_PREFIX,
@@ -370,7 +372,11 @@ export const expoClient = (opts: ExpoClientOptions) => {
 	return {
 		id: "expo",
 		version: PACKAGE_VERSION,
-		getActions(_, $store) {
+		getActions(
+			_$fetch: BetterFetch,
+			$store: ClientStore,
+			_options: BetterAuthClientOptions | undefined,
+		) {
 			store = $store;
 			// Restore the last persisted session as the initial value of the session atom
 			const sessionAtom = $store.atoms.session;

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -1,8 +1,18 @@
+import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "better-auth/api";
+import { createAuthClient } from "better-auth/client";
 import { magicLinkClient } from "better-auth/client/plugins";
 import { magicLink, oAuthProxy } from "better-auth/plugins";
 import { getTestInstance } from "better-auth/test";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	beforeAll,
+	describe,
+	expect,
+	expectTypeOf,
+	it,
+	vi,
+} from "vitest";
 import { expo } from "../src";
 import { expoClient, storageAdapter } from "../src/client";
 
@@ -1540,5 +1550,32 @@ describe("expo authorization proxy", async () => {
 			"https://accounts.google.com/o/oauth2/v2/auth?client_id=x&state=abc";
 		const res = await proxy(target);
 		expect(res.headers.get("location")).toBe(target);
+	});
+});
+
+/**
+ * Declaration emit previously left `getActions`'s parameters un-annotated.
+ * With no import of `BetterFetch` in the file, emit had no name to reference
+ * and inlined `import("@better-fetch/fetch").BetterFetch` instead - a form not
+ * assignable to `BetterAuthClientPlugin`'s `getActions`, so `expoClient()`
+ * failed `createAuthClient`'s check and the client lost `getCookie` along with
+ * every other plugin's actions.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10767
+ */
+describe("expoClient types", () => {
+	const storage = {
+		getItem: () => null,
+		setItem: () => undefined,
+	};
+
+	it("should be assignable to BetterAuthClientPlugin", () => {
+		const plugin: BetterAuthClientPlugin = expoClient({ storage });
+		expect(plugin.id).toBe("expo");
+	});
+
+	it("should preserve the getCookie client action", () => {
+		const client = createAuthClient({ plugins: [expoClient({ storage })] });
+		expectTypeOf(client.getCookie).toBeFunction();
 	});
 });


### PR DESCRIPTION
## Problem

`expoClient`'s `getActions` left its parameters un-annotated. With no import of `BetterFetch` in the file, declaration emit had no name to reference, so it wrote the inline form instead:

```ts
// 1.6.23 — named import at the top of client.d.ts
import * as _better_fetch_fetch0 from "@better-fetch/fetch";
getActions(_: _better_fetch_fetch0.BetterFetch, $store: ClientStore): { … }

// 1.6.24+ — inline
getActions(_: import("@better-fetch/fetch").BetterFetch, $store: ClientStore): { … }
```

The inline form is not assignable to `BetterAuthClientPlugin`'s `getActions`, so `expoClient()` fails `createAuthClient`'s check with `TS2322`, and the client falls back to `ReactAuthClient<BetterAuthClientOptions>` — losing `getCookie` **and every other plugin's actions** in the same call, plus `additionalFields` inference.

This is the same declaration-emit root cause as #10583 (`oneTapClient`), fixed by #10635. The fix was not applied to the expo plugin. #10515 reports the same class for `jwtClient`.

Reported in #10767, where another user hits it on the `organization` plugin too.

## Fix

Mirrors #10635 exactly — import the types and annotate `getActions` with its full three-parameter arity:

```diff
 import type {
+	BetterAuthClientOptions,
 	BetterAuthClientPlugin,
 	ClientFetchOption,
 	ClientStore,
 } from "@better-auth/core";
 import type { Session, User } from "@better-auth/core/db";
 import { safeJSONParse } from "@better-auth/core/utils/json";
+import type { BetterFetch } from "@better-fetch/fetch";

-		getActions(_, $store) {
+		getActions(
+			_$fetch: BetterFetch,
+			$store: ClientStore,
+			_options: BetterAuthClientOptions | undefined,
+		) {
```

`@better-fetch/fetch` is already a declared dependency of `@better-auth/expo`, so nothing changes in `package.json`.

## About the test

The added test mirrors the one #10635 introduced for one-tap, and it is worth being precise about what it does and does not cover.

It asserts that `expoClient()` stays assignable to `BetterAuthClientPlugin` and that `getCookie` survives on the built client. It **cannot reproduce the original bug**: the plugin object ends in `} satisfies BetterAuthClientPlugin`, so from source the `getActions` parameters are contextually typed and everything checks out. The failure only appears once TypeScript emits the `.d.ts` and a consumer reads it back.

The harness that *would* reproduce it is `packages/better-auth/src/client/client-declaration.test.ts`, which builds a synthetic composite project with `emitDeclarationOnly`. Adding an expo case there means wiring `@better-auth/expo` into that project, and it lives in a different package — happy to do it in this PR if you'd prefer that over the mirrored test.

## Verification

Checked on the emitted declaration rather than on compilation alone. After the change, `packages/expo`'s `client.d.ts` carries the named import and references it in `getActions` — the 1.6.23 shape:

```ts
import type { BetterFetch } from "@better-fetch/fetch";
// …
getActions(_$fetch: BetterFetch, $store: ClientStore, _options: BetterAuthClientOptions | undefined): { … }
```

`pnpm --filter @better-auth/expo test` → 57 passed.

### Downstream

Reproduced on Expo SDK 57 / React Native 0.86 / TypeScript 6.0 in a pnpm workspace:

| better-auth | `tsc --noEmit` |
| --- | --- |
| 1.6.23 | ✅ clean |
| 1.6.26 | ❌ fails |
| 1.6.27 | ❌ fails |

I verified there is no duplicate instance of `@better-fetch/fetch` or `@better-auth/core` in the tree, and that `BetterAuthClientPlugin` itself is unchanged between 1.6.23 and 1.6.26 — only the emitted form differs.

Closes #10767


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost client plugin type inference in Expo by importing `BetterFetch` and fully typing `expoClient`’s getActions. Previously the emitted `.d.ts` inlined `import("@better-fetch/fetch").BetterFetch`, making `expoClient` not assignable to BetterAuthClientPlugin and causing `createAuthClient` to drop plugin actions like getCookie; now the named import is emitted and inference is preserved.

- Mirrors the one-tap fix: adds a `BetterFetch` type import, annotates getActions with three parameters, and keeps runtime behavior unchanged.
- Adds tests to assert the plugin remains assignable and getCookie is present on the client.
- No `package.json` changes; `@better-fetch/fetch` is already a dependency. Patch release prepared for `@better-auth/expo`.

<sup>Written for commit 66c9316af8250b5994742caf469b033453555075. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

