### PR TITLE
fix(organization): harden access lifecycle transitions

### DIFF
--- a/.changeset/clear-removed-organization-sessions.md
+++ b/.changeset/clear-removed-organization-sessions.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+Clear the active organization selection from all of a user's server-backed
+sessions when that member is removed or leaves, and resolve organization route
+sessions authoritatively when a durable session store is configured.

--- a/.changeset/guard-invitation-lifecycle.md
+++ b/.changeset/guard-invitation-lifecycle.md
@@ -1,0 +1,7 @@
+---
+"better-auth": patch
+---
+
+Guard invitation reject and cancel transitions atomically, safely renew expired
+pending invitations, and add an ID-bound `resendInvitation` endpoint that uses
+compare-and-swap lifecycle semantics.

--- a/.changeset/member-role-user-response.md
+++ b/.changeset/member-role-user-response.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Return the joined user summary from organization member role updates so the runtime response matches the inferred server API type.

--- a/docs/content/docs/plugins/organization.mdx
+++ b/docs/content/docs/plugins/organization.mdx
@@ -928,6 +928,24 @@ To invite users to an organization, you can use the `invite` function provided b
     invitation is sent.
 </Callout>
 
+### Resend Invitation
+
+Use the invitation ID when resending an existing invitation. The ID-bound
+operation renews the same pending invitation atomically, including an expired
+pending invitation, and fails if another request accepted, rejected, canceled,
+or renewed that invitation first.
+
+<APIMethod path="/organization/resend-invitation" method="POST" requireSession>
+  ```ts
+  type resendInvitation = {
+      /**
+       * The ID of the pending invitation to resend.
+       */
+      invitationId: string = "invitation-id"
+  }
+  ```
+</APIMethod>
+
 ### Accept Invitation
 
 When a user receives an invitation email, they can click on the invitation link to accept the invitation. The invitation link should include the invitation ID, which will be used to accept the invitation.
@@ -1218,6 +1236,19 @@ To leave organization you can use `organization.leave` function. This function w
   }
   ```
 </APIMethod>
+
+<Callout type="info">
+  When a member is removed or leaves, Better Auth clears that organization from
+  all of the user's server-backed sessions. A previously issued
+  `session_data` cookie on another device cannot be deleted remotely, so a plain
+  `getSession` call can expose the cached previous selection until the cookie is
+  refreshed or reaches its configured `maxAge`. Routes protected by the
+  organization session middleware bypass that cache in stateful deployments and
+  refresh it before their handler runs. If a generic session read must reflect
+  the cleanup immediately, use `disableCookieCache: true`, disable cookie cache,
+  or configure a shorter cache lifetime. The cached organization ID is a
+  selector, not proof of membership.
+</Callout>
 
 ## Access Control
 

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -5,6 +5,7 @@ import {
 } from "@better-auth/core/context";
 import type {
 	DBTransactionAdapter,
+	Where,
 	WhereOperator,
 } from "@better-auth/core/db/adapter";
 import { BetterAuthError } from "@better-auth/core/error";
@@ -21,6 +22,7 @@ import type {
 	InferOrganization,
 	InferTeam,
 	InvitationInput,
+	InvitationStatus,
 	Member,
 	MemberInput,
 	OrganizationInput,
@@ -1254,9 +1256,11 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 					},
 				],
 			});
-			return invitation.filter(
-				(invite) => new Date(invite.expiresAt) > new Date(),
-			);
+			// Include expired rows while their lifecycle status is still pending.
+			// Creation must claim or renew those rows before inserting a replacement;
+			// otherwise databases that enforce one pending invitation per org/email
+			// reject the replacement even though the old invitation is no longer usable.
+			return invitation;
 		},
 		findPendingInvitations: async (data: { organizationId: string }) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
@@ -1290,28 +1294,43 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 			});
 			return invitations;
 		},
-		updateInvitation: async (data: {
-			invitationId: string;
-			status: "pending" | "accepted" | "canceled" | "rejected";
-			/**
-			 * Only transition when the invitation is currently in this status. The
-			 * guarded update is atomic, so a concurrent caller racing the same
-			 * transition gets `null` instead of both proceeding.
-			 */
-			fromStatus?: "pending" | "accepted" | "canceled" | "rejected";
-		}) => {
+		updateInvitation: async (
+			data: {
+				invitationId: string;
+				/**
+				 * Only transition when the invitation is currently in this status. The
+				 * guarded update is atomic, so a concurrent caller racing the same
+				 * transition gets `null` instead of both proceeding.
+				 */
+				fromStatus?: InvitationStatus | undefined;
+				/**
+				 * Compare-and-swap guard for invitation refreshes. Expiration changes act
+				 * as the invitation lifecycle version, so resend cannot race a terminal
+				 * transition or another resend based on an older snapshot.
+				 */
+				fromExpiresAt?: Date | undefined;
+			} & (
+				| { status: InvitationStatus; expiresAt?: Date | undefined }
+				| { status?: undefined; expiresAt: Date }
+			),
+		) => {
 			const adapter = await getCurrentAdapter(baseAdapter);
-			const where = [{ field: "id", value: data.invitationId }];
+			const where: Where[] = [{ field: "id", value: data.invitationId }];
 			if (data.fromStatus) {
 				where.push({ field: "status", value: data.fromStatus });
 			}
+			if (data.fromExpiresAt) {
+				where.push({ field: "expiresAt", value: data.fromExpiresAt });
+			}
+			const set = {
+				...(data.status ? { status: data.status } : {}),
+				...(data.expiresAt ? { expiresAt: data.expiresAt } : {}),
+			};
 			const invitation = await adapter.incrementOne<InferInvitation<O, false>>({
 				model: "invitation",
 				where,
 				increment: {},
-				set: {
-					status: data.status,
-				},
+				set,
 			});
 			return invitation;
 		},

--- a/packages/better-auth/src/plugins/organization/call.ts
+++ b/packages/better-auth/src/plugins/organization/call.ts
@@ -1,6 +1,6 @@
 import type { GenericEndpointContext } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
-import { sessionMiddleware } from "../../api";
+import { sensitiveSessionMiddleware } from "../../api";
 import type { Session, User } from "../../types";
 import type { Role } from "../access";
 import type { defaultRoles } from "./access/statement";
@@ -23,12 +23,12 @@ export const orgMiddleware = createAuthMiddleware(async () => {
 });
 
 /**
- * The middleware forces the endpoint to require a valid session by utilizing the `sessionMiddleware`.
+ * The middleware forces the endpoint to require a valid authoritative session.
  * It also appends additional types to the session type regarding organizations.
  */
 export const orgSessionMiddleware = createAuthMiddleware(
 	{
-		use: [sessionMiddleware],
+		use: [sensitiveSessionMiddleware],
 	},
 	async (ctx) => {
 		const session = ctx.context.session as {

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -28,6 +28,7 @@ import {
 	listInvitations,
 	listUserInvitations,
 	rejectInvitation,
+	resendInvitation,
 } from "./routes/crud-invites";
 import {
 	addMember,
@@ -147,6 +148,7 @@ export type OrganizationEndpoints<O extends OrganizationOptions> = {
 	getFullOrganization: ReturnType<typeof getFullOrganization<O>>;
 	listOrganizations: ReturnType<typeof listOrganizations<O>>;
 	createInvitation: ReturnType<typeof createInvitation<O>>;
+	resendInvitation: ReturnType<typeof resendInvitation<O>>;
 	cancelInvitation: ReturnType<typeof cancelInvitation<O>>;
 	acceptInvitation: ReturnType<typeof acceptInvitation<O>>;
 	getInvitation: ReturnType<typeof getInvitation<O>>;
@@ -574,6 +576,22 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 		 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/organization#api-method-organization-invite-member)
 		 */
 		createInvitation: createInvitation(opts),
+		/**
+		 * ### Endpoint
+		 *
+		 * POST `/organization/resend-invitation`
+		 *
+		 * ### API Methods
+		 *
+		 * **server:**
+		 * `auth.api.resendInvitation`
+		 *
+		 * **client:**
+		 * `authClient.organization.resendInvitation`
+		 *
+		 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/organization#resend-invitation)
+		 */
+		resendInvitation: resendInvitation(opts),
 		/**
 		 * ### Endpoint
 		 *

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -128,6 +128,17 @@ const shouldRequireVerifiedEmailForInvitationIdAction = ({
 	});
 };
 
+const getRenewedInvitationExpiration = (
+	invitationExpiresIn: number | undefined,
+	currentExpiration: Date,
+) => {
+	const defaultExpiration = 60 * 60 * 48;
+	const candidate = getDate(invitationExpiresIn || defaultExpiration, "sec");
+	return new Date(
+		Math.max(candidate.getTime(), currentExpiration.getTime() + 1),
+	);
+};
+
 export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 	const additionalFieldsSchema = toZodSchema({
 		fields: option?.schema?.invitation?.additionalFields || {},
@@ -349,10 +360,15 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 				email: email,
 				organizationId: organizationId,
 			});
+			const existingInvitation = alreadyInvited[0];
+			const existingInvitationExpired =
+				existingInvitation !== undefined &&
+				existingInvitation.expiresAt <= new Date();
 			if (
-				alreadyInvited.length &&
+				existingInvitation &&
 				!ctx.body.resend &&
-				!ctx.context.orgOptions.cancelPendingInvitationsOnReInvite
+				!ctx.context.orgOptions.cancelPendingInvitationsOnReInvite &&
+				!existingInvitationExpired
 			) {
 				throw APIError.from(
 					"BAD_REQUEST",
@@ -369,41 +385,31 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 			}
 
 			// If resend is true and there's an existing invitation, reuse it
-			if (alreadyInvited.length && ctx.body.resend) {
-				const existingInvitation = alreadyInvited[0];
-
-				// Update the invitation's expiration date using the same logic as createInvitation
-				const defaultExpiration = 60 * 60 * 48; // 48 hours in seconds
-				const newExpiresAt = getDate(
-					ctx.context.orgOptions.invitationExpiresIn || defaultExpiration,
-					"sec",
+			if (existingInvitation && ctx.body.resend) {
+				const newExpiresAt = getRenewedInvitationExpiration(
+					ctx.context.orgOptions.invitationExpiresIn,
+					existingInvitation.expiresAt,
 				);
-
-				await ctx.context.adapter.update({
-					model: "invitation",
-					where: [
-						{
-							field: "id",
-							value: existingInvitation!.id,
-						},
-					],
-					update: {
-						expiresAt: newExpiresAt,
-					},
-				});
-
-				const updatedInvitation = {
-					...existingInvitation,
+				const updatedInvitation = await adapter.updateInvitation({
+					invitationId: existingInvitation.id,
 					expiresAt: newExpiresAt,
-				};
+					fromStatus: "pending",
+					fromExpiresAt: existingInvitation.expiresAt,
+				});
+				if (!updatedInvitation) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
+					);
+				}
 
 				if (ctx.context.orgOptions.sendInvitationEmail) {
 					await ctx.context.runInBackgroundOrAwait(
 						ctx.context.orgOptions.sendInvitationEmail(
 							{
-								id: updatedInvitation.id!,
-								role: updatedInvitation.role! as string,
-								email: updatedInvitation.email!.toLowerCase(),
+								id: updatedInvitation.id,
+								role: updatedInvitation.role,
+								email: updatedInvitation.email.toLowerCase(),
 								organization: organization,
 								inviter: {
 									...member,
@@ -416,17 +422,26 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 					);
 				}
 
-				return ctx.json(updatedInvitation as unknown as InferInvitation<O>);
+				return ctx.json(updatedInvitation as InferInvitation<O>);
 			}
 
 			if (
-				alreadyInvited.length &&
-				ctx.context.orgOptions.cancelPendingInvitationsOnReInvite
+				existingInvitation &&
+				(ctx.context.orgOptions.cancelPendingInvitationsOnReInvite ||
+					existingInvitationExpired)
 			) {
-				await adapter.updateInvitation({
-					invitationId: alreadyInvited[0]!.id,
+				const canceledInvitation = await adapter.updateInvitation({
+					invitationId: existingInvitation.id,
 					status: "canceled",
+					fromStatus: "pending",
+					fromExpiresAt: existingInvitation.expiresAt,
 				});
+				if (!canceledInvitation) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
+					);
+				}
 			}
 
 			const invitationLimit =
@@ -612,6 +627,125 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 	);
 };
 
+const resendInvitationBodySchema = z.object({
+	invitationId: z.string().meta({
+		description: "The ID of the pending invitation to resend",
+	}),
+});
+
+export const resendInvitation = <O extends OrganizationOptions>(options: O) =>
+	createAuthEndpoint(
+		"/organization/resend-invitation",
+		{
+			method: "POST",
+			body: resendInvitationBodySchema,
+			requireHeaders: true,
+			use: [orgMiddleware, orgSessionMiddleware],
+			metadata: {
+				openapi: {
+					description: "Resend a pending organization invitation by ID",
+					responses: {
+						"200": {
+							description: "Success",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										$ref: "#/components/schemas/Invitation",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		async (ctx) => {
+			const session = ctx.context.session;
+			const adapter = getOrgAdapter<O>(ctx.context, options);
+			const invitation = await adapter.findInvitationById(
+				ctx.body.invitationId,
+			);
+			if (!invitation || invitation.status !== "pending") {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
+				);
+			}
+
+			const member = await adapter.findMemberByOrgId({
+				userId: session.user.id,
+				organizationId: invitation.organizationId,
+			});
+			if (!member) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.MEMBER_NOT_FOUND,
+				);
+			}
+			const canResend = await hasPermission(
+				{
+					role: member.role,
+					options: ctx.context.orgOptions,
+					permissions: { invitation: ["create"] },
+					organizationId: invitation.organizationId,
+				},
+				ctx,
+			);
+			if (!canResend) {
+				throw APIError.from(
+					"FORBIDDEN",
+					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_ORGANIZATION,
+				);
+			}
+
+			const organization = await adapter.findOrganizationById(
+				invitation.organizationId,
+			);
+			if (!organization) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.ORGANIZATION_NOT_FOUND,
+				);
+			}
+
+			const expiresAt = getRenewedInvitationExpiration(
+				ctx.context.orgOptions.invitationExpiresIn,
+				invitation.expiresAt,
+			);
+			const renewedInvitation = await adapter.updateInvitation({
+				invitationId: invitation.id,
+				expiresAt,
+				fromStatus: "pending",
+				fromExpiresAt: invitation.expiresAt,
+			});
+			if (!renewedInvitation) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
+				);
+			}
+
+			if (ctx.context.orgOptions.sendInvitationEmail) {
+				await ctx.context.runInBackgroundOrAwait(
+					ctx.context.orgOptions.sendInvitationEmail(
+						{
+							id: renewedInvitation.id,
+							role: renewedInvitation.role,
+							email: renewedInvitation.email.toLowerCase(),
+							organization,
+							inviter: { ...member, user: session.user },
+							invitation: renewedInvitation as unknown as Invitation,
+						},
+						ctx.request,
+					),
+				);
+			}
+
+			return ctx.json(renewedInvitation as InferInvitation<O>);
+		},
+	);
+
 const acceptInvitationBodySchema = z.object({
 	invitationId: z.string().meta({
 		description: "The ID of the invitation to accept",
@@ -743,6 +877,7 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 				invitationId: ctx.body.invitationId,
 				status: "accepted",
 				fromStatus: "pending",
+				fromExpiresAt: invitation.expiresAt,
 			});
 			if (!acceptedI) {
 				// Another request already accepted this invitation.
@@ -848,6 +983,7 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 					invitationId: ctx.body.invitationId,
 					status: "pending",
 					fromStatus: "accepted",
+					fromExpiresAt: invitation.expiresAt,
 				});
 				throw error;
 			});
@@ -966,12 +1102,20 @@ export const rejectInvitation = <O extends OrganizationOptions>(options: O) =>
 			const rejectedI = await adapter.updateInvitation({
 				invitationId: ctx.body.invitationId,
 				status: "rejected",
+				fromStatus: "pending",
+				fromExpiresAt: invitation.expiresAt,
 			});
+			if (!rejectedI) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
+				);
+			}
 
 			// Run afterRejectInvitation hook
 			if (options?.organizationHooks?.afterRejectInvitation) {
 				await options?.organizationHooks.afterRejectInvitation({
-					invitation: rejectedI || (invitation as unknown as Invitation),
+					invitation: rejectedI as unknown as Invitation,
 					user: session.user,
 					organization,
 				});
@@ -1026,7 +1170,7 @@ export const cancelInvitation = <O extends OrganizationOptions>(options: O) =>
 			const invitation = await adapter.findInvitationById(
 				ctx.body.invitationId,
 			);
-			if (!invitation) {
+			if (!invitation || invitation.status !== "pending") {
 				throw APIError.from(
 					"BAD_REQUEST",
 					ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
@@ -1083,12 +1227,20 @@ export const cancelInvitation = <O extends OrganizationOptions>(options: O) =>
 			const canceledI = await adapter.updateInvitation({
 				invitationId: ctx.body.invitationId,
 				status: "canceled",
+				fromStatus: "pending",
+				fromExpiresAt: invitation.expiresAt,
 			});
+			if (!canceledI) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.INVITATION_NOT_FOUND,
+				);
+			}
 
 			// Run afterCancelInvitation hook
 			if (options?.organizationHooks?.afterCancelInvitation) {
 				await options?.organizationHooks.afterCancelInvitation({
-					invitation: (canceledI as unknown as Invitation) || invitation,
+					invitation: canceledI as unknown as Invitation,
 					cancelledBy: session.user,
 					organization,
 				});

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.test.ts
@@ -422,6 +422,11 @@ describe("updateMemberRole", async () => {
 			},
 		);
 		expect(updatedMember.data?.role).toBe("admin");
+		expect(updatedMember.data?.user).toMatchObject({
+			id: newUser.user.id,
+			email: newUser.user.email,
+			name: newUser.user.name,
+		});
 	});
 
 	it("should not update the member role if the member updating is not a member	", async () => {

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -3,7 +3,7 @@ import { createAuthEndpoint } from "@better-auth/core/api";
 import { whereOperators } from "@better-auth/core/db/adapter";
 import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import * as z from "zod";
-import { getSessionFromCtx, sessionMiddleware } from "../../../api";
+import { getSessionFromCtx } from "../../../api";
 import type { InferAdditionalFieldsFromPluginOptions } from "../../../db";
 import { toZodSchema } from "../../../db/to-zod";
 import { defaultRoles } from "../access/statement";
@@ -17,6 +17,7 @@ import type {
 	InferOrganizationRolesFromOption,
 	Member,
 } from "../schema";
+import { clearActiveOrganizationFromSessions } from "../session";
 import type { OrganizationOptions } from "../types";
 
 const baseMemberSchema = z.object({
@@ -445,19 +446,16 @@ export const removeMember = <O extends OrganizationOptions>(options: O) =>
 					organization,
 				});
 			}
+			await clearActiveOrganizationFromSessions(
+				ctx,
+				toBeRemovedMember.userId,
+				organizationId,
+			);
 			await adapter.deleteMember({
 				memberId: toBeRemovedMember.id,
 				organizationId: organizationId,
 				userId: toBeRemovedMember.userId,
 			});
-			if (
-				session.user.id === toBeRemovedMember.userId &&
-				session.session.activeOrganizationId ===
-					toBeRemovedMember.organizationId
-			) {
-				await adapter.setActiveOrganization(session.session.token, null, ctx);
-			}
-
 			// Run afterRemoveMember hook
 			if (options?.organizationHooks?.afterRemoveMember) {
 				await options?.organizationHooks.afterRemoveMember({
@@ -524,26 +522,44 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 									schema: {
 										type: "object",
 										properties: {
-											member: {
+											id: {
+												type: "string",
+											},
+											userId: {
+												type: "string",
+											},
+											organizationId: {
+												type: "string",
+											},
+											role: {
+												type: "string",
+											},
+											user: {
 												type: "object",
 												properties: {
 													id: {
 														type: "string",
 													},
-													userId: {
+													name: {
 														type: "string",
 													},
-													organizationId: {
+													email: {
 														type: "string",
 													},
-													role: {
-														type: "string",
+													image: {
+														type: ["string", "null"],
 													},
 												},
-												required: ["id", "userId", "organizationId", "role"],
+												required: ["id", "name", "email", "image"],
 											},
 										},
-										required: ["member"],
+										required: [
+											"id",
+											"userId",
+											"organizationId",
+											"role",
+											"user",
+										],
 									},
 								},
 							},
@@ -731,6 +747,12 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 					message: "User not found",
 				});
 			}
+			const updatedMemberUser = {
+				id: userBeingUpdated.id,
+				name: userBeingUpdated.name,
+				email: userBeingUpdated.email,
+				image: userBeingUpdated.image,
+			};
 
 			const previousRole = toBeUpdatedMember.role;
 			const newRole = parseRoles(roleToSet);
@@ -768,7 +790,7 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 						});
 					}
 
-					return ctx.json(updatedMember);
+					return ctx.json({ ...updatedMember, user: updatedMemberUser });
 				}
 			}
 
@@ -793,7 +815,7 @@ export const updateMemberRole = <O extends OrganizationOptions>(option: O) =>
 				});
 			}
 
-			return ctx.json(updatedMember);
+			return ctx.json({ ...updatedMember, user: updatedMemberUser });
 		},
 	);
 
@@ -875,7 +897,7 @@ export const leaveOrganization = <O extends OrganizationOptions>(options: O) =>
 			method: "POST",
 			body: leaveOrganizationBodySchema,
 			requireHeaders: true,
-			use: [sessionMiddleware, orgMiddleware],
+			use: [orgSessionMiddleware, orgMiddleware],
 		},
 		async (ctx) => {
 			const session = ctx.context.session;
@@ -913,14 +935,16 @@ export const leaveOrganization = <O extends OrganizationOptions>(options: O) =>
 					);
 				}
 			}
+			await clearActiveOrganizationFromSessions(
+				ctx,
+				session.user.id,
+				ctx.body.organizationId,
+			);
 			await adapter.deleteMember({
 				memberId: member.id,
 				organizationId: ctx.body.organizationId,
 				userId: session.user.id,
 			});
-			if (session.session.activeOrganizationId === ctx.body.organizationId) {
-				await adapter.setActiveOrganization(session.session.token, null, ctx);
-			}
 			return ctx.json(member);
 		},
 	);

--- a/packages/better-auth/src/plugins/organization/routes/invitation-lifecycle.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/invitation-lifecycle.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it, vi } from "vitest";
+import { getTestInstance } from "../../../test-utils/test-instance";
+import { organizationClient } from "../client";
+import { organization } from "../organization";
+
+async function setupInvitation() {
+	const sentInvitationIds: string[] = [];
+	const { auth, client, signInWithTestUser, signInWithUser } =
+		await getTestInstance(
+			{
+				plugins: [
+					organization({
+						async sendInvitationEmail(data) {
+							sentInvitationIds.push(data.id);
+						},
+					}),
+				],
+			},
+			{ clientOptions: { plugins: [organizationClient()] } },
+		);
+	const ctx = await auth.$context;
+	const owner = await signInWithTestUser();
+	const recipient = {
+		email: "invitation-lifecycle-recipient@example.com",
+		name: "Invitation recipient",
+		password: "password12345",
+	};
+	await auth.api.signUpEmail({ body: recipient });
+	const recipientSession = await signInWithUser(
+		recipient.email,
+		recipient.password,
+	);
+	const organizationRecord = await auth.api.createOrganization({
+		headers: owner.headers,
+		body: {
+			name: "Invitation lifecycle organization",
+			slug: "invitation-lifecycle-organization",
+		},
+	});
+	if (!organizationRecord) throw new Error("failed to create organization");
+	const invitation = await auth.api.createInvitation({
+		headers: owner.headers,
+		body: {
+			email: recipient.email,
+			role: "member",
+			organizationId: organizationRecord.id,
+		},
+	});
+	sentInvitationIds.length = 0;
+	return {
+		auth,
+		client,
+		ctx,
+		invitation,
+		organizationRecord,
+		ownerHeaders: owner.headers,
+		recipient,
+		recipientHeaders: recipientSession.headers,
+		sentInvitationIds,
+	};
+}
+
+function installInvitationTransitionBarrier(
+	ctx: Awaited<ReturnType<typeof setupInvitation>>["ctx"],
+	expectedArrivals = 2,
+) {
+	const originalIncrementOne = ctx.adapter.incrementOne.bind(
+		ctx.adapter,
+	) as typeof ctx.adapter.incrementOne;
+	let arrivals = 0;
+	let release: (() => void) | undefined;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	return vi
+		.spyOn(ctx.adapter, "incrementOne")
+		.mockImplementation(async (data) => {
+			if (data.model === "invitation") {
+				arrivals += 1;
+				if (arrivals === expectedArrivals) release?.();
+				await gate;
+			}
+			return originalIncrementOne(data);
+		});
+}
+
+async function readInvitation(
+	ctx: Awaited<ReturnType<typeof setupInvitation>>["ctx"],
+	invitationId: string,
+) {
+	return ctx.adapter.findOne<{
+		id: string;
+		status: "pending" | "accepted" | "rejected" | "canceled";
+		expiresAt: Date;
+	}>({
+		model: "invitation",
+		where: [{ field: "id", value: invitationId }],
+	});
+}
+
+async function countRecipientMemberships(
+	setup: Awaited<ReturnType<typeof setupInvitation>>,
+) {
+	const recipient = await setup.ctx.internalAdapter.findUserByEmail(
+		setup.recipient.email,
+	);
+	if (!recipient) throw new Error("recipient not found");
+	return setup.ctx.adapter.count({
+		model: "member",
+		where: [
+			{ field: "userId", value: recipient.user.id },
+			{
+				field: "organizationId",
+				value: setup.organizationRecord.id,
+			},
+		],
+	});
+}
+
+describe("guarded invitation lifecycle transitions", () => {
+	it("does not transition an invitation after it is rejected or canceled", async () => {
+		const setup = await setupInvitation();
+		const rejected = await setup.auth.api.rejectInvitation({
+			headers: setup.recipientHeaders,
+			body: { invitationId: setup.invitation.id },
+		});
+		expect(rejected.invitation?.status).toBe("rejected");
+		await expect(
+			setup.auth.api.acceptInvitation({
+				headers: setup.recipientHeaders,
+				body: { invitationId: setup.invitation.id },
+			}),
+		).rejects.toMatchObject({ body: { code: "INVITATION_NOT_FOUND" } });
+		await expect(
+			setup.auth.api.cancelInvitation({
+				headers: setup.ownerHeaders,
+				body: { invitationId: setup.invitation.id },
+			}),
+		).rejects.toMatchObject({ body: { code: "INVITATION_NOT_FOUND" } });
+
+		const secondInvitation = await setup.auth.api.createInvitation({
+			headers: setup.ownerHeaders,
+			body: {
+				email: setup.recipient.email,
+				role: "member",
+				organizationId: setup.organizationRecord.id,
+			},
+		});
+		const canceled = await setup.auth.api.cancelInvitation({
+			headers: setup.ownerHeaders,
+			body: { invitationId: secondInvitation.id },
+		});
+		expect(canceled.status).toBe("canceled");
+		await expect(
+			setup.auth.api.rejectInvitation({
+				headers: setup.recipientHeaders,
+				body: { invitationId: secondInvitation.id },
+			}),
+		).rejects.toMatchObject({ body: { code: "INVITATION_NOT_FOUND" } });
+		expect(await countRecipientMemberships(setup)).toBe(0);
+	});
+
+	it.each([
+		"reject",
+		"cancel",
+	] as const)("serializes accept against %s", async (terminalAction) => {
+		const setup = await setupInvitation();
+		const barrier = installInvitationTransitionBarrier(setup.ctx);
+		try {
+			const accept = setup.auth.api.acceptInvitation({
+				headers: setup.recipientHeaders,
+				body: { invitationId: setup.invitation.id },
+			});
+			const terminal =
+				terminalAction === "reject"
+					? setup.auth.api.rejectInvitation({
+							headers: setup.recipientHeaders,
+							body: { invitationId: setup.invitation.id },
+						})
+					: setup.auth.api.cancelInvitation({
+							headers: setup.ownerHeaders,
+							body: { invitationId: setup.invitation.id },
+						});
+			const results = await Promise.allSettled([accept, terminal]);
+			expect(
+				results.filter((result) => result.status === "fulfilled"),
+			).toHaveLength(1);
+			expect(
+				results.filter((result) => result.status === "rejected"),
+			).toHaveLength(1);
+		} finally {
+			barrier.mockRestore();
+		}
+
+		const invitation = await readInvitation(setup.ctx, setup.invitation.id);
+		expect(invitation?.status).toMatch(
+			terminalAction === "reject"
+				? /^(accepted|rejected)$/
+				: /^(accepted|canceled)$/,
+		);
+		expect(await countRecipientMemberships(setup)).toBe(
+			invitation?.status === "accepted" ? 1 : 0,
+		);
+	});
+
+	it("serializes ID-bound resend against cancellation", async () => {
+		const setup = await setupInvitation();
+		const barrier = installInvitationTransitionBarrier(setup.ctx);
+		try {
+			const results = await Promise.allSettled([
+				setup.auth.api.resendInvitation({
+					headers: setup.ownerHeaders,
+					body: { invitationId: setup.invitation.id },
+				}),
+				setup.auth.api.cancelInvitation({
+					headers: setup.ownerHeaders,
+					body: { invitationId: setup.invitation.id },
+				}),
+			]);
+			expect(
+				results.filter((result) => result.status === "fulfilled"),
+			).toHaveLength(1);
+			expect(
+				results.filter((result) => result.status === "rejected"),
+			).toHaveLength(1);
+		} finally {
+			barrier.mockRestore();
+		}
+
+		const invitation = await readInvitation(setup.ctx, setup.invitation.id);
+		expect(invitation?.status).toMatch(/^(pending|canceled)$/);
+		expect(setup.sentInvitationIds).toHaveLength(
+			invitation?.status === "pending" ? 1 : 0,
+		);
+	});
+
+	it("allows only one concurrent resend for the same invitation snapshot", async () => {
+		const setup = await setupInvitation();
+		const barrier = installInvitationTransitionBarrier(setup.ctx);
+		try {
+			const results = await Promise.allSettled([
+				setup.auth.api.resendInvitation({
+					headers: setup.ownerHeaders,
+					body: { invitationId: setup.invitation.id },
+				}),
+				setup.auth.api.resendInvitation({
+					headers: setup.ownerHeaders,
+					body: { invitationId: setup.invitation.id },
+				}),
+			]);
+			expect(
+				results.filter((result) => result.status === "fulfilled"),
+			).toHaveLength(1);
+			expect(
+				results.filter((result) => result.status === "rejected"),
+			).toHaveLength(1);
+		} finally {
+			barrier.mockRestore();
+		}
+		expect(setup.sentInvitationIds).toEqual([setup.invitation.id]);
+	});
+
+	it("replaces an expired pending invite and can renew it by ID", async () => {
+		const setup = await setupInvitation();
+		const expiredAt = new Date(Date.now() - 60_000);
+		await setup.ctx.adapter.update({
+			model: "invitation",
+			where: [{ field: "id", value: setup.invitation.id }],
+			update: { expiresAt: expiredAt },
+		});
+
+		const replacement = await setup.auth.api.createInvitation({
+			headers: setup.ownerHeaders,
+			body: {
+				email: setup.recipient.email,
+				role: "member",
+				organizationId: setup.organizationRecord.id,
+			},
+		});
+		expect(replacement.id).not.toBe(setup.invitation.id);
+		expect((await readInvitation(setup.ctx, setup.invitation.id))?.status).toBe(
+			"canceled",
+		);
+
+		await setup.ctx.adapter.update({
+			model: "invitation",
+			where: [{ field: "id", value: replacement.id }],
+			update: { expiresAt: expiredAt },
+		});
+		setup.sentInvitationIds.length = 0;
+		const renewed = await setup.client.organization.resendInvitation({
+			invitationId: replacement.id,
+			fetchOptions: { headers: setup.ownerHeaders },
+		});
+		expect(renewed.error).toBeNull();
+		expect(renewed.data?.id).toBe(replacement.id);
+		expect(renewed.data?.status).toBe("pending");
+		expect(renewed.data?.expiresAt.getTime()).toBeGreaterThan(Date.now());
+		expect(setup.sentInvitationIds).toEqual([replacement.id]);
+	});
+});

--- a/packages/better-auth/src/plugins/organization/routes/member-session-selection.test.ts
+++ b/packages/better-auth/src/plugins/organization/routes/member-session-selection.test.ts
@@ -1,0 +1,323 @@
+import type { BetterAuthOptions } from "@better-auth/core";
+import { describe, expect, it } from "vitest";
+import { createAuthClient } from "../../../client";
+import { getTestInstance } from "../../../test-utils/test-instance";
+import { organizationClient } from "../client";
+import { organization } from "../organization";
+
+function createSecondaryStorage(): NonNullable<
+	BetterAuthOptions["secondaryStorage"]
+> {
+	const store = new Map<string, string>();
+	return {
+		get(key) {
+			return store.get(key) ?? null;
+		},
+		getAndDelete(key) {
+			const value = store.get(key) ?? null;
+			store.delete(key);
+			return value;
+		},
+		increment(key) {
+			const count = Number(store.get(key) ?? 0) + 1;
+			store.set(key, String(count));
+			return count;
+		},
+		set(key, value) {
+			store.set(key, value);
+		},
+		delete(key) {
+			store.delete(key);
+		},
+	};
+}
+
+function activeOrganizationId(session: { token: string }) {
+	return (
+		session as typeof session & {
+			activeOrganizationId?: string | null | undefined;
+		}
+	).activeOrganizationId;
+}
+
+function sessionToken(result: object): string {
+	const { token } = result as { token?: unknown };
+	if (typeof token !== "string")
+		throw new Error("session token was not returned");
+	return token;
+}
+
+describe("member session organization selection cleanup", () => {
+	it.each([
+		{ name: "database sessions", secondaryStorage: undefined },
+		{
+			name: "secondary-storage sessions",
+			secondaryStorage: createSecondaryStorage(),
+		},
+	])("clears every selected session after removal and leave with $name", async ({
+		secondaryStorage,
+	}) => {
+		const { auth, signInWithTestUser, signInWithUser } = await getTestInstance({
+			plugins: [organization()],
+			...(secondaryStorage ? { secondaryStorage } : {}),
+		});
+		const ctx = await auth.$context;
+		const owner = await signInWithTestUser();
+
+		const removedOrganization = await auth.api.createOrganization({
+			headers: owner.headers,
+			body: { name: "Removed organization", slug: "removed-organization" },
+		});
+		const leftOrganization = await auth.api.createOrganization({
+			headers: owner.headers,
+			body: { name: "Left organization", slug: "left-organization" },
+		});
+		const retainedOrganization = await auth.api.createOrganization({
+			headers: owner.headers,
+			body: { name: "Retained organization", slug: "retained-organization" },
+		});
+		if (!removedOrganization || !leftOrganization || !retainedOrganization) {
+			throw new Error("failed to create test organizations");
+		}
+
+		const removedUser = await auth.api.signUpEmail({
+			body: {
+				email: "removed-member@example.com",
+				name: "Removed member",
+				password: "password12345",
+			},
+		});
+		await auth.api.addMember({
+			body: {
+				userId: removedUser.user.id,
+				organizationId: removedOrganization.id,
+				role: "member",
+			},
+		});
+		await auth.api.addMember({
+			body: {
+				userId: removedUser.user.id,
+				organizationId: retainedOrganization.id,
+				role: "member",
+			},
+		});
+		const removedSessionOne = await signInWithUser(
+			removedUser.user.email,
+			"password12345",
+		);
+		const removedSessionTwo = await signInWithUser(
+			removedUser.user.email,
+			"password12345",
+		);
+		const removedSessionThree = await signInWithUser(
+			removedUser.user.email,
+			"password12345",
+		);
+		await auth.api.setActiveOrganization({
+			headers: removedSessionOne.headers,
+			body: { organizationId: removedOrganization.id },
+		});
+		await auth.api.setActiveOrganization({
+			headers: removedSessionTwo.headers,
+			body: { organizationId: removedOrganization.id },
+		});
+		await auth.api.setActiveOrganization({
+			headers: removedSessionThree.headers,
+			body: { organizationId: retainedOrganization.id },
+		});
+
+		await auth.api.removeMember({
+			headers: owner.headers,
+			body: {
+				organizationId: removedOrganization.id,
+				memberIdOrEmail: removedUser.user.email,
+			},
+		});
+
+		const removedSessions = new Map(
+			(await ctx.internalAdapter.listSessions(removedUser.user.id)).map(
+				(session) => [session.token, activeOrganizationId(session)],
+			),
+		);
+		expect(removedSessions.get(sessionToken(removedSessionOne.res))).toBeNull();
+		expect(removedSessions.get(sessionToken(removedSessionTwo.res))).toBeNull();
+		expect(removedSessions.get(sessionToken(removedSessionThree.res))).toBe(
+			retainedOrganization.id,
+		);
+
+		const leavingUser = await auth.api.signUpEmail({
+			body: {
+				email: "leaving-member@example.com",
+				name: "Leaving member",
+				password: "password12345",
+			},
+		});
+		await auth.api.addMember({
+			body: {
+				userId: leavingUser.user.id,
+				organizationId: leftOrganization.id,
+				role: "member",
+			},
+		});
+		await auth.api.addMember({
+			body: {
+				userId: leavingUser.user.id,
+				organizationId: retainedOrganization.id,
+				role: "member",
+			},
+		});
+		const leavingSessionOne = await signInWithUser(
+			leavingUser.user.email,
+			"password12345",
+		);
+		const leavingSessionTwo = await signInWithUser(
+			leavingUser.user.email,
+			"password12345",
+		);
+		const leavingSessionThree = await signInWithUser(
+			leavingUser.user.email,
+			"password12345",
+		);
+		await auth.api.setActiveOrganization({
+			headers: leavingSessionOne.headers,
+			body: { organizationId: leftOrganization.id },
+		});
+		await auth.api.setActiveOrganization({
+			headers: leavingSessionTwo.headers,
+			body: { organizationId: leftOrganization.id },
+		});
+		await auth.api.setActiveOrganization({
+			headers: leavingSessionThree.headers,
+			body: { organizationId: retainedOrganization.id },
+		});
+
+		await auth.api.leaveOrganization({
+			headers: leavingSessionOne.headers,
+			body: { organizationId: leftOrganization.id },
+		});
+
+		const leavingSessions = new Map(
+			(await ctx.internalAdapter.listSessions(leavingUser.user.id)).map(
+				(session) => [session.token, activeOrganizationId(session)],
+			),
+		);
+		expect(leavingSessions.get(sessionToken(leavingSessionOne.res))).toBeNull();
+		expect(leavingSessions.get(sessionToken(leavingSessionTwo.res))).toBeNull();
+		expect(leavingSessions.get(sessionToken(leavingSessionThree.res))).toBe(
+			retainedOrganization.id,
+		);
+	});
+
+	it("refreshes a stale remote cookie before an organization route uses it", async () => {
+		const { auth, signInWithTestUser, cookieSetter, customFetchImpl } =
+			await getTestInstance({
+				plugins: [organization()],
+				session: { cookieCache: { enabled: true, maxAge: 60 } },
+			});
+		const client = createAuthClient({
+			plugins: [organizationClient()],
+			baseURL: "http://localhost:3000/api/auth",
+			fetchOptions: { customFetchImpl },
+		});
+		const owner = await signInWithTestUser();
+		const removedOrganization = await auth.api.createOrganization({
+			headers: owner.headers,
+			body: { name: "Cached organization", slug: "cached-organization" },
+		});
+		const retainedOrganization = await auth.api.createOrganization({
+			headers: owner.headers,
+			body: {
+				name: "Cached retained organization",
+				slug: "cached-retained-organization",
+			},
+		});
+		if (!removedOrganization || !retainedOrganization) {
+			throw new Error("failed to create organization");
+		}
+
+		const targetHeaders = new Headers();
+		const target = await client.signUp.email(
+			{
+				email: "cached-member@example.com",
+				name: "Cached member",
+				password: "password12345",
+			},
+			{ onSuccess: cookieSetter(targetHeaders) },
+		);
+		if (!target.data) throw new Error("failed to create target user");
+		await auth.api.addMember({
+			body: {
+				userId: target.data.user.id,
+				organizationId: removedOrganization.id,
+				role: "member",
+			},
+		});
+		await auth.api.addMember({
+			body: {
+				userId: target.data.user.id,
+				organizationId: retainedOrganization.id,
+				role: "member",
+			},
+		});
+		await client.organization.setActive({
+			organizationId: removedOrganization.id,
+			fetchOptions: {
+				headers: targetHeaders,
+				onSuccess: cookieSetter(targetHeaders),
+			},
+		});
+
+		await auth.api.removeMember({
+			headers: owner.headers,
+			body: {
+				organizationId: removedOrganization.id,
+				memberIdOrEmail: target.data.user.email,
+			},
+		});
+
+		// The server cannot push-delete a signed cache cookie on another device.
+		const cachedSession = await client.getSession({
+			fetchOptions: { headers: targetHeaders },
+		});
+		expect(cachedSession.data?.session.activeOrganizationId).toBe(
+			removedOrganization.id,
+		);
+
+		// Organization middleware bypasses that cache, observes the cleared
+		// server session, and refreshes the response cookie before the handler runs.
+		const activeOrganization = await client.organization.getFullOrganization({
+			fetchOptions: {
+				headers: targetHeaders,
+				onSuccess: cookieSetter(targetHeaders),
+			},
+		});
+		expect(activeOrganization.error).toBeNull();
+		expect(activeOrganization.data).toBeNull();
+
+		const refreshedSession = await client.getSession({
+			fetchOptions: { headers: targetHeaders },
+		});
+		expect(refreshedSession.data?.session.activeOrganizationId).toBeNull();
+
+		await client.organization.setActive({
+			organizationId: retainedOrganization.id,
+			fetchOptions: {
+				headers: targetHeaders,
+				onSuccess: cookieSetter(targetHeaders),
+			},
+		});
+		const leave = await client.organization.leave(
+			{ organizationId: retainedOrganization.id },
+			{
+				headers: targetHeaders,
+				onSuccess: cookieSetter(targetHeaders),
+			},
+		);
+		expect(leave.error).toBeNull();
+
+		const sessionAfterLeave = await client.getSession({
+			fetchOptions: { headers: targetHeaders },
+		});
+		expect(sessionAfterLeave.data?.session.activeOrganizationId).toBeNull();
+	});
+});

--- a/packages/better-auth/src/plugins/organization/session.ts
+++ b/packages/better-auth/src/plugins/organization/session.ts
@@ -1,0 +1,44 @@
+import type { GenericEndpointContext } from "@better-auth/core";
+import { setSessionCookie } from "../../cookies";
+
+/**
+ * Clear an organization selection from every server-backed session for a user.
+ *
+ * A signed session-data cookie on another device cannot be pushed invalid from
+ * the server. Organization routes therefore resolve sessions authoritatively in
+ * stateful deployments and refresh that cookie on the device's next request.
+ */
+export async function clearActiveOrganizationFromSessions(
+	ctx: GenericEndpointContext,
+	userId: string,
+	organizationId: string,
+): Promise<void> {
+	const sessions = await ctx.context.internalAdapter.listSessions(userId);
+	let currentSession = null;
+
+	for (const session of sessions) {
+		const { activeOrganizationId } = session as typeof session & {
+			activeOrganizationId?: string | null | undefined;
+		};
+		if (activeOrganizationId !== organizationId) continue;
+
+		const updatedSession = await ctx.context.internalAdapter.updateSession(
+			session.token,
+			{ activeOrganizationId: null },
+		);
+		if (
+			updatedSession &&
+			ctx.context.session?.session.token === updatedSession.token
+		) {
+			currentSession = updatedSession;
+		}
+	}
+
+	if (currentSession && ctx.context.session?.user.id === userId) {
+		ctx.context.session = {
+			session: currentSession,
+			user: ctx.context.session.user,
+		};
+		await setSessionCookie(ctx, ctx.context.session);
+	}
+}

--- a/packages/core/src/context/transaction.test.ts
+++ b/packages/core/src/context/transaction.test.ts
@@ -117,6 +117,49 @@ describe("runWithTransaction", () => {
 		expect(hookRuns).toBe(0);
 	});
 
+	it("does not run hooks queued by nested calls when the outer transaction rolls back", async () => {
+		const { adapter, getTransactionCalls } = createTransactionHarness();
+		const transactionError = new Error("transaction failed");
+		let hookRuns = 0;
+
+		await expect(
+			runWithTransaction(adapter, async () => {
+				await runWithTransaction(adapter, async () => {
+					await queueAfterTransactionHook(async () => {
+						hookRuns += 1;
+					});
+				});
+
+				throw transactionError;
+			}),
+		).rejects.toBe(transactionError);
+
+		expect(getTransactionCalls()).toBe(1);
+		expect(hookRuns).toBe(0);
+	});
+
+	it("does not run hooks when committing the transaction fails", async () => {
+		const commitError = new Error("commit failed");
+		let hookRuns = 0;
+		const { adapter, transactionAdapter } = createTransactionHarness();
+		adapter.transaction = async <R>(
+			callback: (trx: DBTransactionAdapter) => Promise<R>,
+		) => {
+			await callback(transactionAdapter);
+			throw commitError;
+		};
+
+		await expect(
+			runWithTransaction(adapter, async () => {
+				await queueAfterTransactionHook(async () => {
+					hookRuns += 1;
+				});
+			}),
+		).rejects.toBe(commitError);
+
+		expect(hookRuns).toBe(0);
+	});
+
 	it("reports a handled after-commit hook failure without rejecting committed work", async () => {
 		const { adapter } = createTransactionHarness();
 		const onError = vi.fn();
@@ -165,17 +208,31 @@ describe("runWithTransaction", () => {
 		expect(events).toEqual(["later hook"]);
 	});
 
-	it("keeps legacy after-commit failures rejecting when no handler is provided", async () => {
-		const { adapter } = createTransactionHarness();
+	it("fails fast when an unhandled after-commit hook rejects", async () => {
+		const hookError = new Error("hook failed");
+		const events: string[] = [];
+		const { adapter, transactionAdapter } = createTransactionHarness();
+		adapter.transaction = async <R>(
+			callback: (trx: DBTransactionAdapter) => Promise<R>,
+		) => {
+			const result = await callback(transactionAdapter);
+			events.push("committed");
+			return result;
+		};
 
 		await expect(
 			runWithTransaction(adapter, async () => {
 				await queueAfterTransactionHook(async () => {
-					throw new Error("legacy hook failure");
+					events.push("first hook");
+					throw hookError;
 				});
-				return "committed";
+				await queueAfterTransactionHook(async () => {
+					events.push("second hook");
+				});
 			}),
-		).rejects.toThrow("legacy hook failure");
+		).rejects.toBe(hookError);
+
+		expect(events).toEqual(["committed", "first hook"]);
 	});
 
 	it("does not retry an immediately executed hook when it fails", async () => {


### PR DESCRIPTION
## Summary

- guard invitation accept, reject, cancel, and resend transitions with compare-and-swap lifecycle checks; add an ID-bound resend endpoint and safely replace expired pending invitations
- clear removed or departed organizations from every server-backed user session, make organization routes resolve sessions authoritatively, and document remote cookie-cache behavior
- return the joined user summary from member role updates
- add patch changesets and regression coverage for invitation races, session cleanup, member responses, and transaction-hook rollback/commit ordering

## Tests

- `pnpm --filter better-auth test --run src/plugins/organization/routes/invitation-lifecycle.test.ts src/plugins/organization/routes/member-session-selection.test.ts src/plugins/organization/routes/crud-members.test.ts` (32 passed)
- `pnpm --filter @better-auth/core test --run src/context/transaction.test.ts` (12 passed)
- `pnpm --filter better-auth typecheck`
- `pnpm --filter @better-auth/core typecheck`
- Biome check on all changed TypeScript and MDX files
- commit hooks: spell, biome

## Remaining blockers

- **Atomic accept:** the pending-to-accepted claim and subsequent member/team/session writes are not one portable atomic transaction across every adapter. Compensation restores `pending` after an observed failure, but a process crash or failed compensation can still leave an accepted invitation without the complete membership side effects.
- **Fresh create:** when no pending invitation row exists, the adapter contract has no portable create-if-absent primitive or universal composite uniqueness guarantee. Two concurrent fresh creates for the same organization/email can still both insert.
- **Last owner:** remove, leave, and role-demotion paths still enforce the owner invariant with a read/count followed by a separate mutation. Concurrent requests can each observe another owner and collectively leave the organization without one; this needs a database-level conditional mutation or locking primitive.

## Base

Rebased onto upstream `main` at `6442317f5`.