### PR TITLE
docs(scim): align release notes with final model

### DIFF
--- a/.changeset/scim-group-resources.md
+++ b/.changeset/scim-group-resources.md
@@ -2,4 +2,6 @@
 "@better-auth/scim": minor
 ---
 
-Add durable SCIM Group resources with organization-scoped membership, role projection, metadata, and Group lifecycle endpoints.
+Add durable SCIM Group resources with connection-scoped membership, projection
+callbacks, metadata, and Group lifecycle endpoints. Groups belong to SCIM
+connections rather than Better Auth Organizations.

--- a/.changeset/scim-org-scoped-connections.md
+++ b/.changeset/scim-org-scoped-connections.md
@@ -2,10 +2,13 @@
 "@better-auth/scim": minor
 ---
 
-Runtime SCIM tokens now require `organizationId`; use `staticProviders` for app-level SCIM.
+SCIM connections are now independent of the Organization and SSO plugins. Define
+them statically, resolve them with `authentication.verifyBearerToken`, or use the
+optional `managedConnections` catalog.
 
-SCIM-managed accounts now use namespaced provider IDs (`scim:{organizationId}:{providerId}` or `scim:{providerId}` for app-level static providers). Migrate only known SCIM-managed account rows before upgrading; leave non-SCIM accounts unchanged even when they share the same provider ID.
+Legacy connection management, organization-scoped configuration, and SCIM-created
+authentication accounts are removed. Use identity and projection callbacks to
+connect SCIM resources to application users and roles.
 
-Organization-scoped `active: false` now makes a user inactive in that organization while keeping SCIM group and team associations available for reactivation. Use `DELETE` to fully deprovision organization-scoped SCIM state.
-
-`defaultSCIM` has been replaced by `staticProviders`. `linkExistingUsers.trustedDomains` has been removed; use `requireExistingOrgMembership`, `shouldLinkUser`, or explicit `true` instead.
+Legacy SCIM state is not migrated. Back it up, issue new credentials, and fully
+reprovision Users and Groups after upgrading.

--- a/.changeset/scim-personal-provider-ownership.md
+++ b/.changeset/scim-personal-provider-ownership.md
@@ -2,10 +2,9 @@
 "@better-auth/scim": minor
 ---
 
-Personal (non-organization) SCIM connections now always belong to the user who created them. Owner binding used to be opt-in through the `providerOwnership` option, which defaulted to off. With it off, a personal connection was stored without an owner, and the management endpoints denied access only when a stored owner differed from the caller. An unowned connection passed that check for any signed-in user, who could read it, list it, regenerate its token, or delete it. Regenerating the token rotated the secret and invalidated the original.
+Remove the legacy user-session connection management endpoints and
+`providerOwnership`. Applications now authorize their own SCIM administration
+workflows instead of relying on Better Auth user ownership.
 
-`generateSCIMToken` now records the creator's `userId` on every personal connection. The `generate-token`, `list-provider-connections`, `get-provider-connection`, and `delete-provider-connection` endpoints grant access only to that owner. Organization-scoped connections keep their existing behavior and continue to use organization membership and the configured `requiredRole` checks.
-
-This release is breaking. It removes the `providerOwnership` option, and owner binding can no longer be disabled. The `scimProvider.userId` column is now a permanent part of the schema, so run a migration after upgrading with `npx auth migrate` or `npx auth generate`.
-
-Connections created before this release carry no owner. Access now fails closed, so those connections are no longer reachable through the management endpoints, including token regeneration. Reclaim them at the database level: delete `scimProvider` rows that have neither `organizationId` nor `userId`, or set `userId` to the intended owner, then regenerate tokens as needed. Organization-scoped connections are not affected.
+Legacy `scimProvider` rows and credentials are not migrated. Follow the 1.7 SCIM
+upgrade guide, issue new credentials, and fully reprovision Users and Groups.


### PR DESCRIPTION
Related to #10390 and #10592

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns SCIM release notes with the final connection-scoped model in `@better-auth/scim`. Groups now belong to SCIM connections (previously organizations), connections are independent of Organization/SSO plugins, and legacy owner-based management endpoints and `providerOwnership` are removed.

- Define SCIM connections statically, resolve them with `authentication.verifyBearerToken`, or use `managedConnections`.
- Link SCIM Users/Groups to your app with identity and projection callbacks; SCIM-created auth accounts are removed.
- No automatic migration: back up existing SCIM state, issue new credentials, and fully reprovision Users and Groups.

<sup>Written for commit 24c4cacab1fcbd98d38bdf5e768045db6ae032d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

