### PR TITLE
fix(e2e): remove invalid null version from workspace-only packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -37,7 +37,7 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "bumpVersionsWithWorkspaceProtocolOnly": true,
-  "ignore": [],
+  "ignore": ["@better-auth-test/adapter-base", "@better-auth-test/test-utils"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/e2e/adapter/package.json
+++ b/e2e/adapter/package.json
@@ -17,6 +17,5 @@
   "dependencies": {
     "deepmerge": "^4.3.1",
     "kysely": "catalog:"
-  },
-  "version": null
+  }
 }

--- a/e2e/integration/test-utils/package.json
+++ b/e2e/integration/test-utils/package.json
@@ -7,6 +7,5 @@
   "private": true,
   "devDependencies": {
     "terminate": "^2.8.0"
-  },
-  "version": null
+  }
 }


### PR DESCRIPTION
Every CI job on the `next` branch fails during workspace setup, before any build, lint, typecheck, or test work starts. Turborepo cannot parse the workspace graph because two package manifests carry `"version": null`, and `version` must be a string when the key is present.

`@better-auth-test/adapter-base` and `@better-auth-test/test-utils` are private, workspace-only packages that are never published and have never had a version. Other e2e packages depend on them through the `workspace:*` protocol, so when those consumers get a real version bump, changesets cascades a bump onto these two as well. With no baseline version string to increment, it writes `null`.

Adding both package names to the `ignore` list in the changesets config keeps their versions untouched no matter what depends on them, and the two manifests go back to having no `version` key. The existing `privatePackages: false` setting does not cover this case, since it governs packages that have a version rather than packages that have none.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks CI by removing invalid null versions from workspace-only packages and instructing Changesets to ignore them. Previously `@better-auth-test/adapter-base` and `@better-auth-test/test-utils` received `"version": null`, which caused Turborepo to fail parsing the workspace; now the version key is omitted and the workspace graph builds.

- Adds `@better-auth-test/adapter-base` and `@better-auth-test/test-utils` to `ignore` in `.changeset/config.json`.
- Removes `"version": null` from `e2e/adapter/package.json` and `e2e/integration/test-utils/package.json` so these manifests have no `version` key.
- No runtime or publish changes; CI should pass from the workspace setup step.

<sup>Written for commit 3024ceb67df14bda84af20fb0f1f7fb5de3d7f71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

