### PR TITLE
test(e2e): cover concurrent async context initialization in Workerd

### DIFF
--- a/e2e/smoke/test/fixtures/cloudflare/package.json
+++ b/e2e/smoke/test/fixtures/cloudflare/package.json
@@ -2,6 +2,7 @@
   "name": "@better-auth-test/fixtures-cloudflare",
   "private": true,
   "dependencies": {
+    "@better-auth/core": "workspace:*",
     "@better-auth/sso": "workspace:*",
     "better-auth": "workspace:*",
     "drizzle-orm": "^0.45.2",

--- a/e2e/smoke/test/fixtures/cloudflare/src/index.ts
+++ b/e2e/smoke/test/fixtures/cloudflare/src/index.ts
@@ -1,3 +1,14 @@
+import type { AuthEndpointContext } from "@better-auth/core/context";
+import {
+	getCurrentAdapter,
+	getCurrentAuthContext,
+	runWithEndpointContext,
+	runWithTransaction,
+} from "@better-auth/core/context";
+import type {
+	DBAdapter,
+	DBTransactionAdapter,
+} from "@better-auth/core/db/adapter";
 import { sso } from "@better-auth/sso";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -26,6 +37,54 @@ const app = new Hono<{
 		auth: Auth;
 	};
 }>();
+
+// Keep this before the auth middleware to test first-time async context initialization.
+app.get("/async-context/concurrency", async (c) => {
+	const contexts = Array.from(
+		{ length: 32 },
+		() => ({}) as AuthEndpointContext,
+	);
+	const currentContexts = await Promise.allSettled(
+		contexts.map((context) =>
+			runWithEndpointContext(context, async () => {
+				await Promise.resolve();
+				return getCurrentAuthContext();
+			}),
+		),
+	);
+
+	const adapters = Array.from({ length: 32 }, () => {
+		const transactionAdapter = {} as DBTransactionAdapter;
+		const adapter = {
+			transaction: async <R>(
+				callback: (trx: DBTransactionAdapter) => Promise<R>,
+			) => callback(transactionAdapter),
+		} as DBAdapter;
+		return { adapter, transactionAdapter };
+	});
+	const currentAdapters = await Promise.allSettled(
+		adapters.map(({ adapter }) =>
+			runWithTransaction(adapter, async () => {
+				await Promise.resolve();
+				return getCurrentAdapter(adapter);
+			}),
+		),
+	);
+
+	return c.json({
+		endpointContextMatches: currentContexts.filter(
+			(currentContext, index) =>
+				currentContext.status === "fulfilled" &&
+				currentContext.value === contexts[index],
+		).length,
+		transactionAdapterMatches: currentAdapters.filter(
+			(currentAdapter, index) =>
+				currentAdapter.status === "fulfilled" &&
+				currentAdapter.value === adapters[index]?.transactionAdapter,
+		).length,
+		total: contexts.length,
+	});
+});
 
 app.use("*", async (c, next) => {
 	const auth = createAuth(c.env);

--- a/e2e/smoke/test/fixtures/cloudflare/test/cold-start.test.ts
+++ b/e2e/smoke/test/fixtures/cloudflare/test/cold-start.test.ts
@@ -1,0 +1,30 @@
+import { afterAll, beforeAll, expect, it } from "vitest";
+import { createTestHarness } from "wrangler";
+
+const server = createTestHarness({
+	workers: [{ configPath: "./wrangler.json" }],
+});
+
+beforeAll(async () => {
+	await server.listen();
+});
+
+afterAll(async () => {
+	await server.close();
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10832
+ */
+it("preserves async contexts across concurrent first calls in the Workers runtime", async () => {
+	const response = await server.fetch(
+		"http://localhost:8787/async-context/concurrency",
+	);
+	expect(response.status).toBe(200);
+	const body: unknown = await response.json();
+	expect(body).toEqual({
+		endpointContextMatches: 32,
+		transactionAdapterMatches: 32,
+		total: 32,
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -807,6 +807,9 @@ importers:
 
   e2e/smoke/test/fixtures/cloudflare:
     dependencies:
+      '@better-auth/core':
+        specifier: workspace:*
+        version: link:../../../../../packages/core
       '@better-auth/sso':
         specifier: workspace:*
         version: link:../../../../../packages/sso


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end test that proves Workerd preserves async endpoint and DB transaction contexts across 32 concurrent cold-start requests. This confirms context isolation on first requests in Cloudflare Workers.

- Adds GET /async-context/concurrency in the Cloudflare fixture (before auth) that runs 32 concurrent `runWithEndpointContext` and `runWithTransaction` calls and returns match counts.
- Adds cold-start.test.ts using `wrangler` to assert 32/32 matches for endpoint and transaction contexts.
- Adds `@better-auth/core` to the Cloudflare fixture dependencies and lockfile.
- Test-only changes; no runtime or library behavior changes.

<sup>Written for commit 5d0ae5d8d7c521221b9301a1a45f8fd6ebd279b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

