### PR TITLE
fix(db): use static zod lookup in toZodSchema so locales tree-shake

### DIFF
--- a/.changeset/organization-zod-locales.md
+++ b/.changeset/organization-zod-locales.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+The organization plugin no longer pulls every zod locale into server bundles.

--- a/e2e/smoke/test/esbuild.spec.ts
+++ b/e2e/smoke/test/esbuild.spec.ts
@@ -69,6 +69,43 @@ it("build minimal without unexpected imports", async () => {
 });
 
 /**
+ * @see https://github.com/better-auth/better-auth/issues/10865
+ */
+it("build organization plugin without zod locales", async () => {
+	const esbuildDir = join(fixturesDir, "esbuild");
+	const buildProcess = spawn(
+		"npx",
+		[
+			"esbuild",
+			"src/organization.ts",
+			"--bundle",
+			"--outfile=dist/organization.js",
+		],
+		{
+			cwd: esbuildDir,
+			stdio: "pipe",
+		},
+	);
+	await new Promise<void>((resolve, reject) => {
+		buildProcess.on("close", (code) => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject(
+					new Error(`esbuild organization build failed with code ${code}`),
+				);
+			}
+		});
+	});
+	const outputFile = join(esbuildDir, "dist", "organization.js");
+	const outputContent = await readFile(outputFile, "utf-8");
+	assert.ok(
+		!outputContent.includes("zod/v4/locales/ar.js"),
+		"Built output should not contain zod locales",
+	);
+});
+
+/**
  * @see https://github.com/better-auth/better-auth/issues/10366
  */
 it("bundles the Kysely adapter with Kysely 0.29", async () => {

--- a/e2e/smoke/test/esbuild.spec.ts
+++ b/e2e/smoke/test/esbuild.spec.ts
@@ -99,9 +99,11 @@ it("build organization plugin without zod locales", async () => {
 	});
 	const outputFile = join(esbuildDir, "dist", "organization.js");
 	const outputContent = await readFile(outputFile, "utf-8");
-	assert.ok(
-		!outputContent.includes("zod/v4/locales/ar.js"),
-		"Built output should not contain zod locales",
+	const locales = outputContent.match(/zod\/v4\/locales\/[\w-]+\.js/g) ?? [];
+	assert.deepStrictEqual(
+		[...new Set(locales)],
+		["zod/v4/locales/en.js"],
+		"Built output should only contain the default zod locale",
 	);
 });
 

--- a/e2e/smoke/test/fixtures/esbuild/src/organization.ts
+++ b/e2e/smoke/test/fixtures/esbuild/src/organization.ts
@@ -1,0 +1,4 @@
+import { betterAuth } from "better-auth/minimal";
+import { organization } from "better-auth/plugins";
+
+export const auth = betterAuth({ plugins: [organization()] });

--- a/packages/better-auth/src/db/to-zod.test.ts
+++ b/packages/better-auth/src/db/to-zod.test.ts
@@ -33,6 +33,24 @@ describe("toZodSchema", () => {
 		});
 	});
 
+	describe("scalar field types", () => {
+		it("should map each scalar type to its zod schema", () => {
+			const schema = toZodSchema({
+				fields: {
+					name: { type: "string" },
+					age: { type: "number" },
+					active: { type: "boolean" },
+					createdAt: { type: "date" },
+				},
+				isClientSide: true,
+			});
+
+			const valid = { name: "a", age: 1, active: true, createdAt: new Date() };
+			expect(schema.parse(valid)).toEqual(valid);
+			expect(schema.safeParse({ ...valid, age: "1" }).success).toBe(false);
+		});
+	});
+
 	describe("required: false field nullability", () => {
 		it("should accept null, undefined, and a value for an optional field", () => {
 			const schema = toZodSchema({

--- a/packages/better-auth/src/db/to-zod.ts
+++ b/packages/better-auth/src/db/to-zod.ts
@@ -2,6 +2,17 @@ import type { DBFieldAttribute } from "@better-auth/core/db";
 import type { ZodType } from "zod";
 import * as z from "zod";
 
+/**
+ * Static lookup keeps `zod` tree-shakeable. `z[field.type]()` forces bundlers
+ * to retain every `zod` export, including all locales.
+ */
+const scalarSchemas = {
+	string: z.string,
+	number: z.number,
+	boolean: z.boolean,
+	date: z.date,
+};
+
 export function toZodSchema<
 	Fields extends Record<string, DBFieldAttribute | never>,
 	IsClientSide extends boolean,
@@ -32,7 +43,7 @@ export function toZodSchema<
 		} else if (Array.isArray(field.type)) {
 			schema = z.any();
 		} else {
-			schema = z[field.type]();
+			schema = scalarSchemas[field.type]();
 		}
 
 		if (field?.required === false) {


### PR DESCRIPTION
Closes #10865

## What

`toZodSchema` (`packages/better-auth/src/db/to-zod.ts`) built scalar schemas with `z[field.type]()`. A dynamic property access on the `zod` namespace forces every bundler to keep all `zod` exports, including `export * as locales` (~50 files, ~270 kB). Only the organization plugin routes import `to-zod`, so the existing `/minimal` smoke test did not catch it.

This replaces the dynamic lookup with a static map for `string | number | boolean | date`. Same pattern as #10503, same goal as #5995.

## Tests

- `to-zod.test.ts`: scalar types map to the right zod schema.
- `e2e/smoke` esbuild: new `organization.ts` fixture; asserts the bundle has no `zod/v4/locales`. Fails on `main`, passes here.

Run locally: `pnpm vitest packages/better-auth/src/db --run`, `pnpm vitest packages/better-auth/src/plugins/organization --run` (253 pass), `pnpm -F @better-auth-test/smoke e2e:smoke` (esbuild cases), `tsc` clean.

## Impact

Vite 8 / Cloudflare Workers app with organization + admin + emailOTP + deviceAuthorization: server bundle 1,538 -> 1,332 kB minified (426 -> 382 kB gzip). No API or behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces dynamic `z[field.type]()` in `toZodSchema` with a static scalar lookup so `zod` locales tree‑shake out of server bundles. Previously bundlers kept all `zod` exports (including locales); now only referenced scalar constructors remain and only the default `en` locale is bundled.

- Maps `string | number | boolean | date` to `zod` via a static `scalarSchemas` object; all other logic remains the same.
- Adds a unit test for scalar mappings and an esbuild e2e using the organization plugin that asserts only `zod/v4/locales/en.js` is included.
- No API or behavior change; example app bundle drops from 1,538 → 1,332 kB minified (426 → 382 kB gzip).
- Patch release for `better-auth`; the organization plugin no longer pulls all `zod` locales into bundles.

<sup>Written for commit 6776e6a2d094353bfaf53bcb02951aa06f45f60a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

