### PR TITLE
fix(solid): add SolidJS 2 support

### DIFF
--- a/.changeset/solid-2-support.md
+++ b/.changeset/solid-2-support.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Add Solid 2 support to the Solid client by replacing `solid-js/store` APIs with APIs shared by Solid 1 and Solid 2.
+Add Solid 2 support to the Solid client by replacing `solid-js/store` APIs with APIs shared by Solid 1 and Solid 2. Because the two versions expose their store APIs from incompatible module paths, Solid accessors now invalidate on each Nanostore update instead of reconciling individual nested properties.

--- a/.changeset/solid-2-support.md
+++ b/.changeset/solid-2-support.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Add Solid 2 support to the Solid client by replacing `solid-js/store` APIs with APIs shared by Solid 1 and Solid 2.

--- a/docs/content/docs/concepts/client.mdx
+++ b/docs/content/docs/concepts/client.mdx
@@ -63,6 +63,8 @@ Import `createAuthClient` from the package for your framework (e.g., "better-aut
   </Tab>
 
   <Tab value="solid" title="lib/auth-client.ts">
+    The Solid client supports both Solid 1 and Solid 2.
+
     ```ts title="lib/auth-client.ts" 
     import { createAuthClient } from "better-auth/solid" // [!code highlight]
     export const authClient = createAuthClient({

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -528,6 +528,7 @@
     "react": "catalog:react19",
     "react-dom": "catalog:react19",
     "solid-js": "^1.9.11",
+    "solid-js-v2": "npm:solid-js@^2.0.0-rc.0",
     "tsdown": "catalog:",
     "type-fest": "^5.4.4",
     "typescript": "catalog:",
@@ -551,7 +552,7 @@
     "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "solid-js": "^1.0.0",
+    "solid-js": "^1.0.0 || ^2.0.0-rc.0",
     "svelte": "^4.0.0 || ^5.0.0",
     "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "vue": "^3.0.0"

--- a/packages/better-auth/src/client/solid/solid-store.test.ts
+++ b/packages/better-auth/src/client/solid/solid-store.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+
+import { atom, cleanStores, onMount } from "nanostores";
+import type { Accessor } from "solid-js-v2";
+import { createEffect, createRoot, flush } from "solid-js-v2";
+import { describe, expect, it, vi } from "vitest";
+import { useStore } from "./solid-store";
+
+describe("useStore with Solid 2", () => {
+	it("tracks nanostore updates and releases the subscription", () => {
+		const store = atom(0);
+		const cleanup = vi.fn();
+		onMount(store, () => {
+			store.set(1);
+			return cleanup;
+		});
+
+		let value: Accessor<number> | undefined;
+		let dispose: (() => void) | undefined;
+		createRoot((rootDispose) => {
+			dispose = rootDispose;
+			value = useStore(store);
+		});
+
+		expect(value?.()).toBe(1);
+
+		store.set(2);
+		flush();
+		expect(value?.()).toBe(2);
+
+		dispose?.();
+		cleanStores(store);
+		expect(cleanup).toHaveBeenCalledOnce();
+	});
+
+	it("preserves function-valued stores", () => {
+		const initialValue = () => 1;
+		const nextValue = () => 2;
+		const store = atom(initialValue);
+
+		let value: Accessor<typeof initialValue> | undefined;
+		let dispose: (() => void) | undefined;
+		createRoot((rootDispose) => {
+			dispose = rootDispose;
+			value = useStore(store);
+		});
+
+		expect(value?.()).toBe(initialValue);
+
+		store.set(nextValue);
+		flush();
+		expect(value?.()).toBe(nextValue);
+
+		dispose?.();
+	});
+
+	it("reactively propagates nested object updates", () => {
+		const store = atom({
+			user: {
+				name: "Ada",
+			},
+		});
+		const observedNames: string[] = [];
+
+		let dispose: (() => void) | undefined;
+		createRoot((rootDispose) => {
+			dispose = rootDispose;
+			const value = useStore(store);
+			createEffect(
+				() => value().user.name,
+				(name) => {
+					observedNames.push(name);
+				},
+			);
+		});
+
+		flush();
+		expect(observedNames).toEqual(["Ada"]);
+
+		store.set({
+			user: {
+				name: "Grace",
+			},
+		});
+
+		expect(observedNames).toEqual(["Ada"]);
+		flush();
+		expect(observedNames).toEqual(["Ada", "Grace"]);
+
+		dispose?.();
+	});
+});

--- a/packages/better-auth/src/client/solid/solid-store.ts
+++ b/packages/better-auth/src/client/solid/solid-store.ts
@@ -1,7 +1,6 @@
 import type { Store, StoreValue } from "nanostores";
 import type { Accessor } from "solid-js";
-import { onCleanup } from "solid-js";
-import { createStore, reconcile } from "solid-js/store";
+import { createSignal, onCleanup } from "solid-js";
 
 /**
  * Subscribes to store changes and gets store’s value.
@@ -17,12 +16,12 @@ export function useStore<
 	// https://github.com/nanostores/solid/issues/19
 	const unbindActivation = store.listen(() => {});
 
-	const [state, setState] = createStore({
+	const [state, setState] = createSignal({
 		value: store.get(),
 	});
 
-	const unsubscribe = store.subscribe((newValue) => {
-		setState("value", reconcile(newValue));
+	const unsubscribe = store.listen((newValue) => {
+		setState({ value: newValue });
 	});
 
 	onCleanup(() => unsubscribe());
@@ -30,5 +29,5 @@ export function useStore<
 	// Remove temporary listener now that there is already a proper subscriber.
 	unbindActivation();
 
-	return () => state.value;
+	return () => state().value;
 }

--- a/packages/better-auth/src/client/solid/solid-store.ts
+++ b/packages/better-auth/src/client/solid/solid-store.ts
@@ -16,6 +16,9 @@ export function useStore<
 	// https://github.com/nanostores/solid/issues/19
 	const unbindActivation = store.listen(() => {});
 
+	// Solid 1 and 2 expose their store APIs from incompatible module paths, so
+	// use their shared signal API. This intentionally invalidates the accessor
+	// for every Nanostore update instead of reconciling nested properties.
 	const [state, setState] = createSignal({
 		value: store.get(),
 	});

--- a/packages/better-auth/src/client/solid/solid-store.v1.test.ts
+++ b/packages/better-auth/src/client/solid/solid-store.v1.test.ts
@@ -1,14 +1,12 @@
 // @vitest-environment happy-dom
 
 import { atom, cleanStores, onMount } from "nanostores";
-import type { Accessor } from "solid-js-v2";
-import { createEffect, createRoot, flush } from "solid-js-v2";
+import type { Accessor } from "solid-js";
+import { createEffect, createRoot } from "solid-js";
 import { describe, expect, it, vi } from "vitest";
 import { useStore } from "./solid-store";
 
-vi.mock("solid-js", async () => import("solid-js-v2"));
-
-describe("useStore with Solid 2", () => {
+describe("useStore with Solid 1", () => {
 	it("tracks nanostore updates and releases the subscription", () => {
 		const store = atom(0);
 		const cleanup = vi.fn();
@@ -27,33 +25,11 @@ describe("useStore with Solid 2", () => {
 		expect(value?.()).toBe(1);
 
 		store.set(2);
-		flush();
 		expect(value?.()).toBe(2);
 
 		dispose?.();
 		cleanStores(store);
 		expect(cleanup).toHaveBeenCalledOnce();
-	});
-
-	it("preserves function-valued stores", () => {
-		const initialValue = () => 1;
-		const nextValue = () => 2;
-		const store = atom(initialValue);
-
-		let value: Accessor<typeof initialValue> | undefined;
-		let dispose: (() => void) | undefined;
-		createRoot((rootDispose) => {
-			dispose = rootDispose;
-			value = useStore(store);
-		});
-
-		expect(value?.()).toBe(initialValue);
-
-		store.set(nextValue);
-		flush();
-		expect(value?.()).toBe(nextValue);
-
-		dispose?.();
 	});
 
 	it("reactively propagates nested object updates", () => {
@@ -68,15 +44,11 @@ describe("useStore with Solid 2", () => {
 		createRoot((rootDispose) => {
 			dispose = rootDispose;
 			const value = useStore(store);
-			createEffect(
-				() => value().user.name,
-				(name) => {
-					observedNames.push(name);
-				},
-			);
+			createEffect(() => {
+				observedNames.push(value().user.name);
+			});
 		});
 
-		flush();
 		expect(observedNames).toEqual(["Ada"]);
 
 		store.set({
@@ -85,8 +57,6 @@ describe("useStore with Solid 2", () => {
 			},
 		});
 
-		expect(observedNames).toEqual(["Ada"]);
-		flush();
 		expect(observedNames).toEqual(["Ada", "Grace"]);
 
 		dispose?.();

--- a/packages/better-auth/vitest.config.ts
+++ b/packages/better-auth/vitest.config.ts
@@ -1,6 +1,19 @@
+import { fileURLToPath } from "node:url";
 import { defineProject } from "vitest/config";
 
+// Keep Solid 1 available to its integrations while exercising the client with
+// Solid 2's browser runtime.
+const solidV2BrowserEntry = fileURLToPath(
+	new URL("./node_modules/solid-js-v2/dist/solid.js", import.meta.url),
+);
+
 export default defineProject({
+	resolve: {
+		alias: {
+			"solid-js": solidV2BrowserEntry,
+			"solid-js-v2": solidV2BrowserEntry,
+		},
+	},
 	test: {
 		testTimeout: 10_000,
 		execArgv: ["--expose-gc"],

--- a/packages/better-auth/vitest.config.ts
+++ b/packages/better-auth/vitest.config.ts
@@ -1,8 +1,12 @@
 import { fileURLToPath } from "node:url";
 import { defineProject } from "vitest/config";
 
-// Keep Solid 1 available to its integrations while exercising the client with
-// Solid 2's browser runtime.
+const solidV1BrowserEntry = fileURLToPath(
+	new URL("./node_modules/solid-js/dist/solid.js", import.meta.url),
+);
+
+// Run the regular Solid tests against Solid 1's browser runtime. The Solid 2
+// compatibility test mocks "solid-js" with this separate browser entry.
 const solidV2BrowserEntry = fileURLToPath(
 	new URL("./node_modules/solid-js-v2/dist/solid.js", import.meta.url),
 );
@@ -10,7 +14,7 @@ const solidV2BrowserEntry = fileURLToPath(
 export default defineProject({
 	resolve: {
 		alias: {
-			"solid-js": solidV2BrowserEntry,
+			"solid-js": solidV1BrowserEntry,
 			"solid-js-v2": solidV2BrowserEntry,
 		},
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1015,6 +1015,9 @@ importers:
       solid-js:
         specifier: ^1.9.11
         version: 1.9.11
+      solid-js-v2:
+        specifier: npm:solid-js@^2.0.0-rc.0
+        version: solid-js@2.0.0-rc.0
       tsdown:
         specifier: 'catalog:'
         version: 0.21.10(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.19.0)(publint@0.3.17)(typescript@6.0.3)
@@ -6250,6 +6253,9 @@ packages:
     resolution: {integrity: sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ==}
     peerDependencies:
       solid-js: ^1.8.6
+
+  '@solidjs/signals@2.0.0-rc.0':
+    resolution: {integrity: sha512-oKZSfvsCcKw1uJjOGbUkJ+OqlhXLHtZ+rShSyu9KH0lUH7UUwfMfsKeh81JPiQxDDg4YLhEwI38hg0JkwzTdvA==}
 
   '@solidjs/start@1.3.2':
     resolution: {integrity: sha512-tasDl3utVbtP0rr4InB3ntBIFV2upvEiFrOOCkRrAA3yBfjx9elpxnc94sJQXo65PNYdAAAkPIC6h93vLrtwHg==}
@@ -12604,6 +12610,9 @@ packages:
 
   solid-js@1.9.11:
     resolution: {integrity: sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==}
+
+  solid-js@2.0.0-rc.0:
+    resolution: {integrity: sha512-3enTJ71VL69nM5p/it2InVBDBt316Cqfij+F0S7VuHZLITc8YV7Rvavjoy52nAKKxYWXM+BcXh2K7KcLTf1zdQ==}
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -19396,6 +19405,8 @@ snapshots:
   '@solidjs/router@0.15.4(solid-js@1.9.11)':
     dependencies:
       solid-js: 1.9.11
+
+  '@solidjs/signals@2.0.0-rc.0': {}
 
   '@solidjs/start@1.3.2(solid-js@1.9.11)(vinxi@0.5.11(fda321adb0ec1a60575cb6b8181efeb3))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -27442,6 +27453,13 @@ snapshots:
       csstype: 3.2.3
       seroval: 1.5.4
       seroval-plugins: 1.5.0(seroval@1.5.4)
+
+  solid-js@2.0.0-rc.0:
+    dependencies:
+      '@solidjs/signals': 2.0.0-rc.0
+      csstype: 3.2.3
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
 
   solid-refresh@0.6.3(solid-js@1.9.11):
     dependencies:


### PR DESCRIPTION
This PR adds SolidJS 2 support while preserving Solid 1 compatibility.

It replaces the removed `solid-js/store` dependency with shared signal APIs and adds browser-runtime coverage for updates, cleanup, function values, and nested reactivity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Solid 2 support to the Solid client without breaking Solid 1. Replaces `solid-js/store` with `createSignal` and Nanostores `listen`, so the Solid accessor now invalidates on every Nanostore update instead of reconciling nested properties.

- Uses `createSignal` initialized from `store.get()`; subscribes via `store.listen`; removes `reconcile`; keeps activation no-op and cleanup.
- Adds tests for both runtimes: Solid 1 (`solid-store.v1.test.ts`) and Solid 2 (`solid-store.test.ts`) covering updates, cleanup, nested reactivity; Solid 2 also covers function-valued stores and uses `flush` with `happy-dom`.
- Test-only aliases map `solid-js` to the Solid 1 browser runtime and `solid-js-v2` to Solid 2; the Solid 2 test mocks `solid-js` to import `solid-js-v2`.
- Adds `solid-js-v2` dev dependency; widens `solid-js` peer to `^1.0.0 || ^2.0.0-rc.0`; docs note dual-version support; changeset included.

**Migration**
- No action required. Solid 1 continues to work; Solid 2 (RC) is supported via `better-auth/solid`.

<sup>Written for commit def6ee45c32159ac08b781c3669014df9952f136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

