### PR TITLE
fix(drizzle-adapter): resolve one-to-one relation keys with usePlural

### DIFF
--- a/.changeset/drizzle-plural-one-to-one-joins.md
+++ b/.changeset/drizzle-plural-one-to-one-joins.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/drizzle-adapter": patch
+---
+
+Prevent one-to-one joins from failing in Drizzle Relations v1 and v2 when `usePlural` is enabled, while preserving support for legacy plural relation keys.

--- a/.changeset/drizzle-plural-one-to-one-joins.md
+++ b/.changeset/drizzle-plural-one-to-one-joins.md
@@ -2,4 +2,4 @@
 "@better-auth/drizzle-adapter": patch
 ---
 
-Prevent one-to-one joins from failing in Drizzle Relations v1 and v2 when `usePlural` is enabled, while preserving support for legacy plural relation keys.
+Prevent one-to-one joins from failing in Drizzle Relations v1 and v2 when `usePlural` is enabled. Resolve generated and legacy relation keys from Drizzle runtime metadata, including Relations v2 setups without an adapter schema.

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.use-plural-joins-relationname.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.use-plural-joins-relationname.test.ts
@@ -316,6 +316,70 @@ describe("drizzle adapter: usePlural + joins + ambiguous relations (#8849)", () 
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/10616
 	 */
+	it("resolves generated relation keys from Drizzle metadata", async () => {
+		const db = drizzle(sqliteDb, {
+			schema: {
+				users,
+				accounts,
+				usersRelationsGenerated,
+				accountsRelationsGenerated,
+			},
+		});
+
+		const adapter = drizzleAdapter(db, {
+			provider: "sqlite",
+			usePlural: true,
+		})({
+			advanced: { database: { joins: true } },
+		});
+
+		const account = await adapter.findOne<Account & { user: User }>({
+			model: "account",
+			where: [{ field: "id", value: "a1" }],
+			join: { user: true },
+		});
+
+		expect(account?.user.id).toBe("u1");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10616
+	 */
+	it("resolves relation keys when schema and query model names differ", async () => {
+		const db = drizzle(sqliteDb, {
+			schema: {
+				usersTable: users,
+				accountsTable: accounts,
+				usersRelationsGenerated,
+				accountsRelationsGenerated,
+			},
+		});
+
+		const adapter = drizzleAdapter(db, {
+			schema: {
+				users,
+				accounts,
+				usersRelationsGenerated,
+				accountsRelationsGenerated,
+			},
+			provider: "sqlite",
+			usePlural: true,
+		})({
+			advanced: { database: { joins: true } },
+		});
+
+		const account = await adapter.findOne<Account & { user: User }>({
+			model: "account",
+			where: [{ field: "id", value: "a1" }],
+			join: { user: true },
+		});
+
+		expect(account?.user.id).toBe("u1");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10616
+	 */
 	it("supports legacy plural forward relation keys with usePlural", async () => {
 		const db = drizzle(sqliteDb, {
 			schema: {

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.use-plural-joins-relationname.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.use-plural-joins-relationname.test.ts
@@ -66,21 +66,28 @@ const verifications = sqliteTable("verifications", {
 	updatedAt: integer("updatedAt", { mode: "timestamp" }),
 });
 
-/** Current main CLI usePlural output: plural many-to-one keys (`users`). */
-const usersRelationsCliMain = relations(users, ({ many }) => ({
+/** Current CLI output: plural reverse keys and singular forward keys. */
+const usersRelationsGenerated = relations(users, ({ many }) => ({
 	sessions: many(sessions),
 	accounts: many(accounts),
 }));
 
-const accountsRelationsCliMain = relations(accounts, ({ one }) => ({
+const accountsRelationsGenerated = relations(accounts, ({ one }) => ({
+	user: one(users, {
+		fields: [accounts.userId],
+		references: [users.id],
+	}),
+}));
+
+const accountsRelationsLegacy = relations(accounts, ({ one }) => ({
 	users: one(users, {
 		fields: [accounts.userId],
 		references: [users.id],
 	}),
 }));
 
-const sessionsRelationsCliMain = relations(sessions, ({ one }) => ({
-	users: one(users, {
+const sessionsRelationsGenerated = relations(sessions, ({ one }) => ({
+	user: one(users, {
 		fields: [sessions.userId],
 		references: [users.id],
 	}),
@@ -238,16 +245,19 @@ describe("drizzle adapter: usePlural + joins + ambiguous relations (#8849)", () 
 		expect(session?.impersonator).toBeNull();
 	});
 
-	it("clean CLI usePlural relations work with usePlural + joins (control)", async () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10616
+	 */
+	it("resolves generated relation keys with usePlural", async () => {
 		const db = drizzle(sqliteDb, {
 			schema: {
 				users,
 				sessions,
 				accounts,
 				verifications,
-				usersRelationsCliMain,
-				accountsRelationsCliMain,
-				sessionsRelationsCliMain,
+				usersRelationsGenerated,
+				accountsRelationsGenerated,
+				sessionsRelationsGenerated,
 			},
 		});
 
@@ -257,6 +267,9 @@ describe("drizzle adapter: usePlural + joins + ambiguous relations (#8849)", () 
 				sessions,
 				accounts,
 				verifications,
+				usersRelationsGenerated,
+				accountsRelationsGenerated,
+				sessionsRelationsGenerated,
 			},
 			provider: "sqlite",
 			usePlural: true,
@@ -288,5 +301,56 @@ describe("drizzle adapter: usePlural + joins + ambiguous relations (#8849)", () 
 		});
 
 		expect(accountWithUser?.user?.id).toBe("u1");
+
+		const accountsWithUser = await adapter.findMany<Account & { user: User }>({
+			model: "account",
+			where: [{ field: "id", value: "a1" }],
+			join: {
+				user: true,
+			},
+		});
+
+		expect(accountsWithUser[0]?.user?.id).toBe("u1");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10616
+	 */
+	it("supports legacy plural forward relation keys with usePlural", async () => {
+		const db = drizzle(sqliteDb, {
+			schema: {
+				users,
+				sessions,
+				accounts,
+				verifications,
+				usersRelationsGenerated,
+				accountsRelationsLegacy,
+				sessionsRelationsGenerated,
+			},
+		});
+
+		const adapter = drizzleAdapter(db, {
+			schema: {
+				users,
+				sessions,
+				accounts,
+				verifications,
+				usersRelationsGenerated,
+				accountsRelationsLegacy,
+				sessionsRelationsGenerated,
+			},
+			provider: "sqlite",
+			usePlural: true,
+		})({
+			advanced: { database: { joins: true } },
+		});
+
+		const account = await adapter.findOne<Account & { user: User }>({
+			model: "account",
+			where: [{ field: "id", value: "a1" }],
+			join: { user: true },
+		});
+
+		expect(account?.user.id).toBe("u1");
 	});
 });

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.use-plural-joins-relationname.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.use-plural-joins-relationname.test.ts
@@ -245,9 +245,6 @@ describe("drizzle adapter: usePlural + joins + ambiguous relations (#8849)", () 
 		expect(session?.impersonator).toBeNull();
 	});
 
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/10616
-	 */
 	it("resolves generated relation keys with usePlural", async () => {
 		const db = drizzle(sqliteDb, {
 			schema: {
@@ -313,9 +310,6 @@ describe("drizzle adapter: usePlural + joins + ambiguous relations (#8849)", () 
 		expect(accountsWithUser[0]?.user?.id).toBe("u1");
 	});
 
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/10616
-	 */
 	it("resolves generated relation keys from Drizzle metadata", async () => {
 		const db = drizzle(sqliteDb, {
 			schema: {
@@ -342,9 +336,6 @@ describe("drizzle adapter: usePlural + joins + ambiguous relations (#8849)", () 
 		expect(account?.user.id).toBe("u1");
 	});
 
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/10616
-	 */
 	it("resolves relation keys when schema and query model names differ", async () => {
 		const db = drizzle(sqliteDb, {
 			schema: {
@@ -377,9 +368,6 @@ describe("drizzle adapter: usePlural + joins + ambiguous relations (#8849)", () 
 		expect(account?.user.id).toBe("u1");
 	});
 
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/10616
-	 */
 	it("supports legacy plural forward relation keys with usePlural", async () => {
 		const db = drizzle(sqliteDb, {
 			schema: {

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-one-to-one-join.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-one-to-one-join.test.ts
@@ -65,13 +65,21 @@ type SessionWithUser = {
  * @see https://github.com/better-auth/better-auth/issues/10616
  */
 test.for([
-	["findOne", "generated singular", generatedAuthRelations],
-	["findMany", "generated singular", generatedAuthRelations],
-	["findOne", "legacy plural", legacyAuthRelations],
-	["findMany", "legacy plural", legacyAuthRelations],
-] as const)("%s resolves a one-to-one relation with %s keys and usePlural", async ([
+	["findOne", "generated singular", "adapter schema", generatedAuthRelations],
+	["findMany", "generated singular", "adapter schema", generatedAuthRelations],
+	["findOne", "legacy plural", "adapter schema", legacyAuthRelations],
+	["findMany", "legacy plural", "adapter schema", legacyAuthRelations],
+	["findOne", "generated singular", "Drizzle metadata", generatedAuthRelations],
+	[
+		"findMany",
+		"generated singular",
+		"Drizzle metadata",
+		generatedAuthRelations,
+	],
+] as const)("%s resolves a one-to-one relation with %s keys from %s", async ([
 	method,
 	,
+	schemaSource,
 	relations,
 ]) => {
 	const sqliteDb = new Database(":memory:");
@@ -112,7 +120,9 @@ test.for([
 
 	const db = drizzle({ client: sqliteDb, relations });
 	const adapter = drizzleAdapter(db, {
-		schema: { ...dbSchema, authRelations: relations },
+		...(schemaSource === "adapter schema"
+			? { schema: { ...dbSchema, authRelations: relations } }
+			: {}),
 		provider: "sqlite",
 		usePlural: true,
 	})({

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-one-to-one-join.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-one-to-one-join.test.ts
@@ -62,21 +62,36 @@ type SessionWithUser = {
 };
 
 test.for([
-	["findOne", "generated singular", "adapter schema", generatedAuthRelations],
-	["findMany", "generated singular", "adapter schema", generatedAuthRelations],
-	["findOne", "legacy plural", "adapter schema", legacyAuthRelations],
-	["findMany", "legacy plural", "adapter schema", legacyAuthRelations],
-	["findOne", "generated singular", "Drizzle metadata", generatedAuthRelations],
+	[
+		"findOne",
+		"generated singular",
+		"with adapter schema",
+		generatedAuthRelations,
+	],
 	[
 		"findMany",
 		"generated singular",
-		"Drizzle metadata",
+		"with adapter schema",
 		generatedAuthRelations,
 	],
-] as const)("%s resolves a one-to-one relation with %s keys from %s", async ([
+	["findOne", "legacy plural", "with adapter schema", legacyAuthRelations],
+	["findMany", "legacy plural", "with adapter schema", legacyAuthRelations],
+	[
+		"findOne",
+		"generated singular",
+		"without adapter schema",
+		generatedAuthRelations,
+	],
+	[
+		"findMany",
+		"generated singular",
+		"without adapter schema",
+		generatedAuthRelations,
+	],
+] as const)("%s resolves a one-to-one relation with %s keys %s", async ([
 	method,
 	,
-	schemaSource,
+	schemaSetup,
 	relations,
 ]) => {
 	const sqliteDb = new Database(":memory:");
@@ -117,7 +132,7 @@ test.for([
 
 	const db = drizzle({ client: sqliteDb, relations });
 	const adapter = drizzleAdapter(db, {
-		...(schemaSource === "adapter schema"
+		...(schemaSetup === "with adapter schema"
 			? { schema: { ...dbSchema, authRelations: relations } }
 			: {}),
 		provider: "sqlite",

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-one-to-one-join.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-one-to-one-join.test.ts
@@ -1,0 +1,141 @@
+import { drizzleAdapter } from "@better-auth/drizzle-adapter/relations-v2";
+import Database from "better-sqlite3";
+import { defineRelationsPart } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { expect, onTestFinished, test } from "vitest";
+
+const users = sqliteTable("users", {
+	id: text("id").primaryKey(),
+	name: text("name").notNull(),
+	email: text("email").notNull(),
+	emailVerified: integer("email_verified", { mode: "boolean" }).notNull(),
+	createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+	updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
+const sessions = sqliteTable("sessions", {
+	id: text("id").primaryKey(),
+	token: text("token").notNull(),
+	expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+	userId: text("user_id")
+		.notNull()
+		.references(() => users.id),
+	createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+	updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
+const dbSchema = { users, sessions };
+const generatedAuthRelations = defineRelationsPart(dbSchema, (relations) => ({
+	users: {
+		sessions: relations.many.sessions({
+			from: relations.users.id,
+			to: relations.sessions.userId,
+		}),
+	},
+	sessions: {
+		user: relations.one.users({
+			from: relations.sessions.userId,
+			to: relations.users.id,
+		}),
+	},
+}));
+
+const legacyAuthRelations = defineRelationsPart(dbSchema, (relations) => ({
+	users: {
+		sessions: relations.many.sessions({
+			from: relations.users.id,
+			to: relations.sessions.userId,
+		}),
+	},
+	sessions: {
+		users: relations.one.users({
+			from: relations.sessions.userId,
+			to: relations.users.id,
+		}),
+	},
+}));
+
+type SessionWithUser = {
+	id: string;
+	user: { id: string };
+};
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10616
+ */
+test.for([
+	["findOne", "generated singular", generatedAuthRelations],
+	["findMany", "generated singular", generatedAuthRelations],
+	["findOne", "legacy plural", legacyAuthRelations],
+	["findMany", "legacy plural", legacyAuthRelations],
+] as const)("%s resolves a one-to-one relation with %s keys and usePlural", async ([
+	method,
+	,
+	relations,
+]) => {
+	const sqliteDb = new Database(":memory:");
+	onTestFinished(() => {
+		sqliteDb.close();
+	});
+
+	const timestamp = 1_700_000_000_000;
+	sqliteDb.exec(`
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			email TEXT NOT NULL,
+			email_verified INTEGER NOT NULL,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			token TEXT NOT NULL,
+			expires_at INTEGER NOT NULL,
+			user_id TEXT NOT NULL REFERENCES users(id),
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		);
+		INSERT INTO users (
+			id, name, email, email_verified, created_at, updated_at
+		) VALUES (
+			'user-1', 'User', 'user@example.com', 0, ${timestamp}, ${timestamp}
+		);
+		INSERT INTO sessions (
+			id, token, expires_at, user_id, created_at, updated_at
+		) VALUES (
+			'session-1', 'token-1', ${timestamp + 60_000},
+			'user-1', ${timestamp}, ${timestamp}
+		);
+	`);
+
+	const db = drizzle({ client: sqliteDb, relations });
+	const adapter = drizzleAdapter(db, {
+		schema: { ...dbSchema, authRelations: relations },
+		provider: "sqlite",
+		usePlural: true,
+	})({
+		advanced: { database: { joins: true } },
+	});
+
+	const session =
+		method === "findOne"
+			? await adapter.findOne<SessionWithUser>({
+					model: "session",
+					where: [{ field: "token", value: "token-1" }],
+					join: { user: true },
+				})
+			: (
+					await adapter.findMany<SessionWithUser>({
+						model: "session",
+						where: [{ field: "token", value: "token-1" }],
+						join: { user: true },
+					})
+				)[0];
+
+	expect(session).toMatchObject({
+		id: "session-1",
+		user: { id: "user-1" },
+	});
+});

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-one-to-one-join.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-one-to-one-join.test.ts
@@ -61,9 +61,6 @@ type SessionWithUser = {
 	user: { id: string };
 };
 
-/**
- * @see https://github.com/better-auth/better-auth/issues/10616
- */
 test.for([
 	["findOne", "generated singular", "adapter schema", generatedAuthRelations],
 	["findMany", "generated singular", "adapter schema", generatedAuthRelations],

--- a/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-one-to-one-join.test.ts
+++ b/e2e/adapter/test/drizzle-v2-relations-adapter/adapter.drizzle.plural-one-to-one-join.test.ts
@@ -62,38 +62,59 @@ type SessionWithUser = {
 };
 
 test.for([
-	[
-		"findOne",
-		"generated singular",
-		"with adapter schema",
-		generatedAuthRelations,
-	],
-	[
-		"findMany",
-		"generated singular",
-		"with adapter schema",
-		generatedAuthRelations,
-	],
-	["findOne", "legacy plural", "with adapter schema", legacyAuthRelations],
-	["findMany", "legacy plural", "with adapter schema", legacyAuthRelations],
-	[
-		"findOne",
-		"generated singular",
-		"without adapter schema",
-		generatedAuthRelations,
-	],
-	[
-		"findMany",
-		"generated singular",
-		"without adapter schema",
-		generatedAuthRelations,
-	],
-] as const)("%s resolves a one-to-one relation with %s keys %s", async ([
+	{
+		method: "findOne",
+		relationKeys: "generated singular",
+		schemaSetup: "with adapter schema",
+		relations: generatedAuthRelations,
+	},
+	{
+		method: "findMany",
+		relationKeys: "generated singular",
+		schemaSetup: "with adapter schema",
+		relations: generatedAuthRelations,
+	},
+	{
+		method: "findOne",
+		relationKeys: "legacy plural",
+		schemaSetup: "with adapter schema",
+		relations: legacyAuthRelations,
+	},
+	{
+		method: "findMany",
+		relationKeys: "legacy plural",
+		schemaSetup: "with adapter schema",
+		relations: legacyAuthRelations,
+	},
+	{
+		method: "findOne",
+		relationKeys: "generated singular",
+		schemaSetup: "without adapter schema",
+		relations: generatedAuthRelations,
+	},
+	{
+		method: "findMany",
+		relationKeys: "generated singular",
+		schemaSetup: "without adapter schema",
+		relations: generatedAuthRelations,
+	},
+	{
+		method: "findOne",
+		relationKeys: "legacy plural",
+		schemaSetup: "without adapter schema",
+		relations: legacyAuthRelations,
+	},
+	{
+		method: "findMany",
+		relationKeys: "legacy plural",
+		schemaSetup: "without adapter schema",
+		relations: legacyAuthRelations,
+	},
+] as const)("$method resolves a one-to-one relation with $relationKeys keys $schemaSetup", async ({
 	method,
-	,
 	schemaSetup,
 	relations,
-]) => {
+}) => {
 	const sqliteDb = new Database(":memory:");
 	onTestFinished(() => {
 		sqliteDb.close();

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -9,16 +9,14 @@ import type {
 import { createAdapterFactory } from "@better-auth/core/db/adapter";
 import { logger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
-import type { SQL, TablesRelationalConfig } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
 import {
 	and,
 	asc,
 	Column,
 	count,
-	createTableRelationsHelpers,
 	desc,
 	eq,
-	extractTablesRelationalConfig,
 	gt,
 	gte,
 	inArray,
@@ -33,8 +31,10 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
-import type { RelationKeysByModel } from "./join-relation-key";
-import { getOneToOneRelationKey } from "./join-relation-key";
+import {
+	buildRelationKeysByModel,
+	getOneToOneRelationKey,
+} from "./join-relation-key";
 import {
 	insensitiveEq,
 	insensitiveIlike,
@@ -45,18 +45,6 @@ import {
 
 export interface DB {
 	[key: string]: any;
-}
-
-function buildV1RelationKeysByModel(
-	...schemas: (TablesRelationalConfig | undefined)[]
-): RelationKeysByModel {
-	const relationKeysByModel = new Map<string, ReadonlySet<string>>();
-	for (const schema of schemas) {
-		for (const [model, table] of Object.entries(schema ?? {})) {
-			relationKeysByModel.set(model, new Set(Object.keys(table.relations)));
-		}
-	}
-	return relationKeysByModel;
 }
 
 /**
@@ -190,14 +178,7 @@ export interface DrizzleAdapterConfig {
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	let mysqlNoIdWarned = false;
-	const configuredRelations = config.schema
-		? extractTablesRelationalConfig(config.schema, createTableRelationsHelpers)
-				.tables
-		: undefined;
-	const relationKeysByModel = buildV1RelationKeysByModel(
-		configuredRelations,
-		db._?.schema,
-	);
+	const relationKeysByModel = buildRelationKeysByModel(db._?.schema);
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({
@@ -787,6 +768,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						getDefaultModelName,
 					});
 				}
+				// Preserve the legacy Relations v1 generator rule: append "s" when usePlural is disabled.
 				return config.usePlural ? joinModel : `${joinModel}s`;
 			}
 

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -15,8 +15,10 @@ import {
 	asc,
 	Column,
 	count,
+	createTableRelationsHelpers,
 	desc,
 	eq,
+	extractTablesRelationalConfig,
 	gt,
 	gte,
 	inArray,
@@ -31,6 +33,8 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
+import type { RelationKeysByModel } from "./join-relation-key";
+import { getOneToOneRelationKey } from "./join-relation-key";
 import {
 	insensitiveEq,
 	insensitiveIlike,
@@ -41,6 +45,22 @@ import {
 
 export interface DB {
 	[key: string]: any;
+}
+
+function buildV1RelationKeysByModel(
+	schema: Record<string, unknown> | undefined,
+): RelationKeysByModel {
+	if (!schema) return new Map();
+	const { tables } = extractTablesRelationalConfig(
+		schema,
+		createTableRelationsHelpers,
+	);
+	return new Map(
+		Object.entries(tables).map(([model, table]) => [
+			model,
+			new Set(Object.keys(table.relations)),
+		]),
+	);
 }
 
 /**
@@ -174,6 +194,7 @@ export interface DrizzleAdapterConfig {
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	let mysqlNoIdWarned = false;
+	const relationKeysByModel = buildV1RelationKeysByModel(config.schema);
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({
@@ -748,6 +769,24 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				return null;
 			}
 
+			function getJoinRelationKey(
+				baseModel: string,
+				joinModel: string,
+				relationKeys: ReadonlySet<string> | undefined,
+				isUnique: boolean,
+			) {
+				if (isUnique) {
+					return getOneToOneRelationKey({
+						baseModel,
+						joinModel,
+						relationKeys,
+						schema: baSchema,
+						getDefaultModelName,
+					});
+				}
+				return config.usePlural ? joinModel : `${joinModel}s`;
+			}
+
 			return {
 				async create({ model, data: values }) {
 					const schemaModel = getSchema(model);
@@ -772,21 +811,28 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| Record<string, { limit: number } | boolean>
 								| undefined;
 
-							const pluralJoinResults: string[] = [];
+							const renamedJoinResults: { key: string; target: string }[] = [];
+							const relationKeys = relationKeysByModel.get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
-							for (const [model, joinAttr] of joinEntries) {
+							for (const [joinModel, joinAttr] of joinEntries) {
 								const limit =
 									joinAttr.limit ??
 									options.advanced?.database?.defaultFindManyLimit ??
 									100;
 								const isUnique = joinAttr.relation === "one-to-one";
-								const pluralSuffix = isUnique || config.usePlural ? "" : "s";
-								includes[`${model}${pluralSuffix}`] = isUnique
-									? true
-									: { limit };
-								if (!isUnique) {
-									pluralJoinResults.push(`${model}${pluralSuffix}`);
+								const relationKey = getJoinRelationKey(
+									model,
+									joinModel,
+									relationKeys,
+									isUnique,
+								);
+								includes[relationKey] = isUnique ? true : { limit };
+								if (relationKey !== joinModel) {
+									renamedJoinResults.push({
+										key: relationKey,
+										target: joinModel,
+									});
 								}
 							}
 							const query = db.query[queryModel].findFirst({
@@ -806,14 +852,9 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							const res = await query;
 
 							if (res) {
-								for (const pluralJoinResult of pluralJoinResults) {
-									const singularKey = !config.usePlural
-										? pluralJoinResult.slice(0, -1)
-										: pluralJoinResult;
-									res[singularKey] = res[pluralJoinResult];
-									if (pluralJoinResult !== singularKey) {
-										delete res[pluralJoinResult];
-									}
+								for (const { key, target } of renamedJoinResults) {
+									res[target] = res[key];
+									delete res[key];
 								}
 							}
 							return res;
@@ -857,21 +898,29 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| Record<string, { limit: number } | boolean>
 								| undefined;
 
-							const pluralJoinResults: string[] = [];
+							const renamedJoinResults: { key: string; target: string }[] = [];
+							const relationKeys = relationKeysByModel.get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
-							for (const [model, joinAttr] of joinEntries) {
+							for (const [joinModel, joinAttr] of joinEntries) {
 								const isUnique = joinAttr.relation === "one-to-one";
 								const limit =
 									joinAttr.limit ??
 									options.advanced?.database?.defaultFindManyLimit ??
 									100;
-								const pluralSuffix = isUnique || config.usePlural ? "" : "s";
-								includes[`${model}${pluralSuffix}`] = isUnique
-									? true
-									: { limit };
-								if (!isUnique)
-									pluralJoinResults.push(`${model}${pluralSuffix}`);
+								const relationKey = getJoinRelationKey(
+									model,
+									joinModel,
+									relationKeys,
+									isUnique,
+								);
+								includes[relationKey] = isUnique ? true : { limit };
+								if (relationKey !== joinModel) {
+									renamedJoinResults.push({
+										key: relationKey,
+										target: joinModel,
+									});
+								}
 							}
 							let orderBy: SQL<unknown>[] | undefined = undefined;
 							if (sortBy?.field) {
@@ -901,13 +950,9 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							const res = await query;
 							if (res) {
 								for (const item of res) {
-									for (const pluralJoinResult of pluralJoinResults) {
-										const singularKey = !config.usePlural
-											? pluralJoinResult.slice(0, -1)
-											: pluralJoinResult;
-										if (singularKey === pluralJoinResult) continue;
-										item[singularKey] = item[pluralJoinResult];
-										delete item[pluralJoinResult];
+									for (const { key, target } of renamedJoinResults) {
+										item[target] = item[key];
+										delete item[key];
 									}
 								}
 							}

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -9,7 +9,7 @@ import type {
 import { createAdapterFactory } from "@better-auth/core/db/adapter";
 import { logger } from "@better-auth/core/env";
 import { BetterAuthError } from "@better-auth/core/error";
-import type { SQL } from "drizzle-orm";
+import type { SQL, TablesRelationalConfig } from "drizzle-orm";
 import {
 	and,
 	asc,
@@ -48,19 +48,15 @@ export interface DB {
 }
 
 function buildV1RelationKeysByModel(
-	schema: Record<string, unknown> | undefined,
+	...schemas: (TablesRelationalConfig | undefined)[]
 ): RelationKeysByModel {
-	if (!schema) return new Map();
-	const { tables } = extractTablesRelationalConfig(
-		schema,
-		createTableRelationsHelpers,
-	);
-	return new Map(
-		Object.entries(tables).map(([model, table]) => [
-			model,
-			new Set(Object.keys(table.relations)),
-		]),
-	);
+	const relationKeysByModel = new Map<string, ReadonlySet<string>>();
+	for (const schema of schemas) {
+		for (const [model, table] of Object.entries(schema ?? {})) {
+			relationKeysByModel.set(model, new Set(Object.keys(table.relations)));
+		}
+	}
+	return relationKeysByModel;
 }
 
 /**
@@ -194,7 +190,14 @@ export interface DrizzleAdapterConfig {
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	let mysqlNoIdWarned = false;
-	const relationKeysByModel = buildV1RelationKeysByModel(config.schema);
+	const configuredRelations = config.schema
+		? extractTablesRelationalConfig(config.schema, createTableRelationsHelpers)
+				.tables
+		: undefined;
+	const relationKeysByModel = buildV1RelationKeysByModel(
+		configuredRelations,
+		db._?.schema,
+	);
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({

--- a/packages/drizzle-adapter/src/join-relation-key.test.ts
+++ b/packages/drizzle-adapter/src/join-relation-key.test.ts
@@ -1,0 +1,178 @@
+import type { BetterAuthDBSchema } from "@better-auth/core/db";
+import { initGetDefaultModelName } from "@better-auth/core/db/adapter";
+import { describe, expect, it } from "vitest";
+import {
+	buildRelationKeysByModel,
+	getOneToOneRelationKey,
+} from "./join-relation-key";
+
+const schema = {
+	user: {
+		modelName: "user",
+		fields: {
+			id: { type: "string" },
+		},
+	},
+	session: {
+		modelName: "session",
+		fields: {
+			userId: {
+				type: "string",
+				references: { model: "user", field: "id" },
+			},
+		},
+	},
+} satisfies BetterAuthDBSchema;
+
+function resolveRelationKey({
+	baseModel,
+	joinModel,
+	relationKeys,
+	usePlural,
+	databaseSchema = schema,
+}: {
+	baseModel: string;
+	joinModel: string;
+	relationKeys: readonly string[] | undefined;
+	usePlural: boolean;
+	databaseSchema?: BetterAuthDBSchema | undefined;
+}) {
+	return getOneToOneRelationKey({
+		baseModel,
+		joinModel,
+		relationKeys: relationKeys ? new Set(relationKeys) : undefined,
+		schema: databaseSchema,
+		getDefaultModelName: initGetDefaultModelName({
+			schema: databaseSchema,
+			usePlural,
+		}),
+	});
+}
+
+describe("buildRelationKeysByModel", () => {
+	it("collects keys from registered relations", () => {
+		const relationKeysByModel = buildRelationKeysByModel({
+			users: {
+				relations: {
+					sessions: {},
+					accounts: {},
+				},
+			},
+			sessions: {},
+		});
+
+		expect(relationKeysByModel.get("users")).toEqual(
+			new Set(["sessions", "accounts"]),
+		);
+		expect(relationKeysByModel.has("sessions")).toBe(false);
+	});
+});
+
+describe("getOneToOneRelationKey", () => {
+	it("resolves a generated forward relation key with plural models", () => {
+		expect(
+			resolveRelationKey({
+				baseModel: "sessions",
+				joinModel: "users",
+				relationKeys: ["user"],
+				usePlural: true,
+			}),
+		).toBe("user");
+	});
+
+	it("prefers a generated key when generated and legacy keys both exist", () => {
+		expect(
+			resolveRelationKey({
+				baseModel: "sessions",
+				joinModel: "users",
+				relationKeys: ["user", "users"],
+				usePlural: true,
+			}),
+		).toBe("user");
+	});
+
+	it("falls back to a legacy plural forward relation key", () => {
+		expect(
+			resolveRelationKey({
+				baseModel: "sessions",
+				joinModel: "users",
+				relationKeys: ["users"],
+				usePlural: true,
+			}),
+		).toBe("users");
+	});
+
+	it("resolves a generated reverse relation key with plural models", () => {
+		expect(
+			resolveRelationKey({
+				baseModel: "users",
+				joinModel: "sessions",
+				relationKeys: ["sessions"],
+				usePlural: true,
+			}),
+		).toBe("sessions");
+	});
+
+	it("resolves a relation key without plural model names", () => {
+		expect(
+			resolveRelationKey({
+				baseModel: "session",
+				joinModel: "user",
+				relationKeys: ["user"],
+				usePlural: false,
+			}),
+		).toBe("user");
+	});
+
+	it("resolves a custom model name", () => {
+		const customSchema = {
+			user: {
+				modelName: "member",
+				fields: {
+					id: { type: "string" },
+				},
+			},
+			session: {
+				modelName: "authSession",
+				fields: {
+					userId: {
+						type: "string",
+						references: { model: "user", field: "id" },
+					},
+				},
+			},
+		} satisfies BetterAuthDBSchema;
+
+		expect(
+			resolveRelationKey({
+				baseModel: "authSessions",
+				joinModel: "members",
+				relationKeys: ["member"],
+				usePlural: true,
+				databaseSchema: customSchema,
+			}),
+		).toBe("member");
+	});
+
+	it("preserves the transformed join model without relation metadata", () => {
+		expect(
+			resolveRelationKey({
+				baseModel: "sessions",
+				joinModel: "users",
+				relationKeys: undefined,
+				usePlural: true,
+			}),
+		).toBe("users");
+	});
+
+	it("uses the generated key when metadata has no matching candidate", () => {
+		expect(
+			resolveRelationKey({
+				baseModel: "sessions",
+				joinModel: "users",
+				relationKeys: ["profile"],
+				usePlural: true,
+			}),
+		).toBe("user");
+	});
+});

--- a/packages/drizzle-adapter/src/join-relation-key.ts
+++ b/packages/drizzle-adapter/src/join-relation-key.ts
@@ -2,6 +2,35 @@ import type { BetterAuthDBSchema } from "@better-auth/core/db";
 
 export type RelationKeysByModel = ReadonlyMap<string, ReadonlySet<string>>;
 
+export type DrizzleRelationRegistry = Readonly<
+	Record<
+		string,
+		{
+			readonly relations?: Readonly<Record<string, unknown>> | undefined;
+		}
+	>
+>;
+
+/**
+ * Reads the relation registry used to build Drizzle relational queries.
+ *
+ * - Drizzle 0.x (Relations v1): `db._.schema`
+ * - Drizzle 1.x (Relations v2): `db._.relations`
+ */
+export function buildRelationKeysByModel(
+	relationRegistry: DrizzleRelationRegistry | undefined,
+): RelationKeysByModel {
+	const relationKeysByModel = new Map<string, ReadonlySet<string>>();
+	for (const [model, tableMetadata] of Object.entries(relationRegistry ?? {})) {
+		if (!tableMetadata.relations) continue;
+		relationKeysByModel.set(
+			model,
+			new Set(Object.keys(tableMetadata.relations)),
+		);
+	}
+	return relationKeysByModel;
+}
+
 export function getOneToOneRelationKey({
 	baseModel,
 	joinModel,
@@ -18,6 +47,8 @@ export function getOneToOneRelationKey({
 	const defaultBaseModelName = getDefaultModelName(baseModel);
 	const defaultJoinModelName = getDefaultModelName(joinModel);
 	const joinModelFields = schema[defaultJoinModelName]?.fields ?? {};
+	// Keep this direction check aligned with transformJoinClause and the
+	// forward/reverse naming in both Drizzle schema generators.
 	const joinModelReferencesBase = Object.values(joinModelFields).some(
 		(field) =>
 			field.references &&

--- a/packages/drizzle-adapter/src/join-relation-key.ts
+++ b/packages/drizzle-adapter/src/join-relation-key.ts
@@ -1,0 +1,34 @@
+import type { BetterAuthDBSchema } from "@better-auth/core/db";
+
+export type RelationKeysByModel = ReadonlyMap<string, ReadonlySet<string>>;
+
+export function getOneToOneRelationKey({
+	baseModel,
+	joinModel,
+	relationKeys,
+	schema,
+	getDefaultModelName,
+}: {
+	baseModel: string;
+	joinModel: string;
+	relationKeys: ReadonlySet<string> | undefined;
+	schema: BetterAuthDBSchema;
+	getDefaultModelName: (model: string) => string;
+}) {
+	const defaultBaseModelName = getDefaultModelName(baseModel);
+	const defaultJoinModelName = getDefaultModelName(joinModel);
+	const joinModelFields = schema[defaultJoinModelName]?.fields ?? {};
+	const joinModelReferencesBase = Object.values(joinModelFields).some(
+		(field) =>
+			field.references &&
+			getDefaultModelName(field.references.model) === defaultBaseModelName,
+	);
+	const generatedRelationKey = joinModelReferencesBase
+		? joinModel
+		: (schema[defaultJoinModelName]?.modelName ?? defaultJoinModelName);
+
+	if (!relationKeys?.size) return joinModel;
+	if (relationKeys.has(generatedRelationKey)) return generatedRelationKey;
+	if (relationKeys.has(joinModel)) return joinModel;
+	return generatedRelationKey;
+}

--- a/packages/drizzle-adapter/src/relations-v2/index.ts
+++ b/packages/drizzle-adapter/src/relations-v2/index.ts
@@ -44,19 +44,16 @@ export interface DB {
 }
 
 function buildV2RelationKeysByModel(
-	schema: Record<string, unknown> | undefined,
+	...schemas: (TablesRelationalConfig | undefined)[]
 ): RelationKeysByModel {
-	const relationKeysByModel = new Map<string, Set<string>>();
-	for (const relations of Object.values(schema ?? {})) {
-		for (const [model, tableRelations] of Object.entries(
-			relations as TablesRelationalConfig,
-		)) {
+	const relationKeysByModel = new Map<string, ReadonlySet<string>>();
+	for (const schema of schemas) {
+		for (const [model, tableRelations] of Object.entries(schema ?? {})) {
 			if (!tableRelations?.relations) continue;
-			const relationKeys = relationKeysByModel.get(model) ?? new Set<string>();
-			for (const relationKey of Object.keys(tableRelations.relations)) {
-				relationKeys.add(relationKey);
-			}
-			relationKeysByModel.set(model, relationKeys);
+			relationKeysByModel.set(
+				model,
+				new Set(Object.keys(tableRelations.relations)),
+			);
 		}
 	}
 	return relationKeysByModel;
@@ -286,7 +283,13 @@ export interface DrizzleAdapterConfig {
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	let mysqlNoIdWarned = false;
-	const relationKeysByModel = buildV2RelationKeysByModel(config.schema);
+	const configuredRelations = Object.values(config.schema ?? {}).map(
+		(value) => value as TablesRelationalConfig,
+	);
+	const relationKeysByModel = buildV2RelationKeysByModel(
+		...configuredRelations,
+		db._?.relations,
+	);
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({ getFieldName, getDefaultModelName, options, schema: baSchema }) => {
@@ -305,13 +308,15 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 			}
 
 			function getSchema(model: string) {
-				const schema = config.schema || db._.fullSchema;
-				if (!schema) {
+				const schemaModel =
+					config.schema?.[model] ??
+					db._?.relations?.[model]?.table ??
+					db._?.fullSchema?.[model];
+				if (!config.schema && !db._?.relations && !db._?.fullSchema) {
 					throw new BetterAuthError(
 						"Drizzle adapter failed to initialize. Schema not found. Please provide a schema object in the adapter options object.",
 					);
 				}
-				const schemaModel = schema[model];
 				if (!schemaModel) {
 					throw new BetterAuthError(
 						`[# Drizzle Adapter]: The model "${model}" was not found in the schema object. Please pass the schema directly to the adapter options.`,

--- a/packages/drizzle-adapter/src/relations-v2/index.ts
+++ b/packages/drizzle-adapter/src/relations-v2/index.ts
@@ -28,9 +28,10 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
-import type { TablesRelationalConfig } from "drizzle-orm/relations";
-import type { RelationKeysByModel } from "../join-relation-key";
-import { getOneToOneRelationKey } from "../join-relation-key";
+import {
+	buildRelationKeysByModel,
+	getOneToOneRelationKey,
+} from "../join-relation-key";
 import {
 	escapedLike,
 	insensitiveEq,
@@ -41,22 +42,6 @@ import {
 
 export interface DB {
 	[key: string]: any;
-}
-
-function buildV2RelationKeysByModel(
-	...schemas: (TablesRelationalConfig | undefined)[]
-): RelationKeysByModel {
-	const relationKeysByModel = new Map<string, ReadonlySet<string>>();
-	for (const schema of schemas) {
-		for (const [model, tableRelations] of Object.entries(schema ?? {})) {
-			if (!tableRelations?.relations) continue;
-			relationKeysByModel.set(
-				model,
-				new Set(Object.keys(tableRelations.relations)),
-			);
-		}
-	}
-	return relationKeysByModel;
 }
 
 function escapeLikePattern(
@@ -283,13 +268,7 @@ export interface DrizzleAdapterConfig {
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	let mysqlNoIdWarned = false;
-	const configuredRelations = Object.values(config.schema ?? {}).map(
-		(value) => value as TablesRelationalConfig,
-	);
-	const relationKeysByModel = buildV2RelationKeysByModel(
-		...configuredRelations,
-		db._?.relations,
-	);
+	const relationKeysByModel = buildRelationKeysByModel(db._?.relations);
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({ getFieldName, getDefaultModelName, options, schema: baSchema }) => {
@@ -312,11 +291,6 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					config.schema?.[model] ??
 					db._?.relations?.[model]?.table ??
 					db._?.fullSchema?.[model];
-				if (!config.schema && !db._?.relations && !db._?.fullSchema) {
-					throw new BetterAuthError(
-						"Drizzle adapter failed to initialize. Schema not found. Please provide a schema object in the adapter options object.",
-					);
-				}
 				if (!schemaModel) {
 					throw new BetterAuthError(
 						`[# Drizzle Adapter]: The model "${model}" was not found in the schema object. Please pass the schema directly to the adapter options.`,
@@ -378,6 +352,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						getDefaultModelName,
 					});
 				}
+				// Match the Relations v2 generator rule: preserve a trailing "s" when usePlural is disabled.
 				if (config.usePlural || joinModel.endsWith("s")) return joinModel;
 				return `${joinModel}s`;
 			}

--- a/packages/drizzle-adapter/src/relations-v2/index.ts
+++ b/packages/drizzle-adapter/src/relations-v2/index.ts
@@ -28,6 +28,9 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
+import type { TablesRelationalConfig } from "drizzle-orm/relations";
+import type { RelationKeysByModel } from "../join-relation-key";
+import { getOneToOneRelationKey } from "../join-relation-key";
 import {
 	escapedLike,
 	insensitiveEq,
@@ -38,6 +41,25 @@ import {
 
 export interface DB {
 	[key: string]: any;
+}
+
+function buildV2RelationKeysByModel(
+	schema: Record<string, unknown> | undefined,
+): RelationKeysByModel {
+	const relationKeysByModel = new Map<string, Set<string>>();
+	for (const relations of Object.values(schema ?? {})) {
+		for (const [model, tableRelations] of Object.entries(
+			relations as TablesRelationalConfig,
+		)) {
+			if (!tableRelations?.relations) continue;
+			const relationKeys = relationKeysByModel.get(model) ?? new Set<string>();
+			for (const relationKey of Object.keys(tableRelations.relations)) {
+				relationKeys.add(relationKey);
+			}
+			relationKeysByModel.set(model, relationKeys);
+		}
+	}
+	return relationKeysByModel;
 }
 
 function escapeLikePattern(
@@ -264,6 +286,7 @@ export interface DrizzleAdapterConfig {
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	let mysqlNoIdWarned = false;
+	const relationKeysByModel = buildV2RelationKeysByModel(config.schema);
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({ getFieldName, getDefaultModelName, options, schema: baSchema }) => {
@@ -335,14 +358,23 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 
 				return null;
 			}
-			/**
-			 * Mirror the schema generator's relation-key naming. One-to-one keeps
-			 * the singular model name. One-to-many is pluralized unless the model
-			 * already ends in "s" or `usePlural` keeps the schema keys as-is.
-			 */
-			function getJoinRelationKey(model: string, isUnique: boolean) {
-				if (isUnique || config.usePlural || model.endsWith("s")) return model;
-				return `${model}s`;
+			function getJoinRelationKey(
+				baseModel: string,
+				joinModel: string,
+				relationKeys: ReadonlySet<string> | undefined,
+				isUnique: boolean,
+			) {
+				if (isUnique) {
+					return getOneToOneRelationKey({
+						baseModel,
+						joinModel,
+						relationKeys,
+						schema: baSchema,
+						getDefaultModelName,
+					});
+				}
+				if (config.usePlural || joinModel.endsWith("s")) return joinModel;
+				return `${joinModel}s`;
 			}
 			const withReturning = async (
 				model: string,
@@ -705,19 +737,28 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| Record<string, { limit: number } | boolean>
 								| undefined;
 
-							const pluralJoinResults: { key: string; target: string }[] = [];
+							const renamedJoinResults: { key: string; target: string }[] = [];
+							const relationKeys = relationKeysByModel.get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
-							for (const [model, joinAttr] of joinEntries) {
+							for (const [joinModel, joinAttr] of joinEntries) {
 								const limit =
 									joinAttr.limit ??
 									options.advanced?.database?.defaultFindManyLimit ??
 									100;
 								const isUnique = joinAttr.relation === "one-to-one";
-								const relationKey = getJoinRelationKey(model, isUnique);
+								const relationKey = getJoinRelationKey(
+									model,
+									joinModel,
+									relationKeys,
+									isUnique,
+								);
 								includes[relationKey] = isUnique ? true : { limit };
-								if (!isUnique) {
-									pluralJoinResults.push({ key: relationKey, target: model });
+								if (relationKey !== joinModel) {
+									renamedJoinResults.push({
+										key: relationKey,
+										target: joinModel,
+									});
 								}
 							}
 							const clause = convertNewWhereClause(where, model);
@@ -738,8 +779,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							const res = await query;
 
 							if (res) {
-								for (const { key, target } of pluralJoinResults) {
-									if (key === target) continue;
+								for (const { key, target } of renamedJoinResults) {
 									res[target] = res[key];
 									delete res[key];
 								}
@@ -785,19 +825,29 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| Record<string, { limit: number; offset?: number } | boolean>
 								| undefined;
 
-							const pluralJoinResults: { key: string; target: string }[] = [];
+							const renamedJoinResults: { key: string; target: string }[] = [];
+							const relationKeys = relationKeysByModel.get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
-							for (const [model, joinAttr] of joinEntries) {
+							for (const [joinModel, joinAttr] of joinEntries) {
 								const isUnique = joinAttr.relation === "one-to-one";
 								const limit =
 									joinAttr.limit ??
 									options.advanced?.database?.defaultFindManyLimit ??
 									100;
-								const relationKey = getJoinRelationKey(model, isUnique);
+								const relationKey = getJoinRelationKey(
+									model,
+									joinModel,
+									relationKeys,
+									isUnique,
+								);
 								includes[relationKey] = isUnique ? true : { limit };
-								if (!isUnique)
-									pluralJoinResults.push({ key: relationKey, target: model });
+								if (relationKey !== joinModel) {
+									renamedJoinResults.push({
+										key: relationKey,
+										target: joinModel,
+									});
+								}
 							}
 							let orderBy: Record<string, "asc" | "desc"> | undefined =
 								undefined;
@@ -828,8 +878,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 							const res = await query;
 							if (res) {
 								for (const item of res) {
-									for (const { key, target } of pluralJoinResults) {
-										if (key === target) continue;
+									for (const { key, target } of renamedJoinResults) {
 										item[target] = item[key];
 										delete item[key];
 									}


### PR DESCRIPTION
> [!NOTE]
> The version split is necessary because Drizzle runtime metadata differs between 0.x (`db._.schema`) and 1.x (`db._.relations`). Drizzle's own integration project, [drizzle-graphql](https://github.com/drizzle-team/drizzle-graphql/blob/c558249fadcc7bd1af8ec17faf292d8cf2d365c5/src/index.ts#L17-L26), similarly reads runtime schema metadata directly from the Drizzle instance.

- Supersedes #10631 by @Nahid-NHB
- Related to #10616
- Related to #10933


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes one-to-one joins in `@better-auth/drizzle-adapter` and `@better-auth/drizzle-adapter/relations-v2` when `usePlural` is enabled. Previously joins could fail due to singular vs legacy plural relation keys; now the adapter resolves the correct key from Drizzle runtime metadata and the BetterAuth schema.

- Reads relation keys at runtime from Drizzle registries (v1: `db._.schema`, v2: `db._.relations`).
- Precomputes relation keys per model and uses them in `findOne`/`findMany` to set includes and rename result fields back to requested join names.
- Aligns one-to-many naming with generator rules (v1: append “s” only when `usePlural` is false; v2: preserve an existing trailing “s” when `usePlural` is false).
- Works without an adapter schema and when schema model names differ from query model names.
- Adds unit tests for relation-key resolution and e2e coverage for Relations v1 and v2, including generated singular and legacy plural keys, with and without an adapter schema.
- No migration required.

<sup>Written for commit 887883a24955776ebfc4b0cb887d1c24049c9b42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



