### PR TITLE
fix(db): support portable index introspection

### DIFF
--- a/.changeset/calm-lions-juggle.md
+++ b/.changeset/calm-lions-juggle.md
@@ -1,0 +1,6 @@
+---
+"better-auth": patch
+"@better-auth/kysely-adapter": patch
+---
+
+Fix programmatic migrations failing on Cloudflare D1 while preserving existing-index validation across supported databases.

--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -5,6 +5,14 @@ yocto
 numberid
 dbgenerated
 dflt
+seqno
+attnum
+attrelid
+indisunique
+indisvalid
+indexrelid
+indnkeyatts
+ordinality
 undim
 timestamptz
 nvarchar

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -13,7 +13,12 @@ import {
 } from "@better-auth/core/db/internal";
 import { createLogger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
-import type { KyselyDatabaseType } from "@better-auth/kysely-adapter";
+import type {
+	DatabaseIndexColumnMetadata,
+	DatabaseIndexIntrospector,
+	DatabaseIndexMetadata,
+	KyselyDatabaseType,
+} from "@better-auth/kysely-adapter";
 import { createKyselyAdapter } from "@better-auth/kysely-adapter";
 import type {
 	AlterTableColumnAlteringBuilder,
@@ -25,8 +30,6 @@ import type {
 } from "kysely";
 import { sql } from "kysely";
 import { getSchema } from "./get-schema";
-
-// cspell:ignore attnum attrelid indisunique indisvalid indexrelid indnkeyatts ordinality seqno
 
 const postgresMap = {
 	string: ["character varying", "varchar", "text", "uuid"],
@@ -168,11 +171,46 @@ function databaseValueIsTrue(value: boolean | number | string | undefined) {
 	return value === "1" || value?.toLowerCase() === "true" || value === "t";
 }
 
-async function getDatabaseIndexes(
+function toDatabaseIndexMap(indexes: readonly DatabaseIndexMetadata[]) {
+	return new Map<string, DatabaseIndexDefinition>(
+		indexes.map((index) => {
+			const columns = [...index.columns].sort(
+				(left, right) => left.position - right.position,
+			);
+			return [
+				createDatabaseIndexKey(index.table, index.name),
+				{
+					columns: columns.flatMap((column) =>
+						column.name === null ? [] : [column.name],
+					),
+					name: index.name,
+					table: index.table,
+					unique: index.unique,
+					validFullColumns:
+						index.valid &&
+						!index.partial &&
+						columns.length > 0 &&
+						columns.every(
+							(column) => column.name !== null && column.fullLength,
+						),
+				},
+			] as const;
+		}),
+	);
+}
+
+async function getDatabaseIndexMap(
 	db: Kysely<unknown>,
 	dbType: KyselyDatabaseType,
 	schemaName: string,
+	tableNames: readonly string[],
+	introspectIndexes: DatabaseIndexIntrospector | undefined,
 ) {
+	if (introspectIndexes) {
+		const indexes = await introspectIndexes(tableNames);
+		return toDatabaseIndexMap(indexes);
+	}
+
 	let rows: readonly DatabaseIndexRow[];
 	if (dbType === "sqlite") {
 		rows = (
@@ -263,16 +301,7 @@ async function getDatabaseIndexes(
 		).rows;
 	}
 
-	const indexRows = new Map<
-		string,
-		{
-			columns: { name: string; position: number }[];
-			name: string;
-			table: string;
-			unique: boolean;
-			validFullColumns: boolean;
-		}
-	>();
+	const indexMetadata = new Map<string, DatabaseIndexMetadata>();
 	for (const row of rows) {
 		const table =
 			row.tableName ??
@@ -301,44 +330,41 @@ async function getDatabaseIndexes(
 				row.seqno ??
 				0,
 		);
-		const index = indexRows.get(key) ?? {
-			columns: [],
-			name,
-			table,
-			unique,
-			validFullColumns: true,
-		};
-		if (column) {
-			index.columns.push({ name: column, position });
-		} else {
-			index.validFullColumns = false;
-		}
-		if (
-			databaseValueIsTrue(row.isPartial) ||
-			databaseValueIsTrue(row.isDisabled) ||
-			databaseValueIsTrue(row.isHypothetical) ||
-			(row.isValid !== undefined && !databaseValueIsTrue(row.isValid)) ||
-			(row.prefixLength !== undefined && row.prefixLength !== null)
-		) {
-			index.validFullColumns = false;
-		}
-		indexRows.set(key, index);
+		const indexColumn = {
+			fullLength:
+				column !== undefined &&
+				column !== null &&
+				(row.prefixLength === undefined || row.prefixLength === null),
+			name: column ?? null,
+			position,
+		} satisfies DatabaseIndexColumnMetadata;
+		const partial = databaseValueIsTrue(row.isPartial);
+		const valid =
+			!databaseValueIsTrue(row.isDisabled) &&
+			!databaseValueIsTrue(row.isHypothetical) &&
+			(row.isValid === undefined || databaseValueIsTrue(row.isValid));
+		const existing = indexMetadata.get(key);
+		indexMetadata.set(
+			key,
+			existing
+				? {
+						...existing,
+						columns: [...existing.columns, indexColumn],
+						partial: existing.partial || partial,
+						valid: existing.valid && valid,
+					}
+				: {
+						columns: [indexColumn],
+						name,
+						partial,
+						table,
+						unique,
+						valid,
+					},
+		);
 	}
 
-	return new Map<string, DatabaseIndexDefinition>(
-		[...indexRows].map(([key, index]) => [
-			key,
-			{
-				columns: index.columns
-					.sort((left, right) => left.position - right.position)
-					.map((column) => column.name),
-				name: index.name,
-				table: index.table,
-				unique: index.unique,
-				validFullColumns: index.validFullColumns,
-			},
-		]),
-	);
+	return toDatabaseIndexMap([...indexMetadata.values()]);
 }
 
 async function getDatabaseColumnBounds(
@@ -609,7 +635,11 @@ export async function getMigrations(
 		unsafeChanges.push(message);
 	};
 
-	let { kysely: db, databaseType: dbType } = await createKyselyAdapter(config);
+	let {
+		kysely: db,
+		databaseType: dbType,
+		introspectIndexes,
+	} = await createKyselyAdapter(config);
 
 	if (!dbType) {
 		logger.warn(
@@ -662,7 +692,13 @@ export async function getMigrations(
 	}
 
 	const allTableMetadata = await db.introspection.getTables();
-	const databaseIndexes = await getDatabaseIndexes(db, dbType, currentSchema);
+	const databaseIndexMap = await getDatabaseIndexMap(
+		db,
+		dbType,
+		currentSchema,
+		allTableMetadata.map((table) => table.name),
+		introspectIndexes,
+	);
 	const databaseColumnBounds = await getDatabaseColumnBounds(
 		db,
 		dbType,
@@ -733,7 +769,7 @@ export async function getMigrations(
 		for (const index of value.indexes ?? []) {
 			const name = index.name;
 			const indexKey = createDatabaseIndexKey(key, name);
-			const existingIndex = databaseIndexes.get(indexKey);
+			const existingIndex = databaseIndexMap.get(indexKey);
 			if (existingIndex) {
 				if (!databaseIndexMatches(existingIndex, index)) {
 					throw new BetterAuthError(
@@ -743,7 +779,7 @@ export async function getMigrations(
 				continue;
 			}
 			if (dbType === "sqlite" || dbType === "postgres") {
-				const indexOnAnotherTable = [...databaseIndexes.values()].find(
+				const indexOnAnotherTable = [...databaseIndexMap.values()].find(
 					(databaseIndex) =>
 						getPortableDatabaseIdentifierKey(databaseIndex.name) ===
 							getPortableDatabaseIdentifierKey(name) &&

--- a/packages/kysely-adapter/src/d1-sqlite-dialect.ts
+++ b/packages/kysely-adapter/src/d1-sqlite-dialect.ts
@@ -19,6 +19,65 @@ import {
 	DEFAULT_MIGRATION_LOCK_TABLE,
 	DEFAULT_MIGRATION_TABLE,
 } from "./kysely-migration-tables";
+import type { DatabaseIndexIntrospector } from "./types";
+
+interface D1IndexListRow {
+	name: string;
+	partial: number;
+	unique: number;
+}
+
+interface D1IndexInfoRow {
+	name: string | null;
+	seqno: number;
+}
+
+function quoteSqliteStringLiteral(value: string) {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function createD1IndexIntrospector(
+	database: D1Database,
+): DatabaseIndexIntrospector {
+	return async (tableNames) => {
+		if (tableNames.length === 0) return [];
+		const indexLists = await database.batch<D1IndexListRow>(
+			tableNames.map((tableName) =>
+				database.prepare(
+					`PRAGMA index_list(${quoteSqliteStringLiteral(tableName)})`,
+				),
+			),
+		);
+		const indexes = indexLists.flatMap((indexList, tablePosition) => {
+			const tableName = tableNames[tablePosition];
+			if (!tableName) return [];
+			return indexList.results.map((index) => ({
+				...index,
+				tableName,
+			}));
+		});
+		if (indexes.length === 0) return [];
+		const indexColumns = await database.batch<D1IndexInfoRow>(
+			indexes.map((index) =>
+				database.prepare(
+					`PRAGMA index_info(${quoteSqliteStringLiteral(index.name)})`,
+				),
+			),
+		);
+		return indexes.map((index, indexPosition) => ({
+			columns: (indexColumns[indexPosition]?.results ?? []).map((column) => ({
+				fullLength: column.name !== null,
+				name: column.name,
+				position: column.seqno,
+			})),
+			name: index.name,
+			partial: index.partial !== 0,
+			table: index.tableName,
+			unique: index.unique !== 0,
+			valid: true,
+		}));
+	};
+}
 
 class D1SqliteAdapter extends SqliteAdapter {}
 

--- a/packages/kysely-adapter/src/dialect.test.ts
+++ b/packages/kysely-adapter/src/dialect.test.ts
@@ -8,7 +8,8 @@ import type {
 	Kysely as KyselyInstance,
 	QueryCompiler,
 } from "kysely";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createD1IndexIntrospector } from "./d1-sqlite-dialect";
 import { createKyselyAdapter } from "./dialect";
 
 class StubDriver implements Driver {
@@ -57,11 +58,13 @@ describe("createKyselyAdapter transaction detection", () => {
 	});
 
 	it("does not report native transaction support for a Cloudflare D1 database", async () => {
-		const { transaction, databaseType } = await createKyselyAdapter({
-			database: fakeD1Database(),
-		});
+		const { transaction, databaseType, introspectIndexes } =
+			await createKyselyAdapter({
+				database: fakeD1Database(),
+			});
 		expect(transaction).toBe(false);
 		expect(databaseType).toBe("sqlite");
+		expect(introspectIndexes).toBeTypeOf("function");
 	});
 
 	it("leaves transaction support unspecified for a caller-supplied dialect of unknown capability", async () => {
@@ -82,5 +85,78 @@ describe("createKyselyAdapter transaction detection", () => {
 			},
 		});
 		expect(transaction).toBe(false);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10551
+ */
+describe("D1 index introspection", () => {
+	it("batches queries and returns normalized index metadata", async () => {
+		const prepare = vi.fn((query: string) => ({ query }));
+		const batch = vi
+			.fn()
+			.mockResolvedValueOnce([
+				{
+					results: [
+						{
+							name: "users'archive_email_name_idx",
+							partial: 0,
+							unique: 1,
+						},
+						{
+							name: "users'archive_expression_idx",
+							partial: 1,
+							unique: 0,
+						},
+					],
+				},
+			])
+			.mockResolvedValueOnce([
+				{
+					results: [
+						{ name: "email", seqno: 0 },
+						{ name: "name", seqno: 1 },
+					],
+				},
+				{ results: [{ name: null, seqno: 0 }] },
+			]);
+		const database = {
+			batch,
+			exec: vi.fn(),
+			prepare,
+		} as unknown as D1Database;
+
+		const indexes = await createD1IndexIntrospector(database)([
+			"users'archive",
+		]);
+
+		expect(batch).toHaveBeenCalledTimes(2);
+		expect(prepare.mock.calls.map(([query]) => query)).toEqual([
+			"PRAGMA index_list('users''archive')",
+			"PRAGMA index_info('users''archive_email_name_idx')",
+			"PRAGMA index_info('users''archive_expression_idx')",
+		]);
+		expect(indexes).toEqual([
+			{
+				columns: [
+					{ fullLength: true, name: "email", position: 0 },
+					{ fullLength: true, name: "name", position: 1 },
+				],
+				name: "users'archive_email_name_idx",
+				partial: false,
+				table: "users'archive",
+				unique: true,
+				valid: true,
+			},
+			{
+				columns: [{ fullLength: false, name: null, position: 0 }],
+				name: "users'archive_expression_idx",
+				partial: true,
+				table: "users'archive",
+				unique: false,
+				valid: true,
+			},
+		]);
 	});
 });

--- a/packages/kysely-adapter/src/dialect.ts
+++ b/packages/kysely-adapter/src/dialect.ts
@@ -7,7 +7,7 @@ import {
 	PostgresDialect,
 	SqliteDialect,
 } from "kysely";
-import type { KyselyDatabaseType } from "./types";
+import type { DatabaseIndexIntrospector, KyselyDatabaseType } from "./types";
 
 export function getKyselyDatabaseType(
 	db: BetterAuthOptions["database"],
@@ -62,6 +62,7 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 		return {
 			kysely: null,
 			databaseType: null,
+			introspectIndexes: undefined,
 			transaction: undefined,
 		};
 	}
@@ -70,6 +71,7 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 		return {
 			kysely: db.db,
 			databaseType: db.type,
+			introspectIndexes: undefined,
 			transaction: db.transaction,
 		};
 	}
@@ -78,11 +80,13 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 		return {
 			kysely: new Kysely<any>({ dialect: db.dialect }),
 			databaseType: db.type,
+			introspectIndexes: undefined,
 			transaction: db.transaction,
 		};
 	}
 
 	let dialect: Dialect | undefined = undefined;
+	let introspectIndexes: DatabaseIndexIntrospector | undefined = undefined;
 	let transaction: boolean | undefined = undefined;
 
 	const databaseType = getKyselyDatabaseType(db);
@@ -153,10 +157,13 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 
 	// Cloudflare D1
 	if ("batch" in db && "exec" in db && "prepare" in db) {
-		const { D1SqliteDialect } = await import("./d1-sqlite-dialect");
+		const { createD1IndexIntrospector, D1SqliteDialect } = await import(
+			"./d1-sqlite-dialect"
+		);
 		dialect = new D1SqliteDialect({
 			database: db,
 		});
+		introspectIndexes = createD1IndexIntrospector(db);
 		// D1 has no interactive transactions; only its batch() API.
 		transaction = false;
 	}
@@ -164,6 +171,7 @@ export const createKyselyAdapter = async (config: BetterAuthOptions) => {
 	return {
 		kysely: dialect ? new Kysely<any>({ dialect }) : null,
 		databaseType,
+		introspectIndexes,
 		transaction,
 	};
 };

--- a/packages/kysely-adapter/src/types.ts
+++ b/packages/kysely-adapter/src/types.ts
@@ -1,1 +1,35 @@
 export type KyselyDatabaseType = "postgres" | "mysql" | "sqlite" | "mssql";
+
+/**
+ * Metadata for a column that participates in a database index.
+ */
+export interface DatabaseIndexColumnMetadata {
+	/**
+	 * Whether the index covers the complete column value rather than a prefix.
+	 */
+	readonly fullLength: boolean;
+	readonly name: string | null;
+	readonly position: number;
+}
+
+/**
+ * Database-agnostic metadata for an index.
+ */
+export interface DatabaseIndexMetadata {
+	readonly columns: readonly DatabaseIndexColumnMetadata[];
+	readonly name: string;
+	readonly partial: boolean;
+	readonly table: string;
+	readonly unique: boolean;
+	/**
+	 * Whether the database reports the index as complete and usable.
+	 */
+	readonly valid: boolean;
+}
+
+/**
+ * Reads normalized index metadata for the provided database tables.
+ */
+export type DatabaseIndexIntrospector = (
+	tableNames: readonly string[],
+) => Promise<readonly DatabaseIndexMetadata[]>;


### PR DESCRIPTION
Closes #10551

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes programmatic migrations failing on Cloudflare D1 by switching index validation to a portable, adapter-provided introspector. Previously we used DB-specific catalog queries; now we call `introspectIndexes` when available and fall back to the old queries, preserving validation semantics.

- Adds `DatabaseIndexMetadata`, `DatabaseIndexColumnMetadata`, and `DatabaseIndexIntrospector` to `@better-auth/kysely-adapter`.
- `createKyselyAdapter` now returns `introspectIndexes`; Cloudflare D1 provides one via `createD1IndexIntrospector` that batches PRAGMA `index_list`/`index_info` with safe SQLite string-literal quoting; other dialects return `undefined`.
- Refactors migration index collection to use normalized metadata and keep behavior: ignore partial/disabled/hypothetical/invalid indexes and prefix-length/unnamed columns; require valid, full-length columns.
- Adds tests for D1 batching, quoting (including apostrophes), normalization, and exposure of `introspectIndexes` on D1.
- Patch releases for `better-auth` and `@better-auth/kysely-adapter`; no migration actions required.

<sup>Written for commit d6fabe373c4b98bc5f7a8d8ca58eda8cbdaf90d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

