### PR TITLE
docs: expose v1.8 beta documentation

### DIFF
--- a/docs/lib/docs-versions.ts
+++ b/docs/lib/docs-versions.ts
@@ -23,15 +23,15 @@ export interface DocsVersion {
 
 export const docsVersions: DocsVersion[] = [
 	{
-		label: "v1.7 (Beta)",
-		version: "1.7",
+		label: "v1.8 (Beta)",
+		version: "1.8",
 		branch: "next",
 		slug: "beta",
 		badge: null,
 	},
 	{
-		label: "v1.6 (Latest)",
-		version: "1.6",
+		label: "v1.7 (Latest)",
+		version: "1.7",
 		branch: "main",
 		slug: null,
 		badge: null,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose v1.8 docs as Beta and set v1.7 as Latest in the docs version switcher. Previously Beta was v1.7 and Latest was v1.6; now Beta is v1.8 and Latest is v1.7, so users see v1.7 by default and can opt into v1.8 via Beta.

- Beta uses branch "next" with slug "beta"; Latest uses branch "main".
- Verify the switcher shows "v1.8 (Beta)" and "v1.7 (Latest)" and routes to the correct branches.

<sup>Written for commit 863971f20b665666b4d776e663fd2d61b000d63e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

