### PR TITLE
fix(admin): clear stale banExpires when banning without an expiration

### DIFF
--- a/.changeset/clear-stale-ban-expiration.md
+++ b/.changeset/clear-stale-ban-expiration.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Clear a previously set `banExpires` when the admin plugin bans a user without `banExpiresIn`, so a permanent ban no longer keeps a stale expiration date that lets the user back in.

--- a/packages/better-auth/src/plugins/admin/admin.test.ts
+++ b/packages/better-auth/src/plugins/admin/admin.test.ts
@@ -588,6 +588,56 @@ describe("Admin plugin", async () => {
 		expect(res.data?.user?.banExpires).toBeDefined();
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10820
+	 */
+	it("should clear a previous ban expiration when banning without one", async () => {
+		const created = await client.admin.createUser(
+			{
+				name: "Permanently Banned User",
+				email: "permanent-ban@email.com",
+				password: "test",
+				role: "user",
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		const userId = created.data?.user?.id || "";
+
+		const temporaryBan = await client.admin.banUser(
+			{
+				userId,
+				banExpiresIn: 60 * 60 * 24,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(temporaryBan.data?.user?.banExpires).toBeDefined();
+
+		const permanentBan = await client.admin.banUser(
+			{
+				userId,
+			},
+			{
+				headers: adminHeaders,
+			},
+		);
+		expect(permanentBan.data?.user?.banned).toBe(true);
+		expect(permanentBan.data?.user?.banExpires).toBeNull();
+
+		// the stale expiration would now be in the past, which used to un-ban the
+		// user on their next sign in attempt
+		vi.useFakeTimers();
+		await vi.advanceTimersByTimeAsync(60 * 60 * 25 * 1000);
+		const signIn = await client.signIn.email({
+			email: "permanent-ban@email.com",
+			password: "test",
+		});
+		expect(signIn.error?.code).toBe("BANNED_USER");
+	});
+
 	it("should not allow banned user to sign in", async () => {
 		const res = await client.signIn.email({
 			email: newUser?.email || "",

--- a/packages/better-auth/src/plugins/admin/routes.ts
+++ b/packages/better-auth/src/plugins/admin/routes.ts
@@ -1146,7 +1146,7 @@ export const banUser = (opts: AdminOptions) =>
 						? getDate(ctx.body.banExpiresIn, "sec")
 						: opts?.defaultBanExpiresIn
 							? getDate(opts.defaultBanExpiresIn, "sec")
-							: undefined,
+							: null,
 					updatedAt: new Date(),
 				},
 			);


### PR DESCRIPTION
When the admin plugin bans a user without `banExpiresIn`, and no `defaultBanExpiresIn` is set, `banUser` passed `undefined` for `banExpires`. The adapter skips undefined fields on update, so an expiration left over from an earlier temporary ban stayed in the database. Once that old date passed, the session hook read the ban as expired, un-banned the user and let them sign in again, even though the last ban was meant to be permanent.

This changes that fallback from `undefined` to `null`, so a ban with no expiry always overwrites the old date.

The regression test bans a user with an expiry, bans again without one, checks `banExpires` comes back null, then moves the clock past the old date and checks sign in still fails with `BANNED_USER`. That last step is what covers the un-ban path. Ran with `pnpm vitest run packages/better-auth/src/plugins/admin/admin.test.ts`, all 93 tests pass.

I used AI assistance while writing this change.

Closes #10820

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Permanent bans now clear any existing expiration in the `better-auth` admin plugin. Previously, banning without `banExpiresIn` (and no `defaultBanExpiresIn`) left the old `banExpires` value, which auto-unbanned the user; now we write `banExpires: null` so permanent bans remain enforced. Fixes #10820.

- Updated admin ban route to set `banExpires` to null when no expiry is provided.
- Added a regression test that verifies a permanent ban overwrites a prior temporary expiration and still blocks sign-in after the old date passes.

<sup>Written for commit ef25394c59dc7eb1e7185123035f09fb0ccf296d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

