### PR TITLE
docs: improve Prisma 7 adapter setup guide

### DIFF
--- a/docs/content/docs/adapters/prisma.mdx
+++ b/docs/content/docs/adapters/prisma.mdx
@@ -5,31 +5,85 @@ description: Integrate Better Auth with Prisma.
 
 Prisma ORM is an open-source database toolkit that simplifies database access and management in applications by providing a type-safe query builder and an intuitive data modeling interface.
 
-Before getting started, make sure you have Prisma installed and configured. For more information, see [Prisma Documentation](https://www.prisma.io/docs/)
+For an introduction to Prisma ORM, see
+[Prisma getting started](https://www.prisma.io/docs/getting-started).
+
+<Callout type="info">
+  This guide uses Prisma 7 and PostgreSQL. If you use Prisma 6 or earlier, a
+  driver adapter is optional and your existing Prisma Client setup can remain
+  unchanged.
+</Callout>
 
 ## Installation
 
-To use the Prisma adapter, you need to install the `@better-auth/prisma-adapter` package:
+To use the Prisma adapter, install `@better-auth/prisma-adapter`:
 
 ```package-install
 @better-auth/prisma-adapter
 ```
 
-Prisma 7 with SQLite requires the SQLite driver adapter:
+The example below uses Prisma 7 and PostgreSQL. If Prisma is not already
+configured, follow
+[Prisma's PostgreSQL quickstart](https://www.prisma.io/docs/prisma-orm/quickstart/postgresql)
+before continuing.
 
-```package-install
-@prisma/adapter-better-sqlite3
+## Setup
+
+The examples below use the following project structure:
+
+<Files>
+  <File name=".env" />
+
+  <File name="prisma.config.ts" />
+
+  <Folder name="prisma" defaultOpen>
+    <File name="schema.prisma" />
+  </Folder>
+
+  <Folder name="src" defaultOpen>
+    <Folder name="generated" defaultOpen>
+      <Folder name="prisma" defaultOpen>
+        <File name="client.ts" />
+      </Folder>
+    </Folder>
+
+    <Folder name="lib" defaultOpen>
+      <File name="prisma.ts" />
+
+      <File name="auth.ts" />
+    </Folder>
+  </Folder>
+</Files>
+
+### Configure Prisma
+
+If you are starting a new Prisma project, initialize it with PostgreSQL and an
+explicit Prisma Client output path:
+
+```package-install title="Initialize Prisma"
+npx prisma init --datasource-provider postgresql --output ../src/generated/prisma
 ```
 
-## Example Usage
+This creates `prisma/schema.prisma`, `prisma.config.ts`, and `.env`. Set
+`DATABASE_URL` in `.env` to your PostgreSQL connection string.
 
-You can use the Prisma adapter to connect to your database as follows.
+If Prisma is already configured in your project, keep your existing datasource
+and output path and skip this initialization command.
 
-```ts title="auth.ts"
-import { betterAuth } from "better-auth";
-import { prismaAdapter } from "better-auth/adapters/prisma";
-import { PrismaClient } from "@prisma/client";
-import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+Generate Prisma Client after configuring its output path:
+
+```package-install title="Generate Prisma Client"
+npx prisma generate
+```
+
+### Create the Prisma client
+
+Import `PrismaClient` from the output path configured in your Prisma schema and
+pass the PostgreSQL driver adapter to it:
+
+```ts title="src/lib/prisma.ts"
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "../generated/prisma/client";
 
 const databaseUrl = process.env.DATABASE_URL;
 
@@ -37,26 +91,38 @@ if (!databaseUrl) {
   throw new Error("DATABASE_URL is not set");
 }
 
-const adapter = new PrismaBetterSqlite3({
-  url: databaseUrl,
+const adapter = new PrismaPg({
+  connectionString: databaseUrl,
 });
-const prisma = new PrismaClient({ adapter });
+
+export const prisma = new PrismaClient({ adapter });
+```
+
+Create one `PrismaClient` instance and reuse it across your application.
+Frameworks with hot reloading or serverless runtimes may require a
+framework-specific lifecycle pattern.
+
+### Configure Better Auth
+
+Pass the Prisma Client instance to the Better Auth Prisma adapter:
+
+```ts title="src/lib/auth.ts"
+import { betterAuth } from "better-auth";
+import { prismaAdapter } from "better-auth/adapters/prisma";
+import { prisma } from "./prisma";
 
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
-    provider: "sqlite",
+    provider: "postgresql",
   }),
 });
 ```
 
-<Callout type="warning">
-  Starting from Prisma 7, the `output` path field is required. If you have configured a custom output path in your `schema.prisma` file (e.g., `output = "../src/generated/prisma"`), make sure to [import the Prisma client from that location](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/generating-prisma-client#the-location-of-prisma-client) instead of `@prisma/client`.
-</Callout>
-
 ## Schema generation & migration
 
-The [Better Auth CLI](/docs/concepts/cli) allows you to generate or migrate
-your database schema based on your Better Auth configuration and plugins.
+The [Better Auth CLI](/docs/concepts/cli) generates the Prisma schema required
+by your Better Auth configuration and plugins. Use the Prisma CLI to create and
+apply a migration from the generated schema.
 
 <table>
   <thead>
@@ -81,6 +147,14 @@ your database schema based on your Better Auth configuration and plugins.
 
 ```package-install title="Schema Generation"
 npx auth@latest generate
+```
+
+The Better Auth CLI updates your Prisma schema but does not apply the migration.
+Use Prisma to create the database migration, then regenerate Prisma Client:
+
+```bash title="Terminal"
+npx prisma migrate dev --name add-better-auth
+npx prisma generate
 ```
 
 ## Joins
@@ -113,4 +187,5 @@ export const auth = betterAuth({
 ## Additional Information
 
 * If you're looking for performance improvements or tips, take a look at our guide to <Link href="/docs/guides/optimizing-for-performance">performance optimizations</Link>.
-* [How to use Prisma ORM with Better Auth and Next.js](https://www.prisma.io/docs/guides/betterauth-nextjs)
+* [How to use Prisma ORM with Better Auth and Next.js](https://www.prisma.io/docs/guides/authentication/better-auth/nextjs)
+* [How to use Prisma ORM with Better Auth and Astro](https://www.prisma.io/docs/guides/authentication/better-auth/astro)

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -136,16 +136,17 @@ description: Learn how to configure Better Auth in your project.
         ```ts title="auth.ts"
         import { betterAuth } from "better-auth";
         import { prismaAdapter } from "better-auth/adapters/prisma";
-        // If your Prisma file is located elsewhere, you can change the path
-        import { PrismaClient } from "@/generated/prisma/client";
+        import { prisma } from "@/lib/prisma"; // your prisma client instance
 
-        const prisma = new PrismaClient();
         export const auth = betterAuth({
             database: prismaAdapter(prisma, {
-                provider: "sqlite", // or "mysql", "postgresql", ...etc
+                provider: "postgresql", // or "mysql", "sqlite", ...etc
             }),
         });
         ```
+
+        See the [Prisma adapter guide](/docs/adapters/prisma) for the Prisma 7
+        driver adapter and generated client setup.
       </Tab>
 
       <Tab value="mongodb">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documents Prisma 7 setup for the Better Auth Prisma adapter and switches examples to PostgreSQL. This clarifies the required driver adapter and generated client import, reducing setup errors; the installation guide now imports a shared Prisma client and defaults to PostgreSQL.

- Replaces SQLite-focused example with PostgreSQL and shows using `@prisma/adapter-pg` plus an explicit Prisma Client output path and import from the generated client.
- Adds step-by-step commands: `npx prisma init --datasource-provider postgresql --output ...`, `npx prisma generate`, `npx auth@latest generate`, and `npx prisma migrate dev`.
- Shows creating a single `PrismaClient` with the adapter in `src/lib/prisma.ts` and wiring it into `prismaAdapter` with provider `postgresql`.
- Notes that adapters are optional for Prisma ≤6, updates the installation snippet to import a shared `prisma` instance, and refreshes guide links (Next.js; adds Astro).

<sup>Written for commit baf11f49e277cb4f20b382d0bb3c7b78942ede58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

