### PR TITLE
fix(organization): apply beforeAddTeamMember data and allow teamMember additionalFields

### DIFF
--- a/.changeset/team-member-hook-data.md
+++ b/.changeset/team-member-hook-data.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Apply the data returned from the organization plugin's `beforeAddTeamMember` hook to the created `teamMember` row, and allow `teamMember` to declare `schema.teamMember.additionalFields` like the plugin's other org-owned models.

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -452,6 +452,23 @@ export const auth = betterAuth({
           if (memberCount >= 10) {
             throw new Error("Team is full");
           }
+
+          // Optionally return data to store on the team member row. The fields
+          // must be declared under `schema.teamMember.additionalFields`.
+          // `teamId`, `userId` and `createdAt` stay authoritative and cannot
+          // be overridden here.
+          //
+          // Two limits worth knowing: this hook only runs on the
+          // `addTeamMember` endpoint, so team members created by
+          // `createOrganization`, `addMember` or `acceptInvitation` do not
+          // receive it; and because adding a member is find-or-create, the
+          // data is applied on insert only, not when the membership already
+          // exists.
+          return {
+            data: {
+              organizationId: organization.id,
+            },
+          };
         },
 
         afterAddTeamMember: async ({
@@ -2477,7 +2494,7 @@ const auth = betterAuth({
 
 #### Additional Fields
 
-Starting with [Better Auth v1.3](https://github.com/better-auth/better-auth/releases/tag/v1.3.0), you can easily add custom fields to the `organization`, `invitation`, `member`, and `team` tables.
+Starting with [Better Auth v1.3](https://github.com/better-auth/better-auth/releases/tag/v1.3.0), you can easily add custom fields to the `organization`, `invitation`, `member`, `team`, and `teamMember` tables.
 
 When you add extra fields to a model, the relevant API endpoints will automatically accept and return these new properties. For instance, if you add a custom field to the `organization` table, the `createOrganization` endpoint will include this field in its request and response payloads as needed.
 

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -395,6 +395,18 @@ export const auth = betterAuth({
   plugins: [
     organization({
       teams: { enabled: true },
+      schema: {
+        teamMember: {
+          additionalFields: {
+            // `beforeAddTeamMember` below returns this field. Hook data is
+            // only persisted for fields declared here.
+            organizationId: {
+              type: "string",
+              required: false,
+            },
+          },
+        },
+      },
       organizationHooks: {
         // Before creating a team
         beforeCreateTeam: async ({ team, user, organization }) => {

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -464,6 +464,11 @@ export const auth = betterAuth({
           // receive it; and because adding a member is find-or-create, the
           // data is applied on insert only, not when the membership already
           // exists.
+          //
+          // Because of the first limit, declare `teamMember` additional
+          // fields as optional or give them a `defaultValue`. A field marked
+          // `required: true` with no default becomes a NOT NULL column that
+          // the other three paths cannot populate.
           return {
             data: {
               organizationId: organization.id,

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -3,6 +3,7 @@ import {
 	getCurrentAdapter,
 	runWithTransaction,
 } from "@better-auth/core/context";
+import type { DBFieldAttribute } from "@better-auth/core/db";
 import type {
 	DBTransactionAdapter,
 	WhereOperator,
@@ -141,15 +142,20 @@ async function createTeamMemberWithKey(
 		teamId: string;
 		userId: string;
 		membershipKey: string;
+		additionalFields?: Record<string, any>;
 	},
 ) {
 	try {
 		const member = await adapter.create<
-			Omit<TeamMember, "id"> & { membershipKey: string },
+			Omit<TeamMember, "id"> & { membershipKey: string } & Record<string, any>,
 			StoredTeamMember
 		>({
 			model: "teamMember",
 			data: {
+				...data.additionalFields,
+				// the identity and audit columns stay authoritative: the row was
+				// validated against these ids before the hook ran, and membershipKey
+				// is the unique index backing find-or-create.
 				teamId: data.teamId,
 				userId: data.userId,
 				membershipKey: data.membershipKey,
@@ -166,13 +172,21 @@ async function createTeamMemberWithKey(
 	}
 }
 
-function stripTeamMembershipKey(member: StoredTeamMember): TeamMember {
+function stripTeamMembershipKey(
+	member: StoredTeamMember,
+	additionalFields?: Record<string, DBFieldAttribute>,
+): TeamMember {
 	const { membershipKey: _membershipKey, ...output } = member;
-	return output;
+	return filterOutputFields(output, additionalFields);
 }
 
-function stripTeamMembershipKeys(members: StoredTeamMember[]): TeamMember[] {
-	return members.map(stripTeamMembershipKey);
+function stripTeamMembershipKeys(
+	members: StoredTeamMember[],
+	additionalFields?: Record<string, DBFieldAttribute>,
+): TeamMember[] {
+	return members.map((member) =>
+		stripTeamMembershipKey(member, additionalFields),
+	);
 }
 
 export const getOrgAdapter = <O extends OrganizationOptions>(
@@ -185,6 +199,8 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 	const invitationAdditionalFields =
 		options?.schema?.invitation?.additionalFields;
 	const teamAdditionalFields = options?.schema?.team?.additionalFields;
+	const teamMemberAdditionalFields =
+		options?.schema?.teamMember?.additionalFields;
 	return {
 		findOrganizationBySlug: async (
 			slug: string,
@@ -844,7 +860,12 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					teamAdditionalFields,
 				) as unknown as InferTeam<O>),
 				...(includeTeamMembers
-					? { members: stripTeamMembershipKeys(teamMember ?? []) }
+					? {
+							members: stripTeamMembershipKeys(
+								teamMember ?? [],
+								teamMemberAdditionalFields,
+							),
+						}
 					: {}),
 			} as any;
 		},
@@ -993,7 +1014,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				],
 			});
 
-			return stripTeamMembershipKeys(members);
+			return stripTeamMembershipKeys(members, teamMemberAdditionalFields);
 		},
 		countTeamMembers: async (data: { teamId: string }) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
@@ -1053,12 +1074,15 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				],
 			});
 
-			return member ? stripTeamMembershipKey(member) : null;
+			return member
+				? stripTeamMembershipKey(member, teamMemberAdditionalFields)
+				: null;
 		},
 
 		findOrCreateTeamMember: async (data: {
 			teamId: string;
 			userId: string;
+			additionalFields?: Record<string, any>;
 		}) => {
 			return runWithTransaction(baseAdapter, async () => {
 				const adapter = await getCurrentAdapter(baseAdapter);
@@ -1067,7 +1091,8 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					...data,
 					membershipKey,
 				});
-				if (existing) return stripTeamMembershipKey(existing);
+				if (existing)
+					return stripTeamMembershipKey(existing, teamMemberAdditionalFields);
 
 				await syncTeamMemberCount(adapter, data.teamId);
 				const result = await createTeamMemberWithKey(adapter, {
@@ -1077,7 +1102,10 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				if (result.status === "created") {
 					await incrementTeamMemberCount(adapter, data.teamId);
 				}
-				return stripTeamMembershipKey(result.member);
+				return stripTeamMembershipKey(
+					result.member,
+					teamMemberAdditionalFields,
+				);
 			});
 		},
 		/**
@@ -1090,6 +1118,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			teamId: string;
 			userId: string;
 			maximumMembersPerTeam: number;
+			additionalFields?: Record<string, any>;
 		}): Promise<
 			{ status: "added"; member: TeamMember } | { status: "limitReached" }
 		> => {
@@ -1102,7 +1131,13 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					membershipKey,
 				});
 				if (existing) {
-					return { status: "added", member: stripTeamMembershipKey(existing) };
+					return {
+						status: "added",
+						member: stripTeamMembershipKey(
+							existing,
+							teamMemberAdditionalFields,
+						),
+					};
 				}
 				await syncTeamMemberCount(adapter, data.teamId);
 				const reserved = await reserveTeamSeat(adapter, {
@@ -1118,6 +1153,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 						teamId: data.teamId,
 						userId: data.userId,
 						membershipKey,
+						additionalFields: data.additionalFields,
 					});
 				} catch (error) {
 					await releaseTeamSeats(adapter, data.teamId, 1);
@@ -1128,7 +1164,10 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				}
 				return {
 					status: "added",
-					member: stripTeamMembershipKey(result.member),
+					member: stripTeamMembershipKey(
+						result.member,
+						teamMemberAdditionalFields,
+					),
 				};
 			});
 		},

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -69,6 +69,11 @@ export interface OrganizationClientOptions {
 						[key: string]: DBFieldAttribute;
 					};
 				};
+				teamMember?: {
+					additionalFields?: {
+						[key: string]: DBFieldAttribute;
+					};
+				};
 				organizationRole?: {
 					additionalFields?: {
 						[key: string]: DBFieldAttribute;

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -1,3 +1,4 @@
+import { getAuthTables } from "@better-auth/core/db";
 import type { APIError } from "@better-auth/core/error";
 import { memoryAdapter } from "@better-auth/memory-adapter";
 import type { Prettify } from "better-call";
@@ -2467,6 +2468,8 @@ describe("Additional Fields", async () => {
 		}[],
 		teamMember: [] as {
 			id: string;
+			teamMemberOrganizationId?: string | undefined;
+			teamMemberHiddenField?: string | undefined;
 		}[],
 	};
 
@@ -2523,6 +2526,19 @@ describe("Additional Fields", async () => {
 					},
 				},
 			},
+			teamMember: {
+				additionalFields: {
+					teamMemberOrganizationId: {
+						type: "string",
+						required: false,
+					},
+					teamMemberHiddenField: {
+						type: "string",
+						required: false,
+						returned: false,
+					},
+				},
+			},
 			invitation: {
 				additionalFields: {
 					invitationRequiredField: {
@@ -2541,6 +2557,14 @@ describe("Additional Fields", async () => {
 			},
 		},
 		invitationLimit: 3,
+		organizationHooks: {
+			beforeAddTeamMember: async ({ organization }) => ({
+				data: {
+					teamMemberOrganizationId: organization.id,
+					teamMemberHiddenField: "secret",
+				},
+			}),
+		},
 	} satisfies OrganizationOptions;
 
 	const orgClientPlugin = organizationClient({
@@ -3521,6 +3545,131 @@ describe("Additional Fields", async () => {
 		expect(row).toBeDefined();
 		expect(row.teamOptionalField).toBe("hey3");
 		expect(row.teamRequiredField).toBe("hey4");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10707
+	 */
+	it("should declare teamMember additional fields on the table", async () => {
+		const tables = getAuthTables(auth.options);
+		expect(tables.teamMember?.fields.teamMemberOrganizationId).toBeDefined();
+		expect(tables.teamMember?.fields.teamMemberHiddenField).toBeDefined();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10707
+	 */
+	it("should apply data returned from beforeAddTeamMember", async () => {
+		const hookTeam = await auth.api.createTeam({
+			body: {
+				name: "hook-team",
+				teamRequiredField: "hey",
+				organizationId: org.id,
+			},
+			headers,
+		});
+
+		const teamMember = await auth.api.addTeamMember({
+			body: {
+				teamId: hookTeam.id,
+				userId: org.members[0]!.userId,
+				organizationId: org.id,
+			},
+			headers,
+		});
+
+		const row = db.teamMember.find((x) => x.id === teamMember.id)!;
+		expect(row).toBeDefined();
+		expect(row.teamMemberOrganizationId).toBe(org.id);
+		expect(row.teamMemberHiddenField).toBe("secret");
+
+		const listed = (await auth.api.listTeamMembers({
+			query: { teamId: hookTeam.id },
+			headers,
+		})) as Record<string, unknown>[];
+		const found = listed.find((x) => x.id === teamMember.id)!;
+		expect(found).toBeDefined();
+		expect(found.teamMemberOrganizationId).toBe(org.id);
+		// declared `returned: false`, so it must not leave the endpoint
+		expect(found.teamMemberHiddenField).toBeUndefined();
+	});
+});
+
+/**
+ * The seat-limited insert path (`addTeamMemberWithLimit`) is a second, separate
+ * call site that the reported scenario never reaches.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10707
+ */
+describe("beforeAddTeamMember data with maximumMembersPerTeam", async () => {
+	const { auth, signInWithTestUser } = await getTestInstance({
+		plugins: [
+			organization({
+				teams: { enabled: true, maximumMembersPerTeam: 5 },
+				schema: {
+					teamMember: {
+						additionalFields: {
+							teamMemberOrganizationId: {
+								type: "string",
+								required: false,
+							},
+						},
+					},
+				},
+				organizationHooks: {
+					beforeAddTeamMember: async ({ organization }) => ({
+						data: { teamMemberOrganizationId: organization.id },
+					}),
+				},
+			}),
+		],
+	});
+	const { headers } = await signInWithTestUser();
+
+	it("applies the hook data on the seat-limited insert path", async () => {
+		const org = await auth.api.createOrganization({
+			body: { name: "limited", slug: "limited" },
+			headers,
+		});
+		if (!org) throw new Error("Organization is null");
+		const team = await auth.api.createTeam({
+			body: { name: "limited-team", organizationId: org.id },
+			headers,
+		});
+
+		const teamMember = await auth.api.addTeamMember({
+			body: {
+				teamId: team.id,
+				userId: org.members[0]!.userId,
+				organizationId: org.id,
+			},
+			headers,
+		});
+
+		const [listed] = (await auth.api.listTeamMembers({
+			query: { teamId: team.id },
+			headers,
+		})) as Record<string, unknown>[];
+		expect(listed!.id).toBe(teamMember.id);
+		expect(listed!.teamMemberOrganizationId).toBe(org.id);
+	});
+
+	/**
+	 * The client schema has to mirror the server one, otherwise declaring only
+	 * `teamMember` additional fields makes `inferOrgAdditionalFields` produce an
+	 * object with no properties in common with the client option type.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10707
+	 */
+	it("lets the client schema declare teamMember additional fields", () => {
+		const clientSchema = {
+			teamMember: {
+				additionalFields: {
+					teamMemberOrganizationId: { type: "string", required: false },
+				},
+			},
+		} satisfies NonNullable<Parameters<typeof organizationClient>[0]>["schema"];
+		expect(clientSchema.teamMember.additionalFields).toBeDefined();
 	});
 });
 

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -1034,6 +1034,7 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 							required: false,
 							fieldName: opts.schema?.teamMember?.fields?.createdAt,
 						},
+						...(opts.schema?.teamMember?.additionalFields || {}),
 					},
 				},
 			} satisfies BetterAuthPluginDBSchema)

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -1260,6 +1260,7 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 			}
 
 			// Run beforeAddTeamMember hook
+			let additionalFields: Record<string, any> | undefined;
 			if (options?.organizationHooks?.beforeAddTeamMember) {
 				const response = await options?.organizationHooks.beforeAddTeamMember({
 					teamMember: {
@@ -1272,6 +1273,7 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 				});
 				if (response && typeof response === "object" && "data" in response) {
 					// Allow the hook to modify the data
+					additionalFields = response.data;
 				}
 			}
 
@@ -1293,6 +1295,7 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 					teamId: ctx.body.teamId,
 					userId: ctx.body.userId,
 					maximumMembersPerTeam,
+					additionalFields,
 				});
 				if (result.status === "limitReached") {
 					throw APIError.from(
@@ -1305,6 +1308,7 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 				teamMember = await adapter.findOrCreateTeamMember({
 					teamId: ctx.body.teamId,
 					userId: ctx.body.userId,
+					additionalFields,
 				});
 			}
 

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -339,6 +339,9 @@ export interface OrganizationOptions {
 					fields?: {
 						[key in keyof Omit<TeamMember, "id"> | "membershipKey"]?: string;
 					};
+					additionalFields?: {
+						[key in string]: DBFieldAttribute;
+					};
 				};
 				organizationRole?: {
 					modelName?: string;


### PR DESCRIPTION
Fixes #10707.

## What

`beforeAddTeamMember` is typed `Promise<void | { data: Record<string, any> }>`, the same as `beforeCreateTeam` and `beforeUpdateTeam`. It does not honour that return value. At `routes/crud-team.ts` the call site read the hook's result, tested it, and then did nothing with it:

```ts
if (response && typeof response === "object" && "data" in response) {
    // Allow the hook to modify the data
}
```

The plugin has ten `"data" in response` sites and this was the only one with an empty body. `git log -L` puts its origin in bba0a42ee ("feat(organization): organization life cycle hooks"), the same PR that added the working siblings — so it shipped empty rather than having been broken later. The comment describes the opposite of what the block does.

Fixing that alone is not enough to make the reporter's case work. `teamMember` was also the only one of the plugin's six org-owned models whose schema option omitted `additionalFields` — the other five all carry it. Since `transformInput` iterates the *declared* fields (`packages/core/src/db/adapter/factory.ts:210`) and never `Object.keys(data)`, an undeclared key is dropped silently before it reaches any adapter. So the hook had nothing it could legally write, and the two defects are only observable together.

That gap looks like scope drift rather than a decision: `additionalFields` landed in 93698afd4, whose title names exactly the four models that existed then; `teamMember` arrived later with only `modelName` + `fields`, and the next model added after it (`organizationRole`) did ship with `additionalFields`.

## How

- `types.ts` / `organization.ts` — give `teamMember` the `additionalFields` option and spread it into the model's fields, matching the five siblings.
- `routes/crud-team.ts` — capture `response.data` and pass it to both insert paths. There are two: `addTeamMemberWithLimit` when `teams.maximumMembersPerTeam` is set, and `findOrCreateTeamMember` otherwise. Threading only the second would have left the seat-limited path silently dropping hook data, so both are covered and both are tested.
- `adapter.ts` — thread the fields through to `createTeamMemberWithKey`, the single `adapter.create({ model: "teamMember" })` in non-test source. They are spread **first**, so `teamId` / `userId` / `membershipKey` / `createdAt` are re-applied after and stay authoritative. That ordering is load-bearing, not tidiness:
  - the route validates the team, the target user's org membership and the user record *before* the hook runs, so a merged `{ data: { teamId: "…" } }` would insert into a team that was never checked;
  - `membershipKey` is declared `input: false`, but nothing in `packages/core/src/db/adapter/` enforces `input: false` — `transformInput` has no such check. The ordering is the only thing protecting the unique membership key.
- `adapter.ts` — `stripTeamMembershipKey` now runs through `filterOutputFields`. Every teamMember-returning path used that hand-rolled helper instead of `filterOutputFields`, which is what enforces `returned: false` for the siblings; enabling `additionalFields` without this would have leaked any field declared `returned: false`.
- `client.ts` — `OrganizationClientOptions["schema"]` listed five models and omitted `teamMember` too. Without this, declaring `teamMember` fields on the client fails to compile, and the documented `inferOrgAdditionalFields` pattern fails with `TS2559: has no properties in common` when `teamMember` is the only model with additional fields — which is exactly the reported use case.

`computeTeamMembershipKey` still hashes only `[teamId, userId]`, so no additional field can perturb the dedup key or the unique index. Nothing under `packages/core` is touched.

## Direction — worth a maintainer's call

I implemented the reading that the type signature promises. The honest counter-argument is that this hook's JSDoc never advertised the mutation: "You can return a `data` object to override the default data." appears seven times in `types.ts` and never for `beforeAddTeamMember`, and the docs example only validates and throws.

The alternative is narrowing the return type to `Promise<void>` and admitting the hook is validate-only. I did not take it because the TypeScript contract is unambiguous and identical to two hooks that *do* honour it, and because narrowing is a breaking type change for anyone returning data today — currently a silent no-op, afterwards a compile error — with no runtime benefit. If you would rather have the narrowing, say so and I will swap it; the failing test is already here either way.

Two smaller semantics I picked and would happily change:

- **Re-add applies nothing.** Both adapter methods are find-or-create, so when the membership already exists the existing row is returned untouched. I think not silently rewriting an established membership is right, but it does differ from `beforeUpdateTeam`.
- **`createdAt` stays authoritative**, unlike `beforeCreateTeam`, which lets the hook override it. One rule seemed easier to explain than two: the hook adds fields, it does not rewrite the row's identity or timestamp.

## Scope

Section 3 of the issue — that only the dedicated endpoint fires teamMember hooks — is deliberately **not** here. The other three insert paths (`crud-org.ts`, `crud-members.ts`, `crud-invites.ts`) create rows without running this hook, so hook-supplied fields are absent there. Changing that changes *when hooks fire*, which is an API decision rather than a bug fix. It is now stated in the docs example so nobody adopts the pattern expecting full coverage, and I am glad to follow up if you want it.

## Verification

Baseline captured on `main` @ 64da15b0b before any edit; `pnpm test` avoided per AGENTS.md, so this is the organization plugin suite.

| | Before | After |
| --- | --- | --- |
| `vitest run src/plugins/organization/` | 253 passed, 1 todo | **257 passed, 1 todo** |
| `pnpm typecheck` | exit 2 | **exit 0** |
| `biome check` (26 files) | clean | clean |

Zero pre-existing failures, and no test that passed in the baseline fails now. All four new tests were watched failing before the fix:

- `should declare teamMember additional fields on the table` — the schema spread, via `getAuthTables`
- `should apply data returned from beforeAddTeamMember` — end to end on the find-or-create path, including `returned: false` filtering
- `applies the hook data on the seat-limited insert path` — the `maximumMembersPerTeam` path the report never reaches
- `lets the client schema declare teamMember additional fields` — the client-side gap

The compile-time half of the bug reproduces as `TS2353` on the `satisfies` form and `TS2769` on the `organization({ … })` call form.

Changeset included (`better-auth: patch`).

Parts of this were written with AI assistance; I have reviewed the change and can discuss any of it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies `beforeAddTeamMember` returned data and adds `schema.teamMember.additionalFields`, so member-level fields persist and round-trip like other org models. Previously the hook’s data was ignored and undeclared fields were dropped.

- Threads `additionalFields` from the route through the adapter into both insert paths (find-or-create and seat-limited). `teamId`, `userId`, `membershipKey`, and `createdAt` remain authoritative and override hook data.
- Filters `teamMember` responses via `filterOutputFields` to honor `returned: false`; `membershipKey` remains server-only.
- Extends server types and client `OrganizationClientOptions["schema"]` to include `teamMember.additionalFields`, unblocking `inferOrgAdditionalFields`.
- Docs clarify limits (hook runs only on `addTeamMember`, applies on insert only), require optional or `defaultValue` fields for other creation paths, and the example now declares the `teamMember` field it returns.

**Migration**
- Declare `schema.teamMember.additionalFields` on both server and client if you want to store extra member-level data.
- Make those fields optional or give them a `defaultValue` if you also add members via `createOrganization`, `addMember`, or `acceptInvitation` (these do not invoke the hook).
- Do not rely on overriding `teamId`, `userId`, `membershipKey`, or `createdAt` in the hook; they are ignored.

<sup>Written for commit 50f9c940c4e3a3c0a3864d8d688bf1f0a1503255. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

