### PR TITLE
docs: improve database table attribute display

### DIFF
--- a/docs/components/docs/mdx-components.tsx
+++ b/docs/components/docs/mdx-components.tsx
@@ -427,11 +427,14 @@ export function DatabaseTable({
 			{view === "table" ? (
 				<div className="overflow-x-auto">
 					{/* Column headers */}
-					<div className="grid grid-cols-[minmax(160px,1.2fr)_minmax(100px,0.8fr)_minmax(112px,0.6fr)_minmax(150px,2fr)] min-w-[600px] border-b bg-foreground/2">
+					<div className="grid grid-cols-[minmax(160px,1.2fr)_minmax(100px,0.8fr)_minmax(128px,0.6fr)_minmax(150px,2fr)] min-w-[600px] border-b bg-foreground/2">
 						{["Field", "Type", "Attributes", "Description"].map((label) => (
 							<div
 								key={label}
-								className="px-4 py-1 text-[11px] font-mono font-medium uppercase tracking-wider text-foreground/60"
+								className={cn(
+									"py-1 text-[11px] font-mono font-medium uppercase tracking-wider text-foreground/60",
+									label === "Attributes" ? "px-2" : "px-4",
+								)}
 							>
 								{label}
 							</div>
@@ -442,7 +445,7 @@ export function DatabaseTable({
 					{fields.map((field) => (
 						<div
 							key={field.name}
-							className="grid grid-cols-[minmax(160px,1.2fr)_minmax(100px,0.8fr)_minmax(112px,0.6fr)_minmax(150px,2fr)] min-w-[600px] items-center border-b border-dashed border-foreground/10 last:border-b-0 hover:bg-foreground/[0.02] transition-colors"
+							className="grid grid-cols-[minmax(160px,1.2fr)_minmax(100px,0.8fr)_minmax(128px,0.6fr)_minmax(150px,2fr)] min-w-[600px] items-center border-b border-dashed border-foreground/10 last:border-b-0 hover:bg-foreground/[0.02] transition-colors"
 						>
 							<div className="px-4 py-2 font-mono text-[13px] text-foreground/80 break-all">
 								{field.name}
@@ -462,7 +465,7 @@ export function DatabaseTable({
 									{field.type}
 								</span>
 							</div>
-							<div className="px-4 py-2 flex flex-nowrap items-center gap-2">
+							<div className="px-2 py-2 flex flex-nowrap items-center gap-2">
 								{field.isPrimaryKey && (
 									<span className="inline-flex items-center gap-1 font-mono text-[13px] text-amber-600 dark:text-amber-500 uppercase">
 										<Key className="size-2.5" />

--- a/docs/components/docs/mdx-components.tsx
+++ b/docs/components/docs/mdx-components.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ExternalLink, Key, Link as LinkIcon } from "lucide-react";
+import { EqualNot, ExternalLink, Key, LinkIcon } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { startTransition, useState } from "react";
@@ -427,8 +427,8 @@ export function DatabaseTable({
 			{view === "table" ? (
 				<div className="overflow-x-auto">
 					{/* Column headers */}
-					<div className="grid grid-cols-[minmax(160px,1.2fr)_minmax(100px,0.8fr)_minmax(40px,0.4fr)_minmax(150px,2fr)] min-w-[600px] border-b bg-foreground/2">
-						{["Field", "Type", "Key", "Description"].map((label) => (
+					<div className="grid grid-cols-[minmax(160px,1.2fr)_minmax(100px,0.8fr)_minmax(112px,0.6fr)_minmax(150px,2fr)] min-w-[600px] border-b bg-foreground/2">
+						{["Field", "Type", "Attributes", "Description"].map((label) => (
 							<div
 								key={label}
 								className="px-4 py-1 text-[11px] font-mono font-medium uppercase tracking-wider text-foreground/60"
@@ -442,7 +442,7 @@ export function DatabaseTable({
 					{fields.map((field) => (
 						<div
 							key={field.name}
-							className="grid grid-cols-[minmax(160px,1.2fr)_minmax(100px,0.8fr)_minmax(40px,0.4fr)_minmax(150px,2fr)] min-w-[600px] items-center border-b border-dashed border-foreground/10 last:border-b-0 hover:bg-foreground/[0.02] transition-colors"
+							className="grid grid-cols-[minmax(160px,1.2fr)_minmax(100px,0.8fr)_minmax(112px,0.6fr)_minmax(150px,2fr)] min-w-[600px] items-center border-b border-dashed border-foreground/10 last:border-b-0 hover:bg-foreground/[0.02] transition-colors"
 						>
 							<div className="px-4 py-2 font-mono text-[13px] text-foreground/80 break-all">
 								{field.name}
@@ -462,7 +462,7 @@ export function DatabaseTable({
 									{field.type}
 								</span>
 							</div>
-							<div className="px-4 py-2 flex flex-wrap items-center gap-1.5">
+							<div className="px-4 py-2 flex flex-nowrap items-center gap-2">
 								{field.isPrimaryKey && (
 									<span className="inline-flex items-center gap-1 font-mono text-[13px] text-amber-600 dark:text-amber-500 uppercase">
 										<Key className="size-2.5" />
@@ -475,14 +475,15 @@ export function DatabaseTable({
 										FK
 									</span>
 								)}
-								{field.isIndexed && (
+								{field.isUnique && (
 									<span className="inline-flex items-center gap-1 font-mono text-[13px] text-emerald-600 dark:text-emerald-500 uppercase">
-										IDX
+										<EqualNot className="size-3" />
+										UQ
 									</span>
 								)}
 								{!field.isPrimaryKey &&
 									!field.isForeignKey &&
-									!field.isIndexed && (
+									!field.isUnique && (
 										<span className="text-foreground/20 uppercase">-</span>
 									)}
 							</div>


### PR DESCRIPTION
I don't think there's much value in showing indexes in the UI.

We should keep the UI representation separate from the underlying schema metadata.

For the UI, let's only show `PK` (Primary Key), `FK` (Foreign Key), and `UQ` (Unique).

<img width="500" alt="example" src="https://github.com/user-attachments/assets/c5fb8650-4bf5-4d6a-8d07-1f99df3b1d70" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows only PK, FK, and UQ in the docs DatabaseTable to reduce noise and prevent overflow. Previously the “Key” column showed IDX for indexed fields; now the “Attributes” column lists PK/FK/UQ only and keeps badges on one line.

- UI-only change in docs/components/docs/mdx-components.tsx; schema metadata unchanged; no migrations. `field.isIndexed` is ignored.
- Displays UQ when `field.isUnique` is true using `EqualNot` from `lucide-react`; shows “-” when no attributes apply.
- Layout: rename “Key” to “Attributes”, widen that column, adjust padding, and prevent badge wrapping.

<sup>Written for commit f3b1b4caa4b6382e54db365e795b7d1cd84fbe2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

