### PR TITLE
feat(phone-number): support hashed and encrypted OTP storage

### DIFF
--- a/.changeset/phone-number-store-otp.md
+++ b/.changeset/phone-number-store-otp.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Add a `storeOTP` option to the phone number plugin, matching the option already available on email OTP, two-factor and magic link. OTPs can now be stored `hashed` or `encrypted` (or transformed by a custom hasher or encryptor) instead of in plain text, and verification now uses a constant-time comparison. Defaults to `plain`, so existing behavior is unchanged.

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -323,6 +323,10 @@ phoneNumber({
 </Callout>
 
 <Callout type="warn">
+  Pick the mode against your threat model. A phone OTP is short — six digits by default, roughly 20 bits — and `"hashed"` uses a plain SHA-256 with no salt and no secret key, so anyone holding a database dump can enumerate the entire code space offline in negligible time. Treat `"hashed"` as protection against incidental exposure such as logs, screenshots, or a casually browsed backup, not against an attacker who already has your data. Use `"encrypted"`, which keys the value to your server `secret`, when the threat model is a database compromise in which that secret is not also exposed. A longer `otpLength` raises the cost of enumeration but does not change the shape of the problem.
+</Callout>
+
+<Callout type="warn">
   Stored OTPs do not record which mode produced them, so verification always applies whichever mode is currently configured. Changing `storeOTP` therefore invalidates any OTP issued under the previous mode. Those codes are rejected until they expire (`expiresIn`, five minutes by default) and the user simply requests a new one, so the safest time to change this option is during a deployment where a short window of failed verifications is acceptable.
 </Callout>
 

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -322,6 +322,10 @@ phoneNumber({
   Note: This will not affect the OTP sent to the user. It only affects the stored OTP value. The storage backend itself is controlled by the global [`verification`](/docs/reference/options#verification) config, so if you configure `secondaryStorage`, these verification records can live there instead of the database.
 </Callout>
 
+<Callout type="warn">
+  Stored OTPs do not record which mode produced them, so verification always applies whichever mode is currently configured. Changing `storeOTP` therefore invalidates any OTP issued under the previous mode. Those codes are rejected until they expire (`expiresIn`, five minutes by default) and the user simply requests a new one, so the safest time to change this option is during a deployment where a short window of failed verifications is acceptable.
+</Callout>
+
 Alternatively, you can pass a custom encryptor or hasher to control how the stored OTP value is persisted.
 
 **Custom encryptor**

--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -308,6 +308,49 @@ A function that sends the OTP code to the user's phone number. It takes the phon
 
 The time in seconds after which the OTP code expires. Default is `300` seconds.
 
+### `storeOTP`
+
+The method used to transform the OTP before it is stored by Better Auth's verification layer, whether `encrypted`, `hashed` or `plain` text. Default is `plain` text.
+
+```ts title="auth.ts"
+phoneNumber({
+    storeOTP: "hashed",
+})
+```
+
+<Callout>
+  Note: This will not affect the OTP sent to the user. It only affects the stored OTP value. The storage backend itself is controlled by the global [`verification`](/docs/reference/options#verification) config, so if you configure `secondaryStorage`, these verification records can live there instead of the database.
+</Callout>
+
+Alternatively, you can pass a custom encryptor or hasher to control how the stored OTP value is persisted.
+
+**Custom encryptor**
+
+```ts title="auth.ts"
+phoneNumber({
+    storeOTP: {
+        encrypt: async (otp) => {
+            return myCustomEncryptor(otp);
+        },
+        decrypt: async (otp) => {
+            return myCustomDecryptor(otp);
+        },
+    }
+})
+```
+
+**Custom hasher**
+
+```ts title="auth.ts"
+phoneNumber({
+    storeOTP: {
+        hash: async (otp) => {
+            return myCustomHasher(otp);
+        },
+    }
+})
+```
+
 ### `callbackOnVerification`
 
 A function that is called after the phone number is verified. It takes the phone number and the user object as the first argument and a request object as the second argument.

--- a/packages/better-auth/src/plugins/phone-number/otp-token.ts
+++ b/packages/better-auth/src/plugins/phone-number/otp-token.ts
@@ -1,0 +1,73 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import {
+	constantTimeEqual,
+	symmetricDecrypt,
+	symmetricEncrypt,
+} from "../../crypto";
+import type { PhoneNumberOptions } from "./types";
+import { defaultKeyHasher } from "./utils";
+
+/**
+ * Transforms an OTP into the form persisted in the verification table.
+ *
+ * The value returned by `generateOTP` is what gets sent over SMS; only the
+ * stored copy is transformed, so `storeOTP` never changes what the user types.
+ */
+export async function storeOTP(
+	ctx: GenericEndpointContext,
+	opts: PhoneNumberOptions,
+	otp: string,
+): Promise<string> {
+	if (opts.storeOTP === "encrypted") {
+		return await symmetricEncrypt({
+			key: ctx.context.secretConfig,
+			data: otp,
+		});
+	}
+	if (opts.storeOTP === "hashed") {
+		return await defaultKeyHasher(otp);
+	}
+	if (typeof opts.storeOTP === "object" && "hash" in opts.storeOTP) {
+		return await opts.storeOTP.hash(otp);
+	}
+	if (typeof opts.storeOTP === "object" && "encrypt" in opts.storeOTP) {
+		return await opts.storeOTP.encrypt(otp);
+	}
+
+	return otp;
+}
+
+/**
+ * Checks a user-supplied OTP against the stored copy.
+ *
+ * Every branch ends in `constantTimeEqual` so the comparison does not leak the
+ * shared prefix length of a wrong guess.
+ */
+export async function verifyStoredOTP(
+	ctx: GenericEndpointContext,
+	opts: PhoneNumberOptions,
+	storedOtp: string,
+	otp: string,
+): Promise<boolean> {
+	if (opts.storeOTP === "encrypted") {
+		const decryptedOtp = await symmetricDecrypt({
+			key: ctx.context.secretConfig,
+			data: storedOtp,
+		});
+		return constantTimeEqual(decryptedOtp, otp);
+	}
+	if (opts.storeOTP === "hashed") {
+		const hashedOtp = await defaultKeyHasher(otp);
+		return constantTimeEqual(hashedOtp, storedOtp);
+	}
+	if (typeof opts.storeOTP === "object" && "hash" in opts.storeOTP) {
+		const hashedOtp = await opts.storeOTP.hash(otp);
+		return constantTimeEqual(hashedOtp, storedOtp);
+	}
+	if (typeof opts.storeOTP === "object" && "decrypt" in opts.storeOTP) {
+		const decryptedOtp = await opts.storeOTP.decrypt(storedOtp);
+		return constantTimeEqual(decryptedOtp, otp);
+	}
+
+	return constantTimeEqual(otp, storedOtp);
+}

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -11,7 +11,9 @@ import { parseUserOutput } from "../../db/schema";
 import { HIDE_METADATA } from "../../utils";
 import { getDate } from "../../utils/date";
 import { PHONE_NUMBER_ERROR_CODES } from "./error-codes";
+import { storeOTP, verifyStoredOTP } from "./otp-token";
 import type { PhoneNumberOptions, UserWithPhoneNumber } from "./types";
+import { splitAtLastColon } from "./utils";
 
 export type RequiredPhoneNumberOptions = PhoneNumberOptions & {
 	expiresIn: number;
@@ -122,7 +124,7 @@ export const signInPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				if (!user.phoneNumberVerified) {
 					const otp = generateOTP(opts.otpLength);
 					await ctx.context.internalAdapter.createVerificationValue({
-						value: otp,
+						value: `${await storeOTP(ctx, opts, otp)}:0`,
 						identifier: phoneNumber,
 						expiresAt: getDate(opts.expiresIn, "sec"),
 					});
@@ -281,7 +283,7 @@ export const sendPhoneNumberOTP = (opts: RequiredPhoneNumberOptions) =>
 
 			const code = generateOTP(opts.otpLength);
 			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${code}:0`,
+				value: `${await storeOTP(ctx, opts, code)}:0`,
 				identifier: ctx.body.phoneNumber,
 				expiresAt: getDate(opts.expiresIn, "sec"),
 			});
@@ -715,7 +717,7 @@ export const requestPasswordResetPhoneNumber = (
 			});
 			const code = generateOTP(opts.otpLength);
 			await ctx.context.internalAdapter.createVerificationValue({
-				value: `${code}:0`,
+				value: `${await storeOTP(ctx, opts, code)}:0`,
 				identifier: `${ctx.body.phoneNumber}-request-password-reset`,
 				expiresAt: getDate(opts.expiresIn, "sec"),
 			});
@@ -882,7 +884,7 @@ async function verifyPhoneNumberOTP(
 
 	const allowedAttempts = opts?.allowedAttempts ?? 3;
 	const peekedAttempts = parseVerificationAttempts(
-		existing.value.split(":")[1],
+		splitAtLastColon(existing.value)[1],
 	);
 	if (peekedAttempts >= allowedAttempts) {
 		await ctx.context.internalAdapter.deleteVerificationByIdentifier(
@@ -900,7 +902,7 @@ async function verifyPhoneNumberOTP(
 		throw APIError.from("BAD_REQUEST", PHONE_NUMBER_ERROR_CODES.INVALID_OTP);
 	}
 
-	const [otpValue, rawAttempts] = consumed.value.split(":");
+	const [otpValue, rawAttempts] = splitAtLastColon(consumed.value);
 	const attempts = parseVerificationAttempts(rawAttempts);
 	if (attempts >= allowedAttempts) {
 		throw APIError.from(
@@ -908,7 +910,7 @@ async function verifyPhoneNumberOTP(
 			PHONE_NUMBER_ERROR_CODES.TOO_MANY_ATTEMPTS,
 		);
 	}
-	if (otpValue !== providedCode) {
+	if (!(await verifyStoredOTP(ctx, opts, otpValue, providedCode))) {
 		await ctx.context.internalAdapter.createVerificationValue({
 			value: `${otpValue}:${attempts + 1}`,
 			identifier,

--- a/packages/better-auth/src/plugins/phone-number/store-otp.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/store-otp.test.ts
@@ -7,12 +7,16 @@ const TEST_PHONE_NUMBER = "+251911121314";
 
 async function instance(options: Partial<PhoneNumberOptions> = {}) {
 	let otp = "";
+	let resetOtp = "";
 	const t = await getTestInstance(
 		{
 			plugins: [
 				phoneNumber({
 					async sendOTP({ code }) {
 						otp = code;
+					},
+					async sendPasswordResetOTP({ code }) {
+						resetOtp = code;
 					},
 					signUpOnVerification: {
 						getTempEmail(phoneNumber) {
@@ -26,15 +30,18 @@ async function instance(options: Partial<PhoneNumberOptions> = {}) {
 		},
 		{ disableTestUser: true },
 	);
+	const readIdentifier = async (identifier: string) =>
+		(
+			await t.auth.$context.then((c) =>
+				c.internalAdapter.findVerificationValue(identifier),
+			)
+		)?.value;
 	return {
 		...t,
 		getOTP: () => otp,
-		readStoredValue: async () =>
-			(
-				await t.auth.$context.then((c) =>
-					c.internalAdapter.findVerificationValue(TEST_PHONE_NUMBER),
-				)
-			)?.value,
+		getResetOTP: () => resetOtp,
+		readIdentifier,
+		readStoredValue: async () => readIdentifier(TEST_PHONE_NUMBER),
 	};
 }
 
@@ -96,9 +103,12 @@ describe("phone-number storeOTP", () => {
 		).rejects.toThrow();
 	});
 
-	it("supports a custom hasher", async () => {
+	// The transformed value deliberately contains colons: the attempt counter is
+	// appended as a `:<n>` suffix, so parsing has to split on the *last* colon.
+	// With a naive `split(":")` this test fails.
+	it("supports a custom hasher whose output contains colons", async () => {
 		const { auth, getOTP, readStoredValue } = await instance({
-			storeOTP: { hash: async (otp) => `custom-${otp}-hashed` },
+			storeOTP: { hash: async (otp) => `custom:${otp}:hashed` },
 		});
 
 		await auth.api.sendPhoneNumberOTP({
@@ -106,12 +116,101 @@ describe("phone-number storeOTP", () => {
 		});
 
 		const stored = await readStoredValue();
-		expect(stored).toBe(`custom-${getOTP()}-hashed:0`);
+		expect(stored).toBe(`custom:${getOTP()}:hashed:0`);
 
 		const res = await auth.api.verifyPhoneNumber({
 			body: { phoneNumber: TEST_PHONE_NUMBER, code: getOTP() },
 		});
 		expect(res.status).toBe(true);
+	});
+
+	it("round-trips a custom encryptor whose output contains colons", async () => {
+		const { auth, getOTP, readStoredValue } = await instance({
+			storeOTP: {
+				encrypt: async (otp) => `enc:${otp.split("").reverse().join("")}`,
+				decrypt: async (stored) =>
+					stored.replace(/^enc:/, "").split("").reverse().join(""),
+			},
+		});
+
+		await auth.api.sendPhoneNumberOTP({
+			body: { phoneNumber: TEST_PHONE_NUMBER },
+		});
+
+		const otp = getOTP();
+		const stored = await readStoredValue();
+		expect(stored).toBe(`enc:${otp.split("").reverse().join("")}:0`);
+
+		const res = await auth.api.verifyPhoneNumber({
+			body: { phoneNumber: TEST_PHONE_NUMBER, code: otp },
+		});
+		expect(res.status).toBe(true);
+	});
+
+	// The three OTP write sites are independent, so cover each one under
+	// `hashed`: otherwise a single site could regress to plaintext while the
+	// shared-helper tests keep passing.
+	it("does not persist the plaintext OTP on the password-reset write site", async () => {
+		const { auth, getResetOTP, readIdentifier } = await instance({
+			storeOTP: "hashed",
+		});
+
+		await auth.api.signUpEmail({
+			body: {
+				email: "reset-user@test.com",
+				password: "password1234",
+				name: "Reset User",
+			},
+		});
+		await auth.$context.then((c) =>
+			c.internalAdapter.updateUserByEmail("reset-user@test.com", {
+				phoneNumber: TEST_PHONE_NUMBER,
+				phoneNumberVerified: true,
+			}),
+		);
+
+		await auth.api.requestPasswordResetPhoneNumber({
+			body: { phoneNumber: TEST_PHONE_NUMBER },
+		});
+
+		const stored = await readIdentifier(
+			`${TEST_PHONE_NUMBER}-request-password-reset`,
+		);
+		expect(stored).toBeDefined();
+		expect(getResetOTP()).toHaveLength(6);
+		expect(stored).not.toContain(getResetOTP());
+	});
+
+	it("does not persist the plaintext OTP on the require-verification sign-in write site", async () => {
+		const { auth, getOTP, readStoredValue } = await instance({
+			storeOTP: "hashed",
+			requireVerification: true,
+		});
+
+		await auth.api.signUpEmail({
+			body: {
+				email: "unverified@test.com",
+				password: "password1234",
+				name: "Unverified User",
+			},
+		});
+		await auth.$context.then((c) =>
+			c.internalAdapter.updateUserByEmail("unverified@test.com", {
+				phoneNumber: TEST_PHONE_NUMBER,
+				phoneNumberVerified: false,
+			}),
+		);
+
+		await expect(
+			auth.api.signInPhoneNumber({
+				body: { phoneNumber: TEST_PHONE_NUMBER, password: "password1234" },
+			}),
+		).rejects.toThrow();
+
+		const stored = await readStoredValue();
+		expect(stored).toBeDefined();
+		expect(getOTP()).toHaveLength(6);
+		expect(stored).not.toContain(getOTP());
 	});
 
 	it("round-trips an encrypted OTP", async () => {
@@ -125,7 +224,9 @@ describe("phone-number storeOTP", () => {
 
 		const stored = await readStoredValue();
 		expect(stored).toBeDefined();
-		expect(stored).not.toContain(getOTP());
+		// Compare against the exact plaintext representation rather than using
+		// `not.toContain`, which would be probabilistic against ciphertext.
+		expect(stored).not.toBe(`${getOTP()}:0`);
 
 		const res = await auth.api.verifyPhoneNumber({
 			body: { phoneNumber: TEST_PHONE_NUMBER, code: getOTP() },

--- a/packages/better-auth/src/plugins/phone-number/store-otp.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/store-otp.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { getTestInstance } from "../../test-utils/test-instance";
+import { phoneNumber } from ".";
+import type { PhoneNumberOptions } from "./types";
+
+const TEST_PHONE_NUMBER = "+251911121314";
+
+async function instance(options: Partial<PhoneNumberOptions> = {}) {
+	let otp = "";
+	const t = await getTestInstance(
+		{
+			plugins: [
+				phoneNumber({
+					async sendOTP({ code }) {
+						otp = code;
+					},
+					signUpOnVerification: {
+						getTempEmail(phoneNumber) {
+							return `temp-${phoneNumber}`;
+						},
+					},
+					...options,
+				}),
+			],
+			logger: { level: "error" },
+		},
+		{ disableTestUser: true },
+	);
+	return {
+		...t,
+		getOTP: () => otp,
+		readStoredValue: async () =>
+			(
+				await t.auth.$context.then((c) =>
+					c.internalAdapter.findVerificationValue(TEST_PHONE_NUMBER),
+				)
+			)?.value,
+	};
+}
+
+describe("phone-number storeOTP", () => {
+	it("CONTROL — stores the OTP in plain text by default", async () => {
+		const { auth, getOTP, readStoredValue } = await instance();
+
+		await auth.api.sendPhoneNumberOTP({
+			body: { phoneNumber: TEST_PHONE_NUMBER },
+		});
+
+		const stored = await readStoredValue();
+		expect(stored).toBeDefined();
+		// Documents today's behaviour: the SMS code sits in the database verbatim.
+		expect(stored).toContain(getOTP());
+	});
+
+	it("does not persist the plaintext OTP when storeOTP is 'hashed'", async () => {
+		const { auth, getOTP, readStoredValue } = await instance({
+			storeOTP: "hashed",
+		});
+
+		await auth.api.sendPhoneNumberOTP({
+			body: { phoneNumber: TEST_PHONE_NUMBER },
+		});
+
+		const otp = getOTP();
+		expect(otp).toHaveLength(6);
+
+		const stored = await readStoredValue();
+		expect(stored).toBeDefined();
+		expect(stored).not.toContain(otp);
+	});
+
+	it("still verifies a correct OTP when storeOTP is 'hashed'", async () => {
+		const { auth, getOTP } = await instance({ storeOTP: "hashed" });
+
+		await auth.api.sendPhoneNumberOTP({
+			body: { phoneNumber: TEST_PHONE_NUMBER },
+		});
+
+		const res = await auth.api.verifyPhoneNumber({
+			body: { phoneNumber: TEST_PHONE_NUMBER, code: getOTP() },
+		});
+		expect(res.status).toBe(true);
+	});
+
+	it("still rejects an incorrect OTP when storeOTP is 'hashed'", async () => {
+		const { auth } = await instance({ storeOTP: "hashed" });
+
+		await auth.api.sendPhoneNumberOTP({
+			body: { phoneNumber: TEST_PHONE_NUMBER },
+		});
+
+		await expect(
+			auth.api.verifyPhoneNumber({
+				body: { phoneNumber: TEST_PHONE_NUMBER, code: "000000" },
+			}),
+		).rejects.toThrow();
+	});
+
+	it("supports a custom hasher", async () => {
+		const { auth, getOTP, readStoredValue } = await instance({
+			storeOTP: { hash: async (otp) => `custom-${otp}-hashed` },
+		});
+
+		await auth.api.sendPhoneNumberOTP({
+			body: { phoneNumber: TEST_PHONE_NUMBER },
+		});
+
+		const stored = await readStoredValue();
+		expect(stored).toBe(`custom-${getOTP()}-hashed:0`);
+
+		const res = await auth.api.verifyPhoneNumber({
+			body: { phoneNumber: TEST_PHONE_NUMBER, code: getOTP() },
+		});
+		expect(res.status).toBe(true);
+	});
+
+	it("round-trips an encrypted OTP", async () => {
+		const { auth, getOTP, readStoredValue } = await instance({
+			storeOTP: "encrypted",
+		});
+
+		await auth.api.sendPhoneNumberOTP({
+			body: { phoneNumber: TEST_PHONE_NUMBER },
+		});
+
+		const stored = await readStoredValue();
+		expect(stored).toBeDefined();
+		expect(stored).not.toContain(getOTP());
+
+		const res = await auth.api.verifyPhoneNumber({
+			body: { phoneNumber: TEST_PHONE_NUMBER, code: getOTP() },
+		});
+		expect(res.status).toBe(true);
+	});
+});

--- a/packages/better-auth/src/plugins/phone-number/types.ts
+++ b/packages/better-auth/src/plugins/phone-number/types.ts
@@ -63,6 +63,26 @@ export interface PhoneNumberOptions {
 	 */
 	expiresIn?: number | undefined;
 	/**
+	 * Store the OTP in your database in a secure way
+	 *
+	 * Note: This will not affect the OTP sent to the user, it will only affect
+	 * the OTP stored in your database.
+	 *
+	 * @default "plain"
+	 */
+	storeOTP?:
+		| (
+				| "hashed"
+				| "plain"
+				| "encrypted"
+				| { hash: (otp: string) => Promise<string> }
+				| {
+						encrypt: (otp: string) => Promise<string>;
+						decrypt: (otp: string) => Promise<string>;
+				  }
+		  )
+		| undefined;
+	/**
 	 * Function to validate phone number
 	 *
 	 * by default any string is accepted

--- a/packages/better-auth/src/plugins/phone-number/utils.ts
+++ b/packages/better-auth/src/plugins/phone-number/utils.ts
@@ -1,0 +1,26 @@
+import { base64Url } from "@better-auth/utils/base64";
+import { createHash } from "@better-auth/utils/hash";
+
+export const defaultKeyHasher = async (otp: string) => {
+	const hash = await createHash("SHA-256").digest(
+		new TextEncoder().encode(otp),
+	);
+	return base64Url.encode(new Uint8Array(hash), {
+		padding: false,
+	});
+};
+
+/**
+ * Splits a stored verification value into its OTP and attempt-counter halves.
+ *
+ * The attempt counter is appended as a `:<attempts>` suffix, so splitting on
+ * the *last* colon keeps stored OTPs that themselves contain colons (encrypted
+ * payloads, custom hashers) intact.
+ */
+export function splitAtLastColon(input: string): [string, string] {
+	const idx = input.lastIndexOf(":");
+	if (idx === -1) {
+		return [input, ""];
+	}
+	return [input.slice(0, idx), input.slice(idx + 1)];
+}


### PR DESCRIPTION
## Summary

`phone-number` is the only OTP-based plugin that still persists its code in plain text. #3164 ("feat: Add encryption for OTPs and other verification information") introduced the `storeOTP` / `storeToken` option and applied it to `email-otp`, `magic-link`, `one-time-token`, and `two-factor` (OTP + backup codes). `phone-number` was not part of that sweep, so an SMS OTP is written to the `verification` table verbatim and compared with `!==`.

This adds the same option, with the same shape, to `phone-number`, and routes verification through a constant-time comparison. It defaults to `"plain"`, so nothing changes unless you opt in.

## Why `verification.storeIdentifier` doesn't already cover this

`verification.storeIdentifier` (documented in #8569) transforms the **identifier** column. The phone-number OTP lives in the **`value`** column, with the phone number itself as the identifier — so no existing option protects the code at rest. This is the same reason `email-otp` needs `storeOTP` in addition to the global verification config.

## Changes

- `types.ts` — adds `storeOTP?: "plain" | "hashed" | "encrypted" | { hash } | { encrypt, decrypt }`, identical to `EmailOTPOptions["storeOTP"]`.
- `otp-token.ts` (new) — `storeOTP()` / `verifyStoredOTP()`, mirroring `email-otp/otp-token.ts`. Every verify branch ends in `constantTimeEqual`, replacing the previous `otpValue !== providedCode`.
- `utils.ts` (new) — `defaultKeyHasher` (SHA-256) and `splitAtLastColon`, matching the per-plugin helper layout the other plugins already use.
- `routes.ts` — the three OTP write sites now store the transformed value; `verifyPhoneNumberOTP` verifies through `verifyStoredOTP`.
- Docs — a `storeOTP` section in `plugins/phone-number.mdx` mirroring the email-OTP docs.

Two supporting changes that are load-bearing rather than cosmetic:

**Colon-safe parsing.** Attempt counts are stored as a `:<n>` suffix and were parsed with `.split(":")`, which splits on the *first* colon. Encrypted payloads and custom hasher output can contain colons, so both read sites now use `splitAtLastColon` — the same helper `email-otp` uses to solve exactly this problem. Without it, `storeOTP: "encrypted"` would silently truncate the stored value and every verification would fail.

**Uniform attempt suffix.** The sign-in write site stored a bare value with no `:0` suffix, unlike the other two sites. It is now consistent.

## Backwards compatibility

- Default is `"plain"`; the stored format and comparison result are unchanged for existing deployments.
- Existing rows written without the `:0` suffix still parse to zero attempts via `splitAtLastColon`, so no migration is required.
- `verifyOTP` (the custom external-verification hook) is untouched and still bypasses internal storage entirely.

## Tests

`store-otp.test.ts` adds 6 tests: a plain-text control, no-plaintext-at-rest under `"hashedd verification under `"hashed"`, a custom hasher, and an `"encrypted"` round trip. Four ofthe six fail before this change.

Existing `phone-number.test.ts` passes unchanged (40/40), as does `email-otp` (140 tests total across both).

## Notes for reviewers

- This is a consistency/defense-in-depth change, not a fix for a reported break — the argument is that a merged, accepted pattern skipped one plugin.
- Heads-up on possible textual conflicts depending on merge order: #9476 refactors `verifyPame file, and #10698 also calls `verifyPhoneNumberOTP`. Happy to rebase behind either.
- The stale request in #6070 claimed the default hasher is SHA-1; it is SHA-256 (`defaultKeyHasher`), and this PR reuses that. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `storeOTP` to `phone-number` so OTPs can be stored hashed or encrypted and verified in constant time. Previously OTPs were stored in plaintext and compared with `!==`; now they are transformed at rest without changing the SMS payload, with colon‑safe parsing and a uniform `:0` attempt suffix.

- Exposes `storeOTP: "plain" | "hashed" | "encrypted" | { hash } | { encrypt, decrypt }` in `PhoneNumberOptions`, matching `email-otp`.
- Adds `otp-token.ts` with `storeOTP()`/`verifyStoredOTP()` (SHA‑256 default hasher; symmetric encryption keyed by the app secret); all checks use `constantTimeEqual`.
- All OTP write sites now persist transformed values with `:0`; verification uses `verifyStoredOTP`. Parsing now uses `splitAtLastColon` to preserve colon‑bearing values.
- Docs add threat‑model guidance: `"hashed"` uses unsalted SHA‑256 and does not protect against offline enumeration from a DB dump; use `"encrypted"` to bind to the server secret.
- Tests cover plain/hashed/encrypted, custom hasher/encryptor, colon‑bearing transforms, and all write sites.

**Rollout**
- No migration; default remains `"plain"`.
- To opt in, set `storeOTP: "hashed"` or `"encrypted"` (or provide a custom transformer). For `"encrypted"`, ensure a stable secret is configured.
- Changing `storeOTP` mode invalidates in‑flight OTPs until they expire.

<sup>Written for commit 7b5cd32dcbe5f1aea8430c334a901be5a53dd2e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

