### PR TITLE
fix(client): compare dates by instant in the session equality gate

### DIFF
--- a/.changeset/json-equal-dates.md
+++ b/.changeset/json-equal-dates.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Compare dates by instant in the client equality gate. The client parser revives ISO strings into `Date` instances, so session payloads always held dates that were equal but never identical. `isJsonEqual` reported those as changed, so the gate never suppressed a `set()` and every session refetch re-rendered subscribers.

--- a/packages/better-auth/src/client/equality.test.ts
+++ b/packages/better-auth/src/client/equality.test.ts
@@ -74,6 +74,42 @@ describe("isJsonEqual", () => {
 	it("returns false for array vs object", () => {
 		expect(isJsonEqual([], {})).toBe(false);
 	});
+
+	it("returns true for dates with the same instant", () => {
+		expect(
+			isJsonEqual(
+				new Date("2026-01-01T00:00:00.000Z"),
+				new Date("2026-01-01T00:00:00.000Z"),
+			),
+		).toBe(true);
+	});
+
+	it("returns false for dates with different instants", () => {
+		expect(
+			isJsonEqual(
+				new Date("2026-01-01T00:00:00.000Z"),
+				new Date("2026-01-02T00:00:00.000Z"),
+			),
+		).toBe(false);
+	});
+
+	it("returns true for session-shaped data holding equal dates", () => {
+		// The client parser revives ISO strings into `Date` instances, so the
+		// session payload compared by the equality gate always contains dates.
+		// Without date support every refetch looks like a change and the gate
+		// never aborts, defeating the re-render suppression it exists for.
+		const build = () => ({
+			user: { id: "1", createdAt: new Date("2026-01-01T00:00:00.000Z") },
+			session: { id: "s1", expiresAt: new Date("2026-01-08T00:00:00.000Z") },
+		});
+		expect(isJsonEqual(build(), build())).toBe(true);
+	});
+
+	it("does not treat a date as equal to a non-date", () => {
+		const date = new Date("2026-01-01T00:00:00.000Z");
+		expect(isJsonEqual(date, "2026-01-01T00:00:00.000Z")).toBe(false);
+		expect(isJsonEqual(date, {})).toBe(false);
+	});
 });
 
 describe("withEquality", () => {

--- a/packages/better-auth/src/client/equality.test.ts
+++ b/packages/better-auth/src/client/equality.test.ts
@@ -110,6 +110,19 @@ describe("isJsonEqual", () => {
 		expect(isJsonEqual(date, "2026-01-01T00:00:00.000Z")).toBe(false);
 		expect(isJsonEqual(date, {})).toBe(false);
 	});
+
+	it("returns true for two invalid dates", () => {
+		expect(isJsonEqual(new Date("nope"), new Date("also nope"))).toBe(true);
+	});
+
+	it("compares dates nested in arrays", () => {
+		expect(
+			isJsonEqual(
+				[new Date("2026-01-01T00:00:00.000Z")],
+				[new Date("2026-01-01T00:00:00.000Z")],
+			),
+		).toBe(true);
+	});
 });
 
 describe("withEquality", () => {

--- a/packages/better-auth/src/client/equality.ts
+++ b/packages/better-auth/src/client/equality.ts
@@ -9,6 +9,11 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return prototype === Object.prototype || prototype === null;
 }
 
+/** `instanceof` misses dates from another realm, the brand check does not. */
+function isDate(value: unknown): value is Date {
+	return Object.prototype.toString.call(value) === "[object Date]";
+}
+
 /**
  * Deep structural equality for JSON-serializable values.
  * Handles: primitives, null, arrays, plain objects, and dates.
@@ -16,19 +21,18 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  *
  * Dates are compared by instant because the client parser revives ISO strings
  * into `Date` instances, so payloads reaching this function routinely hold
- * dates that are equal but never identical.
+ * dates that are equal but never identical. Two invalid dates compare equal,
+ * so a corrupted value does not report a change on every set.
  */
 export function isJsonEqual(a: unknown, b: unknown): boolean {
 	if (a === b) return true;
 
-	if (a instanceof Date || b instanceof Date) {
+	const aIsDate = isDate(a);
+	const bIsDate = isDate(b);
+	if (aIsDate || bIsDate) {
 		// `Object.is` so two invalid dates (NaN) still compare equal, which
 		// keeps the gate stable instead of reporting a change on every set.
-		return (
-			a instanceof Date &&
-			b instanceof Date &&
-			Object.is(a.getTime(), b.getTime())
-		);
+		return aIsDate && bIsDate && Object.is(a.getTime(), b.getTime());
 	}
 
 	if (Array.isArray(a) && Array.isArray(b)) {

--- a/packages/better-auth/src/client/equality.ts
+++ b/packages/better-auth/src/client/equality.ts
@@ -11,11 +11,25 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 /**
  * Deep structural equality for JSON-serializable values.
- * Handles: primitives, null, arrays, and plain objects.
+ * Handles: primitives, null, arrays, plain objects, and dates.
  * Short-circuits on referential equality at every recursion level.
+ *
+ * Dates are compared by instant because the client parser revives ISO strings
+ * into `Date` instances, so payloads reaching this function routinely hold
+ * dates that are equal but never identical.
  */
 export function isJsonEqual(a: unknown, b: unknown): boolean {
 	if (a === b) return true;
+
+	if (a instanceof Date || b instanceof Date) {
+		// `Object.is` so two invalid dates (NaN) still compare equal, which
+		// keeps the gate stable instead of reporting a change on every set.
+		return (
+			a instanceof Date &&
+			b instanceof Date &&
+			Object.is(a.getTime(), b.getTime())
+		);
+	}
 
 	if (Array.isArray(a) && Array.isArray(b)) {
 		if (a.length !== b.length) return false;


### PR DESCRIPTION
## Summary

`isJsonEqual` had no `Date` branch, so two equal dates fell through to `false`. The client parser revives ISO strings into `Date` instances, so the session payload compared by the equality gate always holds dates. Two identical session responses therefore compared as different, `withEquality` never called `abort()`, and every session refetch re-rendered `useSession` consumers.

Closes #10950

## Why it happens

A `Date` is not an array, and `isPlainObject` rejects it because its prototype is `Date.prototype`, so it reached the final `return false`.

The gate is wired up in two places, both of which pass parsed payloads:

- `client/session-atom.ts`: `isSessionAtomEqual` calls `isJsonEqual(a.data, b.data)`, then `withEquality(session, isSessionAtomEqual)`
- `client/query.ts`: `withEquality(value, isAuthQueryStateEqual)`

Measured on a real instance before the fix:

```
expiresAt instanceof Date: true
two identical getSession() fetches, isJsonEqual -> false
```

and after:

```
two identical getSession() fetches, isJsonEqual -> true
```

## The fix

```diff
 	if (a === b) return true;
 
+	if (a instanceof Date || b instanceof Date) {
+		return (
+			a instanceof Date &&
+			b instanceof Date &&
+			Object.is(a.getTime(), b.getTime())
+		);
+	}
+
 	if (Array.isArray(a) && Array.isArray(b)) {
```

Checking `a instanceof Date || b instanceof Date` first means a date is never mistaken for a plain object, and a date compared against a non-date is correctly unequal. `Object.is` is used so two invalid dates (`NaN`) stay equal rather than reporting a change on every set, which would reintroduce the same loop for malformed values.

The JSDoc now records that dates are compared by instant, and why.

## Tests

Four tests added to the existing `isJsonEqual` suite: equal instants, different instants, session-shaped data holding dates, and a date compared against a non-date.

The two positive tests fail on the unpatched code with `expected false to be true`, which is the bug. Full `equality.test.ts` is 21/21 and the whole `client/` suite is 119/119.

`pnpm typecheck` reports no new errors. The 8 pre-existing `schemaName` errors in `packages/cli/test/generate.test.ts` are present on a clean `main` as well and are unrelated.

## Risk

Behaviour only becomes more permissive: payloads that were previously reported as changed on every fetch can now be recognised as unchanged. No API or type change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the client equality gate so identical session payloads containing dates no longer re-render. Previously `isJsonEqual` returned false for `Date` values, so the gate never aborted updates and every session refetch re-rendered consumers.

**Bug Fixes**
- Detect dates via the `[object Date]` brand and extract the instant with `Date.prototype.getTime.call`, so dates from other realms compare correctly.
- Compare `getTime()` with `Object.is` so two invalid dates are equal and avoid update thrash.
- Add tests for cross-realm dates, spoofed `Date` tags, equal/different instants, session-shaped payloads, nested dates in arrays, and date vs non-date.
- No API or type changes.

<sup>Written for commit 9c723476194cd3d356b43e7825285a0ba88e82b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

