### PR TITLE
feat(api): add oauth-providers discovery endpoint

### DIFF
--- a/docs/content/docs/concepts/oauth.mdx
+++ b/docs/content/docs/concepts/oauth.mdx
@@ -27,6 +27,61 @@ export const auth = betterAuth({
 });
 ```
 
+## Discover enabled login methods
+
+Better Auth exposes a public discovery endpoint for building login UIs dynamically — for example, to render only the email and social sign-in buttons that are enabled on your server.
+
+The endpoint lives at `{baseURL}/.well-known/oauth-providers`. If your auth handler is mounted at `/api/auth`, the full URL is `https://example.com/api/auth/.well-known/oauth-providers`.
+
+<APIMethod path="/.well-known/oauth-providers" method="GET" isExternalOnly note="Lists enabled email/password and social login methods for client UI discovery.">
+  ```ts
+  type getOAuthProviders = {
+  }
+  ```
+</APIMethod>
+
+Example response:
+
+```json
+{
+  "issuer": "https://example.com/api/auth",
+  "providers": [
+    { "id": "email", "enabled": true },
+    {
+      "id": "google",
+      "enabled": true,
+      "redirectUri": "https://example.com/api/auth/callback/google"
+    }
+  ]
+}
+```
+
+**Response fields**
+
+* **`issuer`**: Auth server identifier. Defaults to your Better Auth `baseURL`. If the [JWT plugin](/docs/plugins/jwt) sets `jwt.issuer`, that value is used instead.
+* **`providers`**: Enabled login methods on this server.
+  * `{ id: "email", enabled: true }` when `emailAndPassword.enabled` is `true`
+  * `{ id: "<providerId>", enabled: true, redirectUri: "..." }` for each configured social provider
+
+For social providers, `redirectUri` is the IdP-registered callback URL: your `socialProviders[providerId].redirectURI` override when set, otherwise `{baseURL}/callback/{providerId}`.
+
+Server-side:
+
+```ts
+const { issuer, providers } = await auth.api.getOAuthProviders();
+```
+
+From a separate frontend or mobile app:
+
+```ts
+const response = await fetch("https://example.com/api/auth/.well-known/oauth-providers");
+const { issuer, providers } = await response.json();
+```
+
+<Callout>
+  This endpoint reflects email/password and `socialProviders` configuration. Other plugin sign-in methods (magic link, passkey, username, and similar) are not listed.
+</Callout>
+
 ## Usage
 
 ### Sign In

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -357,6 +357,8 @@ export const auth = betterAuth({
 * `disableDefaultScope`: Disable the provider's default scopes (optional)
 * `authorizationEndpoint`: Custom authorization endpoint URL (optional)
 
+Clients can discover which providers are enabled at runtime via `GET {baseURL}/.well-known/oauth-providers`. See [Discover enabled login methods](/docs/concepts/oauth#discover-enabled-login-methods).
+
 ## `plugins`
 
 List of Better Auth plugins.

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -29,6 +29,7 @@ import {
 	deleteUserCallback,
 	error,
 	getAccessToken,
+	getOAuthProviders,
 	getSession,
 	linkSocialAccount,
 	listSessions,
@@ -263,6 +264,7 @@ export function getEndpoints<Option extends BetterAuthOptions>(
 		...pluginEndpoints,
 		ok,
 		error,
+		getOAuthProviders,
 	} as const;
 	const api = toAuthEndpoints(endpoints, ctx);
 	return {

--- a/packages/better-auth/src/api/routes/index.ts
+++ b/packages/better-auth/src/api/routes/index.ts
@@ -2,6 +2,7 @@ export * from "./account";
 export * from "./callback";
 export * from "./email-verification";
 export * from "./error";
+export * from "./oauth-providers";
 export * from "./ok";
 export * from "./password";
 export * from "./session";

--- a/packages/better-auth/src/api/routes/oauth-providers.test.ts
+++ b/packages/better-auth/src/api/routes/oauth-providers.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { jwt } from "../../plugins/jwt";
+import { getTestInstance } from "../../test-utils/test-instance";
+
+describe("oauth-providers discovery", () => {
+	it("should list email and configured social providers", async () => {
+		const { customFetchImpl } = await getTestInstance({
+			baseURL: "http://localhost:3000",
+			basePath: "/api/auth",
+			emailAndPassword: { enabled: true },
+			socialProviders: {
+				google: {
+					clientId: "google-client-id",
+					clientSecret: "google-client-secret",
+				},
+				microsoft: {
+					clientId: "microsoft-client-id",
+					clientSecret: "microsoft-client-secret",
+					tenantId: "common",
+				},
+			},
+		});
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/.well-known/oauth-providers",
+			{ method: "GET" },
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			issuer: string;
+			providers: Array<{ id: string; enabled: boolean }>;
+		};
+
+		expect(body.issuer).toBe("http://localhost:3000/api/auth");
+		expect(body.providers).toEqual([
+			{ id: "email", enabled: true },
+			{
+				id: "google",
+				enabled: true,
+				redirectUri: "http://localhost:3000/api/auth/callback/google",
+			},
+			{
+				id: "microsoft",
+				enabled: true,
+				redirectUri: "http://localhost:3000/api/auth/callback/microsoft",
+			},
+		]);
+	});
+
+	it("should honor social provider redirectURI override", async () => {
+		const { customFetchImpl } = await getTestInstance(
+			{
+				baseURL: "http://localhost:3000",
+				basePath: "/api/auth",
+				emailAndPassword: { enabled: false },
+				socialProviders: {
+					google: {
+						clientId: "google-client-id",
+						clientSecret: "google-client-secret",
+						redirectURI: "https://auth.example.com/custom/google",
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/.well-known/oauth-providers",
+			{ method: "GET" },
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			providers: Array<{ id: string; enabled: boolean; redirectUri?: string }>;
+		};
+
+		expect(body.providers).toEqual([
+			{
+				id: "google",
+				enabled: true,
+				redirectUri: "https://auth.example.com/custom/google",
+			},
+		]);
+	});
+
+	it("should omit email when email/password is disabled", async () => {
+		const { customFetchImpl } = await getTestInstance(
+			{
+				baseURL: "http://localhost:3000",
+				basePath: "/api/auth",
+				emailAndPassword: { enabled: false },
+				socialProviders: {
+					google: {
+						clientId: "google-client-id",
+						clientSecret: "google-client-secret",
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/.well-known/oauth-providers",
+			{ method: "GET" },
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			providers: Array<{ id: string; enabled: boolean }>;
+		};
+
+		expect(body.providers).toEqual([
+			{
+				id: "google",
+				enabled: true,
+				redirectUri: "http://localhost:3000/api/auth/callback/google",
+			},
+		]);
+	});
+
+	it("should use JWT plugin issuer when configured", async () => {
+		const { customFetchImpl } = await getTestInstance({
+			baseURL: "http://localhost:3000",
+			basePath: "/api/auth",
+			emailAndPassword: { enabled: true },
+			plugins: [
+				jwt({
+					jwt: {
+						issuer: "https://auth.example.com/api/auth",
+					},
+				}),
+			],
+		});
+
+		const response = await customFetchImpl(
+			"http://localhost:3000/api/auth/.well-known/oauth-providers",
+			{ method: "GET" },
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { issuer: string };
+		expect(body.issuer).toBe("https://auth.example.com/api/auth");
+	});
+});

--- a/packages/better-auth/src/api/routes/oauth-providers.ts
+++ b/packages/better-auth/src/api/routes/oauth-providers.ts
@@ -1,0 +1,115 @@
+import type { AuthContext, GenericEndpointContext } from "@better-auth/core";
+import { createAuthEndpoint } from "@better-auth/core/api";
+import type { JwtOptions } from "../../plugins/jwt/types";
+import { HIDE_METADATA } from "../../utils/hide-metadata";
+
+export interface OAuthProviderInfo {
+	id: string;
+	enabled: boolean;
+	/** IdP-registered redirect URI for social providers (Better Auth callback). */
+	redirectUri?: string;
+}
+
+export interface OAuthProvidersResponse {
+	issuer: string;
+	providers: OAuthProviderInfo[];
+}
+
+function getJwtPluginOptions(ctx: AuthContext): JwtOptions | undefined {
+	const jwtPlugin = ctx.options.plugins?.find((plugin) => plugin.id === "jwt");
+	if (!jwtPlugin || !("options" in jwtPlugin)) {
+		return undefined;
+	}
+
+	return jwtPlugin.options as JwtOptions | undefined;
+}
+
+function resolveSocialProviderRedirectUri(
+	ctx: AuthContext,
+	providerId: string,
+): string {
+	const providerConfig = ctx.options.socialProviders?.[providerId];
+	if (
+		providerConfig &&
+		typeof providerConfig === "object" &&
+		"redirectURI" in providerConfig &&
+		typeof providerConfig.redirectURI === "string" &&
+		providerConfig.redirectURI.length > 0
+	) {
+		return providerConfig.redirectURI;
+	}
+
+	return `${ctx.baseURL}/callback/${providerId}`;
+}
+
+/** Builds login-method discovery payload from runtime Better Auth configuration. */
+export function buildOAuthProvidersResponse(
+	ctx: GenericEndpointContext,
+): OAuthProvidersResponse {
+	const providers: OAuthProviderInfo[] = [];
+
+	if (ctx.context.options.emailAndPassword?.enabled) {
+		providers.push({ id: "email", enabled: true });
+	}
+
+	for (const provider of ctx.context.socialProviders) {
+		providers.push({
+			id: provider.id,
+			enabled: true,
+			redirectUri: resolveSocialProviderRedirectUri(ctx.context, provider.id),
+		});
+	}
+
+	const jwtOptions = getJwtPluginOptions(ctx.context);
+
+	return {
+		issuer: jwtOptions?.jwt?.issuer ?? ctx.context.baseURL,
+		providers,
+	};
+}
+
+/** Public discovery for login UIs — which auth methods are enabled on this server. */
+export const getOAuthProviders = createAuthEndpoint(
+	"/.well-known/oauth-providers",
+	{
+		method: "GET",
+		metadata: {
+			...HIDE_METADATA,
+			openapi: {
+				description:
+					"Lists enabled login methods (email/password and social providers) for client UI discovery.",
+				responses: {
+					"200": {
+						description: "Enabled login methods",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										issuer: { type: "string" },
+										providers: {
+											type: "array",
+											items: {
+												type: "object",
+												properties: {
+													id: { type: "string" },
+													enabled: { type: "boolean" },
+													redirectUri: { type: "string" },
+												},
+												required: ["id", "enabled"],
+											},
+										},
+									},
+									required: ["issuer", "providers"],
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	async (ctx) => {
+		return ctx.json(buildOAuthProvidersResponse(ctx));
+	},
+);

--- a/packages/better-auth/src/api/routes/oauth-providers.ts
+++ b/packages/better-auth/src/api/routes/oauth-providers.ts
@@ -28,15 +28,30 @@ function resolveSocialProviderRedirectUri(
 	ctx: AuthContext,
 	providerId: string,
 ): string {
-	const providerConfig = ctx.options.socialProviders?.[providerId];
-	if (
-		providerConfig &&
-		typeof providerConfig === "object" &&
-		"redirectURI" in providerConfig &&
-		typeof providerConfig.redirectURI === "string" &&
-		providerConfig.redirectURI.length > 0
-	) {
-		return providerConfig.redirectURI;
+	const configs = ctx.options.socialProviders;
+	if (!configs) {
+		return `${ctx.baseURL}/callback/${providerId}`;
+	}
+
+	for (const [key, originalConfig] of Object.entries(configs)) {
+		if (key !== providerId) {
+			continue;
+		}
+
+		const providerConfig =
+			typeof originalConfig === "function" ? undefined : originalConfig;
+
+		if (
+			providerConfig &&
+			typeof providerConfig === "object" &&
+			"redirectURI" in providerConfig &&
+			typeof providerConfig.redirectURI === "string" &&
+			providerConfig.redirectURI.length > 0
+		) {
+			return providerConfig.redirectURI;
+		}
+
+		break;
 	}
 
 	return `${ctx.baseURL}/callback/${providerId}`;


### PR DESCRIPTION
## Summary
- Expose `GET /.well-known/oauth-providers` so login clients can discover enabled email/social providers, issuer, and IdP redirect URIs from runtime config.
- Includes docs and a typing fix for dynamic social provider id lookup.

## Test plan
- [ ] Unit tests in `oauth-providers.test.ts` pass
- [ ] Manual: configure social providers and confirm discovery JSON lists them with redirect URIs
- [ ] Confirm OpenAPI snapshot updates if required by CI


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public discovery endpoint so login UIs can dynamically render only enabled email/social providers and use the correct callback URIs. Previously there was no discovery; clients relied on manual configuration.

**New Features**
- Exposes `GET {basePath}/.well-known/oauth-providers` that returns `issuer` and a list of enabled providers.
- Includes `redirectUri` for each social provider, honoring any `redirectURI` override or defaulting to `{baseURL}/callback/{providerId}`.
- Uses the JWT plugin’s `issuer` when configured; otherwise falls back to `baseURL`.
- Lists email only when `emailAndPassword.enabled` is true; other plugin methods are not included.
- Adds docs, OpenAPI schema, and tests for the endpoint.

**Bug Fixes**
- Resolves social provider config via `Object.entries` to support dynamic provider IDs without type errors.

<sup>Written for commit f6722fba38403c1ef5201514d066e5e7704db2f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

