### PR TITLE
fix(drizzle-adapter): add supportsDates option for text date columns

### DIFF
--- a/.changeset/drizzle-supports-dates.md
+++ b/.changeset/drizzle-supports-dates.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/drizzle-adapter": patch
+---
+
+Add a `supportsDates` option to the Drizzle adapter. Set it to `false` when your date columns are declared as `text()`, so Better Auth writes an ISO 8601 string instead of a raw `Date` that strict drivers such as Cloudflare D1 reject.

--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -211,6 +211,37 @@ export const auth = betterAuth({
 });
 ```
 
+## Text Date Columns
+
+Drizzle converts `Date` values itself before they reach the driver, so Better
+Auth hands it a `Date` and lets it do the work. That is what the generated
+schema relies on: `timestamp` on PostgreSQL and MySQL, and
+`integer({ mode: "timestamp_ms" })` on SQLite.
+
+A `text()` column has no such conversion. If you declared your date columns as
+`text()` instead, the raw `Date` reaches the driver, and a strict driver such as
+Cloudflare D1 rejects it:
+
+```
+D1_TYPE_ERROR: Type 'object' not supported for value 'Mon Aug 10 2026 14:47:14 GMT-0400'
+```
+
+Set `supportsDates` to `false` so Better Auth writes an ISO 8601 string and
+parses it back into a `Date` on read:
+
+```ts
+export const auth = betterAuth({
+  database: drizzleAdapter(db, {
+    provider: "sqlite",
+    supportsDates: false, // [!code highlight]
+  }),
+});
+```
+
+Leave it alone if your date columns came from the Better Auth CLI. Setting it to
+`false` against a `timestamp` or `integer({ mode: "timestamp_ms" })` column sends
+a string to a column that expects a `Date`, which fails.
+
 ## Custom Schema namespace
 
 If you're using PostgreSQL and you want to generate the schema with a custom schema namespace,

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -6,6 +6,12 @@ import {
 	text,
 	timestamp,
 } from "drizzle-orm/pg-core";
+import type { SQLiteTable } from "drizzle-orm/sqlite-core";
+import {
+	integer as sqliteInteger,
+	sqliteTable,
+	text as sqliteText,
+} from "drizzle-orm/sqlite-core";
 import { describe, expect, it, vi } from "vitest";
 import { drizzleAdapter } from "./drizzle-adapter";
 
@@ -594,6 +600,169 @@ describe("drizzle-adapter", () => {
 			});
 
 			expect(result).toBeNull();
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10816
+	 */
+	describe("supportsDates", () => {
+		const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
+		const expiresAt = new Date("2026-08-14T21:35:53.000Z");
+
+		// Mirrors the SQLite schema the Better Auth CLI generates. Drizzle's
+		// timestamp column converts a `Date` itself, so the adapter must keep
+		// handing it a `Date`.
+		const timestampVerification = sqliteTable("verification", {
+			id: sqliteText("id").primaryKey(),
+			identifier: sqliteText("identifier").notNull(),
+			value: sqliteText("value").notNull(),
+			expiresAt: sqliteInteger("expires_at", {
+				mode: "timestamp_ms",
+			}).notNull(),
+			createdAt: sqliteInteger("created_at", {
+				mode: "timestamp_ms",
+			}).notNull(),
+			updatedAt: sqliteInteger("updated_at", {
+				mode: "timestamp_ms",
+			}).notNull(),
+		});
+
+		// The schema from the report. A `text()` column has no conversion of its
+		// own, so whatever the adapter hands over reaches the driver unchanged.
+		const textVerification = sqliteTable("verification", {
+			id: sqliteText("id").primaryKey(),
+			identifier: sqliteText("identifier").notNull(),
+			value: sqliteText("value").notNull(),
+			expiresAt: sqliteText("expires_at").notNull(),
+			createdAt: sqliteText("created_at").notNull(),
+			updatedAt: sqliteText("updated_at").notNull(),
+		});
+
+		function createDb(verification: SQLiteTable) {
+			const calls: {
+				inserted?: Record<string, unknown>;
+				whereArgs?: unknown[];
+			} = {};
+			const db = {
+				_: { fullSchema: { verification } },
+				insert: vi.fn().mockReturnValue({
+					values: vi.fn((row: Record<string, unknown>) => {
+						calls.inserted = row;
+						return { returning: vi.fn().mockResolvedValue([row]) };
+					}),
+				}),
+				select: vi.fn().mockReturnValue({
+					from: vi.fn().mockReturnValue({
+						where: vi.fn((...args: unknown[]) => {
+							calls.whereArgs = args;
+							return Promise.resolve([]);
+						}),
+					}),
+				}),
+			} as any;
+			return { db, calls };
+		}
+
+		function createVerification(db: any, supportsDates?: boolean) {
+			const adapter = drizzleAdapter(db, {
+				provider: "sqlite",
+				...(supportsDates === undefined ? {} : { supportsDates }),
+			})({ secret: defaultSecret });
+			return adapter.create({
+				model: "verification",
+				data: {
+					identifier: "email-verification",
+					value: "token",
+					expiresAt,
+					createdAt: expiresAt,
+					updatedAt: expiresAt,
+				},
+			});
+		}
+
+		it("hands Drizzle a Date by default so its own conversion still runs", async () => {
+			const { db, calls } = createDb(timestampVerification);
+
+			await createVerification(db);
+
+			// A timestamp column calls `value.getTime()`, which only a Date has.
+			// Serialising here would break every generated SQLite schema.
+			expect(calls.inserted?.expiresAt).toBeInstanceOf(Date);
+			expect(calls.inserted?.expiresAt).toEqual(expiresAt);
+		});
+
+		it("keeps the Date when supportsDates is set to true explicitly", async () => {
+			const { db, calls } = createDb(timestampVerification);
+
+			await createVerification(db, true);
+
+			expect(calls.inserted?.expiresAt).toBeInstanceOf(Date);
+		});
+
+		it("writes an ISO string when supportsDates is false", async () => {
+			const { db, calls } = createDb(textVerification);
+
+			await createVerification(db, false);
+
+			// A `text()` column passes the value straight to the driver, which
+			// rejects a Date. An ISO string is what such a column expects.
+			expect(calls.inserted?.expiresAt).toBe("2026-08-14T21:35:53.000Z");
+			expect(calls.inserted?.createdAt).toBe("2026-08-14T21:35:53.000Z");
+		});
+
+		it("reads an ISO string back as a Date when supportsDates is false", async () => {
+			const { db } = createDb(textVerification);
+
+			const created = await createVerification(db, false);
+
+			// The stored string must not leak into application code.
+			expect((created as { expiresAt: Date }).expiresAt).toBeInstanceOf(Date);
+			expect((created as { expiresAt: Date }).expiresAt).toEqual(expiresAt);
+		});
+
+		it("serialises a Date in a range comparison when supportsDates is false", async () => {
+			const { db, calls } = createDb(textVerification);
+			const adapter = drizzleAdapter(db, {
+				provider: "sqlite",
+				supportsDates: false,
+			})({ secret: defaultSecret });
+
+			await adapter.findOne({
+				model: "verification",
+				where: [{ field: "expiresAt", value: expiresAt, operator: "lt" }],
+			});
+
+			const clause = calls.whereArgs?.[0];
+			expect(is(clause, SQL)).toBe(true);
+			const params = (clause as SQL).queryChunks.filter((chunk) =>
+				is(chunk, Param),
+			);
+			// `WHERE expires_at < ?` binds the same ISO string the column stores,
+			// so the comparison matches instead of failing on a Date operand.
+			expect(params.map((param) => (param as Param).value)).toContain(
+				"2026-08-14T21:35:53.000Z",
+			);
+		});
+
+		it("leaves a Date in a range comparison by default", async () => {
+			const { db, calls } = createDb(timestampVerification);
+			const adapter = drizzleAdapter(db, { provider: "sqlite" })({
+				secret: defaultSecret,
+			});
+
+			await adapter.findOne({
+				model: "verification",
+				where: [{ field: "expiresAt", value: expiresAt, operator: "lt" }],
+			});
+
+			const clause = calls.whereArgs?.[0];
+			const params = (clause as SQL).queryChunks.filter((chunk) =>
+				is(chunk, Param),
+			);
+			expect(params.map((param) => (param as Param).value)).toContainEqual(
+				expiresAt,
+			);
 		});
 	});
 });

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -154,6 +154,25 @@ export interface DrizzleAdapterConfig {
 	 */
 	transaction?: boolean | undefined;
 	/**
+	 * Whether the Drizzle columns backing `date` fields accept a JavaScript
+	 * `Date` value.
+	 *
+	 * Drizzle normally converts `Date` values itself, so the default is `true`
+	 * for every provider. That covers the schema the Better Auth CLI generates:
+	 * `timestamp` on PostgreSQL, `timestamp` on MySQL and
+	 * `integer({ mode: "timestamp_ms" })` on SQLite all convert a `Date` before
+	 * it reaches the driver.
+	 *
+	 * Set this to `false` when your date columns are declared as `text()`
+	 * instead. A `text()` column passes the value straight through, so the raw
+	 * `Date` reaches the driver and strict drivers such as Cloudflare D1 reject
+	 * it. With `false`, Better Auth writes an ISO 8601 string and parses it back
+	 * into a `Date` on read.
+	 *
+	 * @default true
+	 */
+	supportsDates?: boolean | undefined;
+	/**
 	 * Database schema namespace, used during the Better Auth CLI to generate the schema.
 	 *
 	 * Only applies to PostgreSQL. It will generate something like this:
@@ -1145,6 +1164,10 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					? true
 					: false,
 			supportsArrays: config.provider === "pg" ? true : false,
+			// Drizzle converts `Date` values in its own column layer, so the
+			// adapter defers to it by default on every provider. Users whose date
+			// columns are `text()` have no such conversion and opt out here.
+			supportsDates: config.supportsDates ?? true,
 			customTransformOutput: ({ data, fieldAttributes }) => {
 				// not all providers support dates
 				// one such example case is https://github.com/better-auth/better-auth/issues/7819

--- a/packages/drizzle-adapter/src/relations-v2/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/relations-v2/drizzle-adapter.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { drizzleAdapter } from "./index";
+
+describe("drizzle-adapter relations-v2", () => {
+	const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
+
+	function createAdapter(config: { supportsDates?: boolean }) {
+		const db = { _: { fullSchema: {} } } as any;
+		return drizzleAdapter(db, { provider: "sqlite", ...config })({
+			secret: defaultSecret,
+		});
+	}
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10816
+	 */
+	describe("supportsDates", () => {
+		it("defers date conversion to Drizzle by default", () => {
+			const adapter = createAdapter({});
+
+			expect(adapter.options?.adapterConfig.supportsDates).toBe(true);
+		});
+
+		it("lets a text-column schema opt out", () => {
+			const adapter = createAdapter({ supportsDates: false });
+
+			expect(adapter.options?.adapterConfig.supportsDates).toBe(false);
+		});
+	});
+});

--- a/packages/drizzle-adapter/src/relations-v2/index.ts
+++ b/packages/drizzle-adapter/src/relations-v2/index.ts
@@ -244,6 +244,25 @@ export interface DrizzleAdapterConfig {
 	 */
 	transaction?: boolean | undefined;
 	/**
+	 * Whether the Drizzle columns backing `date` fields accept a JavaScript
+	 * `Date` value.
+	 *
+	 * Drizzle normally converts `Date` values itself, so the default is `true`
+	 * for every provider. That covers the schema the Better Auth CLI generates:
+	 * `timestamp` on PostgreSQL, `timestamp` on MySQL and
+	 * `integer({ mode: "timestamp_ms" })` on SQLite all convert a `Date` before
+	 * it reaches the driver.
+	 *
+	 * Set this to `false` when your date columns are declared as `text()`
+	 * instead. A `text()` column passes the value straight through, so the raw
+	 * `Date` reaches the driver and strict drivers such as Cloudflare D1 reject
+	 * it. With `false`, Better Auth writes an ISO 8601 string and parses it back
+	 * into a `Date` on read.
+	 *
+	 * @default true
+	 */
+	supportsDates?: boolean | undefined;
+	/**
 	 * Database schema namespace, used during the Better Auth CLI to generate the schema.
 	 *
 	 * Only applies to PostgreSQL. It will generate something like this:
@@ -1079,6 +1098,10 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 			// cause double-stringification). For PostgreSQL, native arrays are used.
 			// See: https://github.com/better-auth/better-auth/issues/7440
 			supportsArrays: true,
+			// Drizzle converts `Date` values in its own column layer, so the
+			// adapter defers to it by default on every provider. Users whose date
+			// columns are `text()` have no such conversion and opt out here.
+			supportsDates: config.supportsDates ?? true,
 			transaction:
 				(config.transaction ?? false)
 					? (cb) =>


### PR DESCRIPTION
The Drizzle adapter's factory config sets `supportsUUIDs`, `supportsJSON` and `supportsArrays` but never `supportsDates`, so the core factory falls back to `true` and `DrizzleAdapterConfig` has no field to change it.

That is right for the schema the CLI generates and wrong for date columns declared as `text()`, one of Drizzle's two documented ways to store a SQLite timestamp. `text()` applies no conversion, so the raw `Date` reaches the driver and Cloudflare D1 rejects it with `D1_TYPE_ERROR: Type 'object' not supported`. The `verification` insert is the first write in most flows, so sign-up, social sign-in and session refresh all fail, as do `WHERE expires_at < ?` comparisons.

Deriving the flag from `config.provider` would break more than it fixes. Checking `drizzle-orm` source rather than assuming:

| Column | Behavior with a `Date` |
| --- | --- |
| `timestamp()` on PostgreSQL / MySQL | `mapToDriverValue` calls `value.toISOString()` |
| `integer({ mode: "timestamp_ms" })` on SQLite | `mapToDriverValue` calls `value.getTime()` |
| `text()` on SQLite | no conversion, the `Date` reaches the driver |

The CLI generates the first two, and both would throw on a string, so `supportsDates: false` for SQLite (what the Kysely adapter does) would break the schema Better Auth itself generates. Deriving from the column type is wrong too: `supportsDates` is one boolean per adapter, and a schema can mix `text()` and `integer({ mode: "timestamp_ms" })` date columns; expressing that needs a per-column contract.

That leaves the escape hatch: `config.supportsDates ?? true`, exposed on `DrizzleAdapterConfig`, added to both the main and `relations-v2` adapters since they carry separate config blocks. Behavior is unchanged for anyone who does not set it.

Six cases under a `supportsDates` describe block in `packages/drizzle-adapter/src/drizzle-adapter.test.ts`, on real `sqliteTable` definitions for both schemas, plus two in `relations-v2/drizzle-adapter.test.ts`. Three fail on `main` without the source change; the rest pin the existing default so a later change cannot flip it silently.

`pnpm -F @better-auth/drizzle-adapter typecheck` passes, package suite green at 47. I did not run the Docker-backed adapter suites or the e2e tests.

Fixes #10816

## AI disclosure

This was written with AI assistance. Per the AI policy in CONTRIBUTING.md, I have reviewed the change, verified the Drizzle column behavior in `drizzle-orm` source rather than assuming it, and can discuss the reasoning above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `supportsDates` option to the Drizzle adapters in `@better-auth/drizzle-adapter`, defaulting to true. Previously the adapter always passed `Date` objects through; apps using SQLite `text()` date columns couldn’t change this and hit Cloudflare D1 type errors. Now you can disable passthrough so Better Auth serializes to ISO strings on writes and where operands, and parses on reads.

- Migration: If your SQLite schema stores timestamps as `text()`, set `supportsDates: false` in the Drizzle adapter config to avoid driver rejections.
- Caution: Do not set `supportsDates: false` when using Drizzle `timestamp` columns (PostgreSQL/MySQL) or SQLite `integer({ mode: "timestamp_ms" })`; those expect a `Date` and will fail.

<sup>Written for commit b375e39a4d2c0e62eab3d59c357f85cdba297745. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


