### PR TITLE
docs: sync sidebar navigation and links

### DIFF
--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -1507,6 +1507,11 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				href: "/docs/integrations/tanstack",
 			},
 			{
+				title: "Waku",
+				icon: Icons.react,
+				href: "/docs/integrations/waku",
+			},
+			{
 				group: true,
 				title: "Backend",
 				href: "",
@@ -1902,6 +1907,11 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				),
 			},
 			{
+				title: "CIMD",
+				href: "/docs/plugins/cimd",
+				icon: () => <FileBoxIcon className="size-4" />,
+			},
+			{
 				title: "SSO",
 				icon: () => (
 					<svg
@@ -1938,6 +1948,18 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 					</svg>
 				),
 				href: "/docs/plugins/scim",
+				subpages: [
+					{
+						title: "Groups and custom roles",
+						href: "/docs/plugins/scim/groups-and-roles",
+						icon: () => <Users2 className="size-4" />,
+					},
+					{
+						title: "Reference",
+						href: "/docs/plugins/scim/reference",
+						icon: () => <Book className="size-4" />,
+					},
+				],
 			},
 			{
 				title: "Utility",

--- a/docs/content/docs/authentication/email-password.mdx
+++ b/docs/content/docs/authentication/email-password.mdx
@@ -238,7 +238,7 @@ Similarly, the `/change-email` endpoint no longer reveals whether the target ema
 
 ##### Plugins that add user fields
 
-If you use plugins that add fields to the user table (e.g. [admin](/docs/plugins/admin), [two-factor](/docs/plugins/two-factor), [phone-number](/docs/plugins/phone-number)), the synthetic response needs to include those fields to be indistinguishable from a real sign-up. Use the `customSyntheticUser` option to build the complete user object:
+If you use plugins that add fields to the user table (e.g. [admin](/docs/plugins/admin), [two-factor](/docs/plugins/2fa), [phone-number](/docs/plugins/phone-number)), the synthetic response needs to include those fields to be indistinguishable from a real sign-up. Use the `customSyntheticUser` option to build the complete user object:
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -9,7 +9,7 @@ The Generic OAuth plugin lets you add any OAuth 2.1 or OpenID Connect (OIDC) pro
 
 Use the Generic OAuth plugin when:
 
-* Your provider is not one of the [built-in social providers](/docs/authentication/social) (Google, GitHub, Discord, etc.)
+* Your provider is not one of the [built-in social providers](/docs/concepts/oauth) (Google, GitHub, Discord, etc.)
 * You need to connect to a corporate identity provider (Keycloak, Okta, Auth0, Microsoft Entra ID)
 * You want to support a provider with custom or non-standard OAuth endpoints
 

--- a/docs/content/docs/plugins/meta.json
+++ b/docs/content/docs/plugins/meta.json
@@ -32,6 +32,7 @@
     "polar",
     "autumn",
     "creem",
+    "chargebee",
     "dodopayments",
     "commet",
     "captcha",


### PR DESCRIPTION
Added Waku, CIMD and SCIM sub-pages

Updated broken links

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs docs sidebar with available content and fixes broken internal links. Previously, Waku and CIMD were missing and SCIM had no nested pages; now they appear in the sidebar, and outdated link slugs point to current pages.

- Adds Waku to Integrations (`/docs/integrations/waku`).
- Adds CIMD to Plugins (`/docs/plugins/cimd`).
- Adds SCIM subpages: Groups and custom roles (`/docs/plugins/scim/groups-and-roles`) and Reference (`/docs/plugins/scim/reference`).
- Fixes broken links: two-factor plugin path to `/docs/plugins/2fa`; “built-in social providers” path to `/docs/concepts/oauth`.
- Updates `meta.json` to include “chargebee” for plugin indexing.

<sup>Written for commit b334e62293af1119ebacadfe73265712a3bfe36f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

