### PR TITLE
fix(admin): ban without a duration should clear the previous expiration

### DIFF
--- a/.changeset/fix-permanent-reban-expiration.md
+++ b/.changeset/fix-permanent-reban-expiration.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Ensure permanently banning a user clears any expiration from a previous temporary ban.

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -682,6 +682,9 @@ describe("Admin plugin", async () => {
 		expect(res.data?.user).toBeDefined();
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10820
+	 */
 	it("should clear the expired expiration when banning again without a duration", async () => {
 		const created = await client.admin.createUser(
 			{

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -682,6 +682,47 @@ describe("Admin plugin", async () => {
 		expect(res.data?.user).toBeDefined();
 	});
 
+	it("should clear the expired expiration when banning again without a duration", async () => {
+		const created = await client.admin.createUser(
+			{
+				name: "Reban User",
+				email: "reban@email.com",
+				password: "test",
+				role: "user",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		const userId = created.data?.user.id || "";
+		await client.admin.banUser(
+			{
+				userId,
+				banExpiresIn: 60 * 60,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		vi.useFakeTimers();
+		await vi.advanceTimersByTimeAsync(60 * 60 * 2 * 1000);
+		const res = await client.admin.banUser(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(res.data?.user?.banned).toBe(true);
+		expect(res.data?.user?.banExpires).toBeNull();
+		const signIn = await client.signIn.email({
+			email: "reban@email.com",
+			password: "test",
+		});
+		expect(signIn.error?.status).toBe(403);
+	});
+
 	it("should allow to unban user", async () => {
 		const res = await client.admin.unbanUser(
 			{

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1142,11 +1142,13 @@ export const banUser = (opts: AdminOptions) =>
 					banned: true,
 					banReason:
 						ctx.body.banReason || opts?.defaultBanReason || "No reason",
+					// null (not undefined) so a permanent ban clears any expiration
+					// left over from a previous temporary ban.
 					banExpires: ctx.body.banExpiresIn
 						? getDate(ctx.body.banExpiresIn, "sec")
 						: opts?.defaultBanExpiresIn
 							? getDate(opts.defaultBanExpiresIn, "sec")
-							: undefined,
+							: null,
 					updatedAt: new Date(),
 				},
 			);


### PR DESCRIPTION
Fixes #10820.

## Problem

In the `banUser` handler, when `banExpiresIn` is omitted (and no `defaultBanExpiresIn` is configured), `banExpires` is written as `undefined` — a no-op update that leaves any pre-existing `banExpires` on the row instead of clearing it.

Any **ban → ban** sequence without an intervening unban hits this:

- A temporary ban lapses naturally (expiry is only checked at sign-in, never written back), then an admin re-bans permanently: the stale past `banExpires` survives, so the ban check treats the user as not banned — the "permanent" ban silently has no effect.
- An active temporary ban is escalated to permanent: the old `banExpires` survives and the "permanent" ban silently ends on the original date.

This is the same root cause as #1468; the closing PR #1469 added `banExpires: null` to the **unban** path only, so the ban path still has the gap.

## Fix

Write `null` instead of `undefined` in the fallback branch, mirroring what `unbanUser` has done since #1469. One-line change.

## Test

Added a self-contained regression test reproducing the expired-temp-ban → permanent-re-ban scenario: it asserts `banExpires` is `null` after the second ban and that the user can no longer sign in. Verified the test fails on the previous code and passes with the fix; the full admin suite (93 tests) passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Banning a user without a duration now clears any previous expiration so the ban is permanent. Previously the ban path wrote `undefined` to `banExpires`, leaving stale expirations that could nullify or shorten a permanent re-ban.

- Write `banExpires: null` in `banUser` when neither `banExpiresIn` nor `defaultBanExpiresIn` is provided.
- Add a regression test for expired temporary ban → permanent re-ban; asserts `banExpires` is `null`, sign-in is blocked, and references #10820.
- Add a changeset to release a patch in `better-auth`.

<sup>Written for commit 8b33c4784030e1d300726aaad425cd02caf555de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

