### PR TITLE
docs: fix "exmaples" typo in sidebar description

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -77,7 +77,7 @@ export function getPageTree(): Root {
 				type: "folder",
 				root: true,
 				name: "Examples",
-				description: "exmaples and guides.",
+				description: "examples and guides.",
 				children: examples.map(contentToPageTree),
 			},
 		],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a typo in the docs sidebar: updates the "Examples" folder description from "exmaples and guides." to "examples and guides." to improve copy quality. No functional, routing, or build changes.

<sup>Written for commit 2602b3be70a83c2d03523ea0268cce7858d9b80c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

