### PR TITLE
fix(oauth-provider): complete RP-initiated logout flow

### DIFF
--- a/.changeset/rp-initiated-logout-conformance.md
+++ b/.changeset/rp-initiated-logout-conformance.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+The RP-Initiated Logout endpoint continues to accept `GET` and now accepts form-encoded `POST` requests. It also supports the JSON bodies sent by Better Auth's generated client. After explicit confirmation, browser users can log out without an `id_token_hint`. They receive clear confirmation, success, or error pages. Invalid ID token hints fail safely, and logout redirects require an exact registered `post_logout_redirect_uri`.

--- a/docs/content/docs/guides/1-7-upgrade-guide.mdx
+++ b/docs/content/docs/guides/1-7-upgrade-guide.mdx
@@ -270,6 +270,14 @@ When a session ends, the access tokens tied to it are now revoked. They read as 
 
 If you import or retain clients with a `backchannel_logout_uri`, audit those registrations before cutover. Back-channel logout requires the JWT plugin, and every URI must be an absolute public HTTPS URL without credentials or a fragment. Private, reserved, tunneled, and cloud-metadata targets are rejected.
 
+### RP-Initiated Logout can require browser confirmation
+
+In 1.6, `/oauth2/end-session` accepted only `GET` requests and rejected requests without an `id_token_hint`. In 1.7, the endpoint also accepts form-encoded `POST` requests. For browser navigation without a valid hint, Better Auth asks the user to confirm before ending the current session. The same browser confirmation is required when the hint refers to a different session than the browser session. API calls receive a protocol error when confirmation is required.
+
+The confirmation flow preserves the existing redirect rule: `post_logout_redirect_uri` must exactly match a registered URI. Better Auth adds `state` only to that verified redirect.
+
+**What to do:** if your browser flow expected a missing or invalid hint to fail immediately, update its flow and tests to handle the confirmation page. Standard clients that send a valid hint do not need changes. Enable `enable_end_session` only for trusted clients, and register every allowed post-logout redirect URI exactly.
+
 ### Custom ID-token claims cannot override protocol claims
 
 Your custom ID-token claims can no longer set protocol claims that the standard reserves for the server: issuer, subject, audience, expiry, nonce, session binding, `auth_time`, `acr`, `amr`, and `azp`. Your own namespaced claims still appear. ID tokens also report `acr: "0"` rather than a vendor-specific value.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -714,11 +714,13 @@ Because a JWT `access_token` cannot be revoked individually, plan for it:
 
 ### End Session Endpoint
 
-[RP-initiated](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)-compliant Logout
+[OpenID Connect RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html) lets a relying party ask the provider to end a user's session.
 
-This endpoint allows specified trusted clients to logout remotely.
+The endpoint is available to clients registered with `enable_end_session: true`. It accepts logout parameters in a `GET` query or an `application/x-www-form-urlencoded` `POST` body. Better Auth's generated client sends the same parameters as JSON. A verified `id_token_hint` can end its referenced session immediately. Without a valid hint, Better Auth asks the user to confirm before ending the current session. The same confirmation is required when the hint refers to a different session than the browser session.
 
-To allow rp-initiated logout, a trusted client must specifically be created to perform session logout.
+Better Auth redirects after logout only when `post_logout_redirect_uri` exactly matches a registered URI. It adds `state` only to that verified redirect. An unregistered or query-modified URI does not cause a redirect. Browser navigation receives confirmation, success, and error pages as HTML. API callers receive the protocol response.
+
+Enable this endpoint only for clients you trust:
 
 ```ts title="admin-create-oauth.ts"
 import { auth } from "@/lib/auth"
@@ -732,9 +734,7 @@ await auth.api.adminCreateOAuthClient({
 });
 ```
 
-<Callout type="info">
-  If `disableJwtPlugin: true`, public clients will never be able to logout using this endpoint since no `id_token` is sent.
-</Callout>
+Better Auth protects confirmation with origin and CSRF checks plus a short-lived, signed cookie. When a current session exists, the cookie is tied to it. Successful browser logout returns a logged-out page. Session deletion continues through the normal hooks, including Back-Channel Logout delivery to registered relying parties.
 
 ### Back-Channel Logout
 

--- a/packages/oauth-provider/src/logout.test.ts
+++ b/packages/oauth-provider/src/logout.test.ts
@@ -3,14 +3,27 @@ import {
 	createAuthorizationURL,
 } from "@better-auth/core/oauth2";
 import { createAuthClient } from "better-auth/client";
+import {
+	applySetCookies,
+	parseCookies,
+	parseSetCookieHeader,
+} from "better-auth/cookies";
 import { generateRandomString } from "better-auth/crypto";
 import { toNodeHandler } from "better-auth/node";
 import { jwt } from "better-auth/plugins/jwt";
 import { getTestInstance } from "better-auth/test";
-import { decodeJwt } from "jose";
+import { decodeJwt, UnsecuredJWT } from "jose";
 import type { Listener } from "listhen";
 import { listen } from "listhen";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { oauthProviderClient } from "./client";
 import { oauthProvider } from "./oauth";
 import type { OAuthClient } from "./types/oauth";
@@ -24,19 +37,24 @@ describe("oauth logout", async () => {
 	const state = "123";
 	const scopes = ["openid", "email", "profile", "offline_access"];
 
-	const { auth, signInWithTestUser, customFetchImpl } = await getTestInstance({
-		baseURL: baseUrl,
-		plugins: [
-			oauthProvider({
-				loginPage: "/login",
-				consentPage: "/consent",
-				allowDynamicClientRegistration: true,
-				scopes,
-			}),
-			jwt(),
-		],
-	});
+	const { auth, signInWithTestUser, customFetchImpl, cookieSetter } =
+		await getTestInstance({
+			baseURL: baseUrl,
+			advanced: {
+				disableOriginCheck: false,
+			},
+			plugins: [
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					allowDynamicClientRegistration: true,
+					scopes,
+				}),
+				jwt(),
+			],
+		});
 	let { headers } = await signInWithTestUser();
+	headers.set("origin", baseUrl);
 	const client = createAuthClient({
 		plugins: [oauthProviderClient()],
 		baseURL: baseUrl,
@@ -50,6 +68,107 @@ describe("oauth logout", async () => {
 	const providerId = "test";
 	const redirectUri = `${rpBaseUrl}/api/auth/callback/${providerId}`;
 	const logoutRedirectUri = `${rpBaseUrl}/api/auth/callback/logout`;
+	const endSessionEndpoint = `${baseUrl}/api/auth/oauth2/end-session`;
+	const confirmationEndpoint = `${endSessionEndpoint}/confirm`;
+
+	async function requestEndSession(input: {
+		method?: "GET" | "POST";
+		query?: Record<string, string>;
+		body?: Record<string, string>;
+		accept?: string;
+		includeSessionCookie?: boolean;
+		origin?: string;
+	}) {
+		const method = input.method ?? "GET";
+		const url = new URL(endSessionEndpoint);
+		for (const [key, value] of Object.entries(input.query ?? {})) {
+			url.searchParams.set(key, value);
+		}
+		const requestHeaders = new Headers(headers);
+		if (input.includeSessionCookie === false) {
+			requestHeaders.delete("cookie");
+		}
+		requestHeaders.set("accept", input.accept ?? "text/html");
+		let body: URLSearchParams | undefined;
+		if (input.body) {
+			body = new URLSearchParams(input.body);
+			requestHeaders.set("content-type", "application/x-www-form-urlencoded");
+			requestHeaders.set("origin", input.origin ?? baseUrl);
+		}
+		const response = await customFetchImpl(url.toString(), {
+			method,
+			headers: requestHeaders,
+			body,
+			redirect: "manual",
+		});
+		return { response, body: await response.text() };
+	}
+
+	async function requestConfirmation(input: {
+		body?: Record<string, string>;
+		accept?: string;
+		origin?: string;
+	}) {
+		const requestHeaders = new Headers(headers);
+		requestHeaders.set("accept", input.accept ?? "text/html");
+		requestHeaders.set("content-type", "application/x-www-form-urlencoded");
+		requestHeaders.set("origin", input.origin ?? baseUrl);
+		const response = await customFetchImpl(confirmationEndpoint, {
+			method: "POST",
+			headers: requestHeaders,
+			body: new URLSearchParams(input.body ?? { action: "confirm" }),
+			redirect: "manual",
+		});
+		return { response, body: await response.text() };
+	}
+
+	function captureResponseCookies(response: Response) {
+		cookieSetter(headers)({ response } as never);
+	}
+
+	function getConfirmationCookie(response: Response) {
+		const setCookies = parseSetCookieHeader(
+			response.headers.get("set-cookie") ?? "",
+		);
+		const entry = Array.from(setCookies.entries()).find(([name]) =>
+			name.endsWith(".oauth_logout_confirmation"),
+		);
+		if (!entry) throw new Error("confirmation cookie was not set");
+		return { name: entry[0], value: entry[1].value };
+	}
+
+	function replaceCookie(target: Headers, name: string, value: string) {
+		const cookies = parseCookies(target.get("cookie") ?? "");
+		cookies.set(name, value);
+		target.set(
+			"cookie",
+			Array.from(
+				cookies,
+				([cookieName, cookieValue]) =>
+					`${cookieName}=${encodeURIComponent(cookieValue)}`,
+			).join("; "),
+		);
+	}
+
+	async function completeBrowserConfirmation(input: {
+		query?: Record<string, string>;
+	}) {
+		const confirmation = await requestEndSession({
+			query: input.query,
+			accept: "text/html",
+		});
+		captureResponseCookies(confirmation.response);
+		expect(confirmation.response.status).toBe(200);
+		expect(confirmation.response.headers.get("cache-control")).toBe("no-store");
+		expect(confirmation.response.headers.get("content-security-policy")).toBe(
+			"default-src 'none'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+		);
+		expect(confirmation.body).toContain("Confirm logout");
+		const completed = await requestConfirmation({
+			accept: "text/html",
+		});
+		return { confirmation, completed };
+	}
 
 	// Registers a confidential client application to work with
 	beforeAll(async () => {
@@ -84,6 +203,7 @@ describe("oauth logout", async () => {
 	// Login again after each test
 	beforeEach(async () => {
 		const { headers: _headers } = await signInWithTestUser();
+		_headers.set("origin", baseUrl);
 		headers = _headers;
 	});
 
@@ -154,13 +274,383 @@ describe("oauth logout", async () => {
 		return tokens;
 	}
 
+	async function issueTokens(
+		input: { client?: OAuthClient; headers?: Headers; scopes?: string[] } = {},
+	) {
+		const registeredClient = input.client ?? oauthClient;
+		if (!registeredClient?.client_id || !registeredClient.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const codeVerifier = generateRandomString(32);
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: registeredClient.client_id,
+				clientSecret: registeredClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			redirectURI: "",
+			authorizationEndpoint: `${baseUrl}/api/auth/oauth2/authorize`,
+			state,
+			scopes: input.scopes ?? scopes,
+			codeVerifier,
+		});
+
+		let callbackRedirectUrl = "";
+		await client.$fetch(authUrl.toString(), {
+			headers: input.headers ?? headers,
+			onError(context) {
+				callbackRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+		const callback = new URL(callbackRedirectUrl);
+		return validateAuthCode({
+			code: callback.searchParams.get("code")!,
+			codeVerifier,
+			options: {
+				clientId: registeredClient.client_id,
+				clientSecret: registeredClient.client_secret,
+			},
+		});
+	}
+
+	async function createLogoutRedirectClient() {
+		const response = await auth.api.adminCreateOAuthClient({
+			headers,
+			body: {
+				redirect_uris: [redirectUri],
+				application_type: "native",
+				token_endpoint_auth_method: "client_secret_post",
+				enable_end_session: true,
+				skip_consent: true,
+				post_logout_redirect_uris: [logoutRedirectUri],
+			},
+		});
+		if (!response?.client_id || !response.client_secret) {
+			throw Error("logout redirect client registration failed");
+		}
+		return response;
+	}
+
 	it("should fail with invalid id_token_hint", async () => {
 		const logoutRes = await client.oauth2.endSession({
 			query: {
 				id_token_hint: "",
 			},
 		});
-		expect(logoutRes.error?.status).toBe(401);
+		expect(logoutRes.error?.status).toBeGreaterThanOrEqual(400);
+		expect(logoutRes.error?.status).toBeLessThan(500);
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("requires confirmation before deleting the session without a hint", async () => {
+		const before = await auth.api.getSession({ headers });
+		expect(before).not.toBeNull();
+
+		const { confirmation, completed } = await completeBrowserConfirmation({});
+		expect(confirmation.body).toContain(
+			'<form method="post" data-oidc-logout-confirmation',
+		);
+		expect(confirmation.body).toContain('name="action" value="confirm"');
+		expect(completed.response.status).toBe(200);
+		expect(completed.response.headers.get("cache-control")).toBe("no-store");
+		expect(completed.response.headers.get("content-security-policy")).toBe(
+			"default-src 'none'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+		);
+		expect(completed.body).toContain('data-oidc-logout-state="logged-out"');
+		expect(completed.body).toContain("Logged out");
+		expect(completed.response.headers.get("location")).toBeNull();
+
+		const after = await auth.api.getSession({ headers });
+		expect(after).toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("does not delete on an initial no-hint POST", async () => {
+		const result = await requestEndSession({
+			method: "POST",
+			body: {},
+			accept: "text/html",
+		});
+		expect(result.response.status).toBe(200);
+		expect(result.body).toContain("data-oidc-logout-confirmation");
+		expect(await auth.api.getSession({ headers })).not.toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("confirms a no-hint form POST when the initial navigation omits the session cookie", async () => {
+		const sessionHeaders = new Headers(headers);
+		const initial = await requestEndSession({
+			method: "POST",
+			body: {},
+			accept: "text/html",
+			includeSessionCookie: false,
+			origin: "https://rp.example",
+		});
+		expect(initial.response.status).toBe(200);
+		expect(initial.body).toContain(
+			'<form method="post" data-oidc-logout-confirmation',
+		);
+		expect(initial.body).not.toContain('data-oidc-logout-state="logged-out"');
+		expect(
+			await auth.api.getSession({ headers: sessionHeaders }),
+		).not.toBeNull();
+
+		captureResponseCookies(initial.response);
+		const completed = await requestConfirmation({ accept: "text/html" });
+		expect(completed.response.status).toBe(200);
+		expect(completed.body).toContain('data-oidc-logout-state="logged-out"');
+		expect(await auth.api.getSession({ headers: sessionHeaders })).toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("does not delete when the confirmation state is missing or tampered", async () => {
+		const confirmation = await requestEndSession({ accept: "text/html" });
+		expect(confirmation.body).toContain("data-oidc-logout-confirmation");
+		const missingState = await requestConfirmation({ accept: "text/html" });
+		expect(missingState.response.status).toBeGreaterThanOrEqual(400);
+		expect(missingState.response.headers.get("cache-control")).toBe("no-store");
+		expect(missingState.response.headers.get("content-security-policy")).toBe(
+			"default-src 'none'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+		);
+		expect(await auth.api.getSession({ headers })).not.toBeNull();
+
+		captureResponseCookies(confirmation.response);
+		const confirmationCookie = getConfirmationCookie(confirmation.response);
+		replaceCookie(headers, confirmationCookie.name, "tampered");
+		const tamperedState = await requestConfirmation({ accept: "text/html" });
+		expect(tamperedState.response.status).toBeGreaterThanOrEqual(400);
+		expect(tamperedState.response.headers.get("cache-control")).toBe(
+			"no-store",
+		);
+		expect(await auth.api.getSession({ headers })).not.toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("rejects confirmation state bound to a different current session", async () => {
+		const confirmation = await requestEndSession({ accept: "text/html" });
+		captureResponseCookies(confirmation.response);
+		const confirmationCookie = getConfirmationCookie(confirmation.response);
+		const otherSession = await signInWithTestUser();
+		const originalHeaders = headers;
+		applySetCookies(otherSession.headers, [
+			`${confirmationCookie.name}=${encodeURIComponent(confirmationCookie.value)}; Path=/`,
+		]);
+		headers = otherSession.headers;
+		try {
+			const result = await requestConfirmation({ accept: "text/html" });
+			expect(result.response.status).toBeGreaterThanOrEqual(400);
+			expect(
+				await auth.api.getSession({ headers: originalHeaders }),
+			).not.toBeNull();
+			expect(
+				await auth.api.getSession({ headers: otherSession.headers }),
+			).not.toBeNull();
+		} finally {
+			headers = originalHeaders;
+		}
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("rejects a cross-origin confirmation POST", async () => {
+		const confirmation = await requestEndSession({ accept: "text/html" });
+		captureResponseCookies(confirmation.response);
+		const result = await requestConfirmation({
+			accept: "text/html",
+			origin: "https://attacker.example",
+		});
+		expect(result.response.status).toBe(403);
+		expect(await auth.api.getSession({ headers })).not.toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#Redirection
+	 */
+	it("does not redirect or delete for a redirect request without a hint", async () => {
+		const result = await requestEndSession({
+			query: { post_logout_redirect_uri: logoutRedirectUri },
+			accept: "text/html",
+		});
+		expect(result.response.status).toBe(200);
+		expect(result.response.headers.get("location")).toBeNull();
+		expect(result.body).toContain("data-oidc-logout-confirmation");
+		expect(await auth.api.getSession({ headers })).not.toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("redirects after confirming a no-hint request for an identified client", async () => {
+		const redirectClient = await createLogoutRedirectClient();
+		const confirmation = await requestEndSession({
+			query: {
+				client_id: redirectClient.client_id,
+				post_logout_redirect_uri: logoutRedirectUri,
+				state: "confirmed-state",
+			},
+			accept: "text/html",
+		});
+		captureResponseCookies(confirmation.response);
+		expect(confirmation.response.status).toBe(200);
+		expect(confirmation.response.headers.get("location")).toBeNull();
+		expect(confirmation.body).toContain("data-oidc-logout-confirmation");
+
+		const completed = await requestConfirmation({ accept: "text/html" });
+		expect(completed.response.status).toBe(302);
+		expect(completed.response.headers.get("location")).toBe(
+			`${logoutRedirectUri}?state=confirmed-state`,
+		);
+		expect(await auth.api.getSession({ headers })).toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#Redirection
+	 */
+	it("revalidates a no-hint redirect before completing confirmation", async () => {
+		const redirectClient = await createLogoutRedirectClient();
+		const confirmation = await requestEndSession({
+			query: {
+				client_id: redirectClient.client_id,
+				post_logout_redirect_uri: logoutRedirectUri,
+				state: "stale-registration-state",
+			},
+			accept: "text/html",
+		});
+		captureResponseCookies(confirmation.response);
+		expect(confirmation.response.status).toBe(200);
+		expect(confirmation.response.headers.get("location")).toBeNull();
+
+		const context = await auth.$context;
+		await context.adapter.update({
+			model: "oauthClient",
+			where: [{ field: "clientId", value: redirectClient.client_id }],
+			update: { postLogoutRedirectUris: [] },
+		});
+
+		const completed = await requestConfirmation({ accept: "text/html" });
+		expect(completed.response.status).toBe(200);
+		expect(completed.response.headers.get("location")).toBeNull();
+		expect(completed.body).toContain('data-oidc-logout-state="logged-out"');
+		expect(completed.body).toContain(
+			"The requested post-logout redirect was not registered.",
+		);
+		expect(completed.body).not.toContain("stale-registration-state");
+		expect(await auth.api.getSession({ headers })).toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("requires confirmation for a state-only request", async () => {
+		const result = await requestEndSession({
+			query: { state: "opaque-state" },
+			accept: "text/html",
+		});
+		expect(result.response.status).toBe(200);
+		expect(result.response.headers.get("location")).toBeNull();
+		expect(result.body).toContain("data-oidc-logout-confirmation");
+		expect(result.body).not.toContain("opaque-state");
+		expect(await auth.api.getSession({ headers })).not.toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("rejects alg=none hints as controlled errors", async () => {
+		const hint = new UnsecuredJWT({ sid: "not-a-session" })
+			.setIssuer(baseUrl)
+			.setAudience(oauthClient!.client_id)
+			.encode();
+		const result = await client.oauth2.endSession({
+			query: { id_token_hint: hint },
+		});
+		expect(result.error?.status).toBeGreaterThanOrEqual(400);
+		expect(result.error?.status).toBeLessThan(500);
+		expect(await auth.api.getSession({ headers })).not.toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#Validation
+	 */
+	it("offers confirmation for an invalid hint without an unsafe redirect", async () => {
+		const result = await requestEndSession({
+			query: {
+				id_token_hint: "not-a-jwt",
+				post_logout_redirect_uri: "https://evil.example/logout",
+			},
+			accept: "text/html",
+		});
+		expect(result.response.status).toBe(200);
+		expect(result.response.headers.get("location")).toBeNull();
+		expect(result.body).toContain("data-oidc-logout-confirmation");
+		expect(result.body).not.toContain("evil.example");
+		expect(await auth.api.getSession({ headers })).not.toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+	 */
+	it("does not fan out client lookups across unverified hint audiences", async () => {
+		const context = await auth.$context;
+		const lookup = vi.spyOn(context.adapter, "findOne");
+		const hint = new UnsecuredJWT({ sid: "not-a-session", sub: "test-user" })
+			.setIssuer(baseUrl)
+			.setAudience(
+				Array.from({ length: 100 }, (_, index) => `unknown-client-${index}`),
+			)
+			.encode();
+
+		try {
+			const result = await requestEndSession({
+				query: { id_token_hint: hint },
+				accept: "text/html",
+			});
+			expect(result.response.status).toBe(200);
+			expect(result.body).toContain("data-oidc-logout-confirmation");
+			const clientLookups = lookup.mock.calls.filter(
+				([query]) => query.model === "oauthClient",
+			);
+			expect(clientLookups).toHaveLength(0);
+		} finally {
+			lookup.mockRestore();
+		}
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+	 */
+	it("resolves a valid multi-audience logout hint through azp", async () => {
+		const tokens = await issueTokens();
+		const payload = decodeJwt(tokens.data?.id_token!);
+		const hint = await auth.api.signJWT({
+			body: {
+				payload: {
+					...payload,
+					aud: [oauthClient!.client_id, "https://other-audience.example"],
+					azp: oauthClient!.client_id,
+				},
+			},
+		});
+
+		const result = await requestEndSession({
+			query: { id_token_hint: hint!.token },
+			accept: "text/html",
+		});
+		expect(result.response.status).toBe(200);
+		expect(result.body).toContain('data-oidc-logout-state="logged-out"');
+		expect(await auth.api.getSession({ headers })).toBeNull();
 	});
 
 	it("should not allow registration of rp-initiated clients, specifically enable_end_session", async () => {
@@ -303,6 +793,155 @@ describe("oauth logout", async () => {
 		expect(sessionAfter.error).toBeNull();
 	});
 
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("supports a valid hint in a form POST", async () => {
+		const tokens = await issueTokens();
+		const result = await requestEndSession({
+			method: "POST",
+			body: { id_token_hint: tokens.data?.id_token! },
+			accept: "application/json",
+		});
+		expect(result.response.status).toBe(200);
+		expect(result.response.headers.get("location")).toBeNull();
+		expect(await auth.api.getSession({ headers })).toBeNull();
+	});
+
+	it("supports a valid hint through the generated client", async () => {
+		const tokens = await issueTokens();
+		const logoutRes = await client.oauth2.endSession({
+			id_token_hint: tokens.data?.id_token!,
+		});
+		if (logoutRes.error) {
+			expect(logoutRes.error.status).toBe(302);
+		} else {
+			expect(logoutRes.data).toBeNull();
+		}
+		expect(await auth.api.getSession({ headers })).toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("logs out a valid hinted session without browser cookies", async () => {
+		const tokens = await issueTokens();
+		const requestHeaders = new Headers({ accept: "application/json" });
+		const result = await customFetchImpl(
+			`${endSessionEndpoint}?id_token_hint=${encodeURIComponent(tokens.data?.id_token!)}`,
+			{ headers: requestHeaders },
+		);
+		expect(result.status).toBe(200);
+		expect(await auth.api.getSession({ headers })).toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+	 */
+	it("requires confirmation when a valid hint conflicts with the current session", async () => {
+		const currentHeaders = new Headers(headers);
+		const otherSignIn = await signInWithTestUser();
+		const otherTokens = await issueTokens({ headers: otherSignIn.headers });
+		headers = currentHeaders;
+
+		const result = await requestEndSession({
+			query: { id_token_hint: otherTokens.data?.id_token! },
+			accept: "text/html",
+		});
+		captureResponseCookies(result.response);
+		expect(result.response.status).toBe(200);
+		expect(result.body).toContain("data-oidc-logout-confirmation");
+		expect(await auth.api.getSession({ headers })).not.toBeNull();
+		expect(
+			await auth.api.getSession({ headers: otherSignIn.headers }),
+		).not.toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#Validation
+	 */
+	it("rejects a bad signed hint without deleting the session", async () => {
+		const tokens = await issueTokens();
+		const idToken = tokens.data?.id_token!;
+		const [header, payload, signature] = idToken.split(".");
+		const replacement = signature?.[0] === "A" ? "B" : "A";
+		const badHint = [
+			header,
+			payload,
+			`${replacement}${signature?.slice(1)}`,
+		].join(".");
+		const result = await client.oauth2.endSession({
+			query: { id_token_hint: badHint },
+		});
+		expect(result.error?.status).toBeGreaterThanOrEqual(400);
+		expect(result.error?.status).toBeLessThan(500);
+		expect(await auth.api.getSession({ headers })).not.toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#Redirection
+	 */
+	it("logs out and suppresses an unregistered post-logout redirect", async () => {
+		const redirectClient = await createLogoutRedirectClient();
+		const tokens = await issueTokens({ client: redirectClient });
+		const result = await requestEndSession({
+			query: {
+				id_token_hint: tokens.data?.id_token!,
+				post_logout_redirect_uri: "https://evil.example/logout",
+			},
+			accept: "text/html",
+		});
+		expect(result.response.status).toBe(200);
+		expect(result.response.headers.get("location")).toBeNull();
+		expect(result.body).toContain('data-oidc-logout-state="logged-out"');
+		expect(result.body).toContain("Logged out");
+		expect(result.body).not.toContain("evil.example");
+		expect(result.body).not.toContain("attacker");
+		expect(await auth.api.getSession({ headers })).toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#Redirection
+	 */
+	it("logs out and suppresses a query-added post-logout redirect", async () => {
+		const redirectClient = await createLogoutRedirectClient();
+		const tokens = await issueTokens({ client: redirectClient });
+		const result = await requestEndSession({
+			query: {
+				id_token_hint: tokens.data?.id_token!,
+				post_logout_redirect_uri: `${logoutRedirectUri}?attacker=1`,
+			},
+			accept: "text/html",
+		});
+		expect(result.response.status).toBe(200);
+		expect(result.response.headers.get("location")).toBeNull();
+		expect(result.body).toContain('data-oidc-logout-state="logged-out"');
+		expect(result.body).toContain("Logged out");
+		expect(result.body).not.toContain("attacker");
+		expect(await auth.api.getSession({ headers })).toBeNull();
+	});
+
+	/**
+	 * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html#Validation
+	 */
+	it("surfaces session deletion failures without redirecting as successful", async () => {
+		const tokens = await issueTokens();
+		const context = await auth.$context;
+		const deletion = vi
+			.spyOn(context.internalAdapter, "deleteSession")
+			.mockRejectedValue(new Error("adapter failure"));
+		try {
+			const result = await client.oauth2.endSession({
+				query: { id_token_hint: tokens.data?.id_token! },
+			});
+			expect(result.error?.status).toBeGreaterThanOrEqual(500);
+			expect(result.error?.status).toBeLessThan(600);
+			expect(await auth.api.getSession({ headers })).not.toBeNull();
+		} finally {
+			deletion.mockRestore();
+		}
+	});
+
 	it("should pass with redirection", async () => {
 		const response = await auth.api.adminCreateOAuthClient({
 			headers,
@@ -379,6 +1018,65 @@ describe("oauth logout", async () => {
 		expect(logoutRedirectRes).toContain(logoutRedirectUri);
 		expect(logoutRedirectRes).toContain("state=123");
 		expect(logoutRes.error?.status).toBe(302);
+	});
+});
+
+describe("oauth logout confirmation with a custom base path", async () => {
+	const baseUrl = "http://localhost:3006";
+	const basePath = "/custom/auth";
+	const { auth, client, signInWithTestUser } = await getTestInstance(
+		{
+			baseURL: baseUrl,
+			basePath,
+			plugins: [
+				oauthProvider({
+					loginPage: "/login",
+					consentPage: "/consent",
+					scopes: ["openid"],
+				}),
+				jwt(),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [oauthProviderClient()],
+			},
+		},
+	);
+
+	it("uses the custom base path for confirmation navigation and cookies", async () => {
+		const { headers } = await signInWithTestUser();
+		const response = await auth.handler(
+			new Request(`${baseUrl}${basePath}/oauth2/end-session`, {
+				headers: {
+					accept: "text/html",
+					cookie: headers.get("cookie") ?? "",
+				},
+			}),
+		);
+		const body = await response.text();
+		const confirmationURL = `${baseUrl}${basePath}/oauth2/end-session/confirm`;
+		expect(response.status).toBe(200);
+		expect(body).toContain(`action="${confirmationURL}"`);
+
+		const cookies = parseSetCookieHeader(
+			response.headers.get("set-cookie") ?? "",
+		);
+		const confirmationCookie = Array.from(cookies.entries()).find(([name]) =>
+			name.endsWith(".oauth_logout_confirmation"),
+		);
+		expect(confirmationCookie?.[1].path).toBe(
+			`${basePath}/oauth2/end-session/confirm`,
+		);
+
+		// @ts-expect-error HTTP-scoped endpoints are excluded from the server API.
+		auth.api.oauth2EndSessionConfirmation;
+		// @ts-expect-error HTTP-scoped endpoints are excluded from generated clients.
+		client.oauth2.endSessionConfirmation;
+		if (false) {
+			// @ts-expect-error The internal confirmation action is not public logout input.
+			client.oauth2.endSession({ action: "confirm" });
+		}
 	});
 });
 

--- a/packages/oauth-provider/src/logout.ts
+++ b/packages/oauth-provider/src/logout.ts
@@ -1,5 +1,7 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { getCurrentAdapter } from "@better-auth/core/context";
+import { isBrowserFetchRequest } from "@better-auth/core/utils/fetch-metadata";
+import { deleteSessionCookie } from "better-auth/cookies";
 import { generateRandomString } from "better-auth/crypto";
 import { getJwks } from "better-auth/oauth2";
 import { resolveSigningKey, signJWT } from "better-auth/plugins";
@@ -7,7 +9,8 @@ import type { Session } from "better-auth/types";
 import { APIError } from "better-call";
 import type { JWTPayload } from "jose";
 import { compactVerify, createLocalJWKSet, decodeJwt } from "jose";
-import { handleRedirect } from "./authorize";
+import type { OAuthRedirectResult } from "./authorize";
+import { getIssuer, handleRedirect } from "./authorize";
 import type { OAuthOptions, SchemaClient, Scope } from "./types";
 import {
 	decryptStoredClientSecret,
@@ -325,10 +328,555 @@ async function deliverBackchannelLogoutTokens(
 
 export { applyBackchannelLogoutPlan, prepareBackchannelLogoutPlan };
 
+const LOGOUT_CONFIRMATION_TTL_SECONDS = 5 * 60;
+const LOGOUT_CONFIRMATION_COOKIE_SUFFIX = ".oauth_logout_confirmation";
+
+type RPInitiatedLogoutRequest = {
+	id_token_hint?: string;
+	client_id?: string;
+	post_logout_redirect_uri?: string;
+	state?: string;
+};
+
+type CurrentBrowserSession = {
+	session: Session;
+};
+
+type LogoutConfirmationState = {
+	sessionId?: string;
+	clientId?: string;
+	postLogoutRedirectUri?: string;
+	state?: string;
+	redirectInvalid?: boolean;
+	expiresAt: number;
+};
+
+type LogoutConfirmationContext = Omit<
+	LogoutConfirmationState,
+	"sessionId" | "expiresAt"
+>;
+
+function escapeHtml(value: string): string {
+	return value.replace(/[&<>"']/g, (character) => {
+		switch (character) {
+			case "&":
+				return "&amp;";
+			case "<":
+				return "&lt;";
+			case ">":
+				return "&gt;";
+			case '"':
+				return "&quot;";
+			case "'":
+				return "&#39;";
+			default:
+				return character;
+		}
+	});
+}
+
+function isBrowserNavigation(ctx: GenericEndpointContext): boolean {
+	const headers = ctx.request?.headers ?? ctx.headers;
+	if (!headers || isBrowserFetchRequest(headers)) return false;
+	const accept = headers.get("accept") ?? "";
+	return (
+		headers.get("sec-fetch-mode") === "navigate" ||
+		accept.includes("text/html") ||
+		accept.includes("application/xhtml+xml")
+	);
+}
+
+function logoutPage(title: string, body: string, status = 200): Response {
+	return new Response(
+		`<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title></head><body>${body}</body></html>`,
+		{
+			status,
+			headers: {
+				"cache-control": "no-store",
+				"content-security-policy":
+					"default-src 'none'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+				"content-type": "text/html; charset=utf-8",
+				pragma: "no-cache",
+				"x-content-type-options": "nosniff",
+			},
+		},
+	);
+}
+
+function logoutConfirmationPath(ctx: GenericEndpointContext): string {
+	return `${ctx.context.baseURL.replace(/\/$/, "")}/oauth2/end-session/confirm`;
+}
+
+function logoutConfirmationCookiePath(ctx: GenericEndpointContext): string {
+	try {
+		const url = new URL(logoutConfirmationPath(ctx));
+		return url.pathname;
+	} catch {
+		return "/oauth2/end-session/confirm";
+	}
+}
+
+function logoutConfirmationPage(ctx: GenericEndpointContext): Response {
+	const action = logoutConfirmationPath(ctx);
+	return logoutPage(
+		"Confirm logout",
+		`<main><h1>Confirm logout</h1><p>Do you want to log out of this account?</p><form method="post" data-oidc-logout-confirmation action="${escapeHtml(action)}"><button type="submit" name="action" value="confirm">Confirm logout</button></form></main>`,
+	);
+}
+
+function logoutSuccessPage(note?: string): Response {
+	const message = note ? `Logged out. ${escapeHtml(note)}` : "Logged out.";
+	return logoutPage(
+		"Logged out",
+		`<main><p data-oidc-logout-state="logged-out">${message}</p></main>`,
+	);
+}
+
+function logoutErrorPage(description: string, status: number): Response {
+	return logoutPage(
+		"Logout error",
+		`<main><h1>Logout error</h1><p data-oidc-logout-state="error">${escapeHtml(description)}</p></main>`,
+		status,
+	);
+}
+
+function logoutProtocolError(
+	ctx: GenericEndpointContext,
+	status: "BAD_REQUEST" | "UNAUTHORIZED" | "INTERNAL_SERVER_ERROR",
+	error: string,
+	description: string,
+): Response {
+	if (isBrowserNavigation(ctx)) {
+		const statusCode =
+			status === "BAD_REQUEST" ? 400 : status === "UNAUTHORIZED" ? 401 : 500;
+		return logoutErrorPage(description, statusCode);
+	}
+	throw new APIError(status, {
+		error,
+		error_description: description,
+	});
+}
+
+function logoutConfirmationCookieName(ctx: GenericEndpointContext): string {
+	return `${ctx.context.authCookies.sessionToken.name}${LOGOUT_CONFIRMATION_COOKIE_SUFFIX}`;
+}
+
+function logoutConfirmationCookieOptions(
+	ctx: GenericEndpointContext,
+	maxAge: number,
+) {
+	return {
+		...ctx.context.authCookies.sessionToken.attributes,
+		httpOnly: true,
+		maxAge,
+		path: logoutConfirmationCookiePath(ctx),
+		sameSite: "lax" as const,
+	};
+}
+
+async function setLogoutConfirmationState(
+	ctx: GenericEndpointContext,
+	sessionId?: string,
+	confirmation: LogoutConfirmationContext = {},
+): Promise<void> {
+	const state: LogoutConfirmationState = {
+		...(sessionId ? { sessionId } : {}),
+		...confirmation,
+		expiresAt: Date.now() + LOGOUT_CONFIRMATION_TTL_SECONDS * 1000,
+	};
+	await ctx.setSignedCookie(
+		logoutConfirmationCookieName(ctx),
+		JSON.stringify(state),
+		ctx.context.secret,
+		logoutConfirmationCookieOptions(ctx, LOGOUT_CONFIRMATION_TTL_SECONDS),
+	);
+}
+
+async function getLogoutConfirmationState(
+	ctx: GenericEndpointContext,
+): Promise<LogoutConfirmationState | null> {
+	const value = await ctx.getSignedCookie(
+		logoutConfirmationCookieName(ctx),
+		ctx.context.secret,
+	);
+	if (typeof value !== "string") return null;
+
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (typeof parsed !== "object" || parsed === null) return null;
+		const record = parsed as Record<string, unknown>;
+		if (
+			(record.sessionId !== undefined &&
+				(typeof record.sessionId !== "string" ||
+					record.sessionId.length === 0)) ||
+			(record.clientId !== undefined &&
+				(typeof record.clientId !== "string" ||
+					record.clientId.length === 0)) ||
+			(record.postLogoutRedirectUri !== undefined &&
+				(typeof record.postLogoutRedirectUri !== "string" ||
+					record.postLogoutRedirectUri.length === 0)) ||
+			(record.state !== undefined && typeof record.state !== "string") ||
+			(record.redirectInvalid !== undefined &&
+				typeof record.redirectInvalid !== "boolean") ||
+			(record.postLogoutRedirectUri !== undefined &&
+				record.clientId === undefined) ||
+			typeof record.expiresAt !== "number" ||
+			!Number.isFinite(record.expiresAt)
+		) {
+			return null;
+		}
+		return {
+			...(typeof record.sessionId === "string"
+				? { sessionId: record.sessionId }
+				: {}),
+			...(typeof record.clientId === "string"
+				? { clientId: record.clientId }
+				: {}),
+			...(typeof record.postLogoutRedirectUri === "string"
+				? { postLogoutRedirectUri: record.postLogoutRedirectUri }
+				: {}),
+			...(typeof record.state === "string" ? { state: record.state } : {}),
+			...(typeof record.redirectInvalid === "boolean"
+				? { redirectInvalid: record.redirectInvalid }
+				: {}),
+			expiresAt: record.expiresAt,
+		};
+	} catch {
+		return null;
+	}
+}
+
+function clearLogoutConfirmationState(ctx: GenericEndpointContext): void {
+	ctx.setCookie(
+		logoutConfirmationCookieName(ctx),
+		"",
+		logoutConfirmationCookieOptions(ctx, 0),
+	);
+}
+
+async function getCurrentBrowserSession(
+	ctx: GenericEndpointContext,
+): Promise<CurrentBrowserSession | null> {
+	const token = await ctx.getSignedCookie(
+		ctx.context.authCookies.sessionToken.name,
+		ctx.context.secret,
+	);
+	if (typeof token !== "string" || token.length === 0) return null;
+
+	try {
+		const result = await ctx.context.internalAdapter.findSession(token);
+		return result ? { session: result.session } : null;
+	} catch (error) {
+		ctx.context.logger.error(
+			"Failed to read the current logout session",
+			error,
+		);
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error: "server_error",
+			error_description: "Unable to read the current session",
+		});
+	}
+}
+
+async function findHintedSession(
+	ctx: GenericEndpointContext,
+	sessionId: string,
+): Promise<Session | null> {
+	try {
+		return await ctx.context.adapter.findOne<Session>({
+			model: "session",
+			where: [{ field: "id", value: sessionId }],
+		});
+	} catch (error) {
+		ctx.context.logger.error("Failed to read the hinted logout session", error);
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error: "server_error",
+			error_description: "Unable to read the hinted session",
+		});
+	}
+}
+
+async function deleteLogoutSession(
+	ctx: GenericEndpointContext,
+	session: Session,
+): Promise<void> {
+	if (typeof session.token !== "string" || session.token.length === 0) {
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error: "server_error",
+			error_description: "Unable to complete logout",
+		});
+	}
+	try {
+		await ctx.context.internalAdapter.deleteSession(session.token);
+	} catch (error) {
+		ctx.context.logger.error("Failed to delete the logout session", error);
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error: "server_error",
+			error_description: "Unable to complete logout",
+		});
+	}
+}
+
+async function getLogoutClient(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	clientId: string,
+): Promise<SchemaClient<Scope[]> | null> {
+	try {
+		return await getClient(ctx, opts, clientId);
+	} catch (error) {
+		ctx.context.logger.error("Failed to resolve the logout client", error);
+		throw new APIError("INTERNAL_SERVER_ERROR", {
+			error: "server_error",
+			error_description: "Unable to resolve the logout client",
+		});
+	}
+}
+
+function normalizeLogoutAudiences(value: unknown): string[] {
+	const values = Array.isArray(value) ? value : [value];
+	return values.filter(
+		(candidate): candidate is string => typeof candidate === "string",
+	);
+}
+
+function getHintClientId(payload: JWTPayload): string | null {
+	if (typeof payload.aud === "string" && payload.aud.length > 0) {
+		return payload.aud;
+	}
+	if (typeof payload.azp === "string" && payload.azp.length > 0) {
+		return payload.azp;
+	}
+	const audiences = normalizeLogoutAudiences(payload.aud);
+	return audiences.length === 1 ? audiences[0]! : null;
+}
+
+async function resolveHintClient(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	hint: string,
+	clientId?: string,
+): Promise<SchemaClient<Scope[]> | null> {
+	if (clientId) return getLogoutClient(ctx, opts, clientId);
+
+	let decoded: JWTPayload;
+	try {
+		decoded = decodeJwt(hint);
+	} catch {
+		return null;
+	}
+	// The hint is unverified at this point. Resolve at most one client before
+	// signature verification so an attacker cannot amplify database lookups
+	// with a large audience array. Multi-audience ID Tokens identify the
+	// authorized party through azp.
+	const candidate = getHintClientId(decoded);
+	return candidate ? getLogoutClient(ctx, opts, candidate) : null;
+}
+
+async function verifyLogoutHint(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	hint: string,
+	client: SchemaClient<Scope[]>,
+): Promise<JWTPayload | null> {
+	try {
+		let payload: JWTPayload;
+		if (opts.disableJwtPlugin) {
+			if (!client.clientSecret) return null;
+			const secret = await decryptStoredClientSecret(
+				ctx,
+				opts.storeClientSecret,
+				client.clientSecret,
+			);
+			const { payload: verifiedPayload } = await compactVerify(
+				hint,
+				new TextEncoder().encode(secret),
+			);
+			payload = JSON.parse(
+				new TextDecoder().decode(verifiedPayload),
+			) as JWTPayload;
+		} else {
+			const jwtPluginOptions = getJwtPlugin(ctx.context).options;
+			const jwksUrl =
+				jwtPluginOptions?.jwks?.remoteUrl ??
+				`${ctx.context.baseURL}${jwtPluginOptions?.jwks?.jwksPath ?? "/jwks"}`;
+			const jwks = await getJwks(hint, { jwksFetch: jwksUrl });
+			const { payload: verifiedPayload } = await compactVerify(
+				hint,
+				createLocalJWKSet(jwks),
+			);
+			payload = JSON.parse(
+				new TextDecoder().decode(verifiedPayload),
+			) as JWTPayload;
+		}
+
+		if (payload.iss !== getIssuer(ctx, opts)) return null;
+		if (!normalizeLogoutAudiences(payload.aud).includes(client.clientId)) {
+			return null;
+		}
+		if (
+			typeof payload.sid !== "string" ||
+			payload.sid.length === 0 ||
+			typeof payload.sub !== "string" ||
+			payload.sub.length === 0
+		) {
+			return null;
+		}
+		return payload;
+	} catch {
+		return null;
+	}
+}
+
+function getRegisteredLogoutRedirect(
+	client: SchemaClient<Scope[]>,
+	requestedURI?: string,
+	state?: string,
+): { uri?: string; invalid: boolean } {
+	if (!requestedURI) return { invalid: false };
+	if (!client.postLogoutRedirectUris?.includes(requestedURI)) {
+		return { invalid: true };
+	}
+	if (!state) return { uri: requestedURI, invalid: false };
+	try {
+		const redirectURI = new URL(requestedURI);
+		redirectURI.searchParams.set("state", state);
+		return { uri: redirectURI.toString(), invalid: false };
+	} catch {
+		return { invalid: true };
+	}
+}
+
+function getLogoutConfirmationContext(
+	client: SchemaClient<Scope[]>,
+	request: RPInitiatedLogoutRequest,
+): LogoutConfirmationContext {
+	if (!request.post_logout_redirect_uri) return {};
+	const redirect = getRegisteredLogoutRedirect(
+		client,
+		request.post_logout_redirect_uri,
+		request.state,
+	);
+	if (redirect.invalid) return { redirectInvalid: true };
+	return {
+		clientId: client.clientId,
+		postLogoutRedirectUri: request.post_logout_redirect_uri,
+		...(request.state !== undefined ? { state: request.state } : {}),
+	};
+}
+
+async function getConfirmedLogoutRedirect(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+	state: LogoutConfirmationState,
+): Promise<{ uri?: string; invalid: boolean }> {
+	if (state.redirectInvalid) return { invalid: true };
+	if (!state.clientId || !state.postLogoutRedirectUri) {
+		return { invalid: false };
+	}
+	const client = await getLogoutClient(ctx, opts, state.clientId);
+	if (!client || client.disabled || !client.enableEndSession) {
+		return { invalid: true };
+	}
+	return getRegisteredLogoutRedirect(
+		client,
+		state.postLogoutRedirectUri,
+		state.state,
+	);
+}
+
+async function confirmationRequired(
+	ctx: GenericEndpointContext,
+	currentSession: CurrentBrowserSession | null,
+	confirmation: LogoutConfirmationContext = {},
+): Promise<Response> {
+	if (!currentSession) {
+		if (isBrowserNavigation(ctx)) {
+			await setLogoutConfirmationState(ctx, undefined, confirmation);
+			return logoutConfirmationPage(ctx);
+		}
+		return logoutProtocolError(
+			ctx,
+			"BAD_REQUEST",
+			"invalid_request",
+			"No active session is available for logout",
+		);
+	}
+	if (!isBrowserNavigation(ctx)) {
+		return logoutProtocolError(
+			ctx,
+			"BAD_REQUEST",
+			"invalid_request",
+			"User confirmation is required to complete logout",
+		);
+	}
+	await setLogoutConfirmationState(
+		ctx,
+		currentSession.session.id,
+		confirmation,
+	);
+	return logoutConfirmationPage(ctx);
+}
+
+async function completeConfirmedLogout(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+): Promise<OAuthRedirectResult | Response | null> {
+	const state = await getLogoutConfirmationState(ctx);
+	const currentSession = await getCurrentBrowserSession(ctx);
+	if (!state || state.expiresAt <= Date.now()) {
+		return logoutProtocolError(
+			ctx,
+			"BAD_REQUEST",
+			"invalid_request",
+			"The logout confirmation is invalid or expired",
+		);
+	}
+	const redirect = await getConfirmedLogoutRedirect(ctx, opts, state);
+	if (!currentSession) {
+		clearLogoutConfirmationState(ctx);
+		if (redirect.uri) return handleRedirect(ctx, redirect.uri);
+		return isBrowserNavigation(ctx)
+			? logoutSuccessPage(
+					redirect.invalid
+						? "The requested post-logout redirect was not registered."
+						: undefined,
+				)
+			: logoutProtocolError(
+					ctx,
+					"BAD_REQUEST",
+					"invalid_request",
+					"No active session is available for logout",
+				);
+	}
+	if (state.sessionId && state.sessionId !== currentSession.session.id) {
+		return logoutProtocolError(
+			ctx,
+			"BAD_REQUEST",
+			"invalid_request",
+			"The logout confirmation is invalid or expired",
+		);
+	}
+
+	await deleteLogoutSession(ctx, currentSession.session);
+	deleteSessionCookie(ctx);
+	clearLogoutConfirmationState(ctx);
+	if (redirect.uri) return handleRedirect(ctx, redirect.uri);
+	return isBrowserNavigation(ctx)
+		? logoutSuccessPage(
+				redirect.invalid
+					? "The requested post-logout redirect was not registered."
+					: undefined,
+			)
+		: null;
+}
+
 /**
  * RP-Initiated Logout (OIDC RP-Initiated Logout 1.0). The RP presents a signed
  * `id_token_hint`; after verification, the OP terminates the matching session
- * and optionally redirects to `post_logout_redirect_uri`.
+ * and optionally redirects to `post_logout_redirect_uri`. Requests without a
+ * usable hint, and hints that do not identify the current browser session, use
+ * a signed, short-lived OP confirmation state before terminating that session.
  *
  * Session termination goes through `internalAdapter.deleteSession`, which fires
  * `session.delete.after` so the hook drives revocation and back-channel
@@ -340,166 +888,146 @@ export async function rpInitiatedLogoutEndpoint(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
 ) {
-	const {
-		id_token_hint,
-		client_id,
-		post_logout_redirect_uri,
-		state,
-	}: {
-		// id_token_hint is RECOMMENDED by spec; required here to prevent DoS
-		id_token_hint: string;
-		client_id?: string;
-		post_logout_redirect_uri?: string;
-		state?: string;
-	} = ctx.query;
+	const query = (ctx.query ?? {}) as RPInitiatedLogoutRequest;
+	const body = (ctx.body ?? {}) as RPInitiatedLogoutRequest;
+	const request: RPInitiatedLogoutRequest = { ...query, ...body };
 
-	const baseURL = ctx.context.baseURL;
-	const jwtPlugin = opts.disableJwtPlugin
-		? undefined
-		: getJwtPlugin(ctx.context);
-	const jwtPluginOptions = jwtPlugin?.options;
-	const jwksUrl =
-		jwtPluginOptions?.jwks?.remoteUrl ??
-		`${baseURL}${jwtPluginOptions?.jwks?.jwksPath ?? "/jwks"}`;
+	const currentSession = await getCurrentBrowserSession(ctx);
+	const hasHint = request.id_token_hint !== undefined;
 
-	let clientId = client_id;
-	if (!clientId) {
-		let decoded: JWTPayload;
-		try {
-			decoded = decodeJwt(id_token_hint);
-		} catch (_e) {
-			throw new APIError("UNAUTHORIZED", {
-				error_description: "invalid id token",
-				error: "invalid_token",
-			});
+	if (!hasHint) {
+		let confirmation: LogoutConfirmationContext = {};
+		if (request.client_id) {
+			const client = await getLogoutClient(ctx, opts, request.client_id);
+			if (!client) {
+				return logoutProtocolError(
+					ctx,
+					"BAD_REQUEST",
+					"invalid_client",
+					"The logout client does not exist",
+				);
+			}
+			if (client.disabled) {
+				return logoutProtocolError(
+					ctx,
+					"BAD_REQUEST",
+					"invalid_client",
+					"The logout client is disabled",
+				);
+			}
+			if (!client.enableEndSession) {
+				return logoutProtocolError(
+					ctx,
+					"UNAUTHORIZED",
+					"invalid_client",
+					"The client is not allowed to initiate logout",
+				);
+			}
+			confirmation = getLogoutConfirmationContext(client, request);
 		}
-		clientId = decoded?.aud as string | undefined;
-		if (!clientId) {
-			throw new APIError("INTERNAL_SERVER_ERROR", {
-				error_description: "id token missing audience",
-				error: "invalid_request",
-			});
-		}
+		return confirmationRequired(ctx, currentSession, confirmation);
 	}
 
-	const client = await getClient(ctx, opts, clientId);
+	const client = await resolveHintClient(
+		ctx,
+		opts,
+		request.id_token_hint!,
+		request.client_id,
+	);
 	if (!client) {
-		throw new APIError("BAD_REQUEST", {
-			error_description: "client doesn't exist",
-			error: "invalid_client",
-		});
+		if (currentSession && isBrowserNavigation(ctx)) {
+			return confirmationRequired(ctx, currentSession);
+		}
+		return logoutProtocolError(
+			ctx,
+			"BAD_REQUEST",
+			"invalid_client",
+			"The logout client does not exist",
+		);
 	}
 	if (client.disabled) {
-		throw new APIError("BAD_REQUEST", {
-			error_description: "client is disabled",
-			error: "invalid_client",
-		});
+		return logoutProtocolError(
+			ctx,
+			"BAD_REQUEST",
+			"invalid_client",
+			"The logout client is disabled",
+		);
 	}
 	if (!client.enableEndSession) {
-		throw new APIError("UNAUTHORIZED", {
-			error_description: "client unable to logout",
-			error: "invalid_client",
-		});
-	}
-
-	let idTokenPayload: JWTPayload | undefined;
-	if (opts.disableJwtPlugin) {
-		const clientSecret = client.clientSecret;
-		if (!clientSecret) {
-			throw new APIError("UNAUTHORIZED", {
-				error_description: "missing required credentials",
-				error: "invalid_client",
-			});
-		}
-
-		const secret = await decryptStoredClientSecret(
+		return logoutProtocolError(
 			ctx,
-			opts.storeClientSecret,
-			clientSecret,
+			"UNAUTHORIZED",
+			"invalid_client",
+			"The client is not allowed to initiate logout",
 		);
-		const key = new TextEncoder().encode(secret);
-
-		const { payload } = await compactVerify(id_token_hint, key);
-		idTokenPayload = JSON.parse(new TextDecoder().decode(payload));
-	} else {
-		const jwks = await getJwks(id_token_hint, { jwksFetch: jwksUrl });
-		const { payload } = await compactVerify(
-			id_token_hint,
-			createLocalJWKSet(jwks),
-		);
-		idTokenPayload = JSON.parse(new TextDecoder().decode(payload));
 	}
 
+	const idTokenPayload = await verifyLogoutHint(
+		ctx,
+		opts,
+		request.id_token_hint!,
+		client,
+	);
 	if (!idTokenPayload) {
-		throw new APIError("INTERNAL_SERVER_ERROR", {
-			error_description: "missing payload",
-			error: "invalid_request",
-		});
-	}
-
-	const issuer = jwtPluginOptions?.jwt?.issuer ?? ctx.context.baseURL;
-	if (issuer !== idTokenPayload.iss) {
-		throw new APIError("INTERNAL_SERVER_ERROR", {
-			error_description: "invalid issuer",
-			error: "invalid_request",
-		});
-	}
-
-	const idTokenAudience =
-		typeof idTokenPayload.aud === "string"
-			? [idTokenPayload.aud]
-			: idTokenPayload.aud;
-	if (!idTokenAudience) {
-		throw new APIError("INTERNAL_SERVER_ERROR", {
-			error_description: "id token missing audience",
-			error: "invalid_request",
-		});
-	}
-	if (client_id && !idTokenAudience.includes(client_id)) {
-		throw new APIError("BAD_REQUEST", {
-			error_description: "audience mismatch",
-			error: "invalid_request",
-		});
-	}
-
-	const sessionId = idTokenPayload.sid as string | undefined;
-	if (!sessionId) {
-		throw new APIError("INTERNAL_SERVER_ERROR", {
-			error_description: "id token missing session",
-			error: "invalid_request",
-		});
-	}
-
-	try {
-		const session = await ctx.context.adapter.findOne<Session>({
-			model: "session",
-			where: [{ field: "id", value: sessionId }],
-		});
-		if (session?.token) {
-			// internalAdapter.deleteSession fires `session.delete.before`, which
-			// runs revocation and back-channel dispatch for every RP on this
-			// session.
-			await ctx.context.internalAdapter.deleteSession(session.token);
-		} else if (session) {
-			// A persisted session always carries a token; this only guards a
-			// corrupted row by removing it directly (best effort).
-			await ctx.context.adapter.delete<Session>({
-				model: "session",
-				where: [{ field: "id", value: session.id }],
-			});
+		if (currentSession && isBrowserNavigation(ctx)) {
+			return confirmationRequired(
+				ctx,
+				currentSession,
+				request.client_id ? getLogoutConfirmationContext(client, request) : {},
+			);
 		}
-	} catch {
-		// Session already gone; nothing further to do.
+		return logoutProtocolError(
+			ctx,
+			"UNAUTHORIZED",
+			"invalid_token",
+			"The id_token_hint is invalid",
+		);
 	}
 
-	if (post_logout_redirect_uri) {
-		const registeredUris = client.postLogoutRedirectUris;
-		if (registeredUris?.includes(post_logout_redirect_uri)) {
-			const redirectUri = new URL(post_logout_redirect_uri);
-			if (state) {
-				redirectUri.searchParams.set("state", state);
-			}
-			return handleRedirect(ctx, redirectUri.toString());
-		}
+	const sessionId = idTokenPayload.sid as string;
+	const hintedSession = await findHintedSession(ctx, sessionId);
+	const matchesCurrentSession = currentSession?.session.id === sessionId;
+	if (currentSession && !matchesCurrentSession) {
+		return confirmationRequired(
+			ctx,
+			currentSession,
+			getLogoutConfirmationContext(client, request),
+		);
 	}
+
+	const redirect = getRegisteredLogoutRedirect(
+		client,
+		request.post_logout_redirect_uri,
+		request.state,
+	);
+	const sessionToDelete =
+		hintedSession ?? (matchesCurrentSession ? currentSession?.session : null);
+	if (sessionToDelete) {
+		// internalAdapter.deleteSession triggers the normal before/after session
+		// hooks, including revocation and back-channel dispatch for every RP.
+		await deleteLogoutSession(ctx, sessionToDelete);
+	}
+	if (matchesCurrentSession) deleteSessionCookie(ctx);
+	clearLogoutConfirmationState(ctx);
+
+	if (redirect.uri) return handleRedirect(ctx, redirect.uri);
+	return isBrowserNavigation(ctx)
+		? logoutSuccessPage(
+				redirect.invalid
+					? "The requested post-logout redirect was not registered."
+					: undefined,
+			)
+		: null;
+}
+
+/**
+ * Completes the browser confirmation flow for RP-Initiated Logout. This route
+ * is intentionally scoped to HTTP delivery so it does not become a generated
+ * client action; the signed cookie is the only confirmation context it accepts.
+ */
+export async function rpInitiatedLogoutConfirmationEndpoint(
+	ctx: GenericEndpointContext,
+	opts: OAuthOptions<Scope[]>,
+) {
+	return completeConfirmedLogout(ctx, opts);
 }

--- a/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
+++ b/packages/oauth-provider/src/oauth-endpoint.integration.test.ts
@@ -479,7 +479,7 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 	});
 
 	describe("oauth2EndSession (JSON delivery)", () => {
-		it("missing id_token_hint → invalid_request with envelope", async () => {
+		it("missing id_token_hint → controlled invalid_request with envelope", async () => {
 			const { status, body } = await captureJsonResponse(
 				"/oauth2/end-session",
 				{ method: "GET" },
@@ -487,7 +487,7 @@ describe("RFC envelope compliance across OAuth endpoints", async () => {
 			expect(status).toBe(400);
 			expect(body).toEqual({
 				error: "invalid_request",
-				error_description: "id_token_hint is required",
+				error_description: "User confirmation is required to complete logout",
 			});
 		});
 	});

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -26,6 +26,7 @@ import type { BackchannelLogoutPlan } from "./logout";
 import {
 	applyBackchannelLogoutPlan,
 	prepareBackchannelLogoutPlan,
+	rpInitiatedLogoutConfirmationEndpoint,
 	rpInitiatedLogoutEndpoint,
 } from "./logout";
 import {
@@ -78,6 +79,24 @@ export const DEFAULT_OAUTH_SCOPES = [
 	"email",
 	"offline_access",
 ] as const;
+
+const rpInitiatedLogoutRequestSchema = z.object({
+	id_token_hint: z.string().optional(),
+	client_id: z.string().optional(),
+	post_logout_redirect_uri: SafeUrlSchema.optional(),
+	state: z.string().optional(),
+});
+
+type RPInitiatedLogoutFields = {
+	id_token_hint?: string;
+	client_id?: string;
+	post_logout_redirect_uri?: string;
+	state?: string;
+};
+
+type RPInitiatedLogoutClientInput =
+	| RPInitiatedLogoutFields
+	| { query: RPInitiatedLogoutFields };
 
 declare module "@better-auth/core" {
 	interface BetterAuthPluginRegistry<AuthOptions, Options> {
@@ -1413,21 +1432,27 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 			oauth2EndSession: createOAuthEndpoint(
 				"/oauth2/end-session",
 				{
-					method: "GET",
-					query: z.object({
-						id_token_hint: z.string(),
-						client_id: z.string().optional(),
-						post_logout_redirect_uri: SafeUrlSchema.optional(),
-						state: z.string().optional(),
-					}),
+					method: ["GET", "POST"],
+					body: rpInitiatedLogoutRequestSchema.optional(),
+					query: rpInitiatedLogoutRequestSchema.optional(),
 					metadata: {
+						noStore: true,
+						allowedMediaTypes: [
+							"application/x-www-form-urlencoded",
+							// Better Auth's generated client sends endpoint bodies as JSON.
+							"application/json",
+						],
+						$Infer: {
+							body: {} as RPInitiatedLogoutClientInput,
+							query: {} as RPInitiatedLogoutFields,
+						},
 						openapi: {
 							description:
-								"RP-Initiated Logout endpoint. Allows clients to notify the OP that the End-User has logged out.",
+								"RP-Initiated Logout endpoint. Accepts standard logout parameters through GET or an application/x-www-form-urlencoded POST body, plus JSON for Better Auth generated-client calls. Requests without a usable id_token_hint may require explicit OP confirmation.",
 							responses: {
 								"200": {
 									description:
-										"Logout successful. May include redirect_uri if post_logout_redirect_uri was provided.",
+										"Logout completed, or an HTML confirmation page was returned for browser navigation. A redirect is used only for an exact registered post_logout_redirect_uri.",
 									content: {
 										"application/json": {
 											schema: {
@@ -1446,6 +1471,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 												},
 											},
 										},
+										"text/html": {
+											schema: { type: "string" },
+										},
 									},
 								},
 							},
@@ -1454,6 +1482,23 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 				},
 				async (ctx) => {
 					return rpInitiatedLogoutEndpoint(ctx, opts);
+				},
+			),
+			oauth2EndSessionConfirmation: createOAuthEndpoint(
+				"/oauth2/end-session/confirm",
+				{
+					method: "POST",
+					body: z.object({
+						action: z.literal("confirm"),
+					}),
+					metadata: {
+						noStore: true,
+						allowedMediaTypes: ["application/x-www-form-urlencoded"],
+						scope: "http",
+					},
+				},
+				async (ctx) => {
+					return rpInitiatedLogoutConfirmationEndpoint(ctx, opts);
 				},
 			),
 			registerOAuthClient: createOAuthEndpoint(


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes OIDC RP‑Initiated Logout in `@better-auth/oauth-provider`. Previously only GET with a valid `id_token_hint` was allowed; now GET, form‑encoded POST, and generated‑client JSON are accepted, browser logouts can proceed without a hint after OP confirmation, and redirects are limited to exact registered `post_logout_redirect_uri`s.

- Adds an HTTP‑scoped confirmation POST at `/oauth2/end-session/confirm`, protected by origin checks and a short‑lived signed cookie bound to the current session. Cookie path honors custom base paths, and the route is excluded from generated clients.
- Without a usable hint: browsers see a confirmation page; API calls get a 400 invalid_request (“User confirmation is required to complete logout”).
- Redirects only to an exact registered `post_logout_redirect_uri`; `state` is appended only after verification. Redirects are revalidated at confirmation; unregistered or query‑modified URIs render a logged‑out page instead of redirecting.
- Hint handling: invalid or `alg=none` hints fail with controlled 4xx; multi‑audience hints resolve via `azp` without fanning out client lookups.
- On success, the session is deleted via normal hooks, the session cookie is cleared, and Back‑Channel Logout is delivered. Deletion failures return 5xx without redirecting.

**Required actions for relying parties**
- Register exact `post_logout_redirect_uris`; do not add query parameters dynamically. The OP will only append `state`.
- Programmatic callers must send a valid `id_token_hint` or handle a 400 “User confirmation is required to complete logout” or the HTML confirmation flow.
- If `disableJwtPlugin` is set, public clients cannot use a hint and must use the browser confirmation flow; confidential clients with a secret can continue to use signed hints.
- Enable `enable_end_session` only for trusted clients.

<sup>Written for commit 9ed34c31276bf99ede4c1376c100031e1501b360. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

