### PR TITLE
docs(database): update redis secondary storage example

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -188,7 +188,7 @@ The Redis storage supports all ioredis connection modes including standalone, cl
 
 **Manual Implementation:**
 
-If you prefer to implement your own Redis secondary storage, here's a basic example:
+If you're using Redis 7 or later, you can use the following implementation:
 
 ```typescript title="auth.ts"
 import { createClient } from "redis";
@@ -196,14 +196,6 @@ import { betterAuth } from "better-auth";
 
 const redis = createClient();
 await redis.connect();
-
-const incrementScript = `
-local value = redis.call("INCR", KEYS[1])
-if value == 1 then
-  redis.call("EXPIRE", KEYS[1], ARGV[1])
-end
-return value
-`;
 
 export const auth = betterAuth({
 	// ... other options
@@ -215,11 +207,17 @@ export const auth = betterAuth({
 			return await redis.getDel(key);
 		},
 		increment: async (key, ttl) => {
-			const value = await redis.eval(incrementScript, {
-				keys: [key],
-				arguments: [String(ttl)],
-			});
-			return Number(value);
+			if (!Number.isInteger(ttl) || ttl <= 0) {
+				throw new TypeError("Redis increment TTL must be a positive integer");
+			}
+
+			const [value] = await redis
+				.multi()
+				.incr(key)
+				.expire(key, ttl, "NX")
+				.exec();
+
+			return value;
 		},
 		set: async (key, value, ttl) => {
 			if (ttl) await redis.set(key, value, { EX: ttl });
@@ -273,7 +271,7 @@ export const redisSecondaryStorage: SecondaryStorage = {
 
   async increment(key: string, ttl: number) {
     if (!Number.isInteger(ttl) || ttl <= 0) {
-      throw new TypeError("Redis increment ttl must be a positive integer");
+      throw new TypeError("Redis increment TTL must be a positive integer");
     }
 
     const [value] = await redis

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -259,63 +259,36 @@ After that, we can create a secondary storage implementation:
 ```typescript
 // src/lib/auth/adapters/redis-secondary-storage.ts
 
-import { SecondaryStorage } from "better-auth";
+import type { SecondaryStorage } from "better-auth";
 import { redis } from "~/lib/redis";
 
 export const redisSecondaryStorage: SecondaryStorage = {
-  async get(key: string) {
-    try {
-      const value = await redis.get(key);
-
-      // Handle different return types from Redis
-      if (value === null || value === undefined) {
-        return null;
-      }
-
-      // If it's already a string, return it
-      if (typeof value === "string") {
-        return value;
-      }
-
-      // If it's an object, stringify it
-      if (typeof value === "object") {
-        return JSON.stringify(value);
-      }
-
-      // Convert to string for any other type
-      return String(value);
-    } catch (error) {
-      console.error("Redis get error:", error);
-      return null;
-    }
+  async get(key) {
+    return await redis.get(key);
   },
 
-  async set(key: string, value: string, ttl?: number) {
-    try {
-      // Ensure value is a string
-      const stringValue =
-        typeof value === "string" ? value : JSON.stringify(value);
+  async getAndDelete(key) {
+    return await redis.getdel(key);
+  },
 
-      if (ttl) {
-        // Set with TTL in seconds
-        await redis.set(key, stringValue, { ex: ttl });
-      } else {
-        // Set without TTL
-        await redis.set(key, stringValue);
-      }
-    } catch (error) {
-      console.error("Redis set error:", error);
-      throw error;
+  async increment(key, ttl) {
+    const value = await redis.incr(key);
+    if (value === 1) {
+      await redis.expire(key, ttl);
+    }
+    return value;
+  },
+
+  async set(key, value, ttl) {
+    if (ttl) {
+      await redis.set(key, value, { ex: ttl });
+    } else {
+      await redis.set(key, value);
     }
   },
 
   async delete(key: string) {
-    try {
-      await redis.del(key);
-    } catch (error) {
-      console.error("Redis delete error:", error);
-      throw error;
-    }
+    await redis.del(key);
   },
 };
 ```

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -262,6 +262,14 @@ After that, we can create a secondary storage implementation:
 import type { SecondaryStorage } from "better-auth";
 import { redis } from "~/lib/redis";
 
+const incrementScript = `
+local value = redis.call("INCR", KEYS[1])
+if value == 1 then
+  redis.call("EXPIRE", KEYS[1], ARGV[1])
+end
+return value
+`;
+
 export const redisSecondaryStorage: SecondaryStorage = {
   async get(key) {
     return await redis.get(key);
@@ -271,12 +279,8 @@ export const redisSecondaryStorage: SecondaryStorage = {
     return await redis.getdel(key);
   },
 
-  async increment(key, ttl) {
-    const value = await redis.incr(key);
-    if (value === 1) {
-      await redis.expire(key, ttl);
-    }
-    return value;
+  async increment(key: string, ttl: number) {
+    return redis.eval(incrementScript, [key], [ttl]);
   },
 
   async set(key, value, ttl) {

--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -262,14 +262,6 @@ After that, we can create a secondary storage implementation:
 import type { SecondaryStorage } from "better-auth";
 import { redis } from "~/lib/redis";
 
-const incrementScript = `
-local value = redis.call("INCR", KEYS[1])
-if value == 1 then
-  redis.call("EXPIRE", KEYS[1], ARGV[1])
-end
-return value
-`;
-
 export const redisSecondaryStorage: SecondaryStorage = {
   async get(key) {
     return await redis.get(key);
@@ -280,7 +272,17 @@ export const redisSecondaryStorage: SecondaryStorage = {
   },
 
   async increment(key: string, ttl: number) {
-    return redis.eval(incrementScript, [key], [ttl]);
+    if (!Number.isInteger(ttl) || ttl <= 0) {
+      throw new TypeError("Redis increment ttl must be a positive integer");
+    }
+
+    const [value] = await redis
+      .multi()
+      .incr(key)
+      .expire(key, ttl, "NX")
+      .exec();
+
+    return value;
   },
 
   async set(key, value, ttl) {


### PR DESCRIPTION
This PR updates the Upstash Redis example in the `SecondaryStorage` documentation to be more concise and complete.

**Changes:**
- Implements missing required interface methods (`getAndDelete`, `increment`).
- Simplifies the `get` and `set` methods by relying on Upstash Redis's native type handling instead of manually parsing and stringifying values.

This ensures developers copying the example get a fully working implementation of the `SecondaryStorage` interface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernizes the Redis secondary storage docs to provide complete, copy-safe examples. Replaces the Lua-based increment with a transaction so TTL is set only on the first increment.

- Redis 7 example: scopes the manual example to Redis 7+, adds `getAndDelete` via `GETDEL`, switches to `MULTI` + `INCR` + `EXPIRE ... NX`, validates positive integer `ttl`, and uses native `get`/`set` with optional TTL.
- Upstash example: implements `getAndDelete` via `getdel`, uses `multi().incr().expire(..., "NX")` for atomic increment with TTL-once semantics, simplifies `get`/`set` with `{ ex: ttl }`, and imports `SecondaryStorage` from `better-auth` as a type.

<sup>Written for commit 17a57f2f57019a83cd0e44dbad6621d9751c111e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

