### PR TITLE
fix(core): guard numeric id coercion in the adapter factory

### DIFF
--- a/.changeset/serial-id-coercion-guard.md
+++ b/.changeset/serial-id-coercion-guard.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Raise a clear error naming the model and field when a non-numeric value is used as an id under `generateId: "serial"`, instead of silently sending `NaN` to the database and surfacing an opaque driver validation error.

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -439,6 +439,18 @@ describe("createAdapterFactory where value coercion", () => {
 		});
 		await adapter.findMany({
 			model: "session",
+			where: [
+				{
+					field: "userId",
+					operator: "in",
+					// `Where["value"]` does not admit null elements, but runtime
+					// callers still reach this branch with one.
+					value: ["1", null] as unknown as string[],
+				},
+			],
+		});
+		await adapter.findMany({
+			model: "session",
 			where: [{ field: "userId", operator: "eq", value: null }],
 		});
 		await adapter.create({
@@ -449,6 +461,7 @@ describe("createAdapterFactory where value coercion", () => {
 		expect(seenWhere.map((where) => where[0]!.value)).toEqual([
 			42,
 			[1, 2],
+			[1, null],
 			null,
 		]);
 		expect(seenCreateData[0]!.userId).toBe(7);

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -333,4 +333,124 @@ describe("createAdapterFactory where value coercion", () => {
 			],
 		]);
 	});
+
+	function createSerialIdAdapter({
+		seenWhere,
+		seenCreateData,
+	}: {
+		seenWhere: CleanedWhere[][];
+		seenCreateData: Record<string, unknown>[];
+	}) {
+		return createAdapterFactory({
+			config: {
+				adapterId: "test-adapter",
+				adapterName: "Test Adapter",
+			},
+			adapter: () =>
+				createCustomAdapter({
+					findMany: async <T>(
+						params: Parameters<CustomAdapter["findMany"]>[0],
+					) => {
+						if (params.where) {
+							seenWhere.push(params.where);
+						}
+						return [] as T[];
+					},
+					create: async <T>(params: Parameters<CustomAdapter["create"]>[0]) => {
+						seenCreateData.push(params.data);
+						return params.data as T;
+					},
+				}),
+		})({
+			advanced: { database: { generateId: "serial" } },
+		});
+	}
+
+	/**
+	 * A non-numeric value on an id field used to be coerced with a bare
+	 * `Number()`, so it reached the driver as `NaN` and surfaced as an opaque
+	 * driver-level validation error.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10773
+	 */
+	it("rejects non-numeric id values instead of passing NaN to the adapter", async () => {
+		const seenWhere: CleanedWhere[][] = [];
+		const seenCreateData: Record<string, unknown>[] = [];
+		const adapter = createSerialIdAdapter({ seenWhere, seenCreateData });
+
+		await expect(
+			adapter.findMany({
+				model: "user",
+				where: [{ field: "id", operator: "eq", value: "agent-host-xyz" }],
+			}),
+		).rejects.toThrow(/numeric id/);
+
+		await expect(
+			adapter.findMany({
+				model: "session",
+				where: [{ field: "userId", operator: "eq", value: "agent-host-xyz" }],
+			}),
+		).rejects.toThrow(/numeric id/);
+
+		await expect(
+			adapter.findMany({
+				model: "user",
+				where: [
+					{ field: "id", operator: "in", value: ["1", "agent-host-xyz"] },
+				],
+			}),
+		).rejects.toThrow(/numeric id/);
+
+		// `Number("")` and `Number(" ")` are `0`, which no serial column ever holds.
+		await expect(
+			adapter.findMany({
+				model: "user",
+				where: [{ field: "id", operator: "eq", value: " " }],
+			}),
+		).rejects.toThrow(/numeric id/);
+
+		// the write path coerces id-referencing fields with the same bare `Number()`
+		await expect(
+			adapter.create({
+				model: "session",
+				data: { userId: "agent-host-xyz", token: "token" },
+			}),
+		).rejects.toThrow(/numeric id/);
+
+		expect(seenWhere).toEqual([]);
+		expect(seenCreateData).toEqual([]);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10773
+	 */
+	it("still coerces valid numeric ids and leaves null id filters alone", async () => {
+		const seenWhere: CleanedWhere[][] = [];
+		const seenCreateData: Record<string, unknown>[] = [];
+		const adapter = createSerialIdAdapter({ seenWhere, seenCreateData });
+
+		await adapter.findMany({
+			model: "user",
+			where: [{ field: "id", operator: "eq", value: "42" }],
+		});
+		await adapter.findMany({
+			model: "session",
+			where: [{ field: "userId", operator: "in", value: ["1", "2"] }],
+		});
+		await adapter.findMany({
+			model: "session",
+			where: [{ field: "userId", operator: "eq", value: null }],
+		});
+		await adapter.create({
+			model: "session",
+			data: { userId: "7", token: "token" },
+		});
+
+		expect(seenWhere.map((where) => where[0]!.value)).toEqual([
+			42,
+			[1, 2],
+			null,
+		]);
+		expect(seenCreateData[0]!.userId).toBe(7);
+	});
 });

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -573,7 +573,9 @@ export const createAdapterFactory =
 					if (useNumberId) {
 						if (Array.isArray(value)) {
 							newValue = value.map((v) =>
-								toNumberId(v, defaultModelName, defaultFieldName),
+								v === null || v === undefined
+									? v
+									: toNumberId(v, defaultModelName, defaultFieldName),
 							);
 						} else if (value !== null) {
 							newValue = toNumberId(value, defaultModelName, defaultFieldName);

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -192,6 +192,31 @@ export const createAdapterFactory =
 			customIdGenerator: config.customIdGenerator,
 		});
 
+		/**
+		 * Coerce a value that targets a numeric (`serial`) id column.
+		 *
+		 * A bare `Number()` turns any non-numeric input into `NaN`, which is then
+		 * forwarded to the driver and surfaces as an opaque driver-level validation
+		 * error. Fail here instead, where the offending model and field are known.
+		 */
+		const toNumberId = (
+			value: unknown,
+			model: string,
+			field: string,
+		): number => {
+			// `Number("")` and `Number(" ")` are `0`, which no serial column holds.
+			const parsed =
+				typeof value === "string" && value.trim() === ""
+					? Number.NaN
+					: Number(value);
+			if (!Number.isInteger(parsed)) {
+				throw new BetterAuthError(
+					`[${config.adapterName}] Expected a numeric id for "${model}.${field}" because "advanced.database.generateId" is set to "serial", but received ${JSON.stringify(value)}.`,
+				);
+			}
+			return parsed;
+		};
+
 		const transformInput = async (
 			data: Record<string, any>,
 			defaultModelName: string,
@@ -253,9 +278,13 @@ export const createAdapterFactory =
 
 				if (fieldAttributes!.references?.field === "id" && useNumberId) {
 					if (Array.isArray(newValue)) {
-						newValue = newValue.map((x) => (x !== null ? Number(x) : null));
-					} else {
-						newValue = newValue !== null ? Number(newValue) : null;
+						newValue = newValue.map((x) =>
+							x === null || x === undefined
+								? x
+								: toNumberId(x, defaultModelName, field),
+						);
+					} else if (newValue !== null && newValue !== undefined) {
+						newValue = toNumberId(newValue, defaultModelName, field);
 					}
 				} else if (
 					config.supportsJSON === false &&
@@ -543,9 +572,11 @@ export const createAdapterFactory =
 				) {
 					if (useNumberId) {
 						if (Array.isArray(value)) {
-							newValue = value.map(Number);
-						} else {
-							newValue = Number(value);
+							newValue = value.map((v) =>
+								toNumberId(v, defaultModelName, defaultFieldName),
+							);
+						} else if (value !== null) {
+							newValue = toNumberId(value, defaultModelName, defaultFieldName);
 						}
 					}
 				}


### PR DESCRIPTION
Under `advanced.database.generateId: "serial"` the adapter factory coerces any value on an
`id`-referencing field with a bare `Number()` and never looks at the result. A non-numeric string
becomes `NaN`, and `NaN` goes to the driver untouched — so the caller gets a driver-level type
error naming neither the model nor the field, rather than no match or an actionable message. The
same mechanism has surfaced through three unrelated plugins now: passkey (#6762, closed on
needs-repro), verification/core (#3450), and agent-auth
(better-auth/agent-auth#37, which carries a full trace).

There are two such sites, not one, and both are on `main`: `transformInput` coerces
id-referencing fields on the write path, and `transformWhereClause` coerces both `id` itself and
id-referencing fields on the read path. The read path is the one that produces the reported
crash. Driving the unpatched factory against a stub adapter shows exactly what reaches the
driver:

```
WHERE -> id eq "NaN"        // where id = "agent-host-xyz"
WHERE -> userId eq "NaN"    // where userId = "agent-host-xyz"
WHERE -> id in "1,NaN"      // where id in ["1","agent-host-xyz"]
WHERE -> id eq "0"          // where id = " "   <- silently wrong, and not NaN
CREATE data -> { ..., userId: NaN }
```

That last pair matters: `Number("")` and `Number(" ")` are `0`, so those inputs never throw at
all today, they just quietly query a row id no serial column ever holds.

## What changes

- Both coercion sites now route through one closure-local `toNumberId` helper, so the read and
  write paths cannot drift apart again. It throws a `BetterAuthError` naming the model and field
  when the coercion does not produce an integer.
- The guard is `Number.isInteger` plus an explicit empty/whitespace-string rejection.
  `Number.isFinite` alone is not enough here — `Number("")` is `0`, so `isFinite` returns `true`
  for it. `isInteger` additionally rejects `Infinity` and decimals.
- Tests cover both branches at both sites: the scalar value, the `in`-operator array, the read
  path and the write path. They assert the underlying adapter is *never called*, not merely that
  something threw, plus a companion test proving valid numeric ids still coerce.
- Patch changeset for `@better-auth/core`.

Throwing rather than skipping follows the file's dominant idiom — it already has 11
`throw new BetterAuthError` sites, including one that rejects a `useNumberId` misconfiguration
outright, and `factory.test.ts` already has a "throws a clear error when updateMany does not
return a finite count" test in the same shape.

Every changed line is behind `generateId === "serial"`, which is opt-in, so this is inert for
anyone not using numeric ids.

## Testing

| Suite | Result |
| --- | --- |
| `@better-auth/core` unit | 572 → **574 passed, 0 failed** (+2 new) |
| e2e memory-adapter (runs `numberIdTestSuite`) | 454 passed, 5 skipped, 0 failed |
| e2e kysely sqlite + node-sqlite-dialect (both run `numberIdTestSuite`) | 905 passed, 2 skipped, 0 failed |
| e2e drizzle sqlite | 458 passed, 1 skipped, 0 failed |
| e2e drizzle-v2-relations sqlite | 458 passed, 1 skipped, 0 failed |
| `pnpm typecheck` | clean |
| Biome + cspell on changed files | clean |

Baseline before the change was 572 passed / 0 failed, so nothing that passed now fails. The four
SQLite/in-memory e2e adapters above all execute the shared `numberIdTestSuite`, which is the exact
`generateId: "serial"` path this touches, against real SQL. I have no Docker locally, so the
Postgres/MySQL/MSSQL/Mongo/Prisma suites were not run.

## Two behaviour changes worth flagging

- **Empty and whitespace-only id strings now throw.** Today they coerce to `0`, so the query runs
  and resolves empty. Every other newly-throwing input already threw at the driver, so only the
  message changes there — this is the one genuine non-throwing → throwing transition, and I took
  it deliberately because silently querying `id = 0` is the same defect in a quieter form. Happy
  to make it resolve empty instead if you would rather.
- **`null` id filters are no longer coerced to `0`.** `Number(null)` is `0`, so `where userId =
  null` was being turned into `= 0`. It now passes through as a real null. `null` is a documented
  member of `Where["value"]`, so this seemed like the same root cause rather than scope creep, and
  it is covered by a test.

## Open question

This does **not** restore the fallback path in better-auth/agent-auth#37. That plugin needs the
first lookup to resolve empty so its fallback runs, and this change still throws — it just throws
early with a message that names the model and field instead of failing opaquely inside Prisma.

Making an uncoercible id filter short-circuit to "no match" would fix that case properly, but it
is a semantic change to query dispatch and felt like yours to approve rather than mine to land
unilaterally. Happy to follow up with it if you want that behaviour.

Closes #10773

---

This patch was written with AI assistance; I have reviewed and understand the change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `NaN` and silent `0` coercions for numeric ids under `advanced.database.generateId: "serial"` by throwing a `BetterAuthError` that names the model and field. Old behavior sent `NaN`/`0` to the driver and produced opaque errors; new behavior validates early and preserves `null` in filters, including inside `in` arrays.

- Applies only when `generateId` is `serial`; other modes unchanged.
- Both read (`transformWhereClause`) and write (`transformInput`) paths use a shared `toNumberId` helper; the adapter is not called on invalid ids.
- Empty or whitespace-only id strings now throw. Numeric ids still coerce to integers. `null` filters and `null` elements in `in` filters now pass through as `null`.
- Callers using serial ids must validate `id` and id-referencing fields and stop sending non-numeric strings.

Package: `@better-auth/core` (patch).

<sup>Written for commit 3e275c5955b2b206be5e2320ebd3ff183a4e1372. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

