### PR TITLE
fix(origin-check): improve relative callback URL validation

### DIFF
--- a/.changeset/parse-relative-redirect-urls.md
+++ b/.changeset/parse-relative-redirect-urls.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Allow relative callback URLs to use standard path, query, and fragment syntax while preserving open-redirect protections.

--- a/.changeset/parse-relative-redirect-urls.md
+++ b/.changeset/parse-relative-redirect-urls.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Allow relative callback URLs to use standard path, query, and fragment syntax while preserving open-redirect protections.
+Allow relative callback and redirect URLs to use standard path and query syntax while preserving open-redirect protections.

--- a/docs/content/docs/reference/security.mdx
+++ b/docs/content/docs/reference/security.mdx
@@ -219,7 +219,7 @@ If you're serving your app from multiple approved domains, you'll typically want
 
 Trusted origins prevent CSRF attacks and block open redirects. You can set a list of trusted origins in the `trustedOrigins` configuration option. Requests from origins not on this list are automatically blocked.
 
-Relative callback and redirect URLs support standard path, query, and fragment syntax, but must begin with a single `/`. Better Auth rejects protocol-relative URLs (`//...`), backslashes, control characters, and encoded path separators.
+Relative callback and redirect URLs support standard path and query syntax, but must begin with a single `/`. Better Auth rejects fragments, protocol-relative URLs (`//...`), backslashes, control characters, and encoded path separators in the path.
 
 ### Basic Usage
 

--- a/docs/content/docs/reference/security.mdx
+++ b/docs/content/docs/reference/security.mdx
@@ -219,6 +219,8 @@ If you're serving your app from multiple approved domains, you'll typically want
 
 Trusted origins prevent CSRF attacks and block open redirects. You can set a list of trusted origins in the `trustedOrigins` configuration option. Requests from origins not on this list are automatically blocked.
 
+Relative callback and redirect URLs support standard path, query, and fragment syntax, but must begin with a single `/`. Better Auth rejects protocol-relative URLs (`//...`), backslashes, control characters, and encoded path separators.
+
 ### Basic Usage
 
 The most basic usage is to specify exact origins, below is an example of a trusted origins configuration:

--- a/packages/better-auth/src/auth/trusted-origins.test.ts
+++ b/packages/better-auth/src/auth/trusted-origins.test.ts
@@ -47,7 +47,10 @@ async function createAuthTestInstance(overrides?: Partial<BetterAuthOptions>) {
 		settings?: { allowRelativePaths: boolean },
 	) => {
 		const result = await client.testTrustedOrigin({
-			query: { url, ...settings },
+			query: {
+				url,
+				allowRelativePaths: settings?.allowRelativePaths.toString(),
+			},
 		});
 
 		if (result.error) {
@@ -225,12 +228,31 @@ describe("trusted origins", () => {
 			).resolves.toBe(true);
 		});
 
-		it("should reject urls with double dash", async () => {
+		it("should allow standards-compliant relative URLs", async () => {
 			const { isTrustedOrigin } = await createAuthTestInstance();
+			const relativeURLs = [
+				"/docs/!$&'()*+,;=:@~",
+				"/café#profile",
+				"/search?next=/settings?tab=security",
+				"/callback?next=%2Fdashboard",
+			];
 
-			await expect(
-				isTrustedOrigin("//evil.com", { allowRelativePaths: true }),
-			).resolves.toBe(false);
+			for (const url of relativeURLs) {
+				await expect(
+					isTrustedOrigin(url, { allowRelativePaths: true }),
+				).resolves.toBe(true);
+			}
+		});
+
+		it("should reject URLs with ambiguous path prefixes", async () => {
+			const { isTrustedOrigin } = await createAuthTestInstance();
+			const ambiguousURLs = ["//evil.com", "///evil.com", `/\\evil.com`];
+
+			for (const url of ambiguousURLs) {
+				await expect(
+					isTrustedOrigin(url, { allowRelativePaths: true }),
+				).resolves.toBe(false);
+			}
 		});
 
 		it("should reject urls with encoded malicious content", async () => {
@@ -241,8 +263,15 @@ describe("trusted origins", () => {
 				"/%2F/evil.com",
 				"/%5c/evil.com",
 				"/%5C/evil.com",
+				"/safe/%2f/evil.com",
+				"/safe/%2F/evil.com",
+				"/safe/%5c/evil.com",
+				"/safe/%5C/evil.com",
 				`/\\/\\/evil.com`,
 				"/..%2F..%2Fevil.com",
+				`/\u0000evil.com`,
+				`/\u007fevil.com`,
+				`/\u0085evil.com`,
 				"javascript:alert('xss')",
 				"data:text/html,<script>alert('xss')</script>",
 			];

--- a/packages/better-auth/src/auth/trusted-origins.test.ts
+++ b/packages/better-auth/src/auth/trusted-origins.test.ts
@@ -228,11 +228,14 @@ describe("trusted origins", () => {
 			).resolves.toBe(true);
 		});
 
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/10022
+		 */
 		it("should allow standards-compliant relative URLs", async () => {
 			const { isTrustedOrigin } = await createAuthTestInstance();
 			const relativeURLs = [
 				"/docs/!$&'()*+,;=:@~",
-				"/café#profile",
+				"/café/profile",
 				"/search?next=/settings?tab=security",
 				"/callback?next=%2Fdashboard",
 			];
@@ -272,6 +275,11 @@ describe("trusted origins", () => {
 				`/\u0000evil.com`,
 				`/\u007fevil.com`,
 				`/\u0085evil.com`,
+				`/\t/evil.com`,
+				`/\n/evil.com`,
+				`/\r/evil.com`,
+				"/profile#section",
+				"/profile#section?tab=security",
 				"javascript:alert('xss')",
 				"data:text/html,<script>alert('xss')</script>",
 			];

--- a/packages/better-auth/src/auth/trusted-origins.ts
+++ b/packages/better-auth/src/auth/trusted-origins.ts
@@ -64,47 +64,38 @@ const parseCustomSchemeOrigin = (value: string) => {
 };
 
 const RELATIVE_URL_PARSER_ORIGIN = "https://better-auth.invalid";
-const ENCODED_PATH_SEPARATORS = ["%2f", "%2F", "%5c", "%5C"] as const;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/;
+const ENCODED_PATH_SEPARATOR_PATTERN = /%2[fF]|%5[cC]/;
 
-function hasControlCharacter(value: string): boolean {
-	for (let index = 0; index < value.length; index++) {
-		const characterCode = value.charCodeAt(index);
-		if (
-			characterCode <= 0x1f ||
-			(characterCode >= 0x7f && characterCode <= 0x9f)
-		) {
-			return true;
-		}
-	}
-	return false;
-}
-
-function hasEncodedPathSeparator(path: string): boolean {
-	for (const separator of ENCODED_PATH_SEPARATORS) {
-		if (path.includes(separator)) {
-			return true;
-		}
-	}
-	return false;
-}
-
+/**
+ * Validates root-relative redirects against ambiguous browser and router parsing.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc3986.html#section-4.2
+ * @see https://url.spec.whatwg.org/#concept-basic-url-parser
+ */
 const isSafeRelativeURL = (value: string): boolean => {
+	// Fragments would swallow query parameters appended by downstream redirects.
+	if (value.includes("#")) {
+		return false;
+	}
+
 	if (
 		!value.startsWith("/") ||
 		value.startsWith("//") ||
 		value.includes("\\") ||
-		hasControlCharacter(value)
+		CONTROL_CHARACTER_PATTERN.test(value)
 	) {
 		return false;
 	}
 
-	const pathEnd = value.search(/[?#]/);
-	const path = pathEnd === -1 ? value : value.slice(0, pathEnd);
-	if (hasEncodedPathSeparator(path)) {
+	const queryStart = value.indexOf("?");
+	const path = queryStart === -1 ? value : value.slice(0, queryStart);
+	if (ENCODED_PATH_SEPARATOR_PATTERN.test(path)) {
 		return false;
 	}
 
 	try {
+		// Recheck authority after web-platform URL normalization.
 		return (
 			new URL(value, RELATIVE_URL_PARSER_ORIGIN).origin ===
 			RELATIVE_URL_PARSER_ORIGIN

--- a/packages/better-auth/src/auth/trusted-origins.ts
+++ b/packages/better-auth/src/auth/trusted-origins.ts
@@ -63,6 +63,57 @@ const parseCustomSchemeOrigin = (value: string) => {
 	return { scheme, authority: authority.toLowerCase(), path };
 };
 
+const RELATIVE_URL_PARSER_ORIGIN = "https://better-auth.invalid";
+const ENCODED_PATH_SEPARATORS = ["%2f", "%2F", "%5c", "%5C"] as const;
+
+function hasControlCharacter(value: string): boolean {
+	for (let index = 0; index < value.length; index++) {
+		const characterCode = value.charCodeAt(index);
+		if (
+			characterCode <= 0x1f ||
+			(characterCode >= 0x7f && characterCode <= 0x9f)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function hasEncodedPathSeparator(path: string): boolean {
+	for (const separator of ENCODED_PATH_SEPARATORS) {
+		if (path.includes(separator)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+const isSafeRelativeURL = (value: string): boolean => {
+	if (
+		!value.startsWith("/") ||
+		value.startsWith("//") ||
+		value.includes("\\") ||
+		hasControlCharacter(value)
+	) {
+		return false;
+	}
+
+	const pathEnd = value.search(/[?#]/);
+	const path = pathEnd === -1 ? value : value.slice(0, pathEnd);
+	if (hasEncodedPathSeparator(path)) {
+		return false;
+	}
+
+	try {
+		return (
+			new URL(value, RELATIVE_URL_PARSER_ORIGIN).origin ===
+			RELATIVE_URL_PARSER_ORIGIN
+		);
+	} catch {
+		return false;
+	}
+};
+
 /**
  * Matches the given url against an origin or origin pattern
  * See "options.trustedOrigins" for details of supported patterns
@@ -78,16 +129,7 @@ export const matchesOriginPattern = (
 	settings?: { allowRelativePaths: boolean },
 ): boolean => {
 	if (url.startsWith("/")) {
-		if (settings?.allowRelativePaths) {
-			return (
-				url.startsWith("/") &&
-				/^\/(?!\/|\\|%2[fF]|%5[cC])[\w\-.\+/@~]*(?:\?[\w\-.\+/=&%@~]*)?$/.test(
-					url,
-				)
-			);
-		}
-
-		return false;
+		return settings?.allowRelativePaths === true && isSafeRelativeURL(url);
 	}
 
 	// Check if pattern contains wildcard characters (*, **, or ?)


### PR DESCRIPTION
follow-up from https://github.com/better-auth/better-auth/pull/10041

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts standards-compliant relative callback and redirect URLs and tightens origin checks in `better-auth`. Previously a regex rejected valid paths and missed ambiguous prefixes and fragments; now we parse root‑relative URLs, require a single leading slash, and reject fragments, protocol‑relative prefixes, backslashes, control characters, and encoded path separators to prevent open redirects and query loss.

- Migration: If you send relative redirects with fragments, backslashes, protocol‑relative forms, control characters, or encoded `%2F`/`%5C` in the path, change them to start with a single `/` and remove those characters. Enable `trustedOrigins.allowRelativePaths: true` when using relative URLs.

<sup>Written for commit 7c4ea1d46eaa809e28ba62a2d783252fccba90bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

