### PR TITLE
fix(db): reject disabled MyISAM indexes

### DIFF
--- a/.changeset/soft-tigers-warn.md
+++ b/.changeset/soft-tigers-warn.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Prevent disabled MyISAM indexes from satisfying migration index checks.

--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -6,6 +6,7 @@ numberid
 dbgenerated
 dflt
 seqno
+MyISAM
 attnum
 attrelid
 indisunique

--- a/e2e/adapter/test/kysely-adapter/adapter.kysely.mysql.test.ts
+++ b/e2e/adapter/test/kysely-adapter/adapter.kysely.mysql.test.ts
@@ -1,9 +1,10 @@
+import type { BetterAuthOptions, BetterAuthPlugin } from "@better-auth/core";
 import { kyselyAdapter } from "@better-auth/kysely-adapter";
-import { testAdapter } from "@better-auth/test-utils/adapter";
+import { createTestSuite, testAdapter } from "@better-auth/test-utils/adapter";
 import { getMigrations } from "better-auth/db/migration";
 import { Kysely, MysqlDialect } from "kysely";
 import { createPool } from "mysql2/promise";
-import { assert } from "vitest";
+import { assert, expect } from "vitest";
 import {
 	authFlowTestSuite,
 	caseInsensitiveTestSuite,
@@ -23,6 +24,55 @@ const mysqlDB = createPool({
 const kyselyDB = new Kysely({
 	dialect: new MysqlDialect(mysqlDB),
 });
+
+const mysqlDisabledIndexTestSuite = createTestSuite(
+	"mysql migration index introspection",
+	{},
+	() => ({
+		/**
+		 * @see https://dev.mysql.com/doc/refman/8.4/en/alter-table.html
+		 */
+		"rejects a disabled MyISAM index": async () => {
+			const tableName = "mysql_disabled_index_subject";
+			const indexName = "mysql_disabled_subject_idx";
+			const options = {
+				database: mysqlDB,
+				plugins: [
+					{
+						id: "mysql-disabled-index",
+						schema: {
+							mysqlDisabledIndexSubject: {
+								modelName: tableName,
+								fields: {
+									subject: { type: "string" },
+								},
+								indexes: [{ fields: ["subject"], name: indexName }],
+							},
+						},
+					} satisfies BetterAuthPlugin,
+				],
+			} satisfies BetterAuthOptions;
+
+			await mysqlDB.query(`
+				CREATE TABLE \`${tableName}\` (
+					\`id\` varchar(191) NOT NULL,
+					\`subject\` varchar(191) NOT NULL,
+					PRIMARY KEY (\`id\`),
+					INDEX \`${indexName}\` (\`subject\`)
+				) ENGINE=MyISAM
+			`);
+			try {
+				await expect(getMigrations(options)).resolves.toBeDefined();
+				await mysqlDB.query(`ALTER TABLE \`${tableName}\` DISABLE KEYS`);
+				await expect(getMigrations(options)).rejects.toThrow(
+					`Database index "${indexName}" on table "${tableName}" does not match the configured fields and uniqueness.`,
+				);
+			} finally {
+				await mysqlDB.query(`DROP TABLE \`${tableName}\``);
+			}
+		},
+	}),
+);
 
 const { execute } = await testAdapter({
 	adapter: () =>
@@ -53,6 +103,7 @@ const { execute } = await testAdapter({
 		numberIdTestSuite(),
 		joinsTestSuite(),
 		uuidTestSuite(),
+		mysqlDisabledIndexTestSuite(),
 		caseInsensitiveTestSuite({
 			disableTests: {
 				"findOne - eq with mode sensitive (default) should not match different case": true,

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -266,7 +266,8 @@ async function getDatabaseIndexMap(
 					column_name AS columnName,
 					non_unique AS nonUnique,
 					seq_in_index AS columnPosition,
-					sub_part AS prefixLength
+					sub_part AS prefixLength,
+					COALESCE(LOWER(comment) = 'disabled', FALSE) AS isDisabled
 				FROM information_schema.statistics
 				WHERE table_schema = DATABASE()
 			`.execute(db)


### PR DESCRIPTION
This is a narrow MyISAM-specific edge case and is unlikely to affect most users. While checking index introspection, I noticed disabled MyISAM indexes were still treated as active, so this PR corrects that behavior. InnoDB indexes are unaffected.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects disabled MyISAM indexes during migration checks. Previously they counted as present; now the check ignores them and raises an index mismatch. InnoDB behavior is unchanged.

- Excludes indexes where `information_schema.statistics.comment = 'disabled'` in the MySQL introspection used by `getMigrations` in `better-auth`; adds an e2e test that passes when enabled and fails after `ALTER TABLE ... DISABLE KEYS`.
- Action required for MyISAM users who use DISABLE KEYS: run `ALTER TABLE <table> ENABLE KEYS` or recreate the index.

<sup>Written for commit 578f185d75c14dd89b54be3dc344327569f398c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

