### PR TITLE
fix(client): a client with more plugins fits a narrower client type again

### DIFF
--- a/.changeset/hydrate-session-variance.md
+++ b/.changeset/hydrate-session-variance.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-A client created with more plugins is again assignable to a client type declaring fewer plugins, as in 1.6. `hydrateSession` is now declared with method syntax, so its session parameter no longer blocks the assignment.
+A client created with more plugins is again assignable to a client type declaring fewer plugins, as in 1.6.

--- a/.changeset/hydrate-session-variance.md
+++ b/.changeset/hydrate-session-variance.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+A client created with more plugins is again assignable to a client type declaring fewer plugins, as in 1.6. `hydrateSession` is now declared with method syntax, so its session parameter no longer blocks the assignment.

--- a/packages/better-auth/src/client/client.test.ts
+++ b/packages/better-auth/src/client/client.test.ts
@@ -420,10 +420,10 @@ describe("run time proxy", async () => {
 });
 
 describe("type", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10897
+	 */
 	it("keeps a client with more plugins assignable to a client type with fewer plugins", () => {
-		// Regression for #10897: hydrateSession as an arrow-function property
-		// made this check contravariant, so any plugin that widens the session
-		// (admin adds user.banned) broke the assignment.
 		type EmailOtpClient = ReactAuthClient<{
 			plugins: [ReturnType<typeof emailOTPClient>];
 		}>;

--- a/packages/better-auth/src/client/client.test.ts
+++ b/packages/better-auth/src/client/client.test.ts
@@ -17,6 +17,7 @@ import {
 	organizationClient,
 	twoFactorClient,
 } from "./plugins";
+import type { ReactAuthClient } from "./react";
 import { createAuthClient as createReactClient } from "./react";
 import { createAuthClient as createSolidClient } from "./solid";
 import { createAuthClient as createSvelteClient } from "./svelte";
@@ -419,6 +420,19 @@ describe("run time proxy", async () => {
 });
 
 describe("type", () => {
+	it("keeps a client with more plugins assignable to a client type with fewer plugins", () => {
+		// Regression for #10897: hydrateSession as an arrow-function property
+		// made this check contravariant, so any plugin that widens the session
+		// (admin adds user.banned) broke the assignment.
+		type EmailOtpClient = ReactAuthClient<{
+			plugins: [ReturnType<typeof emailOTPClient>];
+		}>;
+		const client = createReactClient({
+			plugins: [emailOTPClient(), adminClient()],
+		});
+		expectTypeOf(client).toMatchTypeOf<EmailOtpClient>();
+	});
+
 	it("should not infer non-action endpoints", () => {
 		const client = createReactClient({
 			plugins: [testClientPlugin()],

--- a/packages/better-auth/src/client/lynx/index.ts
+++ b/packages/better-auth/src/client/lynx/index.ts
@@ -60,12 +60,6 @@ export type LynxAuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			/**
-			 * Method syntax on purpose: TypeScript checks method parameters
-			 * loosely, so a client with more plugins stays assignable to a
-			 * client type declaring fewer. An arrow-function property here
-			 * breaks that (see #10897).
-			 */
 			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: () => {
 				data: ClientSession<Option>;

--- a/packages/better-auth/src/client/lynx/index.ts
+++ b/packages/better-auth/src/client/lynx/index.ts
@@ -60,9 +60,13 @@ export type LynxAuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			hydrateSession: (
-				session: NonNullable<ClientSession<Option>> | null,
-			) => void;
+			/**
+			 * Method syntax on purpose: TypeScript checks method parameters
+			 * loosely, so a client with more plugins stays assignable to a
+			 * client type declaring fewer. An arrow-function property here
+			 * breaks that (see #10897).
+			 */
+			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: () => {
 				data: ClientSession<Option>;
 				isPending: boolean;

--- a/packages/better-auth/src/client/react/index.ts
+++ b/packages/better-auth/src/client/react/index.ts
@@ -60,12 +60,6 @@ export type ReactAuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			/**
-			 * Method syntax on purpose: TypeScript checks method parameters
-			 * loosely, so a client with more plugins stays assignable to a
-			 * client type declaring fewer. An arrow-function property here
-			 * breaks that (see #10897).
-			 */
 			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: () => {
 				data: ClientSession<Option>;

--- a/packages/better-auth/src/client/react/index.ts
+++ b/packages/better-auth/src/client/react/index.ts
@@ -60,9 +60,13 @@ export type ReactAuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			hydrateSession: (
-				session: NonNullable<ClientSession<Option>> | null,
-			) => void;
+			/**
+			 * Method syntax on purpose: TypeScript checks method parameters
+			 * loosely, so a client with more plugins stays assignable to a
+			 * client type declaring fewer. An arrow-function property here
+			 * breaks that (see #10897).
+			 */
+			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: () => {
 				data: ClientSession<Option>;
 				isPending: boolean;

--- a/packages/better-auth/src/client/solid/index.ts
+++ b/packages/better-auth/src/client/solid/index.ts
@@ -61,12 +61,6 @@ export type SolidAuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			/**
-			 * Method syntax on purpose: TypeScript checks method parameters
-			 * loosely, so a client with more plugins stays assignable to a
-			 * client type declaring fewer. An arrow-function property here
-			 * breaks that (see #10897).
-			 */
 			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: () => Accessor<{
 				data: ClientSession<Option>;

--- a/packages/better-auth/src/client/solid/index.ts
+++ b/packages/better-auth/src/client/solid/index.ts
@@ -61,9 +61,13 @@ export type SolidAuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			hydrateSession: (
-				session: NonNullable<ClientSession<Option>> | null,
-			) => void;
+			/**
+			 * Method syntax on purpose: TypeScript checks method parameters
+			 * loosely, so a client with more plugins stays assignable to a
+			 * client type declaring fewer. An arrow-function property here
+			 * breaks that (see #10897).
+			 */
+			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: () => Accessor<{
 				data: ClientSession<Option>;
 				isPending: boolean;

--- a/packages/better-auth/src/client/svelte/index.ts
+++ b/packages/better-auth/src/client/svelte/index.ts
@@ -56,12 +56,6 @@ export type SvelteAuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			/**
-			 * Method syntax on purpose: TypeScript checks method parameters
-			 * loosely, so a client with more plugins stays assignable to a
-			 * client type declaring fewer. An arrow-function property here
-			 * breaks that (see #10897).
-			 */
 			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: () => Atom<{
 				data: ClientSession<Option>;

--- a/packages/better-auth/src/client/svelte/index.ts
+++ b/packages/better-auth/src/client/svelte/index.ts
@@ -56,9 +56,13 @@ export type SvelteAuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			hydrateSession: (
-				session: NonNullable<ClientSession<Option>> | null,
-			) => void;
+			/**
+			 * Method syntax on purpose: TypeScript checks method parameters
+			 * loosely, so a client with more plugins stays assignable to a
+			 * client type declaring fewer. An arrow-function property here
+			 * breaks that (see #10897).
+			 */
+			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: () => Atom<{
 				data: ClientSession<Option>;
 				error: BetterFetchError | null;

--- a/packages/better-auth/src/client/vanilla.ts
+++ b/packages/better-auth/src/client/vanilla.ts
@@ -56,9 +56,13 @@ export type AuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			hydrateSession: (
-				session: NonNullable<ClientSession<Option>> | null,
-			) => void;
+			/**
+			 * Method syntax on purpose: TypeScript checks method parameters
+			 * loosely, so a client with more plugins stays assignable to a
+			 * client type declaring fewer. An arrow-function property here
+			 * breaks that (see #10897).
+			 */
+			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: Atom<{
 				data: ClientSession<Option>;
 				error: BetterFetchError | null;

--- a/packages/better-auth/src/client/vanilla.ts
+++ b/packages/better-auth/src/client/vanilla.ts
@@ -56,12 +56,6 @@ export type AuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			/**
-			 * Method syntax on purpose: TypeScript checks method parameters
-			 * loosely, so a client with more plugins stays assignable to a
-			 * client type declaring fewer. An arrow-function property here
-			 * breaks that (see #10897).
-			 */
 			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: Atom<{
 				data: ClientSession<Option>;

--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -88,9 +88,13 @@ export type VueAuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			hydrateSession: (
-				session: NonNullable<ClientSession<Option>> | null,
-			) => void;
+			/**
+			 * Method syntax on purpose: TypeScript checks method parameters
+			 * loosely, so a client with more plugins stays assignable to a
+			 * client type declaring fewer. An arrow-function property here
+			 * breaks that (see #10897).
+			 */
+			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: VueUseSession<Option>;
 			$Infer: {
 				Session: NonNullable<ClientSession<Option>>;

--- a/packages/better-auth/src/client/vue/index.ts
+++ b/packages/better-auth/src/client/vue/index.ts
@@ -88,12 +88,6 @@ export type VueAuthClient<Option extends BetterAuthClientOptions> =
 	UnionToIntersection<InferResolvedHooks<Option>> &
 		InferClientAPI<Option> &
 		InferActions<Option> & {
-			/**
-			 * Method syntax on purpose: TypeScript checks method parameters
-			 * loosely, so a client with more plugins stays assignable to a
-			 * client type declaring fewer. An arrow-function property here
-			 * breaks that (see #10897).
-			 */
 			hydrateSession(session: NonNullable<ClientSession<Option>> | null): void;
 			useSession: VueUseSession<Option>;
 			$Infer: {


### PR DESCRIPTION
Closes #10897. Option 1 from the issue, as @bytaesu suggested there.

hydrateSession is now declared as a method. TypeScript checks method parameters loosely, so a client with more plugins matches a narrower client type again, like on 1.6. No runtime change.

Added a type test for this. It fails on main and passes here.

I think the portable types plan in #10801 is the longer-term answer to the shared-package problem from the issue. This PR only restores the 1.6 behavior on the 1.7 track.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores 1.6 assignability: clients created with more plugins match narrower client types again by declaring hydrateSession as a method. In 1.7 it was an arrow-function property, which made the session parameter contravariant and broke assignments; this restores the 1.6 behavior with no runtime change.

- Converts hydrateSession to a method in all `better-auth` clients: react, vue, svelte, solid, lynx, and vanilla.
- Adds a type test to ensure a multi-plugin client is assignable to a client type with fewer plugins.
- Patch release to `better-auth`; no migration required.

<sup>Written for commit 8d3d71d4c7f24bc4830543e0ff60b266a017299f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

