### PR TITLE
docs(oauth-provider): document cloned form requests

### DIFF
--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1523,6 +1523,8 @@ A claims contributor can add new claim names but never replaces an identity, aut
 
 A grant handler receives a `provider` capability surface (`getClient`, `authenticateClient`, `issueTokens`, `hashToken`, `validateAccessToken`, `requireActiveAccessToken`). A plugin that needs those from its own endpoints (a back-channel authorization endpoint, a polling endpoint) obtains the same object with `getOAuthProviderApi(ctx, opts, grantType?)`, so it can resolve a client or verify a token without reaching into provider internals. Use `validateAccessToken` for introspection-style flows that can handle inactive payloads, and `requireActiveAccessToken` for protected-resource endpoints that should reject inactive or unknown tokens with an OAuth bearer challenge. Pass the grant type to mint tokens away from the token endpoint; omit it for read-only use, in which case `issueTokens` throws rather than mint an unlabeled grant.
 
+When a companion endpoint accepts `application/x-www-form-urlencoded`, set `cloneRequest: true` in its endpoint options before calling `authenticateClient()`. Client authentication re-reads the raw form body to enforce that client credentials are not repeated or combined across authentication methods, so the endpoint must preserve a readable request after parsing the form.
+
 To sender-constrain an issued token (RFC 7800 `cnf`), pass `confirmation` to `issueTokens`, or return it from a `clientAuthentication` strategy. The provider stamps it as the access token's `cnf` and marks the response `token_type` accordingly. `cnf` is authorization-server-owned and cannot be set through a claim contributor.
 
 #### Client authentication obligations

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -243,7 +243,10 @@ export interface OAuthProviderApi {
 	 * or none). For assertion-based methods, the RFC 7523 audience is bound to the
 	 * endpoint serving the request, so an assertion cannot be replayed across
 	 * endpoints. Returns the authenticated client, plus any `confirmation` an
-	 * assertion strategy proved.
+	 * assertion strategy proved. A companion endpoint that accepts
+	 * `application/x-www-form-urlencoded` must set `cloneRequest: true` in its
+	 * endpoint options because client authentication re-reads the raw form body
+	 * to enforce credential cardinality and reject mixed authentication methods.
 	 */
 	authenticateClient: (
 		request?: OAuthClientAuthenticationRequest,


### PR DESCRIPTION
Companion OAuth Provider endpoints can accept form-encoded client authentication, but `authenticateClient()` re-reads the raw request after endpoint parsing to enforce repeated-field and mixed-method validation. Without `cloneRequest: true`, plugin authors can define an endpoint whose form body is no longer readable during client authentication.

This documents the requirement on the public `OAuthProviderApi.authenticateClient` capability and in the OAuth Provider extension guide, while keeping the runtime contract unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents that form-encoded companion endpoints must set `cloneRequest: true` before calling `OAuthProviderApi.authenticateClient()`. This clarifies a previously implicit requirement so client auth can re-read the raw body to validate repeated fields and mixed methods; runtime behavior is unchanged.

- Required for plugins with `application/x-www-form-urlencoded` endpoints: set `cloneRequest: true` in endpoint options before parsing the form and calling `authenticateClient()`.

<sup>Written for commit 5e1d57c29c75d56ebbe9c050a8c1b0253e519254. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

