### PR TITLE
fix(origin-check): validate null origins using fetch metadata

### DIFF
--- a/.changeset/null-origin-trusted-target.md
+++ b/.changeset/null-origin-trusted-target.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Allow same-origin form submissions from pages using `Referrer-Policy: no-referrer` while continuing to reject untrusted request origins.

--- a/docs/content/docs/reference/security.mdx
+++ b/docs/content/docs/reference/security.mdx
@@ -41,6 +41,8 @@ Better Auth includes multiple safeguards to prevent Cross-Site Request Forgery (
 2. **Origin Validation**
    Each request’s `Origin` header is verified to confirm it comes from your application or another explicitly trusted source. Requests from untrusted origins are rejected. By default, Better Auth trusts the base URL of your app, but you can specify additional trusted origins via the `trustedOrigins` configuration option.
 
+   A same-origin form submission from a page using `Referrer-Policy: no-referrer` can carry `Origin: null`. When `Sec-Fetch-Site` confirms the request is same-origin, Better Auth validates the request URL's origin against `trustedOrigins` instead. Requests without that Fetch Metadata evidence and requests targeting an untrusted origin remain rejected.
+
 3. **Secure Cookie Settings**
    Session cookies use the `SameSite=Lax` attribute by default, preventing browsers from sending cookies with most cross-site requests. You can override this behavior using the `defaultCookieAttributes` option.
 

--- a/packages/better-auth/src/api/middlewares/origin-check.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.ts
@@ -4,6 +4,7 @@ import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import { deprecate } from "@better-auth/core/utils/deprecate";
 import { normalizePathname } from "@better-auth/core/utils/url";
 import { matchesOriginPattern } from "../../auth/trusted-origins";
+import { getBaseURL, getOrigin } from "../../utils/url";
 
 /**
  * Checks if CSRF should be skipped for backward compatibility.
@@ -253,9 +254,19 @@ async function validateOrigin(
 	// Fetch Metadata lets us infer the origin from the request target.
 	const canInferOriginFromFetchMetadata =
 		origin === "null" && headers.get("sec-fetch-site") === "same-origin";
-	const originToValidate = canInferOriginFromFetchMetadata
-		? new URL(ctx.request.url).origin
-		: originHeader;
+	const inferredBaseURL = canInferOriginFromFetchMetadata
+		? getBaseURL(
+				undefined,
+				ctx.context.options.basePath,
+				ctx.request,
+				false,
+				ctx.context.options.advanced?.trustedProxyHeaders,
+			)
+		: undefined;
+	const inferredOrigin = inferredBaseURL
+		? getOrigin(inferredBaseURL)
+		: undefined;
+	const originToValidate = inferredOrigin ?? originHeader;
 
 	if (!originToValidate || originToValidate === "null") {
 		throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN);

--- a/packages/better-auth/src/api/middlewares/origin-check.ts
+++ b/packages/better-auth/src/api/middlewares/origin-check.ts
@@ -225,7 +225,8 @@ async function validateOrigin(
 	if (!headers || !ctx.request) {
 		return;
 	}
-	const originHeader = headers.get("origin") || headers.get("referer") || "";
+	const origin = headers.get("origin");
+	const originHeader = origin || headers.get("referer") || "";
 	const useCookies = headers.has("cookie");
 
 	if (ctx.context.skipCSRFCheck) {
@@ -248,7 +249,15 @@ async function validateOrigin(
 		return;
 	}
 
-	if (!originHeader || originHeader === "null") {
+	// A same-origin form using `no-referrer` can send `Origin: null`.
+	// Fetch Metadata lets us infer the origin from the request target.
+	const canInferOriginFromFetchMetadata =
+		origin === "null" && headers.get("sec-fetch-site") === "same-origin";
+	const originToValidate = canInferOriginFromFetchMetadata
+		? new URL(ctx.request.url).origin
+		: originHeader;
+
+	if (!originToValidate || originToValidate === "null") {
 		throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN);
 	}
 
@@ -264,12 +273,12 @@ async function validateOrigin(
 			];
 
 	const isTrustedOrigin = trustedOrigins.some((origin) =>
-		matchesOriginPattern(originHeader, origin),
+		matchesOriginPattern(originToValidate, origin),
 	);
 	if (!isTrustedOrigin) {
-		ctx.context.logger.error(`Invalid origin: ${originHeader}`);
+		ctx.context.logger.error(`Invalid origin: ${originToValidate}`);
 		ctx.context.logger.info(
-			`If it's a valid URL, please add ${originHeader} to trustedOrigins in your auth config\n`,
+			`If it's a valid URL, please add ${originToValidate} to trustedOrigins in your auth config\n`,
 			`Current list of trustedOrigins: ${trustedOrigins}`,
 		);
 		throw APIError.from("FORBIDDEN", BASE_ERROR_CODES.INVALID_ORIGIN);

--- a/packages/better-auth/src/api/routes/sign-in.test.ts
+++ b/packages/better-auth/src/api/routes/sign-in.test.ts
@@ -371,13 +371,14 @@ describe("sign-in with additionalFields", async () => {
 
 describe("sign-in with form data", async () => {
 	const { auth, testUser } = await getTestInstance({
-		trustedOrigins: ["http://localhost:3000"],
+		trustedOrigins: ["http://localhost:3000", "https://app.example.com"],
 		emailAndPassword: {
 			enabled: true,
 		},
 		advanced: {
 			disableCSRFCheck: false,
 			disableOriginCheck: false,
+			trustedProxyHeaders: true,
 		},
 	});
 	const createFormRequest = (url: string, headers: Record<string, string>) =>
@@ -427,6 +428,22 @@ describe("sign-in with form data", async () => {
 			createFormRequest("http://localhost:3000/api/auth/sign-in/email", {
 				origin: "null",
 				"Sec-Fetch-Site": "same-origin",
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const data = await response.json();
+		expect(data.token).toBeTypeOf("string");
+		expect(data.user.email).toBe(testUser.email);
+	});
+
+	it("infers a null Origin from trusted proxy headers", async () => {
+		const response = await auth.handler(
+			createFormRequest("http://internal:3000/api/auth/sign-in/email", {
+				origin: "null",
+				"Sec-Fetch-Site": "same-origin",
+				"x-forwarded-host": "app.example.com",
+				"x-forwarded-proto": "https",
 			}),
 		);
 

--- a/packages/better-auth/src/api/routes/sign-in.test.ts
+++ b/packages/better-auth/src/api/routes/sign-in.test.ts
@@ -377,8 +377,24 @@ describe("sign-in with form data", async () => {
 		},
 		advanced: {
 			disableCSRFCheck: false,
+			disableOriginCheck: false,
 		},
 	});
+	const createFormRequest = (url: string, headers: Record<string, string>) =>
+		new Request(url, {
+			method: "POST",
+			headers: {
+				"content-type": "application/x-www-form-urlencoded",
+				cookie: "better-auth.session_token=expired",
+				"Sec-Fetch-Mode": "navigate",
+				"Sec-Fetch-Dest": "document",
+				...headers,
+			},
+			body: new URLSearchParams({
+				email: testUser.email,
+				password: testUser.password,
+			}),
+		});
 
 	it("should accept form-urlencoded content type", async () => {
 		const formRequest = new Request(
@@ -404,6 +420,81 @@ describe("sign-in with form data", async () => {
 		const data = await response.json();
 		expect(data.token).toBeDefined();
 		expect(data.user.email).toBe(testUser.email);
+	});
+
+	it("accepts a null Origin when Fetch Metadata confirms a trusted target", async () => {
+		const response = await auth.handler(
+			createFormRequest("http://localhost:3000/api/auth/sign-in/email", {
+				origin: "null",
+				"Sec-Fetch-Site": "same-origin",
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const data = await response.json();
+		expect(data.token).toBeTypeOf("string");
+		expect(data.user.email).toBe(testUser.email);
+	});
+
+	it("rejects a null Origin when the same-origin target is not trusted", async () => {
+		const response = await auth.handler(
+			createFormRequest("https://untrusted.example/api/auth/sign-in/email", {
+				origin: "null",
+				"Sec-Fetch-Site": "same-origin",
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toMatchObject({
+			code: BASE_ERROR_CODES.INVALID_ORIGIN.code,
+			message: BASE_ERROR_CODES.INVALID_ORIGIN.message,
+		});
+	});
+
+	it.each([
+		"cross-site",
+		"same-site",
+	])("rejects a null Origin for a %s form submission", async (site) => {
+		const response = await auth.handler(
+			createFormRequest("http://localhost:3000/api/auth/sign-in/email", {
+				origin: "null",
+				"Sec-Fetch-Site": site,
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toMatchObject({
+			code: BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN.code,
+			message: BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN.message,
+		});
+	});
+
+	it("rejects a null Origin without Fetch Metadata", async () => {
+		const response = await auth.handler(
+			createFormRequest("http://localhost:3000/api/auth/sign-in/email", {
+				origin: "null",
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toMatchObject({
+			code: BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN.code,
+			message: BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN.message,
+		});
+	});
+
+	it("rejects a missing Origin even when Fetch Metadata says same-origin", async () => {
+		const response = await auth.handler(
+			createFormRequest("http://localhost:3000/api/auth/sign-in/email", {
+				"Sec-Fetch-Site": "same-origin",
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toMatchObject({
+			code: BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN.code,
+			message: BASE_ERROR_CODES.MISSING_OR_NULL_ORIGIN.message,
+		});
 	});
 
 	it("should block cross-site form submissions", async () => {

--- a/packages/better-auth/src/api/routes/sign-in.test.ts
+++ b/packages/better-auth/src/api/routes/sign-in.test.ts
@@ -371,17 +371,20 @@ describe("sign-in with additionalFields", async () => {
 
 describe("sign-in with form data", async () => {
 	const { auth, testUser } = await getTestInstance({
-		trustedOrigins: ["http://localhost:3000", "https://app.example.com"],
+		trustedOrigins: ["http://localhost:3000"],
 		emailAndPassword: {
 			enabled: true,
 		},
 		advanced: {
 			disableCSRFCheck: false,
 			disableOriginCheck: false,
-			trustedProxyHeaders: true,
 		},
 	});
-	const createFormRequest = (url: string, headers: Record<string, string>) =>
+	const createFormRequest = (
+		url: string,
+		headers: Record<string, string>,
+		credentials: { email: string; password: string } = testUser,
+	) =>
 		new Request(url, {
 			method: "POST",
 			headers: {
@@ -392,8 +395,8 @@ describe("sign-in with form data", async () => {
 				...headers,
 			},
 			body: new URLSearchParams({
-				email: testUser.email,
-				password: testUser.password,
+				email: credentials.email,
+				password: credentials.password,
 			}),
 		});
 
@@ -437,20 +440,50 @@ describe("sign-in with form data", async () => {
 		expect(data.user.email).toBe(testUser.email);
 	});
 
-	it("infers a null Origin from trusted proxy headers", async () => {
-		const response = await auth.handler(
-			createFormRequest("http://internal:3000/api/auth/sign-in/email", {
-				origin: "null",
-				"Sec-Fetch-Site": "same-origin",
-				"x-forwarded-host": "app.example.com",
-				"x-forwarded-proto": "https",
-			}),
+	it("accepts a null Origin through a trusted reverse proxy", async () => {
+		const { auth: proxyAuth, testUser: proxyTestUser } = await getTestInstance({
+			trustedOrigins: ["https://app.example.com"],
+			emailAndPassword: { enabled: true },
+			advanced: {
+				disableCSRFCheck: false,
+				disableOriginCheck: false,
+				trustedProxyHeaders: true,
+			},
+		});
+		const response = await proxyAuth.handler(
+			createFormRequest(
+				"http://internal:3000/api/auth/sign-in/email",
+				{
+					origin: "null",
+					"Sec-Fetch-Site": "same-origin",
+					"x-forwarded-host": "app.example.com",
+					"x-forwarded-proto": "https",
+				},
+				proxyTestUser,
+			),
 		);
 
 		expect(response.status).toBe(200);
 		const data = await response.json();
 		expect(data.token).toBeTypeOf("string");
-		expect(data.user.email).toBe(testUser.email);
+		expect(data.user.email).toBe(proxyTestUser.email);
+	});
+
+	it("ignores forwarded origins when proxy headers are not trusted", async () => {
+		const response = await auth.handler(
+			createFormRequest("https://untrusted.example/api/auth/sign-in/email", {
+				origin: "null",
+				"Sec-Fetch-Site": "same-origin",
+				"x-forwarded-host": "localhost:3000",
+				"x-forwarded-proto": "http",
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toMatchObject({
+			code: BASE_ERROR_CODES.INVALID_ORIGIN.code,
+			message: BASE_ERROR_CODES.INVALID_ORIGIN.message,
+		});
 	});
 
 	it("rejects a null Origin when the same-origin target is not trusted", async () => {


### PR DESCRIPTION
Fixes same-origin form submissions that send `Origin: null` under
`Referrer-Policy: no-referrer`.

When `Sec-Fetch-Site: same-origin` confirms that the initiator and target share
an origin, Better Auth validates the request target against `trustedOrigins`
instead of rejecting the null Origin.

| Reference | Key statement |
|---|---|
| [WHATWG Fetch](https://fetch.spec.whatwg.org/#append-a-request-origin-header) | Under `no-referrer`, a non-CORS POST serializes its Origin as `null`. |
| [Fetch Metadata](https://w3c.github.io/webappsec-fetch-metadata/#sec-fetch-site-header) | `same-origin` means the initiator and request target have the same origin. |

Supersedes #10944 by @himself65.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts same-origin form submissions that send Origin: null under Referrer-Policy: no-referrer. Previously rejected; now `better-auth` infers the origin via Fetch Metadata from the request URL (or trusted proxy headers) and validates it against `trustedOrigins`. Requests without same-origin evidence or targeting an untrusted origin remain rejected; a missing Origin is still rejected even with `Sec-Fetch-Site: same-origin`.

- Review notes: In `origin-check.ts`, when `origin === "null"` and `Sec-Fetch-Site === "same-origin"`, we derive the origin using `getBaseURL`/`getOrigin`, respecting `advanced.trustedProxyHeaders` for `x-forwarded-*`; matching, logs, and errors use the computed origin.
- Tests/docs: Added isolated proxied and non-proxied accept/reject cases in `sign-in.test.ts`; updated the security reference.
- Migration: none. Remove `"null"` from `trustedOrigins` or any origin-check workarounds if present.

<sup>Written for commit 642504f9f77f16ca22922b3f4a0ce8134eda71f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

