### PR TITLE
fix(cli): emit defineRelationsPart for drizzle-orm 1.0 in generate

### DIFF
--- a/.changeset/drizzle-1.0-relations-generate.md
+++ b/.changeset/drizzle-1.0-relations-generate.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+Fix `generate` emitting the removed Drizzle `relations()` API when drizzle-orm 1.0 is installed. The generator now detects the project's drizzle-orm version and emits `defineRelationsPart` instead so the generated schema compiles against drizzle-orm 1.0+.

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -197,6 +197,7 @@ async function generateAction(opts: any) {
 		adapter,
 		file: resolvedOutputPath ?? options.output,
 		options: config,
+		cwd,
 	});
 
 	spinner.stop();

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1169,6 +1169,7 @@ export const auth = betterAuth({
 					adapter,
 					options: config,
 					file: outputPath,
+					cwd,
 				});
 			} else if (isPrisma) {
 				// For Prisma, output to prisma/schema.prisma

--- a/packages/cli/src/generators/drizzle.ts
+++ b/packages/cli/src/generators/drizzle.ts
@@ -10,6 +10,7 @@ import type { BetterAuthDBSchema, DBFieldAttribute } from "better-auth/db";
 import { getAuthTables } from "better-auth/db";
 import type { BetterAuthOptions } from "better-auth/types";
 import prettier from "prettier";
+import { getDrizzleVersion } from "../utils/get-package-info";
 import type { SchemaGenerator } from "./types";
 
 function convertToSnakeCase(str: string, camelCase?: boolean) {
@@ -37,6 +38,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	options,
 	file,
 	adapter,
+	cwd,
 }) => {
 	const tables = getAuthTables(options);
 	const filePath = file || "./auth-schema.ts";
@@ -52,11 +54,20 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	}
 	const fileExist = existsSync(filePath);
 
+	// Drizzle 1.0 removed the `relations()` API in favor of `defineRelations`/
+	// `defineRelationsPart`. Detect the installed major version so the emitted
+	// code compiles against whichever drizzle-orm the project has installed.
+	// See https://github.com/better-auth/better-auth/issues/10924
+	const drizzleMajorVersion = cwd ? getDrizzleVersion(cwd) : null;
+	const useRelationsV2 =
+		drizzleMajorVersion !== null && drizzleMajorVersion >= 1;
+
 	let code: string = generateImport({
 		databaseType,
 		tables,
 		options,
 		schemaName,
+		useRelationsV2,
 	});
 
 	// Add schema declaration for PostgreSQL when schemaName is provided
@@ -392,6 +403,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 	}
 
 	let relationsString: string = "";
+	const relationsV2ByModel = new Map<string, string[]>();
 	for (const tableKey in tables) {
 		const table = tables[tableKey]!;
 		if (isMigrationDisabled(tableKey)) {
@@ -518,6 +530,18 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 					relationKey = `${relationKey}By${fieldName.charAt(0).toUpperCase()}${fieldName.slice(1)}`;
 				}
 
+				// Only needed for the v2 (`defineRelationsPart`) form: unlike the old
+				// `relations()` API, drizzle 1.0 requires every side of a relation to
+				// declare its own `from`/`to`, so the reverse side needs a reference too.
+				const fromField = `${getModelName(tableKey)}.${getFieldName({
+					model: tableKey,
+					field: field.references!.field || "id",
+				})}`;
+				const toField = `${getModelName(modelName)}.${getFieldName({
+					model: modelName,
+					field: fieldName,
+				})}`;
+
 				manyRelations.push({
 					key: relationKey,
 					model: getModelName(modelName),
@@ -525,56 +549,90 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 					relationName: hasMultipleRelations
 						? `${getModelName(modelName)}_${fieldName}`
 						: undefined,
+					reference: { field: fromField, references: toField },
 				});
 			}
 		}
 
-		const hasForwardOne = oneRelations.length > 0;
-		const hasReverseOne = manyRelations.some(
-			(relation) => relation.type === "one",
-		);
-		const hasReverseMany = manyRelations.some(
-			(relation) => relation.type === "many",
-		);
-		const hasOne = hasForwardOne || hasReverseOne;
-		const hasMany = hasReverseMany;
+		if (useRelationsV2) {
+			// Drizzle 1.0's `defineRelations`/`defineRelationsPart` require every
+			// side of a relation to declare its own `from`/`to`, so both the
+			// forward ("one") and reverse ("one"/"many") relations render the
+			// same way here (disambiguation comes purely from the entry `key`,
+			// there's no `relationName`/alias equivalent to emit).
+			const renderV2Relation = (relation: Relation) =>
+				relation.reference
+					? `  ${relation.key}: r.${relation.type}.${relation.model}({\n    from: r.${relation.reference.field},\n    to: r.${relation.reference.references},\n  })`
+					: null;
 
-		const renderOneRelation = (relation: Relation) =>
-			relation.reference
-				? ` ${relation.key}: one(${relation.model}, {
-					fields: [${relation.reference.field}],
-					references: [${relation.reference.references}],
-					${relation.relationName ? `relationName: "${relation.relationName}",` : ""}
-				})`
-				: "";
-
-		const renderReverseRelation = ({
-			key,
-			model,
-			type,
-			relationName,
-		}: Relation) => {
-			const relationFn = type === "one" ? "one" : "many";
-			return ` ${key}: ${relationFn}(${model}${relationName ? `, { relationName: "${relationName}" }` : ""})`;
-		};
-
-		if (hasOne || hasMany) {
-			const helpers = [hasOne ? "one" : null, hasMany ? "many" : null]
-				.filter(Boolean)
-				.join(", ");
 			const relationEntries = [
-				...oneRelations.map(renderOneRelation).filter((x) => x !== ""),
-				...manyRelations.map(renderReverseRelation),
-			].join(",\n ");
+				...oneRelations.map(renderV2Relation),
+				...manyRelations.map(renderV2Relation),
+			].filter((entry): entry is string => entry !== null);
 
-			const tableRelation = `export const ${modelName}Relations = relations(${getModelName(
-				table.modelName,
-			)}, ({ ${helpers} }) => ({
-				${relationEntries}
-			}))`;
+			if (relationEntries.length > 0) {
+				relationsV2ByModel.set(modelName, relationEntries);
+			}
+		} else {
+			const hasForwardOne = oneRelations.length > 0;
+			const hasReverseOne = manyRelations.some(
+				(relation) => relation.type === "one",
+			);
+			const hasReverseMany = manyRelations.some(
+				(relation) => relation.type === "many",
+			);
+			const hasOne = hasForwardOne || hasReverseOne;
+			const hasMany = hasReverseMany;
 
-			relationsString += `\n${tableRelation}\n`;
+			const renderOneRelation = (relation: Relation) =>
+				relation.reference
+					? ` ${relation.key}: one(${relation.model}, {
+						fields: [${relation.reference.field}],
+						references: [${relation.reference.references}],
+						${relation.relationName ? `relationName: "${relation.relationName}",` : ""}
+					})`
+					: "";
+
+			const renderReverseRelation = ({
+				key,
+				model,
+				type,
+				relationName,
+			}: Relation) => {
+				const relationFn = type === "one" ? "one" : "many";
+				return ` ${key}: ${relationFn}(${model}${relationName ? `, { relationName: "${relationName}" }` : ""})`;
+			};
+
+			if (hasOne || hasMany) {
+				const helpers = [hasOne ? "one" : null, hasMany ? "many" : null]
+					.filter(Boolean)
+					.join(", ");
+				const relationEntries = [
+					...oneRelations.map(renderOneRelation).filter((x) => x !== ""),
+					...manyRelations.map(renderReverseRelation),
+				].join(",\n ");
+
+				const tableRelation = `export const ${modelName}Relations = relations(${getModelName(
+					table.modelName,
+				)}, ({ ${helpers} }) => ({
+					${relationEntries}
+				}))`;
+
+				relationsString += `\n${tableRelation}\n`;
+			}
 		}
+	}
+
+	if (useRelationsV2 && relationsV2ByModel.size > 0) {
+		const schemaObjectKeys = Object.keys(tables)
+			.filter((tableKey) => !isMigrationDisabled(tableKey))
+			.map((tableKey) => getModelName(tableKey));
+		const schemaObject = `{ ${schemaObjectKeys.join(", ")} }`;
+		const relationsEntries = [...relationsV2ByModel.entries()].map(
+			([relationsModelName, entries]) =>
+				`  ${relationsModelName}: {\n${entries.join(",\n")}\n  }`,
+		);
+		relationsString = `\nexport const authRelations = defineRelationsPart(${schemaObject}, (r) => ({\n${relationsEntries.join(",\n")}\n}));\n`;
 	}
 	code += `\n${relationsString}`;
 
@@ -593,13 +651,17 @@ function generateImport({
 	tables,
 	options,
 	schemaName,
+	useRelationsV2,
 }: {
 	databaseType: "sqlite" | "mysql" | "pg";
 	tables: BetterAuthDBSchema;
 	options: BetterAuthOptions;
 	schemaName?: string;
+	useRelationsV2: boolean;
 }) {
-	const rootImports: string[] = ["relations"];
+	const rootImports: string[] = [
+		useRelationsV2 ? "defineRelationsPart" : "relations",
+	];
 	const coreImports: string[] = [];
 
 	let hasBigint = false;

--- a/packages/cli/src/generators/index.ts
+++ b/packages/cli/src/generators/index.ts
@@ -15,6 +15,7 @@ export const generateSchema = async (opts: {
 	adapter: DBAdapter;
 	file?: string;
 	options: BetterAuthOptions;
+	cwd?: string;
 }): Promise<SchemaGeneratorResult> => {
 	const adapter = opts.adapter;
 

--- a/packages/cli/src/generators/types.ts
+++ b/packages/cli/src/generators/types.ts
@@ -18,5 +18,6 @@ export interface SchemaGenerator {
 		file?: string;
 		adapter: DBAdapter;
 		options: Options;
+		cwd?: string;
 	}): Promise<SchemaGeneratorResult>;
 }

--- a/packages/cli/src/utils/get-package-info.ts
+++ b/packages/cli/src/utils/get-package-info.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import * as semver from "semver";
 import { tryCatch } from "./helper";
 
 export function getPackageInfo(cwd?: string) {
@@ -27,6 +28,31 @@ export function getPrismaVersion(cwd?: string): number | null {
 		// Handles versions like "^5.0.0", "~7.1.0", "7.0.0", etc.
 		const match = prismaVersion.match(/(\d+)/);
 		return match ? parseInt(match[1], 10) : null;
+	} catch {
+		// If package.json doesn't exist or can't be read, return null
+		return null;
+	}
+}
+
+/**
+ * Reads the declared `drizzle-orm` dependency range from package.json and
+ * returns its major version, so callers can tell drizzle-orm 1.0 (which
+ * removed the `relations()` API in favor of `defineRelations`/
+ * `defineRelationsPart`) apart from the 0.x releases.
+ */
+export function getDrizzleVersion(cwd?: string): number | null {
+	try {
+		const packageInfo = getPackageInfo(cwd);
+		const drizzleVersionRange =
+			packageInfo.dependencies?.["drizzle-orm"] ||
+			packageInfo.devDependencies?.["drizzle-orm"];
+
+		if (!drizzleVersionRange) {
+			return null;
+		}
+
+		const version = semver.minVersion(drizzleVersionRange);
+		return version ? version.major : null;
 	} catch {
 		// If package.json doesn't exist or can't be read, return null
 		return null;

--- a/packages/cli/src/utils/get-package-info.ts
+++ b/packages/cli/src/utils/get-package-info.ts
@@ -35,12 +35,50 @@ export function getPrismaVersion(cwd?: string): number | null {
 }
 
 /**
- * Reads the declared `drizzle-orm` dependency range from package.json and
- * returns its major version, so callers can tell drizzle-orm 1.0 (which
- * removed the `relations()` API in favor of `defineRelations`/
- * `defineRelationsPart`) apart from the 0.x releases.
+ * Reads the actually-installed version of a package from its
+ * `node_modules/<name>/package.json`. This reflects what will really be
+ * resolved, unlike a declared dependency range: a range like
+ * `"^0.45.2 || >=1.0.0-rc.1"` would report its lowest satisfying version via
+ * `semver.minVersion` even when the installed version is much newer.
+ */
+function getInstalledPackageVersion(
+	cwd: string,
+	packageName: string,
+): string | null {
+	try {
+		const packageJsonPath = path.join(
+			cwd,
+			"node_modules",
+			packageName,
+			"package.json",
+		);
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+		return typeof packageJson.version === "string" ? packageJson.version : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Returns the major version of the project's `drizzle-orm`, so callers can
+ * tell drizzle-orm 1.0 (which removed the `relations()` API in favor of
+ * `defineRelations`/`defineRelationsPart`) apart from the 0.x releases.
+ *
+ * Prefers the actually-installed version (`node_modules/drizzle-orm`) and
+ * only falls back to the declared dependency range in package.json when
+ * that isn't available (e.g. dependencies haven't been installed yet).
  */
 export function getDrizzleVersion(cwd?: string): number | null {
+	if (cwd) {
+		const installedVersion = getInstalledPackageVersion(cwd, "drizzle-orm");
+		if (installedVersion) {
+			const parsed = semver.parse(installedVersion);
+			if (parsed) {
+				return parsed.major;
+			}
+		}
+	}
+
 	try {
 		const packageInfo = getPackageInfo(cwd);
 		const drizzleVersionRange =

--- a/packages/cli/test/drizzle-relations-v2.test.ts
+++ b/packages/cli/test/drizzle-relations-v2.test.ts
@@ -94,6 +94,41 @@ describe("drizzle schema generation for drizzle-orm 1.0", () => {
 		);
 	});
 
+	it("prefers the installed drizzle-orm version over a declared range spanning 0.x and 1.x", async () => {
+		// A range like this (matching the drizzle adapter's own peer range)
+		// resolves its lowest version via `semver.minVersion` to a 0.x release
+		// even when the actually-installed version is 1.x.
+		await withTmpProject(
+			{ dependencies: { "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0" } },
+			async (cwd) => {
+				const nodeModulesDir = path.join(cwd, "node_modules", "drizzle-orm");
+				fs.mkdirSync(nodeModulesDir, { recursive: true });
+				fs.writeFileSync(
+					path.join(nodeModulesDir, "package.json"),
+					JSON.stringify({ name: "drizzle-orm", version: "1.0.0-rc.4" }),
+				);
+
+				const schema = await generateDrizzleSchema({
+					file: "test.drizzle",
+					cwd,
+					adapter: drizzleAdapter(
+						{},
+						{ provider: "sqlite", schema: {} },
+					)({} as BetterAuthOptions),
+					options: {
+						database: drizzleAdapter({}, { provider: "sqlite", schema: {} }),
+						plugins: [],
+					},
+				});
+
+				expect(schema.code).toContain(
+					"export const authRelations = defineRelationsPart(",
+				);
+				expect(schema.code).not.toContain("relations(");
+			},
+		);
+	});
+
 	it("keeps emitting the classic relations() API when no cwd is provided", async () => {
 		const schema = await generateDrizzleSchema({
 			file: "test.drizzle",

--- a/packages/cli/test/drizzle-relations-v2.test.ts
+++ b/packages/cli/test/drizzle-relations-v2.test.ts
@@ -1,0 +1,170 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { BetterAuthOptions, BetterAuthPlugin } from "@better-auth/core";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { describe, expect, it } from "vitest";
+import { generateDrizzleSchema } from "../src/generators/drizzle";
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10924
+ *
+ * Drizzle 1.0 removed the `relations()` API in favor of `defineRelations`/
+ * `defineRelationsPart`. The generator must detect an installed drizzle-orm
+ * 1.0+ and emit code that compiles against it, instead of always emitting
+ * the old `relations()` form.
+ */
+describe("drizzle schema generation for drizzle-orm 1.0", () => {
+	function withTmpProject(
+		packageJson: Record<string, unknown>,
+		run: (cwd: string) => Promise<void>,
+	) {
+		const tmpDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "drizzle-relations-v2-test-"),
+		);
+		fs.writeFileSync(
+			path.join(tmpDir, "package.json"),
+			JSON.stringify(packageJson),
+		);
+		return run(tmpDir).finally(() => {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		});
+	}
+
+	it("emits defineRelationsPart when drizzle-orm 1.0 (rc) is installed", async () => {
+		await withTmpProject(
+			{ dependencies: { "drizzle-orm": "1.0.0-rc.4" } },
+			async (cwd) => {
+				const schema = await generateDrizzleSchema({
+					file: "test.drizzle",
+					cwd,
+					adapter: drizzleAdapter(
+						{},
+						{ provider: "sqlite", schema: {} },
+					)({} as BetterAuthOptions),
+					options: {
+						database: drizzleAdapter({}, { provider: "sqlite", schema: {} }),
+						plugins: [],
+					},
+				});
+
+				expect(schema.code).toContain(
+					'import { defineRelationsPart, sql } from "drizzle-orm"',
+				);
+				expect(schema.code).not.toContain("relations(");
+
+				expect(schema.code).toContain(
+					"export const authRelations = defineRelationsPart(",
+				);
+				// Forward "many" side: user -> sessions
+				expect(schema.code).toMatch(
+					/sessions:\s*r\.many\.session\(\{\s*from:\s*r\.user\.id,\s*to:\s*r\.session\.userId,/,
+				);
+				// Reverse "one" side: session -> user
+				expect(schema.code).toMatch(
+					/user:\s*r\.one\.user\(\{\s*from:\s*r\.session\.userId,\s*to:\s*r\.user\.id,/,
+				);
+			},
+		);
+	});
+
+	it("keeps emitting the classic relations() API when drizzle-orm is <1.0", async () => {
+		await withTmpProject(
+			{ dependencies: { "drizzle-orm": "^0.45.2" } },
+			async (cwd) => {
+				const schema = await generateDrizzleSchema({
+					file: "test.drizzle",
+					cwd,
+					adapter: drizzleAdapter(
+						{},
+						{ provider: "sqlite", schema: {} },
+					)({} as BetterAuthOptions),
+					options: {
+						database: drizzleAdapter({}, { provider: "sqlite", schema: {} }),
+						plugins: [],
+					},
+				});
+
+				expect(schema.code).toContain("import { relations, sql }");
+				expect(schema.code).not.toContain("defineRelationsPart");
+				expect(schema.code).toContain(
+					"export const userRelations = relations(user,",
+				);
+			},
+		);
+	});
+
+	it("keeps emitting the classic relations() API when no cwd is provided", async () => {
+		const schema = await generateDrizzleSchema({
+			file: "test.drizzle",
+			adapter: drizzleAdapter(
+				{},
+				{ provider: "sqlite", schema: {} },
+			)({} as BetterAuthOptions),
+			options: {
+				database: drizzleAdapter({}, { provider: "sqlite", schema: {} }),
+				plugins: [],
+			},
+		});
+
+		expect(schema.code).toContain("import { relations, sql }");
+		expect(schema.code).not.toContain("defineRelationsPart");
+	});
+
+	// Minimal plugin that reproduces the two-FKs-to-the-same-model bug from
+	// the classic API: two fields on the same table referencing "user".
+	const testPlugin = (): BetterAuthPlugin => ({
+		id: "test",
+		schema: {
+			test: {
+				fields: {
+					userId: {
+						type: "string",
+						required: false,
+						references: { model: "user", field: "id", onDelete: "set null" },
+					},
+					managerId: {
+						type: "string",
+						required: false,
+						references: { model: "user", field: "id", onDelete: "set null" },
+					},
+				},
+			},
+		},
+	});
+
+	it("disambiguates duplicate relations to the same model without relationName", async () => {
+		await withTmpProject(
+			{ dependencies: { "drizzle-orm": "1.0.0-rc.4" } },
+			async (cwd) => {
+				const schema = await generateDrizzleSchema({
+					file: "test.drizzle",
+					cwd,
+					adapter: drizzleAdapter(
+						{},
+						{ provider: "sqlite", schema: {} },
+					)({} as BetterAuthOptions),
+					options: {
+						database: drizzleAdapter({}, { provider: "sqlite", schema: {} }),
+						plugins: [testPlugin()],
+					},
+				});
+
+				// Distinct keys alone disambiguate — no `relationName`/alias needed.
+				expect(schema.code).not.toContain("relationName");
+				expect(schema.code).toMatch(
+					/testsByUserId:\s*r\.many\.test\(\{\s*from:\s*r\.user\.id,\s*to:\s*r\.test\.userId,/,
+				);
+				expect(schema.code).toMatch(
+					/testsByManagerId:\s*r\.many\.test\(\{\s*from:\s*r\.user\.id,\s*to:\s*r\.test\.managerId,/,
+				);
+				expect(schema.code).toMatch(
+					/user:\s*r\.one\.user\(\{\s*from:\s*r\.test\.userId,\s*to:\s*r\.user\.id,/,
+				);
+				expect(schema.code).toMatch(
+					/manager:\s*r\.one\.user\(\{\s*from:\s*r\.test\.managerId,\s*to:\s*r\.user\.id,/,
+				);
+			},
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #10924.

`generate` for the Drizzle adapter always emitted the old `relations()` API. Drizzle 1.0 removed `relations()` in favor of `defineRelations`/`defineRelationsPart`, so the generated `auth-schema.ts` fails to compile once a project installs drizzle-orm 1.0 (`'"drizzle-orm"' has no exported member named 'relations'`), even though better-auth's peer range already allows `>=1.0.0-rc.1`.

- Added `getDrizzleVersion(cwd)` to read the project's declared `drizzle-orm` version.
- Threaded `cwd` through the schema generator so it can detect the installed version.
- When drizzle-orm `>=1.0.0` is detected, `generateDrizzleSchema` now emits a single `defineRelationsPart({...}, (r) => ({...}))` block (the same shape already used by `@better-auth/drizzle-adapter/relations-v2`'s generator) instead of per-table `relations()` calls. Below 1.0, or when no `cwd` is available, output is unchanged.

## Test plan

- [x] New tests in `packages/cli/test/drizzle-relations-v2.test.ts`: drizzle-orm 1.0 detection, <1.0 fallback, no-`cwd` fallback, duplicate-relation disambiguation without `relationName`.
- [x] Existing `generate`/`generate-all-db` suites pass unchanged (no snapshot diffs).
- [x] Full `cli` package test suite passes (364 passed, 1 pre-existing skip).
- [x] `tsc` typecheck of the `cli` package passes.
- [x] Manually reproduced the issue: ran the built CLI against a project with `drizzle-orm@1.0.0-rc.4` installed (matching the issue) and confirmed the generated `auth-schema.ts` now type-checks cleanly with real `tsc` against that install.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates Drizzle relations that compile with `drizzle-orm` 1.0+. Previously the CLI always emitted per-table `relations()`; for 1.0+ it now emits a single `defineRelationsPart({...}, (r) => ({...}))`. Output for `<1.0` or when `cwd` is unknown is unchanged.

- Detects the installed `drizzle-orm` major via `getDrizzleVersion(cwd)`; prefers the version in `node_modules/drizzle-orm/package.json` and falls back to the declared range. Threads `cwd` through `generate` and `init`.
- Switches imports between `relations` and `defineRelationsPart` and renders v2 relations with explicit from/to on both sides. Duplicate FKs to the same model are disambiguated by distinct keys (no `relationName`).
- Migration (projects on `drizzle-orm` 1.0+): if you import per-table `*Relations`, change to the single `authRelations` export.

<sup>Written for commit 339782de2942e156b653ec0cad6192df5ee91fd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

