### PR TITLE
docs: update infrastructure docs

### DIFF
--- a/docs/content/docs/infrastructure/plugins/dash.mdx
+++ b/docs/content/docs/infrastructure/plugins/dash.mdx
@@ -86,8 +86,9 @@ The `managedDirectorySync` option enables the plugin-managed mode for directory-
 
 Use this when the application wants Better Auth to manage the runtime tenant connection lifecycle for SCIM and pair it with SSO-based identity resolution. It is intended for the new 1.7 flow and complements `scim({ managedConnections })`.
 
-> \[!important]
-> Enabling `managedDirectorySync` requires the corresponding database migrations for the managed directory-sync tables. Run the migration step before using the managed runtime flow.
+<Callout type="warning">
+  Enabling `managedDirectorySync` requires the corresponding database migrations for the managed directory-sync tables. Run the migration step before using the managed runtime flow.
+</Callout>
 
 ```package-install
 npx auth migrate

--- a/docs/content/docs/infrastructure/plugins/dash.mdx
+++ b/docs/content/docs/infrastructure/plugins/dash.mdx
@@ -70,9 +70,9 @@ This opt-in control plane is for the SCIM 1.7 plugin-managed runtime flow. In Be
 
 * static code-defined connections
 * application-owned runtime verification
-* plugin-managed runtime connections via `managedDirectorySync`
+* plugin-managed runtime connections via `managedConnections`
 
-The `managedDirectorySync` option enables the plugin-managed mode for directory-sync provisioning. It creates the reserved schema and APIs needed to manage directory connections and paired SSO state.
+The `managedDirectorySync` option enables the plugin-managed mode for directory-sync provisioning in `dash`. It creates the reserved schema and APIs needed to manage directory connections and paired SSO state.
 
 #### Managed directory sync options
 
@@ -112,7 +112,7 @@ Stores the managed directory's organization, SCIM connection, SSO pairing, lifec
 | `provisioningDomainId`  | `string`  | Required, unique              | SCIM provisioning domain.                        |
 | `activeOrganizationKey` | `string`  | Required, unique, hidden      | Active organization key for reconciliation.      |
 | `connectionId`          | `string`  | Optional, unique              | Managed SCIM connection identifier.              |
-| `creationRequestId`     | `string`  | Required, unique, hidden      | Idempotent creation correlation value.           |
+| `creationRequestId`     | `string`  | Required, unique, hidden      | Immutable ownership correlation value.           |
 | `status`                | `string`  | Required                      | Current directory lifecycle status.              |
 | `revision`              | `number`  | Required, default `0`, hidden | Mutation revision used for concurrency control.  |
 | `createdAt`             | `date`    | Required                      | Creation timestamp.                              |

--- a/docs/content/docs/infrastructure/plugins/dash.mdx
+++ b/docs/content/docs/infrastructure/plugins/dash.mdx
@@ -24,14 +24,17 @@ export const auth = betterAuth({
 
 ### DashOptions
 
-| Option             | Type     | Description                                                           |
-| ------------------ | -------- | --------------------------------------------------------------------- |
-| `apiUrl`           | `string` | Better Auth Infrastructure API URL                                    |
-| `kvUrl`            | `string` | KV store URL for caching                                              |
-| `apiKey`           | `string` | Your API key for authentication                                       |
-| `apiTimeout`       | `number` | Timeout in ms for infra API HTTP requests (`apiUrl`). Default: `3000` |
-| `kvTimeout`        | `number` | Timeout in ms for KV HTTP requests (`kvUrl`). Default: `1000`         |
-| `activityTracking` | `object` | Activity tracking configuration                                       |
+| Option                 | Type     | Description                                                                                  |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `apiUrl`               | `string` | Better Auth infrastructure URL. Default: `https://dash.better-auth.com`                      |
+| `kvUrl`                | `string` | Better Auth identification infrastructure URL. Default: `https://kv.better-auth.com`         |
+| `apiKey`               | `string` | Your API key for authentication.                                                             |
+| `apiOptions`           | `object` | Dash API HTTP client options. Accepts `timeout?: number` in ms.                              |
+| `kvOptions`            | `object` | KV HTTP client options. Accepts `timeout?: number` and `retry?: { attempts?: number; ... }`. |
+| `apiTimeout`           | `number` | Deprecated alias for `apiOptions.timeout`.                                                   |
+| `kvTimeout`            | `number` | Deprecated alias for `kvOptions.timeout`.                                                    |
+| `activityTracking`     | `object` | Activity tracking configuration.                                                             |
+| `managedDirectorySync` | `object` | Managed SCIM/directory-sync control plane options.                                           |
 
 ### Activity Tracking
 
@@ -46,6 +49,102 @@ dash({
 ```
 
 When enabled, this adds a `lastActiveAt` field to your user schema that's automatically updated on user activity.
+
+### Managed Directory Sync
+
+```ts
+dash({
+  apiKey: process.env.BETTER_AUTH_API_KEY,
+  managedDirectorySync: {
+    enabled: true,
+    ssoPairing: true,
+    membershipProjection: {
+      enabled: true,
+      role: "member",
+    },
+  },
+})
+```
+
+This opt-in control plane is for the SCIM 1.7 plugin-managed runtime flow. In Better Auth 1.7, SCIM supports three connection modes:
+
+* static code-defined connections
+* application-owned runtime verification
+* plugin-managed runtime connections via `managedDirectorySync`
+
+The `managedDirectorySync` option enables the plugin-managed mode for directory-sync provisioning. It creates the reserved schema and APIs needed to manage directory connections and paired SSO state.
+
+#### Managed directory sync options
+
+| Option                         | Type      | Description                                                                                                                                                  |
+| ------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`                      | `boolean` | Enables the managed directory-sync control plane and the SCIM reservation tables / APIs. Default: `false`.                                                   |
+| `ssoPairing`                   | `boolean` | Installs the SSO `resolveUser` and provider-mutation hooks required when a paired directory needs to reconcile a user identity through SSO. Default: `true`. |
+| `membershipProjection`         | `object`  | Enables SCIM-to-organization membership projection when a directory should create group or member membership records.                                        |
+| `membershipProjection.enabled` | `boolean` | Enables the projection hook. Default: `true`.                                                                                                                |
+| `membershipProjection.role`    | `string`  | Role assigned to projected organization memberships. Default: `"member"`.                                                                                    |
+
+Use this when the application wants Better Auth to manage the runtime tenant connection lifecycle for SCIM and pair it with SSO-based identity resolution. It is intended for the new 1.7 flow and complements `scim({ managedConnections })`.
+
+> \[!important]
+> Enabling `managedDirectorySync` requires the corresponding database migrations for the managed directory-sync tables. Run the migration step before using the managed runtime flow.
+
+```package-install
+npx auth migrate
+```
+
+If your app manages schema generation separately, run `npx auth generate` and apply the generated migration with your preferred tool.
+
+### Database Schema
+
+When `managedDirectorySync.enabled` is `true`, the dash plugin adds the following models. Better Auth supplies the primary `id` field for each model.
+
+#### `directorySyncConnection`
+
+Stores the managed directory's organization, SCIM connection, SSO pairing, lifecycle, and decommission state.
+
+| Column                  | Type      | Constraints                   | Description                                      |
+| ----------------------- | --------- | ----------------------------- | ------------------------------------------------ |
+| `organizationId`        | `string`  | Required, indexed             | Organization that owns the directory.            |
+| `providerId`            | `string`  | Required                      | SSO provider identifier.                         |
+| `aliasKey`              | `string`  | Required, unique, hidden      | Internal directory alias.                        |
+| `provisioningDomainId`  | `string`  | Required, unique              | SCIM provisioning domain.                        |
+| `activeOrganizationKey` | `string`  | Required, unique, hidden      | Active organization key for reconciliation.      |
+| `connectionId`          | `string`  | Optional, unique              | Managed SCIM connection identifier.              |
+| `creationRequestId`     | `string`  | Required, unique, hidden      | Idempotent creation correlation value.           |
+| `status`                | `string`  | Required                      | Current directory lifecycle status.              |
+| `revision`              | `number`  | Required, default `0`, hidden | Mutation revision used for concurrency control.  |
+| `createdAt`             | `date`    | Required                      | Creation timestamp.                              |
+| `createdByActorId`      | `string`  | Required                      | Actor that created the directory.                |
+| `updatedAt`             | `date`    | Required                      | Last update timestamp.                           |
+| `lastActorId`           | `string`  | Required                      | Actor responsible for the latest mutation.       |
+| `ssoProviderId`         | `string`  | Optional                      | Paired SSO provider ID.                          |
+| `ssoProviderRecordId`   | `string`  | Optional, indexed             | Paired SSO provider record.                      |
+| `activeSsoProviderKey`  | `string`  | Required, unique, hidden      | Active SSO provider key.                         |
+| `serializedSsoPairing`  | `string`  | Optional, hidden              | Serialized SSO pairing metadata.                 |
+| `pairingEnforced`       | `boolean` | Required, default `false`     | Whether the SSO pairing requirement is enforced. |
+| `unpairedAt`            | `date`    | Optional                      | Time at which the directory was unpaired.        |
+| `unpairedBy`            | `string`  | Optional                      | Actor that removed the pairing.                  |
+| `decommissionStartedAt` | `date`    | Optional                      | Time decommissioning started.                    |
+| `decommissionedAt`      | `date`    | Optional                      | Time decommissioning completed.                  |
+| `lastError`             | `string`  | Optional, hidden              | Most recent reconciliation error.                |
+
+#### `directorySyncMembershipProvenance`
+
+Tracks organization memberships created or managed by directory-sync projection so the plugin can reconcile only the memberships it owns.
+
+| Column                 | Type     | Constraints              | Description                                |
+| ---------------------- | -------- | ------------------------ | ------------------------------------------ |
+| `membershipKey`        | `string` | Required, unique, hidden | Stable key for the projected membership.   |
+| `organizationId`       | `string` | Required, indexed        | Organization containing the membership.    |
+| `userId`               | `string` | Required, indexed        | Better Auth User receiving the membership. |
+| `memberId`             | `string` | Required, unique         | Organization `member` record identifier.   |
+| `ownership`            | `string` | Required, hidden         | Projection ownership state.                |
+| `provisioningDomainId` | `string` | Required, indexed        | SCIM provisioning domain that produced it. |
+| `createdAt`            | `date`   | Required                 | Creation timestamp.                        |
+| `updatedAt`            | `date`   | Required                 | Last update timestamp.                     |
+
+For the full SCIM model and migration guidance, see the [SCIM plugin reference](/docs/plugins/scim/reference) and the [1.7 upgrade guide](/docs/guides/1-7-upgrade-guide).
 
 ## Event Tracking
 

--- a/docs/content/docs/infrastructure/plugins/dashboard.mdx
+++ b/docs/content/docs/infrastructure/plugins/dashboard.mdx
@@ -20,14 +20,17 @@ export const auth = betterAuth({
 
 ## Configuration Options
 
-| Option             | Type     | Description                                                           |
-| ------------------ | -------- | --------------------------------------------------------------------- |
-| `apiUrl`           | `string` | Better Auth Infrastructure API URL                                    |
-| `kvUrl`            | `string` | KV store URL for caching                                              |
-| `apiKey`           | `string` | Your API key for authentication                                       |
-| `apiTimeout`       | `number` | Timeout in ms for Infra API HTTP requests (`apiUrl`). Default: `3000` |
-| `kvTimeout`        | `number` | Timeout in ms for KV HTTP requests (`kvUrl`). Default: `1000`         |
-| `activityTracking` | `object` | Activity tracking configuration                                       |
+| Option                 | Type     | Description                                                                                  |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `apiUrl`               | `string` | Better Auth Infrastructure API URL. Default: `https://dash.better-auth.com`                  |
+| `kvUrl`                | `string` | KV store URL. Default: `https://kv.better-auth.com`                                          |
+| `apiKey`               | `string` | Your API key for authentication. Falls back to `BETTER_AUTH_API_KEY` in env.                 |
+| `apiOptions`           | `object` | Dash API HTTP client options. Accepts `timeout?: number` in ms.                              |
+| `kvOptions`            | `object` | KV HTTP client options. Accepts `timeout?: number` and `retry?: { attempts?: number; ... }`. |
+| `apiTimeout`           | `number` | Deprecated alias for `apiOptions.timeout`.                                                   |
+| `kvTimeout`            | `number` | Deprecated alias for `kvOptions.timeout`.                                                    |
+| `activityTracking`     | `object` | Activity tracking configuration.                                                             |
+| `managedDirectorySync` | `object` | Managed directory-sync control-plane options.                                                |
 
 ## Activity Tracking
 
@@ -58,6 +61,32 @@ user: {
 ```
 
 Make sure to run database migrations after enabling activity tracking.
+
+## Managed Directory Sync
+
+The `managedDirectorySync` option is the dashboard-side companion to the SCIM 1.7 plugin-managed runtime flow. In 1.7, SCIM supports three modes:
+
+* static code-defined connections
+* application-owned runtime verification
+* plugin-managed runtime connections tied to the Better Auth dashboard
+
+When `enabled` is `true`, the dashboard installs the reservation tables and APIs needed for managed directory-sync state. `ssoPairing` enables the SSO hooks needed when a directory-backed user identity is paired with an SSO provider, and `membershipProjection` lets the system project SCIM membership changes into organization membership records.
+
+```ts
+dash({
+  apiKey: process.env.BETTER_AUTH_API_KEY,
+  managedDirectorySync: {
+    enabled: true,
+    ssoPairing: true,
+    membershipProjection: {
+      enabled: true,
+      role: "member",
+    },
+  },
+})
+```
+
+This is specifically for the 1.7 managed-directory-sync flow. For the full SCIM model and migration details, see the [SCIM plugin reference](/docs/plugins/scim/reference) and the [1.7 upgrade guide](/docs/guides/1-7-upgrade-guide).
 
 ## Client Setup
 

--- a/docs/content/docs/infrastructure/plugins/dashboard.mdx
+++ b/docs/content/docs/infrastructure/plugins/dashboard.mdx
@@ -64,29 +64,18 @@ Make sure to run database migrations after enabling activity tracking.
 
 ## Managed Directory Sync
 
-The `managedDirectorySync` option is the dashboard-side companion to the SCIM 1.7 plugin-managed runtime flow. In 1.7, SCIM supports three modes:
-
-* static code-defined connections
-* application-owned runtime verification
-* plugin-managed runtime connections tied to the Better Auth dashboard
-
-When `enabled` is `true`, the dashboard installs the reservation tables and APIs needed for managed directory-sync state. `ssoPairing` enables the SSO hooks needed when a directory-backed user identity is paired with an SSO provider, and `membershipProjection` lets the system project SCIM membership changes into organization membership records.
+The `managedDirectorySync` option is the dashboard-side companion to the SCIM 1.7 plugin-managed runtime flow. When `enabled` is `true`, the dashboard installs the reservation tables and APIs needed for managed directory-sync state. `ssoPairing` enables the SSO hooks needed when a directory-backed user identity is paired with an SSO provider, and `membershipProjection` lets the system project SCIM membership changes into organization membership records.
 
 ```ts
 dash({
   apiKey: process.env.BETTER_AUTH_API_KEY,
   managedDirectorySync: {
     enabled: true,
-    ssoPairing: true,
-    membershipProjection: {
-      enabled: true,
-      role: "member",
-    },
   },
 })
 ```
 
-This is specifically for the 1.7 managed-directory-sync flow. For the full SCIM model and migration details, see the [SCIM plugin reference](/docs/plugins/scim/reference) and the [1.7 upgrade guide](/docs/guides/1-7-upgrade-guide).
+This is specifically for the 1.7 managed-directory-sync flow. See the [managed directory sync section in the Dashboard Plugin (`dash()`)](/docs/infrastructure/plugins/dash#managed-directory-sync) for the complete managed-directory schema and options. For the full SCIM model and migration details, see the [SCIM plugin reference](/docs/plugins/scim/reference) and the [1.7 upgrade guide](/docs/guides/1-7-upgrade-guide).
 
 ## Client Setup
 

--- a/docs/content/docs/infrastructure/plugins/sentinel.mdx
+++ b/docs/content/docs/infrastructure/plugins/sentinel.mdx
@@ -24,14 +24,16 @@ export const auth = betterAuth({
 
 ### SentinelOptions
 
-| Option       | Type              | Description                                                           |
-| ------------ | ----------------- | --------------------------------------------------------------------- |
-| `apiUrl`     | `string`          | Better Auth Infrastructure API URL                                    |
-| `kvUrl`      | `string`          | KV store URL for rate limiting data                                   |
-| `apiKey`     | `string`          | Your API key for authentication                                       |
-| `apiTimeout` | `number`          | Timeout in ms for Infra API HTTP requests (`apiUrl`). Default: `3000` |
-| `kvTimeout`  | `number`          | Timeout in ms for KV HTTP requests (`kvUrl`). Default: `1000`         |
-| `security`   | `SecurityOptions` | Security feature configuration                                        |
+| Option       | Type              | Description                                                                           |
+| ------------ | ----------------- | ------------------------------------------------------------------------------------- |
+| `apiUrl`     | `string`          | Better Auth infrastructure API URL. Default: `https://dash.better-auth.com`           |
+| `kvUrl`      | `string`          | Better Auth identification infrastructure URL. Default: `https://kv.better-auth.com`  |
+| `apiKey`     | `string`          | Your API key for authentication.                                                      |
+| `apiOptions` | `object`          | Dash API HTTP options. Accepts `timeout?: number` in ms.                              |
+| `kvOptions`  | `object`          | KV HTTP options. Accepts `timeout?: number` and `retry?: { attempts?: number; ... }`. |
+| `apiTimeout` | `number`          | Deprecated alias for `apiOptions.timeout`.                                            |
+| `kvTimeout`  | `number`          | Deprecated alias for `kvOptions.timeout`.                                             |
+| `security`   | `SecurityOptions` | Security feature configuration.                                                       |
 
 ### SecurityOptions
 
@@ -342,10 +344,12 @@ export const authClient = createAuthClient({
 
 ### Configuration
 
-| Option               | Type      | Default | Description                                             |
-| -------------------- | --------- | ------- | ------------------------------------------------------- |
-| `autoSolveChallenge` | `boolean` | `true`  | Automatically solve PoW challenges                      |
-| `kvTimeout`          | `number`  | `1000`  | Timeout in ms for KV identify and related HTTP requests |
+| Option               | Type      | Default                                                                    | Description                                     |
+| -------------------- | --------- | -------------------------------------------------------------------------- | ----------------------------------------------- |
+| `identifyUrl`        | `string`  | `BETTER_AUTH_KV_URL` or `https://kv.better-auth.com`                       | Base URL for the identify endpoint.             |
+| `identifyOptions`    | `object`  | `{ timeout: 1000, retry: { attempts: 2, baseDelay: 400, maxDelay: 600 } }` | Identify HTTP client settings.                  |
+| `autoSolveChallenge` | `boolean` | `true`                                                                     | Automatically solve PoW challenges.             |
+| `kvTimeout`          | `number`  | `1000`                                                                     | Deprecated alias for `identifyOptions.timeout`. |
 
 ### Browser Fingerprinting
 
@@ -424,15 +428,16 @@ export const authClient = createAuthClient({
 
 #### `sentinelNativeClient` options
 
-| Option                | Type                            | Default                                                 | Description                                                                 |
-| --------------------- | ------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `identifyUrl`         | `string`                        | `BETTER_AUTH_KV_URL`, then `https://kv.better-auth.com` | KV identify endpoint base URL                                               |
-| `kvTimeout`           | `number`                        | `1000`                                                  | Timeout in ms for KV identify and related HTTP requests                     |
-| `autoSolveChallenge`  | `boolean`                       | `true`                                                  | On `423` with `X-PoW-Challenge`, solve and retry once with `X-PoW-Solution` |
-| `onChallengeReceived` | `(reason: string) => void`      | —                                                       | Called when a PoW challenge is received                                     |
-| `onChallengeSolved`   | `(solveTimeMs: number) => void` | —                                                       | Called after a successful solve                                             |
-| `onChallengeFailed`   | `(error: Error) => void`        | —                                                       | Called if solving fails                                                     |
-| `storage`             | `{ getItem, setItem }`          | Async Storage when installed                            | Persistent async storage for a stable per-install visitor ID                |
+| Option                | Type                            | Default                                                                    | Description                                                                  |
+| --------------------- | ------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `identifyUrl`         | `string`                        | `BETTER_AUTH_KV_URL`, then `https://kv.better-auth.com`                    | Identify endpoint base URL.                                                  |
+| `identifyOptions`     | `object`                        | `{ timeout: 1000, retry: { attempts: 2, baseDelay: 400, maxDelay: 600 } }` | Identify HTTP timeout and retry policy.                                      |
+| `kvTimeout`           | `number`                        | `1000`                                                                     | Deprecated alias for `identifyOptions.timeout`.                              |
+| `autoSolveChallenge`  | `boolean`                       | `true`                                                                     | On `423` with `X-PoW-Challenge`, solve and retry once with `X-PoW-Solution`. |
+| `onChallengeReceived` | `(reason: string) => void`      | —                                                                          | Called when a PoW challenge is received.                                     |
+| `onChallengeSolved`   | `(solveTimeMs: number) => void` | —                                                                          | Called after a successful solve.                                             |
+| `onChallengeFailed`   | `(error: Error) => void`        | —                                                                          | Called if solving fails.                                                     |
+| `storage`             | `{ getItem, setItem }`          | Async Storage when installed                                               | Persistent async storage for a stable per-install visitor ID.                |
 
 ## Security Events
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates infrastructure docs to add SCIM 1.7 managed directory sync and unify HTTP client configuration across `dash`, `dashboard`, and `sentinel`. Previously you set `apiTimeout`/`kvTimeout`; docs now use `apiOptions`/`kvOptions` (servers) and `identifyOptions` (clients) with default endpoints and retry, and keep legacy timeouts as deprecated aliases.

- `managedDirectorySync`: documents the SCIM 1.7 plugin‑managed runtime flow with `ssoPairing` and `membershipProjection` (default role: "member"); adds the reserved tables `directorySyncConnection` and `directorySyncMembershipProvenance` and explains their purpose.
- Defaults: `apiUrl` = https://dash.better-auth.com, `kvUrl` = https://kv.better-auth.com; `dashboard` `apiKey` falls back to `BETTER_AUTH_API_KEY`.
- Server docs: prefer `apiOptions.timeout` and `kvOptions` (supports `timeout` and `retry`) over `apiTimeout`/`kvTimeout`.
- Client docs (`sentinel`): prefer `identifyUrl` (defaults to `BETTER_AUTH_KV_URL` or https://kv.better-auth.com) and `identifyOptions` with defaults `{ timeout: 1000, retry: { attempts: 2, baseDelay: 400, maxDelay: 600 } }`; `kvTimeout` is a deprecated alias.

**Rollout and migration**
- Before enabling `managedDirectorySync`, run migrations: `npx auth migrate` (or `npx auth generate` and apply).
- Update configs from `apiTimeout`/`kvTimeout` to `apiOptions.timeout`/`kvOptions.timeout`, and from `kvTimeout` to `identifyOptions.timeout`; aliases continue to work but are deprecated.

<sup>Written for commit c945478925f1e9e880cfbe4cf74fd47ec1c150c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

