### PR TITLE
fix(organization): skip the user lookup when listMembers matches zero members

### DIFF
--- a/.changeset/quiet-members-empty-page.md
+++ b/.changeset/quiet-members-empty-page.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Skip the user lookup in organization `listMembers` when no members match, so an empty page no longer builds an `IN ()` query that MSSQL rejects.

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -219,6 +219,11 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					],
 				}),
 			]);
+			// On an empty page the user lookup below would build `IN ()` and
+			// `limit: 0`, which MSSQL rejects as a syntax error.
+			if (!members[0].length) {
+				return { members: [], total: members[1] };
+			}
 			// Prisma/Drizzle default findMany to ~100 when limit is omitted.
 			// Bound by the members result so every joined user row is fetched.
 			const users = await adapter.findMany<User>({

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AuthQueryAtom } from "../../../client";
 import { createAuthClient } from "../../../client";
 import { getTestInstance } from "../../../test-utils/test-instance";
@@ -285,6 +285,50 @@ describe("listMembers", async () => {
 			ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_A_MEMBER_OF_THIS_ORGANIZATION
 				.message,
 		);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10508
+	 */
+	it("should not look up users when the filter matches zero members", async () => {
+		const spy = vi.spyOn(ctx.adapter, "findMany");
+		const members = await client.organization.listMembers({
+			fetchOptions: {
+				headers,
+			},
+			query: {
+				organizationId: org.data?.id as string,
+				filterField: "role",
+				filterValue: "nonexistent-role",
+			},
+		});
+		const models = spy.mock.calls.map(([query]) => query.model);
+		spy.mockRestore();
+
+		expect(members.data?.members).toEqual([]);
+		expect(members.data?.total).toBe(0);
+		// Guards the assertion below: if the member query were missing too, the
+		// spy would not be observing the adapter the request actually used.
+		expect(models).toContain("member");
+		// An empty `in` list renders as `IN ()`, which MSSQL rejects.
+		expect(models).not.toContain("user");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10508
+	 */
+	it("should keep the total when the offset lands past the last member", async () => {
+		const members = await client.organization.listMembers({
+			fetchOptions: {
+				headers,
+			},
+			query: {
+				organizationId: org.data?.id as string,
+				offset: 100,
+			},
+		});
+		expect(members.data?.members).toEqual([]);
+		expect(members.data?.total).toBeGreaterThan(0);
 	});
 });
 

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
@@ -292,26 +292,29 @@ describe("listMembers", async () => {
 	 */
 	it("should not look up users when the filter matches zero members", async () => {
 		const spy = vi.spyOn(ctx.adapter, "findMany");
-		const members = await client.organization.listMembers({
-			fetchOptions: {
-				headers,
-			},
-			query: {
-				organizationId: org.data?.id as string,
-				filterField: "role",
-				filterValue: "nonexistent-role",
-			},
-		});
-		const models = spy.mock.calls.map(([query]) => query.model);
-		spy.mockRestore();
+		try {
+			const members = await client.organization.listMembers({
+				fetchOptions: {
+					headers,
+				},
+				query: {
+					organizationId: org.data?.id as string,
+					filterField: "role",
+					filterValue: "nonexistent-role",
+				},
+			});
+			const models = spy.mock.calls.map(([query]) => query.model);
 
-		expect(members.data?.members).toEqual([]);
-		expect(members.data?.total).toBe(0);
-		// Guards the assertion below: if the member query were missing too, the
-		// spy would not be observing the adapter the request actually used.
-		expect(models).toContain("member");
-		// An empty `in` list renders as `IN ()`, which MSSQL rejects.
-		expect(models).not.toContain("user");
+			expect(members.data?.members).toEqual([]);
+			expect(members.data?.total).toBe(0);
+			// Guards the assertion below: if the member query were missing too, the
+			// spy would not be observing the adapter the request actually used.
+			expect(models).toContain("member");
+			// An empty `in` list renders as `IN ()`, which MSSQL rejects.
+			expect(models).not.toContain("user");
+		} finally {
+			spy.mockRestore();
+		}
 	});
 
 	/**


### PR DESCRIPTION
Fixes #10508.

`listMembers` runs the member query and then always looks the users up with an `in` on the member user ids. When the member query comes back empty that turns into `IN ()` with `limit: 0`, and MSSQL rejects it with "Incorrect syntax near ')'". Postgres and MySQL happen to accept an empty `IN` list, which is why this only showed up on MSSQL. Any filter matching zero rows hits it, and so does an offset past the last member.

I return early when the page is empty. The total still comes from the count query, so pagination stays right in the case where the page is empty but the overall count is not. `findFullOrganization` in the same file already guards its user lookup the same way. This also drops a round trip on empty pages.

The default test database is SQLite, which accepts `IN ()`, so a plain "returns an empty array" check would pass with or without the change. Instead the test spies on the adapter and asserts the user query is never sent, plus a second assertion that the member query was sent so the test cannot pass just because the spy missed the adapter. I checked it fails on the current code and passes with the change. The rest of the organization suite passes.

Disclosure: I used Claude Code to help write this fix, and I reviewed and tested it myself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the user lookup in organization `listMembers` when the page is empty, preventing MSSQL’s “Incorrect syntax near ')'” and keeping totals correct. Previously it always queried users and built `IN ()`; now it returns early and also avoids a DB round trip.

- Updates `packages/better-auth/src/plugins/organization/adapter.ts` to return early; behavior for non-empty pages is unchanged and matches the guard in `findFullOrganization`.
- Adds tests in `crud-members.test.ts` to verify: no user lookup on zero matches and total preserved when the offset is past the last member; restores the adapter spy in a finally block to avoid leaking mocks across tests.
- No API changes.

<sup>Written for commit 249897dc8483ed4254007e706fcf685f5790e448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

