### PR TITLE
docs: fix "Database joins is" grammar across all 7 adapter docs

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -61,7 +61,7 @@ To generate and apply the migration, run the following commands:
 
 ## Joins (Experimental)
 
-Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
+Database joins are useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 

--- a/docs/content/docs/adapters/mongo.mdx
+++ b/docs/content/docs/adapters/mongo.mdx
@@ -41,7 +41,7 @@ For MongoDB, we don't need to generate or migrate the schema.
 
 ## Joins (Experimental)
 
-Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
+Database joins are useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 

--- a/docs/content/docs/adapters/mssql.mdx
+++ b/docs/content/docs/adapters/mssql.mdx
@@ -105,7 +105,7 @@ your database schema based on your Better Auth configuration and plugins.
 
 ## Joins (Experimental)
 
-Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
+Database joins are useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 

--- a/docs/content/docs/adapters/mysql.mdx
+++ b/docs/content/docs/adapters/mysql.mdx
@@ -83,7 +83,7 @@ your database schema based on your Better Auth configuration and plugins.
 
 ## Joins (Experimental)
 
-Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
+Database joins are useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 

--- a/docs/content/docs/adapters/postgresql.mdx
+++ b/docs/content/docs/adapters/postgresql.mdx
@@ -69,7 +69,7 @@ your database schema based on your Better Auth configuration and plugins.
 
 ## Joins (Experimental)
 
-Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
+Database joins are useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 

--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -69,7 +69,7 @@ npx auth@latest generate
 
 ## Joins (Experimental)
 
-Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
+Database joins are useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 

--- a/docs/content/docs/adapters/sqlite.mdx
+++ b/docs/content/docs/adapters/sqlite.mdx
@@ -110,7 +110,7 @@ your database schema based on your Better Auth configuration and plugins.
 
 ## Joins (Experimental)
 
-Database joins is useful when Better-Auth needs to fetch related data from multiple tables in a single query.
+Database joins are useful when Better-Auth needs to fetch related data from multiple tables in a single query.
 Endpoints like `/get-session`, `/get-full-organization` and many others benefit greatly from this feature,
 seeing upwards of 2x to 3x performance improvements depending on database latency.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes grammar in all seven adapter docs by changing “Database joins is useful...” to “Database joins are useful...”. Improves clarity and consistency; docs-only change with no behavior, API, or configuration impact.

<sup>Written for commit 160ff8597fe4f5697ceb59b23e06da9b676c2bd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

