### PR TITLE
fix(core): prevent async context initialization races

### DIFF
--- a/.changeset/calm-contexts-share.md
+++ b/.changeset/calm-contexts-share.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Prevent concurrent cold-start requests from intermittently losing authentication or transaction context.

--- a/packages/core/src/context/endpoint-context.test.ts
+++ b/packages/core/src/context/endpoint-context.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import type { AuthEndpointContext } from "./endpoint-context";
+import { __getBetterAuthGlobal } from "./global";
+
+describe("runWithEndpointContext", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10832
+	 */
+	it("preserves each endpoint context across concurrent first calls", async () => {
+		vi.resetModules();
+		const globalContext = __getBetterAuthGlobal().context;
+		const previousStorageDescriptor = Object.getOwnPropertyDescriptor(
+			globalContext,
+			"endpointContextAsyncStorage",
+		);
+		onTestFinished(() => {
+			if (previousStorageDescriptor) {
+				Object.defineProperty(
+					globalContext,
+					"endpointContextAsyncStorage",
+					previousStorageDescriptor,
+				);
+			} else {
+				Reflect.deleteProperty(globalContext, "endpointContextAsyncStorage");
+			}
+		});
+		Reflect.deleteProperty(globalContext, "endpointContextAsyncStorage");
+		const mod = await import("./endpoint-context");
+
+		const contexts = Array.from(
+			{ length: 32 },
+			() => ({}) as AuthEndpointContext,
+		);
+		const currentContexts = await Promise.all(
+			contexts.map((context) =>
+				mod.runWithEndpointContext(context, async () => {
+					await Promise.resolve();
+					return mod.getCurrentAuthContext();
+				}),
+			),
+		);
+
+		const matchingContextCount = currentContexts.filter(
+			(currentContext, index) => currentContext === contexts[index],
+		).length;
+		expect(matchingContextCount).toBe(contexts.length);
+	});
+});

--- a/packages/core/src/context/endpoint-context.ts
+++ b/packages/core/src/context/endpoint-context.ts
@@ -12,11 +12,13 @@ export type AuthEndpointContext = Partial<
 
 const ensureAsyncStorage = async () => {
 	const betterAuthGlobal = __getBetterAuthGlobal();
-	if (!betterAuthGlobal.context.endpointContextAsyncStorage) {
-		const AsyncLocalStorage = await getAsyncLocalStorage();
-		betterAuthGlobal.context.endpointContextAsyncStorage =
-			new AsyncLocalStorage<AuthEndpointContext>();
+	const existing = betterAuthGlobal.context.endpointContextAsyncStorage;
+	if (existing) {
+		return existing as AsyncLocalStorage<AuthEndpointContext>;
 	}
+	const AsyncLocalStorage = await getAsyncLocalStorage();
+	betterAuthGlobal.context.endpointContextAsyncStorage ??=
+		new AsyncLocalStorage<AuthEndpointContext>();
 	return betterAuthGlobal.context
 		.endpointContextAsyncStorage as AsyncLocalStorage<AuthEndpointContext>;
 };

--- a/packages/core/src/context/request-state.test.ts
+++ b/packages/core/src/context/request-state.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import { __getBetterAuthGlobal } from "./global";
 import type { RequestStateWeakMap } from "./request-state";
 import {
 	defineRequestState,
@@ -92,40 +93,48 @@ describe("request-state", () => {
 		});
 	});
 
-	describe("AsyncLocalStorage init race", () => {
-		it("shares one AsyncLocalStorage across concurrent first-callers", async () => {
-			// Force a cold start: reset the module (clears the memoized init) and
-			// clear the global singleton, so the concurrent burst below all races
-			// through ensureAsyncStorage()'s lazy initialization.
+	describe("concurrent first calls", () => {
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10832
+		 */
+		it("preserves each request state", async () => {
 			vi.resetModules();
-			const betterAuthGlobalSymbol = Symbol.for("better-auth:global");
-			const betterAuthGlobal = (globalThis as any)[betterAuthGlobalSymbol];
-			if (betterAuthGlobal?.context) {
-				betterAuthGlobal.context.requestStateAsyncStorage = undefined;
-			}
+			const globalContext = __getBetterAuthGlobal().context;
+			const previousStorageDescriptor = Object.getOwnPropertyDescriptor(
+				globalContext,
+				"requestStateAsyncStorage",
+			);
+			onTestFinished(() => {
+				if (previousStorageDescriptor) {
+					Object.defineProperty(
+						globalContext,
+						"requestStateAsyncStorage",
+						previousStorageDescriptor,
+					);
+				} else {
+					Reflect.deleteProperty(globalContext, "requestStateAsyncStorage");
+				}
+			});
+			Reflect.deleteProperty(globalContext, "requestStateAsyncStorage");
 			const mod = await import("./request-state");
 
-			const N = 32;
-			const outcomes = await Promise.all(
-				Array.from({ length: N }, () =>
-					mod
-						.runWithRequestState(new WeakMap(), async () => {
-							// Yield so every caller interleaves through the cold init
-							// window before any of them reads its state back.
-							await Promise.resolve();
-							await new Promise((resolve) => setTimeout(resolve, 0));
-							// Throws "No request state found" if this caller's run()
-							// executed on a different instance than the one resolved here.
-							await mod.getCurrentRequestState();
-						})
-						.then(
-							() => true,
-							() => false,
-						),
+			const stores: RequestStateWeakMap[] = Array.from(
+				{ length: 32 },
+				() => new WeakMap<object, unknown>(),
+			);
+			const currentStores = await Promise.all(
+				stores.map((store) =>
+					mod.runWithRequestState(store, async () => {
+						await Promise.resolve();
+						return mod.getCurrentRequestState();
+					}),
 				),
 			);
 
-			expect(outcomes.every(Boolean)).toBe(true);
+			const matchingStoreCount = currentStores.filter(
+				(currentStore, index) => currentStore === stores[index],
+			).length;
+			expect(matchingStoreCount).toBe(stores.length);
 		});
 	});
 });

--- a/packages/core/src/context/request-state.ts
+++ b/packages/core/src/context/request-state.ts
@@ -4,35 +4,17 @@ import { __getBetterAuthGlobal } from "./global";
 
 export type RequestStateWeakMap = WeakMap<object, any>;
 
-// Memoizes the in-flight AsyncLocalStorage initialization so concurrent
-// first-callers share a single instance instead of each constructing one.
-let asyncStorageInit: Promise<AsyncLocalStorage<RequestStateWeakMap>> | null =
-	null;
-
 const ensureAsyncStorage = async () => {
 	const betterAuthGlobal = __getBetterAuthGlobal();
 	const existing = betterAuthGlobal.context.requestStateAsyncStorage;
 	if (existing) {
 		return existing as AsyncLocalStorage<RequestStateWeakMap>;
 	}
-	// Without memoizing the init, several concurrent callers can each pass the
-	// check above, each `await getAsyncLocalStorage()`, and each assign a fresh
-	// instance — last write wins. `runWithRequestState().run()` then executes on
-	// one instance while a nested `getCurrentRequestState()` reads the
-	// overwritten one, throwing "No request state found". This shows up
-	// intermittently on serverless cold start (e.g. Cloudflare Workers), where
-	// the first requests hit before the lazy `node:async_hooks` import settles.
-	// The idempotent `??=` keeps the global singleton stable even if multiple
-	// BetterAuth copies (Dual Module Hazard) race here.
-	if (!asyncStorageInit) {
-		asyncStorageInit = getAsyncLocalStorage().then((AsyncLocalStorage) => {
-			betterAuthGlobal.context.requestStateAsyncStorage ??=
-				new AsyncLocalStorage<RequestStateWeakMap>();
-			return betterAuthGlobal.context
-				.requestStateAsyncStorage as AsyncLocalStorage<RequestStateWeakMap>;
-		});
-	}
-	return asyncStorageInit;
+	const AsyncLocalStorage = await getAsyncLocalStorage();
+	betterAuthGlobal.context.requestStateAsyncStorage ??=
+		new AsyncLocalStorage<RequestStateWeakMap>();
+	return betterAuthGlobal.context
+		.requestStateAsyncStorage as AsyncLocalStorage<RequestStateWeakMap>;
 };
 
 export async function getRequestStateAsyncLocalStorage() {

--- a/packages/core/src/context/transaction.test.ts
+++ b/packages/core/src/context/transaction.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import type { DBAdapter, DBTransactionAdapter } from "../db/adapter";
+import { __getBetterAuthGlobal } from "./global";
 import {
 	getCurrentAdapter,
 	queueAfterTransactionHook,
@@ -80,5 +81,54 @@ describe("runWithTransaction", () => {
 		expect(getTransactionCalls()).toBe(1);
 		expect(hookRunsInsideTransaction).toBe(0);
 		expect(hookRuns).toBe(1);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10832
+	 */
+	it("preserves each transaction adapter across concurrent first calls", async () => {
+		vi.resetModules();
+		const globalContext = __getBetterAuthGlobal().context;
+		const previousStorageDescriptor = Object.getOwnPropertyDescriptor(
+			globalContext,
+			"adapterAsyncStorage",
+		);
+		onTestFinished(() => {
+			if (previousStorageDescriptor) {
+				Object.defineProperty(
+					globalContext,
+					"adapterAsyncStorage",
+					previousStorageDescriptor,
+				);
+			} else {
+				Reflect.deleteProperty(globalContext, "adapterAsyncStorage");
+			}
+		});
+		Reflect.deleteProperty(globalContext, "adapterAsyncStorage");
+		const mod = await import("./transaction");
+		const harnesses = Array.from({ length: 32 }, () => {
+			const transactionAdapter = {} as DBTransactionAdapter;
+			const adapter = {
+				transaction: async <R>(
+					callback: (trx: DBTransactionAdapter) => Promise<R>,
+				) => callback(transactionAdapter),
+			} as DBAdapter;
+			return { adapter, transactionAdapter };
+		});
+
+		const currentAdapters = await Promise.all(
+			harnesses.map(({ adapter }) =>
+				mod.runWithTransaction(adapter, async () => {
+					await Promise.resolve();
+					return mod.getCurrentAdapter(adapter);
+				}),
+			),
+		);
+
+		const transactionAdapterCount = currentAdapters.filter(
+			(currentAdapter, index) =>
+				currentAdapter === harnesses[index]?.transactionAdapter,
+		).length;
+		expect(transactionAdapterCount).toBe(harnesses.length);
 	});
 });

--- a/packages/core/src/context/transaction.ts
+++ b/packages/core/src/context/transaction.ts
@@ -1,4 +1,4 @@
-import type { AsyncLocalStorage } from "node:async_hooks";
+import type { AsyncLocalStorage } from "@better-auth/core/async_hooks";
 import { getAsyncLocalStorage } from "@better-auth/core/async_hooks";
 import type { DBAdapter, DBTransactionAdapter } from "../db/adapter";
 import type { BetterAuthOptions } from "../types";
@@ -14,10 +14,12 @@ type HookContext = {
 
 const ensureAsyncStorage = async () => {
 	const betterAuthGlobal = __getBetterAuthGlobal();
-	if (!betterAuthGlobal.context.adapterAsyncStorage) {
-		const AsyncLocalStorage = await getAsyncLocalStorage();
-		betterAuthGlobal.context.adapterAsyncStorage = new AsyncLocalStorage();
+	const existing = betterAuthGlobal.context.adapterAsyncStorage;
+	if (existing) {
+		return existing as AsyncLocalStorage<HookContext>;
 	}
+	const AsyncLocalStorage = await getAsyncLocalStorage();
+	betterAuthGlobal.context.adapterAsyncStorage ??= new AsyncLocalStorage();
 	return betterAuthGlobal.context
 		.adapterAsyncStorage as AsyncLocalStorage<HookContext>;
 };


### PR DESCRIPTION
It looks like we need a cleaner overall approach to `AsyncLocalStorage`, but for this PR, I've at least standardized the existing logic to be consistent and correct.

Closes #10832

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents races during `AsyncLocalStorage` initialization so concurrent cold-start requests no longer lose endpoint, request, or transaction context. Previously, first calls could each create and overwrite separate storages; now all callers share one global storage per context via nullish assignment.

- Standardizes `ensureAsyncStorage` in `endpoint-context.ts`, `request-state.ts`, and `transaction.ts` to return existing storage or set it once with `??=`; removes ad-hoc promise memoization in request state.
- Adds concurrency tests that verify per-call context is preserved for endpoint contexts, request state, and transaction adapters.
- Updates type import to `@better-auth/core/async_hooks` in `transaction.ts`; releases a patch for `@better-auth/core`.
- No API changes; no migration required.

<sup>Written for commit c0a20f8135e81b89b6eec2a8770e3f2d50504a4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

