### PR TITLE
fix(account): accept serialized account cookie selector

### DIFF
--- a/.changeset/account-info-cookie-query.md
+++ b/.changeset/account-info-cookie-query.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Accept the serialized `useAccountCookie=true` query selector on the `accountInfo` endpoint.

--- a/packages/better-auth/src/api/routes/account.test.ts
+++ b/packages/better-auth/src/api/routes/account.test.ts
@@ -2912,6 +2912,28 @@ describe("account resolution in stateless mode", async () => {
 		expect(info.data).toMatchObject({ accessTokenSeen: "idp-access-token" });
 	});
 
+	it("resolves accountInfo from a serialized useAccountCookie query parameter", async () => {
+		const auth = makeStatelessAuth();
+		const { jar } = await signIn(auth);
+
+		const response = await auth.handler(
+			new Request(
+				"http://localhost:3000/api/auth/account-info?useAccountCookie=true",
+				{ headers: requestHeaders(jar) },
+			),
+		);
+
+		expect(response.status).toBe(200);
+
+		const rejected = await auth.handler(
+			new Request(
+				"http://localhost:3000/api/auth/account-info?useAccountCookie=false",
+				{ headers: requestHeaders(jar) },
+			),
+		);
+		expect(rejected.status).toBe(400);
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/9978
 	 */

--- a/packages/better-auth/src/api/routes/account.ts
+++ b/packages/better-auth/src/api/routes/account.ts
@@ -562,9 +562,12 @@ const accountSelectionSchema = z.union([
 			.optional(),
 	}),
 	z.strictObject({
-		useAccountCookie: z.literal(true).meta({
-			description: "Select the current OAuth account from its signed cookie",
-		}),
+		useAccountCookie: z
+			.literal([true, "true"])
+			.transform(() => true as const)
+			.meta({
+				description: "Select the current OAuth account from its signed cookie",
+			}),
 		userId: z
 			.string()
 			.meta({

--- a/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
+++ b/packages/better-auth/src/plugins/open-api/__snapshots__/open-api.test.ts.snap
@@ -1518,6 +1518,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
                         "description": "Select the current OAuth account from its signed cookie",
                         "enum": [
                           true,
+                          "true",
                         ],
                       },
                       "userId": {
@@ -2659,6 +2660,7 @@ exports[`open-api > should generate OpenAPI schema > openAPISchema 1`] = `
                         "description": "Select the current OAuth account from its signed cookie",
                         "enum": [
                           true,
+                          "true",
                         ],
                       },
                       "userId": {


### PR DESCRIPTION
## Summary

Fix `accountInfo` requests that use `useAccountCookie: true`.

Because `accountInfo` is a GET endpoint, the value reaches the server as the query string `"true"`, which was rejected by `z.literal(true)`.

The selector now accepts both `true` and `"true"`, normalizes them to boolean `true`, and continues to reject false values.

## Testing

- Added HTTP regression coverage for `useAccountCookie=true`
- Verified `useAccountCookie=false` is rejected
- Updated OpenAPI snapshots
- Ran the account and OpenAPI test suites
- Ran `pnpm typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts the serialized `useAccountCookie=true` selector on the `accountInfo` GET endpoint. Previously, the server rejected `?useAccountCookie=true` because the query string `"true"` did not match `z.literal(true)`; now both `true` and `"true"` are accepted, normalized to boolean `true`, and false values remain rejected.

**Review notes**
- Update in `packages/better-auth/src/api/routes/account.ts`: the `accountSelectionSchema` accepts `true` or `"true"` and transforms to boolean `true`; no other selectors changed.
- OpenAPI snapshots updated to include `enum: [true, "true"]`.
- Added regression test for `?useAccountCookie=true` and a rejection test for `?useAccountCookie=false`. No migration or config changes required.

<sup>Written for commit 31fd272c1c0830c7a4b858e3957bc227b8021721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

