### PR TITLE
fix(types): make plugin declarations portable

### DIFF
--- a/.changeset/tidy-plugin-declarations.md
+++ b/.changeset/tidy-plugin-declarations.md
@@ -1,0 +1,13 @@
+---
+"@better-auth/api-key": patch
+"@better-auth/electron": patch
+"@better-auth/expo": patch
+"@better-auth/i18n": patch
+"@better-auth/oauth-provider": patch
+"@better-auth/passkey": patch
+"@better-auth/scim": patch
+"@better-auth/sso": patch
+"better-auth": patch
+---
+
+Use public plugin types to keep inferred auth declarations portable.

--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -74,16 +74,27 @@ Both server and client plugins can use the same `id`.
 ```ts title="plugin.ts"
 import type { BetterAuthPlugin } from "better-auth";
 
-export const myPlugin = () => {
+const createMyPlugin = () => {
     return {
         id: "my-plugin",
     } satisfies BetterAuthPlugin
 }
+
+type InferredMyPlugin = ReturnType<typeof createMyPlugin>;
+
+/**
+ * The plugin instance.
+ */
+export interface MyPlugin extends InferredMyPlugin {}
+
+export const myPlugin = (): MyPlugin => createMyPlugin();
 ```
 
 <Callout>
   You don't have to make the plugin a function, but it's recommended to do so. This way, you can pass options to the plugin and it's consistent with the built-in plugins.
 </Callout>
+
+Using an internal factory with a named public interface preserves exact inference while keeping generated declarations portable for consumers of published plugins.
 
 ### Endpoints
 

--- a/docs/content/docs/concepts/typescript.mdx
+++ b/docs/content/docs/concepts/typescript.mdx
@@ -31,9 +31,10 @@ if you can't set `strict` to `true`, you can enable `strictNullChecks`:
 
 When `strict` is `true`, `strictNullChecks` is enabled as well. If you explicitly set `strictNullChecks` to `false`, type inference issues could occur.
 
-<Callout type="warn">
-  If you're running into issues with TypeScript inference exceeding maximum length the compiler will serialize,
-  then please make sure you're following the instructions above, as well as ensuring that both `declaration` and `composite` are not enabled.
+<Callout type="info">
+  Better Auth supports projects that enable `declaration` or `composite`. If you publish a custom plugin,
+  expose a named plugin type as shown in the <Link href="/docs/guides/your-first-plugin">plugin guide</Link>
+  so generated declarations remain portable.
 </Callout>
 
 ## Inferring Types

--- a/docs/content/docs/guides/your-first-plugin.mdx
+++ b/docs/content/docs/guides/your-first-plugin.mdx
@@ -42,15 +42,26 @@ In this guide, we’ll walk you through the steps of creating your first Better 
     This will be what we will later add to our plugin list in the `auth.ts` file.
 
     ```ts title="index.ts"
-    import { createAuthClient } from "better-auth/client";
     import type { BetterAuthPlugin } from "better-auth";
 
-    export const birthdayPlugin = () =>
+    const createBirthdayPlugin = () =>
       ({
         id: "birthdayPlugin",
       } satisfies BetterAuthPlugin);
 
+    type InferredBirthdayPlugin = ReturnType<typeof createBirthdayPlugin>;
+
+    /**
+     * The birthday plugin instance.
+     */
+    export interface BirthdayPlugin extends InferredBirthdayPlugin {}
+
+    export const birthdayPlugin = (): BirthdayPlugin =>
+      createBirthdayPlugin();
     ```
+
+    The internal factory preserves the plugin's exact inferred type, while the exported interface gives TypeScript
+    a stable public name to use when another package generates declarations.
 
     Although this does nothing, you have technically just made yourself your first plugin, congratulations! 🎉
   </Step>
@@ -68,7 +79,7 @@ In this guide, we’ll walk you through the steps of creating your first Better 
 
     ```ts title="index.ts"
     //...
-    export const birthdayPlugin = () =>
+    const createBirthdayPlugin = () =>
       ({
         id: "birthdayPlugin",
         schema: {// [!code highlight]
@@ -95,7 +106,7 @@ In this guide, we’ll walk you through the steps of creating your first Better 
     To do this, we’ll utilize <Link href="/docs/concepts/plugins#hooks">Hooks</Link>, which allows us to run code `before` or `after` an action is performed.
 
     ```ts title="index.ts"
-    export const birthdayPlugin = () => ({
+    const createBirthdayPlugin = () => ({
         //...
         // In our case, we want to write authorization logic,
         // meaning we want to intercept it `before` hand.
@@ -175,14 +186,12 @@ In this guide, we’ll walk you through the steps of creating your first Better 
 
     ```ts title="client.ts"
     import type { BetterAuthClientPlugin } from "better-auth/client";
-    import type { birthdayPlugin } from "./index"; // make sure to import the server plugin as a type // [!code highlight]
-
-    type BirthdayPlugin = typeof birthdayPlugin;
+    import type { BirthdayPlugin } from "./index"; // [!code highlight]
 
     export const birthdayClientPlugin = () => {
       return {
         id: "birthdayPlugin",
-        $InferServerPlugin: {} as ReturnType<BirthdayPlugin>,
+        $InferServerPlugin: {} as BirthdayPlugin,
       } satisfies BetterAuthClientPlugin;
     };
     ```

--- a/e2e/smoke/test/fixtures/tsconfig-composite-client/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-composite-client/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --build tsconfig.json"
+    "typecheck": "tsc --build tsconfig.json --force"
   },
   "dependencies": {
     "better-auth": "workspace:*",

--- a/e2e/smoke/test/fixtures/tsconfig-declaration/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --project tsconfig.json"
+    "typecheck": "tsc --build tsconfig.json --force"
   },
   "dependencies": {
     "@better-auth/api-key": "workspace:*",

--- a/e2e/smoke/test/fixtures/tsconfig-declaration/package.json
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/package.json
@@ -7,8 +7,12 @@
   },
   "dependencies": {
     "@better-auth/api-key": "workspace:*",
+    "@better-auth/electron": "workspace:*",
+    "@better-auth/expo": "workspace:*",
+    "@better-auth/i18n": "workspace:*",
     "@better-auth/oauth-provider": "workspace:*",
     "@better-auth/passkey": "workspace:*",
+    "@better-auth/scim": "workspace:*",
     "@better-auth/sso": "workspace:*",
     "@better-auth/stripe": "workspace:*",
     "better-auth": "workspace:*",

--- a/e2e/smoke/test/fixtures/tsconfig-declaration/src/api-key.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/src/api-key.ts
@@ -3,10 +3,13 @@ import { betterAuth } from "better-auth";
 
 /**
  * @see https://github.com/better-auth/better-auth/issues/9757
+ * @see https://github.com/better-auth/better-auth/issues/10710
  *
- * Declaration emit must not produce TS4023 for MiddlewareOptions
- * when using the api-key plugin.
+ * Declaration emit must use the public ApiKeyPlugin type instead of
+ * leaking transitive endpoint schema types.
  */
-export const auth = betterAuth({
-	plugins: [apiKey()],
-});
+export function initAuth() {
+	return betterAuth({
+		plugins: [apiKey()],
+	});
+}

--- a/e2e/smoke/test/fixtures/tsconfig-declaration/src/client.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/src/client.ts
@@ -1,0 +1,56 @@
+import { apiKeyClient } from "@better-auth/api-key/client";
+import { electronProxyClient } from "@better-auth/electron/proxy";
+import { i18nClient } from "@better-auth/i18n/client";
+import { oauthProviderClient } from "@better-auth/oauth-provider/client";
+import { passkeyClient } from "@better-auth/passkey/client";
+import { scimClient } from "@better-auth/scim/client";
+import { ssoClient } from "@better-auth/sso/client";
+import { stripeClient } from "@better-auth/stripe/client";
+import { createAuthClient } from "better-auth/client";
+import {
+	adminClient,
+	anonymousClient,
+	deviceAuthorizationClient,
+	emailOTPClient,
+	genericOAuthClient,
+	jwtClient,
+	magicLinkClient,
+	multiSessionClient,
+	oauthPopupClient,
+	oidcClient,
+	oneTimeTokenClient,
+	organizationClient,
+	phoneNumberClient,
+	siweClient,
+	twoFactorClient,
+	usernameClient,
+} from "better-auth/client/plugins";
+
+export const authClient = createAuthClient({
+	plugins: [
+		adminClient(),
+		anonymousClient(),
+		deviceAuthorizationClient(),
+		emailOTPClient(),
+		genericOAuthClient(),
+		jwtClient(),
+		magicLinkClient(),
+		multiSessionClient(),
+		oauthPopupClient(),
+		oidcClient(),
+		oneTimeTokenClient(),
+		organizationClient(),
+		phoneNumberClient(),
+		siweClient(),
+		twoFactorClient(),
+		usernameClient(),
+		apiKeyClient(),
+		electronProxyClient({ protocol: "app://" }),
+		i18nClient(),
+		oauthProviderClient(),
+		passkeyClient(),
+		scimClient(),
+		ssoClient(),
+		stripeClient({ subscription: true }),
+	],
+});

--- a/e2e/smoke/test/fixtures/tsconfig-declaration/src/demo.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/src/demo.ts
@@ -9,16 +9,31 @@ import {
 	bearer,
 	customSession,
 	deviceAuthorization,
+	emailOTP,
+	genericOAuth,
+	jwt,
 	lastLoginMethod,
+	magicLink,
+	mcp,
 	multiSession,
 	oAuthProxy,
+	oauthPopup,
+	oidcProvider,
 	oneTap,
+	oneTimeToken,
 	openAPI,
 	organization,
+	phoneNumber,
+	siwe,
 	twoFactor,
+	username,
 } from "better-auth/plugins";
 import { Stripe } from "stripe";
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10556
+ * @see https://github.com/better-auth/better-auth/issues/10789
+ */
 export const auth = betterAuth({
 	appName: "Better Auth Demo",
 	plugins: [
@@ -31,9 +46,28 @@ export const auth = betterAuth({
 		/* cspell:disable-next-line */
 		admin({ adminUserIds: ["EXD5zjob2SD6CBWcEQ6OpLRHcyoUbnaB"] }),
 		multiSession(),
+		emailOTP({ async sendVerificationOTP() {} }),
+		genericOAuth({ config: [] }),
+		jwt(),
+		magicLink({ async sendMagicLink() {} }),
+		mcp({ loginPage: "/login" }),
+		oauthPopup(),
 		oAuthProxy(),
+		oidcProvider({ loginPage: "/login" }),
 		nextCookies(),
 		oneTap(),
+		oneTimeToken(),
+		phoneNumber({ async sendOTP() {} }),
+		siwe({
+			domain: "localhost",
+			async getNonce() {
+				return "nonce";
+			},
+			async verifyMessage() {
+				return true;
+			},
+		}),
+		username(),
 		customSession(async (session) => {
 			return {
 				...session,

--- a/e2e/smoke/test/fixtures/tsconfig-declaration/src/index.ts
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/src/index.ts
@@ -1,13 +1,23 @@
+import { electron } from "@better-auth/electron";
+import { expo } from "@better-auth/expo";
+import { i18n } from "@better-auth/i18n";
 import { oauthProvider } from "@better-auth/oauth-provider";
+import { oauthProviderResourceClient } from "@better-auth/oauth-provider/resource-client";
+import { scim } from "@better-auth/scim";
 import { betterAuth } from "better-auth";
+import { createAuthClient } from "better-auth/client";
 import { organization } from "better-auth/plugins";
 import type { GoogleProfile, JoinConfig, JoinOption } from "better-auth/types";
 
 /**
  * @see https://github.com/better-auth/better-auth/issues/9378
+ * @see https://github.com/better-auth/better-auth/issues/10789
  */
 export const auth = betterAuth({
 	plugins: [
+		electron(),
+		expo(),
+		i18n({ translations: { en: {} } }),
 		organization({}),
 		oauthProvider({
 			loginPage: "/auth/sign-in",
@@ -16,7 +26,12 @@ export const auth = betterAuth({
 			allowDynamicClientRegistration: true,
 			allowUnauthenticatedClientRegistration: true,
 		}),
+		scim(),
 	],
+});
+
+export const resourceClient = createAuthClient({
+	plugins: [oauthProviderResourceClient()],
 });
 
 auth.api

--- a/e2e/smoke/test/fixtures/tsconfig-declaration/tsconfig.json
+++ b/e2e/smoke/test/fixtures/tsconfig-declaration/tsconfig.json
@@ -14,6 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "declaration": true
+    "declaration": true,
+    "composite": true
   }
 }

--- a/e2e/smoke/test/typecheck.spec.ts
+++ b/e2e/smoke/test/typecheck.spec.ts
@@ -7,108 +7,111 @@ import { fileURLToPath } from "node:url";
 
 const fixturesDir = fileURLToPath(new URL("./fixtures", import.meta.url));
 
-[
-	{ dir: "tsconfig-declaration", skip: false },
-	{ dir: "tsconfig-composite-client", skip: false },
-	{ dir: "tsconfig-exact-optional-property-types", skip: false },
-	{ dir: "tsconfig-verbatim-module-syntax-node10", skip: false },
-	{ dir: "tsconfig-isolated-module-bundler", skip: false },
-].forEach(({ dir, skip }) => {
-	test(`typecheck ${dir}`, { skip }, () => {
-		const cwd = resolve(fixturesDir, dir);
-		const output = spawnSync("pnpm", ["run", "typecheck"], {
-			stdio: "inherit",
-			cwd,
-			timeout: 10 * 1000, // 10 seconds
-		});
-		assert.equal(
-			output.error,
-			undefined,
-			`Running typecheck in ${cwd} should not throw an error`,
-		);
-		assert.equal(
-			output.status,
-			0,
-			`Running typecheck in ${cwd} should exit with status 0`,
-		);
-
-		if (dir === "tsconfig-declaration") {
-			const apiKeyDeclaration = readFileSync(
-				resolve(cwd, "dist/api-key.d.ts"),
-				"utf8",
-			);
-			assert.match(
-				apiKeyDeclaration,
-				/import\("@better-auth\/api-key"\)\.ApiKeyPlugin/,
-				"API Key declarations should use the public plugin type",
-			);
-
-			const demoDeclaration = readFileSync(
-				resolve(cwd, "dist/demo.d.ts"),
-				"utf8",
-			);
-			const publicPluginTypes = [
-				"AdminPlugin",
-				"CustomSessionPlugin",
-				"DeviceAuthorizationPlugin",
-				"EmailOTPPlugin",
-				"GenericOAuthPlugin",
-				"JwtPlugin",
-				"MagicLinkPlugin",
-				"MCPPlugin",
-				"MultiSessionPlugin",
-				"OAuthPopupPlugin",
-				"OAuthProxyPlugin",
-				"OIDCProviderPlugin",
-				"OneTapPlugin",
-				"OneTimeTokenPlugin",
-				"PhoneNumberPlugin",
-				"SIWEPlugin",
-				"TwoFactorPlugin",
-				"UsernamePlugin",
-			];
-			for (const pluginType of publicPluginTypes) {
-				assert.match(
-					demoDeclaration,
-					new RegExp(`import\\("better-auth/plugins"\\)\\.${pluginType}`),
-					`${pluginType} declarations should use the public plugin type`,
-				);
-			}
-			assert.match(
-				demoDeclaration,
-				/import\("@better-auth\/passkey"\)\.PasskeyPlugin/,
-				"Passkey declarations should use the public plugin type",
-			);
-			assert.match(
-				demoDeclaration,
-				/import\("@better-auth\/sso"\)\.SSODomainVerificationPlugin/,
-				"SSO declarations should use the public plugin type",
-			);
-
-			const oauthProviderDeclaration = readFileSync(
-				resolve(cwd, "dist/index.d.ts"),
-				"utf8",
-			);
-			const externalPluginTypes = [
-				["@better-auth/electron", "ElectronPlugin"],
-				["@better-auth/expo", "ExpoPlugin"],
-				["@better-auth/i18n", "I18nPlugin"],
-				["@better-auth/oauth-provider", "OAuthProviderPlugin"],
-				[
-					"@better-auth/oauth-provider/resource-client",
-					"OAuthProviderResourceClientPlugin",
-				],
-				["@better-auth/scim", "SCIMPlugin"],
-			] as const;
-			for (const [moduleName, pluginType] of externalPluginTypes) {
-				assert.match(
-					oauthProviderDeclaration,
-					new RegExp(
-						`import\\("${moduleName.replaceAll("/", "\\/")}\"\\)\\.${pluginType}`,
-					),
-					`${pluginType} declarations should use the public plugin type`,
-				);
-			}
-		}
+function runTypecheckFixture(dir: string) {
+	const cwd = resolve(fixturesDir, dir);
+	const output = spawnSync("pnpm", ["run", "typecheck"], {
+		stdio: "inherit",
+		cwd,
+		timeout: 10 * 1000, // 10 seconds
 	});
+	assert.equal(
+		output.error,
+		undefined,
+		`Running typecheck in ${cwd} should not throw an error`,
+	);
+	assert.equal(
+		output.status,
+		0,
+		`Running typecheck in ${cwd} should exit with status 0`,
+	);
+	return cwd;
+}
+
+function assertPublicPluginType(
+	declaration: string,
+	moduleName: string,
+	pluginType: string,
+) {
+	assert.ok(
+		declaration.includes(`import("${moduleName}").${pluginType}`),
+		`${pluginType} declarations should use the public plugin type`,
+	);
+}
+
+for (const dir of [
+	"tsconfig-composite-client",
+	"tsconfig-exact-optional-property-types",
+	"tsconfig-verbatim-module-syntax-node10",
+	"tsconfig-isolated-module-bundler",
+]) {
+	test(`typecheck ${dir}`, () => {
+		runTypecheckFixture(dir);
+	});
+}
+
+test("emits portable public plugin types in declarations", () => {
+	const cwd = runTypecheckFixture("tsconfig-declaration");
+	const apiKeyDeclaration = readFileSync(
+		resolve(cwd, "dist/api-key.d.ts"),
+		"utf8",
+	);
+	assertPublicPluginType(
+		apiKeyDeclaration,
+		"@better-auth/api-key",
+		"ApiKeyPlugin",
+	);
+
+	const demoDeclaration = readFileSync(resolve(cwd, "dist/demo.d.ts"), "utf8");
+	const publicPluginTypes = [
+		"AdminPlugin",
+		"CustomSessionPlugin",
+		"DeviceAuthorizationPlugin",
+		"EmailOTPPlugin",
+		"GenericOAuthPlugin",
+		"JwtPlugin",
+		"MagicLinkPlugin",
+		"MCPPlugin",
+		"MultiSessionPlugin",
+		"OAuthPopupPlugin",
+		"OAuthProxyPlugin",
+		"OIDCProviderPlugin",
+		"OneTapPlugin",
+		"OneTimeTokenPlugin",
+		"PhoneNumberPlugin",
+		"SIWEPlugin",
+		"TwoFactorPlugin",
+		"UsernamePlugin",
+	];
+	for (const pluginType of publicPluginTypes) {
+		assertPublicPluginType(demoDeclaration, "better-auth/plugins", pluginType);
+	}
+	assertPublicPluginType(
+		demoDeclaration,
+		"@better-auth/passkey",
+		"PasskeyPlugin",
+	);
+	assertPublicPluginType(
+		demoDeclaration,
+		"@better-auth/sso",
+		"SSODomainVerificationPlugin",
+	);
+
+	const indexDeclaration = readFileSync(
+		resolve(cwd, "dist/index.d.ts"),
+		"utf8",
+	);
+	const externalPluginTypes = [
+		["@better-auth/electron", "ElectronPlugin"],
+		["@better-auth/expo", "ExpoPlugin"],
+		["@better-auth/i18n", "I18nPlugin"],
+		["@better-auth/oauth-provider", "OAuthProviderPlugin"],
+		[
+			"@better-auth/oauth-provider/resource-client",
+			"OAuthProviderResourceClientPlugin",
+		],
+		["@better-auth/scim", "SCIMPlugin"],
+	] as const;
+	for (const [moduleName, pluginType] of externalPluginTypes) {
+		assertPublicPluginType(indexDeclaration, moduleName, pluginType);
+	}
 });

--- a/e2e/smoke/test/typecheck.spec.ts
+++ b/e2e/smoke/test/typecheck.spec.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -30,5 +31,84 @@ const fixturesDir = fileURLToPath(new URL("./fixtures", import.meta.url));
 			0,
 			`Running typecheck in ${cwd} should exit with status 0`,
 		);
+
+		if (dir === "tsconfig-declaration") {
+			const apiKeyDeclaration = readFileSync(
+				resolve(cwd, "dist/api-key.d.ts"),
+				"utf8",
+			);
+			assert.match(
+				apiKeyDeclaration,
+				/import\("@better-auth\/api-key"\)\.ApiKeyPlugin/,
+				"API Key declarations should use the public plugin type",
+			);
+
+			const demoDeclaration = readFileSync(
+				resolve(cwd, "dist/demo.d.ts"),
+				"utf8",
+			);
+			const publicPluginTypes = [
+				"AdminPlugin",
+				"CustomSessionPlugin",
+				"DeviceAuthorizationPlugin",
+				"EmailOTPPlugin",
+				"GenericOAuthPlugin",
+				"JwtPlugin",
+				"MagicLinkPlugin",
+				"MCPPlugin",
+				"MultiSessionPlugin",
+				"OAuthPopupPlugin",
+				"OAuthProxyPlugin",
+				"OIDCProviderPlugin",
+				"OneTapPlugin",
+				"OneTimeTokenPlugin",
+				"PhoneNumberPlugin",
+				"SIWEPlugin",
+				"TwoFactorPlugin",
+				"UsernamePlugin",
+			];
+			for (const pluginType of publicPluginTypes) {
+				assert.match(
+					demoDeclaration,
+					new RegExp(`import\\("better-auth/plugins"\\)\\.${pluginType}`),
+					`${pluginType} declarations should use the public plugin type`,
+				);
+			}
+			assert.match(
+				demoDeclaration,
+				/import\("@better-auth\/passkey"\)\.PasskeyPlugin/,
+				"Passkey declarations should use the public plugin type",
+			);
+			assert.match(
+				demoDeclaration,
+				/import\("@better-auth\/sso"\)\.SSODomainVerificationPlugin/,
+				"SSO declarations should use the public plugin type",
+			);
+
+			const oauthProviderDeclaration = readFileSync(
+				resolve(cwd, "dist/index.d.ts"),
+				"utf8",
+			);
+			const externalPluginTypes = [
+				["@better-auth/electron", "ElectronPlugin"],
+				["@better-auth/expo", "ExpoPlugin"],
+				["@better-auth/i18n", "I18nPlugin"],
+				["@better-auth/oauth-provider", "OAuthProviderPlugin"],
+				[
+					"@better-auth/oauth-provider/resource-client",
+					"OAuthProviderResourceClientPlugin",
+				],
+				["@better-auth/scim", "SCIMPlugin"],
+			] as const;
+			for (const [moduleName, pluginType] of externalPluginTypes) {
+				assert.match(
+					oauthProviderDeclaration,
+					new RegExp(
+						`import\\("${moduleName.replaceAll("/", "\\/")}\"\\)\\.${pluginType}`,
+					),
+					`${pluginType} declarations should use the public plugin type`,
+				);
+			}
+		}
 	});
 });

--- a/e2e/smoke/test/typecheck.spec.ts
+++ b/e2e/smoke/test/typecheck.spec.ts
@@ -39,7 +39,6 @@ function assertPublicPluginType(
 }
 
 for (const dir of [
-	"tsconfig-composite-client",
 	"tsconfig-exact-optional-property-types",
 	"tsconfig-verbatim-module-syntax-node10",
 	"tsconfig-isolated-module-bundler",
@@ -49,6 +48,25 @@ for (const dir of [
 	});
 }
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10789
+ */
+test("emits portable client plugin types in composite declarations", () => {
+	const cwd = runTypecheckFixture("tsconfig-composite-client");
+	const declaration = readFileSync(
+		resolve(cwd, ".tsc/app/lib/auth-client.d.ts"),
+		"utf8",
+	);
+	assertPublicPluginType(
+		declaration,
+		"better-auth/client/plugins",
+		"AdminPlugin",
+	);
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10789
+ */
 test("emits portable public plugin types in declarations", () => {
 	const cwd = runTypecheckFixture("tsconfig-declaration");
 	const apiKeyDeclaration = readFileSync(
@@ -114,4 +132,43 @@ test("emits portable public plugin types in declarations", () => {
 	for (const [moduleName, pluginType] of externalPluginTypes) {
 		assertPublicPluginType(indexDeclaration, moduleName, pluginType);
 	}
+
+	const clientDeclaration = readFileSync(
+		resolve(cwd, "dist/client.d.ts"),
+		"utf8",
+	);
+	const clientPluginTypes = [
+		["better-auth/plugins", "AdminPlugin"],
+		["better-auth/plugins", "AnonymousPlugin"],
+		["better-auth/plugins", "DeviceAuthorizationPlugin"],
+		["better-auth/plugins", "EmailOTPPlugin"],
+		["better-auth/plugins", "GenericOAuthPlugin"],
+		["better-auth/plugins", "JwtPlugin"],
+		["better-auth/plugins", "MagicLinkPlugin"],
+		["better-auth/plugins", "MultiSessionPlugin"],
+		["better-auth/plugins", "OAuthPopupPlugin"],
+		["better-auth/plugins", "OIDCProviderPlugin"],
+		["better-auth/plugins", "OneTimeTokenPlugin"],
+		["better-auth/plugins", "OrganizationPlugin"],
+		["better-auth/plugins", "PhoneNumberPlugin"],
+		["better-auth/plugins", "SIWEPlugin"],
+		["better-auth/plugins", "TwoFactorPlugin"],
+		["better-auth/plugins", "UsernamePlugin"],
+		["@better-auth/api-key", "ApiKeyPlugin"],
+		["@better-auth/electron", "ElectronPlugin"],
+		["@better-auth/i18n", "I18nPlugin"],
+		["@better-auth/oauth-provider", "OAuthProviderPlugin"],
+		["@better-auth/passkey", "PasskeyPlugin"],
+		["@better-auth/scim", "SCIMPlugin"],
+		["@better-auth/sso", "SSOPlugin"],
+		["@better-auth/stripe", "StripePlugin"],
+	] as const;
+	for (const [moduleName, pluginType] of clientPluginTypes) {
+		assertPublicPluginType(clientDeclaration, moduleName, pluginType);
+	}
+	assert.doesNotMatch(
+		clientDeclaration,
+		/node_modules|\.pnpm|\/dist\/|-[A-Za-z0-9_-]{6,}\.mjs/,
+		"Client declarations should not reference installation or build internals",
+	);
 });

--- a/packages/api-key/src/client.ts
+++ b/packages/api-key/src/client.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
-import type { apiKey } from ".";
+import type { ApiKeyPlugin } from ".";
 import { API_KEY_ERROR_CODES } from "./error-codes";
 import { PACKAGE_VERSION } from "./version";
 
@@ -9,7 +9,7 @@ export const apiKeyClient = () => {
 	return {
 		id: "api-key",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof apiKey>,
+		$InferServerPlugin: {} as ApiKeyPlugin,
 		pathMethods: {
 			"/api-key/create": "POST",
 			"/api-key/delete": "POST",
@@ -21,4 +21,5 @@ export const apiKeyClient = () => {
 
 export type ApiKeyClientPlugin = ReturnType<typeof apiKeyClient>;
 
+export type { ApiKeyPlugin } from ".";
 export type * from "./types";

--- a/packages/api-key/src/index.ts
+++ b/packages/api-key/src/index.ts
@@ -38,11 +38,13 @@ export { API_KEY_ERROR_CODES } from "./error-codes";
 
 export const API_KEY_TABLE_NAME = "apikey";
 
-export function apiKey(
-	_configurations?:
-		| (ApiKeyConfigurationOptions & ApiKeyOptions)
-		| ApiKeyConfigurationOptions[]
-		| undefined,
+type ApiKeyConfigurationInput =
+	| (ApiKeyConfigurationOptions & ApiKeyOptions)
+	| ApiKeyConfigurationOptions[]
+	| undefined;
+
+function createApiKeyPlugin(
+	_configurations?: ApiKeyConfigurationInput,
 	_options?: ApiKeyOptions | undefined,
 ) {
 	if (Array.isArray(_configurations) && _configurations.length > 0) {
@@ -382,6 +384,20 @@ export function apiKey(
 		},
 		schema,
 	} satisfies BetterAuthPlugin;
+}
+
+type InferredApiKeyPlugin = ReturnType<typeof createApiKeyPlugin>;
+
+/**
+ * The API Key plugin instance.
+ */
+export interface ApiKeyPlugin extends InferredApiKeyPlugin {}
+
+export function apiKey(
+	_configurations?: ApiKeyConfigurationInput,
+	_options?: ApiKeyOptions | undefined,
+): ApiKeyPlugin {
+	return createApiKeyPlugin(_configurations, _options);
 }
 
 export type * from "./types";

--- a/packages/better-auth/src/plugins/admin/admin.ts
+++ b/packages/better-auth/src/plugins/admin/admin.ts
@@ -38,7 +38,7 @@ declare module "@better-auth/core" {
 	}
 }
 
-export const admin = <O extends AdminOptions>(options?: O | undefined) => {
+const createAdminPlugin = <O extends AdminOptions>(options?: O | undefined) => {
 	const opts = {
 		...(options || {}),
 		defaultRole: options?.defaultRole ?? "user",
@@ -169,3 +169,17 @@ export const admin = <O extends AdminOptions>(options?: O | undefined) => {
 		options: options as NoInfer<O>,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredAdminPlugin<O extends AdminOptions> = ReturnType<
+	typeof createAdminPlugin<O>
+>;
+
+/**
+ * The admin plugin instance.
+ */
+export interface AdminPlugin<O extends AdminOptions = AdminOptions>
+	extends InferredAdminPlugin<O> {}
+
+export const admin = <O extends AdminOptions>(
+	options?: O | undefined,
+): AdminPlugin<O> => createAdminPlugin(options);

--- a/packages/better-auth/src/plugins/admin/client.ts
+++ b/packages/better-auth/src/plugins/admin/client.ts
@@ -3,7 +3,7 @@ import { PACKAGE_VERSION } from "../../version";
 import type { AccessControl, ArrayElement, Role } from "../access";
 import type { defaultStatements } from "./access";
 import { adminAc, userAc } from "./access";
-import type { admin } from "./admin";
+import type { AdminPlugin } from "./admin";
 import { ADMIN_ERROR_CODES } from "./error-codes";
 import { hasPermission } from "./has-permission";
 
@@ -44,19 +44,17 @@ export const adminClient = <O extends AdminClientOptions>(
 	return {
 		id: "admin-client",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<
-			typeof admin<{
-				ac: O["ac"] extends AccessControl
-					? O["ac"]
-					: AccessControl<DefaultStatements>;
-				roles: O["roles"] extends Record<string, Role>
-					? O["roles"]
-					: {
-							admin: Role;
-							user: Role;
-						};
-			}>
-		>,
+		$InferServerPlugin: {} as AdminPlugin<{
+			ac: O["ac"] extends AccessControl
+				? O["ac"]
+				: AccessControl<DefaultStatements>;
+			roles: O["roles"] extends Record<string, Role>
+				? O["roles"]
+				: {
+						admin: Role;
+						user: Role;
+					};
+		}>,
 		getActions: () => ({
 			admin: {
 				checkRolePermission: <
@@ -97,4 +95,5 @@ export const adminClient = <O extends AdminClientOptions>(
 	} satisfies BetterAuthClientPlugin;
 };
 
+export type { AdminPlugin } from "./admin";
 export type * from "./types";

--- a/packages/better-auth/src/plugins/anonymous/client.ts
+++ b/packages/better-auth/src/plugins/anonymous/client.ts
@@ -1,13 +1,13 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { anonymous } from ".";
+import type { AnonymousPlugin } from ".";
 import { ANONYMOUS_ERROR_CODES } from "./error-codes";
 
 export const anonymousClient = () => {
 	return {
 		id: "anonymous",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof anonymous>,
+		$InferServerPlugin: {} as AnonymousPlugin,
 		pathMethods: {
 			"/sign-in/anonymous": "POST",
 			"/delete-anonymous-user": "POST",
@@ -22,6 +22,7 @@ export const anonymousClient = () => {
 	} satisfies BetterAuthClientPlugin;
 };
 
+export type { AnonymousPlugin } from ".";
 export * from "./error-codes";
 export type * from "./schema";
 export type * from "./types";

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -356,4 +356,5 @@ export const anonymous = (options?: AnonymousOptions | undefined) => {
 	} satisfies BetterAuthPlugin;
 };
 
+export type AnonymousPlugin = ReturnType<typeof anonymous>;
 export type * from "./types";

--- a/packages/better-auth/src/plugins/custom-session/index.ts
+++ b/packages/better-auth/src/plugins/custom-session/index.ts
@@ -33,17 +33,25 @@ export type CustomSessionPluginOptions = {
 	shouldMutateListDeviceSessionsEndpoint?: boolean | undefined;
 };
 
-export const customSession = <
-	Returns extends Record<string, any>,
+/**
+ * Transforms the default session returned by the custom session plugin.
+ */
+export type CustomSessionHandler<
+	Result extends object,
+	O extends BetterAuthOptions = BetterAuthOptions,
+> = (
+	session: {
+		user: User<O["user"], O["plugins"]>;
+		session: Session<O["session"], O["plugins"]>;
+	},
+	ctx: GenericEndpointContext,
+) => Promise<Result>;
+
+const createCustomSessionPlugin = <
+	Result extends object,
 	O extends BetterAuthOptions = BetterAuthOptions,
 >(
-	fn: (
-		session: {
-			user: User<O["user"], O["plugins"]>;
-			session: Session<O["session"], O["plugins"]>;
-		},
-		ctx: GenericEndpointContext,
-	) => Promise<Returns>,
+	fn: CustomSessionHandler<Result, O>,
 	options?: O | undefined,
 	pluginOptions?: CustomSessionPluginOptions | undefined,
 ) => {
@@ -97,7 +105,7 @@ export const customSession = <
 					},
 					requireHeaders: true,
 				},
-				async (ctx): Promise<Returns | null> => {
+				async (ctx): Promise<Result | null> => {
 					const session = await getSession()({
 						...ctx,
 						method: "GET",
@@ -110,7 +118,10 @@ export const customSession = <
 					if (!session?.response) {
 						return ctx.json(null);
 					}
-					const fnResult = await fn(session.response as any, ctx);
+					const fnResult = await fn(
+						session.response as Parameters<typeof fn>[0],
+						ctx,
+					);
 
 					for (const cookieStr of session.headers.getSetCookie()) {
 						const parsed = parseSetCookieHeader(cookieStr);
@@ -133,3 +144,26 @@ export const customSession = <
 		options: pluginOptions,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredCustomSessionPlugin<
+	Result extends object,
+	O extends BetterAuthOptions,
+> = ReturnType<typeof createCustomSessionPlugin<Result, O>>;
+
+/**
+ * The custom session plugin instance.
+ */
+export interface CustomSessionPlugin<
+	Result extends object,
+	O extends BetterAuthOptions = BetterAuthOptions,
+> extends InferredCustomSessionPlugin<Result, O> {}
+
+export const customSession = <
+	Result extends object,
+	O extends BetterAuthOptions = BetterAuthOptions,
+>(
+	fn: CustomSessionHandler<Result, O>,
+	options?: O | undefined,
+	pluginOptions?: CustomSessionPluginOptions | undefined,
+): CustomSessionPlugin<Result, O> =>
+	createCustomSessionPlugin(fn, options, pluginOptions);

--- a/packages/better-auth/src/plugins/device-authorization/client.ts
+++ b/packages/better-auth/src/plugins/device-authorization/client.ts
@@ -1,12 +1,12 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { deviceAuthorization } from ".";
+import type { DeviceAuthorizationPlugin } from ".";
 
 export const deviceAuthorizationClient = () => {
 	return {
 		id: "device-authorization",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof deviceAuthorization>,
+		$InferServerPlugin: {} as DeviceAuthorizationPlugin,
 		pathMethods: {
 			"/device/code": "POST",
 			"/device/token": "POST",
@@ -16,3 +16,5 @@ export const deviceAuthorizationClient = () => {
 		},
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type { DeviceAuthorizationPlugin } from ".";

--- a/packages/better-auth/src/plugins/device-authorization/index.ts
+++ b/packages/better-auth/src/plugins/device-authorization/index.ts
@@ -126,7 +126,7 @@ export type DeviceAuthorizationOptions = z.infer<
 	typeof deviceAuthorizationOptionsSchema
 >;
 
-export const deviceAuthorization = (
+const createDeviceAuthorizationPlugin = (
 	options: Partial<DeviceAuthorizationOptions> = {},
 ) => {
 	const opts = deviceAuthorizationOptionsSchema.parse(options);
@@ -146,5 +146,19 @@ export const deviceAuthorization = (
 		options,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredDeviceAuthorizationPlugin = ReturnType<
+	typeof createDeviceAuthorizationPlugin
+>;
+
+/**
+ * The device authorization plugin instance.
+ */
+export interface DeviceAuthorizationPlugin
+	extends InferredDeviceAuthorizationPlugin {}
+
+export const deviceAuthorization = (
+	options: Partial<DeviceAuthorizationOptions> = {},
+): DeviceAuthorizationPlugin => createDeviceAuthorizationPlugin(options);
 
 export type * from "../../utils/time";

--- a/packages/better-auth/src/plugins/email-otp/client.ts
+++ b/packages/better-auth/src/plugins/email-otp/client.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { emailOTP } from ".";
+import type { EmailOTPPlugin } from ".";
 import { EMAIL_OTP_ERROR_CODES } from "./error-codes";
 
 export * from "./error-codes";
@@ -9,7 +9,7 @@ export const emailOTPClient = () => {
 	return {
 		id: "email-otp",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof emailOTP>,
+		$InferServerPlugin: {} as EmailOTPPlugin,
 		atomListeners: [
 			{
 				matcher: (path) =>
@@ -22,3 +22,5 @@ export const emailOTPClient = () => {
 		$ERROR_CODES: EMAIL_OTP_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type { EmailOTPPlugin } from ".";

--- a/packages/better-auth/src/plugins/email-otp/index.ts
+++ b/packages/better-auth/src/plugins/email-otp/index.ts
@@ -35,7 +35,7 @@ export type { EmailOTPOptions } from "./types";
 const defaultOTPGenerator = (options: EmailOTPOptions) =>
 	generateRandomString(options.otpLength ?? 6, "0-9");
 
-export const emailOTP = (options: EmailOTPOptions) => {
+const createEmailOTPPlugin = (options: EmailOTPOptions) => {
 	const opts = {
 		expiresIn: 5 * 60,
 		generateOTP: () => defaultOTPGenerator(options),
@@ -196,3 +196,13 @@ export const emailOTP = (options: EmailOTPOptions) => {
 		$ERROR_CODES: EMAIL_OTP_ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredEmailOTPPlugin = ReturnType<typeof createEmailOTPPlugin>;
+
+/**
+ * The email OTP plugin instance.
+ */
+export interface EmailOTPPlugin extends InferredEmailOTPPlugin {}
+
+export const emailOTP = (options: EmailOTPOptions): EmailOTPPlugin =>
+	createEmailOTPPlugin(options);

--- a/packages/better-auth/src/plugins/generic-oauth/client.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/client.ts
@@ -1,21 +1,22 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { genericOAuth } from ".";
+import type { GenericOAuthPlugin } from ".";
 import { GENERIC_OAUTH_ERROR_CODES } from "./error-codes";
 
 export const genericOAuthClient = () => {
 	return {
 		id: "generic-oauth-client",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof genericOAuth>,
+		$InferServerPlugin: {} as GenericOAuthPlugin,
 		$ERROR_CODES: GENERIC_OAUTH_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };
 
-export * from "./error-codes";
 export type {
 	BaseOAuthProviderOptions,
 	GenericOAuthConfig,
 	GenericOAuthOptions,
-} from "./index";
+	GenericOAuthPlugin,
+} from ".";
+export * from "./error-codes";
 export type * from "./providers";

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -58,10 +58,7 @@ export type BaseOAuthProviderOptions = Omit<
 	clientSecret: string;
 };
 
-/**
- * A generic OAuth plugin that can be used to add OAuth support to any provider
- */
-export const genericOAuth = (options: GenericOAuthOptions) => {
+const createGenericOAuthPlugin = (options: GenericOAuthOptions) => {
 	const seenIds = new Set<string>();
 	const nonUniqueIds = new Set<string>();
 
@@ -273,3 +270,17 @@ export const genericOAuth = (options: GenericOAuthOptions) => {
 		$ERROR_CODES: GENERIC_OAUTH_ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredGenericOAuthPlugin = ReturnType<typeof createGenericOAuthPlugin>;
+
+/**
+ * The generic OAuth plugin instance.
+ */
+export interface GenericOAuthPlugin extends InferredGenericOAuthPlugin {}
+
+/**
+ * A generic OAuth plugin that can be used to add OAuth support to any provider
+ */
+export const genericOAuth = (
+	options: GenericOAuthOptions,
+): GenericOAuthPlugin => createGenericOAuthPlugin(options);

--- a/packages/better-auth/src/plugins/jwt/client.ts
+++ b/packages/better-auth/src/plugins/jwt/client.ts
@@ -7,7 +7,7 @@ import type {
 import type { BetterFetch } from "@better-fetch/fetch";
 import type { JSONWebKeySet } from "jose";
 import { PACKAGE_VERSION } from "../../version";
-import type { jwt } from "./index";
+import type { JwtPlugin } from ".";
 
 interface JwtClientOptions {
 	jwks?: {
@@ -27,7 +27,7 @@ export const jwtClient = (options?: JwtClientOptions) => {
 	return {
 		id: "better-auth-client",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof jwt>,
+		$InferServerPlugin: {} as JwtPlugin,
 		pathMethods: {
 			[jwksPath]: "GET",
 		},
@@ -46,4 +46,5 @@ export const jwtClient = (options?: JwtClientOptions) => {
 	} satisfies BetterAuthClientPlugin;
 };
 
+export type { JwtPlugin } from ".";
 export type * from "./types";

--- a/packages/better-auth/src/plugins/jwt/index.ts
+++ b/packages/better-auth/src/plugins/jwt/index.ts
@@ -39,7 +39,7 @@ const verifyJWTBodySchema = z.object({
 	issuer: z.string().optional(),
 });
 
-export const jwt = <O extends JwtOptions>(options?: O) => {
+const createJwtPlugin = <O extends JwtOptions>(options?: O) => {
 	// Remote url must be set when using signing function
 	if (options?.jwt?.sign && !options.jwks?.remoteUrl) {
 		throw new BetterAuthError(
@@ -350,5 +350,18 @@ export const jwt = <O extends JwtOptions>(options?: O) => {
 		schema: mergeSchema(schema, options?.schema),
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredJwtPlugin<O extends JwtOptions> = ReturnType<
+	typeof createJwtPlugin<O>
+>;
+
+/**
+ * The JWT plugin instance.
+ */
+export interface JwtPlugin<O extends JwtOptions = JwtOptions>
+	extends InferredJwtPlugin<O> {}
+
+export const jwt = <O extends JwtOptions>(options?: O): JwtPlugin<O> =>
+	createJwtPlugin(options);
 
 export { getJwtToken };

--- a/packages/better-auth/src/plugins/magic-link/client.ts
+++ b/packages/better-auth/src/plugins/magic-link/client.ts
@@ -1,11 +1,13 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { magicLink } from ".";
+import type { MagicLinkPlugin } from ".";
 
 export const magicLinkClient = () => {
 	return {
 		id: "magic-link",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof magicLink>,
+		$InferServerPlugin: {} as MagicLinkPlugin,
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type { MagicLinkPlugin } from ".";

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -157,7 +157,7 @@ const magicLinkVerifyQuerySchema = z.object({
 		})
 		.optional(),
 });
-export const magicLink = (options: MagicLinkOptions) => {
+const createMagicLinkPlugin = (options: MagicLinkOptions) => {
 	const opts = {
 		storeToken: "plain",
 		allowedAttempts: 1,
@@ -456,3 +456,13 @@ export const magicLink = (options: MagicLinkOptions) => {
 		options,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredMagicLinkPlugin = ReturnType<typeof createMagicLinkPlugin>;
+
+/**
+ * The magic link plugin instance.
+ */
+export interface MagicLinkPlugin extends InferredMagicLinkPlugin {}
+
+export const magicLink = (options: MagicLinkOptions): MagicLinkPlugin =>
+	createMagicLinkPlugin(options);

--- a/packages/better-auth/src/plugins/mcp/index.ts
+++ b/packages/better-auth/src/plugins/mcp/index.ts
@@ -46,7 +46,10 @@ declare module "@better-auth/core" {
 	}
 }
 
-interface MCPOptions {
+/**
+ * Options for the MCP plugin.
+ */
+export interface MCPOptions {
 	loginPage: string;
 	resource?: string | undefined;
 	oidcConfig?: OIDCOptions | undefined;
@@ -179,7 +182,7 @@ const registerMcpClientBodySchema = z.object({
 
 const mcpOAuthTokenBodySchema = z.record(z.any(), z.any());
 
-export const mcp = (options: MCPOptions) => {
+const createMCPPlugin = (options: MCPOptions) => {
 	const opts = {
 		codeExpiresIn: 600,
 		defaultScope: "openid",
@@ -1055,6 +1058,15 @@ export const mcp = (options: MCPOptions) => {
 		options,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredMCPPlugin = ReturnType<typeof createMCPPlugin>;
+
+/**
+ * The MCP plugin instance.
+ */
+export interface MCPPlugin extends InferredMCPPlugin {}
+
+export const mcp = (options: MCPOptions): MCPPlugin => createMCPPlugin(options);
 
 export const withMcpAuth = <
 	Auth extends {

--- a/packages/better-auth/src/plugins/multi-session/client.ts
+++ b/packages/better-auth/src/plugins/multi-session/client.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { multiSession } from ".";
+import type { MultiSessionPlugin } from ".";
 import { MULTI_SESSION_ERROR_CODES } from "./error-codes";
 
 export * from "./error-codes";
@@ -9,7 +9,7 @@ export const multiSessionClient = () => {
 	return {
 		id: "multi-session",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof multiSession>,
+		$InferServerPlugin: {} as MultiSessionPlugin,
 		atomListeners: [
 			{
 				matcher(path) {
@@ -22,4 +22,4 @@ export const multiSessionClient = () => {
 	} satisfies BetterAuthClientPlugin;
 };
 
-export type { MultiSessionConfig } from "./index";
+export type { MultiSessionConfig, MultiSessionPlugin } from ".";

--- a/packages/better-auth/src/plugins/multi-session/index.ts
+++ b/packages/better-auth/src/plugins/multi-session/index.ts
@@ -49,7 +49,7 @@ const revokeDeviceSessionBodySchema = z.object({
 	}),
 });
 
-export const multiSession = (options?: MultiSessionConfig | undefined) => {
+const createMultiSessionPlugin = (options?: MultiSessionConfig | undefined) => {
 	const opts = {
 		maximumSessions: 5,
 		...options,
@@ -418,3 +418,14 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 		$ERROR_CODES: ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredMultiSessionPlugin = ReturnType<typeof createMultiSessionPlugin>;
+
+/**
+ * The multi-session plugin instance.
+ */
+export interface MultiSessionPlugin extends InferredMultiSessionPlugin {}
+
+export const multiSession = (
+	options?: MultiSessionConfig | undefined,
+): MultiSessionPlugin => createMultiSessionPlugin(options);

--- a/packages/better-auth/src/plugins/oauth-popup/client.ts
+++ b/packages/better-auth/src/plugins/oauth-popup/client.ts
@@ -6,7 +6,7 @@ import type {
 import type { BetterFetch, BetterFetchPlugin } from "@better-fetch/fetch";
 import { getBaseURL } from "../../utils/url";
 import { PACKAGE_VERSION } from "../../version";
-import type { oauthPopup } from ".";
+import type { OAuthPopupPlugin } from ".";
 import { OAUTH_POPUP_MESSAGE_TYPE, POPUP_TOKEN_STORAGE_KEY } from "./constants";
 import { OAUTH_POPUP_ERROR_CODES } from "./error-codes";
 import type { OAuthPopupError } from "./types";
@@ -342,7 +342,7 @@ export const oauthPopupClient = () => {
 	return {
 		id: "oauth-popup",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof oauthPopup>,
+		$InferServerPlugin: {} as OAuthPopupPlugin,
 		$ERROR_CODES: OAUTH_POPUP_ERROR_CODES,
 		fetchPlugins: [popupBearerFetchPlugin],
 		getActions: (
@@ -361,5 +361,6 @@ export const oauthPopupClient = () => {
 	} satisfies BetterAuthClientPlugin;
 };
 
+export type { OAuthPopupPlugin } from ".";
 export { POPUP_TOKEN_STORAGE_KEY } from "./constants";
 export { OAUTH_POPUP_ERROR_CODES } from "./error-codes";

--- a/packages/better-auth/src/plugins/oauth-popup/index.ts
+++ b/packages/better-auth/src/plugins/oauth-popup/index.ts
@@ -261,13 +261,7 @@ const oauthPopupStart = createAuthEndpoint(
 	},
 );
 
-/**
- * Server plugin for popup-based OAuth. `signIn.popup` navigates the popup to
- * `/oauth-popup/start`; on the OAuth callback this plugin swaps the redirect for
- * a page that posts the session token (or error) back to the opener. Pair with
- * the `bearer` plugin and `oauthPopupClient`.
- */
-export const oauthPopup = () => {
+const createOAuthPopupPlugin = () => {
 	return {
 		id: "oauth-popup",
 		version: PACKAGE_VERSION,
@@ -361,6 +355,21 @@ export const oauthPopup = () => {
 		},
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredOAuthPopupPlugin = ReturnType<typeof createOAuthPopupPlugin>;
+
+/**
+ * The OAuth popup plugin instance.
+ */
+export interface OAuthPopupPlugin extends InferredOAuthPopupPlugin {}
+
+/**
+ * Server plugin for popup-based OAuth. `signIn.popup` navigates the popup to
+ * `/oauth-popup/start`; on the OAuth callback this plugin swaps the redirect for
+ * a page that posts the session token (or error) back to the opener. Pair with
+ * the `bearer` plugin and `oauthPopupClient`.
+ */
+export const oauthPopup = (): OAuthPopupPlugin => createOAuthPopupPlugin();
 
 export {
 	OAUTH_POPUP_DATA_ELEMENT_ID,

--- a/packages/better-auth/src/plugins/oauth-proxy/index.ts
+++ b/packages/better-auth/src/plugins/oauth-proxy/index.ts
@@ -139,7 +139,7 @@ const oauthCallbackQuerySchema = z.object({
 	user: z.string().optional(),
 });
 
-export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
+const createOAuthProxyPlugin = <O extends OAuthProxyOptions>(opts?: O) => {
 	const maxAge = opts?.maxAge ?? 60; // Default 60 seconds
 	const getEncryptionKey = (
 		ctx: GenericEndpointContext,
@@ -702,3 +702,18 @@ export const oAuthProxy = <O extends OAuthProxyOptions>(opts?: O) => {
 		},
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredOAuthProxyPlugin<O extends OAuthProxyOptions> = ReturnType<
+	typeof createOAuthProxyPlugin<O>
+>;
+
+/**
+ * The OAuth proxy plugin instance.
+ */
+export interface OAuthProxyPlugin<
+	O extends OAuthProxyOptions = OAuthProxyOptions,
+> extends InferredOAuthProxyPlugin<O> {}
+
+export const oAuthProxy = <O extends OAuthProxyOptions>(
+	opts?: O,
+): OAuthProxyPlugin<O> => createOAuthProxyPlugin(opts);

--- a/packages/better-auth/src/plugins/oidc-provider/client.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/client.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { oidcProvider } from ".";
+import type { OIDCProviderPlugin } from ".";
 
 /**
  * @deprecated Use `@better-auth/oauth-provider` instead. This plugin will be removed in the next major version.
@@ -10,10 +10,11 @@ export const oidcClient = () => {
 	return {
 		id: "oidc-client",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof oidcProvider>,
+		$InferServerPlugin: {} as OIDCProviderPlugin,
 	} satisfies BetterAuthClientPlugin;
 };
 
 export type OidcClientPlugin = ReturnType<typeof oidcClient>;
 
+export type { OIDCProviderPlugin } from ".";
 export type * from "./types";

--- a/packages/better-auth/src/plugins/oidc-provider/index.ts
+++ b/packages/better-auth/src/plugins/oidc-provider/index.ts
@@ -294,18 +294,7 @@ const warnOidcDeprecation = deprecate(
 		"See: https://www.better-auth.com/docs/plugins/oauth-provider",
 );
 
-/**
- * OpenID Connect (OIDC) plugin for Better Auth. This plugin implements the
- * authorization code flow and the token exchange flow. It also implements the
- * userinfo endpoint.
- *
- * @deprecated Use `@better-auth/oauth-provider` instead. This plugin will be removed in the next major version.
- * @see https://www.better-auth.com/docs/plugins/oauth-provider
- *
- * @param options - The options for the OIDC plugin.
- * @returns A Better Auth plugin.
- */
-export const oidcProvider = (options: OIDCOptions) => {
+const createOIDCProviderPlugin = (options: OIDCOptions) => {
 	if (!options.__skipDeprecationWarning) {
 		warnOidcDeprecation();
 	}
@@ -1873,4 +1862,26 @@ export const oidcProvider = (options: OIDCOptions) => {
 		},
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredOIDCProviderPlugin = ReturnType<typeof createOIDCProviderPlugin>;
+
+/**
+ * The OIDC provider plugin instance.
+ */
+export interface OIDCProviderPlugin extends InferredOIDCProviderPlugin {}
+
+/**
+ * OpenID Connect (OIDC) plugin for Better Auth. This plugin implements the
+ * authorization code flow and the token exchange flow. It also implements the
+ * userinfo endpoint.
+ *
+ * @deprecated Use `@better-auth/oauth-provider` instead. This plugin will be removed in the next major version.
+ * @see https://www.better-auth.com/docs/plugins/oauth-provider
+ *
+ * @param options - The options for the OIDC plugin.
+ * @returns A Better Auth plugin.
+ */
+export const oidcProvider = (options: OIDCOptions): OIDCProviderPlugin =>
+	createOIDCProviderPlugin(options);
+
 export type * from "./types";

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -55,7 +55,7 @@ const oneTapCallbackBodySchema = z.object({
 		.optional(),
 });
 
-export const oneTap = (options?: OneTapOptions | undefined) =>
+const createOneTapPlugin = (options?: OneTapOptions | undefined) =>
 	({
 		id: "one-tap",
 		version: PACKAGE_VERSION,
@@ -198,3 +198,13 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 		},
 		options,
 	}) satisfies BetterAuthPlugin;
+
+type InferredOneTapPlugin = ReturnType<typeof createOneTapPlugin>;
+
+/**
+ * The One Tap plugin instance.
+ */
+export interface OneTapPlugin extends InferredOneTapPlugin {}
+
+export const oneTap = (options?: OneTapOptions | undefined): OneTapPlugin =>
+	createOneTapPlugin(options);

--- a/packages/better-auth/src/plugins/one-time-token/client.ts
+++ b/packages/better-auth/src/plugins/one-time-token/client.ts
@@ -1,13 +1,13 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { oneTimeToken } from "./index";
+import type { OneTimeTokenPlugin } from ".";
 
 export const oneTimeTokenClient = () => {
 	return {
 		id: "one-time-token",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof oneTimeToken>,
+		$InferServerPlugin: {} as OneTimeTokenPlugin,
 	} satisfies BetterAuthClientPlugin;
 };
 
-export type { OneTimeTokenOptions } from "./index";
+export type { OneTimeTokenOptions, OneTimeTokenPlugin } from ".";

--- a/packages/better-auth/src/plugins/one-time-token/index.ts
+++ b/packages/better-auth/src/plugins/one-time-token/index.ts
@@ -74,7 +74,9 @@ const verifyOneTimeTokenBodySchema = z.object({
 	}),
 });
 
-export const oneTimeToken = (options?: OneTimeTokenOptions | undefined) => {
+const createOneTimeTokenPlugin = (
+	options?: OneTimeTokenOptions | undefined,
+) => {
 	const opts = {
 		storeToken: "plain",
 		...options,
@@ -244,3 +246,14 @@ export const oneTimeToken = (options?: OneTimeTokenOptions | undefined) => {
 		options,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredOneTimeTokenPlugin = ReturnType<typeof createOneTimeTokenPlugin>;
+
+/**
+ * The one-time token plugin instance.
+ */
+export interface OneTimeTokenPlugin extends InferredOneTimeTokenPlugin {}
+
+export const oneTimeToken = (
+	options?: OneTimeTokenOptions | undefined,
+): OneTimeTokenPlugin => createOneTimeTokenPlugin(options);

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -331,4 +331,5 @@ export const inferOrgAdditionalFields = <
 	return {} as undefined extends S ? Schema : S;
 };
 
+export type { OrganizationPlugin } from "./organization";
 export type * from "./schema";

--- a/packages/better-auth/src/plugins/phone-number/client.ts
+++ b/packages/better-auth/src/plugins/phone-number/client.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { phoneNumber } from ".";
+import type { PhoneNumberPlugin } from ".";
 import { PHONE_NUMBER_ERROR_CODES } from "./error-codes";
 
 export * from "./error-codes";
@@ -9,7 +9,7 @@ export const phoneNumberClient = () => {
 	return {
 		id: "phoneNumber",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof phoneNumber>,
+		$InferServerPlugin: {} as PhoneNumberPlugin,
 		atomListeners: [
 			{
 				matcher(path) {
@@ -26,4 +26,5 @@ export const phoneNumberClient = () => {
 	} satisfies BetterAuthClientPlugin;
 };
 
+export type { PhoneNumberPlugin } from ".";
 export type * from "./types";

--- a/packages/better-auth/src/plugins/phone-number/index.ts
+++ b/packages/better-auth/src/plugins/phone-number/index.ts
@@ -25,7 +25,7 @@ declare module "@better-auth/core" {
 	}
 }
 
-export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
+const createPhoneNumberPlugin = (options?: PhoneNumberOptions | undefined) => {
 	const opts = {
 		expiresIn: options?.expiresIn || 300,
 		otpLength: options?.otpLength || 6,
@@ -109,3 +109,14 @@ export const phoneNumber = (options?: PhoneNumberOptions | undefined) => {
 		$ERROR_CODES: PHONE_NUMBER_ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredPhoneNumberPlugin = ReturnType<typeof createPhoneNumberPlugin>;
+
+/**
+ * The phone number plugin instance.
+ */
+export interface PhoneNumberPlugin extends InferredPhoneNumberPlugin {}
+
+export const phoneNumber = (
+	options?: PhoneNumberOptions | undefined,
+): PhoneNumberPlugin => createPhoneNumberPlugin(options);

--- a/packages/better-auth/src/plugins/siwe/client.ts
+++ b/packages/better-auth/src/plugins/siwe/client.ts
@@ -1,15 +1,17 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { siwe } from ".";
+import type { SIWEPlugin } from ".";
 
 export const siweClient = () => {
 	return {
 		id: "siwe",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof siwe>,
+		$InferServerPlugin: {} as SIWEPlugin,
 		pathMethods: {
 			"/siwe/nonce": "POST",
 			"/siwe/get-nonce": "POST",
 		},
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type { SIWEPlugin } from ".";

--- a/packages/better-auth/src/plugins/siwe/index.ts
+++ b/packages/better-auth/src/plugins/siwe/index.ts
@@ -53,7 +53,7 @@ const getSiweNonceBodySchema = z
 		path: ["walletAddress"],
 	});
 
-export const siwe = (options: SIWEPluginOptions) => {
+const createSIWEPlugin = (options: SIWEPluginOptions) => {
 	const createSiweNonceEndpoint = (path: "/siwe/nonce" | "/siwe/get-nonce") =>
 		createAuthEndpoint(
 			path,
@@ -396,3 +396,13 @@ export const siwe = (options: SIWEPluginOptions) => {
 		options,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredSIWEPlugin = ReturnType<typeof createSIWEPlugin>;
+
+/**
+ * The SIWE plugin instance.
+ */
+export interface SIWEPlugin extends InferredSIWEPlugin {}
+
+export const siwe = (options: SIWEPluginOptions): SIWEPlugin =>
+	createSIWEPlugin(options);

--- a/packages/better-auth/src/plugins/two-factor/client.ts
+++ b/packages/better-auth/src/plugins/two-factor/client.ts
@@ -1,7 +1,7 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { isSafeUrlScheme } from "@better-auth/core/utils/url";
 import { PACKAGE_VERSION } from "../../version";
-import type { twoFactor as twoFa } from ".";
+import type { TwoFactorPlugin } from ".";
 import { TWO_FACTOR_ERROR_CODES } from "./error-code";
 
 export * from "./error-code";
@@ -37,7 +37,7 @@ export const twoFactorClient = (
 	return {
 		id: "two-factor",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof twoFa>,
+		$InferServerPlugin: {} as TwoFactorPlugin,
 		atomListeners: [
 			{
 				matcher: (path) => path.startsWith("/two-factor/"),
@@ -85,6 +85,7 @@ export const twoFactorClient = (
 	} satisfies BetterAuthClientPlugin;
 };
 
+export type { TwoFactorPlugin } from ".";
 export type * from "./backup-codes";
 export type * from "./otp";
 export type * from "./totp";

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -44,7 +44,7 @@ declare module "@better-auth/core" {
 		};
 	}
 }
-export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
+const createTwoFactorPlugin = <O extends TwoFactorOptions>(options?: O) => {
 	const opts = {
 		twoFactorTable: "twoFactor",
 	};
@@ -569,6 +569,20 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 		$ERROR_CODES: TWO_FACTOR_ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredTwoFactorPlugin<O extends TwoFactorOptions> = ReturnType<
+	typeof createTwoFactorPlugin<O>
+>;
+
+/**
+ * The two-factor plugin instance.
+ */
+export interface TwoFactorPlugin<O extends TwoFactorOptions = TwoFactorOptions>
+	extends InferredTwoFactorPlugin<O> {}
+
+export const twoFactor = <O extends TwoFactorOptions>(
+	options?: O,
+): TwoFactorPlugin<O> => createTwoFactorPlugin(options);
 
 export * from "./client";
 export * from "./types";

--- a/packages/better-auth/src/plugins/username/client.ts
+++ b/packages/better-auth/src/plugins/username/client.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { PACKAGE_VERSION } from "../../version";
-import type { username } from ".";
+import type { UsernamePlugin } from ".";
 import { USERNAME_ERROR_CODES } from "./error-codes";
 
 export * from "./error-codes";
@@ -9,7 +9,7 @@ export const usernameClient = () => {
 	return {
 		id: "username",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof username>,
+		$InferServerPlugin: {} as UsernamePlugin,
 		atomListeners: [
 			{
 				matcher: (path) => path === "/sign-in/username",
@@ -19,3 +19,5 @@ export const usernameClient = () => {
 		$ERROR_CODES: USERNAME_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type { UsernamePlugin } from ".";

--- a/packages/better-auth/src/plugins/username/index.ts
+++ b/packages/better-auth/src/plugins/username/index.ts
@@ -121,7 +121,7 @@ const isUsernameAvailableBodySchema = z.object({
 	}),
 });
 
-export const username = (options?: UsernameOptions | undefined) => {
+const createUsernamePlugin = (options?: UsernameOptions | undefined) => {
 	const normalizer = (username: string) => {
 		if (options?.usernameNormalization === false) {
 			return username;
@@ -727,3 +727,14 @@ export const username = (options?: UsernameOptions | undefined) => {
 		$ERROR_CODES: ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredUsernamePlugin = ReturnType<typeof createUsernamePlugin>;
+
+/**
+ * The username plugin instance.
+ */
+export interface UsernamePlugin extends InferredUsernamePlugin {}
+
+export const username = (
+	options?: UsernameOptions | undefined,
+): UsernamePlugin => createUsernamePlugin(options);

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -99,7 +99,7 @@ describe("general types", async () => {
 		expect(twoFactorPlugin).toBeDefined();
 		expect(twoFactorPlugin.id).toBe(id);
 		type TwoFactorPluginFromContext = typeof twoFactorPlugin;
-		expectTypeOf<TwoFactorPluginFromContext>().toMatchObjectType<TwoFactorPlugin>();
+		expectTypeOf<TwoFactorPluginFromContext>().toEqualTypeOf<TwoFactorPlugin>();
 		const testTypePlugin = context.getPlugin("test-type-plugin")!;
 		type PingEndpointFromPlugin = typeof testTypePlugin.endpoints.pingEndpoint;
 		expectTypeOf<PingEndpointFromPlugin>().toEqualTypeOf(pingEndpoint);

--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -28,7 +28,7 @@ declare module "@better-auth/core" {
 	}
 }
 
-export const electron = (options?: ElectronOptions | undefined) => {
+const createElectronPlugin = (options?: ElectronOptions | undefined) => {
 	const opts = {
 		codeExpiresIn: 300, // 5 minutes
 		redirectCookieExpiresIn: 120, // 2 minutes
@@ -236,5 +236,16 @@ export const electron = (options?: ElectronOptions | undefined) => {
 		$ERROR_CODES: ELECTRON_ERROR_CODES,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredElectronPlugin = ReturnType<typeof createElectronPlugin>;
+
+/**
+ * The Electron plugin instance.
+ */
+export interface ElectronPlugin extends InferredElectronPlugin {}
+
+export const electron = (
+	options?: ElectronOptions | undefined,
+): ElectronPlugin => createElectronPlugin(options);
 
 export type * from "./types";

--- a/packages/electron/src/proxy.ts
+++ b/packages/electron/src/proxy.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
 import { parseCookies } from "better-auth/cookies";
-import type { electron } from "./index";
+import type { ElectronPlugin } from ".";
 import type { ElectronProxyClientOptions } from "./types/client";
 import { parseProtocolScheme } from "./utils";
 import { PACKAGE_VERSION } from "./version";
@@ -87,6 +87,8 @@ export const electronProxyClient = (options: ElectronProxyClientOptions) => {
 		pathMethods: {
 			"/electron/transfer-user": "POST",
 		},
-		$InferServerPlugin: {} as ReturnType<typeof electron>,
+		$InferServerPlugin: {} as ElectronPlugin,
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type { ElectronPlugin } from ".";

--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -19,7 +19,7 @@ declare module "@better-auth/core" {
 	}
 }
 
-export const expo = (options?: ExpoOptions | undefined) => {
+const createExpoPlugin = (options?: ExpoOptions | undefined) => {
 	return {
 		id: "expo",
 		version: PACKAGE_VERSION,
@@ -111,3 +111,13 @@ export const expo = (options?: ExpoOptions | undefined) => {
 		options,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredExpoPlugin = ReturnType<typeof createExpoPlugin>;
+
+/**
+ * The Expo plugin instance.
+ */
+export interface ExpoPlugin extends InferredExpoPlugin {}
+
+export const expo = (options?: ExpoOptions | undefined): ExpoPlugin =>
+	createExpoPlugin(options);

--- a/packages/i18n/src/client.ts
+++ b/packages/i18n/src/client.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthClientPlugin } from "@better-auth/core";
-import type { i18n } from ".";
+import type { I18nPlugin } from ".";
 import { PACKAGE_VERSION } from "./version";
 
 /**
@@ -23,6 +23,8 @@ export const i18nClient = () => {
 	return {
 		id: "i18n",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof i18n>,
+		$InferServerPlugin: {} as I18nPlugin,
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type { I18nPlugin } from ".";

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -40,30 +40,7 @@ function parseAcceptLanguage(header: string | null): string[] {
 		.map((item) => item.locale);
 }
 
-/**
- * i18n plugin for Better Auth
- *
- * Translates error messages based on detected locale.
- *
- * @example
- * ```ts
- * import { betterAuth } from "better-auth";
- * import { i18n } from "@better-auth/i18n";
- *
- * export const auth = betterAuth({
- *   plugins: [
- *     i18n({
- *       translations: {
- *         en: { USER_NOT_FOUND: "User not found" },
- *         fr: { USER_NOT_FOUND: "Utilisateur non trouvé" },
- *       },
- *       detection: ["header", "cookie"],
- *     }),
- *   ],
- * });
- * ```
- */
-export const i18n = <Locales extends string[]>(
+const createI18nPlugin = <Locales extends string[]>(
 	options: I18nOptions<Locales>,
 ) => {
 	const availableLocales = Object.keys(options.translations);
@@ -188,5 +165,42 @@ export const i18n = <Locales extends string[]>(
 		options: opts,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredI18nPlugin<Locales extends string[]> = ReturnType<
+	typeof createI18nPlugin<Locales>
+>;
+
+/**
+ * The internationalization plugin instance.
+ */
+export interface I18nPlugin<Locales extends string[] = string[]>
+	extends InferredI18nPlugin<Locales> {}
+
+/**
+ * i18n plugin for Better Auth
+ *
+ * Translates error messages based on detected locale.
+ *
+ * @example
+ * ```ts
+ * import { betterAuth } from "better-auth";
+ * import { i18n } from "@better-auth/i18n";
+ *
+ * export const auth = betterAuth({
+ *   plugins: [
+ *     i18n({
+ *       translations: {
+ *         en: { USER_NOT_FOUND: "User not found" },
+ *         fr: { USER_NOT_FOUND: "Utilisateur non trouvé" },
+ *       },
+ *       detection: ["header", "cookie"],
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export const i18n = <Locales extends string[]>(
+	options: I18nOptions<Locales>,
+): I18nPlugin<Locales> => createI18nPlugin(options);
 
 export type * from "./types";

--- a/packages/oauth-provider/src/client-resource.ts
+++ b/packages/oauth-provider/src/client-resource.ts
@@ -12,16 +12,19 @@ import type { ResourceServerMetadata } from "./types/oauth";
 import { getJwtPlugin, getOAuthProviderPlugin } from "./utils";
 import { PACKAGE_VERSION } from "./version";
 
-type ResourceClientAuth = {
+/**
+ * An auth instance usable by the OAuth provider resource client plugin.
+ */
+export interface OAuthProviderResourceClientAuth {
 	options: {
 		baseURL?: BetterAuthOptions["baseURL"];
 		basePath?: BetterAuthOptions["basePath"];
 	};
 	$context: Promise<unknown>;
-};
+}
 
-export const oauthProviderResourceClient = <
-	T extends ResourceClientAuth | undefined = undefined,
+const createOAuthProviderResourceClient = <
+	T extends OAuthProviderResourceClientAuth | undefined = undefined,
 >(
 	auth?: T,
 ) => {
@@ -216,6 +219,24 @@ export const oauthProviderResourceClient = <
 		},
 	} satisfies BetterAuthClientPlugin;
 };
+
+type InferredOAuthProviderResourceClientPlugin<
+	T extends OAuthProviderResourceClientAuth | undefined,
+> = ReturnType<typeof createOAuthProviderResourceClient<T>>;
+
+/**
+ * The OAuth provider resource client plugin instance.
+ */
+export interface OAuthProviderResourceClientPlugin<
+	T extends OAuthProviderResourceClientAuth | undefined = undefined,
+> extends InferredOAuthProviderResourceClientPlugin<T> {}
+
+export const oauthProviderResourceClient = <
+	T extends OAuthProviderResourceClientAuth | undefined = undefined,
+>(
+	auth?: T,
+): OAuthProviderResourceClientPlugin<T> =>
+	createOAuthProviderResourceClient(auth);
 
 export interface VerifyAccessTokenRemote {
 	/** Full url of the introspect endpoint. Should end with `/oauth2/introspect` */

--- a/packages/oauth-provider/src/client.ts
+++ b/packages/oauth-provider/src/client.ts
@@ -1,6 +1,6 @@
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import type { BetterAuthClientPlugin } from "better-auth/types";
-import type { oauthProvider } from "./oauth";
+import type { OAuthProviderPlugin } from "./oauth";
 import { buildSignedOAuthQuery } from "./signed-query";
 import { PACKAGE_VERSION } from "./version";
 
@@ -38,6 +38,9 @@ export const oauthProviderClient = () => {
 				},
 			},
 		],
-		$InferServerPlugin: {} as ReturnType<typeof oauthProvider>,
+		$InferServerPlugin: {} as OAuthProviderPlugin,
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type { OAuthProviderPlugin } from "./oauth";
+export type { OAuthOptions, Scope } from "./types";

--- a/packages/oauth-provider/src/index.ts
+++ b/packages/oauth-provider/src/index.ts
@@ -5,5 +5,9 @@ export {
 	oauthProviderOpenIdConfigMetadata,
 	oidcServerMetadata,
 } from "./metadata";
-export { getOAuthProviderState, oauthProvider } from "./oauth";
+export {
+	getOAuthProviderState,
+	type OAuthProviderPlugin,
+	oauthProvider,
+} from "./oauth";
 export type * from "./types";

--- a/packages/oauth-provider/src/oauth.test.ts
+++ b/packages/oauth-provider/src/oauth.test.ts
@@ -1906,6 +1906,9 @@ describe("oauth - prompt", async () => {
 				onSuccess: cookieSetter(headers),
 			},
 		);
+		if (!data.url) {
+			throw new Error("missing authorization URL");
+		}
 
 		let selectAccountRedirectUri = "";
 		await serverClient.$fetch(data.url, {

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -61,14 +61,9 @@ export const oAuthState = defineRequestState<{
 } | null>(() => null);
 export const getOAuthProviderState = oAuthState.get;
 
-/**
- * oAuth 2.1 provider plugin for Better Auth.
- *
- * @see https://better-auth.com/docs/plugins/oauth-provider
- * @param options - The options for the oAuth Provider plugin.
- * @returns A Better Auth plugin.
- */
-export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
+const createOAuthProviderPlugin = <O extends OAuthOptions<Scope[]>>(
+	options: O,
+) => {
 	let clientRegistrationAllowedScopes = options.clientRegistrationAllowedScopes;
 	if (options.clientRegistrationDefaultScopes) {
 		const _allowedScopes = clientRegistrationAllowedScopes
@@ -1553,3 +1548,25 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 		],
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredOAuthProviderPlugin<O extends OAuthOptions<Scope[]>> = ReturnType<
+	typeof createOAuthProviderPlugin<O>
+>;
+
+/**
+ * The OAuth provider plugin instance.
+ */
+export interface OAuthProviderPlugin<
+	O extends OAuthOptions<Scope[]> = OAuthOptions<Scope[]>,
+> extends InferredOAuthProviderPlugin<O> {}
+
+/**
+ * oAuth 2.1 provider plugin for Better Auth.
+ *
+ * @see https://better-auth.com/docs/plugins/oauth-provider
+ * @param options - The options for the oAuth Provider plugin.
+ * @returns A Better Auth plugin.
+ */
+export const oauthProvider = <O extends OAuthOptions<Scope[]>>(
+	options: O,
+): OAuthProviderPlugin<O> => createOAuthProviderPlugin(options);

--- a/packages/passkey/src/client.ts
+++ b/packages/passkey/src/client.ts
@@ -22,7 +22,7 @@ import type {
 import { useAuthQuery } from "better-auth/client";
 import type { Session, User } from "better-auth/types";
 import { atom } from "nanostores";
-import type { passkey } from ".";
+import type { PasskeyPlugin } from ".";
 import { PASSKEY_ERROR_CODES } from "./error-codes";
 import type { Passkey } from "./types";
 import { PACKAGE_VERSION } from "./version";
@@ -307,7 +307,7 @@ export const passkeyClient = () => {
 	return {
 		id: "passkey",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof passkey>,
+		$InferServerPlugin: {} as PasskeyPlugin,
 		getActions: ($fetch, $store) =>
 			getPasskeyActions($fetch, {
 				$listPasskeys,
@@ -353,5 +353,6 @@ export const passkeyClient = () => {
 };
 
 export type * from "@simplewebauthn/server";
+export type { PasskeyPlugin } from ".";
 export * from "./error-codes";
 export type * from "./types";

--- a/packages/passkey/src/index.ts
+++ b/packages/passkey/src/index.ts
@@ -30,7 +30,7 @@ export { PASSKEY_ERROR_CODES } from "./error-codes";
 
 const MAX_AGE_IN_SECONDS = 60 * 5; // 5 minutes
 
-export const passkey = (options?: PasskeyOptions | undefined) => {
+const createPasskeyPlugin = (options?: PasskeyOptions | undefined) => {
 	const opts = {
 		origin: null,
 		...options,
@@ -63,5 +63,15 @@ export const passkey = (options?: PasskeyOptions | undefined) => {
 		options,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredPasskeyPlugin = ReturnType<typeof createPasskeyPlugin>;
+
+/**
+ * The Passkey plugin instance.
+ */
+export interface PasskeyPlugin extends InferredPasskeyPlugin {}
+
+export const passkey = (options?: PasskeyOptions | undefined): PasskeyPlugin =>
+	createPasskeyPlugin(options);
 
 export type { Passkey, PasskeyOptions };

--- a/packages/scim/src/client.ts
+++ b/packages/scim/src/client.ts
@@ -1,11 +1,13 @@
 import type { BetterAuthClientPlugin } from "better-auth/client";
-import type { scim } from "./index";
+import type { SCIMPlugin } from ".";
 import { PACKAGE_VERSION } from "./version";
 
 export const scimClient = () => {
 	return {
 		id: "scim-client",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<typeof scim>,
+		$InferServerPlugin: {} as SCIMPlugin,
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type { SCIMPlugin } from ".";

--- a/packages/scim/src/index.ts
+++ b/packages/scim/src/index.ts
@@ -28,7 +28,7 @@ declare module "@better-auth/core" {
 	}
 }
 
-export const scim = (options?: SCIMOptions) => {
+const createSCIMPlugin = (options?: SCIMOptions) => {
 	const opts = {
 		storeSCIMToken: "plain",
 		...options,
@@ -92,5 +92,15 @@ export const scim = (options?: SCIMOptions) => {
 		options,
 	} satisfies BetterAuthPlugin;
 };
+
+type InferredSCIMPlugin = ReturnType<typeof createSCIMPlugin>;
+
+/**
+ * The SCIM plugin instance.
+ */
+export interface SCIMPlugin extends InferredSCIMPlugin {}
+
+export const scim = (options?: SCIMOptions): SCIMPlugin =>
+	createSCIMPlugin(options);
 
 export * from "./types";

--- a/packages/sso/src/client.ts
+++ b/packages/sso/src/client.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthClientPlugin } from "better-auth/client";
-import type { SSOPlugin } from "./index";
+import type { SSOPlugin } from ".";
 import { PACKAGE_VERSION } from "./version";
 
 interface SSOClientOptions {
@@ -29,3 +29,5 @@ export const ssoClient = <CO extends SSOClientOptions>(
 		},
 	} satisfies BetterAuthClientPlugin;
 };
+
+export type { SSOPlugin } from ".";

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -112,14 +112,28 @@ type SSOEndpoints<O extends SSOOptions> = {
 	deleteSSOProvider: ReturnType<typeof deleteSSOProvider>;
 };
 
-export type SSOPlugin<O extends SSOOptions> = {
+/**
+ * The SSO plugin instance.
+ */
+export interface SSOPlugin<O extends SSOOptions> {
 	id: "sso";
 	version: string;
 	endpoints: SSOEndpoints<O> &
 		(O extends { domainVerification: { enabled: true } }
 			? DomainVerificationEndpoints
 			: {});
-};
+	options: NoInfer<O>;
+}
+
+/**
+ * The SSO plugin instance with domain verification enabled.
+ */
+export interface SSODomainVerificationPlugin<
+	O extends SSOOptions & { domainVerification?: { enabled: true } },
+> extends SSOPlugin<O> {
+	endpoints: SSOEndpoints<O> & DomainVerificationEndpoints;
+	schema: NonNullable<BetterAuthPlugin["schema"]>;
+}
 
 /**
  * SAML endpoint paths that should skip origin check validation.
@@ -136,25 +150,18 @@ export function sso<
 	O extends SSOOptions & {
 		domainVerification?: { enabled: true };
 	},
->(
-	options?: O | undefined,
-): {
-	id: "sso";
-	version: string;
-	endpoints: SSOEndpoints<O> & DomainVerificationEndpoints;
-	schema: NonNullable<BetterAuthPlugin["schema"]>;
-	options: NoInfer<O>;
-};
+>(options?: O | undefined): SSODomainVerificationPlugin<O>;
 export function sso<O extends SSOOptions>(
 	options?: O | undefined,
-): {
-	id: "sso";
-	version: string;
-	endpoints: SSOEndpoints<O>;
-	options: NoInfer<O>;
-};
+): SSOPlugin<O>;
 
 export function sso<O extends SSOOptions>(
+	options?: O | undefined,
+): BetterAuthPlugin {
+	return createSSOPlugin(options);
+}
+
+function createSSOPlugin<O extends SSOOptions>(
 	options?: O | undefined,
 ): BetterAuthPlugin {
 	const optionsWithStore = options as O;

--- a/packages/stripe/src/client.ts
+++ b/packages/stripe/src/client.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthClientPlugin } from "better-auth/client";
+import type { StripePlan, StripePlugin } from ".";
 import { STRIPE_ERROR_CODES } from "./error-codes";
-import type { StripePlan, stripe } from "./index";
 import { PACKAGE_VERSION } from "./version";
 
 export const stripeClient = <
@@ -13,22 +13,20 @@ export const stripeClient = <
 	return {
 		id: "stripe-client",
 		version: PACKAGE_VERSION,
-		$InferServerPlugin: {} as ReturnType<
-			typeof stripe<
-				O["subscription"] extends true
-					? {
-							stripeClient: any;
-							stripeWebhookSecret: string;
-							subscription: {
-								enabled: true;
-								plans: StripePlan[];
-							};
-						}
-					: {
-							stripeClient: any;
-							stripeWebhookSecret: string;
-						}
-			>
+		$InferServerPlugin: {} as StripePlugin<
+			O["subscription"] extends true
+				? {
+						stripeClient: any;
+						stripeWebhookSecret: string;
+						subscription: {
+							enabled: true;
+							plans: StripePlan[];
+						};
+					}
+				: {
+						stripeClient: any;
+						stripeWebhookSecret: string;
+					}
 		>,
 		pathMethods: {
 			"/subscription/billing-portal": "POST",
@@ -37,4 +35,5 @@ export const stripeClient = <
 		$ERROR_CODES: STRIPE_ERROR_CODES,
 	} satisfies BetterAuthClientPlugin;
 };
+export type { StripePlan, StripePlugin } from ".";
 export * from "./error-codes";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,12 +793,24 @@ importers:
       '@better-auth/api-key':
         specifier: workspace:*
         version: link:../../../../../packages/api-key
+      '@better-auth/electron':
+        specifier: workspace:*
+        version: link:../../../../../packages/electron
+      '@better-auth/expo':
+        specifier: workspace:*
+        version: link:../../../../../packages/expo
+      '@better-auth/i18n':
+        specifier: workspace:*
+        version: link:../../../../../packages/i18n
       '@better-auth/oauth-provider':
         specifier: workspace:*
         version: link:../../../../../packages/oauth-provider
       '@better-auth/passkey':
         specifier: workspace:*
         version: link:../../../../../packages/passkey
+      '@better-auth/scim':
+        specifier: workspace:*
+        version: link:../../../../../packages/scim
       '@better-auth/sso':
         specifier: workspace:*
         version: link:../../../../../packages/sso


### PR DESCRIPTION
Projects can now use either or both of these TypeScript options when exporting Better Auth instances:

```json
{
  "compilerOptions": {
    "declaration": true,
    "composite": true
  }
}
```

This enables monorepos to build and share a dedicated `auth` package with portable TypeScript declarations, and benefits libraries and plugins built on top of Better Auth.

For example:

```text
packages/
  auth/
apps/
  web/
  api/
  admin/
```

Related real-world workarounds:

- https://github.com/stagewise-io/stagewise/commit/1966c66168082383d4804278094ebe4fb5d2c97b
- https://github.com/trycompai/comp/commit/7118c6e7db83752e82f2e28321bbbcbb1a4f510d

**_Before_**

<img width="600" alt="before" src="https://github.com/user-attachments/assets/b348a0d7-ab69-434e-9269-2c56e0be4724" />

**_After_**

<img width="600" alt="after" src="https://github.com/user-attachments/assets/b6cb624c-f7a1-47cd-951c-153bfd60cc01" />

---

- Closes #10532
- Closes #10556
- Closes #10710
- Closes #10560
- Supersedes #10636
- Supersedes #10689

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes plugin type declarations by introducing named public plugin interfaces across server and client. This keeps emitted `.d.ts` portable under `declaration` and `composite` and replaces `ReturnType<typeof plugin>` inference with stable interfaces; runtime behavior is unchanged.

- Core and external server plugins now use an internal `createXPlugin` factory and export named interfaces (for example `AdminPlugin`, `JwtPlugin`, `OAuthProviderPlugin`, `OAuthPopupPlugin`, `ApiKeyPlugin`, `PasskeyPlugin`, `SCIMPlugin`, `I18nPlugin`, `ExpoPlugin`, `ElectronPlugin`, `OAuthProviderResourceClientPlugin`, `SSOPlugin`, `SSODomainVerificationPlugin`). Client plugins’ `$InferServerPlugin` now reference these public interfaces and re-export them for consumer typing across `better-auth` and `@better-auth/*`.
- E2E typecheck adds composite and declaration fixtures and asserts emitted `.d.ts` import only public plugin types (including `@better-auth/oauth-provider/resource-client`) and do not reference build internals. Tests cover a wide set of server and client plugins.
- Docs clarify the factory + named-interface pattern and support for projects enabling `declaration`/`composite`. Patch releases across affected packages.

- Migration: no changes required for app code. For published custom plugins and their clients, export a named plugin interface and use it in `$InferServerPlugin` to keep declarations portable.

<sup>Written for commit fedeb4cd882df767c6194df0b9ba9c62a6c5e3fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

