### PR TITLE
docs: update and add community plugin data

### DIFF
--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -130,10 +130,21 @@ export const communityPlugins: CommunityPlugin[] = [
 		},
 	},
 	{
-		name: "@alexasomba/better-auth-paystack",
+		name: "better-auth-paystack",
 		url: "https://github.com/alexasomba/better-auth-paystack",
 		description:
-			"Paystack plugin for Better Auth — integrates Paystack transactions, webhooks, and subscription flows.",
+			"Production-ready Paystack billing plugin for Better Auth with native and locally managed subscriptions, one-time payments, organization billing, trials, secure webhooks, automated limits, and more.",
+		author: {
+			name: "alexasomba",
+			github: "alexasomba",
+			avatar: "https://github.com/alexasomba.png",
+		},
+	},
+	{
+		name: "better-auth-flutterwave",
+		url: "https://github.com/alexasomba/better-auth-flutterwave",
+		description:
+			"Flutterwave plugin for Better Auth — integrates Flutterwave payments, subscriptions, organization billing, marketplace split payments, webhooks, refunds, reconciliation, and more.",
 		author: {
 			name: "alexasomba",
 			github: "alexasomba",

--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -152,6 +152,17 @@ export const communityPlugins: CommunityPlugin[] = [
 		},
 	},
 	{
+		name: "better-auth-solana-payments",
+		url: "https://github.com/alexasomba/better-auth-solana-payments",
+		description:
+			"One-time Solana payment integration for Better Auth with Solana Pay checkout, server-side transfer verification, payment tracking, organization payments, and more.",
+		author: {
+			name: "alexasomba",
+			github: "alexasomba",
+			avatar: "https://github.com/alexasomba.png",
+		},
+	},
+	{
 		name: "better-auth-lark",
 		url: "https://github.com/uselark/better-auth-lark",
 		description:


### PR DESCRIPTION
## Summary

- Update the Paystack community plugin entry to the unscoped `better-auth-paystack` package.
- Add the `better-auth-flutterwave` community plugin.
- Refresh both descriptions to reflect their billing capabilities.

## Validation

- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Paystack plugin reference from `@alexasomba/better-auth-paystack` to `better-auth-paystack`, and adds `better-auth-flutterwave` and `better-auth-solana-payments` to the community plugins list to keep billing docs current. Descriptions now highlight key capabilities (subscriptions, one-time payments, organization billing, webhooks, marketplace splits/refunds, trials, automated limits, Solana Pay checkout and verification) and include author metadata.

**Required action**
- If you referenced the scoped Paystack package, update to `better-auth-paystack`.

<sup>Written for commit a0f4c705c676ffb1f4eb08a0d270eb28e07d56ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

