### PR TITLE
ci(e2e): retry compose startup once

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -243,7 +243,9 @@ jobs:
             echo "Container startup failed; resetting and retrying once."
             docker compose ps --all || true
             docker compose logs --no-color "${compose_services[@]}" || true
-            docker compose down --volumes --remove-orphans
+            if ! docker compose down --volumes --remove-orphans; then
+              echo "::warning::Container cleanup failed; retrying startup with remaining resources."
+            fi
           done
 
       - name: Adapter Integration

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -231,7 +231,20 @@ jobs:
         if: matrix.compose_services != ''
         run: |
           read -r -a compose_services <<< "$COMPOSE_SERVICES"
-          docker compose up -d --wait --wait-timeout 60 "${compose_services[@]}"
+          for startup_attempt in 1 2; do
+            if docker compose up -d --wait --wait-timeout 60 "${compose_services[@]}"; then
+              exit 0
+            fi
+
+            if [[ "$startup_attempt" -eq 2 ]]; then
+              exit 1
+            fi
+
+            echo "Container startup failed; resetting and retrying once."
+            docker compose ps --all || true
+            docker compose logs --no-color "${compose_services[@]}" || true
+            docker compose down --volumes --remove-orphans
+          done
 
       - name: Adapter Integration
         run: pnpm e2e:integration --filter="$FILTER"
@@ -244,10 +257,16 @@ jobs:
           docker compose logs --no-color "${compose_services[@]}" || true
 
           # Capture container exit and OOM state without masking the test failure.
+          # cspell:ignore pids Pids
           for compose_service in "${compose_services[@]}"; do
             container_id="$(docker compose ps --all --quiet "$compose_service")"
             if [[ -n "$container_id" ]]; then
               docker inspect --format 'name={{.Name}} status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}' "$container_id" || true
+              docker inspect --format 'name={{.Name}} pids_limit={{.HostConfig.PidsLimit}} memory_limit={{.HostConfig.Memory}} memory_swap={{.HostConfig.MemorySwap}}' "$container_id" || true
+              image_id="$(docker inspect --format '{{.Image}}' "$container_id" || true)"
+              if [[ -n "$image_id" ]]; then
+                docker image inspect --format 'image_id={{.Id}} repo_digests={{json .RepoDigests}}' "$image_id" || true
+              fi
             fi
           done
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Retries Docker Compose startup once in the e2e workflow and expands diagnostics to deflake transient container starts. Previously we tried `docker compose up` once; now we reset and retry once before failing.

- On failure of `docker compose up -d --wait --wait-timeout 60`, print `docker compose ps --all` and service logs, attempt `docker compose down --volumes --remove-orphans`, then retry; continue even if cleanup fails (warn only). Fail the job if the second attempt fails.
- After tests, inspect each service container to record status, exit code, OOM state, PID/memory limits, and image repo digests.
- Impact: slightly longer setup only when the first startup fails; no changes to test commands or success paths.

<sup>Written for commit c6bb9a8cdb5aea03867732cf60e7550691e353c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

