### PR TITLE
fix(oauth-provider): accept issuer audience for client assertions

### DIFF
--- a/.changeset/private-key-jwt-issuer-audience.md
+++ b/.changeset/private-key-jwt-issuer-audience.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+`private_key_jwt` client assertions can use either the receiving endpoint URL or the OpenID Provider issuer as `aud`. The claim may be a string or an array containing at least one accepted value. This rule applies to token, introspection, and revocation requests.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -578,14 +578,14 @@ grant_type=authorization_code
 
 The assertion JWT must contain:
 
-| Claim | Requirement                                                            |
-| ----- | ---------------------------------------------------------------------- |
-| `iss` | Must be the `client_id`                                                |
-| `sub` | Must be the `client_id`                                                |
-| `aud` | Must be the token endpoint URL                                         |
-| `exp` | Required, must not exceed `assertionMaxLifetime` from now              |
-| `jti` | Required, must be unique (single-use)                                  |
-| `iat` | Optional, but if present must not be older than `assertionMaxLifetime` |
+| Claim | Requirement                                                                                                                                                        |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `iss` | Must be the `client_id`                                                                                                                                            |
+| `sub` | Must be the `client_id`                                                                                                                                            |
+| `aud` | Must contain either the URL of the endpoint receiving the assertion or the OpenID Provider issuer. Use a string or an array containing at least one accepted value |
+| `exp` | Required, must not exceed `assertionMaxLifetime` from now                                                                                                          |
+| `jti` | Required, must be unique (single-use)                                                                                                                              |
+| `iat` | Optional, but if present must not be older than `assertionMaxLifetime`                                                                                             |
 
 Supported signing algorithms: `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, `EdDSA`.
 

--- a/packages/oauth-provider/src/private-key-jwt.test.ts
+++ b/packages/oauth-provider/src/private-key-jwt.test.ts
@@ -23,6 +23,7 @@ import {
 
 describe("private_key_jwt authentication", async () => {
 	const authServerBaseUrl = "http://localhost:3000";
+	const customIssuer = "https://issuer.example.com";
 	const rpBaseUrl = "http://localhost:5000";
 	const tokenEndpoint = `${authServerBaseUrl}/api/auth/oauth2/token`;
 	const introspectEndpoint = `${authServerBaseUrl}/api/auth/oauth2/introspect`;
@@ -36,7 +37,7 @@ describe("private_key_jwt authentication", async () => {
 		baseURL: authServerBaseUrl,
 		trustedOrigins: ["https://trusted.example.com"],
 		plugins: [
-			jwt({ jwt: { issuer: authServerBaseUrl } }),
+			jwt({ jwt: { issuer: customIssuer } }),
 			oauthProvider({
 				loginPage: "/login",
 				consentPage: "/consent",
@@ -132,7 +133,7 @@ describe("private_key_jwt authentication", async () => {
 
 	async function signAssertion(overrides?: {
 		clientId?: string;
-		aud?: string;
+		aud?: string | string[];
 		exp?: number;
 		jti?: string;
 		kid?: string;
@@ -549,6 +550,23 @@ describe("private_key_jwt authentication", async () => {
 		expect(tokens.data?.token_type).toBe("Bearer");
 	});
 
+	it("should accept the configured issuer as a token audience", async () => {
+		const codeVerifier = generateRandomString(32);
+		const code = await getAuthCode(assertionClient.client_id, codeVerifier);
+		const assertion = await signAssertion({
+			aud: customIssuer,
+		});
+
+		const tokens = await exchangeCodeForTokens({
+			code,
+			codeVerifier,
+			assertion,
+		});
+
+		expect(tokens.data?.access_token).toBeDefined();
+		expect(tokens.data?.token_type).toBe("Bearer");
+	});
+
 	it("should exchange code using a trusted jwks_uri", async () => {
 		vi.stubGlobal(
 			"fetch",
@@ -908,7 +926,15 @@ describe("private_key_jwt authentication", async () => {
 		expect(result.error?.status).toBeLessThan(500);
 	});
 
-	it("should introspect an access token using private_key_jwt authentication", async () => {
+	it.each([
+		{
+			name: "issuer audience array",
+			audience: [customIssuer, "https://unrelated.example.com/introspect"],
+		},
+		{ name: "endpoint audience", audience: introspectEndpoint },
+	])("should introspect an access token using private_key_jwt with $name", async ({
+		audience,
+	}) => {
 		const codeVerifier = generateRandomString(32);
 		const code = await getAuthCode(assertionClient.client_id, codeVerifier);
 		const tokens = await exchangeCodeForTokens({
@@ -927,7 +953,7 @@ describe("private_key_jwt authentication", async () => {
 				client_id: assertionClient.client_id,
 				client_assertion_type:
 					"urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-				client_assertion: await signAssertion({ aud: introspectEndpoint }),
+				client_assertion: await signAssertion({ aud: audience }),
 				token: tokens.data?.access_token ?? "",
 				token_type_hint: "access_token",
 			}),
@@ -938,7 +964,12 @@ describe("private_key_jwt authentication", async () => {
 		expect(result.data?.client_id).toBe(assertionClient.client_id);
 	});
 
-	it("should revoke a refresh token using private_key_jwt authentication", async () => {
+	it.each([
+		{ name: "issuer audience", audience: customIssuer },
+		{ name: "endpoint audience", audience: revokeEndpoint },
+	])("should revoke a refresh token using private_key_jwt with $name", async ({
+		audience,
+	}) => {
 		const codeVerifier = generateRandomString(32);
 		const code = await getAuthCode(assertionClient.client_id, codeVerifier, [
 			"openid",
@@ -958,7 +989,7 @@ describe("private_key_jwt authentication", async () => {
 				client_id: assertionClient.client_id,
 				client_assertion_type:
 					"urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-				client_assertion: await signAssertion({ aud: revokeEndpoint }),
+				client_assertion: await signAssertion({ aud: audience }),
 				token: tokens.data?.refresh_token ?? "",
 				token_type_hint: "refresh_token",
 			}),

--- a/packages/oauth-provider/src/utils/client-assertion.ts
+++ b/packages/oauth-provider/src/utils/client-assertion.ts
@@ -14,6 +14,7 @@ import {
 	decodeProtectedHeader,
 	jwtVerify,
 } from "jose";
+import { getIssuer } from "../authorize";
 import { validatePublicClientJwks } from "../client-jwks";
 import { getClientDiscoveries } from "../extensions";
 import type {
@@ -447,8 +448,9 @@ export async function consumeClientAssertion(
 /**
  * Verifies a client assertion JWT for `private_key_jwt` authentication.
  *
- * Validates: signature, iss=client_id, sub=client_id, aud=token_endpoint,
- * exp, assertion max lifetime, jti uniqueness (replay prevention).
+ * Validates: signature, iss=client_id, sub=client_id, aud=the endpoint serving
+ * the assertion or the normalized OP issuer, exp, assertion max lifetime,
+ * jti uniqueness (replay prevention).
  */
 export async function verifyClientAssertion(
 	ctx: GenericEndpointContext,
@@ -533,11 +535,14 @@ export async function verifyClientAssertion(
 
 	// Fetch JWKS and verify signature + claims
 	const jwks = await fetchClientJwks(ctx, opts, client);
-	const audience = expectedAudience ?? `${ctx.context.baseURL}/oauth2/token`;
+	const endpointAudience =
+		expectedAudience ?? `${ctx.context.baseURL}/oauth2/token`;
+	const issuerAudience = getIssuer(ctx, opts);
+	const acceptedAudiences = [...new Set([endpointAudience, issuerAudience])];
 	const verifyOpts = {
 		issuer: clientId,
 		subject: clientId,
-		audience,
+		audience: acceptedAudiences,
 		algorithms: ALGORITHMS_LIST,
 	};
 
@@ -588,6 +593,15 @@ export async function verifyClientAssertion(
 		}
 	}
 
+	const assertionAudiences = Array.isArray(payload.aud)
+		? payload.aud
+		: [payload.aud];
+	// jwtVerify already matched the payload against this same audience set.
+	const acceptedAudience = assertionAudiences.find(
+		(value): value is string =>
+			typeof value === "string" && acceptedAudiences.includes(value),
+	)!;
+
 	// Audience, lifetime, and jti single-use replay protection, shared with
 	// extension client-auth methods through `consumeClientAssertion` so both
 	// paths enforce RFC 7523 §3 identically. jose already matched `aud` via
@@ -596,7 +610,7 @@ export async function verifyClientAssertion(
 	await consumeClientAssertion(ctx, opts, {
 		namespace: `private_key_jwt:${clientId}`,
 		payload,
-		expectedAudience: audience,
+		expectedAudience: acceptedAudience,
 	});
 
 	return { clientId };


### PR DESCRIPTION
`private_key_jwt` clients can identify the OpenID Provider issuer as the client assertion audience, but verification accepted only the exact endpoint URL. That rejected a valid RFC 7523 interoperability form and produced an OpenID conformance warning.

## What changes

- Accept the exact serving endpoint or the normalized provider issuer as `aud`, including arrays containing either value.
- Apply the same audience policy to token, introspection, and revocation authentication.
- Preserve the existing signature, client binding, lifetime, JTI replay protection, and JWK refresh behavior.
- Document the expanded audience contract for OAuth Provider users.

The OpenID `oidcc-ensure-client-assertion-with-iss-aud-succeeds` module now completes with 51 successful conditions and no warnings.
