### PR TITLE
fix(db): ignore references to unknown models when resolving join clauses

### DIFF
--- a/.changeset/join-unknown-reference-model.md
+++ b/.changeset/join-unknown-reference-model.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Ignore `references` that point at tables outside the better-auth schema when resolving joins, so `getSession` no longer fails with "Failed to get session" when a `user.additionalFields` entry references an application table such as `roles`.

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -309,3 +309,30 @@ describe("createAdapterFactory where value coercion", () => {
 		]);
 	});
 });
+
+describe("createAdapterFactory join clause", () => {
+	it("ignores references to models outside the better-auth schema when joining", async () => {
+		const adapter = createTestAdapter({
+			adapter: createCustomAdapter({ findOne: async () => null }),
+			options: {
+				user: {
+					additionalFields: {
+						roleId: {
+							type: "string",
+							required: false,
+							references: { model: "roles", field: "id" },
+						},
+					},
+				},
+			},
+		});
+
+		await expect(
+			adapter.findOne({
+				model: "session",
+				where: [{ field: "token", value: "t" }],
+				join: { user: true },
+			}),
+		).resolves.toBeNull();
+	});
+});

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -628,6 +628,18 @@ export const createAdapterFactory =
 			}) as any;
 		};
 
+		// `references.model` may point at an application table that better-auth
+		// knows nothing about. Such a reference can never match the model being
+		// joined, so treat it as a non-match rather than letting the strict
+		// resolver throw and take the whole query down.
+		const resolveReferencedModel = (model: string): string | undefined => {
+			try {
+				return getDefaultModelName(model);
+			} catch {
+				return undefined;
+			}
+		};
+
 		const transformJoinClause = (
 			baseModel: string,
 			unsanitizedJoin: JoinOption | undefined,
@@ -647,7 +659,7 @@ export const createAdapterFactory =
 				).filter(
 					([field, fieldAttributes]) =>
 						fieldAttributes.references &&
-						getDefaultModelName(fieldAttributes.references.model) ===
+						resolveReferencedModel(fieldAttributes.references.model) ===
 							defaultBaseModelName,
 				);
 
@@ -660,7 +672,7 @@ export const createAdapterFactory =
 					).filter(
 						([field, fieldAttributes]) =>
 							fieldAttributes.references &&
-							getDefaultModelName(fieldAttributes.references.model) ===
+							resolveReferencedModel(fieldAttributes.references.model) ===
 								defaultModelName,
 					);
 					isForwardJoin = false;


### PR DESCRIPTION
`getSession` fails on every call when a `user.additionalFields` entry has a `references.model` pointing at a table better-auth does not manage. In the issue that table is a plain application table called `roles`. Sign up and sign in still work and the field is persisted correctly, only the session read breaks, and it surfaces as a generic "Failed to get session".

The cause is in `transformJoinClause`. When it builds the session to user join it walks every field of both models looking for foreign keys and passes each `references.model` through the strict model resolver, which throws `Model "roles" not found in schema` for anything outside the better-auth schema. One unrelated reference is enough to take the whole query down. I resolve those reference models through a small non-throwing helper that returns undefined for an unknown model. A model better-auth knows nothing about can never match the model being joined, so it is skipped instead of aborting the query. The two resolver calls for the models actually being joined stay strict, since a failure there is a real config error worth surfacing. With `roles` skipped the join matches on `session.userId` as it always has, which is the same result you get today by deleting the `references` key, the workaround from the issue.

The test in `packages/core/src/db/adapter/factory.test.ts` throws `Model "roles" not found in schema` before this change and resolves after. I also ran the reporter's config end to end against the memory adapter and confirmed `getSession` returns the user, and the existing session route tests still pass. Changeset included.

Closes #10716.

I used AI assistance on this change, and I have reviewed and tested it myself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore `references` to non-better-auth models when resolving join clauses, so `getSession` no longer fails when `user.additionalFields` points to an app table like `roles`. Previously, `transformJoinClause` threw “Model ... not found in schema”; now unknown references are skipped, while strict checks remain for the joined models.

**Reviewer notes**
- Add `resolveReferencedModel` helper that returns undefined for unknown models; use it when scanning fields for foreign keys.
- Keep strict resolution for the base and target join models; join behavior otherwise unchanged (e.g., session-user join on `userId`).
- Add a test for an additional field referencing `roles`; include a patch changeset for `@better-auth/core`. No migration required.

<sup>Written for commit 0f579a5b76155c255ffc69287e93dafa319c7da7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

