### PR TITLE
refactor: centralize placeholder email generation

### DIFF
--- a/.changeset/centralize-placeholder-emails.md
+++ b/.changeset/centralize-placeholder-emails.md
@@ -1,0 +1,6 @@
+---
+"@better-auth/core": minor
+"better-auth": minor
+---
+
+Built-in placeholder emails now consistently use the namespaced `{identifier}@{namespace}.placeholder.invalid` format.

--- a/.changeset/centralize-placeholder-emails.md
+++ b/.changeset/centralize-placeholder-emails.md
@@ -1,6 +1,6 @@
 ---
-"@better-auth/core": minor
-"better-auth": minor
+"@better-auth/core": patch
+"better-auth": patch
 ---
 
 Built-in placeholder emails now consistently use the namespaced `{identifier}@{namespace}.placeholder.invalid` format.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@ This is the Better Auth repository - a comprehensive authentication framework fo
 - JSDoc comments for public APIs
 - Plugins should be as independent as possible. When working on a plugin, prefer modifying the plugin over changing core.
 
+### Placeholder Emails
+
+`User.email` is currently required and unique, which is a limitation of the current architecture.
+
+When a flow must synthesize an email, use `createPlaceholderEmail` with a stable identifier and namespace. Keep placeholder emails unverified, and preserve flows that delegate generation to user code.
+
 ## Issue Triage and Architecture
 
 - A reproducible error is not automatically a bug. First prove the behavior violates Better Auth's documented contract, TypeScript contract, or established runtime semantics.

--- a/docs/content/docs/authentication/roblox.mdx
+++ b/docs/content/docs/authentication/roblox.mdx
@@ -12,7 +12,7 @@ description: Roblox provider setup and usage.
     Make sure to set the redirect URL to `http://localhost:3000/api/auth/callback/roblox` for local development. For production, you should set it to the URL of your application. If you change the base path of the auth routes, you should update the redirect URL accordingly.
 
     <Callout type="info">
-      The Roblox API does not provide email addresses. As a workaround, the user's `email` field uses the `preferred_username` value instead.
+      The Roblox API does not provide email addresses. Better Auth uses the user's stable `sub` claim to create a non-routable `{sub}@roblox.placeholder.invalid` address.
     </Callout>
   </Step>
 

--- a/docs/content/docs/authentication/tiktok.mdx
+++ b/docs/content/docs/authentication/tiktok.mdx
@@ -26,7 +26,7 @@ description: TikTok provider setup and usage.
     Make sure to set the redirect URL to a valid HTTPS domain for local development. For production, you should set it to the URL of your application. If you change the base path of the auth routes, you should update the redirect URL accordingly.
 
     <Callout type="info">
-      * The TikTok API does not provide email addresses. As a workaround, this implementation uses the user's `username` value for the `email` field, which is why it requires the `user.info.profile` scope instead of just `user.info.basic`.
+      * The TikTok API does not provide email addresses. Better Auth uses the user's stable `open_id` to create a non-routable `{open_id}@tiktok.placeholder.invalid` address.
       * For production use, you will need to request approval from TikTok for the scopes you intend to use.
     </Callout>
   </Step>

--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -417,9 +417,9 @@ The table below summarises, for each affected provider, when `email` may be abse
 | GitHub             | User has set email to private; GitHub App lacks the "Email addresses" permission                                                                                         | `profile.id` (numeric)                      | Reliable                                                                                                                                                            |
 | LinkedIn           | No confirmed email on the member; `email` scope not granted                                                                                                              | `profile.sub` (pairwise per app)            | Reliable when present                                                                                                                                               |
 | Microsoft Entra ID | Managed users without a `mail` attribute, unless `email` is configured as an [optional claim](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims) | `profile.oid` (stable within `profile.tid`) | **Untrustworthy**: Microsoft [explicitly warns](https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference) never to use for authorization |
-| Roblox             | The default Roblox profile flow does not return an email; Better Auth currently falls back to `preferred_username`                                                       | `profile.sub` (Roblox user ID)              | Unknown for the default profile flow                                                                                                                                |
+| Roblox             | The default Roblox profile flow does not return an email; Better Auth creates a non-routable placeholder from `profile.sub`                                              | `profile.sub` (Roblox user ID)              | Unknown for the default profile flow                                                                                                                                |
 
-### Synthesize a placeholder email with `mapProfileToUser`
+### Create a placeholder email with `mapProfileToUser`
 
 Fall back to the provider's stable ID when the `email` field is null or absent:
 
@@ -432,21 +432,21 @@ export const auth = betterAuth({
       clientId: process.env.DISCORD_CLIENT_ID!,
       clientSecret: process.env.DISCORD_CLIENT_SECRET!,
       mapProfileToUser: (profile) => ({
-        email: profile.email ?? `${profile.id}@discord.placeholder.local`,
+        email: profile.email ?? `${profile.id}@discord.placeholder.invalid`,
       }),
     },
     apple: {
       clientId: process.env.APPLE_CLIENT_ID!,
       clientSecret: process.env.APPLE_CLIENT_SECRET!,
       mapProfileToUser: (profile) => ({
-        email: profile.email ?? `${profile.sub}@apple.placeholder.local`,
+        email: profile.email ?? `${profile.sub}@apple.placeholder.invalid`,
       }),
     },
     microsoft: {
       clientId: process.env.MICROSOFT_CLIENT_ID!,
       clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
       mapProfileToUser: (profile) => ({
-        email: profile.email ?? `${profile.oid}@entra.placeholder.local`,
+        email: profile.email ?? `${profile.oid}@entra.placeholder.invalid`,
       }),
     },
   },
@@ -454,7 +454,7 @@ export const auth = betterAuth({
 ```
 
 <Callout type="warn">
-  Synthesized emails are placeholders, not contact addresses. Plugins that send mail (password reset, magic link, email verification, organization invites) cannot deliver to them. Use a domain you control, or a reserved suffix like `.invalid` or `.local`, so no real inbox is ever addressed by mistake.
+  Placeholder emails are not contact addresses. Plugins that send mail (password reset, magic link, email verification, organization invites) cannot deliver to them. Use a domain you control or the reserved `.invalid` domain so no real inbox is ever addressed by mistake.
 </Callout>
 
 ### Provider-specific notes

--- a/docs/content/docs/plugins/anonymous.mdx
+++ b/docs/content/docs/plugins/anonymous.mdx
@@ -139,7 +139,7 @@ To delete an anonymous user, you can call the `/delete-anonymous-user` endpoint.
 
 ### `emailDomainName`
 
-The domain name to use when generating an email address for anonymous users. If not provided, the default format `temp@{id}.com` is used.
+The domain name to use when generating an email address for anonymous users. If not provided, the default format `{id}@anonymous.placeholder.invalid` is used.
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth"

--- a/docs/content/docs/plugins/siwe.mdx
+++ b/docs/content/docs/plugins/siwe.mdx
@@ -153,7 +153,7 @@ const { data, error } = await authClient.siwe.verify({
 The SIWE plugin accepts the following configuration options:
 
 * **domain**: The domain name of your application (required for SIWE message generation)
-* **emailDomainName**: The email domain name for creating user accounts when not using anonymous mode. Defaults to the domain from your base URL
+* **emailDomainName**: A custom email domain for wallet-derived addresses. If omitted, the plugin uses `{walletAddress}@siwe.placeholder.invalid`
 * **anonymous**: Whether to allow anonymous sign-ins without requiring an email. Default is `true`
 * **getNonce**: Function to generate a globally unique nonce for each sign-in attempt. You must implement this function to return a cryptographically secure ERC-4361 nonce: 8-250 alphanumeric characters. Must return a `Promise<string>`
 * **verifyMessage**: Function to verify the signature over the SIWE message. It only needs to perform signature recovery for the supplied address (e.g. viem's `verifyMessage`) and return `Promise<boolean>` — the plugin independently validates the message's nonce, domain, address, Chain ID, and time bounds before creating a session

--- a/packages/better-auth/src/oauth2/errors.ts
+++ b/packages/better-auth/src/oauth2/errors.ts
@@ -61,5 +61,5 @@ export function missingEmailLogMessage(
 			? `Generic OAuth provider "${providerId}"`
 			: `Provider "${providerId}"`;
 	const where = options?.source === "id_token" ? " in the id token" : "";
-	return `${subject} did not return an email${where}. Either request the provider's email scope, or synthesize one via \`mapProfileToUser\`. See ${HANDLING_DOCS_URL}`;
+	return `${subject} did not return an email${where}. Either request the provider's email scope, or create a placeholder via \`mapProfileToUser\`. See ${HANDLING_DOCS_URL}`;
 }

--- a/packages/better-auth/src/oauth2/link-account.test.ts
+++ b/packages/better-auth/src/oauth2/link-account.test.ts
@@ -2119,7 +2119,7 @@ describe("oauth2 - providers without email", async () => {
 
 	// Preserve existing coverage for custom profile mapping that only augments
 	// optional fields without removing the provider account identifier.
-	describe("with mapProfileToUser synthesizing email", async () => {
+	describe("with mapProfileToUser creating a placeholder email", async () => {
 		const { auth, client, cookieSetter } = await getTestInstance({
 			socialProviders: {
 				discord: {
@@ -2127,7 +2127,7 @@ describe("oauth2 - providers without email", async () => {
 					clientSecret: "test",
 					enabled: true,
 					mapProfileToUser: (profile) => ({
-						email: profile.email ?? `${profile.id}@discord.placeholder.local`,
+						email: profile.email ?? `${profile.id}@discord.placeholder.invalid`,
 					}),
 				},
 			},
@@ -2135,7 +2135,7 @@ describe("oauth2 - providers without email", async () => {
 
 		const ctx = await auth.$context;
 
-		it("signs in a Discord phone-only user with a synthesized email", async () => {
+		it("signs in a Discord phone-only user with a placeholder email", async () => {
 			const discordId = "920138789012345001";
 			mockDiscordToken(discordId, "phoneonly");
 
@@ -2163,13 +2163,13 @@ describe("oauth2 - providers without email", async () => {
 
 			expect(redirectLocation).not.toContain("error");
 
-			const synthesizedEmail = `${discordId}@discord.placeholder.local`;
+			const placeholderEmail = `${discordId}@discord.placeholder.invalid`;
 			const user = await ctx.adapter.findOne<User>({
 				model: "user",
-				where: [{ field: "email", value: synthesizedEmail }],
+				where: [{ field: "email", value: placeholderEmail }],
 			});
 			expect(user).toBeTruthy();
-			expect(user?.email).toBe(synthesizedEmail);
+			expect(user?.email).toBe(placeholderEmail);
 
 			const accounts = await ctx.adapter.findMany<{
 				providerId: string;

--- a/packages/better-auth/src/plugins/anonymous/anon.test.ts
+++ b/packages/better-auth/src/plugins/anonymous/anon.test.ts
@@ -138,6 +138,14 @@ describe("anonymous", async () => {
 		expect(session.data?.user.isAnonymous).toBe(true);
 	});
 
+	it("uses a namespaced placeholder email by default", async () => {
+		const result = await client.signIn.anonymous();
+
+		expect(result.data?.user.email).toMatch(
+			/^[^@]+@anonymous\.placeholder\.invalid$/,
+		);
+	});
+
 	it("should reject anonymous sign-in when validateUserInfo returns error", async () => {
 		const { client } = await getTestInstance(
 			{

--- a/packages/better-auth/src/plugins/anonymous/index.ts
+++ b/packages/better-auth/src/plugins/anonymous/index.ts
@@ -6,6 +6,7 @@ import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "@better-auth/core/api";
+import { createPlaceholderEmail } from "@better-auth/core/utils/email";
 import { generateId } from "@better-auth/core/utils/id";
 import * as z from "zod";
 import {
@@ -106,7 +107,10 @@ async function getAnonUserEmail(
 		return `temp-${id}@${options.emailDomainName}`;
 	}
 
-	return `temp@${id}.com`;
+	return createPlaceholderEmail({
+		identifier: id,
+		namespace: "anonymous",
+	});
 }
 
 export const anonymous = (options?: AnonymousOptions | undefined) => {

--- a/packages/better-auth/src/plugins/anonymous/types.ts
+++ b/packages/better-auth/src/plugins/anonymous/types.ts
@@ -17,9 +17,8 @@ export interface UserWithAnonymous extends User {
 
 export interface AnonymousOptions {
 	/**
-	 * Configure the domain name of the temporary email
-	 * address for anonymous users in the database.
-	 * @default "baseURL"
+	 * Configure a custom domain for anonymous user email addresses.
+	 * @default "anonymous.placeholder.invalid"
 	 */
 	emailDomainName?: string | undefined;
 	/**

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -3118,9 +3118,9 @@ describe("oauth2", async () => {
 				sub: "token-pairwise-sub",
 				oid: "token-stable-oid",
 				tid: "token-tenant-id",
+				email: "token-stable-oid@microsoft-entra-id.placeholder.invalid",
 				emailVerified: false,
 			});
-			expect(userInfo?.email).toBeUndefined();
 			expect(userInfo?.name).toBeUndefined();
 			expect(userInfo?.image).toBeUndefined();
 		});

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -3125,6 +3125,40 @@ describe("oauth2", async () => {
 			expect(userInfo?.image).toBeUndefined();
 		});
 
+		it("keeps the placeholder unverified for unexpected null email claims", async () => {
+			const msConfig = microsoftEntraId({
+				clientId: "ms-client-id",
+				clientSecret: "ms-client-secret",
+				tenantId,
+			});
+			mswServer.use(
+				http.get("https://graph.microsoft.com/oidc/userinfo", () =>
+					HttpResponse.json({
+						sub: "token-pairwise-sub",
+						email: null,
+						email_verified: true,
+					}),
+				),
+			);
+			const idToken = await createMicrosoftIdToken({
+				sub: "token-pairwise-sub",
+				oid: "token-stable-oid",
+				tid: "token-tenant-id",
+				email: null,
+				email_verified: true,
+			});
+
+			const userInfo = await msConfig.getUserInfo!({
+				accessToken: "ms-access-token",
+				idToken,
+			});
+
+			expect(userInfo).toMatchObject({
+				email: "token-stable-oid@microsoft-entra-id.placeholder.invalid",
+				emailVerified: false,
+			});
+		});
+
 		it("should normalize personal Microsoft account givenname and familyname claims", async () => {
 			const msConfig = microsoftEntraId({
 				clientId: "ms-client-id",

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -3125,7 +3125,7 @@ describe("oauth2", async () => {
 			expect(userInfo?.image).toBeUndefined();
 		});
 
-		it("keeps the placeholder unverified for unexpected null email claims", async () => {
+		it("keeps the placeholder unverified for an unexpected null Graph email claim", async () => {
 			const msConfig = microsoftEntraId({
 				clientId: "ms-client-id",
 				clientSecret: "ms-client-secret",
@@ -3135,6 +3135,7 @@ describe("oauth2", async () => {
 				http.get("https://graph.microsoft.com/oidc/userinfo", () =>
 					HttpResponse.json({
 						sub: "token-pairwise-sub",
+						name: "Graph User",
 						email: null,
 						email_verified: true,
 					}),
@@ -3144,8 +3145,6 @@ describe("oauth2", async () => {
 				sub: "token-pairwise-sub",
 				oid: "token-stable-oid",
 				tid: "token-tenant-id",
-				email: null,
-				email_verified: true,
 			});
 
 			const userInfo = await msConfig.getUserInfo!({
@@ -3154,6 +3153,7 @@ describe("oauth2", async () => {
 			});
 
 			expect(userInfo).toMatchObject({
+				name: "Graph User",
 				email: "token-stable-oid@microsoft-entra-id.placeholder.invalid",
 				emailVerified: false,
 			});

--- a/packages/better-auth/src/plugins/generic-oauth/providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/microsoft-entra-id.ts
@@ -146,7 +146,7 @@ export function microsoftEntraId(
 			return tokenUserInfo;
 		}
 
-		const profileEmail = tokenProfile.email ?? profile.email;
+		const emailClaim = tokenProfile.email ?? profile.email;
 		const profileWithClaims = {
 			...profile,
 			...tokenProfile,
@@ -154,7 +154,7 @@ export function microsoftEntraId(
 				getMicrosoftProfileName(tokenProfile) ??
 				getMicrosoftProfileName(profile),
 			email:
-				profileEmail ??
+				emailClaim ??
 				createPlaceholderEmail({
 					identifier: oid,
 					namespace: "microsoft-entra-id",
@@ -164,7 +164,7 @@ export function microsoftEntraId(
 			// It must be configured as an optional claim in the app registration.
 			// We default to false when not provided.
 			emailVerified:
-				profileEmail !== undefined
+				emailClaim != null
 					? (tokenProfile.email_verified ?? profile.email_verified ?? false)
 					: false,
 		};

--- a/packages/better-auth/src/plugins/generic-oauth/providers/microsoft-entra-id.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/microsoft-entra-id.ts
@@ -1,4 +1,5 @@
 import type { OAuth2Tokens } from "@better-auth/core/oauth2";
+import { createPlaceholderEmail } from "@better-auth/core/utils/email";
 import { betterFetch } from "@better-fetch/fetch";
 import { decodeJwt } from "jose";
 import type {
@@ -107,12 +108,20 @@ export function microsoftEntraId(
 		if (!oid) {
 			return null;
 		}
+		const tokenEmail = tokenProfile.email;
 		const tokenUserInfo = {
 			...tokenProfile,
 			name: getMicrosoftProfileName(tokenProfile),
-			email: tokenProfile.email ?? tokenProfile.preferred_username ?? undefined,
+			email:
+				tokenEmail ??
+				createPlaceholderEmail({
+					identifier: oid,
+					namespace: "microsoft-entra-id",
+				}),
 			image: tokenProfile.picture,
-			emailVerified: tokenProfile.email_verified ?? false,
+			emailVerified: tokenEmail
+				? (tokenProfile.email_verified ?? false)
+				: false,
 		};
 		if (!tokens.accessToken) {
 			return tokenUserInfo;
@@ -137,6 +146,7 @@ export function microsoftEntraId(
 			return tokenUserInfo;
 		}
 
+		const profileEmail = tokenProfile.email ?? profile.email;
 		const profileWithClaims = {
 			...profile,
 			...tokenProfile,
@@ -144,17 +154,19 @@ export function microsoftEntraId(
 				getMicrosoftProfileName(tokenProfile) ??
 				getMicrosoftProfileName(profile),
 			email:
-				tokenProfile.email ??
-				profile.email ??
-				tokenProfile.preferred_username ??
-				profile.preferred_username ??
-				undefined,
+				profileEmail ??
+				createPlaceholderEmail({
+					identifier: oid,
+					namespace: "microsoft-entra-id",
+				}),
 			image: tokenProfile.picture ?? profile.picture,
 			// Note: Microsoft Entra ID does NOT include email_verified claim by default.
 			// It must be configured as an optional claim in the app registration.
 			// We default to false when not provided.
 			emailVerified:
-				tokenProfile.email_verified ?? profile.email_verified ?? false,
+				profileEmail !== undefined
+					? (tokenProfile.email_verified ?? profile.email_verified ?? false)
+					: false,
 		};
 		return profileWithClaims;
 	};

--- a/packages/better-auth/src/plugins/siwe/index.ts
+++ b/packages/better-auth/src/plugins/siwe/index.ts
@@ -1,6 +1,7 @@
 import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import { createLocalAccountIssuer } from "@better-auth/core/db";
+import { createPlaceholderEmail } from "@better-auth/core/utils/email";
 import * as z from "zod";
 import { APIError } from "../../api";
 import { setSessionCookie } from "../../cookies";
@@ -8,7 +9,6 @@ import { mergeSchema } from "../../db/schema";
 import type { InferOptionSchema, User } from "../../types";
 import { toChecksumAddress } from "../../utils/hashing";
 import { isAPIError } from "../../utils/is-api-error";
-import { getOrigin } from "../../utils/url";
 import { PACKAGE_VERSION } from "../../version";
 import { normalizeSiweDomain, parseSiweMessage } from "./parse-message";
 import type { WalletAddressSchema } from "./schema";
@@ -292,10 +292,13 @@ export const siwe = (options: SIWEPluginOptions) => {
 
 						// Create new user if none exists
 						if (!user) {
-							const domain =
-								options.emailDomainName ?? getOrigin(ctx.context.baseURL);
 							const normalizedEmail = email?.toLowerCase();
-							const walletEmail = `${walletAddress}@${domain}`;
+							const walletEmail = options.emailDomainName
+								? `${walletAddress}@${options.emailDomainName}`
+								: createPlaceholderEmail({
+										identifier: walletAddress,
+										namespace: "siwe",
+									});
 							// SIWE proves wallet control, not email ownership: bind the caller
 							// email only when unclaimed and atomically reserved, else keep
 							// the wallet-derived address.

--- a/packages/better-auth/src/plugins/siwe/siwe.test.ts
+++ b/packages/better-auth/src/plugins/siwe/siwe.test.ts
@@ -573,7 +573,7 @@ describe("siwe", async () => {
 			const session = await client.getSession({ fetchOptions: { headers } });
 			expect(session.data?.user.email).not.toBe("user@example.com");
 			expect(session.data?.user.email).toBe(
-				`${walletAddress.toLowerCase()}@http://localhost:3000`,
+				`${walletAddress.toLowerCase()}@siwe.placeholder.invalid`,
 			);
 		} finally {
 			context.internalAdapter.reserveVerificationValue =
@@ -763,8 +763,8 @@ describe("siwe", async () => {
 		expect(error?.message).toBe("[body.email] Invalid email address");
 	});
 
-	it("should allow verification without email when anonymous is true", async () => {
-		const { client } = await getTestInstance(
+	it("uses a namespaced placeholder email when no email is provided", async () => {
+		const { client, sessionSetter } = await getTestInstance(
 			{
 				plugins: [
 					siwe({
@@ -787,13 +787,20 @@ describe("siwe", async () => {
 			},
 		);
 
+		const headers = new Headers();
 		await client.siwe.nonce();
 		const { data, error } = await client.siwe.verify({
 			message: siweMessage(),
 			signature: "valid_signature",
+			fetchOptions: { onSuccess: sessionSetter(headers) },
 		});
 		expect(error).toBeNull();
 		expect(data?.success).toBe(true);
+		const session = await client.getSession({ fetchOptions: { headers } });
+
+		expect(session.data?.user.email).toBe(
+			`${walletAddress.toLowerCase()}@siwe.placeholder.invalid`,
+		);
 	});
 
 	// The nonce is single-use. Two requests presenting the same valid nonce at

--- a/packages/better-auth/src/social.test.ts
+++ b/packages/better-auth/src/social.test.ts
@@ -3424,10 +3424,12 @@ describe("Reddit Provider — profile email mapping", async () => {
 		} as any);
 
 		// Without a mapped email the provider derives a unique, per-user
-		// synthetic email from the Reddit user id rather than falling back to
+		// placeholder email from the Reddit user id rather than falling back to
 		// the shared oauth_client_id, so users can never collide on one address.
 		// The non-routable `.invalid` domain keeps it from matching a real mailbox.
-		expect(result?.user.email).toBe("reddit-user-123@reddit.invalid");
+		expect(result?.user.email).toBe(
+			"reddit-user-123@reddit.placeholder.invalid",
+		);
 		expect(result?.user.email).not.toBe(profile.oauth_client_id);
 		expect(result?.user.emailVerified).toBe(false);
 	});

--- a/packages/cli/src/commands/init/configs/temp-plugins.config.ts
+++ b/packages/cli/src/commands/init/configs/temp-plugins.config.ts
@@ -1520,7 +1520,7 @@ export const tempPluginsConfig = {
 				{
 					flag: "siwe-email-domain-name",
 					question: "What is the email domain name?",
-					description: "The email domain name for anonymous users.",
+					description: "A custom email domain for wallet-derived addresses.",
 					skip: "prompt",
 					argument: {
 						index: 0,

--- a/packages/core/src/social-providers/reddit.test.ts
+++ b/packages/core/src/social-providers/reddit.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@better-fetch/fetch", () => ({
+vi.mock(import("@better-fetch/fetch"), () => ({
 	betterFetch: vi.fn(),
 }));
 

--- a/packages/core/src/social-providers/reddit.test.ts
+++ b/packages/core/src/social-providers/reddit.test.ts
@@ -26,7 +26,7 @@ describe("reddit.getUserInfo (no provider email)", () => {
 		mockedBetterFetch.mockReset();
 	});
 
-	it("synthesizes a non-routable placeholder email and never trusts oauth_client_id", async () => {
+	it("creates a non-routable placeholder email and never trusts oauth_client_id", async () => {
 		mockedBetterFetch.mockResolvedValue(
 			profileResponse({
 				id: "reddit-user-1",
@@ -42,9 +42,9 @@ describe("reddit.getUserInfo (no provider email)", () => {
 			accessToken: "access-token",
 		} as any);
 
-		expect(res?.user.email).toBe("reddit-user-1@reddit.invalid");
+		expect(res?.user.email).toBe("reddit-user-1@reddit.placeholder.invalid");
 		// `has_verified_email` describes the user's real Reddit email, not the
-		// synthetic placeholder, so the placeholder must never be marked verified.
+		// placeholder, so it must never be marked verified.
 		expect(res?.user.emailVerified).toBe(false);
 		// The OAuth app's client id must never become the user's identity anchor.
 		expect(res?.user.email).not.toContain("shared-app-client-id");
@@ -77,8 +77,8 @@ describe("reddit.getUserInfo (no provider email)", () => {
 		);
 		const b = await provider.getUserInfo({ accessToken: "t-b" } as any);
 
-		expect(a?.user.email).toBe("user-a@reddit.invalid");
-		expect(b?.user.email).toBe("user-b@reddit.invalid");
+		expect(a?.user.email).toBe("user-a@reddit.placeholder.invalid");
+		expect(b?.user.email).toBe("user-b@reddit.placeholder.invalid");
 		expect(a?.user.email).not.toBe(b?.user.email);
 	});
 

--- a/packages/core/src/social-providers/reddit.ts
+++ b/packages/core/src/social-providers/reddit.ts
@@ -6,6 +6,7 @@ import {
 	getOAuth2Tokens,
 	refreshAccessToken,
 } from "../oauth2";
+import { createPlaceholderEmail } from "../utils/email";
 
 export interface RedditProfile {
 	id: string;
@@ -110,7 +111,12 @@ export const reddit = (options: RedditOptions) => {
 			// non-routable placeholder (RFC 2606 `.invalid`) keyed to the user's
 			// Reddit id rather than the routable `reddit.com`, which could collide
 			// with a real address. Left unverified; `mapProfileToUser` can override.
-			const email = userMap?.email || `${profile.id}@reddit.invalid`;
+			const email =
+				userMap?.email ||
+				createPlaceholderEmail({
+					identifier: profile.id,
+					namespace: "reddit",
+				});
 			return {
 				user: {
 					name: profile.name,

--- a/packages/core/src/social-providers/roblox.test.ts
+++ b/packages/core/src/social-providers/roblox.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@better-fetch/fetch", () => ({
+	betterFetch: vi.fn(),
+}));
+
+import { betterFetch } from "@better-fetch/fetch";
+
+import { roblox } from "./roblox";
+
+const mockedBetterFetch = vi.mocked(betterFetch);
+
+describe("roblox.getUserInfo", () => {
+	it("uses the user ID in the placeholder email", async () => {
+		mockedBetterFetch.mockResolvedValue({
+			data: {
+				sub: "roblox-user-1",
+				preferred_username: "builderman",
+				nickname: "Builderman",
+				name: "Builderman",
+				created_at: 0,
+				profile: "https://www.roblox.com/users/1/profile",
+				picture: "https://example.com/avatar.png",
+			},
+			error: null,
+		});
+
+		const result = await roblox({
+			clientId: "roblox-app",
+			clientSecret: "roblox-secret",
+		}).getUserInfo({ accessToken: "access-token" });
+
+		expect(result?.user.email).toBe("roblox-user-1@roblox.placeholder.invalid");
+	});
+});

--- a/packages/core/src/social-providers/roblox.test.ts
+++ b/packages/core/src/social-providers/roblox.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@better-fetch/fetch", () => ({
+vi.mock(import("@better-fetch/fetch"), () => ({
 	betterFetch: vi.fn(),
 }));
 

--- a/packages/core/src/social-providers/roblox.ts
+++ b/packages/core/src/social-providers/roblox.ts
@@ -5,6 +5,7 @@ import {
 	refreshAccessToken,
 	validateAuthorizationCode,
 } from "../oauth2";
+import { createPlaceholderEmail } from "../utils/email";
 
 export interface RobloxProfile extends Record<string, any> {
 	/** the user's id */
@@ -97,13 +98,14 @@ export const roblox = (options: RobloxOptions) => {
 			}
 
 			const userMap = await options.mapProfileToUser?.(profile);
-			// Roblox does not provide email or email_verified claim.
-			// We default to false for security consistency.
 			return {
 				user: {
 					name: profile.nickname || profile.preferred_username || "",
 					image: profile.picture,
-					email: profile.preferred_username || null, // Roblox does not provide email
+					email: createPlaceholderEmail({
+						identifier: profile.sub,
+						namespace: "roblox",
+					}),
 					emailVerified: false,
 					...userMap,
 				},

--- a/packages/core/src/social-providers/tiktok.test.ts
+++ b/packages/core/src/social-providers/tiktok.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@better-fetch/fetch", () => ({
+	betterFetch: vi.fn(),
+}));
+
+import { betterFetch } from "@better-fetch/fetch";
+
+import { tiktok } from "./tiktok";
+
+const mockedBetterFetch = vi.mocked(betterFetch);
+
+describe("tiktok.getUserInfo", () => {
+	it("uses the open id for the placeholder email", async () => {
+		mockedBetterFetch.mockResolvedValue({
+			data: {
+				data: {
+					user: {
+						open_id: "tiktok-user-1",
+						avatar_large_url: "https://example.com/avatar.png",
+						display_name: "TikTok User",
+						username: "tiktok-user",
+					},
+				},
+			},
+			error: null,
+		});
+
+		const result = await tiktok({
+			clientKey: "tiktok-app",
+			clientSecret: "tiktok-secret",
+		}).getUserInfo({ accessToken: "access-token" });
+
+		expect(result?.user.email).toBe("tiktok-user-1@tiktok.placeholder.invalid");
+	});
+});

--- a/packages/core/src/social-providers/tiktok.test.ts
+++ b/packages/core/src/social-providers/tiktok.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@better-fetch/fetch", () => ({
+vi.mock(import("@better-fetch/fetch"), () => ({
 	betterFetch: vi.fn(),
 }));
 

--- a/packages/core/src/social-providers/tiktok.ts
+++ b/packages/core/src/social-providers/tiktok.ts
@@ -5,6 +5,7 @@ import {
 	refreshAccessToken,
 	validateAuthorizationCode,
 } from "../oauth2";
+import { createPlaceholderEmail } from "../utils/email";
 
 /**
  * [More info](https://developers.tiktok.com/doc/tiktok-api-v2-get-user-info/)
@@ -210,7 +211,12 @@ export const tiktok = (options: TiktokOptions) => {
 
 			return {
 				user: {
-					email: profile.data.user.email || profile.data.user.username,
+					email:
+						profile.data.user.email ||
+						createPlaceholderEmail({
+							identifier: profile.data.user.open_id,
+							namespace: "tiktok",
+						}),
 					name:
 						profile.data.user.display_name || profile.data.user.username || "",
 					image: profile.data.user.avatar_large_url,

--- a/packages/core/src/social-providers/twitter.test.ts
+++ b/packages/core/src/social-providers/twitter.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@better-fetch/fetch", () => ({
+vi.mock(import("@better-fetch/fetch"), () => ({
 	betterFetch: vi.fn(),
 }));
 

--- a/packages/core/src/social-providers/twitter.test.ts
+++ b/packages/core/src/social-providers/twitter.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@better-fetch/fetch", () => ({
+	betterFetch: vi.fn(),
+}));
+
+import { betterFetch } from "@better-fetch/fetch";
+
+import { twitter } from "./twitter";
+
+const mockedBetterFetch = vi.mocked(betterFetch);
+
+describe("twitter.getUserInfo", () => {
+	beforeEach(() => {
+		mockedBetterFetch.mockReset();
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				data: {
+					id: "twitter-user-1",
+					name: "Twitter User",
+					username: "twitter-user",
+				},
+			},
+			error: null,
+		});
+	});
+
+	it("uses the user id for the placeholder when no confirmed email exists", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: null,
+			error: { message: "Email unavailable" },
+		});
+
+		const result = await twitter({
+			clientId: "twitter-app",
+			clientSecret: "twitter-secret",
+		}).getUserInfo({ accessToken: "access-token" });
+
+		expect(result?.user.email).toBe(
+			"twitter-user-1@twitter.placeholder.invalid",
+		);
+	});
+
+	it("keeps a confirmed email", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: { data: { confirmed_email: "user@example.com" } },
+			error: null,
+		});
+
+		const result = await twitter({
+			clientId: "twitter-app",
+			clientSecret: "twitter-secret",
+		}).getUserInfo({ accessToken: "access-token" });
+
+		expect(result?.user.email).toBe("user@example.com");
+	});
+});

--- a/packages/core/src/social-providers/twitter.ts
+++ b/packages/core/src/social-providers/twitter.ts
@@ -5,6 +5,7 @@ import {
 	refreshAccessToken,
 	validateAuthorizationCode,
 } from "../oauth2";
+import { createPlaceholderEmail } from "../utils/email";
 
 export interface TwitterProfile {
 	data: {
@@ -187,9 +188,14 @@ export const twitter = (options: TwitterOption) => {
 			return {
 				user: {
 					name: profile.data.name,
-					email: profile.data.email || profile.data.username || null,
+					email:
+						profile.data.email ||
+						createPlaceholderEmail({
+							identifier: profile.data.id,
+							namespace: "twitter",
+						}),
 					image: profile.data.profile_image_url,
-					emailVerified: emailVerified,
+					emailVerified,
 					...userMap,
 				},
 				data: profile,

--- a/packages/core/src/social-providers/wechat.test.ts
+++ b/packages/core/src/social-providers/wechat.test.ts
@@ -26,7 +26,7 @@ describe("wechat.getUserInfo (no provider email)", () => {
 		mockedBetterFetch.mockReset();
 	});
 
-	it("synthesizes a non-routable placeholder email keyed to unionid", async () => {
+	it("creates a non-routable placeholder email keyed to unionid", async () => {
 		mockedBetterFetch.mockResolvedValue(
 			profileResponse({
 				openid: "open-123",
@@ -41,7 +41,7 @@ describe("wechat.getUserInfo (no provider email)", () => {
 			openid: "open-123",
 		} as any);
 
-		expect(res?.user.email).toBe("union-abc@wechat.invalid");
+		expect(res?.user.email).toBe("union-abc@wechat.placeholder.invalid");
 		expect(res?.user.emailVerified).toBe(false);
 		expect(res?.user).not.toHaveProperty("id");
 		expect(typeof provider.accountSubject).toBe("function");
@@ -68,7 +68,7 @@ describe("wechat.getUserInfo (no provider email)", () => {
 			openid: "open-456",
 		} as any);
 
-		expect(res?.user.email).toBe("open-456@wechat.invalid");
+		expect(res?.user.email).toBe("open-456@wechat.placeholder.invalid");
 		expect(res?.user.emailVerified).toBe(false);
 	});
 

--- a/packages/core/src/social-providers/wechat.test.ts
+++ b/packages/core/src/social-providers/wechat.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@better-fetch/fetch", () => ({
+vi.mock(import("@better-fetch/fetch"), () => ({
 	betterFetch: vi.fn(),
 }));
 

--- a/packages/core/src/social-providers/wechat.ts
+++ b/packages/core/src/social-providers/wechat.ts
@@ -1,6 +1,7 @@
 import { betterFetch } from "@better-fetch/fetch";
 import type { OAuth2Tokens, OAuthProvider, ProviderOptions } from "../oauth2";
 import { RESERVED_AUTHORIZATION_PARAMS_SET } from "../oauth2";
+import { createPlaceholderEmail } from "../utils/email";
 
 /**
  * WeChat user profile information
@@ -205,17 +206,16 @@ export const wechat = (options: WeChatOptions) => {
 			}
 
 			const userMap = await options.mapProfileToUser?.(profile);
+			const userId = profile.unionid || profile.openid || openid;
 			return {
 				user: {
 					name: profile.nickname,
-					// WeChat does not return an email, and the OAuth callback rejects a
-					// missing one, so the default sign-in would always fail. Synthesize a
-					// stable, non-routable placeholder (RFC 2606 `.invalid`) keyed to the
-					// user's WeChat id, left unverified. Applications that collect a real
-					// email override it via `mapProfileToUser`.
 					email:
 						profile.email ||
-						`${profile.unionid || profile.openid || openid}@wechat.invalid`,
+						createPlaceholderEmail({
+							identifier: userId,
+							namespace: "wechat",
+						}),
 					image: profile.headimgurl,
 					emailVerified: false,
 					...userMap,


### PR DESCRIPTION
Requiring unique email is a limitation of the current architecture, and we plan to make this more flexible in v2. Until then, if we need to generate placeholder emails, the behavior should at least be consistent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes placeholder email generation in a shared utility and standardizes the non‑routable `{identifier}@{namespace}.placeholder.invalid` format. This replaces ad‑hoc fallbacks, removes collision risks, and ensures placeholders are never marked verified.

- Refactors
  - Reddit, WeChat, Twitter, TikTok, Roblox, and `microsoft-entra-id` now create placeholders from stable IDs when no email is returned.
  - `generic-oauth` with `microsoft-entra-id` fills a placeholder from `oid` and keeps it unverified even if Graph sets `email_verified=true` with a null email.
  - Anonymous defaults to `{id}@anonymous.placeholder.invalid`; SIWE uses `{wallet}@siwe.placeholder.invalid` unless `emailDomainName` is set.
  - Docs explain the placeholder convention and update examples to the `.invalid` domain.

- Migration
  - Update tests or code relying on old formats (e.g., `.local`, username-based, or `temp@{id}.com`).
  - If you depended on SIWE’s base-URL domain or Anonymous’s old default, set `emailDomainName` or adopt the `{namespace}.placeholder.invalid` default.
  - Ensure email-sending flows skip placeholders and continue collecting real emails where needed.

<sup>Written for commit bb1464df3768348cf520d43b8079a833eac87a3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

