### PR TITLE
fix(access): deny inherited object members instead of throwing

### DIFF
--- a/.changeset/access-prototype-key-fail-closed.md
+++ b/.changeset/access-prototype-key-fail-closed.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Deny permission checks that name a member inherited from `Object.prototype`. Resource names in `has-permission` requests are caller-supplied strings, so a value such as `constructor` or `valueOf` resolved to a function through the prototype chain instead of `undefined`, slipped past the unknown-resource guard, and threw a `TypeError` while evaluating actions. Such resources are now reported as unknown and fail closed.

--- a/packages/better-auth/src/plugins/access/access.test.ts
+++ b/packages/better-auth/src/plugins/access/access.test.ts
@@ -224,4 +224,37 @@ describe("access", () => {
 			error: 'unauthorized to access resource "project"',
 		});
 	});
+
+	// Resource names arrive from the request body, typed as
+	// `z.record(z.string(), z.array(z.string()))`, so a caller can name any
+	// string, including one inherited from `Object.prototype`. A plain index
+	// lookup resolves those to a truthy function rather than `undefined`, which
+	// slips past the unknown-resource branch.
+	it.each([
+		"constructor",
+		"toString",
+		"valueOf",
+		"hasOwnProperty",
+		"__proto__",
+	])("should deny the inherited object member %s instead of throwing", (resource) => {
+		const response = role1.authorize({ [resource]: ["create"] } as never);
+
+		expect(response.success).toBe(false);
+	});
+
+	it("should report an inherited object member as an unknown resource", () => {
+		expect(role1.authorize({ constructor: ["create"] } as never)).toEqual({
+			success: false,
+			error: "You are not allowed to access resource: constructor",
+		});
+	});
+
+	it("should not authorize an inherited object member under the OR connector", () => {
+		const response = role1.authorize(
+			{ constructor: ["create"] } as never,
+			"OR",
+		);
+
+		expect(response.success).toBe(false);
+	});
 });

--- a/packages/better-auth/src/plugins/access/access.ts
+++ b/packages/better-auth/src/plugins/access/access.ts
@@ -118,8 +118,16 @@ export function role<
 			for (const [requestedResource, requestedActions] of Object.entries(
 				request,
 			)) {
-				const allowedActions = statements[requestedResource];
-				if (!allowedActions) {
+				// Resource names come from the request, so they can name members
+				// inherited from `Object.prototype` such as `constructor`. A plain
+				// index lookup resolves those to a truthy function, which would slip
+				// past this guard and fail on `allowedActions.includes` further down.
+				// Require an own, array-valued statement so anything else is treated
+				// as an unknown resource and fails closed.
+				const allowedActions = Object.hasOwn(statements, requestedResource)
+					? statements[requestedResource]
+					: undefined;
+				if (!Array.isArray(allowedActions)) {
 					if (connector === "AND") {
 						return unknownResourceResponse(requestedResource);
 					}


### PR DESCRIPTION
## Summary

Resource names in a permission check come from the request body, typed as `z.record(z.string(), z.array(z.string()))` (`packages/better-auth/src/plugins/admin/routes.ts:1769`, for both the `permission` and `permissions` variants). A caller can therefore name any string, including one inherited from `Object.prototype`.

`role.authorize` resolves the resource with a plain index lookup:

```ts
const allowedActions = statements[requestedResource];
if (!allowedActions) { /* unknown resource -> fail closed */ }
```

For `constructor`, `toString`, `valueOf` or `hasOwnProperty`, that lookup returns a **function** off the prototype chain rather than `undefined`. The `!allowedActions` guard sees a truthy value and skips the unknown-resource branch, so evaluation continues and `hasAllowedAction` reaches `allowedActions.includes(requestedAction)` on a function:

```
TypeError: allowedActions.includes is not a function
```

## Reproduction

```json
POST /admin/has-permission
{ "permission": { "constructor": ["x"] } }
```

Returns a 500 rather than a deny. Any authenticated caller can trigger it. `/organization/has-permission` shares the engine.

## Impact

This is a **fail-crash where the contract is fail-closed**, plus a cheap error oracle, not an authorization bypass. Nothing treats the thrown error as "allowed": api-key's `verify` path catches it and returns `false` (`packages/api-key/src/org-authorization.ts:132-138`), and the admin and organization endpoints surface it as a 500.

## Why the existing guards don't cover it

Two merged PRs hardened this same function, and both addressed resources that are **absent**:

- **#9603** — *reject empty action lists and continue "OR" evaluation on unknown resources*
- **#9677** — *flatten role authorization logic*, which per its description made "malformed connectors or non-string actions fail closed"

An inherited member is neither absent nor malformed in the shapes those PRs check: `constructor` is not missing, so `!allowedActions` never fires. This change closes that remaining case with the same intent.

Prototype-key hardening also has precedent in this repo: **#9164** (`fix(stripe): prevent prototype pollution via user-supplied metadata`, GHSA-737v-mqg7-c878).

## Fix

Require an **own, array-valued** statement before evaluating a resource:

```ts
const allowedActions = Object.hasOwn(statements, requestedResource)
    ? statements[requestedResource]
    : undefined;
if (!Array.isArray(allowedActions)) { /* unknown resource -> fail closed */ }
```

`Object.hasOwn` excludes inherited members; `Array.isArray` additionally rejects any non-array own value, so a malformed statements object degrades to a deny rather than a throw. Behaviour for valid resources is unchanged, both the `AND` and `OR` paths keep their existing semantics.

## Tests

Seven new cases in `access.test.ts`: a parameterised set over `constructor`, `toString`, `valueOf`, `hasOwnProperty` and `__proto__`, plus assertions that the error format matches the existing unknown-resource response and that `OR` does not authorize on an inherited member.

All seven fail on `main` with the `TypeError` above. Reverting just the two changed lines makes them fail again, so they pin the fix rather than the surrounding behaviour.

- `access.test.ts`: 25/25
- access + admin + organization suites: 379 passing, no regressions

## Notes for reviewers

- #10118 also touches `access.test.ts` (+99/−1) but not `access.ts`, so any conflict would be confined to the test file. Happy to rebase behind it.
- `__proto__` is included in the test matrix for completeness. It was already handled incidentally, the lookup returns `Object.prototype`, an object rather than an array, but it is covered explicitly now so a future refactor cannot regress it silently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deny permission checks that use `Object.prototype` members and fail closed instead of crashing. Previously, keys like "constructor" resolved to prototype functions, skipped the unknown-resource guard, and threw a TypeError during action evaluation; now we require an own, array-valued statement and treat anything else as an unknown resource.

- Uses `Object.hasOwn` plus `Array.isArray` in `packages/better-auth/src/plugins/access/access.ts` to exclude inherited members and non-array values.
- Behavior change: `/admin/has-permission` and `/organization/has-permission` now return a deny for inherited keys (and any non-array statement) instead of 500; AND/OR semantics for valid resources are unchanged.
- Tests add a parameterized set over `constructor`, `toString`, `valueOf`, `hasOwnProperty`, and `__proto__`, assert unknown-resource messaging, and ensure OR does not authorize on inherited members.

<sup>Written for commit 15f16c2691e51d32094797f5d01896822fc2ece9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

