### PR TITLE
fix(oidc): fallback to ID token email when UserInfo omits email

### DIFF
--- a/.changeset/rich-banks-press.md
+++ b/.changeset/rich-banks-press.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/sso": patch
+---
+
+The ID tokens email will be used if UserInfo does not return an email during the OIDC SSO flow.

--- a/.changeset/rich-banks-press.md
+++ b/.changeset/rich-banks-press.md
@@ -2,4 +2,4 @@
 "@better-auth/sso": patch
 ---
 
-The ID tokens email will be used if UserInfo does not return an email during the OIDC SSO flow.
+The ID token's email will be used if UserInfo does not return an email during the OIDC SSO flow.

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -601,6 +601,93 @@ describe("SSO", async () => {
 		}
 	});
 
+	it("should use the email from the ID token when the UserInfo endpoint response omits it", async () => {
+		const { headers } = await signInWithTestUser();
+
+		await auth.api.registerSSOProvider({
+			body: {
+				issuer: server.issuer.url!,
+				domain: "id-token-email.com",
+				providerId: "id-token-email-provider",
+				oidcConfig: {
+					clientId: "test",
+					clientSecret: "test",
+					authorizationEndpoint: `${server.issuer.url}/authorize`,
+					tokenEndpoint: `${server.issuer.url}/token`,
+					jwksEndpoint: `${server.issuer.url}/jwks`,
+					userInfoEndpoint: `${server.issuer.url}/userinfo`,
+					discoveryEndpoint: `${server.issuer.url}/.well-known/openid-configuration`,
+					mapping: {
+						email: "email",
+						emailVerified: "email_verified",
+						name: "name",
+						image: "picture",
+					},
+				},
+			},
+			headers,
+		});
+
+		const originalUserinfoListeners =
+			server.service.listeners("beforeUserinfo");
+		const originalTokenListeners =
+			server.service.listeners("beforeTokenSigning");
+		server.service.removeAllListeners("beforeUserinfo");
+		server.service.removeAllListeners("beforeTokenSigning");
+
+		const idTokenEmail = "id-token-authoritative@test.com";
+
+		server.service.on("beforeUserinfo", (userInfoResponse: any) => {
+			// Note that no email is included here.
+			userInfoResponse.body = {
+				sub: "id-token-email-user",
+				name: "ID Token Email User",
+				picture: "https://test.com/picture.png",
+				email_verified: true,
+			};
+			userInfoResponse.statusCode = 200;
+		});
+		server.service.on("beforeTokenSigning", (token: any) => {
+			token.payload.sub = "id-token-email-user";
+			token.payload.email = idTokenEmail;
+			token.payload.email_verified = true;
+			token.payload.name = "ID Token Email User";
+			token.payload.picture = "https://test.com/picture.png";
+		});
+
+		try {
+			const signInHeaders = new Headers();
+			const res = await authClient.signIn.sso({
+				providerId: "id-token-email-provider",
+				callbackURL: "/dashboard",
+				fetchOptions: {
+					throw: true,
+					onSuccess: cookieSetter(signInHeaders),
+				},
+			});
+
+			const { callbackURL, headers: sessionHeaders } = await simulateOAuthFlow(
+				res.url,
+				signInHeaders,
+			);
+			expect(callbackURL).toContain("/dashboard");
+
+			const session = await authClient.getSession({
+				fetchOptions: { headers: sessionHeaders },
+			});
+			expect(session.data?.user.email).toBe(idTokenEmail);
+		} finally {
+			server.service.removeAllListeners("beforeUserinfo");
+			server.service.removeAllListeners("beforeTokenSigning");
+			for (const listener of originalUserinfoListeners) {
+				server.service.on("beforeUserinfo", listener as any);
+			}
+			for (const listener of originalTokenListeners) {
+				server.service.on("beforeTokenSigning", listener as any);
+			}
+		}
+	});
+
 	it("should normalize email to lowercase in OIDC authentication", async () => {
 		const { headers } = await signInWithTestUser();
 

--- a/packages/sso/src/oidc.test.ts
+++ b/packages/sso/src/oidc.test.ts
@@ -637,7 +637,7 @@ describe("SSO", async () => {
 
 		const idTokenEmail = "id-token-authoritative@test.com";
 
-		server.service.on("beforeUserinfo", (userInfoResponse: any) => {
+		server.service.on("beforeUserinfo", (userInfoResponse) => {
 			// Note that no email is included here.
 			userInfoResponse.body = {
 				sub: "id-token-email-user",
@@ -647,7 +647,7 @@ describe("SSO", async () => {
 			};
 			userInfoResponse.statusCode = 200;
 		});
-		server.service.on("beforeTokenSigning", (token: any) => {
+		server.service.on("beforeTokenSigning", (token) => {
 			token.payload.sub = "id-token-email-user";
 			token.payload.email = idTokenEmail;
 			token.payload.email_verified = true;
@@ -680,10 +680,10 @@ describe("SSO", async () => {
 			server.service.removeAllListeners("beforeUserinfo");
 			server.service.removeAllListeners("beforeTokenSigning");
 			for (const listener of originalUserinfoListeners) {
-				server.service.on("beforeUserinfo", listener as any);
+				server.service.on("beforeUserinfo", listener);
 			}
 			for (const listener of originalTokenListeners) {
-				server.service.on("beforeTokenSigning", listener as any);
+				server.service.on("beforeTokenSigning", listener);
 			}
 		}
 	});

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1624,6 +1624,14 @@ async function handleOIDCCallback(
 		const fallbackEmail = verifiedIdToken
 			? readStringClaim(verifiedIdToken.payload, mapping.email || "email")
 			: undefined;
+		const fallbackEmailVerified = verifiedIdToken
+			? parseProviderEmailVerified(
+					verifiedIdToken.payload[mapping.emailVerified || "email_verified"],
+				)
+			: undefined;
+		const email = readStringClaim(rawUserInfo, mapping.email || "email");
+		// If we fallback to the ID token's email, we should use its verification status as well.
+		const useFallbackEmailVerified = !email && fallbackEmail;
 		rawProfile = rawUserInfo;
 		userInfo = {
 			...Object.fromEntries(
@@ -1633,12 +1641,13 @@ async function handleOIDCCallback(
 				]),
 			),
 			id: readStringClaim(rawUserInfo, "sub"),
-			email:
-				readStringClaim(rawUserInfo, mapping.email || "email") || fallbackEmail,
+			email: email || fallbackEmail,
 			emailVerified: options?.trustEmailVerified
-				? parseProviderEmailVerified(
-						rawUserInfo[mapping.emailVerified || "email_verified"],
-					)
+				? useFallbackEmailVerified
+					? fallbackEmailVerified
+					: parseProviderEmailVerified(
+							rawUserInfo[mapping.emailVerified || "email_verified"],
+						)
 				: false,
 			name: readStringClaim(rawUserInfo, mapping.name || "name"),
 			image: readStringClaim(rawUserInfo, mapping.image || "picture"),

--- a/packages/sso/src/routes/sso.ts
+++ b/packages/sso/src/routes/sso.ts
@@ -1620,6 +1620,10 @@ async function handleOIDCCallback(
 				"id_token_userinfo_subject_mismatch",
 			);
 		}
+		// We use the ID token's email if the user info endpoint happens to not return an email.
+		const fallbackEmail = verifiedIdToken
+			? readStringClaim(verifiedIdToken.payload, mapping.email || "email")
+			: undefined;
 		rawProfile = rawUserInfo;
 		userInfo = {
 			...Object.fromEntries(
@@ -1629,7 +1633,8 @@ async function handleOIDCCallback(
 				]),
 			),
 			id: readStringClaim(rawUserInfo, "sub"),
-			email: readStringClaim(rawUserInfo, mapping.email || "email"),
+			email:
+				readStringClaim(rawUserInfo, mapping.email || "email") || fallbackEmail,
 			emailVerified: options?.trustEmailVerified
 				? parseProviderEmailVerified(
 						rawUserInfo[mapping.emailVerified || "email_verified"],


### PR DESCRIPTION
When using Microsoft Entra ID for SSO, https://graph.microsoft.com/oidc/userinfo is used to retrieve the user's email. This endpoint returns the email as set in their "Contact Info", which is an optional field that at least in my setup is empty by default.

If this endpoint doesn't return an email, the email should be pulled from the ID token if it's available. Microsoft recommends using the ID token's email when available as well: https://learn.microsoft.com/en-us/entra/identity-platform/userinfo#consider-using-an-id-token-instead

I'll also note here that this behavior may not be ideal if most Entra ID users already have "email" filled in on every user's Contact Information. If I'm the only one with this issue I'll close PR.

This PR updates `handleOIDCCallback` to fallback to using the ID token's email only if the UserInfo endpoint does not return an email. This could change behavior for existing users, but I can't imagine it being negative as currently SSO fails for me with the `missing_user_info` error code.

This is my first contribution to this repo, so please let me know if any changes are needed. Disclaimer: new test is AI-generated as the setup was a bit confusing for me to figure out by hand.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fallback to the ID token email when the OIDC UserInfo response omits email, avoiding missing_user_info failures with providers like Microsoft Entra ID. When falling back and `trustEmailVerified` is enabled, we also use the ID token’s `email_verified`.

- Updates `handleOIDCCallback` to prefer UserInfo `mapping.email` (default "email"), falling back to the ID token claim; if falling back and `trustEmailVerified` is true, uses the ID token’s `mapping.emailVerified` (default "email_verified"). Subject mismatch checks are unchanged.
- Adds a test covering the fallback path; publishes a patch for `@better-auth/sso`.
- No migration needed. If you gated flows on `missing_user_info`, update that logic.

<sup>Written for commit 6f105c89df4ae15f46f7e80db4e703534d02000e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

