### PR TITLE
fix(api-key): defer database usage updates

### DIFF
--- a/.changeset/defer-api-key-database-usage.md
+++ b/.changeset/defer-api-key-database-usage.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/api-key": patch
+---
+
+Defer database-backed API key usage updates through the configured background-task handler while returning an optimistic counter snapshot.

--- a/docs/content/docs/plugins/api-key/reference.mdx
+++ b/docs/content/docs/plugins/api-key/reference.mdx
@@ -226,7 +226,7 @@ Defer non-critical updates (rate limiting counters, timestamps, remaining count)
 Requires `backgroundTasks.handler` to be configured in the main auth options.
 
 <Callout type="warn">
-  Enabling this introduces eventual consistency where the response returns optimistic data before the database is updated. Concurrent verifications can be accepted from the same persisted counter snapshot, so strict concurrent quota and rate-limit enforcement requires synchronous updates. Only enable deferred updates if your application can tolerate this trade-off for improved latency.
+  Enabling this introduces eventual consistency where the response returns optimistic data before the database is updated. Concurrent verifications can be accepted from the same persisted counter snapshot. Synchronous guarded enforcement is available only for database storage and secondary storage with database fallback. Secondary-storage-only enforcement currently uses a best-effort read-modify-write flow until atomic consumption is implemented. Only enable deferred updates if your application can tolerate this trade-off for improved latency.
 </Callout>
 
 <Tabs items={["Vercel", "Cloudflare Workers"]}>

--- a/docs/content/docs/plugins/api-key/reference.mdx
+++ b/docs/content/docs/plugins/api-key/reference.mdx
@@ -226,7 +226,7 @@ Defer non-critical updates (rate limiting counters, timestamps, remaining count)
 Requires `backgroundTasks.handler` to be configured in the main auth options.
 
 <Callout type="warn">
-  Enabling this introduces eventual consistency where the response returns optimistic data before the database is updated. Concurrent verifications can be accepted from the same persisted counter snapshot. Synchronous guarded enforcement is available only for database storage and secondary storage with database fallback. Secondary-storage-only enforcement currently uses a best-effort read-modify-write flow until atomic consumption is implemented. Only enable deferred updates if your application can tolerate this trade-off for improved latency.
+  Enabling this introduces eventual consistency where the response returns optimistic data before the database is updated. Concurrent verifications can be accepted from the same persisted counter snapshot. Policy changes that race an optimistic verification, such as disabling a key or changing its permissions, may take effect on the next verification. Synchronous guarded enforcement is available only for database storage and secondary storage with database fallback. Secondary-storage-only enforcement currently uses a best-effort read-modify-write flow until atomic consumption is implemented. Only enable deferred updates if your application can tolerate this trade-off for improved latency.
 </Callout>
 
 <Tabs items={["Vercel", "Cloudflare Workers"]}>

--- a/docs/content/docs/plugins/api-key/reference.mdx
+++ b/docs/content/docs/plugins/api-key/reference.mdx
@@ -226,7 +226,7 @@ Defer non-critical updates (rate limiting counters, timestamps, remaining count)
 Requires `backgroundTasks.handler` to be configured in the main auth options.
 
 <Callout type="warn">
-  Enabling this introduces eventual consistency where the response returns optimistic data before the database is updated. Only enable if your application can tolerate this trade-off for improved latency.
+  Enabling this introduces eventual consistency where the response returns optimistic data before the database is updated. Concurrent verifications can be accepted from the same persisted counter snapshot, so strict concurrent quota and rate-limit enforcement requires synchronous updates. Only enable deferred updates if your application can tolerate this trade-off for improved latency.
 </Callout>
 
 <Tabs items={["Vercel", "Cloudflare Workers"]}>

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -2,7 +2,11 @@ import type { SecondaryStorage } from "@better-auth/core/db";
 import type { APIError } from "@better-auth/core/error";
 import { getTestInstance } from "better-auth/test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { apiKey, API_KEY_ERROR_CODES as ERROR_CODES } from ".";
+import {
+	apiKey,
+	defaultKeyHasher,
+	API_KEY_ERROR_CODES as ERROR_CODES,
+} from ".";
 import { apiKeyClient } from "./client";
 import type { ApiKey } from "./types";
 import { isAPIError } from "./utils";
@@ -3065,6 +3069,43 @@ describe("api-key", async () => {
 			expect(second.error?.code).toBe("USAGE_EXCEEDED");
 		});
 
+		it("should keep a committed usage claim valid when cache refresh fails", async () => {
+			const { user } = await signInWithTestUser();
+			const createdKey = await auth.api.createApiKey({
+				body: { remaining: 1, userId: user.id },
+			});
+			const hashedKey = await defaultKeyHasher(createdKey.key);
+			const originalSet = fallbackStorage.set.bind(fallbackStorage);
+			const set = vi
+				.spyOn(fallbackStorage, "set")
+				.mockImplementation(async (key, value, ttl) => {
+					if (key === `api-key:${hashedKey}`) {
+						throw new Error("cache unavailable");
+					}
+					return originalSet(key, value, ttl);
+				});
+
+			let result: Awaited<ReturnType<typeof auth.api.verifyApiKey>>;
+			try {
+				result = await auth.api.verifyApiKey({
+					body: { key: createdKey.key },
+				});
+			} finally {
+				set.mockRestore();
+			}
+
+			expect(result.valid).toBe(true);
+			expect(result.key?.remaining).toBe(0);
+			const context = await auth.$context;
+			const stored = await context.adapter.findOne<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: createdKey.id }],
+			});
+			expect(stored?.remaining).toBe(0);
+			expect(store.has(`api-key:${hashedKey}`)).toBe(false);
+			expect(store.has(`api-key:by-id:${createdKey.id}`)).toBe(false);
+		});
+
 		it("should fallback to database when not found in storage and auto-populate storage", async () => {
 			const { headers, user } = await signInWithTestUser();
 
@@ -3834,6 +3875,163 @@ describe("api-key", async () => {
 				where: [{ field: "id", value: key.id }],
 			});
 			expect(stored?.remaining).toBe(2);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
+		it("does not consume quota when the rate limit changes after recovery preflight", async () => {
+			const { auth, signInWithTestUser } =
+				await getDeferredDatabaseTestInstance();
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: {
+					userId: user.id,
+					remaining: 2,
+					rateLimitMax: 1,
+					rateLimitTimeWindow: 60_000,
+				},
+			});
+			const authContext = await auth.$context;
+			const lastRequest = new Date();
+			await authContext.adapter.update<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+				update: { requestCount: 1, lastRequest },
+			});
+			onValidate = async () => {
+				await authContext.adapter.update<ApiKey>({
+					model: "apikey",
+					where: [{ field: "id", value: key.id }],
+					update: { requestCount: 0 },
+				});
+			};
+
+			const originalIncrementOne = authContext.adapter.incrementOne.bind(
+				authContext.adapter,
+			);
+			let injectCompetingClaim = true;
+			const incrementOne = vi
+				.spyOn(authContext.adapter, "incrementOne")
+				.mockImplementation(async (input) => {
+					if (input.model === "apikey" && injectCompetingClaim) {
+						injectCompetingClaim = false;
+						await authContext.adapter.update<ApiKey>({
+							model: "apikey",
+							where: [{ field: "id", value: key.id }],
+							update: { requestCount: 1, lastRequest: new Date() },
+						});
+					}
+					return originalIncrementOne(input);
+				});
+
+			let result: Awaited<ReturnType<typeof auth.api.verifyApiKey>>;
+			try {
+				result = await auth.api.verifyApiKey({
+					body: { key: key.key },
+				});
+				expect(incrementOne).toHaveBeenCalledTimes(1);
+				expect(incrementOne).toHaveBeenCalledWith(
+					expect.objectContaining({
+						increment: {},
+						set: expect.objectContaining({
+							remaining: 1,
+							requestCount: 1,
+							lastRequest: expect.any(Date),
+						}),
+					}),
+				);
+			} finally {
+				incrementOne.mockRestore();
+			}
+
+			expect(result.valid).toBe(false);
+			expect(result.error).toMatchObject({
+				code: "RATE_LIMITED",
+				details: { tryAgainIn: expect.any(Number) },
+			});
+			const stored = await authContext.adapter.findOne<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+			});
+			expect(stored).toMatchObject({ remaining: 2, requestCount: 1 });
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
+		it("does not consume a rate-limit slot when quota changes after recovery preflight", async () => {
+			const { auth, signInWithTestUser } =
+				await getDeferredDatabaseTestInstance();
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: {
+					userId: user.id,
+					remaining: 0,
+					refillAmount: 2,
+					refillInterval: 60_000,
+					rateLimitMax: 2,
+					rateLimitTimeWindow: 60_000,
+				},
+			});
+			const authContext = await auth.$context;
+			onValidate = async () => {
+				await authContext.adapter.update<ApiKey>({
+					model: "apikey",
+					where: [{ field: "id", value: key.id }],
+					update: { remaining: 1 },
+				});
+			};
+
+			const originalIncrementOne = authContext.adapter.incrementOne.bind(
+				authContext.adapter,
+			);
+			let injectCompetingClaim = true;
+			const incrementOne = vi
+				.spyOn(authContext.adapter, "incrementOne")
+				.mockImplementation(async (input) => {
+					if (input.model === "apikey" && injectCompetingClaim) {
+						injectCompetingClaim = false;
+						await authContext.adapter.update<ApiKey>({
+							model: "apikey",
+							where: [{ field: "id", value: key.id }],
+							update: { remaining: 0 },
+						});
+					}
+					return originalIncrementOne(input);
+				});
+
+			let result: Awaited<ReturnType<typeof auth.api.verifyApiKey>>;
+			try {
+				result = await auth.api.verifyApiKey({
+					body: { key: key.key },
+				});
+				expect(incrementOne).toHaveBeenCalledTimes(1);
+				expect(incrementOne).toHaveBeenCalledWith(
+					expect.objectContaining({
+						increment: {},
+						set: expect.objectContaining({
+							remaining: 0,
+							requestCount: 1,
+							lastRequest: expect.any(Date),
+						}),
+					}),
+				);
+			} finally {
+				incrementOne.mockRestore();
+			}
+
+			expect(result.valid).toBe(false);
+			expect(result.error?.code).toBe("USAGE_EXCEEDED");
+			const stored = await authContext.adapter.findOne<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+			});
+			expect(stored).toMatchObject({
+				remaining: 0,
+				requestCount: 0,
+				lastRequest: null,
+			});
 		});
 
 		/**
@@ -5460,7 +5658,7 @@ describe("verify should not write back stale state", async () => {
 			},
 		);
 
-		it("should not re-enable a key disabled during verification", async () => {
+		it("should reject a key disabled during verification", async () => {
 			const { headers } = await signInWithTestUser();
 			const created = await auth.api.createApiKey({ body: {}, headers });
 
@@ -5474,9 +5672,8 @@ describe("verify should not write back stale state", async () => {
 			const result = await auth.api.verifyApiKey({
 				body: { key: created.key },
 			});
-			// the verification read the key before the disable, so it passes,
-			// but its write-back must not revert the disable
-			expect(result.valid).toBe(true);
+			expect(result.valid).toBe(false);
+			expect(result.error?.code).toBe("KEY_DISABLED");
 
 			const stored = await auth.api.getApiKey({
 				query: { id: created.id },

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -3483,6 +3483,178 @@ describe("api-key", async () => {
 	});
 
 	describe("deferUpdates option", () => {
+		let onValidate: (() => Promise<void>) | null = null;
+		const customAPIKeyValidator = async () => {
+			const hook = onValidate;
+			onValidate = null;
+			if (hook) await hook();
+			return true;
+		};
+
+		const getDeferredDatabaseTestInstance = async () => {
+			const deferredPromises: Array<Promise<unknown>> = [];
+			const instance = await getTestInstance({
+				advanced: {
+					backgroundTasks: {
+						handler: (promise: Promise<unknown>) => {
+							deferredPromises.push(promise);
+						},
+					},
+				},
+				plugins: [
+					apiKey({
+						deferUpdates: true,
+						customAPIKeyValidator,
+					}),
+				],
+			});
+			return { ...instance, deferredPromises };
+		};
+
+		afterEach(() => {
+			onValidate = null;
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
+		it("rechecks a stale quota denial against the database", async () => {
+			const { auth, deferredPromises, signInWithTestUser } =
+				await getDeferredDatabaseTestInstance();
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: {
+					userId: user.id,
+					remaining: 0,
+					refillAmount: 2,
+					refillInterval: 60_000,
+				},
+			});
+			const authContext = await auth.$context;
+			onValidate = async () => {
+				await authContext.adapter.update<ApiKey>({
+					model: "apikey",
+					where: [{ field: "id", value: key.id }],
+					update: { remaining: 2 },
+				});
+			};
+
+			const result = await auth.api.verifyApiKey({
+				body: { key: key.key },
+			});
+
+			expect(result.valid).toBe(true);
+			expect(result.key?.remaining).toBe(1);
+			const stored = await authContext.adapter.findOne<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+			});
+			expect(stored?.remaining).toBe(1);
+			await Promise.all(deferredPromises);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
+		it("retains a genuine database quota denial", async () => {
+			const { auth, signInWithTestUser } =
+				await getDeferredDatabaseTestInstance();
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: {
+					userId: user.id,
+					remaining: 0,
+					refillAmount: 2,
+					refillInterval: 60_000,
+				},
+			});
+
+			const result = await auth.api.verifyApiKey({
+				body: { key: key.key },
+			});
+
+			expect(result.valid).toBe(false);
+			expect(result.error?.code).toBe("USAGE_EXCEEDED");
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
+		it("rechecks a stale rate-limit denial against the database", async () => {
+			const { auth, deferredPromises, signInWithTestUser } =
+				await getDeferredDatabaseTestInstance();
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: {
+					userId: user.id,
+					rateLimitMax: 1,
+					rateLimitTimeWindow: 60_000,
+				},
+			});
+			const authContext = await auth.$context;
+			await authContext.adapter.update<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+				update: { requestCount: 1, lastRequest: new Date() },
+			});
+			onValidate = async () => {
+				await authContext.adapter.update<ApiKey>({
+					model: "apikey",
+					where: [{ field: "id", value: key.id }],
+					update: { rateLimitMax: 2, rateLimitTimeWindow: 120_000 },
+				});
+			};
+
+			const result = await auth.api.verifyApiKey({
+				body: { key: key.key },
+			});
+
+			expect(result.valid).toBe(true);
+			expect(result.key?.requestCount).toBe(2);
+			const stored = await authContext.adapter.findOne<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+			});
+			expect(stored).toMatchObject({
+				requestCount: 2,
+				rateLimitMax: 2,
+				rateLimitTimeWindow: 120_000,
+			});
+			await Promise.all(deferredPromises);
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
+		it("retains a genuine database rate-limit denial with details", async () => {
+			const { auth, signInWithTestUser } =
+				await getDeferredDatabaseTestInstance();
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: {
+					userId: user.id,
+					rateLimitMax: 1,
+					rateLimitTimeWindow: 60_000,
+				},
+			});
+			const authContext = await auth.$context;
+			await authContext.adapter.update<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+				update: { requestCount: 1, lastRequest: new Date() },
+			});
+
+			const result = await auth.api.verifyApiKey({
+				body: { key: key.key },
+			});
+
+			expect(result.valid).toBe(false);
+			expect(result.error).toMatchObject({
+				code: "RATE_LIMITED",
+				details: { tryAgainIn: expect.any(Number) },
+			});
+		});
+
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10921
 		 */

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -3483,6 +3483,81 @@ describe("api-key", async () => {
 	});
 
 	describe("deferUpdates option", () => {
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
+		it("does not block database verification on a deferred usage write", async () => {
+			const deferredPromises: Array<Promise<unknown>> = [];
+			const { auth, signInWithTestUser } = await getTestInstance({
+				advanced: {
+					backgroundTasks: {
+						handler: (promise: Promise<unknown>) => {
+							deferredPromises.push(promise);
+						},
+					},
+				},
+				plugins: [apiKey({ deferUpdates: true })],
+			});
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: { userId: user.id, remaining: 2 },
+			});
+			const authContext = await auth.$context;
+			const originalIncrementOne = authContext.adapter.incrementOne.bind(
+				authContext.adapter,
+			);
+			let releaseWrite!: () => void;
+			const writeGate = new Promise<void>((resolve) => {
+				releaseWrite = resolve;
+			});
+			let markWriteStarted!: () => void;
+			const writeStarted = new Promise<void>((resolve) => {
+				markWriteStarted = resolve;
+			});
+			let shouldBlock = true;
+			vi.spyOn(authContext.adapter, "incrementOne").mockImplementation(
+				async (input) => {
+					if (input.model === "apikey" && shouldBlock) {
+						shouldBlock = false;
+						markWriteStarted();
+						await writeGate;
+					}
+					return originalIncrementOne(input);
+				},
+			);
+
+			let settled = false;
+			const verification = auth.api
+				.verifyApiKey({
+					body: { key: key.key },
+				})
+				.then((result) => {
+					settled = true;
+					return result;
+				});
+			await writeStarted;
+			for (let turn = 0; turn < 10 && !settled; turn++) {
+				await Promise.resolve();
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			}
+
+			try {
+				expect(settled).toBe(true);
+				if (settled) {
+					const result = await verification;
+					expect(result.valid).toBe(true);
+					expect(result.key?.remaining).toBe(1);
+				}
+			} finally {
+				releaseWrite();
+				await verification;
+				await Promise.all(deferredPromises);
+			}
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
 		it("should defer updates when deferUpdates is enabled with global backgroundTasks", async () => {
 			const deferredPromises: Array<Promise<unknown>> = [];
 			const { auth, signInWithTestUser } = await getTestInstance({
@@ -3523,6 +3598,9 @@ describe("api-key", async () => {
 			expect(updatedKey.lastRequest).not.toBeNull();
 		});
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
 		it("should still validate rate limits correctly with deferred updates", async () => {
 			const deferredPromises: Array<Promise<unknown>> = [];
 			const { auth, signInWithTestUser } = await getTestInstance({
@@ -3571,6 +3649,9 @@ describe("api-key", async () => {
 			expect((result3.error as any)?.details).toHaveProperty("tryAgainIn");
 		});
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
 		it("should defer remaining count updates", async () => {
 			const deferredPromises: Array<Promise<unknown>> = [];
 			const { auth, signInWithTestUser } = await getTestInstance({
@@ -3611,6 +3692,9 @@ describe("api-key", async () => {
 			expect(updatedKey.remaining).toBe(9);
 		});
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
 		it("should not defer updates when backgroundTasks handler is not configured", async () => {
 			const { auth, signInWithTestUser } = await getTestInstance({
 				plugins: [
@@ -3623,15 +3707,48 @@ describe("api-key", async () => {
 			const { headers, user } = await signInWithTestUser();
 
 			const key = await auth.api.createApiKey({
-				body: { userId: user.id },
-				headers,
+				body: { userId: user.id, remaining: 2 },
 			});
+			const authContext = await auth.$context;
+			const originalIncrementOne = authContext.adapter.incrementOne.bind(
+				authContext.adapter,
+			);
+			let releaseWrite!: () => void;
+			const writeGate = new Promise<void>((resolve) => {
+				releaseWrite = resolve;
+			});
+			let markWriteStarted!: () => void;
+			const writeStarted = new Promise<void>((resolve) => {
+				markWriteStarted = resolve;
+			});
+			let shouldBlock = true;
+			vi.spyOn(authContext.adapter, "incrementOne").mockImplementation(
+				async (input) => {
+					if (input.model === "apikey" && shouldBlock) {
+						shouldBlock = false;
+						markWriteStarted();
+						await writeGate;
+					}
+					return originalIncrementOne(input);
+				},
+			);
 
-			const result = await auth.api.verifyApiKey({
-				body: { key: key.key },
-			});
+			let settled = false;
+			const verification = auth.api
+				.verifyApiKey({
+					body: { key: key.key },
+				})
+				.then((result) => {
+					settled = true;
+					return result;
+				});
+			await writeStarted;
+			expect(settled).toBe(false);
+			releaseWrite();
+			const result = await verification;
 
 			expect(result.valid).toBe(true);
+			expect(result.key?.remaining).toBe(1);
 
 			// Without advanced.backgroundTasks handler, updates should happen synchronously
 			const updatedKey = await auth.api.getApiKey({
@@ -3639,6 +3756,7 @@ describe("api-key", async () => {
 				headers,
 			});
 			expect(updatedKey.lastRequest).not.toBeNull();
+			expect(updatedKey.remaining).toBe(1);
 		});
 	});
 

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -3076,7 +3076,7 @@ describe("api-key", async () => {
 			});
 			const hashedKey = await defaultKeyHasher(createdKey.key);
 			const originalSet = fallbackStorage.set.bind(fallbackStorage);
-			const set = vi
+			const setSpy = vi
 				.spyOn(fallbackStorage, "set")
 				.mockImplementation(async (key, value, ttl) => {
 					if (key === `api-key:${hashedKey}`) {
@@ -3091,7 +3091,7 @@ describe("api-key", async () => {
 					body: { key: createdKey.key },
 				});
 			} finally {
-				set.mockRestore();
+				setSpy.mockRestore();
 			}
 
 			expect(result.valid).toBe(true);

--- a/packages/api-key/src/api-key.test.ts
+++ b/packages/api-key/src/api-key.test.ts
@@ -3556,6 +3556,181 @@ describe("api-key", async () => {
 		/**
 		 * @see https://github.com/better-auth/better-auth/issues/10921
 		 */
+		it("rejects a key disabled while recovering from a stale quota denial", async () => {
+			const { auth, signInWithTestUser } =
+				await getDeferredDatabaseTestInstance();
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: {
+					userId: user.id,
+					remaining: 0,
+					refillAmount: 2,
+					refillInterval: 60_000,
+				},
+			});
+			const authContext = await auth.$context;
+			onValidate = async () => {
+				await authContext.adapter.update<ApiKey>({
+					model: "apikey",
+					where: [{ field: "id", value: key.id }],
+					update: { enabled: false, remaining: 2 },
+				});
+			};
+
+			const result = await auth.api.verifyApiKey({
+				body: { key: key.key },
+			});
+
+			expect(result.valid).toBe(false);
+			expect(result.error?.code).toBe("KEY_DISABLED");
+			const stored = await authContext.adapter.findOne<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+			});
+			expect(stored).toMatchObject({ enabled: false, remaining: 2 });
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
+		it("rejects a key reconfigured while recovering from a stale quota denial", async () => {
+			const { auth, signInWithTestUser } =
+				await getDeferredDatabaseTestInstance();
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: {
+					userId: user.id,
+					remaining: 0,
+					refillAmount: 2,
+					refillInterval: 60_000,
+				},
+			});
+			const authContext = await auth.$context;
+			onValidate = async () => {
+				await authContext.adapter.update<ApiKey>({
+					model: "apikey",
+					where: [{ field: "id", value: key.id }],
+					update: { configId: "other", remaining: 2 },
+				});
+			};
+
+			const result = await auth.api.verifyApiKey({
+				body: { key: key.key },
+			});
+
+			expect(result.valid).toBe(false);
+			expect(result.error?.code).toBe("INVALID_API_KEY");
+			const stored = await authContext.adapter.findOne<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+			});
+			expect(stored).toMatchObject({ configId: "other", remaining: 2 });
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
+		it("rejects and removes a key expired while recovering from a stale quota denial", async () => {
+			const { auth, deferredPromises, signInWithTestUser } =
+				await getDeferredDatabaseTestInstance();
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: {
+					userId: user.id,
+					remaining: 0,
+					refillAmount: 2,
+					refillInterval: 60_000,
+				},
+			});
+			const authContext = await auth.$context;
+			const incrementOne = vi.spyOn(authContext.adapter, "incrementOne");
+			onValidate = async () => {
+				await authContext.adapter.update<ApiKey>({
+					model: "apikey",
+					where: [{ field: "id", value: key.id }],
+					update: {
+						expiresAt: new Date(Date.now() - 1_000),
+						remaining: 2,
+					},
+				});
+			};
+
+			try {
+				const result = await auth.api.verifyApiKey({
+					body: { key: key.key },
+				});
+
+				expect(result.valid).toBe(false);
+				expect(result.error?.code).toBe("KEY_EXPIRED");
+				expect(incrementOne).not.toHaveBeenCalled();
+			} finally {
+				incrementOne.mockRestore();
+				await Promise.all(deferredPromises);
+			}
+			const stored = await authContext.adapter.findOne<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+			});
+			expect(stored).toBeNull();
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
+		it("rejects permissions removed while recovering from a stale rate-limit denial", async () => {
+			const { auth, signInWithTestUser } =
+				await getDeferredDatabaseTestInstance();
+			const { user } = await signInWithTestUser();
+			const key = await auth.api.createApiKey({
+				body: {
+					userId: user.id,
+					permissions: { files: ["read"] },
+					remaining: 2,
+					rateLimitMax: 1,
+					rateLimitTimeWindow: 60_000,
+				},
+			});
+			const authContext = await auth.$context;
+			await authContext.adapter.update<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+				update: { requestCount: 1, lastRequest: new Date() },
+			});
+			onValidate = async () => {
+				await authContext.adapter.update<ApiKey>({
+					model: "apikey",
+					where: [{ field: "id", value: key.id }],
+					update: {
+						permissions: JSON.stringify({ files: [] }),
+						rateLimitMax: 2,
+					},
+				});
+			};
+
+			const result = await auth.api.verifyApiKey({
+				body: {
+					key: key.key,
+					permissions: { files: ["read"] },
+				},
+			});
+
+			expect(result.valid).toBe(false);
+			expect(result.error?.code).toBe("KEY_NOT_FOUND");
+			const stored = await authContext.adapter.findOne<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+			});
+			expect(stored).toMatchObject({
+				permissions: JSON.stringify({ files: [] }),
+				rateLimitMax: 2,
+				remaining: 2,
+				requestCount: 1,
+			});
+		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10921
+		 */
 		it("retains a genuine database quota denial", async () => {
 			const { auth, signInWithTestUser } =
 				await getDeferredDatabaseTestInstance();
@@ -3633,6 +3808,7 @@ describe("api-key", async () => {
 			const key = await auth.api.createApiKey({
 				body: {
 					userId: user.id,
+					remaining: 2,
 					rateLimitMax: 1,
 					rateLimitTimeWindow: 60_000,
 				},
@@ -3653,6 +3829,11 @@ describe("api-key", async () => {
 				code: "RATE_LIMITED",
 				details: { tryAgainIn: expect.any(Number) },
 			});
+			const stored = await authContext.adapter.findOne<ApiKey>({
+				model: "apikey",
+				where: [{ field: "id", value: key.id }],
+			});
+			expect(stored?.remaining).toBe(2);
 		});
 
 		/**

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -196,7 +196,36 @@ async function claimUsageInDatabase({
 		});
 	}
 
-	const mutations = getOptimisticUsageMutations(apiKey, opts);
+	let mutations: Partial<ApiKey>;
+	try {
+		mutations = getOptimisticUsageMutations(apiKey, opts);
+	} catch (error) {
+		if (
+			!isAPIError(error) ||
+			(error.body?.code !== "USAGE_EXCEEDED" &&
+				error.body?.code !== "RATE_LIMITED")
+		) {
+			throw error;
+		}
+
+		const freshApiKey = await ctx.context.adapter.findOne<ApiKey>({
+			model: API_KEY_TABLE_NAME,
+			where: [
+				{ field: "id", value: apiKey.id },
+				{ field: "key", value: hashedKey },
+			],
+		});
+		if (!freshApiKey) {
+			throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
+		}
+
+		return claimUsageInDatabaseAuthoritatively({
+			ctx,
+			apiKey: freshApiKey,
+			opts,
+			hashedKey,
+		});
+	}
 	await ctx.context.runInBackgroundOrAwait(
 		claimUsageInDatabaseAuthoritatively({
 			ctx,

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -74,6 +74,68 @@ export async function validateApiKey({
 		}
 	}
 
+	await validateApiKeyPolicy({ ctx, apiKey, opts, permissions });
+
+	// A non-refillable key that is already exhausted is removed and rejected.
+	if (apiKey.remaining === 0 && apiKey.refillAmount === null) {
+		const deleteExhaustedKey = async () => {
+			if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
+				await deleteApiKey(ctx, apiKey, opts);
+				await ctx.context.adapter.delete({
+					model: API_KEY_TABLE_NAME,
+					where: [{ field: "id", value: apiKey.id }],
+				});
+			} else if (opts.storage === "secondary-storage") {
+				await deleteApiKey(ctx, apiKey, opts);
+			} else {
+				await ctx.context.adapter.delete({
+					model: API_KEY_TABLE_NAME,
+					where: [{ field: "id", value: apiKey.id }],
+				});
+			}
+		};
+
+		if (opts.deferUpdates) {
+			ctx.context.runInBackground(
+				deleteExhaustedKey().catch((error) => {
+					ctx.context.logger.error("Deferred update failed:", error);
+				}),
+			);
+		} else {
+			await deleteExhaustedKey();
+		}
+
+		throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
+	}
+
+	const usesDatabase =
+		opts.storage === "database" ||
+		(opts.storage === "secondary-storage" && opts.fallbackToDatabase);
+
+	const newApiKey = usesDatabase
+		? await claimUsageInDatabase({
+				ctx,
+				apiKey,
+				opts,
+				hashedKey,
+				permissions,
+			})
+		: await claimUsageInSecondaryStorage({ ctx, apiKey, opts, hashedKey });
+
+	return { apiKey: newApiKey, opts };
+}
+
+async function validateApiKeyPolicy({
+	ctx,
+	apiKey,
+	opts,
+	permissions,
+}: {
+	ctx: GenericEndpointContext;
+	apiKey: ApiKey;
+	opts: PredefinedApiKeyOptions;
+	permissions?: Record<string, string[]> | undefined;
+}): Promise<void> {
 	if (apiKey.enabled === false) {
 		throw APIError.from("UNAUTHORIZED", ERROR_CODES.KEY_DISABLED);
 	}
@@ -129,48 +191,6 @@ export async function validateApiKey({
 			throw APIError.from("UNAUTHORIZED", ERROR_CODES.KEY_NOT_FOUND);
 		}
 	}
-
-	// A non-refillable key that is already exhausted is removed and rejected.
-	if (apiKey.remaining === 0 && apiKey.refillAmount === null) {
-		const deleteExhaustedKey = async () => {
-			if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
-				await deleteApiKey(ctx, apiKey, opts);
-				await ctx.context.adapter.delete({
-					model: API_KEY_TABLE_NAME,
-					where: [{ field: "id", value: apiKey.id }],
-				});
-			} else if (opts.storage === "secondary-storage") {
-				await deleteApiKey(ctx, apiKey, opts);
-			} else {
-				await ctx.context.adapter.delete({
-					model: API_KEY_TABLE_NAME,
-					where: [{ field: "id", value: apiKey.id }],
-				});
-			}
-		};
-
-		if (opts.deferUpdates) {
-			ctx.context.runInBackground(
-				deleteExhaustedKey().catch((error) => {
-					ctx.context.logger.error("Deferred update failed:", error);
-				}),
-			);
-		} else {
-			await deleteExhaustedKey();
-		}
-
-		throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
-	}
-
-	const usesDatabase =
-		opts.storage === "database" ||
-		(opts.storage === "secondary-storage" && opts.fallbackToDatabase);
-
-	const newApiKey = usesDatabase
-		? await claimUsageInDatabase({ ctx, apiKey, opts, hashedKey })
-		: await claimUsageInSecondaryStorage({ ctx, apiKey, opts, hashedKey });
-
-	return { apiKey: newApiKey, opts };
 }
 
 async function claimUsageInDatabase({
@@ -178,11 +198,13 @@ async function claimUsageInDatabase({
 	apiKey,
 	opts,
 	hashedKey,
+	permissions,
 }: {
 	ctx: GenericEndpointContext;
 	apiKey: ApiKey;
 	opts: PredefinedApiKeyOptions;
 	hashedKey: string;
+	permissions?: Record<string, string[]> | undefined;
 }): Promise<ApiKey> {
 	const canDefer =
 		opts.deferUpdates &&
@@ -218,6 +240,19 @@ async function claimUsageInDatabase({
 		if (!freshApiKey) {
 			throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
 		}
+		if (!configIdMatches(freshApiKey.configId, apiKey.configId)) {
+			throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
+		}
+
+		await validateApiKeyPolicy({
+			ctx,
+			apiKey: freshApiKey,
+			opts,
+			permissions,
+		});
+		// Reject a known fresh quota or rate-limit denial before the guarded
+		// database path can consume the other counter.
+		getOptimisticUsageMutations(freshApiKey, opts);
 
 		return claimUsageInDatabaseAuthoritatively({
 			ctx,

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -173,6 +173,41 @@ export async function validateApiKey({
 	return { apiKey: newApiKey, opts };
 }
 
+async function claimUsageInDatabase({
+	ctx,
+	apiKey,
+	opts,
+	hashedKey,
+}: {
+	ctx: GenericEndpointContext;
+	apiKey: ApiKey;
+	opts: PredefinedApiKeyOptions;
+	hashedKey: string;
+}): Promise<ApiKey> {
+	const canDefer =
+		opts.deferUpdates &&
+		ctx.context.options.advanced?.backgroundTasks?.handler !== undefined;
+	if (!canDefer) {
+		return claimUsageInDatabaseAuthoritatively({
+			ctx,
+			apiKey,
+			opts,
+			hashedKey,
+		});
+	}
+
+	const mutations = getOptimisticUsageMutations(apiKey, opts);
+	await ctx.context.runInBackgroundOrAwait(
+		claimUsageInDatabaseAuthoritatively({
+			ctx,
+			apiKey,
+			opts,
+			hashedKey,
+		}),
+	);
+	return { ...apiKey, ...mutations };
+}
+
 /**
  * Atomically consume quota and a rate-limit slot against the database row, the
  * source of truth for `database` and `secondary-storage` + `fallbackToDatabase`
@@ -181,7 +216,7 @@ export async function validateApiKey({
  * `requestCount` past the configured max. The cache (when present) is refreshed
  * from the resulting row.
  */
-async function claimUsageInDatabase({
+async function claimUsageInDatabaseAuthoritatively({
 	ctx,
 	apiKey,
 	opts,
@@ -394,31 +429,7 @@ async function claimUsageInSecondaryStorage({
 	opts: PredefinedApiKeyOptions;
 	hashedKey: string;
 }): Promise<ApiKey> {
-	let remaining = apiKey.remaining;
-	let lastRefillAt = apiKey.lastRefillAt;
-
-	if (remaining !== null) {
-		const now = Date.now();
-		const { refillInterval, refillAmount } = apiKey;
-		const lastTime = new Date(lastRefillAt ?? apiKey.createdAt).getTime();
-		if (refillInterval && refillAmount && now - lastTime > refillInterval) {
-			remaining = refillAmount;
-			lastRefillAt = new Date();
-		}
-		if (remaining === 0) {
-			throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
-		}
-		remaining--;
-	}
-
-	const rateLimitUpdate = applyRateLimitToSnapshot(apiKey, opts);
-
-	const mutations: Partial<ApiKey> = {
-		...rateLimitUpdate,
-		remaining,
-		lastRefillAt,
-		updatedAt: new Date(),
-	};
+	const mutations = getOptimisticUsageMutations(apiKey, opts);
 
 	const performUpdate = async (): Promise<ApiKey | null> => {
 		const fresh = await getApiKey(ctx, hashedKey, opts);
@@ -447,6 +458,35 @@ async function claimUsageInSecondaryStorage({
 		);
 	}
 	return updated;
+}
+
+function getOptimisticUsageMutations(
+	apiKey: ApiKey,
+	opts: PredefinedApiKeyOptions,
+): Partial<ApiKey> {
+	let remaining = apiKey.remaining;
+	let lastRefillAt = apiKey.lastRefillAt;
+
+	if (remaining !== null) {
+		const now = Date.now();
+		const { refillInterval, refillAmount } = apiKey;
+		const lastTime = new Date(lastRefillAt ?? apiKey.createdAt).getTime();
+		if (refillInterval && refillAmount && now - lastTime > refillInterval) {
+			remaining = refillAmount;
+			lastRefillAt = new Date();
+		}
+		if (remaining === 0) {
+			throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
+		}
+		remaining--;
+	}
+
+	return {
+		...applyRateLimitToSnapshot(apiKey, opts),
+		remaining,
+		lastRefillAt,
+		updatedAt: new Date(),
+	};
 }
 
 /**

--- a/packages/api-key/src/routes/verify-api-key.ts
+++ b/packages/api-key/src/routes/verify-api-key.ts
@@ -1,5 +1,6 @@
 import type { AuthContext, GenericEndpointContext } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
+import type { Where } from "@better-auth/core/db/adapter";
 import { APIError } from "@better-auth/core/error";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import { role } from "better-auth/plugins/access";
@@ -215,6 +216,7 @@ async function claimUsageInDatabase({
 			apiKey,
 			opts,
 			hashedKey,
+			permissions,
 		});
 	}
 
@@ -259,6 +261,7 @@ async function claimUsageInDatabase({
 			apiKey: freshApiKey,
 			opts,
 			hashedKey,
+			permissions,
 		});
 	}
 	await ctx.context.runInBackgroundOrAwait(
@@ -267,6 +270,7 @@ async function claimUsageInDatabase({
 			apiKey,
 			opts,
 			hashedKey,
+			permissions,
 		}),
 	);
 	return { ...apiKey, ...mutations };
@@ -275,203 +279,104 @@ async function claimUsageInDatabase({
 /**
  * Atomically consume quota and a rate-limit slot against the database row, the
  * source of truth for `database` and `secondary-storage` + `fallbackToDatabase`
- * modes. Each guarded `incrementOne` only mutates the row while the guard still
- * holds, so concurrent verifications cannot drive `remaining` below zero or push
- * `requestCount` past the configured max. The cache (when present) is refreshed
- * from the resulting row.
+ * modes. Quota and rate-limit state are derived from one snapshot and written by
+ * one guarded `incrementOne`, so a request either consumes both allowances or
+ * neither. The cache (when present) is refreshed from the resulting row.
  */
 async function claimUsageInDatabaseAuthoritatively({
 	ctx,
 	apiKey,
 	opts,
 	hashedKey,
+	permissions,
 }: {
 	ctx: GenericEndpointContext;
 	apiKey: ApiKey;
 	opts: PredefinedApiKeyOptions;
 	hashedKey: string;
+	permissions?: Record<string, string[]> | undefined;
 }): Promise<ApiKey> {
-	let row: ApiKey = apiKey;
+	let row = apiKey;
 
-	if (apiKey.remaining !== null) {
-		row = await consumeRemaining(ctx, apiKey);
-	}
-
-	row = await consumeRateLimit(ctx, row, opts);
-
-	// A final `updatedAt` stamp returns the fully consolidated row, reflecting
-	// every guarded counter write applied above.
-	const finalRow = await ctx.context.adapter.update<ApiKey>({
-		model: API_KEY_TABLE_NAME,
-		where: [{ field: "id", value: row.id }],
-		update: { updatedAt: new Date() },
-	});
-
-	// A null result means the row was deleted concurrently (for example the key
-	// was revoked). Do not fall back to the in-memory row and re-cache a key
-	// whose authoritative record is gone.
-	if (!finalRow) {
-		throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
-	}
-
-	if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
-		await setApiKey(ctx, finalRow, opts);
-	}
-
-	return finalRow;
-}
-
-/**
- * Guarded quota consumption. When a refill is due, exactly one verification wins
- * the refill (compare-and-swap on the observed `lastRefillAt`); any concurrent
- * verification falls through to the plain guarded decrement against the refilled
- * value. The decrement only applies while `remaining > 0`, so it can never go
- * negative. Returns the updated row; throws when the quota is exhausted.
- */
-async function consumeRemaining(
-	ctx: GenericEndpointContext,
-	apiKey: ApiKey,
-): Promise<ApiKey> {
-	const now = new Date();
-	const { refillInterval, refillAmount } = apiKey;
-
-	if (refillInterval && refillAmount) {
-		const lastTime = new Date(
-			apiKey.lastRefillAt ?? apiKey.createdAt,
-		).getTime();
-		if (now.getTime() - lastTime > refillInterval) {
-			const refilled = await ctx.context.adapter.incrementOne<ApiKey>({
-				model: API_KEY_TABLE_NAME,
-				where: [
-					{ field: "id", value: apiKey.id },
-					{ field: "lastRefillAt", value: apiKey.lastRefillAt },
-				],
-				increment: {},
-				set: { remaining: refillAmount - 1, lastRefillAt: now },
-			});
-			if (refilled) {
-				return refilled;
-			}
-			// Lost the refill CAS: another verification already refilled. Fall
-			// through and decrement against the refreshed value.
+	for (;;) {
+		if (!configIdMatches(row.configId, apiKey.configId)) {
+			throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
 		}
-	}
+		await validateApiKeyPolicy({ ctx, apiKey: row, opts, permissions });
 
-	const decremented = await ctx.context.adapter.incrementOne<ApiKey>({
-		model: API_KEY_TABLE_NAME,
-		where: [
-			{ field: "id", value: apiKey.id },
-			{ field: "remaining", operator: "gt", value: 0 },
-		],
-		increment: { remaining: -1 },
-	});
-
-	if (!decremented) {
-		throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
-	}
-
-	return decremented;
-}
-
-/**
- * Guarded rate-limit consumption. The common in-window path increments
- * `requestCount` only while it is below the max (compare-and-swap), so a burst
- * of concurrent verifications can never exceed the limit. Window resets and the
- * first request in a window are guarded conditional sets; a request that loses
- * every guard within an active window is rejected. Returns the updated row, or
- * the unchanged row when rate limiting does not apply.
- */
-async function consumeRateLimit(
-	ctx: GenericEndpointContext,
-	apiKey: ApiKey,
-	opts: PredefinedApiKeyOptions,
-): Promise<ApiKey> {
-	const decision = evaluateRateLimit(apiKey, opts);
-
-	if (decision.type === "deny") {
-		throw new APIError("TOO_MANY_REQUESTS", {
-			message: decision.message,
-			code: "RATE_LIMITED" as const,
-			details: { tryAgainIn: decision.tryAgainIn },
-		});
-	}
-
-	if (decision.type === "skip") {
-		if (decision.lastRequest === null) {
-			return apiKey;
-		}
-		const updated = await ctx.context.adapter.update<ApiKey>({
+		const claimed = await ctx.context.adapter.incrementOne<ApiKey>({
 			model: API_KEY_TABLE_NAME,
-			where: [{ field: "id", value: apiKey.id }],
-			update: { lastRequest: decision.lastRequest },
+			where: getUsageSnapshotGuards(row),
+			increment: {},
+			set: getOptimisticUsageMutations(row, opts),
 		});
-		return updated ?? apiKey;
-	}
+		if (claimed) {
+			if (opts.storage === "secondary-storage" && opts.fallbackToDatabase) {
+				try {
+					await setApiKey(ctx, claimed, opts);
+				} catch (error) {
+					ctx.context.logger.error(
+						"Failed to refresh API key cache after committing usage:",
+						error,
+					);
+					try {
+						await deleteApiKey(ctx, claimed, opts);
+					} catch (invalidationError) {
+						ctx.context.logger.error(
+							"Failed to invalidate API key cache after refresh failure:",
+							invalidationError,
+						);
+					}
+				}
+			}
+			return claimed;
+		}
 
-	if (decision.type === "increment") {
-		const incremented = await ctx.context.adapter.incrementOne<ApiKey>({
+		const fresh = await ctx.context.adapter.findOne<ApiKey>({
 			model: API_KEY_TABLE_NAME,
 			where: [
 				{ field: "id", value: apiKey.id },
-				{
-					field: "lastRequest",
-					operator: "gt",
-					value: decision.windowStart,
-				},
-				{
-					field: "requestCount",
-					operator: "lt",
-					value: decision.max,
-				},
+				{ field: "key", value: hashedKey },
 			],
-			increment: { requestCount: 1 },
-			set: { lastRequest: decision.now },
-		});
-		if (incremented) {
-			return incremented;
-		}
-		// The window rolled or the max was reached between the read and the
-		// write. Re-evaluate against the freshest row to apply the right guard.
-		const fresh = await ctx.context.adapter.findOne<ApiKey>({
-			model: API_KEY_TABLE_NAME,
-			where: [{ field: "id", value: apiKey.id }],
 		});
 		if (!fresh) {
 			throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
 		}
-		return consumeRateLimit(ctx, fresh, opts);
+		row = fresh;
 	}
+}
 
-	// "start" and "reset": set the count to 1 for a fresh window, guarded so a
-	// concurrent increment in the same window cannot be silently overwritten.
-	const windowGuard =
-		decision.type === "reset"
-			? {
-					field: "lastRequest",
-					operator: "lte" as const,
-					value: decision.windowStart,
-				}
-			: { field: "lastRequest", operator: "eq" as const, value: null };
+/**
+ * Exact compare-and-set guards for every field that affects whether this request
+ * may consume usage. A concurrent policy or counter change makes the claim miss,
+ * after which the fresh row is revalidated and reevaluated before another write.
+ */
+function getUsageSnapshotGuards(apiKey: ApiKey): Where[] {
+	const permissions =
+		typeof apiKey.permissions === "string"
+			? apiKey.permissions
+			: apiKey.permissions == null
+				? null
+				: JSON.stringify(apiKey.permissions);
 
-	const started = await ctx.context.adapter.incrementOne<ApiKey>({
-		model: API_KEY_TABLE_NAME,
-		where: [{ field: "id", value: apiKey.id }, windowGuard],
-		increment: {},
-		set: { requestCount: 1, lastRequest: decision.now },
-	});
-	if (started) {
-		return started;
-	}
-	// Another verification already opened the window. Re-evaluate so this
-	// request consumes an increment slot instead of resetting the count.
-	const fresh = await ctx.context.adapter.findOne<ApiKey>({
-		model: API_KEY_TABLE_NAME,
-		where: [{ field: "id", value: apiKey.id }],
-	});
-	if (!fresh) {
-		throw APIError.from("UNAUTHORIZED", ERROR_CODES.INVALID_API_KEY);
-	}
-	return consumeRateLimit(ctx, fresh, opts);
+	return [
+		{ field: "id", value: apiKey.id },
+		{ field: "key", value: apiKey.key },
+		{ field: "configId", value: apiKey.configId ?? null },
+		{ field: "enabled", value: apiKey.enabled },
+		{ field: "expiresAt", value: apiKey.expiresAt },
+		{ field: "permissions", value: permissions },
+		{ field: "remaining", value: apiKey.remaining },
+		{ field: "refillInterval", value: apiKey.refillInterval },
+		{ field: "refillAmount", value: apiKey.refillAmount },
+		{ field: "lastRefillAt", value: apiKey.lastRefillAt },
+		{ field: "createdAt", value: apiKey.createdAt },
+		{ field: "rateLimitEnabled", value: apiKey.rateLimitEnabled },
+		{ field: "rateLimitTimeWindow", value: apiKey.rateLimitTimeWindow },
+		{ field: "rateLimitMax", value: apiKey.rateLimitMax },
+		{ field: "requestCount", value: apiKey.requestCount },
+		{ field: "lastRequest", value: apiKey.lastRequest },
+	];
 }
 
 /**
@@ -539,7 +444,7 @@ function getOptimisticUsageMutations(
 			remaining = refillAmount;
 			lastRefillAt = new Date();
 		}
-		if (remaining === 0) {
+		if (remaining <= 0) {
 			throw APIError.from("TOO_MANY_REQUESTS", ERROR_CODES.USAGE_EXCEEDED);
 		}
 		remaining--;

--- a/packages/api-key/src/types.ts
+++ b/packages/api-key/src/types.ts
@@ -258,6 +258,8 @@ export interface ApiKeyConfigurationOptions {
 	 * enforcement is available only for database storage and secondary storage with
 	 * database fallback. Secondary-storage-only enforcement currently uses a
 	 * best-effort read-modify-write flow until atomic consumption is implemented.
+	 * Policy changes that race an optimistic verification, such as disabling a key
+	 * or changing its permissions, may take effect on the next verification.
 	 *
 	 * @default false
 	 */

--- a/packages/api-key/src/types.ts
+++ b/packages/api-key/src/types.ts
@@ -254,8 +254,10 @@ export interface ApiKeyConfigurationOptions {
 	 * returns optimistic data before the database is updated. If the deferred update
 	 * fails, the database will have stale values. Only enable if your application
 	 * can tolerate this trade-off for improved latency. Concurrent verifications
-	 * can be accepted from the same persisted counter snapshot, so strict concurrent
-	 * quota and rate-limit enforcement requires synchronous updates.
+	 * can be accepted from the same persisted counter snapshot. Synchronous guarded
+	 * enforcement is available only for database storage and secondary storage with
+	 * database fallback. Secondary-storage-only enforcement currently uses a
+	 * best-effort read-modify-write flow until atomic consumption is implemented.
 	 *
 	 * @default false
 	 */

--- a/packages/api-key/src/types.ts
+++ b/packages/api-key/src/types.ts
@@ -253,7 +253,9 @@ export interface ApiKeyConfigurationOptions {
 	 * ⚠️ Warning: Enabling this introduces eventual consistency where the response
 	 * returns optimistic data before the database is updated. If the deferred update
 	 * fails, the database will have stale values. Only enable if your application
-	 * can tolerate this trade-off for improved latency.
+	 * can tolerate this trade-off for improved latency. Concurrent verifications
+	 * can be accepted from the same persisted counter snapshot, so strict concurrent
+	 * quota and rate-limit enforcement requires synchronous updates.
 	 *
 	 * @default false
 	 */


### PR DESCRIPTION
Closes #10921.

## Summary

- Honor `deferUpdates` for database-backed API-key verification when an `advanced.backgroundTasks.handler` is configured, returning an optimistic result while the authoritative claim runs through that handler.
- Retry stale optimistic quota or rate-limit denials against the authoritative row, rechecking configuration, enabled state, expiry, and requested permissions.
- Claim quota and rate-limit usage together with one exact-snapshot compare-and-set, so a request consumes both allowances or neither under contention.
- Keep secondary-storage fallback cache refresh best-effort after a database claim has committed, invalidating partial cache writes on failure instead of rejecting an already-consumed request.
- Document the eventual-consistency trade-off for deferred updates, including racing policy changes taking effect on the next verification, and the residual non-atomic secondary-storage-only path.

Default behavior is unchanged: `deferUpdates: false`, and `deferUpdates: true` without a background handler, still await the authoritative database claim and return its persisted row.

## Regression coverage

The deterministic tests use `customAPIKeyValidator` and an intercepted `incrementOne` as between-read-and-claim hooks. They cover:

- stale quota and rate-limit recovery;
- concurrent configuration, disable, expiry, and permission changes;
- atomicity in both cross-counter race directions;
- genuine fresh denials and rate-limit details;
- expired-key deletion;
- non-blocking deferred writes; and
- cache refresh failure after a committed database claim.

The rate-limit/quota interleaving regression failed before the atomic claim because quota changed from 2 to 1 even though verification returned `RATE_LIMITED`. It passes after the fix with quota still at 2.

## Validation

- `pnpm vitest packages/api-key/src/api-key.test.ts --run` — 195 passed
- `pnpm --filter @better-auth/api-key typecheck`
- `pnpm exec biome check packages/api-key/src/routes/verify-api-key.ts packages/api-key/src/api-key.test.ts packages/api-key/src/types.ts`
- `pnpm --filter docs exec remark content/docs/plugins/api-key/reference.mdx --frail`
- `pnpm changeset status` — `@better-auth/api-key` included in patch bumps
- `git diff --check`

Codex assisted with reproducing the concurrency failures, developing the deterministic regressions, and reviewing the selective fallback. I reviewed the storage contract, atomic guard set, final diff, and all validation results above.
