### PR TITLE
ci(e2e): stabilize mssql container startup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -196,6 +196,7 @@ jobs:
     env:
       COMPOSE_SERVICES: ${{ matrix.compose_services }}
       FILTER: ${{ matrix.packages }}
+      MSSQL_RESTART_POLICY: "on-failure:3"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -244,10 +245,16 @@ jobs:
           docker compose logs --no-color "${compose_services[@]}" || true
 
           # Capture container exit and OOM state without masking the test failure.
+          # cspell:ignore pids Pids
           for compose_service in "${compose_services[@]}"; do
             container_id="$(docker compose ps --all --quiet "$compose_service")"
             if [[ -n "$container_id" ]]; then
               docker inspect --format 'name={{.Name}} status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}' "$container_id" || true
+              docker inspect --format 'name={{.Name}} pids_limit={{.HostConfig.PidsLimit}} memory_limit={{.HostConfig.Memory}} memory_swap={{.HostConfig.MemorySwap}}' "$container_id" || true
+              image_id="$(docker inspect --format '{{.Image}}' "$container_id" || true)"
+              if [[ -n "$image_id" ]]; then
+                docker image inspect --format 'image_id={{.Id}} repo_digests={{json .RepoDigests}}' "$image_id" || true
+              fi
             fi
           done
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,8 +145,9 @@ services:
       - mysql-prisma_data:/var/lib/mysql
 
   mssql:
-    image: mcr.microsoft.com/mssql/server:latest
+    image: mcr.microsoft.com/mssql/server:2025-latest
     container_name: mssql
+    restart: "${MSSQL_RESTART_POLICY:-no}"
     environment:
       MSSQL_SA_PASSWORD: "Password123!"
       ACCEPT_EULA: "Y"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes MSSQL container startup in e2e CI by pinning the image and enabling retries, with richer failure diagnostics. Previously used `latest` with no restart and minimal logs; now uses `2025-latest`, retries up to 3 times in CI, and emits detailed container and image info on failure.

- docker-compose: pins `mcr.microsoft.com/mssql/server:2025-latest`; adds `restart: "${MSSQL_RESTART_POLICY:-no}"`.
- e2e workflow: sets `MSSQL_RESTART_POLICY=on-failure:3`; on failure, prints container state (status/exit/oom/error), resource limits (pids/memory/swap), and image repo digests.
- Side effects: CI may retry the container and run slightly longer; local runs will pull SQL Server 2025 on next start. No code changes or migrations.

<sup>Written for commit 912247d18d2496c15350e68da1c83f81ca4ee597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

