### PR TITLE
docs(express): clarify raw body requirements

### DIFF
--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -383,8 +383,7 @@ description: Learn how to configure Better Auth in your project.
 
         app.all("/api/auth/*", toNodeHandler(auth));
 
-        // Mount express json middleware after Better Auth handler
-        // or only apply it to routes that don't interact with Better Auth
+        // Mount JSON middleware after Better Auth to preserve raw request bodies.
         app.use(express.json());
 
         app.listen(port, () => {

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -383,7 +383,7 @@ description: Learn how to configure Better Auth in your project.
 
         app.all("/api/auth/*", toNodeHandler(auth));
 
-        // Mount JSON middleware after Better Auth to preserve raw request bodies.
+        // Mount body-parsing middleware after the Better Auth handler.
         app.use(express.json());
 
         app.listen(port, () => {

--- a/docs/content/docs/integrations/express.mdx
+++ b/docs/content/docs/integrations/express.mdx
@@ -16,7 +16,9 @@ Before you start, make sure you have a Better Auth instance configured. If you h
 To enable Better Auth to handle requests, we need to mount the handler to an API route. Create a catch-all route to manage all requests to `/api/auth/*` in case of ExpressJS v4 or `/api/auth/*splat` in case of ExpressJS v5 (or any other path specified in your Better Auth options).
 
 <Callout type="warn">
-  Don’t use `express.json()` before the Better Auth handler. Use it only for other routes, or the client API will get stuck on "pending".
+  Mount the Better Auth handler before `express.json()`. The middleware consumes
+  the incoming request stream, so the original request body is no longer
+  available after parsing.
 </Callout>
 
 ```ts title="server.ts"
@@ -30,8 +32,7 @@ const port = 3005;
 app.all("/api/auth/*", toNodeHandler(auth)); // For ExpressJS v4
 // app.all("/api/auth/*splat", toNodeHandler(auth)); For ExpressJS v5 
 
-// Mount express json middleware after Better Auth handler
-// or only apply it to routes that don't interact with Better Auth
+// Mount JSON middleware after Better Auth to preserve raw request bodies.
 app.use(express.json());
 
 app.listen(port, () => {

--- a/docs/content/docs/integrations/express.mdx
+++ b/docs/content/docs/integrations/express.mdx
@@ -16,9 +16,9 @@ Before you start, make sure you have a Better Auth instance configured. If you h
 To enable Better Auth to handle requests, we need to mount the handler to an API route. Create a catch-all route to manage all requests to `/api/auth/*` in case of ExpressJS v4 or `/api/auth/*splat` in case of ExpressJS v5 (or any other path specified in your Better Auth options).
 
 <Callout type="warn">
-  Mount the Better Auth handler before `express.json()`. The middleware consumes
-  the incoming request stream, so the original request body is no longer
-  available after parsing.
+  Mount the Better Auth handler before body-parsing middleware such as
+  `express.json()`. Body parsers consume the incoming request stream before
+  passing control to the next handler.
 </Callout>
 
 ```ts title="server.ts"
@@ -32,7 +32,7 @@ const port = 3005;
 app.all("/api/auth/*", toNodeHandler(auth)); // For ExpressJS v4
 // app.all("/api/auth/*splat", toNodeHandler(auth)); For ExpressJS v5 
 
-// Mount JSON middleware after Better Auth to preserve raw request bodies.
+// Mount body-parsing middleware after the Better Auth handler.
 app.use(express.json());
 
 app.listen(port, () => {


### PR DESCRIPTION
Related to https://github.com/better-auth/better-auth/pull/10711#issuecomment-5399746954

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Express integration docs to require mounting the Better Auth handler before any body-parsing middleware (e.g., `express.json()`), since body parsers consume the request stream. This preserves the raw body for Better Auth and prevents client API requests from hanging.

- Generalizes guidance from only `express.json()` to all body-parsing middleware; updates callout and code comments in installation and Express pages.
- Action: If you mount `express.json()` or other body parsers before `toNodeHandler(auth)`, move them after the handler or scope them away from `/api/auth/*`.

<sup>Written for commit 82b0a24f2f606bc5497893f5af9b9d1a69a814f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

