### PR TITLE
fix(db): make verification reservations work with uuid ids

### DIFF
--- a/.changeset/reserve-verification-uuid-ids.md
+++ b/.changeset/reserve-verification-uuid-ids.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Reservations keyed by `reserveVerificationValue` now hold under `advanced.database.generateId: "uuid"`. The reservation id is derived from the identifier, but it was base64url encoded, so the UUID id strategy rejected it and swapped in a random UUID. Each replay then wrote its own row and won the reservation, which turned SAML assertion replay protection into a no-op. The digest is now formatted as a name-based UUID when that strategy is configured, and every other strategy keeps the existing base64url key. `generateId: "serial"` cannot represent a derived id at all, so it throws instead of silently accepting the replay.

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1950,6 +1950,53 @@ describe("internal adapter test", async () => {
 			expect(results.filter((r) => r === false)).toHaveLength(1);
 		});
 
+		/**
+		 * The reservation id is derived from the identifier, but under
+		 * `generateId: "uuid"` the adapter dropped it for a random UUID because it
+		 * was not UUID shaped, so every replay created a new row and won.
+		 *
+		 * @see https://github.com/better-auth/better-auth/issues/10624
+		 */
+		it("returns false the second time when ids are uuids", async () => {
+			const adapter = await makeAdapter({
+				advanced: { database: { generateId: "uuid" } },
+			});
+
+			const first = await adapter.reserveVerificationValue({
+				identifier: "reserve:uuid-once",
+				value: "jti-uuid",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+			expect(first).toBe(true);
+
+			const second = await adapter.reserveVerificationValue({
+				identifier: "reserve:uuid-once",
+				value: "jti-uuid-replay",
+				expiresAt: new Date(Date.now() + 60_000),
+			});
+			expect(second).toBe(false);
+		});
+
+		/**
+		 * A numeric id cannot hold a hash, so a reservation can never be keyed
+		 * deterministically here. Fail loudly instead of always returning true.
+		 *
+		 * @see https://github.com/better-auth/better-auth/issues/10624
+		 */
+		it("throws when ids are database generated numbers", async () => {
+			const adapter = await makeAdapter({
+				advanced: { database: { generateId: "serial" } },
+			});
+
+			await expect(
+				adapter.reserveVerificationValue({
+					identifier: "reserve:serial",
+					value: "jti-serial",
+					expiresAt: new Date(Date.now() + 60_000),
+				}),
+			).rejects.toThrow(/serial/);
+		});
+
 		it("reserves independently across different identifiers", async () => {
 			const adapter = await makeAdapter();
 

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -1449,7 +1449,6 @@ export const createInternalAdapter = (
 			value: string;
 			expiresAt: Date;
 		}): Promise<boolean> => {
-			const reservationId = await getReservationId(data.identifier, options);
 			const storageOption = getStorageOption(
 				data.identifier,
 				options.verification?.storeIdentifier,
@@ -1460,14 +1459,9 @@ export const createInternalAdapter = (
 			);
 
 			if (secondaryStorage && !options.verification?.storeInDatabase) {
-				// Best-effort under concurrency: without a database primary key there
-				// is no first-writer-wins gate, so two callers racing a get-then-set
-				// can both observe an empty key and both win (mirrors the non-atomic
-				// secondary fallback in consumeVerificationValue).
-				// FIXME(reserve-secondary-atomic): require an atomic conditional set
-				// (set-if-absent) on SecondaryStorage, or require database-backed
-				// verification storage for reservations, so this path can guarantee
-				// first-writer-wins across processes.
+				// Secondary-storage-only path: use a string cache key, no database id needed.
+				// Get a reservation id for the cache value, but this won't be written to a DB column.
+				const reservationId = await getReservationId(data.identifier, options);
 				const cacheKey = `verification:${storedIdentifier}`;
 				const existing = await secondaryStorage.get(cacheKey);
 				if (existing) return false;
@@ -1483,6 +1477,10 @@ export const createInternalAdapter = (
 				);
 				return true;
 			}
+
+			// Database-backed path: need a database-compatible reservation id.
+			// This will throw for serial ids since they can't hold a derived key.
+			const reservationId = await getReservationId(data.identifier, options);
 
 			try {
 				await adapter.create({

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -10,6 +10,7 @@ import {
 } from "@better-auth/core/context";
 import type { DBAdapter, Where } from "@better-auth/core/db/adapter";
 import type { InternalLogger } from "@better-auth/core/env";
+import { BetterAuthError } from "@better-auth/core/error";
 import { generateId } from "@better-auth/core/utils/id";
 import { getIp } from "@better-auth/core/utils/ip";
 import { safeJSONParse } from "@better-auth/core/utils/json";
@@ -33,6 +34,56 @@ function getTTLSeconds(expiresAt: Date | number, now = Date.now()): number {
 	const expiresMs =
 		typeof expiresAt === "number" ? expiresAt : expiresAt.getTime();
 	return Math.max(Math.floor((expiresMs - now) / 1000), 0);
+}
+
+/**
+ * Formats the first 16 bytes of a digest as an RFC 4122 name-based UUID, so a
+ * deterministic id is still accepted where the id column holds UUIDs.
+ */
+function formatDigestAsUUID(digest: Uint8Array): string {
+	const bytes = digest.slice(0, 16);
+	// Only the version nibble (5, name-based, the closest match for a digest of
+	// a name) and the two variant bits are rewritten, so the id stays a
+	// function of the identifier.
+	bytes[6] = (bytes[6]! & 0x0f) | 0x50;
+	bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+	const hex = Array.from(bytes, (byte) =>
+		byte.toString(16).padStart(2, "0"),
+	).join("");
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/**
+ * Derives the deterministic primary key that makes a reservation
+ * first-writer-wins: the same identifier always maps to the same row, so a
+ * replay collides with the row the first caller wrote.
+ *
+ * The digest is always `SHA-256` of `reserve:<identifier>`; only the encoding
+ * follows the configured id strategy. Under `generateId: "uuid"` the adapter
+ * throws away any id that is not UUID shaped and puts a random one in its
+ * place, which would let every replay win, so the digest is formatted as a
+ * UUID there. Every other strategy keeps the base64url key.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10624
+ */
+export async function getReservationId(
+	identifier: string,
+	options: Pick<BetterAuthOptions, "advanced">,
+): Promise<string> {
+	const generateId = options.advanced?.database?.generateId;
+	if (generateId === "serial") {
+		throw new BetterAuthError(
+			'Reservations are not supported with `advanced.database.generateId: "serial"`, because a database generated number cannot hold the deterministic id a reservation is keyed by.',
+		);
+	}
+	const digest = new Uint8Array(
+		await createHash("SHA-256").digest(
+			new TextEncoder().encode("reserve:" + identifier),
+		),
+	);
+	return generateId === "uuid"
+		? formatDigestAsUUID(digest)
+		: base64Url.encode(digest, { padding: false });
 }
 
 export const createInternalAdapter = (
@@ -1380,7 +1431,8 @@ export const createInternalAdapter = (
 		 * already taken.
 		 *
 		 * The `verification.identifier` column is non-unique, so uniqueness comes
-		 * from a deterministic primary key (`SHA-256` of `reserve:<identifier>`).
+		 * from a deterministic primary key (`SHA-256` of `reserve:<identifier>`,
+		 * encoded to fit the configured id strategy, see `getReservationId`).
 		 * The database path is atomic: the primary key turns the INSERT into the
 		 * first-writer-wins gate, and a duplicate is detected portably by
 		 * re-reading the row rather than matching adapter-specific errors. The
@@ -1397,14 +1449,7 @@ export const createInternalAdapter = (
 			value: string;
 			expiresAt: Date;
 		}): Promise<boolean> => {
-			const reservationId = base64Url.encode(
-				new Uint8Array(
-					await createHash("SHA-256").digest(
-						new TextEncoder().encode("reserve:" + data.identifier),
-					),
-				),
-				{ padding: false },
-			);
+			const reservationId = await getReservationId(data.identifier, options);
 			const storageOption = getStorageOption(
 				data.identifier,
 				options.verification?.storeIdentifier,


### PR DESCRIPTION
`reserveVerificationValue` writes a replay marker keyed by a deterministic primary key, a SHA-256 of `reserve:<identifier>`, so a second caller collides with the first and gets `false`. The digest was base64url encoded, and that string is not a valid UUID. With `advanced.database.generateId: "uuid"` the adapter drops the id and puts a random UUID in its place, so every replay wrote its own row and got `true` back. The SAML assertion replay check in the sso plugin never fired. On adapters that generate UUIDs in the database the insert fails with a NOT NULL error instead.

The derivation stays the same. Under the uuid strategy the first 16 bytes of the digest are now formatted as a name based UUID, which passes the check and is still a pure function of the identifier. Other strategies keep the base64url key, so no existing rows change shape. `serial` cannot hold a derived id at all, so it throws instead of reporting a reservation that did not happen.

Two tests go in the existing `reserveVerificationValue` block. Both fail before this change. Closes #10624.

Written with AI assistance, reviewed and tested by me.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes verification reservations in `better-auth` when `advanced.database.generateId: "uuid"`, restoring SAML assertion replay protection. The digest is now formatted as a name-based UUID for that strategy; other strategies keep the existing base64url key.

- `generateId: "serial"` now throws in the database-backed path; secondary-storage-only reservations keep working with a string cache key.
- No data migration for non-UUID strategies; for `serial`, only database-backed reservations are affected.

<sup>Written for commit f7be525fdb539fd06f3c3ec5cd52343c06362859. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

