### PR TITLE
fix(db): recover null-user session cache entries

### DIFF
--- a/.changeset/repair-null-session-users.md
+++ b/.changeset/repair-null-session-users.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Recover secondary-storage sessions after transient user lookup misses instead of caching a null user that breaks later session reads.

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -846,6 +846,134 @@ describe("internal adapter test", async () => {
 		expect(actualTokenExp! - expectedTokenExp).toBeGreaterThanOrEqual(0);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10884
+	 */
+	it("does not cache a null user after a transient user lookup miss", async () => {
+		const testMap = new Map<string, string>();
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: createStringSecondaryStorage(testMap),
+		} satisfies BetterAuthOptions;
+		(await getMigrations(testOpts)).runMigrations();
+		const testCtx = await init(testOpts);
+		const user = await testCtx.internalAdapter.createUser(
+			{
+				name: "transient-miss-user",
+				email: "transient-miss@example.com",
+			},
+			{ method: "test" },
+		);
+
+		vi.spyOn(testCtx.adapter, "findOne").mockResolvedValueOnce(null);
+		const session = await testCtx.internalAdapter.createSession(user.id);
+		const cached = safeJSONParse<{
+			session: Session;
+			user?: User | null;
+		}>(testMap.get(session.token));
+
+		expect(cached?.session.token).toBe(session.token);
+		expect(cached).not.toHaveProperty("user");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10884
+	 */
+	it("recovers a cached session whose user is null", async () => {
+		const testMap = new Map<string, string>();
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: createStringSecondaryStorage(testMap),
+		} satisfies BetterAuthOptions;
+		(await getMigrations(testOpts)).runMigrations();
+		const testCtx = await init(testOpts);
+		const user = await testCtx.internalAdapter.createUser(
+			{
+				name: "cached-null-user",
+				email: "cached-null@example.com",
+			},
+			{ method: "test" },
+		);
+		const session = await testCtx.internalAdapter.createSession(user.id);
+		const cached = safeJSONParse<{ session: Session; user: User }>(
+			testMap.get(session.token),
+		);
+		testMap.set(
+			session.token,
+			JSON.stringify({ session: cached!.session, user: null }),
+		);
+
+		const found = await testCtx.internalAdapter.findSession(session.token);
+
+		expect(found?.session.token).toBe(session.token);
+		expect(found?.user.id).toBe(user.id);
+		expect(
+			safeJSONParse<{ user: User }>(testMap.get(session.token))?.user.id,
+		).toBe(user.id);
+	});
+
+	it("keeps valid secondary session reads on the cache-hit path", async () => {
+		const testMap = new Map<string, string>();
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: createStringSecondaryStorage(testMap),
+		} satisfies BetterAuthOptions;
+		(await getMigrations(testOpts)).runMigrations();
+		const testCtx = await init(testOpts);
+		const user = await testCtx.internalAdapter.createUser(
+			{
+				name: "cached-user",
+				email: "cached@example.com",
+			},
+			{ method: "test" },
+		);
+		const session = await testCtx.internalAdapter.createSession(user.id);
+		const findOne = vi.spyOn(testCtx.adapter, "findOne");
+
+		const found = await testCtx.internalAdapter.findSession(session.token);
+
+		expect(found?.user.id).toBe(user.id);
+		expect(findOne).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10884
+	 */
+	it("recovers null users while finding cached sessions", async () => {
+		const testMap = new Map<string, string>();
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: createStringSecondaryStorage(testMap),
+		} satisfies BetterAuthOptions;
+		(await getMigrations(testOpts)).runMigrations();
+		const testCtx = await init(testOpts);
+		const user = await testCtx.internalAdapter.createUser(
+			{
+				name: "listed-null-user",
+				email: "listed-null@example.com",
+			},
+			{ method: "test" },
+		);
+		const session = await testCtx.internalAdapter.createSession(user.id);
+		const cached = safeJSONParse<{ session: Session; user: User }>(
+			testMap.get(session.token),
+		);
+		testMap.set(
+			session.token,
+			JSON.stringify({ session: cached!.session, user: null }),
+		);
+
+		const sessions = await testCtx.internalAdapter.findSessions([
+			session.token,
+		]);
+
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]?.user.id).toBe(user.id);
+		expect(
+			safeJSONParse<{ user: User }>(testMap.get(session.token))?.user.id,
+		).toBe(user.id);
+	});
+
 	it("should delete on secondary storage", async () => {
 		// Create multiple sessions in past and future
 		const now = Date.now();

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -871,9 +871,17 @@ describe("internal adapter test", async () => {
 			session: Session;
 			user?: User | null;
 		}>(testMap.get(session.token));
+		const found = await testCtx.internalAdapter.findSession(session.token);
+		const cachedAfterRead = safeJSONParse<{
+			session: Session;
+			user?: User | null;
+		}>(testMap.get(session.token));
 
 		expect(cached?.session.token).toBe(session.token);
 		expect(cached).not.toHaveProperty("user");
+		expect(found?.session.token).toBe(session.token);
+		expect(found?.user.id).toBe(user.id);
+		expect(cachedAfterRead).not.toHaveProperty("user");
 	});
 
 	/**
@@ -908,8 +916,114 @@ describe("internal adapter test", async () => {
 		expect(found?.session.token).toBe(session.token);
 		expect(found?.user.id).toBe(user.id);
 		expect(
-			safeJSONParse<{ user: User }>(testMap.get(session.token))?.user.id,
-		).toBe(user.id);
+			safeJSONParse<{ user: User | null }>(testMap.get(session.token))?.user,
+		).toBeNull();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10884
+	 */
+	it.each([
+		"deleteSession",
+		"deleteSessions",
+	] as const)("does not recreate a cached session revoked by %s during user recovery", async (revokeMethod) => {
+		const testMap = new Map<string, string>();
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: createStringSecondaryStorage(testMap),
+		} satisfies BetterAuthOptions;
+		(await getMigrations(testOpts)).runMigrations();
+		const testCtx = await init(testOpts);
+		const user = await testCtx.internalAdapter.createUser(
+			{
+				name: "concurrently-revoked-user",
+				email: `concurrently-revoked-${revokeMethod}@example.com`,
+			},
+			{ method: "test" },
+		);
+		const session = await testCtx.internalAdapter.createSession(user.id);
+		const cached = safeJSONParse<{ session: Session; user: User }>(
+			testMap.get(session.token),
+		);
+		testMap.set(
+			session.token,
+			JSON.stringify({ session: cached!.session, user: null }),
+		);
+
+		const originalFindOne = testCtx.adapter.findOne.bind(testCtx.adapter);
+		let signalLookupStarted!: () => void;
+		const lookupStarted = new Promise<void>((resolve) => {
+			signalLookupStarted = resolve;
+		});
+		let releaseLookup!: () => void;
+		const lookupGate = new Promise<void>((resolve) => {
+			releaseLookup = resolve;
+		});
+		vi.spyOn(testCtx.adapter, "findOne").mockImplementation(async (input) => {
+			signalLookupStarted();
+			await lookupGate;
+			return originalFindOne(input);
+		});
+
+		const inFlightRead = testCtx.internalAdapter.findSession(session.token);
+		await lookupStarted;
+		if (revokeMethod === "deleteSession") {
+			await testCtx.internalAdapter.deleteSession(session.token);
+		} else {
+			await testCtx.internalAdapter.deleteSessions([session.token]);
+		}
+		const wasDeletedBeforeRecoveryFinished = !testMap.has(session.token);
+		releaseLookup();
+		const recovered = await inFlightRead;
+
+		expect(wasDeletedBeforeRecoveryFinished).toBe(true);
+		expect(recovered?.session.token).toBe(session.token);
+		expect(testMap.has(session.token)).toBe(false);
+		expect(await testCtx.internalAdapter.findSession(session.token)).toBeNull();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10884
+	 */
+	it("does not let a secondary-storage write failure break user recovery", async () => {
+		const testMap = new Map<string, string>();
+		const storage = createStringSecondaryStorage(testMap);
+		let failWrites = false;
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				...storage,
+				set(key, value, ttl) {
+					if (failWrites) throw new Error("secondary storage write failed");
+					return storage.set(key, value, ttl);
+				},
+			} satisfies SecondaryStorage,
+		} satisfies BetterAuthOptions;
+		(await getMigrations(testOpts)).runMigrations();
+		const testCtx = await init(testOpts);
+		const user = await testCtx.internalAdapter.createUser(
+			{
+				name: "write-failure-user",
+				email: "write-failure@example.com",
+			},
+			{ method: "test" },
+		);
+		const session = await testCtx.internalAdapter.createSession(user.id);
+		const cached = safeJSONParse<{ session: Session; user: User }>(
+			testMap.get(session.token),
+		);
+		testMap.set(
+			session.token,
+			JSON.stringify({ session: cached!.session, user: null }),
+		);
+		failWrites = true;
+
+		await expect(
+			testCtx.internalAdapter.findSession(session.token),
+		).resolves.toMatchObject({
+			session: { token: session.token },
+			user: { id: user.id },
+		});
 	});
 
 	it("keeps valid secondary session reads on the cache-hit path", async () => {
@@ -970,8 +1084,43 @@ describe("internal adapter test", async () => {
 		expect(sessions).toHaveLength(1);
 		expect(sessions[0]?.user.id).toBe(user.id);
 		expect(
-			safeJSONParse<{ user: User }>(testMap.get(session.token))?.user.id,
-		).toBe(user.id);
+			safeJSONParse<{ user: User | null }>(testMap.get(session.token))?.user,
+		).toBeNull();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10884
+	 */
+	it("propagates authoritative user lookup errors from findSessions", async () => {
+		const testMap = new Map<string, string>();
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: createStringSecondaryStorage(testMap),
+		} satisfies BetterAuthOptions;
+		(await getMigrations(testOpts)).runMigrations();
+		const testCtx = await init(testOpts);
+		const user = await testCtx.internalAdapter.createUser(
+			{
+				name: "lookup-error-user",
+				email: "lookup-error@example.com",
+			},
+			{ method: "test" },
+		);
+		const session = await testCtx.internalAdapter.createSession(user.id);
+		const cached = safeJSONParse<{ session: Session; user: User }>(
+			testMap.get(session.token),
+		);
+		testMap.set(
+			session.token,
+			JSON.stringify({ session: cached!.session, user: null }),
+		);
+		vi.spyOn(testCtx.adapter, "findOne").mockRejectedValueOnce(
+			new Error("authoritative user lookup failed"),
+		);
+
+		await expect(
+			testCtx.internalAdapter.findSessions([session.token]),
+		).rejects.toThrow("authoritative user lookup failed");
 	});
 
 	it("should delete on secondary storage", async () => {

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -1053,6 +1053,43 @@ describe("internal adapter test", async () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/10884
 	 */
+	it("recovers omitted users while finding cached sessions", async () => {
+		const testMap = new Map<string, string>();
+		const testOpts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: createStringSecondaryStorage(testMap),
+		} satisfies BetterAuthOptions;
+		(await getMigrations(testOpts)).runMigrations();
+		const testCtx = await init(testOpts);
+		const user = await testCtx.internalAdapter.createUser(
+			{
+				name: "listed-omitted-user",
+				email: "listed-omitted@example.com",
+			},
+			{ method: "test" },
+		);
+		const session = await testCtx.internalAdapter.createSession(user.id);
+		const cached = safeJSONParse<{ session: Session; user: User }>(
+			testMap.get(session.token),
+		);
+		testMap.set(session.token, JSON.stringify({ session: cached!.session }));
+
+		const sessions = await testCtx.internalAdapter.findSessions([
+			session.token,
+		]);
+
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]?.user.id).toBe(user.id);
+		expect(
+			safeJSONParse<{ session: Session; user?: User | null }>(
+				testMap.get(session.token),
+			),
+		).not.toHaveProperty("user");
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10884
+	 */
 	it("recovers null users while finding cached sessions", async () => {
 		const testMap = new Map<string, string>();
 		const testOpts = {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -203,6 +203,29 @@ export const createInternalAdapter = (
 		);
 	}
 
+	async function resolveCachedSessionUser(
+		session: Session,
+		cachedUser: User | null | undefined,
+	): Promise<User | null> {
+		if (cachedUser) return cachedUser;
+
+		const user = await (await getCurrentAdapter(adapter)).findOne<User>({
+			model: "user",
+			where: [{ field: "id", value: session.userId }],
+		});
+		if (!user || !secondaryStorage) return user;
+
+		const sessionTTL = getTTLSeconds(new Date(session.expiresAt));
+		if (sessionTTL > 0) {
+			await secondaryStorage.set(
+				session.token,
+				JSON.stringify({ session, user }),
+				sessionTTL,
+			);
+		}
+		return user;
+	}
+
 	async function withVerificationConsumeLock<T>(
 		key: string,
 		fn: () => Promise<T>,
@@ -556,7 +579,9 @@ export const createInternalAdapter = (
 				if (sessionTTL > 0) {
 					await secondaryStorage.set(
 						data.token,
-						JSON.stringify({ session: sessionData, user }),
+						JSON.stringify(
+							user ? { session: sessionData, user } : { session: sessionData },
+						),
 						sessionTTL,
 					);
 				}
@@ -620,9 +645,11 @@ export const createInternalAdapter = (
 				if (sessionStringified) {
 					const s = safeJSONParse<{
 						session: Session;
-						user: User;
+						user?: User | null;
 					}>(sessionStringified);
-					if (!s) return null;
+					if (!s?.session) return null;
+					const user = await resolveCachedSessionUser(s.session, s.user);
+					if (!user) return null;
 					const parsedSession = parseSessionOutput(ctx.options, {
 						...s.session,
 						expiresAt: new Date(s.session.expiresAt),
@@ -630,9 +657,9 @@ export const createInternalAdapter = (
 						updatedAt: new Date(s.session.updatedAt),
 					});
 					const parsedUser = parseUserOutput(ctx.options, {
-						...s.user,
-						createdAt: new Date(s.user.createdAt),
-						updatedAt: new Date(s.user.updatedAt),
+						...user,
+						createdAt: new Date(user.createdAt),
+						updatedAt: new Date(user.updatedAt),
 					});
 					return {
 						session: parsedSession,
@@ -690,22 +717,24 @@ export const createInternalAdapter = (
 									: sessionStringified
 							) as {
 								session: Session;
-								user: User;
+								user?: User | null;
 							};
-							if (!s) continue;
+							if (!s?.session) continue;
 							const expiresAt = new Date(s.session.expiresAt);
 							if (options?.onlyActiveSessions && expiresAt <= new Date()) {
 								continue;
 							}
+							const user = await resolveCachedSessionUser(s.session, s.user);
+							if (!user) continue;
 							const session = {
 								session: {
 									...s.session,
 									expiresAt: new Date(s.session.expiresAt),
 								},
 								user: {
-									...s.user,
-									createdAt: new Date(s.user.createdAt),
-									updatedAt: new Date(s.user.updatedAt),
+									...user,
+									createdAt: new Date(user.createdAt),
+									updatedAt: new Date(user.updatedAt),
 								},
 							} as {
 								session: Session;

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -213,16 +213,6 @@ export const createInternalAdapter = (
 			model: "user",
 			where: [{ field: "id", value: session.userId }],
 		});
-		if (!user || !secondaryStorage) return user;
-
-		const sessionTTL = getTTLSeconds(new Date(session.expiresAt));
-		if (sessionTTL > 0) {
-			await secondaryStorage.set(
-				session.token,
-				JSON.stringify({ session, user }),
-				sessionTTL,
-			);
-		}
 		return user;
 	}
 
@@ -710,6 +700,8 @@ export const createInternalAdapter = (
 				for (const sessionToken of sessionTokens) {
 					const sessionStringified = await secondaryStorage.get(sessionToken);
 					if (sessionStringified) {
+						let cachedSession: Session;
+						let cachedUser: User | null | undefined;
 						try {
 							const s = (
 								typeof sessionStringified === "string"
@@ -724,27 +716,29 @@ export const createInternalAdapter = (
 							if (options?.onlyActiveSessions && expiresAt <= new Date()) {
 								continue;
 							}
-							const user = await resolveCachedSessionUser(s.session, s.user);
-							if (!user) continue;
-							const session = {
-								session: {
-									...s.session,
-									expiresAt: new Date(s.session.expiresAt),
-								},
-								user: {
-									...user,
-									createdAt: new Date(user.createdAt),
-									updatedAt: new Date(user.updatedAt),
-								},
-							} as {
-								session: Session;
-								user: User;
+							cachedSession = {
+								...s.session,
+								expiresAt,
 							};
-							sessions.push(session);
+							cachedUser = s.user;
 						} catch {
 							// Skip invalid/corrupt session data
 							continue;
 						}
+
+						const user = await resolveCachedSessionUser(
+							cachedSession,
+							cachedUser,
+						);
+						if (!user) continue;
+						sessions.push({
+							session: cachedSession,
+							user: {
+								...user,
+								createdAt: new Date(user.createdAt),
+								updatedAt: new Date(user.updatedAt),
+							},
+						});
 					}
 				}
 				return sessions;


### PR DESCRIPTION
Closes #10884.

Secondary-only sessions now survive a transient user lookup miss during creation. The cache keeps the session payload without serializing `user: null`; later `findSession` and `findSessions` calls treat a missing or legacy null user as a cache miss and read the authoritative user row.

Recovered reads deliberately do not heal or write back incomplete cache entries, whether `user` is omitted or is legacy `null`. This avoids a read-then-write race that could recreate a session token after `deleteSession` or `deleteSessions` revoked it.

Complete cache entries keep the existing zero-query fast path.

Tests cover the initial transient miss, recovery of missing and legacy null-user entries through single and multi-session reads, both session-revocation races, secondary-storage write failures, authoritative lookup failures, and the valid cache-hit control.

Verified with:

- `pnpm vitest packages/better-auth/src/db/internal-adapter.test.ts packages/better-auth/src/db/secondary-storage.test.ts --run` (86 passed)
- `pnpm typecheck`
- `pnpm exec biome check packages/better-auth/src/db/internal-adapter.ts packages/better-auth/src/db/internal-adapter.test.ts`
- `pnpm changeset status`
- `git diff --check`

Codex assisted with reproducing the cache failure, developing the regression coverage, and reviewing the implementation. I reviewed the session-storage contract, the final diff, and all results above.
