### PR TITLE
fix(logger): respect configured logger in auth request context

### DIFF
--- a/.changeset/scoped-logger-cookie-cache.md
+++ b/.changeset/scoped-logger-cookie-cache.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Logs emitted while handling auth requests now respect the configured custom logger, log level, and disabled setting.

--- a/packages/core/src/context/endpoint-context.ts
+++ b/packages/core/src/context/endpoint-context.ts
@@ -32,6 +32,18 @@ export async function getCurrentAuthContextAsyncLocalStorage() {
 	return ensureAsyncStorage();
 }
 
+/**
+ * Returns the current auth context without initializing async storage.
+ *
+ * @internal
+ */
+export function tryGetCurrentAuthContext(): AuthEndpointContext | undefined {
+	const storage = __getBetterAuthGlobal().context.endpointContextAsyncStorage as
+		| AsyncLocalStorage<AuthEndpointContext>
+		| undefined;
+	return storage?.getStore();
+}
+
 export async function getCurrentAuthContext(): Promise<AuthEndpointContext> {
 	const als = await ensureAsyncStorage();
 	const context = als.getStore();

--- a/packages/core/src/env/logger.test.ts
+++ b/packages/core/src/env/logger.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest";
-import type { LogLevel } from "./logger";
-import { shouldPublishLog } from "./logger";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import type { AuthEndpointContext } from "../context";
+import { runWithEndpointContext } from "../context";
+import { safeJSONParse } from "../utils/json";
+import type { InternalLogger, LogLevel } from "./logger";
+import { createLogger, logger, shouldPublishLog } from "./logger";
 
 describe("shouldPublishLog", () => {
 	const testCases: {
@@ -30,5 +33,79 @@ describe("shouldPublishLog", () => {
 		it(`should return "${expected}" when currentLogLevel is "${currentLogLevel}" and logLevel is "${logLevel}"`, () => {
 			expect(shouldPublishLog(currentLogLevel, logLevel)).toBe(expected);
 		});
+	});
+});
+
+describe("logger", () => {
+	const endpointContext = (logger: InternalLogger) =>
+		({ context: { logger } }) as unknown as AuthEndpointContext;
+
+	it("uses the default logger outside an auth context", () => {
+		const defaultWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		onTestFinished(() => defaultWarn.mockRestore());
+
+		logger.warn("default warning");
+
+		expect(defaultWarn).toHaveBeenCalledTimes(1);
+	});
+
+	it("delegates to the logger in the current auth context", async () => {
+		const defaultWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		onTestFinished(() => defaultWarn.mockRestore());
+		const firstLog = vi.fn();
+		const secondLog = vi.fn();
+		const firstLogger = createLogger({ level: "info", log: firstLog });
+		const secondLogger = createLogger({ level: "error", log: secondLog });
+
+		await Promise.all([
+			runWithEndpointContext(endpointContext(firstLogger), async () => {
+				await Promise.resolve();
+				expect(logger.level).toBe("info");
+				logger.warn("first warning");
+			}),
+			runWithEndpointContext(endpointContext(secondLogger), async () => {
+				await Promise.resolve();
+				expect(logger.level).toBe("error");
+				logger.warn("second warning");
+			}),
+		]);
+
+		expect(firstLog).toHaveBeenCalledWith("warn", "first warning");
+		expect(secondLog).not.toHaveBeenCalled();
+		expect(defaultWarn).not.toHaveBeenCalled();
+	});
+
+	it("routes utility logs through the current auth context", async () => {
+		const defaultError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		onTestFinished(() => defaultError.mockRestore());
+		const log = vi.fn();
+		const configuredLogger = createLogger({ log });
+
+		await runWithEndpointContext(endpointContext(configuredLogger), () => {
+			expect(safeJSONParse("{")).toBeNull();
+		});
+
+		expect(log).toHaveBeenCalledWith(
+			"error",
+			"Error parsing JSON",
+			expect.objectContaining({ error: expect.any(SyntaxError) }),
+		);
+		expect(defaultError).not.toHaveBeenCalled();
+	});
+
+	it("honors disabled logging in the current auth context", async () => {
+		const defaultWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		onTestFinished(() => defaultWarn.mockRestore());
+		const log = vi.fn();
+		const configuredLogger = createLogger({ disabled: true, log });
+
+		await runWithEndpointContext(endpointContext(configuredLogger), () => {
+			logger.warn("hidden warning");
+		});
+
+		expect(log).not.toHaveBeenCalled();
+		expect(defaultWarn).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/env/logger.ts
+++ b/packages/core/src/env/logger.ts
@@ -1,3 +1,4 @@
+import { tryGetCurrentAuthContext } from "../context/endpoint-context";
 import { getColorDepth } from "./color-depth";
 
 export const TTY_COLORS = {
@@ -142,4 +143,22 @@ export const createLogger = (options?: Logger | undefined): InternalLogger => {
 	};
 };
 
-export const logger = createLogger();
+const defaultLogger = createLogger();
+
+const getCurrentLogger = (): InternalLogger => {
+	const currentLogger = tryGetCurrentAuthContext()?.context.logger;
+	return currentLogger && currentLogger !== logger
+		? currentLogger
+		: defaultLogger;
+};
+
+export const logger: InternalLogger = {
+	debug: (...params) => getCurrentLogger().debug(...params),
+	info: (...params) => getCurrentLogger().info(...params),
+	success: (...params) => getCurrentLogger().success(...params),
+	warn: (...params) => getCurrentLogger().warn(...params),
+	error: (...params) => getCurrentLogger().error(...params),
+	get level() {
+		return getCurrentLogger().level;
+	},
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Respect the configured request-scoped logger during auth request handling. Previously logs used the default logger; now they delegate to the current auth context’s logger and fall back to the default outside a context.

- Adds `tryGetCurrentAuthContext()` to read the current endpoint context without initializing async storage.
- Wraps the exported `logger` to resolve the context logger on each call; `logger.level` reflects the active context.
- Routes utility logs (e.g., JSON parse errors) through the context logger; respects disabled logging.
- Patch release for `@better-auth/core`; no migrations.

<sup>Written for commit ec625f8bb4bb6782f9f705f56ad926456a82a949. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

