### PR TITLE
fix(oauth-provider): use a url safe signature for signed oauth queries

### DIFF
--- a/.changeset/url-safe-oauth-signature.md
+++ b/.changeset/url-safe-oauth-signature.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Sign the OAuth query with a base64url `sig` so the signature is not corrupted when a proxy, router, or login page url-decodes the query once. Signatures using the standard base64 alphabet are still accepted, so links issued before this change keep working.

--- a/packages/oauth-provider/src/authorize.test.ts
+++ b/packages/oauth-provider/src/authorize.test.ts
@@ -12,6 +12,7 @@ import {
 	postLoginClearedParam,
 	setSignedOAuthQueryParameterNames,
 	signedQueryIssuedAtParam,
+	toBase64Url,
 } from "./signed-query";
 import type { OAuthClient } from "./types/oauth";
 import { verifyOAuthQueryParams } from "./utils";
@@ -145,6 +146,36 @@ describe("oauth signed query signatures", () => {
 		expect(
 			await verifyOAuthQueryParams(signedParams.toString(), "test-secret"),
 		).toBe(false);
+	});
+
+	/**
+	 * A `sig` in the base64url alphabet is unchanged by a url decode, so the
+	 * signed query still verifies when something in front of the auth server
+	 * decodes it once.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10427
+	 */
+	it("should verify signed params when the query is url-decoded once", async () => {
+		const signedParams = await createSignedParams("test-secret");
+		signedParams.set("sig", toBase64Url(signedParams.get("sig") ?? ""));
+		const decodedOnce = decodeURIComponent(signedParams.toString());
+
+		expect(await verifyOAuthQueryParams(decodedOnce, "test-secret")).toBe(true);
+	});
+
+	/**
+	 * Signed queries issued before the switch to base64url carry a standard
+	 * base64 `sig` and must keep verifying after an upgrade.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10427
+	 */
+	it("should verify signed params carrying a standard base64 signature", async () => {
+		const signedParams = await createSignedParams("test-secret");
+
+		expect(signedParams.get("sig")).toMatch(/=$/);
+		expect(
+			await verifyOAuthQueryParams(signedParams.toString(), "test-secret"),
+		).toBe(true);
 	});
 
 	it("should reject duplicate signature params", async () => {
@@ -323,6 +354,49 @@ describe("oauth authorize - unauthenticated", async () => {
 		expect(await verifyOAuthQueryParams(reordered.toString(), secret)).toBe(
 			true,
 		);
+	});
+
+	/**
+	 * The login redirect is signed with a base64url `sig`, so a proxy or router
+	 * that url-decodes the query once does not corrupt it.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10427
+	 */
+	it("should sign the login redirect with a url safe signature", async () => {
+		if (!oauthClient?.client_id || !oauthClient?.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const authUrl = await createAuthorizationURL({
+			id: providerId,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+			},
+			redirectURI: redirectUri,
+			state: "url-safe-sig",
+			scopes: ["openid"],
+			responseType: "code",
+			codeVerifier: generateRandomString(64),
+			authorizationEndpoint: `${authServerBaseUrl}/api/auth/oauth2/authorize`,
+		});
+
+		let loginRedirectUrl = "";
+		await unauthenticatedClient.$fetch(authUrl.toString(), {
+			onError(context) {
+				loginRedirectUrl = context.response.headers.get("Location") || "";
+			},
+		});
+
+		const loginRedirect = new URL(loginRedirectUrl, authServerBaseUrl);
+		const secret = (auth.options as unknown as { secret: string }).secret;
+
+		expect(loginRedirect.searchParams.get("sig")).toMatch(/^[\w-]+$/);
+		expect(
+			await verifyOAuthQueryParams(
+				decodeURIComponent(loginRedirect.search.slice(1)),
+				secret,
+			),
+		).toBe(true);
 	});
 
 	it("should return login_required when prompt=none and user is not logged in", async () => {

--- a/packages/oauth-provider/src/authorize.ts
+++ b/packages/oauth-provider/src/authorize.ts
@@ -11,6 +11,7 @@ import {
 	postLoginClearedParam,
 	setSignedOAuthQueryParameterNames,
 	signedQueryIssuedAtParam,
+	toBase64Url,
 } from "./signed-query";
 import type {
 	OAuthAuthorizationQuery,
@@ -671,6 +672,6 @@ async function signParams(
 		canonicalizeOAuthQueryParams(params).toString(),
 		ctx.context.secret,
 	);
-	params.set("sig", signature);
+	params.set("sig", toBase64Url(signature));
 	return params.toString();
 }

--- a/packages/oauth-provider/src/signed-query.ts
+++ b/packages/oauth-provider/src/signed-query.ts
@@ -2,6 +2,17 @@ export const signedQueryIssuedAtParam = "ba_iat";
 export const postLoginClearedParam = "ba_pl";
 const signedQueryParameterNameParam = "ba_param";
 
+/**
+ * Rewrites a standard base64 string into the base64url alphabet.
+ *
+ * Signatures travel in the query string, where a `+` turns into a space as soon
+ * as something in front of the auth server url-decodes the query once. The
+ * base64url alphabet has no such characters, so the signature survives.
+ */
+export function toBase64Url(value: string) {
+	return value.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
 export function canonicalizeOAuthQueryParams(params: URLSearchParams) {
 	const canonicalParams = new URLSearchParams();
 	const entries = [...params.entries()].sort(

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -11,7 +11,7 @@ import {
 import type { jwt } from "better-auth/plugins";
 import { APIError } from "better-call";
 import type { oauthProvider } from "../oauth";
-import { canonicalizeOAuthQueryParams } from "../signed-query";
+import { canonicalizeOAuthQueryParams, toBase64Url } from "../signed-query";
 import type {
 	GrantType,
 	OAuthOptions,
@@ -157,10 +157,12 @@ export async function verifyOAuthQueryParams(
 		canonicalizeOAuthQueryParams(queryParams).toString(),
 		secret,
 	);
+	// Compare in base64url so signatures issued before this alphabet change keep
+	// verifying, and so a `sig` that went through a url decode still matches.
 	return (
 		sigs.length === 1 &&
 		!!sig &&
-		constantTimeEqual(sig, verifySig) &&
+		constantTimeEqual(toBase64Url(sig), toBase64Url(verifySig)) &&
 		new Date(exp * 1000) >= new Date()
 	);
 }

--- a/packages/oauth-provider/src/utils/index.ts
+++ b/packages/oauth-provider/src/utils/index.ts
@@ -159,10 +159,12 @@ export async function verifyOAuthQueryParams(
 	);
 	// Compare in base64url so signatures issued before this alphabet change keep
 	// verifying, and so a `sig` that went through a url decode still matches.
+	// URLSearchParams converts + to space, so restore it before converting.
+	const normalizedSig = sig.replace(/ /g, "+");
 	return (
 		sigs.length === 1 &&
 		!!sig &&
-		constantTimeEqual(toBase64Url(sig), toBase64Url(verifySig)) &&
+		constantTimeEqual(toBase64Url(normalizedSig), toBase64Url(verifySig)) &&
 		new Date(exp * 1000) >= new Date()
 	);
 }


### PR DESCRIPTION
The oauth provider signs the authorize query and puts the result in a `sig` query parameter. `makeSignature` returns standard base64, so that value can hold `+`, `/` and `=` padding. When something in front of the auth server url-decodes the query once, a proxy, a framework router, or a login page that reads and rebuilds the query, `%2B` comes back as `+` and is then read as a space. The signature stops matching and the authorize request fails. It only breaks for some requests, since not every signature happens to contain a `+`.

The signer now writes the signature in base64url, which has no characters a decode round can change. The verifier converts both the incoming `sig` and the freshly computed one to base64url before the constant time compare, so queries signed before this change still verify and no one is locked out during a deploy. The duplicate `sig` guard is unchanged.

Tests cover a query that was decoded once, an old style base64 signature, and the login redirect signature.

Fixes #10427

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`@better-auth/oauth-provider` now writes a base64url `sig` for signed OAuth queries and login redirects. Previously the `sig` used standard base64, so a single URL decode by a proxy/router could turn + into a space and break verification; the verifier now turns spaces back into + and normalizes both sides to base64url so old links still verify.

- Behavior change: `sig` no longer includes +, /, or = padding; duplicate-`sig` guard is unchanged.
- Tests: cover a once-decoded query, a legacy base64 `sig`, and a base64url login redirect.
- Rollout: no client action required; addresses #10427.

<sup>Written for commit c4676b15cdb1f1e46c9d8c6d186e25cf5520b9b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

