### PR TITLE
fix(cookies): warn on invalid cookie cache payloads

### DIFF
--- a/.changeset/cookie-cache-payload-visibility.md
+++ b/.changeset/cookie-cache-payload-visibility.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Cookie-cache reads now warn when signed session data is invalid instead of silently appearing as a signed-out session.

--- a/packages/better-auth/src/cookies/cache.ts
+++ b/packages/better-auth/src/cookies/cache.ts
@@ -1,5 +1,6 @@
 import type { CookieCachePayload } from "@better-auth/core";
 import { sessionSchema, userSchema } from "@better-auth/core/db";
+import { logger } from "@better-auth/core/env";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import * as z from "zod";
 
@@ -19,8 +20,22 @@ const compactCookieCacheSchema = z.object({
 export function parseCookieCachePayload(
 	value: unknown,
 ): CookieCachePayload | null {
-	const result = cookieCachePayloadSchema.safeParse(safeJSONParse(value));
-	return result.success ? result.data : null;
+	const parsed = safeJSONParse(value);
+	if (parsed === null) {
+		// safeJSONParse already logs malformed JSON.
+		// otherwise, there is no payload to validate.
+		return null;
+	}
+
+	const result = cookieCachePayloadSchema.safeParse(parsed);
+	if (result.success) {
+		return result.data;
+	}
+
+	logger.warn("Cookie cache payload failed schema validation", {
+		issues: result.error.issues.map(({ code, path }) => ({ code, path })),
+	});
+	return null;
 }
 
 export function parseCompactCookieCache(value: unknown) {

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -1,4 +1,5 @@
 import type { BetterAuthOptions } from "@better-auth/core";
+import { logger } from "@better-auth/core/env";
 import type { GoogleProfile } from "@better-auth/core/social-providers";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { base64Url } from "@better-auth/utils/base64";
@@ -1268,6 +1269,69 @@ describe("Cookie Cache Field Filtering", () => {
 		expect(cache).not.toBeNull();
 		expect(cache?.user?.email).toEqual(testUser.email);
 		expect(cache?.session?.token).toEqual(expect.any(String));
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10902
+	 */
+	it("should warn when a signed compact cookie has an invalid payload", async () => {
+		const secret = "test-secret";
+		const bakeCookie = async (emailVerified: boolean | null) => {
+			const now = new Date().toISOString();
+			const sessionData = {
+				session: {
+					id: "s1",
+					token: "tok",
+					userId: "u1",
+					expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+					createdAt: now,
+					updatedAt: now,
+				},
+				user: {
+					id: "u1",
+					name: "Test",
+					email: "a@b.com",
+					emailVerified,
+					createdAt: now,
+					updatedAt: now,
+				},
+				updatedAt: Date.now(),
+				version: "1",
+			};
+			const expiresAt = Date.now() + 300_000;
+			const signature = await createHMAC("SHA-256", "base64urlnopad").sign(
+				secret,
+				JSON.stringify({ ...sessionData, expiresAt }),
+			);
+			return base64Url.encode(
+				JSON.stringify({ session: sessionData, expiresAt, signature }),
+				{ padding: false },
+			);
+		};
+		const config = {
+			cookiePrefix: "p",
+			isSecure: false,
+			secret,
+		};
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const validCache = await getCookieCache(
+				new Headers({ cookie: `p.session_data=${await bakeCookie(false)}` }),
+				config,
+			);
+			expect(validCache).not.toBeNull();
+			expect(warn).not.toHaveBeenCalled();
+
+			const invalidCache = await getCookieCache(
+				new Headers({ cookie: `p.session_data=${await bakeCookie(null)}` }),
+				config,
+			);
+
+			expect(invalidCache).toBeNull();
+			expect(warn).toHaveBeenCalledTimes(1);
+		} finally {
+			warn.mockRestore();
+		}
 	});
 
 	it("should return null for invalid JWT token", async () => {


### PR DESCRIPTION
Closes #10902

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when cookie cache payloads fail schema validation instead of silently appearing as signed-out sessions. Previously, invalid signed session data returned null with no visibility; now we log a warning and still return null.

- Emits `logger.warn` from `@better-auth/core/env` in `parseCookieCachePayload` with minimal issue details (code, path); valid payload behavior is unchanged; malformed JSON remains logged by `safeJSONParse`.
- Adds a test that verifies a warning for an invalid signed compact cookie and no warning for a valid payload.
- No public API or config changes; no migration required.

<sup>Written for commit b73d7597dab2392002e32b277872bba8bc3dee6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

