### PR TITLE
fix(origin-check): accept a same-origin form post whose Origin the browser nulled

### DIFF
--- a/.changeset/null-origin-same-origin-form-post.md
+++ b/.changeset/null-origin-same-origin-form-post.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Accept a same-origin form submission whose `Origin` the browser nulled. A page served `Referrer-Policy: no-referrer` — the recommended policy for screens whose URL carries a secret, such as password reset and OAuth consent — sends the literal `Origin: null` on an HTML form it navigates with, and `validateOrigin` rejected it as `MISSING_OR_NULL_ORIGIN`. `Sec-Fetch-Site: same-origin` now vouches for that case. Every other `null` Origin still fails: a sandboxed iframe, a `data:` document, or a request with no Fetch Metadata at all. `fetch()` callers are unaffected either way.

--- a/packages/better-auth/src/api/middlewares/origin-check.test.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.test.ts
@@ -553,6 +553,79 @@ describe("Fetch Metadata CSRF Protection", async () => {
 			);
 		}
 	});
+
+	/**
+	 * `Referrer-Policy: no-referrer` is the recommended policy for any page whose
+	 * URL carries a secret — password reset, OAuth consent. A page serving it
+	 * sends the LITERAL `Origin: null` on the HTML form it navigates with, so the
+	 * Origin value alone cannot distinguish a first-party form post from a
+	 * sandboxed iframe. `Sec-Fetch-Site` is what separates them.
+	 *
+	 * @see https://fetch.spec.whatwg.org/#append-a-request-origin-header
+	 */
+	describe("null Origin from a page served Referrer-Policy: no-referrer", () => {
+		const formPost = (headers: Record<string, string>) =>
+			new Request("http://localhost:3000/api/auth/sign-in/email", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					// Signed-in surfaces are where `no-referrer` pages live, and a
+					// request carrying cookies is the path that reaches `validateOrigin`
+					// directly rather than the Fetch Metadata branch.
+					cookie: "better-auth.session_token=whatever",
+					"Sec-Fetch-Mode": "navigate",
+					"Sec-Fetch-Dest": "document",
+					...headers,
+				},
+				body: JSON.stringify({
+					email: testUser.email,
+					password: testUser.password,
+				}),
+			});
+
+		it("should allow a same-origin form post whose Origin the browser nulled", async () => {
+			const response = await auth.handler(
+				formPost({ origin: "null", "Sec-Fetch-Site": "same-origin" }),
+			);
+
+			expect(response.status).not.toBe(403);
+			const error = await response.json().catch(() => null);
+			expect(error?.code).not.toBe("MISSING_OR_NULL_ORIGIN");
+		});
+
+		// `null` is also what a foreign opaque origin sends. Only the browser's own
+		// same-origin verdict may rescue it.
+		it.each([
+			"cross-site",
+			"same-site",
+		])("should still reject a null Origin the browser calls %s", async (site) => {
+			const response = await auth.handler(
+				formPost({ origin: "null", "Sec-Fetch-Site": site }),
+			);
+
+			expect(response.status).toBe(403);
+			const error = await response.json().catch(() => null);
+			expect(error?.code).toBe("MISSING_OR_NULL_ORIGIN");
+		});
+
+		it("should still reject a null Origin with no Sec-Fetch-Site to vouch for it", async () => {
+			const response = await auth.handler(formPost({ origin: "null" }));
+
+			expect(response.status).toBe(403);
+			const error = await response.json().catch(() => null);
+			expect(error?.code).toBe("MISSING_OR_NULL_ORIGIN");
+		});
+
+		it("should still reject a request with no Origin at all", async () => {
+			const response = await auth.handler(
+				formPost({ "Sec-Fetch-Site": "same-origin" }),
+			);
+
+			expect(response.status).toBe(403);
+			const error = await response.json().catch(() => null);
+			expect(error?.code).toBe("MISSING_OR_NULL_ORIGIN");
+		});
+	});
 });
 
 describe("origin check middleware", async () => {

--- a/packages/better-auth/src/api/middlewares/origin-check.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.ts
@@ -249,6 +249,26 @@ async function validateOrigin(
 	}
 
 	if (!originHeader || originHeader === "null") {
+		// A page served `Referrer-Policy: no-referrer` sends the LITERAL string
+		// `Origin: null` on an HTML form it navigates with: per Fetch, "Append a
+		// request `Origin` header" nulls the serialized origin of a non-CORS
+		// non-`GET` request under that policy. `no-referrer` is standard hardening
+		// for exactly the pages whose URL carries a secret — password reset, OAuth
+		// consent — so this is a first-party page posting to its own backend, and
+		// the Origin value alone cannot tell it apart from a sandboxed iframe.
+		//
+		// `Sec-Fetch-Site` can. It is a forbidden header name, so no page may set
+		// it, and `same-origin` is the browser's own statement that the initiator's
+		// origin IS this request's origin — the question `trustedOrigins` below is
+		// asking. Anything else (`cross-site`, `same-site`, or no Fetch Metadata at
+		// all) stays rejected. `fetch()` never reaches this branch: mode "cors"
+		// always carries a real Origin, so only an HTML form submission is affected.
+		if (
+			originHeader === "null" &&
+			headers.get("sec-fetch-site") === "same-origin"
+		) {
+			return;
+		}
 		throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN);
 	}
 


### PR DESCRIPTION
## The bug

`validateOrigin` rejects `Origin: null` outright:

```ts
if (!originHeader || originHeader === "null") {
    throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN);
}
```

That treats `null` as always-foreign. It isn't. Per [Fetch — "Append a request `Origin` header"](https://fetch.spec.whatwg.org/#append-a-request-origin-header) step 3.1, the **initiating document's referrer policy** serializes the origin of a non-CORS non-`GET` request as `null` when that policy is `no-referrer`.

And `Referrer-Policy: no-referrer` is the standard recommendation for exactly the pages whose URL carries a secret — password reset, OAuth consent. So a first-party page, hardened per that recommendation, submitting an HTML form to its own better-auth backend arrives with `Origin: null` and gets a 403.

Two things make it hurt more than it looks:

1. **A request carrying cookies never reaches the Fetch Metadata branch at all.** In `validateFormCsrf`, cookies short-circuit straight into `validateOrigin`:

   ```ts
   const hasAnyCookies = headers.has("cookie");
   if (hasAnyCookies) {
       return await validateOrigin(ctx);
   }
   ```

   So the signed-in form post — consent, re-auth, account settings — is decided purely by the Origin value, which in this case cannot carry the information.

2. **`fetch()` never reproduces it.** Mode `"cors"` always carries a real Origin regardless of referrer policy, so only the plain-HTML-form path breaks — the progressive-enhancement path this middleware exists to support, and the one with no client-side JS to debug it with. The failure lands on the last click of the flow.

## The fix

```ts
if (originHeader === "null" && headers.get("sec-fetch-site") === "same-origin") {
    return;
}
```

`Sec-Fetch-Site` settles it without loosening anything else. It is a **forbidden header name**, so no page can set it, and `same-origin` is the browser's own statement that the initiator's origin *is* this request's origin — precisely the question `trustedOrigins` is asking. An opaque origin (sandboxed iframe, `data:`/`blob:` document) is never same-origin with the target, so it cannot reach this branch.

Deliberately kept as narrow as possible — nothing that passes or fails today changes:

| Case | Before | After |
|---|---|---|
| `Origin: null` + `Sec-Fetch-Site: same-origin` | 403 | **allowed** |
| `Origin: null` + `cross-site` | 403 | 403 |
| `Origin: null` + `same-site` | 403 | 403 |
| `Origin: null`, no Fetch Metadata | 403 | 403 |
| No `Origin` at all (even with `same-origin`) | 403 | 403 |

The last row is intentional: this PR only rescues the case the spec proves a browser produces, and leaves the absent-Origin path exactly as it was.

## Tests

Five tests in `origin-check.test.ts` under `Fetch Metadata CSRF Protection`, one per row above. Verified that removing the fix fails **only** the accepting test — the four rejection tests pass with and without it, so they pin behavior rather than just following the change.

```
Tests  43 passed (43)          # src/api/middlewares/origin-check.test.ts
Tests  427 passed (427)        # src/api
```

`pnpm typecheck` passes. Full `packages/better-auth` suite is 2589 passed with 2 pre-existing failures (`db.test.ts` and `oauth-proxy.test.ts` postgres cases, which need the Docker containers) — confirmed identical on a clean tree with my changes stashed.

## Context

Reported downstream: an app's OAuth consent screen sets `no-referrer` to keep `code_challenge`/`state` out of Referer, and its own CSRF gate — written to the same shape as this one — 403'd every approval for a week. Every MCP client at once, and the `fetch()`-based tests were all green.

Worth noting that `MISSING_OR_NULL_ORIGIN` has generated a steady stream of reports — #5536, #5545, #5573, #5765, #7014, #9490 — but every one of those is Expo, Postman, or cURL. The browser `no-referrer` path doesn't seem to have been reported before, which is probably why `null` reads as "always foreign" in the current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts same-origin HTML form posts whose browser sent Origin: null under Referrer-Policy: no-referrer. Previously these requests returned 403 (MISSING_OR_NULL_ORIGIN); now they pass only when Sec-Fetch-Site is same-origin, with all other null-or-absent Origin cases unchanged.

**Review notes**
- Updates `validateOrigin` in `packages/better-auth/src/api/middlewares/origin-check.ts` to allow Origin: null only when `Sec-Fetch-Site: same-origin`; no other logic paths change.
- Security posture unchanged: `Sec-Fetch-Site` is a forbidden header and cannot be spoofed; absent Origin still rejects.
- Affects HTML form navigation flows; `fetch()` callers are unaffected.
- Adds 5 tests in `packages/better-auth/src/api/middlewares/origin-check.test.ts` covering the accepted case and four rejections.
- No configuration or migration changes required in `better-auth`.

<sup>Written for commit 4250099d4364faab8cac9f5e178c906cec2c1426. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

