### PR TITLE
docs(sso): align SAML release notes with final behavior

### DIFF
--- a/.changeset/sso-saml-hardening.md
+++ b/.changeset/sso-saml-hardening.md
@@ -2,7 +2,7 @@
 "@better-auth/sso": patch
 ---
 
-fix(sso): unify SAML response processing and fix provider/config bugs
+Unify SAML response processing and fix provider and configuration handling.
 
 **Bug fixes:**
 
@@ -10,12 +10,14 @@ fix(sso): unify SAML response processing and fix provider/config bugs
 - Fix `acsEndpoint` skipping DB provider lookup when `defaultSSO` is configured
 - Fix `acsEndpoint` missing encryption fields (`isAssertionEncrypted`, `encPrivateKey`), which caused silent decryption failures
 - Fix `defaultSSO` config parsing in callback path (`safeJsonParse` on already-parsed objects)
-- Fix `createSP` missing `callbackUrl` fallback to auto-generated ACS URL
+- Generate the default ACS URL from `baseURL` and `providerId`; `callbackUrl`
+  remains a post-auth redirect
 - Complete `createSP`/`createIdP` helpers with all encryption and signing fields
 
 **Behavioral changes:**
 
-- ACS error redirect query parameters now use uppercase error codes (e.g. `error=SAML_MULTIPLE_ASSERTIONS` instead of `error=multiple_assertions`). If your application parses these error codes from the redirect URL, update the expected values.
+- ACS error redirects now use the full lowercase code, such as
+  `error=saml_multiple_assertions` instead of `error=multiple_assertions`.
 - SAML provider registration now rejects configs with no usable IdP entry point (no valid `entryPoint` URL, no `idpMetadata.metadata`, and no `idpMetadata.singleSignOnService`). Previously these would register successfully but fail at sign-in.
 - `entryPoint` validation tightened from `startsWith("http")` to `new URL()` parsing, rejecting malformed URLs like `http:evil` or `http//missing-colon`.
 

--- a/.changeset/sso-saml-model-split.md
+++ b/.changeset/sso-saml-model-split.md
@@ -4,8 +4,10 @@
 
 ### Breaking: SAML configuration changes
 
-**`callbackUrl` removed from `samlConfig`.**
-The ACS URL is now always derived from your `baseURL` and `providerId`. Remove `callbackUrl` from your SAML provider configuration. The post-login redirect destination is set per sign-in via `callbackURL` in `signIn.sso()`:
+**`callbackUrl` no longer configures the ACS URL.**
+The default ACS URL is derived from `baseURL` and `providerId`. Use `callbackUrl`
+as the provider-level post-auth redirect, or pass `callbackURL` to `signIn.sso()`
+for an SP-initiated request:
 
 ```ts
 await authClient.signIn.sso({


### PR DESCRIPTION
Aligns the SAML release notes with the final behavior from #9097, #9117, #10178, and #10388.

---

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates `@better-auth/sso` SAML release notes to match the final behavior. The notes now document lowercase, fully qualified ACS error codes and clarify that `callbackUrl` is a post-auth redirect, not ACS configuration.

- Default ACS URL is derived from `baseURL` and `providerId`. Do not configure ACS via `callbackUrl`.
- Use provider-level `callbackUrl` for post-auth redirect, or pass `callbackURL` to `signIn.sso()` for SP-initiated flows.
- Update clients that parse ACS error redirects to expect lowercase full codes (e.g., `saml_multiple_assertions`).
- Provider registration rejects configs without a valid IdP entry point; ensure `entryPoint` is a valid URL or include SSO service in IdP metadata.

<sup>Written for commit bd55e2fa468f0a0db23e39b46f243101b5f3ea92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

