### PR TITLE
fix(oauth-provider): treat an empty allowedScopes as no restriction

### DIFF
--- a/.changeset/oauth-provider-empty-allowed-scopes.md
+++ b/.changeset/oauth-provider-empty-allowed-scopes.md
@@ -3,3 +3,5 @@
 ---
 
 Fix a crash on startup when a resource is configured without `allowedScopes` and the Prisma adapter is used. Seeding wrote a null the adapter cannot store in a scalar list column, so init failed before the resource row existed. A resource with no allowlist now stores an empty list and still accepts every requested scope.
+
+An empty `allowedScopes` therefore means "no allowlist" rather than "reject every scope". Set `disabled` on a resource you no longer want tokens issued for.

--- a/.changeset/oauth-provider-empty-allowed-scopes.md
+++ b/.changeset/oauth-provider-empty-allowed-scopes.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Fix a crash on startup when a resource is configured without `allowedScopes` and the Prisma adapter is used. Seeding wrote a null the adapter cannot store in a scalar list column, so init failed before the resource row existed. A resource with no allowlist now stores an empty list and still accepts every requested scope.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1190,6 +1190,8 @@ oauthProvider({
 })
 ```
 
+`allowedScopes` narrows a token to the scopes it shares with that list, and rejects a request sharing none with `invalid_scope`. Omit it to accept any requested scope; use `disabled` to stop issuing for the resource entirely.
+
 Use the admin resource endpoints when resource policy needs to change at runtime.
 
 Dynamic registration can attach protected resources to the new client in the same transaction as the client row. `clientRegistrationDefaultResources` adds server-owned defaults to every registration. `clientRegistrationAllowedResources` lists additional resources a client may request; the effective allowlist is the union of the default and allowed lists. Defaults appear first, duplicates are removed, and every configured value must also be present in `resources`.

--- a/packages/oauth-provider/src/oauthResource/endpoints.test.ts
+++ b/packages/oauth-provider/src/oauthResource/endpoints.test.ts
@@ -145,6 +145,35 @@ describe("resource admin CRUD", () => {
 		expect(fetched.allowedScopes).toEqual(["read"]); // untouched
 	});
 
+	/**
+	 * The body schema accepts `allowedScopes: null`, which a scalar-list
+	 * column cannot store. Clearing the allowlist persists `[]`.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10867
+	 */
+	it("update clearing allowedScopes persists an empty array", async () => {
+		const instance = await boot();
+		const headers = await signedInHeaders(instance);
+		await instance.auth.api.adminCreateOAuthResource({
+			body: {
+				identifier: "https://api.example.com/clear-scopes",
+				allowedScopes: ["read"],
+			},
+			headers,
+		});
+		const updated = (await instance.auth.api.adminUpdateOAuthResource({
+			params: { identifier: "https://api.example.com/clear-scopes" },
+			body: { allowedScopes: null },
+			headers,
+		})) as OAuthResource;
+		expect(updated.allowedScopes).toEqual([]);
+		const fetched = (await instance.auth.api.adminGetOAuthResource({
+			params: { identifier: "https://api.example.com/clear-scopes" },
+			headers,
+		})) as OAuthResource;
+		expect(fetched.allowedScopes).toEqual([]);
+	});
+
 	it("update on a missing identifier returns 404", async () => {
 		const instance = await boot();
 		const headers = await signedInHeaders(instance);

--- a/packages/oauth-provider/src/oauthResource/endpoints.ts
+++ b/packages/oauth-provider/src/oauthResource/endpoints.ts
@@ -107,7 +107,7 @@ function buildResourceRow(input: OAuthResourceInput, now: Date) {
 		refreshTokenTtl: input.refreshTokenTtl ?? null,
 		signingAlgorithm: input.signingAlgorithm ?? null,
 		signingKeyId: input.signingKeyId ?? null,
-		allowedScopes: input.allowedScopes ?? null,
+		allowedScopes: input.allowedScopes ?? [],
 		customClaims: input.customClaims ?? null,
 		dpopBoundAccessTokensRequired: input.dpopBoundAccessTokensRequired ?? false,
 		disabled: input.disabled ?? false,
@@ -238,6 +238,7 @@ export async function updateResourceEndpoint(
 			update[key] = ctx.body[key];
 		}
 	}
+	if (update.allowedScopes === null) update.allowedScopes = [];
 
 	await ctx.context.adapter.update<OAuthResource>({
 		model: resourceModel(opts),

--- a/packages/oauth-provider/src/resources.test.ts
+++ b/packages/oauth-provider/src/resources.test.ts
@@ -129,8 +129,27 @@ describe("seedResources (integration via plugin init)", () => {
 			policyVersion: 1,
 			accessTokenTtl: null,
 			signingAlgorithm: null,
-			allowedScopes: null,
+			allowedScopes: [],
 		});
+	});
+
+	/**
+	 * Seeding must not write null into `allowedScopes`: the Prisma adapter
+	 * maps it to a non-nullable scalar list and rejects the insert, which
+	 * crashed init before the first resource row existed.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10867
+	 */
+	it("seeds allowedScopes as an array, never null", async () => {
+		const { auth } = await bootWithResourcesOption({
+			resources: ["https://api.example.com/no-allowlist"],
+		});
+		const row = await readResource(
+			auth,
+			"https://api.example.com/no-allowlist",
+		);
+		expect(row?.allowedScopes).toEqual([]);
+		expect(row?.allowedScopes).not.toBeNull();
 	});
 
 	it("seeds object-form `resources` entries with explicit policy", async () => {
@@ -257,7 +276,7 @@ describe("seedResources (integration via plugin init)", () => {
 		expect(row).toMatchObject({
 			name: identifier, // overwrite uses identifier as default name
 			accessTokenTtl: 120,
-			allowedScopes: null, // cleared
+			allowedScopes: [], // cleared
 		});
 	});
 });

--- a/packages/oauth-provider/src/resources.ts
+++ b/packages/oauth-provider/src/resources.ts
@@ -740,7 +740,8 @@ export function collectResourceInputs(
 /**
  * Builds the row payload sent to the adapter for a seed insert. All policy
  * columns default to `null` (= inherit plugin default at issuance time)
- * when the input doesn't specify a value.
+ * when the input doesn't specify a value, except `allowedScopes`, which
+ * defaults to `[]` since a scalar list cannot hold null.
  */
 function buildSeedRow(input: OAuthResourceInput, now: Date) {
 	return {
@@ -765,7 +766,7 @@ function buildSeedRow(input: OAuthResourceInput, now: Date) {
  * Builds the partial update payload when re-seeding an existing row.
  *
  * - `overwrite` mode replaces every policy column with the input value
- *   (omitted fields fall back to `null` to clear stale state).
+ *   (omitted fields are cleared: `null`, or `[]` for `allowedScopes`).
  * - `merge` mode updates only fields present in the input — admin edits to
  *   other fields are preserved.
  */

--- a/packages/oauth-provider/src/resources.ts
+++ b/packages/oauth-provider/src/resources.ts
@@ -195,7 +195,7 @@ export interface ResolvedResourcePolicy {
 	 * resource's `allowedScopes`. When no requested resource defines an
 	 * allowlist, equals `requestedScopes` unchanged.
 	 *
-	 * - A resource with `allowedScopes: null` is treated as "no restriction"
+	 * - A resource with an empty `allowedScopes` is treated as "no restriction"
 	 *   for that resource (other resources' allowlists still apply).
 	 * - A resource whose allowlist excludes every requested scope causes
 	 *   {@link resolveResourcePolicy} to throw `invalid_scope`.
@@ -409,17 +409,18 @@ export async function resolveResourcePolicy(
 	// not a gate.
 	//
 	// Algorithm:
-	//   - For each requested resource with a non-null allowlist, retain only
-	//     the requested scopes that are members of that resource's allowlist.
+	//   - For each requested resource with an allowlist, retain only the
+	//     requested scopes that are members of that resource's allowlist.
 	//   - A resource whose allowlist excludes every requested scope still
 	//     fails closed with `invalid_scope` for that resource (the caller
 	//     would otherwise mint a token with no scopes for a resource that
 	//     refuses all of them).
-	//   - Resources with a null allowlist contribute no narrowing (treated as
-	//     "any requested scope is acceptable here").
+	//   - An empty allowlist means "no allowlist", not "deny everything": a
+	//     Prisma scalar list cannot hold null, so a resource seeded without
+	//     one reads back as `[]`. Use `disabled` to stop issuance.
 	let effectiveScopes: string[] = [...params.requestedScopes];
 	for (const row of resolved) {
-		if (row.allowedScopes === null || row.allowedScopes === undefined) {
+		if (!row.allowedScopes?.length) {
 			continue;
 		}
 		const allowed = new Set(row.allowedScopes);
@@ -749,7 +750,7 @@ function buildSeedRow(input: OAuthResourceInput, now: Date) {
 		refreshTokenTtl: input.refreshTokenTtl ?? null,
 		signingAlgorithm: input.signingAlgorithm ?? null,
 		signingKeyId: input.signingKeyId ?? null,
-		allowedScopes: input.allowedScopes ?? null,
+		allowedScopes: input.allowedScopes ?? [],
 		customClaims: input.customClaims ?? null,
 		dpopBoundAccessTokensRequired: input.dpopBoundAccessTokensRequired ?? false,
 		disabled: input.disabled ?? false,

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1550,8 +1550,7 @@ export interface OAuthResource {
 	/**
 	 * When non-empty, requested scopes must intersect this set or the request
 	 * is rejected with `invalid_scope`. Empty (`[]` or `null`) applies no
-	 * restriction rather than inheriting a plugin default; use `disabled` to
-	 * stop issuance.
+	 * restriction; use `disabled` to stop issuance.
 	 */
 	allowedScopes?: string[] | null;
 	/**

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1548,8 +1548,8 @@ export interface OAuthResource {
 	signingAlgorithm?: JWSAlgorithms | null;
 	signingKeyId?: string | null;
 	/**
-	 * When non-null, requested scopes must intersect this set or the request is
-	 * rejected with `invalid_scope`.
+	 * When non-empty, requested scopes must intersect this set or the request
+	 * is rejected with `invalid_scope`. Empty means no restriction.
 	 */
 	allowedScopes?: string[] | null;
 	/**

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -1549,7 +1549,9 @@ export interface OAuthResource {
 	signingKeyId?: string | null;
 	/**
 	 * When non-empty, requested scopes must intersect this set or the request
-	 * is rejected with `invalid_scope`. Empty means no restriction.
+	 * is rejected with `invalid_scope`. Empty (`[]` or `null`) applies no
+	 * restriction rather than inheriting a plugin default; use `disabled` to
+	 * stop issuance.
 	 */
 	allowedScopes?: string[] | null;
 	/**

--- a/packages/oauth-provider/src/validation-flow.test.ts
+++ b/packages/oauth-provider/src/validation-flow.test.ts
@@ -298,6 +298,31 @@ describe("resolveResourcePolicy — entity path", () => {
 		expect(policy.audienceClaim).toBe(id);
 	});
 
+	/**
+	 * A Prisma scalar list column cannot hold null, so a resource seeded
+	 * without an allowlist reads back as `[]`. That must stay "no
+	 * restriction" rather than refusing every scope.
+	 *
+	 * @see https://github.com/better-auth/better-auth/issues/10867
+	 */
+	it("treats an empty allowedScopes as 'no restriction'", async () => {
+		const id = "https://api.example.com/empty-allowlist";
+		const { ctx, opts } = await bootProvider({
+			resources: [id],
+		});
+		await ctx.adapter.update({
+			model: "oauthResource",
+			where: [{ field: "identifier", value: id }],
+			update: { allowedScopes: [] },
+		});
+		const policy = await resolveResourcePolicy(fakeEndpointCtx(ctx), opts, {
+			resource: id,
+			clientId: "client-x",
+			requestedScopes: ["read", "write", "anything"],
+		});
+		expect(policy.effectiveScopes).toEqual(["read", "write", "anything"]);
+	});
+
 	it("returns single-resource signing config", async () => {
 		const id = "https://api.example.com/signed";
 		const { ctx, opts } = await bootProvider({


### PR DESCRIPTION
## Summary

A resource configured without `allowedScopes` was seeded with an explicit `null`. The Prisma adapter maps `string[]` to a scalar list, which cannot be null, so `create()` rejected the row and init crashed before the first resource existed. Every string-form entry in `resources` hits this, since `collectResourceInputs` normalizes it to `{ identifier }`.

Seeding `[]` instead is not enough on its own. `resolveResourcePolicy` treated any non-null allowlist as a narrowing filter, so an empty one intersected to nothing and failed closed with `invalid_scope`, refusing every token for that resource. A Prisma scalar list reads back as `[]` whether or not it was written that way, so a resource with no allowlist was already taking that path.

- `resolveResourcePolicy` treats an empty `allowedScopes` as "no allowlist", alongside `null` and `undefined`. `disabled` remains the way to stop issuance.
- Both row builders seed `allowedScopes` as `[]`, keeping the seed and admin-CRUD paths writing identical rows.
- The admin PATCH normalizes an explicit `allowedScopes: null` to `[]`, since the endpoint schema accepts null.
- Adds regression tests for both halves, and documents the field's semantics, which were previously only in source comments.

Rows that already hold SQL `NULL` keep resolving as unrestricted, so no backfill is needed.

This is not a fix for #10887, which reports the same seed running inside `init`. The lazy path shares `buildSeedRow`, so moving the seed changes when the insert runs, not what it writes.

Closes #10867

## Testing

- `pnpm vitest packages/oauth-provider packages/mcp --run`
- `pnpm typecheck`

Both regression tests were confirmed to fail with the fix reverted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup crash in `@better-auth/oauth-provider` and treats an empty `allowedScopes` as no restriction. Previously, seeding wrote null into a scalar-list column that Prisma rejects, and an empty list denied all scopes with `invalid_scope`; now empty or missing allowlists don't narrow scopes.

- Seeding and create write `allowedScopes: []`; the admin PATCH normalizes `allowedScopes: null` to `[]`; overwrite clears to `[]`.
- Policy resolution skips empty allowlists; keep using `disabled` to stop token issuance.
- Docs and tests cover the new contract; no backfill needed since existing SQL NULL rows stay unrestricted.
- If you previously used `[]` to block tokens, set `disabled: true` instead.

Closes #10867.

<sup>Written for commit a1731cfd6a29ed49a739b7dbe540f2fd21c10aff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

