### PR TITLE
ci: harden smoke test timeouts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,7 @@ jobs:
           deno-version: 2.6.4
 
       - name: Smoke
+        timeout-minutes: 10
         run: pnpm e2e:smoke
 
       - name: Docker Compose Diagnostics

--- a/e2e/smoke/test/typecheck.spec.ts
+++ b/e2e/smoke/test/typecheck.spec.ts
@@ -5,6 +5,7 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const fixturesDir = fileURLToPath(new URL("./fixtures", import.meta.url));
+const typecheckTimeoutMilliseconds = 60 * 1000;
 
 [
 	{ dir: "tsconfig-declaration", skip: false },
@@ -18,7 +19,7 @@ const fixturesDir = fileURLToPath(new URL("./fixtures", import.meta.url));
 		const output = spawnSync("pnpm", ["run", "typecheck"], {
 			stdio: "inherit",
 			cwd,
-			timeout: 10 * 1000, // 10 seconds
+			timeout: typecheckTimeoutMilliseconds,
 		});
 		assert.equal(
 			output.error,


### PR DESCRIPTION
PRs from forks run on GitHub-hosted runners instead of the faster Starsling runner. The current 10-second typecheck timeout is too tight for those runners, causing intermittent smoke test failures.

---

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase smoke typecheck timeouts to reduce CI flakiness. Old: smoke typecheck aborted after 10s. New: test timeout is 60s; the CI Smoke step now times out after 10 minutes to provide headroom while keeping runs bounded.

**Review notes**
- Changes only `.github/workflows/e2e.yml` and `e2e/smoke/test/typecheck.spec.ts`; no runtime or product behavior changes.
- No developer action required.

<sup>Written for commit 9bf6ff1ceda69f766437bc73dc8428276a84df4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

