### PR TITLE
fix(oauth-provider): report invalid_token and stop misreading scheme errors as DPoP

### DIFF
--- a/.changeset/oauth-challenge-error-attribute.md
+++ b/.changeset/oauth-challenge-error-attribute.md
@@ -1,0 +1,6 @@
+---
+"@better-auth/core": patch
+"@better-auth/oauth-provider": patch
+---
+
+Report `error="invalid_token"` in the `WWW-Authenticate` challenge when a protected resource request presented an access token that failed, so clients can tell a rejected token from credentials that were never sent. A request using an unsupported authorization scheme is no longer answered with a DPoP challenge and keeps its `resource_metadata` pointer.

--- a/packages/core/src/oauth2/dpop.test.ts
+++ b/packages/core/src/oauth2/dpop.test.ts
@@ -1,3 +1,4 @@
+import type { APIError } from "better-call";
 import type { JWK, JWTPayload } from "jose";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -257,6 +258,27 @@ describe("verifyDpopProof", () => {
 				remoteVerifyOptions(),
 			),
 		).rejects.toThrow("authorization scheme must be Bearer or DPoP");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10857
+	 */
+	it("reports an unsupported scheme as absent credentials, not a failed token", async () => {
+		// RFC 6750 §3.1 groups an unsupported authentication method with requests
+		// that lack any authentication information, which carry no error code.
+		// Sending one makes a resource server answer a `Basic` header with a
+		// token-failure challenge for credentials that were never a token.
+		const error = await verifyAccessTokenRequest(
+			{ authorizationHeader: "Basic dXNlcjpwYXNz", method, url },
+			remoteVerifyOptions(),
+		).then(
+			() => undefined,
+			(thrown: APIError) => thrown,
+		);
+
+		expect(error?.body).toEqual({
+			message: "authorization scheme must be Bearer or DPoP",
+		});
 	});
 });
 

--- a/packages/core/src/oauth2/verify.test.ts
+++ b/packages/core/src/oauth2/verify.test.ts
@@ -100,6 +100,7 @@ describe("verifyBearerToken", () => {
 	async function expectUnauthorized(
 		promise: Promise<unknown>,
 		message = "invalid access token",
+		body?: Record<string, unknown>,
 	) {
 		try {
 			await promise;
@@ -112,6 +113,7 @@ describe("verifyBearerToken", () => {
 				message,
 				body: {
 					message,
+					...body,
 				},
 			});
 		}
@@ -436,6 +438,51 @@ describe("verifyBearerToken", () => {
 				verifyOptions: { issuer, audience },
 			}),
 			"token expired",
+		);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10857
+	 */
+	it("should report a rejected token with the invalid_token error code", async () => {
+		// RFC 6750 §3: a request that presented a token which then failed is
+		// answered with `invalid_token`. Without the code a resource server
+		// cannot tell a rejected token from credentials that were never sent.
+		const { publicJWK, privateKey, kid } = await createTestJWKS();
+		const token = await createSignedToken(
+			privateKey,
+			kid,
+			{},
+			Math.floor(Date.now() / 1000) - 60,
+		);
+		mockJWKSResponse(publicJWK);
+
+		await expectUnauthorized(
+			verifyBearerToken(token, {
+				jwksUrl,
+				verifyOptions: { issuer, audience },
+			}),
+			"token expired",
+			{ error: "invalid_token", error_description: "token expired" },
+		);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10857
+	 */
+	it("should report a token it cannot verify with the invalid_token error code", async () => {
+		// A malformed bearer token is neither a JWS this server can verify nor an
+		// opaque token any introspection endpoint was configured for, so it ends
+		// with no payload. A token was still presented, and it still failed.
+		mockJWKSResponse();
+
+		await expectUnauthorized(
+			verifyBearerToken("not-a-jwt", {
+				jwksUrl,
+				verifyOptions: { issuer, audience },
+			}),
+			"no token payload",
+			{ error: "invalid_token", error_description: "no token payload" },
 		);
 	});
 

--- a/packages/core/src/oauth2/verify.ts
+++ b/packages/core/src/oauth2/verify.ts
@@ -373,6 +373,8 @@ async function verifyAccessTokenPayload(
 				} else if (error instanceof joseErrors.JWTExpired) {
 					throw new APIError("UNAUTHORIZED", {
 						message: "token expired",
+						error: "invalid_token",
+						error_description: "token expired",
 					});
 				} else if (error instanceof joseErrors.JOSEError) {
 					if (isJoseInfrastructureError(error)) {
@@ -380,6 +382,8 @@ async function verifyAccessTokenPayload(
 					}
 					throw new APIError("UNAUTHORIZED", {
 						message: "invalid access token",
+						error: "invalid_token",
+						error_description: "invalid access token",
 					});
 				} else {
 					throw error;
@@ -421,6 +425,8 @@ async function verifyAccessTokenPayload(
 		if (!introspect.active)
 			throw new APIError("UNAUTHORIZED", {
 				message: "token inactive",
+				error: "invalid_token",
+				error_description: "token inactive",
 			});
 		// Verifies payload using verify options (token valid through introspect).
 		// Audience is enforced by default: when `verifyOptions.audience` is set
@@ -448,6 +454,8 @@ async function verifyAccessTokenPayload(
 	if (!payload)
 		throw new APIError("UNAUTHORIZED", {
 			message: `no token payload`,
+			error: "invalid_token",
+			error_description: `no token payload`,
 		});
 
 	const grantedScopes = parseGrantedScopes(payload.scope);
@@ -629,12 +637,11 @@ export async function verifyAccessTokenRequest(
 	}
 	// RFC 6750 §2.1 / RFC 9449 §7.1: an access token is presented with the
 	// `Bearer` or `DPoP` scheme. Reject a scheme-less or unknown-scheme value
-	// rather than accept a bare token.
+	// rather than accept a bare token. RFC 6750 §3.1 counts an unsupported
+	// scheme as a request lacking authentication information rather than a
+	// failed token, so it carries no error code.
 	if (authorization.scheme === "Unknown") {
-		throwDpopUnauthorized(
-			"authorization scheme must be Bearer or DPoP",
-			"invalid_token",
-		);
+		throwDpopUnauthorized("authorization scheme must be Bearer or DPoP");
 	}
 
 	const payload = await verifyAccessTokenPayload(authorization.token, opts);

--- a/packages/oauth-provider/src/resource-challenge.test.ts
+++ b/packages/oauth-provider/src/resource-challenge.test.ts
@@ -187,4 +187,92 @@ describe("resource server challenge", () => {
 			),
 		).toThrow("invalid error_description");
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10857
+	 */
+	describe("RFC 6750 error reporting", () => {
+		function challengeFor(
+			body: Record<string, unknown>,
+			opts?: Parameters<typeof createResourceServerChallenge>[2],
+		) {
+			const challenge = createResourceServerChallenge(
+				new APIError("UNAUTHORIZED", body),
+				"https://api.example.com/mcp",
+				opts,
+			) as APIError;
+			return new Headers(challenge.headers).get("WWW-Authenticate");
+		}
+
+		it("omits error when the request presented no credentials", () => {
+			// RFC 6750 §3 reserves `error` for a token that was presented and
+			// failed. A request carrying none has nothing to report, so the
+			// challenge stays a bare invitation to authorize.
+			expect(challengeFor({ message: "missing authorization header" })).toBe(
+				'Bearer resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp"',
+			);
+		});
+
+		it("omits error when the scheme is not one this server accepts", () => {
+			// RFC 6750 §3.1 files an unsupported authentication method under
+			// requests that "lack any authentication information", so it carries
+			// no error code and still has to point at the resource metadata.
+			expect(
+				challengeFor({
+					message: "authorization scheme must be Bearer or DPoP",
+				}),
+			).toBe(
+				'Bearer resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp"',
+			);
+		});
+
+		it("reports error=invalid_token when a presented token failed", () => {
+			// Without this a client cannot tell a rejected token from absent
+			// credentials, and so cannot implement RFC 6750 invalid_token handling.
+			expect(
+				challengeFor({
+					message: "no token payload",
+					error: "invalid_token",
+					error_description: "no token payload",
+				}),
+			).toBe(
+				'Bearer error="invalid_token", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp"',
+			);
+		});
+
+		it("reports the failed token alongside the configured scope hint", () => {
+			expect(
+				challengeFor(
+					{
+						message: "token expired",
+						error: "invalid_token",
+						error_description: "token expired",
+					},
+					{ challengeScopes: ["mcp:read"] },
+				),
+			).toBe(
+				'Bearer error="invalid_token", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp", scope="mcp:read"',
+			);
+		});
+
+		it("keeps the DPoP challenge for a binding failure carrying invalid_token", () => {
+			// `DpopBindingErrorCode` includes `invalid_token`, so a genuine
+			// sender-constraint failure reaches the classifier under that code and
+			// must still advertise `algs` rather than fall through to bearer.
+			expect(
+				challengeFor(
+					{
+						message:
+							"DPoP-bound access token requires the DPoP authorization scheme",
+						error: "invalid_token",
+						error_description:
+							"DPoP-bound access token requires the DPoP authorization scheme",
+					},
+					{ dpopSigningAlgorithms: ["ES256"] },
+				),
+			).toBe(
+				'DPoP error="invalid_token", error_description="DPoP-bound access token requires the DPoP authorization scheme", algs="ES256"',
+			);
+		});
+	});
 });

--- a/packages/oauth-provider/src/resource-challenge.ts
+++ b/packages/oauth-provider/src/resource-challenge.ts
@@ -136,7 +136,11 @@ function buildBearerChallenge(
  * Create an OAuth resource-server challenge for a failed access-token request.
  *
  * Missing/invalid bearer credentials are reported with RFC 6750 plus the RFC
- * 9728 `resource_metadata` pointer. Insufficient-scope failures (built with
+ * 9728 `resource_metadata` pointer. A token that was presented and then failed
+ * also carries its `error` code (RFC 6750 §3), so a client can tell a rejected
+ * token from credentials it never sent; credentials that were absent or used an
+ * unsupported scheme carry no code, per RFC 6750 §3.1. Insufficient-scope
+ * failures (built with
  * `createInsufficientScopeError`) are reported with RFC 6750 §3.1's
  * `insufficient_scope` challenge on a 403 naming the scopes the token lacks, so
  * clients can step up their authorization. DPoP-bound-token failures are
@@ -175,6 +179,11 @@ export function createResourceServerChallenge(
 				{ "WWW-Authenticate": buildDpopChallenge(error, opts) },
 			);
 		}
+		// RFC 6750 §3: a request that presented a token which then failed is
+		// answered with its error code, so a client can tell a rejected token from
+		// credentials it never sent. Credentials that were absent or unsupported
+		// carry no code, and so challenge without one.
+		const { errorCode } = extractDpopError(error);
 		return new APIError(
 			"UNAUTHORIZED",
 			{ message: error.message },
@@ -183,6 +192,7 @@ export function createResourceServerChallenge(
 					resource,
 					opts,
 					(metadataUrl) => [
+						errorCode && `error="${quoteAuthParam(errorCode)}"`,
 						`resource_metadata="${quoteAuthParam(metadataUrl)}"`,
 						challengeScope && `scope="${quoteAuthParam(challengeScope)}"`,
 					],


### PR DESCRIPTION
Two RFC 6750 deviations in the `WWW-Authenticate` challenge a resource server returns, both reached through `createResourceServerChallenge`.

### A failed token was indistinguishable from no credentials

RFC 6750 §3 asks for the `error` attribute when a request carried a token that then failed. The bearer branch never emitted one, so `Bearer not-a-jwt` and a request with no `Authorization` header produced byte-identical challenges, and a client had no way to implement `invalid_token` handling.

The cause sits upstream of the challenge builder. The four token-failure paths in `verifyAccessTokenPayload` (`token expired`, `invalid access token`, `token inactive`, `no token payload`) throw with only a `message` and no error code. `createResourceServerChallenge` only ever sees the error, never the request, so it cannot work out whether a token was presented — the code has to come from core. Those four throws now set `error: "invalid_token"`, matching the shape `parseGrantedScopes` already uses a few lines away, and the bearer branch emits it when the body carries one.

### An unsupported scheme produced a DPoP challenge and dropped `resource_metadata`

RFC 6750 §3.1 puts an unsupported authentication method in the "lacks any authentication information" category, which should carry no error code. `verifyAccessTokenRequest` was rejecting an unknown scheme *with* `invalid_token`, and that rejection's message — "authorization scheme must be Bearer or DPoP" — contains the literal string `DPoP`, which `isDpopChallengeError` substring-matches to choose the challenge type. So a `Basic ...` header came back with a DPoP challenge and no RFC 9728 pointer at all, which breaks discovery for an MCP client.

Fixed at the producer: that throw no longer passes an error code, so `!!errorCode` is false and the classifier returns before the substring clause is ever reached. The bearer challenge goes out with `resource_metadata` intact.

### What I deliberately did not change

`isDpopChallengeError` keeps its `description.includes("DPoP")` clause. Deleting it looks like the obvious fix and is a regression: `DpopBindingErrorCode` includes `invalid_token` while `DPOP_CHALLENGE_ERRORS` holds only `invalid_dpop_proof`, so genuine DPoP binding failures would fall through to the bearer branch and lose the `algs` hint.

That said, the DPoP-vs-bearer decision still keys off prose. This PR removes the collision #10857 reports, but a future error carrying `invalid_token` with "DPoP" in its message would misclassify again. The robust fix is a dedicated code or an explicit flag on the error, which changes a cross-package error contract, so I did not want to make that call unilaterally inside a bug fix. Happy to follow up if you'd like it done.

### Behavior change worth flagging

`verifyAccessTokenRequest` / `verifyBearerToken` now return `error` and `error_description` on rejected-token paths, and the unsupported-scheme path no longer returns `invalid_token`. Not breaking, but visible to anyone matching on `err.body.error`. No in-repo consumer reads those fields: `revoke.ts` matches `unsupported_token_type`, and `introspect.ts`'s `isInactiveTokenError` never imports core's verify.

No breaking changes.

### Tests

8 tests added across the three touched files; 5 of them fail before this change and pass after. The pre-existing guard that a genuine `invalid_dpop_proof` still yields a `DPoP` challenge with `algs` stays green, and a new test covers the `invalid_token` DPoP binding case the classifier depends on.

Focused suites: 83/83. Across `oauth-provider`, `core/oauth2` and `mcp` the pass count goes 315 → 323 with the failure count unchanged at 115 — those are pre-existing `node:sqlite` dialect failures in DB-backed tests, identical with this change stashed. `pnpm typecheck` and Biome both clean.

Closes #10857

Written with AI assistance; I reviewed and verified the change and can discuss it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns RFC 6750-compliant `WWW-Authenticate` challenges: failed bearer tokens now include error="invalid_token", and requests using an unsupported scheme no longer trigger a DPoP challenge and keep the `resource_metadata` pointer. This lets clients distinguish rejected tokens from missing credentials and fixes misclassification that hid RFC 9728 discovery.

- `@better-auth/core`: `verifyAccessTokenPayload` now sets `error: "invalid_token"` and `error_description` for token failures (expired, invalid access token, inactive, no payload). `verifyAccessTokenRequest` stops attaching an error code for unsupported schemes.
- `@better-auth/oauth-provider`: `createResourceServerChallenge` includes the `error` attribute only when a token was presented and failed; unsupported schemes yield a Bearer challenge with `resource_metadata`. Genuine DPoP binding failures still produce a DPoP challenge with `algs`.
- Behavior visible to clients: rejected-token responses now include `error`/`error_description`; unsupported-scheme responses no longer include `invalid_token`. Update any code that matched on these fields if needed.

<sup>Written for commit 2981bfd5005868e0bcd96b793a2eb73c32da57b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

