### PR TITLE
fix(core): prioritize workerd over edge exports

### DIFF
--- a/.changeset/bright-clouds-listen.md
+++ b/.changeset/bright-clouds-listen.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Prevent async context loss in Cloudflare Workers bundles that enable multiple runtime conditions.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,8 +54,8 @@
       "node": "./dist/async_hooks/index.mjs",
       "deno": "./dist/async_hooks/index.mjs",
       "bun": "./dist/async_hooks/index.mjs",
-      "edge": "./dist/async_hooks/pure.index.mjs",
       "workerd": "./dist/async_hooks/index.mjs",
+      "edge": "./dist/async_hooks/pure.index.mjs",
       "browser": "./dist/async_hooks/pure.index.mjs",
       "default": "./dist/async_hooks/index.mjs"
     },


### PR DESCRIPTION
> [!NOTE]
> Within the ["exports"](https://nodejs.org/api/packages.html#exports) object, key order is significant. During condition matching, earlier entries have higher priority and take precedence over later entries. The general rule is that conditions should be from most specific to least specific in object order.
> 
> https://nodejs.org/api/packages.html#conditional-exports

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritizes the `workerd` export over `edge` in `@better-auth/core` so Cloudflare Workers resolve the async_hooks build and preserve async context. Previously, when both conditions were enabled, `edge` matched first and the pure build caused context loss; now `workerd` matches first.

**Impact**
- Cloudflare Workers bundles selecting both conditions now resolve `./dist/async_hooks/index.mjs` (workerd) instead of `./dist/async_hooks/pure.index.mjs` (edge), preventing async context loss.
- Other conditions (`node`, `deno`, `bun`, `browser`, `default`) are unchanged.
- No migration required; update to the patched `@better-auth/core` and rebuild.

<sup>Written for commit 72a4b9dd665653447fd304e70debea667dd532ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

