### PR TITLE
docs: add PrismaPg adapter configuration

### DIFF
--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -31,7 +31,10 @@ import { prismaAdapter } from "better-auth/adapters/prisma";
 import { PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
-const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is not set");
+}
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
 const prisma = new PrismaClient({ adapter });
 
 export const auth = betterAuth({

--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -15,10 +15,10 @@ To use the Prisma adapter, you need to install the `@better-auth/prisma-adapter`
 @better-auth/prisma-adapter
 ```
 
-Prisma 7 with PostgreSQL requires the PostgreSQL driver adapter:
+Prisma 7 with SQLite requires the SQLite driver adapter:
 
 ```package-install
-@prisma/adapter-pg
+@prisma/adapter-better-sqlite3
 ```
 
 ## Example Usage
@@ -29,17 +29,22 @@ You can use the Prisma adapter to connect to your database as follows.
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { PrismaClient } from "@prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 
-if (!process.env.DATABASE_URL) {
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
   throw new Error("DATABASE_URL is not set");
 }
-const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+
+const adapter = new PrismaBetterSqlite3({
+  url: databaseUrl,
+});
 const prisma = new PrismaClient({ adapter });
 
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
-    provider: "postgresql",
+    provider: "sqlite",
   }),
 });
 ```

--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -15,6 +15,12 @@ To use the Prisma adapter, you need to install the `@better-auth/prisma-adapter`
 @better-auth/prisma-adapter
 ```
 
+Prisma 7 with PostgreSQL requires the PostgreSQL driver adapter:
+
+```package-install
+@prisma/adapter-pg
+```
+
 ## Example Usage
 
 You can use the Prisma adapter to connect to your database as follows.
@@ -23,12 +29,14 @@ You can use the Prisma adapter to connect to your database as follows.
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
 
-const prisma = new PrismaClient();
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
 
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
-    provider: "sqlite",
+    provider: "postgresql",
   }),
 });
 ```


### PR DESCRIPTION
## Why this change?

<img width="1077" height="448" alt="Screenshot 2026-08-22 063051" src="https://github.com/user-attachments/assets/fc453818-45e4-45f0-860a-c923e7c6c479" />

Prisma 7 requires a driver adapter when initializing `PrismaClient` for direct database connections. The current example initializes `PrismaClient` without an adapter, while Prisma 7.9.1 requires the adapter-based setup for PostgreSQL.

## Summary

Updates the Prisma adapter documentation for Prisma 7 with PostgreSQL by adding the required `PrismaPg` driver adapter configuration.

## Changes

- Added `@prisma/adapter-pg` installation instructions
- Updated the Prisma client initialization to use `PrismaPg`
- Updated the example provider from `sqlite` to `postgresql`

## Testing

- Verified the updated configuration resolves the Prisma client initialization issue with Prisma 7 and PostgreSQL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the required SQLite driver adapter for Prisma 7 so the Prisma adapter example works with SQLite. Previously the example created PrismaClient without an adapter; now it installs `@prisma/adapter-better-sqlite3`, uses `PrismaBetterSqlite3` with `DATABASE_URL`, and passes it to `PrismaClient`.

- Adds install instructions for `@prisma/adapter-better-sqlite3` and imports `PrismaBetterSqlite3`.
- Validates `DATABASE_URL`, constructs the adapter with `{ url: process.env.DATABASE_URL }`, and initializes `new PrismaClient({ adapter })`.
- Users must set `DATABASE_URL`; the example throws if it is unset.

<sup>Written for commit 28e9dc80bbc65df4221e8c01d645fe1faf6fca16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

