### PR TITLE
refactor(context): clarify auth endpoint context access

### DIFF
--- a/.changeset/auth-endpoint-context.md
+++ b/.changeset/auth-endpoint-context.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Added synchronous auth endpoint context access with `getCurrentAuthEndpointContext` and optional access with `tryGetCurrentAuthEndpointContext`. The existing `getCurrentAuthContext` function remains available as a deprecated alias.

--- a/.changeset/auth-endpoint-context.md
+++ b/.changeset/auth-endpoint-context.md
@@ -2,4 +2,4 @@
 "@better-auth/core": patch
 ---
 
-Added synchronous auth endpoint context access with `getCurrentAuthEndpointContext` and optional access with `tryGetCurrentAuthEndpointContext`. The existing `getCurrentAuthContext` function remains available as a deprecated alias.
+Added synchronous auth endpoint context access with `getCurrentAuthEndpointContext` and optional access with `tryGetCurrentAuthEndpointContext`. The existing `getCurrentAuthContext` and `getCurrentAuthContextAsyncLocalStorage` functions remain available as deprecated compatibility APIs.

--- a/docs/content/docs/concepts/hooks.mdx
+++ b/docs/content/docs/concepts/hooks.mdx
@@ -134,35 +134,6 @@ When you call `createAuthMiddleware` a `ctx` object is passed that provides a lo
 
 and more.
 
-### Accessing the Current Endpoint Context
-
-Prefer the `ctx` argument provided to hooks and endpoint handlers. When a helper
-called during an auth request cannot receive `ctx` directly, use
-`getCurrentAuthEndpointContext`:
-
-```ts
-import { getCurrentAuthEndpointContext } from "@better-auth/core/context";
-
-export function getRequestPath() {
-    return getCurrentAuthEndpointContext().path;
-}
-```
-
-The function throws when it is called outside `runWithEndpointContext`. Use
-`tryGetCurrentAuthEndpointContext` when the helper can also run outside an auth
-request:
-
-```ts
-import { tryGetCurrentAuthEndpointContext } from "@better-auth/core/context";
-
-export function getRequestPath() {
-    return tryGetCurrentAuthEndpointContext()?.path;
-}
-```
-
-`getCurrentAuthContext` is deprecated. Replace
-`await getCurrentAuthContext()` with `getCurrentAuthEndpointContext()`.
-
 ### Request Response
 
 This utilities allows you to get request information and to send response from a hook.

--- a/docs/content/docs/concepts/hooks.mdx
+++ b/docs/content/docs/concepts/hooks.mdx
@@ -134,6 +134,35 @@ When you call `createAuthMiddleware` a `ctx` object is passed that provides a lo
 
 and more.
 
+### Accessing the Current Endpoint Context
+
+Prefer the `ctx` argument provided to hooks and endpoint handlers. When a helper
+called during an auth request cannot receive `ctx` directly, use
+`getCurrentAuthEndpointContext`:
+
+```ts
+import { getCurrentAuthEndpointContext } from "@better-auth/core/context";
+
+export function getRequestPath() {
+    return getCurrentAuthEndpointContext().path;
+}
+```
+
+The function throws when it is called outside `runWithEndpointContext`. Use
+`tryGetCurrentAuthEndpointContext` when the helper can also run outside an auth
+request:
+
+```ts
+import { tryGetCurrentAuthEndpointContext } from "@better-auth/core/context";
+
+export function getRequestPath() {
+    return tryGetCurrentAuthEndpointContext()?.path;
+}
+```
+
+`getCurrentAuthContext` is deprecated. Replace
+`await getCurrentAuthContext()` with `getCurrentAuthEndpointContext()`.
+
 ### Request Response
 
 This utilities allows you to get request information and to send response from a hook.

--- a/e2e/smoke/test/fixtures/cloudflare/src/index.ts
+++ b/e2e/smoke/test/fixtures/cloudflare/src/index.ts
@@ -1,7 +1,7 @@
 import type { AuthEndpointContext } from "@better-auth/core/context";
 import {
 	getCurrentAdapter,
-	getCurrentAuthContext,
+	getCurrentAuthEndpointContext,
 	runWithEndpointContext,
 	runWithTransaction,
 } from "@better-auth/core/context";
@@ -39,7 +39,7 @@ app.get("/_test/async-context/concurrency", async (c) => {
 		contexts.map((context) =>
 			runWithEndpointContext(context, async () => {
 				await Promise.resolve();
-				return getCurrentAuthContext();
+				return getCurrentAuthEndpointContext();
 			}),
 		),
 	);

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -8,9 +8,10 @@ import type {
 } from "@better-auth/core";
 import {
 	getCurrentAdapter,
-	getCurrentAuthContext,
+	getCurrentAuthEndpointContext,
 	queueAfterTransactionHook,
 	runWithTransaction,
+	tryGetCurrentAuthEndpointContext,
 } from "@better-auth/core/context";
 import { createLocalAccountIssuer } from "@better-auth/core/db";
 import type { DBAdapter, Where } from "@better-auth/core/db/adapter";
@@ -288,7 +289,7 @@ export const createInternalAdapter = (
 				let endpointContext: GenericEndpointContext;
 				try {
 					endpointContext =
-						(await getCurrentAuthContext()) as GenericEndpointContext;
+						getCurrentAuthEndpointContext() as GenericEndpointContext;
 				} catch (error) {
 					logger.error(
 						"Unable to run validateUserInfo: missing endpoint context",
@@ -473,7 +474,7 @@ export const createInternalAdapter = (
 				| undefined,
 		) => {
 			const headers: Headers | undefined = await (async () => {
-				const ctx = await getCurrentAuthContext().catch(() => null);
+				const ctx = tryGetCurrentAuthEndpointContext();
 				return ctx?.headers || ctx?.request?.headers;
 			})();
 			const storeInDb = options.session?.storeSessionInDatabase;

--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -1,8 +1,8 @@
 import type { BetterAuthOptions } from "@better-auth/core";
 import {
 	getCurrentAdapter,
-	getCurrentAuthContext,
 	queueAfterTransactionHook,
+	tryGetCurrentAuthEndpointContext,
 } from "@better-auth/core/context";
 import type { BaseModelNames } from "@better-auth/core/db";
 import type { DBAdapter, Where } from "@better-auth/core/db/adapter";
@@ -36,7 +36,7 @@ export function getWithHooks(
 			  }
 			| undefined,
 	) {
-		const context = await getCurrentAuthContext().catch(() => null);
+		const context = tryGetCurrentAuthEndpointContext();
 		let actualData = data;
 		for (const { source, hooks } of hooksEntries) {
 			const toRun = hooks[model]?.create?.before;
@@ -110,7 +110,7 @@ export function getWithHooks(
 			  }
 			| undefined,
 	) {
-		const context = await getCurrentAuthContext().catch(() => null);
+		const context = tryGetCurrentAuthEndpointContext();
 		let actualData = data;
 
 		for (const { source, hooks } of hooksEntries) {
@@ -185,7 +185,7 @@ export function getWithHooks(
 			  }
 			| undefined,
 	) {
-		const context = await getCurrentAuthContext().catch(() => null);
+		const context = tryGetCurrentAuthEndpointContext();
 		let actualData = data;
 
 		for (const { source, hooks } of hooksEntries) {
@@ -260,7 +260,7 @@ export function getWithHooks(
 			  }
 			| undefined,
 	) {
-		const context = await getCurrentAuthContext().catch(() => null);
+		const context = tryGetCurrentAuthEndpointContext();
 		let entityToDelete: T | null = null;
 
 		try {
@@ -344,7 +344,7 @@ export function getWithHooks(
 			  }
 			| undefined,
 	) {
-		const context = await getCurrentAuthContext().catch(() => null);
+		const context = tryGetCurrentAuthEndpointContext();
 		let entitiesToDelete: T[] = [];
 
 		try {
@@ -437,7 +437,7 @@ export function getWithHooks(
 		consumeFn: () => Promise<T | null>,
 		preSnapshot?: T | null,
 	): Promise<T | null> {
-		const context = await getCurrentAuthContext().catch(() => null);
+		const context = tryGetCurrentAuthEndpointContext();
 		const beforeHooks = hooksEntries.flatMap(({ source, hooks }) => {
 			const fn = hooks[model]?.delete?.before;
 			return fn ? [{ source, fn }] : [];

--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
-import { getCurrentAuthContext } from "@better-auth/core/context";
+import { getCurrentAuthEndpointContext } from "@better-auth/core/context";
 import { defineErrorCodes } from "@better-auth/core/utils/error-codes";
 import { createHash } from "@better-auth/utils/hash";
 import { betterFetch } from "@better-fetch/fetch";
@@ -108,7 +108,7 @@ export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions | undefined) => {
 						async hash(password) {
 							if (options?.enabled === false) return originalHash(password);
 
-							const c = await getCurrentAuthContext();
+							const c = getCurrentAuthEndpointContext();
 							if (!c.path || !paths.includes(c.path)) {
 								return originalHash(password);
 							}

--- a/packages/better-auth/src/plugins/jwt/verify.ts
+++ b/packages/better-auth/src/plugins/jwt/verify.ts
@@ -1,5 +1,5 @@
 import type { GenericEndpointContext } from "@better-auth/core";
-import { getCurrentAuthContext } from "@better-auth/core/context";
+import { getCurrentAuthEndpointContext } from "@better-auth/core/context";
 import { base64 } from "@better-auth/utils/base64";
 import type { JWTPayload } from "jose";
 import { importJWK, jwtVerify } from "jose";
@@ -14,7 +14,7 @@ export async function verifyJWT<T extends JWTPayload = JWTPayload>(
 	token: string,
 	options?: JwtOptions,
 ): Promise<(T & Required<Pick<JWTPayload, "sub" | "aud">>) | null> {
-	const ctx = await getCurrentAuthContext();
+	const ctx = getCurrentAuthEndpointContext();
 	try {
 		const parts = token.split(".");
 		if (parts.length !== 3) {

--- a/packages/core/src/context/endpoint-context.test.ts
+++ b/packages/core/src/context/endpoint-context.test.ts
@@ -2,29 +2,34 @@ import { describe, expect, it, onTestFinished, vi } from "vitest";
 import type { AuthEndpointContext } from "./endpoint-context";
 import { __getBetterAuthGlobal } from "./global";
 
+function removeEndpointContextStorage() {
+	const globalContext = __getBetterAuthGlobal().context;
+	const previousStorageDescriptor = Object.getOwnPropertyDescriptor(
+		globalContext,
+		"endpointContextAsyncStorage",
+	);
+	onTestFinished(() => {
+		if (previousStorageDescriptor) {
+			Object.defineProperty(
+				globalContext,
+				"endpointContextAsyncStorage",
+				previousStorageDescriptor,
+			);
+		} else {
+			Reflect.deleteProperty(globalContext, "endpointContextAsyncStorage");
+		}
+	});
+	Reflect.deleteProperty(globalContext, "endpointContextAsyncStorage");
+	return globalContext;
+}
+
 describe("runWithEndpointContext", () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/10832
 	 */
 	it("preserves each endpoint context across concurrent first calls", async () => {
 		vi.resetModules();
-		const globalContext = __getBetterAuthGlobal().context;
-		const previousStorageDescriptor = Object.getOwnPropertyDescriptor(
-			globalContext,
-			"endpointContextAsyncStorage",
-		);
-		onTestFinished(() => {
-			if (previousStorageDescriptor) {
-				Object.defineProperty(
-					globalContext,
-					"endpointContextAsyncStorage",
-					previousStorageDescriptor,
-				);
-			} else {
-				Reflect.deleteProperty(globalContext, "endpointContextAsyncStorage");
-			}
-		});
-		Reflect.deleteProperty(globalContext, "endpointContextAsyncStorage");
+		removeEndpointContextStorage();
 		const mod = await import("./endpoint-context");
 
 		const contexts = Array.from(
@@ -35,7 +40,9 @@ describe("runWithEndpointContext", () => {
 			contexts.map((context) =>
 				mod.runWithEndpointContext(context, async () => {
 					await Promise.resolve();
-					return mod.getCurrentAuthContext();
+					const currentContext = mod.getCurrentAuthEndpointContext();
+					expect(await mod.getCurrentAuthContext()).toBe(currentContext);
+					return currentContext;
 				}),
 			),
 		);
@@ -44,5 +51,22 @@ describe("runWithEndpointContext", () => {
 			(currentContext, index) => currentContext === contexts[index],
 		).length;
 		expect(matchingContextCount).toBe(contexts.length);
+	});
+});
+
+describe("getCurrentAuthEndpointContext", () => {
+	it("does not initialize async storage when no context exists", async () => {
+		vi.resetModules();
+		const globalContext = removeEndpointContextStorage();
+		const mod = await import("./endpoint-context");
+
+		expect(mod.tryGetCurrentAuthEndpointContext()).toBeUndefined();
+		expect(() => mod.getCurrentAuthEndpointContext()).toThrow(
+			"No auth context found",
+		);
+		await expect(mod.getCurrentAuthContext()).rejects.toThrow(
+			"No auth context found",
+		);
+		expect(globalContext.endpointContextAsyncStorage).toBeUndefined();
 	});
 });

--- a/packages/core/src/context/endpoint-context.test.ts
+++ b/packages/core/src/context/endpoint-context.test.ts
@@ -69,4 +69,16 @@ describe("getCurrentAuthEndpointContext", () => {
 		);
 		expect(globalContext.endpointContextAsyncStorage).toBeUndefined();
 	});
+
+	it("keeps the deprecated async storage accessor compatible", async () => {
+		vi.resetModules();
+		removeEndpointContextStorage();
+		const mod = await import("./endpoint-context");
+		const storage = await mod.getCurrentAuthContextAsyncLocalStorage();
+		const context = {} as AuthEndpointContext;
+
+		await mod.runWithEndpointContext(context, () => {
+			expect(storage.getStore()).toBe(context);
+		});
+	});
 });

--- a/packages/core/src/context/endpoint-context.ts
+++ b/packages/core/src/context/endpoint-context.ts
@@ -31,6 +31,14 @@ const getOrCreateEndpointContextStorage = async () => {
 };
 
 /**
+ * @deprecated Use `getCurrentAuthEndpointContext`,
+ * `tryGetCurrentAuthEndpointContext`, or `runWithEndpointContext` instead.
+ */
+export async function getCurrentAuthContextAsyncLocalStorage() {
+	return getOrCreateEndpointContextStorage();
+}
+
+/**
  * Returns the current auth endpoint context, or `undefined` when called outside
  * of `runWithEndpointContext`.
  */

--- a/packages/core/src/context/endpoint-context.ts
+++ b/packages/core/src/context/endpoint-context.ts
@@ -2,7 +2,7 @@ import type { AsyncLocalStorage } from "@better-auth/core/async_hooks";
 import { getAsyncLocalStorage } from "@better-auth/core/async_hooks";
 import type { EndpointContext, InputContext } from "better-call";
 import type { AuthContext } from "../types";
-import { __getBetterAuthGlobal } from "./global";
+import { __getBetterAuthGlobal, __getCurrentEndpointContext } from "./global";
 
 export type AuthEndpointContext = Partial<
 	InputContext<string, any> & EndpointContext<string, any>
@@ -35,7 +35,7 @@ const getOrCreateEndpointContextStorage = async () => {
  * of `runWithEndpointContext`.
  */
 export function tryGetCurrentAuthEndpointContext() {
-	return getExistingEndpointContextStorage()?.getStore();
+	return __getCurrentEndpointContext<AuthEndpointContext>();
 }
 
 /**

--- a/packages/core/src/context/endpoint-context.ts
+++ b/packages/core/src/context/endpoint-context.ts
@@ -10,43 +10,60 @@ export type AuthEndpointContext = Partial<
 	context: AuthContext;
 };
 
-const ensureAsyncStorage = async () => {
-	const betterAuthGlobal = __getBetterAuthGlobal();
-	const existing = betterAuthGlobal.context.endpointContextAsyncStorage;
+type AuthEndpointContextStorage = AsyncLocalStorage<AuthEndpointContext>;
+
+const getExistingEndpointContextStorage = () => {
+	return __getBetterAuthGlobal().context.endpointContextAsyncStorage as
+		| AuthEndpointContextStorage
+		| undefined;
+};
+
+const getOrCreateEndpointContextStorage = async () => {
+	const existing = getExistingEndpointContextStorage();
 	if (existing) {
-		return existing as AsyncLocalStorage<AuthEndpointContext>;
+		return existing;
 	}
 	const AsyncLocalStorage = await getAsyncLocalStorage();
-	betterAuthGlobal.context.endpointContextAsyncStorage ??=
-		new AsyncLocalStorage<AuthEndpointContext>();
-	return betterAuthGlobal.context
-		.endpointContextAsyncStorage as AsyncLocalStorage<AuthEndpointContext>;
+	const globalContext = __getBetterAuthGlobal().context;
+	const storage = (globalContext.endpointContextAsyncStorage ??=
+		new AsyncLocalStorage<AuthEndpointContext>()) as AuthEndpointContextStorage;
+	return storage;
 };
 
 /**
- * This is for internal use only. Most users should use `getCurrentAuthContext` instead.
- *
- * It is exposed for advanced use cases where you need direct access to the AsyncLocalStorage instance.
+ * Returns the current auth endpoint context, or `undefined` when called outside
+ * of `runWithEndpointContext`.
  */
-export async function getCurrentAuthContextAsyncLocalStorage() {
-	return ensureAsyncStorage();
+export function tryGetCurrentAuthEndpointContext() {
+	return getExistingEndpointContextStorage()?.getStore();
 }
 
-export async function getCurrentAuthContext(): Promise<AuthEndpointContext> {
-	const als = await ensureAsyncStorage();
-	const context = als.getStore();
-	if (!context) {
+/**
+ * Returns the current auth endpoint context.
+ *
+ * @throws When called outside of `runWithEndpointContext`.
+ */
+export function getCurrentAuthEndpointContext() {
+	const authEndpointContext = tryGetCurrentAuthEndpointContext();
+	if (!authEndpointContext) {
 		throw new Error(
 			"No auth context found. Please make sure you are calling this function within a `runWithEndpointContext` callback.",
 		);
 	}
-	return context;
+	return authEndpointContext;
+}
+
+/**
+ * @deprecated Use `getCurrentAuthEndpointContext` instead.
+ */
+export async function getCurrentAuthContext() {
+	return getCurrentAuthEndpointContext();
 }
 
 export async function runWithEndpointContext<T>(
-	context: AuthEndpointContext,
+	authEndpointContext: AuthEndpointContext,
 	fn: () => T,
 ): Promise<T> {
-	const als = await ensureAsyncStorage();
-	return als.run(context, fn);
+	const storage = await getOrCreateEndpointContextStorage();
+	return storage.run(authEndpointContext, fn);
 }

--- a/packages/core/src/context/global.ts
+++ b/packages/core/src/context/global.ts
@@ -52,6 +52,13 @@ export function __getBetterAuthGlobal(): BetterAuthGlobal {
 	return (globalThis as any)[symbol] as BetterAuthGlobal;
 }
 
+export function __getCurrentEndpointContext<T>(): T | undefined {
+	const storage = __getBetterAuthGlobal().context.endpointContextAsyncStorage as
+		| AsyncLocalStorage<T>
+		| undefined;
+	return storage?.getStore();
+}
+
 export function getBetterAuthVersion(): string {
 	return __getBetterAuthGlobal().version;
 }

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -1,8 +1,9 @@
 export {
 	type AuthEndpointContext,
 	getCurrentAuthContext,
-	getCurrentAuthContextAsyncLocalStorage,
+	getCurrentAuthEndpointContext,
 	runWithEndpointContext,
+	tryGetCurrentAuthEndpointContext,
 } from "./endpoint-context";
 export { getBetterAuthVersion } from "./global";
 export {

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -1,6 +1,7 @@
 export {
 	type AuthEndpointContext,
 	getCurrentAuthContext,
+	getCurrentAuthContextAsyncLocalStorage,
 	getCurrentAuthEndpointContext,
 	runWithEndpointContext,
 	tryGetCurrentAuthEndpointContext,


### PR DESCRIPTION

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies auth endpoint context access in `@better-auth/core` to avoid implicit async storage and keep async hooks out of client bundles. Old: `getCurrentAuthContext` was async and could initialize storage; new: `getCurrentAuthEndpointContext` is synchronous and throws outside `runWithEndpointContext`, and `tryGetCurrentAuthEndpointContext` returns undefined.

- Migration
  - Replace `await getCurrentAuthContext()` with `getCurrentAuthEndpointContext()` when a context must exist, or `tryGetCurrentAuthEndpointContext()` when optional.
  - Remove unnecessary `await` and update imports to the new exports in `@better-auth/core/context`.
  - `getCurrentAuthContext` and `getCurrentAuthContextAsyncLocalStorage` remain as deprecated compatibility APIs; prefer `runWithEndpointContext` to scope context.

<sup>Written for commit 12ac300f8f8cce6958fd1b724ffcd949607890ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



