### PR TITLE
fix(oauth-provider): document the actual { redirect, url } consent/continue response in the OpenAPI schema

### DIFF
--- a/.changeset/oauth-provider-consent-openapi-schema.md
+++ b/.changeset/oauth-provider-consent-openapi-schema.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+The OpenAPI schema for the `/oauth2/consent` and `/oauth2/continue` endpoints now documents the response body the endpoints actually return (`redirect` and `url`). It previously advertised a required `redirect_uri` field that never appeared in the response, so clients generated from or validated against the spec read a field that was always missing.

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -808,9 +808,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 													},
 													url: {
 														type: "string",
-														format: "uri",
+														format: "uri-reference",
 														description:
-															"The URI to redirect to, either with an authorization code or an error",
+															"The URI to redirect to, either with an authorization code or an error. May be absolute or a server-relative page path.",
 													},
 												},
 												required: ["redirect", "url"],
@@ -851,7 +851,7 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 							description: "Continues OAuth2 authorization flow",
 							responses: {
 								"200": {
-									description: "Consent processed successfully",
+									description: "Authorization flow continued successfully",
 									content: {
 										"application/json": {
 											schema: {
@@ -864,9 +864,9 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 													},
 													url: {
 														type: "string",
-														format: "uri",
+														format: "uri-reference",
 														description:
-															"The URI to redirect to, either with an authorization code or an error",
+															"The URI to redirect to, either with an authorization code or an error. May be absolute or a server-relative page path.",
 													},
 												},
 												required: ["redirect", "url"],

--- a/packages/oauth-provider/src/oauth.ts
+++ b/packages/oauth-provider/src/oauth.ts
@@ -801,14 +801,19 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 											schema: {
 												type: "object",
 												properties: {
-													redirect_uri: {
+													redirect: {
+														type: "boolean",
+														description:
+															"Always true. Indicates the caller should redirect to `url`.",
+													},
+													url: {
 														type: "string",
 														format: "uri",
 														description:
 															"The URI to redirect to, either with an authorization code or an error",
 													},
 												},
-												required: ["redirect_uri"],
+												required: ["redirect", "url"],
 											},
 										},
 									},
@@ -852,14 +857,19 @@ export const oauthProvider = <O extends OAuthOptions<Scope[]>>(options: O) => {
 											schema: {
 												type: "object",
 												properties: {
-													redirect_uri: {
+													redirect: {
+														type: "boolean",
+														description:
+															"Always true. Indicates the caller should redirect to `url`.",
+													},
+													url: {
 														type: "string",
 														format: "uri",
 														description:
 															"The URI to redirect to, either with an authorization code or an error",
 													},
 												},
-												required: ["redirect_uri"],
+												required: ["redirect", "url"],
 											},
 										},
 									},

--- a/packages/oauth-provider/src/openapi-schema.test.ts
+++ b/packages/oauth-provider/src/openapi-schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { oauthProvider } from "./oauth";
+
+/**
+ * The OpenAPI metadata must document the response the endpoints actually
+ * return (`{ redirect, url }`, see `OAuthRedirectResult`) — the generated
+ * spec previously advertised a `redirect_uri` field that never appeared in
+ * the response body.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10880
+ */
+describe("consent and continue OpenAPI response schema", () => {
+	const plugin = oauthProvider({
+		loginPage: "/login",
+		consentPage: "/consent",
+	});
+
+	it.each([
+		"oauth2Consent",
+		"oauth2Continue",
+	] as const)("%s documents the implemented { redirect, url } response body", (endpointName) => {
+		const schema =
+			plugin.endpoints[endpointName].options.metadata?.openapi?.responses?.[
+				"200"
+			]?.content?.["application/json"]?.schema;
+
+		expect(Object.keys(schema?.properties ?? {}).sort()).toEqual([
+			"redirect",
+			"url",
+		]);
+		expect([...(schema?.required ?? [])].sort()).toEqual(["redirect", "url"]);
+	});
+});


### PR DESCRIPTION
Fixes #10880.

The OpenAPI metadata for `POST /oauth2/consent` and `POST /oauth2/continue` declared the 200 response body as `{ redirect_uri: string }` (required), but the endpoints never return that shape: every 2xx JSON response goes through `handleRedirect`, whose return type is `OAuthRedirectResult = { redirect: true; url: string }` (`src/authorize.ts`). Clients generated from or validated against the spec read `redirect_uri` and always get `undefined` — see better-auth/better-auth#10880 for the downstream misdiagnosis this caused in superset-sh/superset#6609.

This PR:

- Updates both metadata blocks in `src/oauth.ts` to document the implemented shape: `{ redirect: boolean, url: string }`, `required: ["redirect", "url"]`.
- Adds `src/openapi-schema.test.ts`, a regression test (with `@see` link per CONTRIBUTING) asserting the declared 200 schema's `properties`/`required` match the implemented response keys for both endpoints. The runtime side is already pinned by the existing flow tests asserting `consentResult.url` contains the code redirect (`src/authorize.test.ts`), so the schema test closes the doc↔implementation loop from the other side.
- Includes a `patch` changeset for `@better-auth/oauth-provider`.

Tested with:

- `pnpm vitest packages/oauth-provider/src/openapi-schema.test.ts --run` — fails on `main` (properties are `["redirect_uri"]`), passes with this change.
- `pnpm vitest packages/oauth-provider --run` — full package suite green.
- `pnpm --filter @better-auth/oauth-provider typecheck` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the actual { redirect: boolean, url: string } JSON response for POST /oauth2/consent and POST /oauth2/continue in the OpenAPI schema, fixing a mismatch that broke generated/validated clients. The spec previously required redirect_uri, which the endpoints never returned.

- Requires redirect (boolean, always true) and url (string, format: uri-reference); url may be absolute or server-relative. Updates the 200 description for /oauth2/continue.
- Adds a regression test to assert the documented properties/required keys; runtime behavior is unchanged.
- Publishes a patch release for `@better-auth/oauth-provider`.

- Migration
  - Regenerate clients. Replace redirect_uri with url and handle redirect (always true). Accept relative URLs.

<sup>Written for commit 4252057240bc7c443ae6408f0ac68bf9047ad505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

