### PR TITLE
fix(organization): apply data returned by beforeAddTeamMember hook

### DIFF
--- a/.changeset/apply-before-add-team-member-data.md
+++ b/.changeset/apply-before-add-team-member-data.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Apply the `data` returned by the organization plugin's `beforeAddTeamMember` hook when creating the team membership, and allow extra columns on the `teamMember` model through `schema.teamMember.additionalFields`.

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -2420,7 +2420,7 @@ const auth = betterAuth({
 
 #### Additional Fields
 
-Starting with [Better Auth v1.3](https://github.com/better-auth/better-auth/releases/tag/v1.3.0), you can easily add custom fields to the `organization`, `invitation`, `member`, and `team` tables.
+Starting with [Better Auth v1.3](https://github.com/better-auth/better-auth/releases/tag/v1.3.0), you can easily add custom fields to the `organization`, `invitation`, `member`, `team`, and `teamMember` tables.
 
 When you add extra fields to a model, the relevant API endpoints will automatically accept and return these new properties. For instance, if you add a custom field to the `organization` table, the `createOrganization` endpoint will include this field in its request and response payloads as needed.
 
@@ -2441,6 +2441,42 @@ const auth = betterAuth({
               required: false, // [!code highlight]
             }, // [!code highlight]
           },
+        },
+      },
+    }),
+  ],
+});
+```
+
+The `teamMember` table works a little differently. `addTeamMember` does not read extra fields from the request, so set them in the `beforeAddTeamMember` hook by returning a `data` object. `teamId`, `userId` and `createdAt` are always set by the plugin and cannot be overwritten by the hook.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { organization } from "better-auth/plugins";
+
+const auth = betterAuth({
+  plugins: [
+    organization({
+      teams: {
+        enabled: true,
+      },
+      schema: {
+        teamMember: {
+          additionalFields: {
+            position: {
+              type: "string",
+              required: false,
+            },
+          },
+        },
+      },
+      organizationHooks: {
+        beforeAddTeamMember: async ({ teamMember, team, user, organization }) => {
+          return {
+            data: {
+              position: "member", // [!code highlight]
+            },
+          };
         },
       },
     }),

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -897,6 +897,8 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		findOrCreateTeamMember: async (data: {
 			teamId: string;
 			userId: string;
+			// This represents the additionalFields for the team member
+			additionalData?: Record<string, any>;
 		}) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
 			const member = await adapter.findOne<TeamMember>({
@@ -918,6 +920,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			return await adapter.create<Omit<TeamMember, "id">, TeamMember>({
 				model: "teamMember",
 				data: {
+					...data.additionalData,
 					teamId: data.teamId,
 					userId: data.userId,
 					createdAt: new Date(),
@@ -940,6 +943,8 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			teamId: string;
 			userId: string;
 			maximumMembersPerTeam: number;
+			// This represents the additionalFields for the team member
+			additionalData?: Record<string, any>;
 		}): Promise<
 			{ status: "added"; member: TeamMember } | { status: "limitReached" }
 		> => {
@@ -966,6 +971,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					{
 						model: "teamMember",
 						data: {
+							...data.additionalData,
 							teamId: data.teamId,
 							userId: data.userId,
 							createdAt: new Date(),

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -69,6 +69,11 @@ export interface OrganizationClientOptions {
 						[key: string]: DBFieldAttribute;
 					};
 				};
+				teamMember?: {
+					additionalFields?: {
+						[key: string]: DBFieldAttribute;
+					};
+				};
 				organizationRole?: {
 					additionalFields?: {
 						[key: string]: DBFieldAttribute;

--- a/packages/better-auth/src/plugins/organization/organization-hook.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization-hook.test.ts
@@ -316,3 +316,81 @@ describe("organization creation in database hooks", async () => {
 		expect((org as any)?.name).toBe("Before-After Org");
 	});
 });
+
+describe("team member hooks", async () => {
+	const { auth, db, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			organization({
+				teams: {
+					enabled: true,
+				},
+				schema: {
+					teamMember: {
+						additionalFields: {
+							position: {
+								type: "string",
+								required: false,
+							},
+						},
+					},
+				},
+				organizationHooks: {
+					beforeAddTeamMember: async () => {
+						return {
+							data: {
+								position: "lead",
+							},
+						};
+					},
+				},
+			}),
+		],
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10707
+	 */
+	it("should persist the data returned by beforeAddTeamMember", async () => {
+		const { headers } = await signInWithTestUser();
+
+		const org = await auth.api.createOrganization({
+			headers,
+			body: {
+				name: "Hook Org",
+				slug: "hook-org",
+			},
+		});
+		expect(org).not.toBeNull();
+
+		const team = await auth.api.createTeam({
+			headers,
+			body: {
+				name: "Hook Team",
+				organizationId: org!.id,
+			},
+		});
+
+		const teamMember = await auth.api.addTeamMember({
+			headers,
+			body: {
+				teamId: team.id,
+				userId: org!.members[0]!.userId,
+			},
+		});
+
+		const stored = await db.findOne({
+			model: "teamMember",
+			where: [
+				{
+					field: "id",
+					value: teamMember.id,
+				},
+			],
+		});
+
+		expect((stored as any)?.position).toBe("lead");
+		// the hook must not be able to overwrite the identity columns
+		expect((stored as any)?.teamId).toBe(team.id);
+		expect((stored as any)?.userId).toBe(org!.members[0]!.userId);
+	});
+});

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -1000,6 +1000,7 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 							required: false,
 							fieldName: opts.schema?.teamMember?.fields?.createdAt,
 						},
+						...(opts.schema?.teamMember?.additionalFields || {}),
 					},
 				},
 			} satisfies BetterAuthPluginDBSchema)

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -1148,6 +1148,8 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 				});
 			}
 
+			let additionalData: Record<string, any> = {};
+
 			// Run beforeAddTeamMember hook
 			if (options?.organizationHooks?.beforeAddTeamMember) {
 				const response = await options?.organizationHooks.beforeAddTeamMember({
@@ -1160,7 +1162,10 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 					organization,
 				});
 				if (response && typeof response === "object" && "data" in response) {
-					// Allow the hook to modify the data
+					additionalData = {
+						...additionalData,
+						...response.data,
+					};
 				}
 			}
 
@@ -1179,6 +1184,7 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 					teamId: ctx.body.teamId,
 					userId: ctx.body.userId,
 					maximumMembersPerTeam,
+					additionalData,
 				});
 				if (result.status === "limitReached") {
 					throw APIError.from(
@@ -1191,6 +1197,7 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 				teamMember = await adapter.findOrCreateTeamMember({
 					teamId: ctx.body.teamId,
 					userId: ctx.body.userId,
+					additionalData,
 				});
 			}
 

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -339,6 +339,9 @@ export interface OrganizationOptions {
 					fields?: {
 						[key in keyof Omit<TeamMember, "id">]?: string;
 					};
+					additionalFields?: {
+						[key in string]: DBFieldAttribute;
+					};
 				};
 				organizationRole?: {
 					modelName?: string;
@@ -742,6 +745,12 @@ export interface OrganizationOptions {
 
 				/**
 				 * A callback that runs before a member is added to a team
+				 *
+				 * You can return a `data` object to override the default data.
+				 * `teamId`, `userId` and `createdAt` are always set by the plugin and
+				 * cannot be overridden.
+				 *
+				 * @see https://github.com/better-auth/better-auth/issues/10707
 				 */
 				beforeAddTeamMember?: (data: {
 					teamMember: {


### PR DESCRIPTION
The `beforeAddTeamMember` hook is typed to return an optional `data` object, and the route already checked for it, but the branch that handled it was empty with a `// Allow the hook to modify the data` comment. Whatever the hook returned was dropped, so it silently did nothing. There was also nowhere for that data to go: `teamMember` was the only model in the organization plugin whose `schema` option had no `additionalFields`.

This adds `additionalFields` to the `teamMember` schema option and the matching field spread in the plugin schema, then passes the hook's data through to whichever insert path runs, `addTeamMemberWithLimit` or `findOrCreateTeamMember`. Both spread it under `teamId`, `userId` and `createdAt`, so a hook can set declared extra columns but cannot change the identity of the row. The client schema option gained a `teamMember` entry too, otherwise `inferOrgAdditionalFields` returns a shape the client rejects.

The other three places that insert a team member (accept invitation, add member, create organization) still fire no hook at all. That felt like a separate behavior decision, so I left it alone.

Regression test in `organization-hook.test.ts`, which had no coverage for these two hooks before. Written with help from Claude Code; I read and tested the change myself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply `beforeAddTeamMember` hook data and add `teamMember` additional fields in `better-auth`’s organization plugin. Previously the hook’s returned `data` was ignored and `teamMember` had no `additionalFields`; now we persist that data and prevent overrides of `teamId`, `userId`, and `createdAt`.

- Review notes:
  - Route captures the hook response and forwards it as `additionalData` to both insert paths (`addTeamMemberWithLimit`, `findOrCreateTeamMember`). The adapter spreads it before identity fields, which remain enforced.
  - Add `schema.teamMember.additionalFields` and a matching client `schema.teamMember` entry to align with `inferOrgAdditionalFields`.
  - Tests and docs updated. Other team-member creation paths (accept invitation, add member, create organization) still do not fire this hook.

- Migration:
  - To store extra team member fields, declare them under `schema.teamMember.additionalFields` and set values by returning `data` from `beforeAddTeamMember`. No other action required.

<sup>Written for commit ffafe7a88088d685203afcfd157a143d25a83f3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

