### PR TITLE
fix(organization): clear active organization only after the delete succeeds

### DIFF
--- a/.changeset/org-delete-active-organization.md
+++ b/.changeset/org-delete-active-organization.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Keep the session's active organization intact when an organization delete does not go through, so a `beforeDeleteOrganization` hook that rejects the request no longer leaves the session without an active organization while that organization still exists.

--- a/packages/better-auth/src/plugins/organization/organization-hook.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization-hook.test.ts
@@ -1,3 +1,4 @@
+import { APIError } from "@better-auth/core/error";
 import { describe, expect, it } from "vitest";
 import { getTestInstance } from "../../test-utils/test-instance";
 import { organization } from ".";
@@ -306,5 +307,75 @@ describe("organization creation in database hooks", async () => {
 		});
 		expect(org).toBeDefined();
 		expect((org as any)?.name).toBe("Before-After Org");
+	});
+});
+
+describe("organization deletion hooks", async () => {
+	const getInstance = async (
+		beforeDeleteOrganization?: () => Promise<void>,
+	) => {
+		const { auth, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				organization({
+					organizationHooks: { beforeDeleteOrganization },
+				}),
+			],
+		});
+		const ctx = await auth.$context;
+		const { headers } = await signInWithTestUser();
+		const org = await auth.api.createOrganization({
+			body: {
+				name: "Delete Hook Org",
+				slug: "delete-hook-org",
+			},
+			headers,
+		});
+		const session = await auth.api.getSession({ headers });
+		expect(session?.session.activeOrganizationId).toBe(org?.id);
+		const findOrganization = () =>
+			ctx.adapter.findOne({
+				model: "organization",
+				where: [{ field: "id", value: org!.id }],
+			});
+		return { auth, findOrganization, headers, org };
+	};
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10590
+	 */
+	it("should keep the active organization when beforeDeleteOrganization rejects the delete", async () => {
+		const { auth, findOrganization, headers, org } = await getInstance(
+			async () => {
+				throw new APIError("BAD_REQUEST", {
+					message: "Organization still has other members",
+				});
+			},
+		);
+
+		await expect(
+			auth.api.deleteOrganization({
+				body: { organizationId: org!.id },
+				headers,
+			}),
+		).rejects.toThrow("Organization still has other members");
+
+		// The delete was refused, so the organization survives and the session
+		// must still point at it.
+		expect(await findOrganization()).not.toBeNull();
+		const session = await auth.api.getSession({ headers });
+		expect(session?.session.activeOrganizationId).toBe(org!.id);
+	});
+
+	it("should clear the active organization when the delete succeeds", async () => {
+		const { auth, findOrganization, headers, org } = await getInstance();
+
+		await auth.api.deleteOrganization({
+			body: { organizationId: org!.id },
+			headers,
+		});
+
+		expect(await findOrganization()).toBeNull();
+		const session = await auth.api.getSession({ headers });
+		expect(session?.session.activeOrganizationId).toBeNull();
 	});
 });

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -593,12 +593,6 @@ export const deleteOrganization = <O extends OrganizationOptions>(
 					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_ORGANIZATION,
 				);
 			}
-			if (organizationId === session.session.activeOrganizationId) {
-				/**
-				 * If the organization is deleted, we set the active organization to null
-				 */
-				await adapter.setActiveOrganization(session.session.token, null, ctx);
-			}
 
 			const org = await adapter.findOrganizationById(organizationId);
 			if (!org) {
@@ -614,6 +608,12 @@ export const deleteOrganization = <O extends OrganizationOptions>(
 				);
 			}
 			await adapter.deleteOrganization(organizationId);
+			if (organizationId === session.session.activeOrganizationId) {
+				/**
+				 * If the organization is deleted, we set the active organization to null
+				 */
+				await adapter.setActiveOrganization(session.session.token, null, ctx);
+			}
 			if (options?.organizationHooks?.afterDeleteOrganization) {
 				await options.organizationHooks.afterDeleteOrganization(
 					{


### PR DESCRIPTION
- Closes #10590

`deleteOrganization` cleared the session's `activeOrganizationId` as its first step, before it
looked the organization up and before `beforeDeleteOrganization` had a chance to refuse. When a
hook rejects the delete the request correctly fails and the organization survives, but the session
has already lost its pointer to it, and nothing restores it. Every early exit below that line hit
the same problem: the organization not being found, the hook throwing, or the adapter delete
throwing all left the caller with an error and an unset active organization.

The block's own comment already described the intent — "If the organization is deleted, we set the
active organization to null" — the ordering just did not implement it.

## What changes

- The `activeOrganizationId` clear moves from the top of the handler to immediately after
  `adapter.deleteOrganization()`, so it only runs once the delete has actually happened.
- It stays *before* `afterDeleteOrganization`, which needs no error handling: if that hook throws,
  the clear has already run, so the session is never left pointing at a deleted organization.
  Placing it after the hook would need the clear wrapped in its own error juggling to survive a
  throwing hook.
- `afterDeleteOrganization` receives `{ organization, user }` explicitly, and
  `adapter.setActiveOrganization` only calls `internalAdapter.updateSession` — it mutates neither
  the handler's local `session` nor `ctx.context` — so clearing before the hook is unobservable to it.

The change is a move of the existing six-line block. No other `setActiveOrganization` call site
(leave, remove-member, set-active) is touched.

## Tests

Adds `describe("organization deletion hooks")` to `organization-hook.test.ts`:

- a regression test that a `beforeDeleteOrganization` throwing `APIError` leaves both the
  organization and the session's `activeOrganizationId` intact
- the positive case, that a successful delete still clears it

Against the unpatched handler the regression test fails with
`expected null to be '<org id>'`; with the fix the scoped suite is green.

```
pnpm vitest packages/better-auth/src/plugins/organization --run
  before:  254 passed, 1 failed  (the new regression test)
  after:   255 passed, 0 failed, 1 todo
pnpm typecheck                              exit 0
biome check <changed files> --error-on-warnings   exit 0
```

## Breaking changes

None. The only behavior change is on paths that already returned an error: a delete that fails no
longer clears the caller's active organization as a side effect. Deleting an organization that
does not exist likewise no longer clears it, which requires an orphaned `member` row to reach at
all, since `findMemberByOrgId` rejects first otherwise.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents clearing the session’s active organization when an organization delete is rejected or fails. Previously, `deleteOrganization` cleared `activeOrganizationId` before validation and hooks; now it clears only after the adapter deletes the organization, so sessions don’t lose their active organization on failed deletes while still never pointing at a deleted one.

- Move the clear to immediately after `adapter.deleteOrganization(...)`, still before `afterDeleteOrganization(...)`, so a throwing hook can’t leave the session pointing at a deleted org.
- Add tests for deletion hooks: rejection preserves both the organization and `activeOrganizationId`; successful delete clears it.
- Patch release in `better-auth`. No breaking changes or migrations.

<sup>Written for commit 50453fb2c269048dfa0f70f2639ea8445392e355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

