### PR TITLE
fix(oauth-provider): validate DPoP against public URL

### DIFF
--- a/.changeset/dpop-public-endpoint-url.md
+++ b/.changeset/dpop-public-endpoint-url.md
@@ -1,0 +1,6 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Fix DPoP proof validation behind reverse proxies when public token or UserInfo
+endpoint URLs differ from internal request URLs.

--- a/packages/oauth-provider/src/dpop.ts
+++ b/packages/oauth-provider/src/dpop.ts
@@ -5,10 +5,3 @@ export function getDpopProofJwt(
 ): string | undefined {
 	return ctx.headers?.get("dpop") ?? undefined;
 }
-
-export function getEndpointUrl(
-	ctx: Pick<GenericEndpointContext, "context"> & { request?: Request },
-	path: string,
-): string {
-	return ctx.request?.url ?? `${ctx.context.baseURL}${path}`;
-}

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -4602,6 +4602,8 @@ describe("oauth token - DPoP", async () => {
 	const jwtResource = "https://dpop-api.example.com";
 	const dpopRequiredResource = "https://dpop-required.example.com";
 	const tokenEndpoint = `${authServerBaseUrl}/api/auth/oauth2/token`;
+	const internalTokenEndpoint =
+		"http://auth-service:3000/api/auth/oauth2/token";
 
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
 		baseURL: `${authServerBaseUrl}/api/auth/`,
@@ -4774,39 +4776,55 @@ describe("oauth token - DPoP", async () => {
 
 	it("validates DPoP against the public token endpoint URL", async () => {
 		const dpopKey = await createDpopKey();
-		const { code, codeVerifier } = await authorizeForCode(
-			dpopKey.jkt,
-			jwtResource,
-		);
-		const proof = await createDpopProof({
-			privateKey: dpopKey.privateKey,
-			publicJwk: dpopKey.publicJwk,
-			method: "POST",
-			url: tokenEndpoint,
-			jti: "public-endpoint-proof",
-		});
-		const { body, headers: requestHeaders } = await authorizationCodeRequest({
-			code,
-			codeVerifier,
-			redirectURI: redirectUri,
-			resource: jwtResource,
-			options: {
-				clientId: oauthClient!.client_id,
-				clientSecret: oauthClient!.client_secret!,
+
+		async function requestTokenWithProofUrl(proofUrl: string, jti: string) {
+			const { code, codeVerifier } = await authorizeForCode(
+				dpopKey.jkt,
+				jwtResource,
+			);
+			const proof = await createDpopProof({
+				privateKey: dpopKey.privateKey,
+				publicJwk: dpopKey.publicJwk,
+				method: "POST",
+				url: proofUrl,
+				jti,
+			});
+			const { body, headers: requestHeaders } = await authorizationCodeRequest({
+				code,
+				codeVerifier,
 				redirectURI: redirectUri,
-			},
-		});
-		const headers = new Headers(requestHeaders);
-		headers.set("DPoP", proof);
+				resource: jwtResource,
+				options: {
+					clientId: oauthClient!.client_id,
+					clientSecret: oauthClient!.client_secret!,
+					redirectURI: redirectUri,
+				},
+			});
+			const headers = new Headers(requestHeaders);
+			headers.set("DPoP", proof);
 
-		const response = await customFetchImpl(
-			"http://auth-service:3000/api/auth/oauth2/token",
-			{ method: "POST", body, headers },
+			const response = await customFetchImpl(internalTokenEndpoint, {
+				method: "POST",
+				body,
+				headers,
+			});
+			const tokens: OAuthTokenResponse = await response.json();
+			return { response, tokens };
+		}
+
+		const publicRequest = await requestTokenWithProofUrl(
+			tokenEndpoint,
+			"public-endpoint-proof",
 		);
-		const tokens: OAuthTokenResponse = await response.json();
+		expect(publicRequest.response.status).toBe(200);
+		expect(publicRequest.tokens.token_type).toBe("DPoP");
 
-		expect(response.status).toBe(200);
-		expect(tokens.token_type).toBe("DPoP");
+		const internalRequest = await requestTokenWithProofUrl(
+			internalTokenEndpoint,
+			"internal-endpoint-proof",
+		);
+		expect(internalRequest.response.status).toBe(400);
+		expect(internalRequest.tokens.error).toBe("invalid_dpop_proof");
 	});
 
 	it("rejects a token request without a proof when the resource requires DPoP", async () => {

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -4604,7 +4604,7 @@ describe("oauth token - DPoP", async () => {
 	const tokenEndpoint = `${authServerBaseUrl}/api/auth/oauth2/token`;
 
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
-		baseURL: authServerBaseUrl,
+		baseURL: `${authServerBaseUrl}/api/auth/`,
 		plugins: [
 			jwt({ jwt: { issuer: authServerBaseUrl } }),
 			oauthProvider({
@@ -4770,6 +4770,43 @@ describe("oauth token - DPoP", async () => {
 		expect(tokens.data?.token_type).toBe("DPoP");
 		const payload = decodeJwt(tokens.data!.access_token!);
 		expect(payload.cnf).toMatchObject({ jkt: dpopKey.jkt });
+	});
+
+	it("validates DPoP against the public token endpoint URL", async () => {
+		const dpopKey = await createDpopKey();
+		const { code, codeVerifier } = await authorizeForCode(
+			dpopKey.jkt,
+			jwtResource,
+		);
+		const proof = await createDpopProof({
+			privateKey: dpopKey.privateKey,
+			publicJwk: dpopKey.publicJwk,
+			method: "POST",
+			url: tokenEndpoint,
+			jti: "public-endpoint-proof",
+		});
+		const { body, headers: requestHeaders } = await authorizationCodeRequest({
+			code,
+			codeVerifier,
+			redirectURI: redirectUri,
+			resource: jwtResource,
+			options: {
+				clientId: oauthClient!.client_id,
+				clientSecret: oauthClient!.client_secret!,
+				redirectURI: redirectUri,
+			},
+		});
+		const headers = new Headers(requestHeaders);
+		headers.set("DPoP", proof);
+
+		const response = await customFetchImpl(
+			"http://auth-service:3000/api/auth/oauth2/token",
+			{ method: "POST", body, headers },
+		);
+		const tokens: OAuthTokenResponse = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(tokens.token_type).toBe("DPoP");
 	});
 
 	it("rejects a token request without a proof when the resource requires DPoP", async () => {

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -22,7 +22,7 @@ import {
 } from "./authentication-context";
 import { resolveAccessTokenClaims } from "./claims";
 import { getRequestedUserInfoClaims } from "./claims-request";
-import { getDpopProofJwt, getEndpointUrl } from "./dpop";
+import { getDpopProofJwt } from "./dpop";
 import {
 	collectExtensionIdTokenClaims,
 	getExtensionGrantHandler,
@@ -817,7 +817,7 @@ async function resolveDpopTokenBinding(
 		const proof = await verifyDpopProof({
 			proofJwt: dpopProofJwt,
 			method: "POST",
-			url: getEndpointUrl(ctx, "/oauth2/token"),
+			url: `${ctx.context.baseURL.replace(/\/+$/, "")}/oauth2/token`,
 			expectedJkt,
 			proofMaxAgeSeconds: opts.dpop?.proofMaxAgeSeconds,
 			signingAlgorithms: opts.dpop?.signingAlgorithms,

--- a/packages/oauth-provider/src/userinfo.test.ts
+++ b/packages/oauth-provider/src/userinfo.test.ts
@@ -27,7 +27,7 @@ describe("oauth userinfo", async () => {
 	const rpBaseUrl = "http://localhost:5000";
 	const validResource = "https://myapi.example.com";
 	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
-		baseURL: authServerBaseUrl,
+		baseURL: `${authServerBaseUrl}/api/auth/`,
 		plugins: [
 			jwt({
 				jwt: {
@@ -527,8 +527,8 @@ describe("oauth userinfo", async () => {
 			jti: "userinfo-proof",
 			accessToken: tokens.data?.access_token,
 		});
-		const userinfo = await client.$fetch<Record<string, string>>(
-			"/oauth2/userinfo",
+		const response = await customFetchImpl(
+			"http://auth-service:3000/api/auth/oauth2/userinfo",
 			{
 				headers: {
 					authorization: `DPoP ${tokens.data?.access_token ?? ""}`,
@@ -536,8 +536,10 @@ describe("oauth userinfo", async () => {
 				},
 			},
 		);
+		const userinfo: Record<string, string> = await response.json();
 
-		expect(userinfo.data).toMatchObject({
+		expect(response.status).toBe(200);
+		expect(userinfo).toMatchObject({
 			sub: user.id,
 			name: user.name,
 			email: user.email,

--- a/packages/oauth-provider/src/userinfo.ts
+++ b/packages/oauth-provider/src/userinfo.ts
@@ -8,7 +8,7 @@ import {
 	parseAccessTokenAuthorization,
 } from "better-auth/oauth2";
 import type { User } from "better-auth/types";
-import { getDpopProofJwt, getEndpointUrl } from "./dpop";
+import { getDpopProofJwt } from "./dpop";
 import {
 	collectExtensionUserInfoClaims,
 	hasUserInfoClaimExtension,
@@ -143,7 +143,7 @@ export async function userInfoEndpoint(
 			authorization: accessTokenAuthorization,
 			proofJwt: getDpopProofJwt(ctx),
 			method: ctx.request?.method ?? "GET",
-			url: getEndpointUrl(ctx, "/oauth2/userinfo"),
+			url: `${ctx.context.baseURL.replace(/\/+$/, "")}/oauth2/userinfo`,
 			proofMaxAgeSeconds: opts.dpop?.proofMaxAgeSeconds,
 			signingAlgorithms: opts.dpop?.signingAlgorithms,
 			replayStore: createDpopReplayStore(ctx.context.internalAdapter),


### PR DESCRIPTION
Related to #10039

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate DPoP proofs against public OAuth endpoint URLs derived from baseURL, not the incoming request URL. Old behavior compared htu to the request URL; new behavior compares to `${baseURL}/oauth2/token` and `${baseURL}/oauth2/userinfo` (trailing slashes trimmed). Proofs bound to internal service URLs are now rejected.

- Remove `getEndpointUrl`; build public endpoints from `ctx.context.baseURL` in token and UserInfo verification.
- Expand tests to accept proofs for public endpoints when requests hit internal URLs, and to reject proofs created for internal endpoints.
- Publish a patch for `@better-auth/oauth-provider`.
- No request/response shape changes.

**Migration**
- Set `baseURL` to your public auth origin (for example, https://auth.example.com/api/auth). Ensure DPoP clients compute htu using the public token and UserInfo endpoints.

<sup>Written for commit 3f1a1fc5ebc61c1ef4da901170c29c1cde96a2dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

