### PR TITLE
perf(db): replace sequential get-then-delete loop with parallel deletes in deleteSessions

### DIFF
--- a/.changeset/pr-10805.md
+++ b/.changeset/pr-10805.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Speed up batch session revocation when secondary storage is enabled by deleting sessions in parallel.

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -810,12 +810,9 @@ export const createInternalAdapter = (
 		},
 		deleteSessions: async (sessionTokens: string[]) => {
 			if (secondaryStorage) {
-				for (const sessionToken of sessionTokens) {
-					const session = await secondaryStorage.get(sessionToken);
-					if (session) {
-						await secondaryStorage.delete(sessionToken);
-					}
-				}
+				await Promise.all(
+					sessionTokens.map((token) => secondaryStorage.delete(token)),
+				);
 			}
 			if (databaseStoresSessions && !preservesDatabaseSessions) {
 				await deleteManyWithHooks(


### PR DESCRIPTION

`deleteSessions` was iterating over each token, doing a `get` to check existence, then conditionally doing a `delete`, all awaited sequentially. For a batch of N sessions this meant 2N serial network round-trips to secondary storage.

The `get` check serves no purpose here. Unlike the single-session `deleteSession` path (which reads the session value to extract `userId` for updating the `active-sessions-*` list), `deleteSessions` reads the value and immediately discards it.   `SecondaryStorage.delete` is idempotent on all standard backends, Redis `DEL`, Cloudflare KV, Upstash, etc. silently no-op a delete on a missing key.

The fix removes the existence check and fans out the deletes in parallel:

```ts
await Promise.all(
    sessionTokens.map((token) => secondaryStorage.delete(token)),
);
```

---------

**Note for reviewers (nice-to-have):** `deleteSessions` still doesn't update the `active-sessions-${userId}` list in secondary storage, unlike `deleteSession` (singular) which does. Batch session revocation therefore leaves stale entries in that list until they expire or get pruned by the next `listSessions` call. Out of scope for this PR, but worth a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up batch session revocation by replacing the sequential get-then-delete loop in `deleteSessions` with parallel deletes against secondary storage. Before: 2N serial network calls per batch. Now: N concurrent deletes; missing keys no-op due to idempotent delete semantics.

- Only affects secondary storage; database deletion path is unchanged.
- Requires idempotent delete on the backend (Redis, Cloudflare KV, Upstash).
- Batch revocation still does not update `active-sessions-${userId}`; stale entries remain until expiry or pruning.
- Adds a changeset to release a `better-auth` patch.

<sup>Written for commit a03e84a6176cbfe18be25e9cc478e6b0945ae383. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

