### PR TITLE
fix(oauth-provider): require openid for claims requests

### DIFF
--- a/.changeset/clever-claims-request.md
+++ b/.changeset/clever-claims-request.md
@@ -4,6 +4,8 @@
 
 The OIDC provider now honors the `claims.userinfo` authorization request parameter. A client can ask for individual standard claims, and the UserInfo endpoint returns the ones it can supply in addition to the scope-granted claims. The requested claims become part of the user's consent, and `claims_parameter_supported` is advertised in discovery.
 
+Authorization requests that use the `claims` parameter without requesting the `openid` scope are rejected.
+
 A claim requested through `claims.userinfo` is honored for opaque access tokens. With a JWT access token, UserInfo returns only the claims the granted scopes cover, so request the backing scope when a client needs a specific claim.
 
 This adds a `requestedUserInfoClaims` column to the OAuth access-token, refresh-token, and consent tables. Run your database migrations after upgrading.

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -3,10 +3,7 @@ import { createAuthEndpoint } from "@better-auth/core/api";
 import { sessionMiddleware } from "better-auth/api";
 import { createAuthClient } from "better-auth/client";
 import { generateRandomString, makeSignature } from "better-auth/crypto";
-import {
-	createAuthorizationURL,
-	generateCodeChallenge,
-} from "better-auth/oauth2";
+import { createAuthorizationURL } from "better-auth/oauth2";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -625,43 +622,17 @@ describe("oauth authorize - ACR requests", async () => {
 		it.each([
 			{ essential: true, value: "1" },
 			{ essential: true, value: 1 },
-		])("ignores claims in OAuth-only requests", async (request) => {
-			if (!oauthClient?.client_id || !oauthClient.client_secret) {
-				throw new Error("beforeAll not run properly");
-			}
-			const codeVerifier = generateRandomString(43);
-			const codeChallenge = await generateCodeChallenge(codeVerifier);
-			const location = await redirectFor(
-				undefined,
-				request,
-				"profile",
-				codeChallenge,
-			);
+		])("rejects claims in OAuth-only requests", async (request) => {
+			const location = await redirectFor(undefined, request, "profile");
 			const callbackRedirect = new URL(location);
-			const code = callbackRedirect.searchParams.get("code");
 
-			expect(callbackRedirect.searchParams.get("error")).toBeNull();
-			if (!code) throw new Error("authorization code not issued");
-
-			const tokenResponse = await authenticatedClient.$fetch<{
-				access_token: string;
-			}>("/oauth2/token", {
-				method: "POST",
-				body: new URLSearchParams({
-					grant_type: "authorization_code",
-					code,
-					code_verifier: codeVerifier,
-					redirect_uri: redirectUri,
-				}),
-				headers: {
-					authorization: `Basic ${Buffer.from(
-						`${oauthClient.client_id}:${oauthClient.client_secret}`,
-					).toString("base64")}`,
-				},
-			});
-
-			expect(tokenResponse.error).toBeNull();
-			expect(tokenResponse.data?.access_token).toEqual(expect.any(String));
+			expect(callbackRedirect.searchParams.get("error")).toBe(
+				"invalid_request",
+			);
+			expect(callbackRedirect.searchParams.get("error_description")).toBe(
+				"openid scope must be requested when using the claims parameter",
+			);
+			expect(callbackRedirect.searchParams.get("code")).toBeNull();
 		});
 
 		it("accepts the current ACR in an essential values request", async () => {

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -67,13 +67,6 @@ function removeMaxAgeFromAuthorizationQuery(
 	return queryWithoutMaxAge;
 }
 
-function removeClaimsFromAuthorizationQuery(
-	query: OAuthAuthorizationQuery,
-): OAuthAuthorizationQuery {
-	const { claims: _claims, ...queryWithoutClaims } = query;
-	return queryWithoutClaims;
-}
-
 /**
  * Formats an error url. Per OIDC Core 1.0 §5 / RFC 6749 §4.2.2.1, errors on
  * implicit and hybrid flows are delivered in the URL fragment, not the query.
@@ -572,10 +565,6 @@ export async function authorizeEndpoint(
 				getIssuer(ctx, opts),
 			),
 		);
-	}
-	if (!openidRequested && query.claims !== undefined) {
-		query = removeClaimsFromAuthorizationQuery(query);
-		ctx.query = query;
 	}
 	if (
 		openidRequested &&

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -549,6 +549,18 @@ export async function authorizeEndpoint(
 		query.scope = requestedScopes.join(" ");
 	}
 	const openidRequested = requestedScopes.includes("openid");
+	if (query.claims !== undefined && !openidRequested) {
+		return handleRedirect(
+			ctx,
+			formatErrorURL(
+				query.redirect_uri,
+				"invalid_request",
+				"openid scope must be requested when using the claims parameter",
+				query.state,
+				getIssuer(ctx, opts),
+			),
+		);
+	}
 	if (openidRequested && !isValidOidcClaimsRequest(query.claims)) {
 		return handleRedirect(
 			ctx,


### PR DESCRIPTION
Stacked on #10790

Authorization requests that use the `claims` parameter without the `openid` scope now fail with `invalid_request` instead of silently ignoring OIDC claims.

Reference:

https://github.com/panva/node-oidc-provider/blob/main/lib/actions/authorization/check_openid_scope.js