### PR TITLE
feat: Flutter / Dart client integration

### DIFF
--- a/.changeset/add-flutter-integration.md
+++ b/.changeset/add-flutter-integration.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/flutter": patch
+---
+
+Add Flutter / Dart client integration with a server plugin for origin override, OAuth proxy deep links, session persistence, session handoff helpers, and common client plugins.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,6 +15,7 @@
       "@better-auth/drizzle-adapter",
       "@better-auth/electron",
       "@better-auth/expo",
+      "@better-auth/flutter",
       "@better-auth/i18n",
       "@better-auth/kysely-adapter",
       "@better-auth/mcp",

--- a/.changeset/flutter-loopback-cookie.md
+++ b/.changeset/flutter-loopback-cookie.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/flutter": patch
+---
+
+Append session cookie to loopback HTTP OAuth redirects for desktop Flutter clients using `http://localhost` callbacks.

--- a/.cspell/third-party.txt
+++ b/.cspell/third-party.txt
@@ -44,6 +44,7 @@ tldts
 headimgurl
 encoredev
 korthout
+dorny
 esac
 elif
 zitadel

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,7 @@
 # ── Platform ──
 /packages/expo/                                    @better-auth/platform
 /packages/electron/                                @better-auth/platform
+/packages/flutter/                                 @better-auth/platform
 /packages/better-auth/src/integrations/            @better-auth/platform
 
 # ── Documentation ──

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -92,6 +92,7 @@ platform:
     - any-glob-to-any-file:
       - 'packages/expo/**'
       - 'packages/electron/**'
+      - 'packages/flutter/**'
       - 'packages/better-auth/src/integrations/**'
 
 devtools:

--- a/.github/scripts/lib/pr-analyzer.ts
+++ b/.github/scripts/lib/pr-analyzer.ts
@@ -75,6 +75,7 @@ const SCOPE_TO_DOMAIN: Record<string, string> = {
 	// platform
 	expo: "platform",
 	electron: "platform",
+	flutter: "platform",
 
 	// devtools
 	cli: "devtools",
@@ -135,6 +136,7 @@ const PATH_TO_DOMAIN: [string, string][] = [
 	["packages/memory-adapter/", "database"],
 	["packages/expo/", "platform"],
 	["packages/electron/", "platform"],
+	["packages/flutter/", "platform"],
 	["packages/better-auth/src/integrations/", "platform"],
 	["packages/cli/", "devtools"],
 	["packages/better-auth/src/plugins/open-api/", "devtools"],
@@ -263,6 +265,7 @@ const SCOPE_TO_PACKAGE: Record<string, string> = {
 	"api-key": "@better-auth/api-key",
 	expo: "@better-auth/expo",
 	electron: "@better-auth/electron",
+	flutter: "@better-auth/flutter",
 	i18n: "@better-auth/i18n",
 	"test-utils": "@better-auth/test-utils",
 	"drizzle-adapter": "@better-auth/drizzle-adapter",
@@ -288,6 +291,7 @@ const PATH_TO_PACKAGE: [string, string][] = [
 	["packages/api-key/", "@better-auth/api-key"],
 	["packages/expo/", "@better-auth/expo"],
 	["packages/electron/", "@better-auth/electron"],
+	["packages/flutter/", "@better-auth/flutter"],
 	["packages/i18n/", "@better-auth/i18n"],
 	["packages/redis-storage/", "@better-auth/redis-storage"],
 	["packages/test-utils/", "@better-auth/test-utils"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,85 @@ env:
   BETTER_AUTH_TELEMETRY_ENDPOINT: ${{ vars.BETTER_AUTH_TELEMETRY_ENDPOINT }}
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      js: ${{ steps.filter.outputs.js }}
+      flutter: ${{ steps.filter.outputs.flutter }}
+      docs: ${{ steps.filter.outputs.docs }}
+      infra: ${{ steps.filter.outputs.infra }}
+      # Full Node package CI (build/typecheck/test matrix)
+      node_ci: ${{ steps.flags.outputs.node_ci }}
+      # Any workflow work needed at all
+      any: ${{ steps.flags.outputs.any }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            js:
+              - 'packages/**'
+              - '!packages/flutter/**'
+              - 'test/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - 'turbo.json'
+              - 'tsconfig.json'
+              - 'tsconfig.base.json'
+              - 'tsconfig.dist-check.json'
+              - 'biome.json'
+              - 'vitest*.ts'
+              - 'docker-compose.yml'
+            flutter:
+              - 'packages/flutter/**'
+            docs:
+              - 'docs/**'
+            infra:
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/e2e.yml'
+              - '.github/workflows/demo.yml'
+              - '.github/workflows/preview.yml'
+              - '.github/actions/**'
+              - 'lefthook.yml'
+              - 'biome.json'
+              - 'turbo.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+
+      - id: flags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          JS: ${{ steps.filter.outputs.js }}
+          FLUTTER: ${{ steps.filter.outputs.flutter }}
+          DOCS: ${{ steps.filter.outputs.docs }}
+          INFRA: ${{ steps.filter.outputs.infra }}
+        run: |
+          # Always run full Node CI on push / merge_group (branch protection safety net).
+          if [ "$EVENT_NAME" != "pull_request" ] || [ "$JS" = "true" ] || [ "$INFRA" = "true" ]; then
+            echo "node_ci=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "node_ci=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "$EVENT_NAME" != "pull_request" ] || [ "$JS" = "true" ] || [ "$FLUTTER" = "true" ] || [ "$DOCS" = "true" ] || [ "$INFRA" = "true" ]; then
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
     runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'better-auth/better-auth' || github.event_name != 'pull_request' && github.repository == 'better-auth/better-auth') && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
@@ -33,6 +111,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache turbo build setup
+        if: needs.changes.outputs.node_ci == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .turbo
@@ -52,6 +131,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
+        if: needs.changes.outputs.node_ci == 'true'
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
@@ -64,12 +144,14 @@ jobs:
         run: pnpm lint
 
       - name: Lint Dependencies
+        if: needs.changes.outputs.node_ci == 'true'
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
         run: pnpm lint:dependencies
 
       - name: Lint Packages
+        if: needs.changes.outputs.node_ci == 'true'
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
@@ -85,12 +167,15 @@ jobs:
         run: pnpm format:check
 
       - name: Lint Types
+        if: needs.changes.outputs.node_ci == 'true'
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
         run: pnpm lint:types
 
   typecheck:
+    needs: changes
+    if: needs.changes.outputs.node_ci == 'true'
     runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'better-auth/better-auth' || github.event_name != 'pull_request' && github.repository == 'better-auth/better-auth') && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
@@ -135,6 +220,8 @@ jobs:
         run: pnpm typecheck:dist
 
   test:
+    needs: changes
+    if: needs.changes.outputs.node_ci == 'true'
     runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'better-auth/better-auth' || github.event_name != 'pull_request' && github.repository == 'better-auth/better-auth') && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
@@ -198,11 +285,61 @@ jobs:
         if: always() && hashFiles('docker-compose.yml') != ''
         run: docker compose down --volumes --remove-orphans
 
+  flutter:
+    name: Flutter / Dart
+    needs: changes
+    if: needs.changes.outputs.flutter == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-flutter-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+        with:
+          sdk: "3.5.0"
+
+      - name: Resolve Dart dependencies
+        working-directory: packages/flutter/dart
+        run: dart pub get
+
+      - name: Analyze Dart
+        working-directory: packages/flutter/dart
+        run: dart analyze --fatal-infos
+
+      - name: Test Dart
+        working-directory: packages/flutter/dart
+        run: dart test
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - name: Install JS workspace (flutter server plugin tests)
+        run: pnpm install --frozen-lockfile
+
+      - name: Build flutter package dependencies
+        run: pnpm --filter @better-auth/flutter... build
+
+      - name: Test @better-auth/flutter
+        run: pnpm --filter @better-auth/flutter exec vitest run
+
   ci:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test]
+    needs: [changes, lint, typecheck, test, flutter]
     if: always()
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
+          # Path filters intentionally skip unrelated heavy jobs.
+          allowed-skips: changes, lint, typecheck, test, flutter
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -16,7 +16,48 @@ env:
   TURBO_TEAM: ${{ vars.TURBO_TEAM || github.repository_owner }}
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      demo: ${{ steps.flags.outputs.demo }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            demo_paths:
+              - 'demo/**'
+              - 'packages/**'
+              - '!packages/flutter/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - 'turbo.json'
+              - '.github/workflows/demo.yml'
+
+      - id: flags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MATCH: ${{ steps.filter.outputs.demo_paths }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ] || [ "$MATCH" = "true" ]; then
+            echo "demo=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "demo=false" >> "$GITHUB_OUTPUT"
+          fi
+
   demo:
+    needs: changes
+    if: needs.changes.outputs.demo == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,8 +17,52 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      e2e: ${{ steps.flags.outputs.e2e }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            e2e_paths:
+              - 'packages/**'
+              - '!packages/flutter/**'
+              - 'e2e/**'
+              - 'test/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - 'turbo.json'
+              - 'docker-compose.yml'
+              - '.github/workflows/e2e.yml'
+              - '.github/actions/**'
+
+      - id: flags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MATCH: ${{ steps.filter.outputs.e2e_paths }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ] || [ "$MATCH" = "true" ]; then
+            echo "e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
   smoke:
     name: Smoke test (${{ matrix.node-version }})
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true'
     timeout-minutes: 30
     runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'better-auth/better-auth' || github.event_name != 'pull_request' && github.repository == 'better-auth/better-auth') && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     strategy:
@@ -88,8 +132,11 @@ jobs:
       - name: Stop Docker Containers
         if: always() && hashFiles('docker-compose.yml') != ''
         run: docker compose down --volumes --remove-orphans
+
   integration:
     name: Integration test
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true'
     timeout-minutes: 60
     runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'better-auth/better-auth' || github.event_name != 'pull_request' && github.repository == 'better-auth/better-auth') && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
@@ -170,8 +217,11 @@ jobs:
       - name: Stop Docker Containers
         if: always() && hashFiles('docker-compose.yml') != ''
         run: docker compose down --volumes --remove-orphans
+
   adapter-integration:
     name: ${{ matrix.packages }} Integration Test
+    needs: changes
+    if: needs.changes.outputs.e2e == 'true'
     runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'better-auth/better-auth' || github.event_name != 'pull_request' && github.repository == 'better-auth/better-auth') && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     timeout-minutes: 30
     permissions:
@@ -279,9 +329,10 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [smoke, integration, adapter-integration]
+    needs: [changes, smoke, integration, adapter-integration]
     if: always()
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
+          allowed-skips: changes, smoke, integration, adapter-integration
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      packages: ${{ steps.filter.outputs.packages }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            packages:
+              - 'packages/**'
+              - '!packages/flutter/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - 'turbo.json'
+              - '.github/workflows/preview.yml'
+
   build:
+    needs: changes
+    # pkg-pr-new requires the GitHub App on the repo (upstream better-auth only).
+    # Skip on forks / private mirrors to avoid 404 failures and wasted builds.
+    if: >
+      needs.changes.outputs.packages == 'true' &&
+      github.repository == 'better-auth/better-auth'
     runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'better-auth/better-auth' || github.event_name != 'pull_request' && github.repository == 'better-auth/better-auth') && 'starsling-ubuntu-24.04' || 'ubuntu-24.04' }}
     permissions:
       contents: read
@@ -39,11 +72,33 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
-      
+
       - name: Install
         run: pnpm install
 
       - name: Build
         run: pnpm build
-          
+
       - run: pnpm dlx pkg-pr-new publish --pnpm './packages/*'
+
+  # Keep the workflow green on forks where pkg-pr-new is not installed.
+  preview:
+    needs: [changes, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report status
+        env:
+          CHANGES: ${{ needs.changes.outputs.packages }}
+          BUILD: ${{ needs.build.result }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "packages changed: $CHANGES"
+          echo "build result: ${BUILD:-skipped}"
+          echo "repository: $REPO"
+          if [ "$REPO" != "better-auth/better-auth" ]; then
+            echo "pkg-pr-new publish skipped (GitHub App not required on this fork)."
+          fi
+          if [ "$BUILD" = "failure" ] || [ "$BUILD" = "cancelled" ]; then
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,6 @@ state.txt
 .claude/worktrees
 
 .deepsec
+
+# Dart / Flutter tooling
+.dart_tool/

--- a/biome.json
+++ b/biome.json
@@ -147,7 +147,9 @@
       "!**/.output",
       "!**/.tmp",
       "!**/tmp-docs-fetch",
-      "!**/.claude/worktrees/**"
+      "!**/.claude/worktrees/**",
+      "!**/.dart_tool",
+      "!**/packages/flutter/dart/.dart_tool/**"
     ]
   }
 }

--- a/docs/components/sidebar-content.tsx
+++ b/docs/components/sidebar-content.tsx
@@ -1569,6 +1569,11 @@ C0.7,239.6,62.1,0.5,62.2,0.4c0,0,54,13.8,119.9,30.8S302.1,62,302.2,62c0.2,0,0.2,
 				href: "/docs/integrations/expo",
 			},
 			{
+				title: "Flutter",
+				icon: Icons.expo,
+				href: "/docs/integrations/flutter",
+			},
+			{
 				title: "Lynx",
 				icon: Icons.lynx,
 				href: "/docs/integrations/lynx",

--- a/docs/content/docs/integrations/flutter.mdx
+++ b/docs/content/docs/integrations/flutter.mdx
@@ -1,0 +1,251 @@
+---
+title: Flutter Integration
+description: Integrate Better Auth with Flutter and Dart.
+---
+
+Flutter is a cross-platform UI toolkit for building apps for Android, iOS, web, and desktop from a single Dart codebase. Better Auth supports Flutter clients talking to a Better Auth backend over HTTP.
+
+## Installation
+
+<Steps>
+  <Step>
+    ## Configure a Better Auth Backend
+
+    Before using Better Auth with Flutter, make sure you have a Better Auth backend set up.
+
+    To get started, check out our [installation](/docs/installation) guide.
+  </Step>
+
+  <Step>
+    ## Install Server Dependencies
+
+    Install Better Auth and the Flutter server plugin from GitHub (git release branches):
+
+    ```json title="package.json"
+    {
+      "dependencies": {
+        "better-auth": "github:2keyapp/better-auth#release",
+        "@better-auth/flutter": "github:2keyapp/better-auth#release-flutter"
+      }
+    }
+    ```
+  </Step>
+
+  <Step>
+    ## Install Client Dependencies
+
+    Add the Dart client from the same GitHub repository:
+
+    ```yaml title="pubspec.yaml"
+    dependencies:
+      better_auth:
+        git:
+          url: https://github.com/2keyapp/better-auth.git
+          ref: main # or a release tag / commit
+          path: packages/flutter/dart
+    ```
+
+    Prefer `flutter_secure_storage` (or similar) for production storage — inject it via `AuthStorage`.
+  </Step>
+
+  <Step>
+    ## Add the Flutter Plugin on Your Server
+
+    ```ts title="lib/auth.ts"
+    import { betterAuth } from "better-auth";
+    import { flutter } from "@better-auth/flutter";
+
+    export const auth = betterAuth({
+        plugins: [flutter()],
+        emailAndPassword: {
+            enabled: true
+        },
+        // Replace "myapp" with your Flutter deep-link scheme
+        trustedOrigins: ["myapp://"]
+    });
+    ```
+  </Step>
+
+  <Step>
+    ## Scheme and Trusted Origins
+
+    Better Auth uses deep links to redirect users back to your app after authentication. Add your app's scheme to `trustedOrigins`.
+
+    ```ts title="auth.ts"
+    export const auth = betterAuth({
+        trustedOrigins: ["myapp://"]
+    })
+    ```
+
+    Register the same scheme in your Flutter app (Android intent filters / iOS URL types, or packages such as `app_links`).
+  </Step>
+
+  <Step>
+    ## Initialize the Dart Client
+
+    ```dart title="lib/auth_client.dart"
+    import 'package:better_auth/better_auth.dart';
+
+    final storage = MemoryAuthStorage(); // use secure storage in production
+
+    final authClient = createAuthClient(
+      baseUrl: 'https://api.example.com',
+      plugin: flutterClient(
+        FlutterClientOptions(
+          scheme: 'myapp',
+          storage: storage,
+          storagePrefix: 'myapp',
+          // Required for social / OAuth sign-in (e.g. wrap flutter_web_auth_2)
+          sessionLauncher: myAuthSessionLauncher,
+        ),
+      ),
+    );
+    ```
+
+    Prefer `flutter_secure_storage` (or similar) for production storage — inject it via `AuthStorage`.
+  </Step>
+</Steps>
+
+## Usage
+
+### Email and password
+
+```dart
+await authClient.signUpEmail(
+  email: 'user@example.com',
+  password: 'password1234',
+  name: 'Jane Doe',
+);
+
+await authClient.signInEmail(
+  email: 'user@example.com',
+  password: 'password1234',
+);
+
+final session = await authClient.getSession();
+print(session.data?.user.email);
+
+await authClient.signOut();
+```
+
+Use `authClient.getCookie()` when calling your own backend APIs that expect the Better Auth session cookie.
+
+### Social sign-in
+
+Provide a `sessionLauncher` that opens an auth session in the system / in-app browser and returns the redirect URL (for example via `flutter_web_auth_2`). Relative `callbackURL` values are converted to deep links using your scheme.
+
+```dart
+await authClient.signInSocial(
+  provider: 'google',
+  callbackURL: '/dashboard',
+);
+```
+
+After a successful social sign-in, the Flutter plugin persists the session cookie from the deep-link callback and refreshes the local session.
+
+### Session refresh
+
+```dart
+final authClient = createAuthClient(
+  baseUrl: 'https://api.example.com',
+  plugin: flutterClient(...),
+  sessionOptions: SessionOptions(
+    refetchInterval: Duration(minutes: 5),
+    refetchOnAppResume: true,
+  ),
+);
+
+// Call when your app returns to the foreground (e.g. WidgetsBindingObserver).
+authClient.onAppResumed();
+```
+
+### Client plugins
+
+Pass optional client plugins via `plugins` (same idea as the TypeScript client). Common helpers:
+
+```dart
+final storage = MemoryAuthStorage();
+
+final authClient = createAuthClient(
+  baseUrl: 'https://api.example.com',
+  plugin: flutterClient(
+    FlutterClientOptions(scheme: 'myapp', storage: storage),
+  ),
+  plugins: [
+    lastLoginMethodClient(
+      LastLoginMethodOptions(storage: storage, storagePrefix: 'myapp'),
+    ),
+    organizationClient(),
+    twoFactorClient(
+      TwoFactorClientOptions(
+        onTwoFactorRedirect: ({twoFactorMethods}) async {
+          // Navigate to your 2FA screen.
+        },
+      ),
+    ),
+  ],
+);
+
+// Last login method
+await authClient.lastLoginMethod?.getLastUsedLoginMethod();
+
+// Organization
+await authClient.organization?.create(name: 'Acme', slug: 'acme');
+await authClient.organization?.list();
+await authClient.organization?.setActive(organizationSlug: 'acme');
+
+// Two-factor
+await authClient.twoFactor?.verifyTotp(code: '123456');
+```
+
+Enable matching server plugins (`organization`, `twoFactor`, `lastLoginMethod`) in your Better Auth config. See the [organization](/docs/plugins/organization), [two-factor](/docs/plugins/2fa), and [last login method](/docs/plugins/last-login-method) docs.
+
+## Session handoff (Flutter → web)
+
+Native apps and browsers store cookies separately, so a Flutter session is not visible to a web app on its own. Use a **session handoff**: the app mints a short-lived one-time token from the existing session, opens the web URL with that token, and the browser verifies it to establish its own cookie.
+
+This is the usual pattern for “continue in browser”, app → web upgrades, and other native-to-web flows. Better Auth provides it via the [one-time-token](/docs/plugins/one-time-token) plugin.
+
+### 1. Enable the plugin on your server
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth";
+import { flutter } from "@better-auth/flutter";
+import { oneTimeToken } from "better-auth/plugins/one-time-token";
+
+export const auth = betterAuth({
+  plugins: [flutter(), oneTimeToken()],
+  trustedOrigins: ["myapp://", "https://app.example.com"],
+});
+```
+
+### 2. Create a handoff URL in Flutter
+
+```dart
+final result = await authClient.createSessionHandoffUrl(
+  targetUrl: 'https://app.example.com/auth/handoff',
+);
+// Open `result.data` with url_launcher (or equivalent).
+```
+
+`createSessionHandoffUrl` calls `/one-time-token/generate` with the Flutter session cookie and appends `?token=...` to `targetUrl`.
+
+### 3. Verify on the web and establish a browser session
+
+On the receiving web page, call the Better Auth client (or a server route that wraps it):
+
+```ts title="app/auth/handoff/page.tsx"
+import { authClient } from "@/lib/auth-client";
+
+// token from the URL search params
+await authClient.oneTimeToken.verify({
+  token,
+});
+// Browser now has a Better Auth session cookie — redirect into the app.
+```
+
+<Callout type="info">
+  Tokens expire quickly (default: 3 minutes) and are single-use. Prefer HTTPS handoff URLs and avoid putting long-lived credentials in the query string.
+</Callout>
+
+If both surfaces are **browsers** on the same parent domain (not a native Flutter app), you can share cookies with [crossSubDomainCookies](/docs/concepts/cookies#cross-subdomain-cookies) instead of a session handoff.

--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @better-auth/flutter
+
+## 1.6.23
+
+### Patch Changes
+
+- Initial Flutter / Dart integration server plugin.

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -1,0 +1,52 @@
+# Better Auth Flutter Plugin
+
+Server-side Better Auth plugin for Flutter and Dart clients.
+
+The Dart client SDK lives at `packages/flutter/dart` and is consumed via
+GitHub (`path: packages/flutter/dart`). This npm package is the TypeScript
+server plugin (`@better-auth/flutter`).
+
+## Installation
+
+Install from the git release branches:
+
+```json
+{
+  "dependencies": {
+    "better-auth": "github:2keyapp/better-auth#release",
+    "@better-auth/flutter": "github:2keyapp/better-auth#release-flutter"
+  }
+}
+```
+
+## Basic Usage
+
+```ts
+import { betterAuth } from "better-auth";
+import { flutter } from "@better-auth/flutter";
+
+export const auth = betterAuth({
+  plugins: [flutter()],
+  emailAndPassword: {
+    enabled: true,
+  },
+  // Replace "myapp" with your Flutter deep-link scheme
+  trustedOrigins: ["myapp://"],
+});
+```
+
+The Dart client should send a `flutter-origin` header (e.g. `myapp://`) on
+authenticated requests so the plugin can satisfy origin checks.
+
+For **session handoff** (Flutter → web while already signed in), use the
+[one-time-token](https://www.better-auth.com/docs/plugins/one-time-token)
+plugin — see the [Flutter integration guide](https://www.better-auth.com/docs/integrations/flutter).
+
+## Documentation
+
+* **Flutter Integration Guide:** [Flutter Integration Guide](https://www.better-auth.com/docs/integrations/flutter)
+* **Main Better Auth Installation:** [Installation Guide](https://www.better-auth.com/docs/installation)
+
+## License
+
+MIT

--- a/packages/flutter/dart/.gitignore
+++ b/packages/flutter/dart/.gitignore
@@ -1,0 +1,8 @@
+# Dart tooling
+.dart_tool/
+.packages
+build/
+pubspec.lock
+**/doc/api/
+*.iml
+.idea/

--- a/packages/flutter/dart/analysis_options.yaml
+++ b/packages/flutter/dart/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    public_member_api_docs: false

--- a/packages/flutter/dart/lib/better_auth.dart
+++ b/packages/flutter/dart/lib/better_auth.dart
@@ -1,0 +1,9 @@
+/// Better Auth client SDK for Dart and Flutter.
+library;
+
+export 'src/client.dart';
+export 'src/cookies.dart';
+export 'src/models.dart';
+export 'src/plugins/plugins.dart';
+export 'src/session_refresh.dart';
+export 'src/storage.dart';

--- a/packages/flutter/dart/lib/src/client.dart
+++ b/packages/flutter/dart/lib/src/client.dart
@@ -1,0 +1,456 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'models.dart';
+import 'plugins/flutter_client.dart';
+import 'plugins/last_login_method.dart';
+import 'plugins/organization.dart';
+import 'plugins/plugin.dart';
+import 'plugins/two_factor.dart';
+import 'session_refresh.dart';
+
+export 'session_refresh.dart' show SessionOptions;
+
+/// Creates a Better Auth client for Dart / Flutter.
+AuthClient createAuthClient({
+	required String baseUrl,
+	String basePath = '/api/auth',
+	FlutterClientPlugin? plugin,
+	List<AuthClientPlugin> plugins = const [],
+	http.Client? httpClient,
+	SessionOptions sessionOptions = const SessionOptions(),
+	bool Function()? isOnline,
+}) {
+	return AuthClient(
+		baseUrl: baseUrl,
+		basePath: basePath,
+		plugin: plugin,
+		plugins: plugins,
+		httpClient: httpClient,
+		sessionOptions: sessionOptions,
+		isOnline: isOnline,
+	);
+}
+
+final class AuthClient implements AuthRequestClient {
+	AuthClient({
+		required this.baseUrl,
+		this.basePath = '/api/auth',
+		this.plugin,
+		List<AuthClientPlugin> plugins = const [],
+		http.Client? httpClient,
+		SessionOptions sessionOptions = const SessionOptions(),
+		bool Function()? isOnline,
+	})  : _http = httpClient ?? http.Client(),
+				_sessionOptions = sessionOptions,
+				_isOnlineOverride = isOnline,
+				_plugins = List<AuthClientPlugin>.unmodifiable(plugins) {
+		_refresh = SessionRefreshManager(
+			fetchSession: () async {
+				await getSession();
+			},
+			options: sessionOptions,
+			isOnline: () => this.isOnline,
+		);
+		_refresh.start();
+		for (final p in _plugins) {
+			p.attach(this);
+		}
+	}
+
+	final String baseUrl;
+	final String basePath;
+	final FlutterClientPlugin? plugin;
+	final List<AuthClientPlugin> _plugins;
+	final http.Client _http;
+	final SessionOptions _sessionOptions;
+	final bool Function()? _isOnlineOverride;
+	late final SessionRefreshManager _refresh;
+
+	final _sessionController = StreamController<SessionData?>.broadcast();
+	SessionData? _session;
+	bool _isOnline = true;
+
+	/// Current session snapshot (may be null).
+	SessionData? get session => _session;
+
+	/// Stream of session changes.
+	Stream<SessionData?> get sessionStream => _sessionController.stream;
+
+	SessionOptions get sessionOptions => _sessionOptions;
+
+	List<AuthClientPlugin> get plugins => _plugins;
+
+	/// Online state used by session refresh. Update via [setOnline].
+	bool get isOnline => _isOnlineOverride?.call() ?? _isOnline;
+
+	void setOnline(bool value) {
+		_isOnline = value;
+	}
+
+	/// Call when the Flutter app returns to the foreground.
+	void onAppResumed() => _refresh.onAppResumed();
+
+	/// First plugin of type [T], if registered.
+	T? pluginOf<T extends AuthClientPlugin>() {
+		for (final p in _plugins) {
+			if (p is T) return p;
+		}
+		return null;
+	}
+
+	OrganizationPlugin? get organization => pluginOf<OrganizationPlugin>();
+
+	TwoFactorPlugin? get twoFactor => pluginOf<TwoFactorPlugin>();
+
+	LastLoginMethodPlugin? get lastLoginMethod =>
+			pluginOf<LastLoginMethodPlugin>();
+
+	Uri get _authBase {
+		final root = baseUrl.endsWith('/')
+				? baseUrl.substring(0, baseUrl.length - 1)
+				: baseUrl;
+		final prefix = basePath.startsWith('/') ? basePath : '/$basePath';
+		return Uri.parse('$root$prefix');
+	}
+
+	Uri _resolve(String path, [Map<String, String>? query]) {
+		final suffix = path.startsWith('/') ? path : '/$path';
+		final uri = Uri.parse('$_authBase$suffix');
+		if (query == null || query.isEmpty) return uri;
+		return uri.replace(queryParameters: {
+			...uri.queryParameters,
+			...query,
+		});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> signInEmail({
+		required String email,
+		required String password,
+		bool rememberMe = true,
+	}) {
+		return postJson('/sign-in/email', {
+			'email': email,
+			'password': password,
+			'rememberMe': rememberMe,
+		}, refreshSession: true);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> signUpEmail({
+		required String email,
+		required String password,
+		required String name,
+	}) {
+		return postJson('/sign-up/email', {
+			'email': email,
+			'password': password,
+			'name': name,
+		}, refreshSession: true);
+	}
+
+	/// Social / OAuth sign-in via the Flutter authorization proxy + session launcher.
+	Future<AuthResponse<Map<String, Object?>>> signInSocial({
+		required String provider,
+		String callbackURL = '/',
+		String? idToken,
+		String? accessToken,
+		Map<String, Object?>? extra,
+	}) async {
+		final body = <String, Object?>{
+			'provider': provider,
+			'callbackURL': callbackURL,
+			if (idToken != null) 'idToken': idToken,
+			if (accessToken != null) 'accessToken': accessToken,
+			...?extra,
+		};
+
+		if (idToken != null || accessToken != null) {
+			return postJson('/sign-in/social', body, refreshSession: true);
+		}
+
+		final flutterPlugin = plugin;
+		if (flutterPlugin == null) {
+			return const AuthResponse(
+				error: AuthError(
+					message:
+							'flutterClient plugin is required for social browser sign-in',
+				),
+			);
+		}
+
+		final resolvedCallback =
+				flutterPlugin.resolveCallbackUrl(callbackURL).toString();
+		body['callbackURL'] = resolvedCallback;
+
+		final result = await postJson('/sign-in/social', body);
+		if (result.error != null) return result;
+
+		final data = result.data ?? {};
+		final redirect = data['redirect'] == true;
+		final url = data['url'] as String?;
+		if (!redirect || url == null || url.isEmpty) {
+			await getSession();
+			return result;
+		}
+
+		try {
+			final captured = await flutterPlugin.completeSocialRedirect(
+				signInUrl: url,
+				authBaseUrl: _authBase.toString(),
+				callbackURL: resolvedCallback,
+			);
+			if (captured) {
+				await getSession();
+			}
+			return AuthResponse(
+				data: {
+					...data,
+					'cookieCaptured': captured,
+				},
+			);
+		} catch (e) {
+			return AuthResponse(
+				error: AuthError(message: e.toString(), raw: e),
+			);
+		}
+	}
+
+	Future<AuthResponse<void>> signOut() async {
+		final result = await postJson('/sign-out', {});
+		_setSession(null);
+		await plugin?.clearSessionCache();
+		if (result.error != null) {
+			return AuthResponse(error: result.error);
+		}
+		return const AuthResponse();
+	}
+
+	Future<AuthResponse<SessionData?>> getSession() async {
+		final uri = _resolve('/get-session');
+		final headers = await _headers(json: false);
+		final response = await _http.get(uri, headers: headers);
+		await _notifyPlugins(uri, response);
+		_refresh.markSessionFetched();
+
+		if (response.statusCode >= 400) {
+			return AuthResponse(error: _errorFromResponse(response));
+		}
+		if (response.body.isEmpty || response.body == 'null') {
+			_setSession(null);
+			return const AuthResponse(data: null);
+		}
+		try {
+			final json =
+					jsonDecode(response.body) as Map<String, Object?>? ?? {};
+			if (json.isEmpty || json['session'] == null) {
+				_setSession(null);
+				return const AuthResponse(data: null);
+			}
+			final data = SessionData.fromJson(json);
+			_setSession(data);
+			return AuthResponse(data: data);
+		} catch (e) {
+			return AuthResponse(
+				error: AuthError(message: 'Failed to parse session', raw: e),
+			);
+		}
+	}
+
+	/// Generates a one-time token for the current session.
+	Future<AuthResponse<String>> generateOneTimeToken() async {
+		final uri = _resolve('/one-time-token/generate');
+		final headers = await _headers(json: false);
+		final response = await _http.get(uri, headers: headers);
+		await _notifyPlugins(uri, response);
+
+		if (response.statusCode >= 400) {
+			return AuthResponse(error: _errorFromResponse(response));
+		}
+		try {
+			final json =
+					jsonDecode(response.body) as Map<String, Object?>? ?? {};
+			final token = json['token'] as String?;
+			if (token == null || token.isEmpty) {
+				return const AuthResponse(
+					error: AuthError(message: 'Missing token in response'),
+				);
+			}
+			return AuthResponse(data: token);
+		} catch (e) {
+			return AuthResponse(
+				error: AuthError(message: 'Failed to parse token', raw: e),
+			);
+		}
+	}
+
+	/// Builds a session-handoff URL: `{targetUrl}?token=...`.
+	Future<AuthResponse<Uri>> createSessionHandoffUrl({
+		required String targetUrl,
+		String tokenQueryParam = 'token',
+	}) async {
+		final tokenResult = await generateOneTimeToken();
+		if (tokenResult.error != null || tokenResult.data == null) {
+			return AuthResponse(error: tokenResult.error);
+		}
+		final base = Uri.parse(targetUrl);
+		final handoff = base.replace(
+			queryParameters: {
+				...base.queryParameters,
+				tokenQueryParam: tokenResult.data!,
+			},
+		);
+		return AuthResponse(data: handoff);
+	}
+
+	/// Cookie header for your own authenticated API calls.
+	Future<String> getCookie() async {
+		return plugin?.getCookie() ?? '';
+	}
+
+	@override
+	Future<void> refreshSession() async {
+		await getSession();
+	}
+
+	@override
+	Future<AuthResponse<Map<String, Object?>>> postJson(
+		String path,
+		Map<String, Object?> body, {
+		bool refreshSession = false,
+	}) async {
+		final uri = _resolve(path);
+		final headers = await _headers(json: true);
+		final response = await _http.post(
+			uri,
+			headers: headers,
+			body: jsonEncode(body),
+		);
+		await _notifyPlugins(uri, response);
+
+		if (response.statusCode >= 400) {
+			return AuthResponse(error: _errorFromResponse(response));
+		}
+
+		final data = _decodeMap(response.body);
+		final shouldRefresh = refreshSession ||
+				_plugins.any((p) => p.triggersSessionRefresh(path));
+		if (shouldRefresh) {
+			await getSession();
+		}
+
+		return AuthResponse(data: data);
+	}
+
+	@override
+	Future<AuthResponse<Map<String, Object?>>> getJson(
+		String path, {
+		Map<String, String>? query,
+		bool refreshSession = false,
+	}) async {
+		final uri = _resolve(path, query);
+		final headers = await _headers(json: false);
+		final response = await _http.get(uri, headers: headers);
+		await _notifyPlugins(uri, response);
+
+		if (response.statusCode >= 400) {
+			return AuthResponse(error: _errorFromResponse(response));
+		}
+
+		final data = _decodeMap(response.body);
+		final shouldRefresh = refreshSession ||
+				_plugins.any((p) => p.triggersSessionRefresh(path));
+		if (shouldRefresh) {
+			await getSession();
+		}
+		return AuthResponse(data: data);
+	}
+
+	Map<String, Object?> _decodeMap(String body) {
+		if (body.isEmpty) return {};
+		try {
+			final decoded = jsonDecode(body);
+			if (decoded is Map<String, Object?>) return decoded;
+			if (decoded is Map) return decoded.cast<String, Object?>();
+		} catch (_) {
+			return {'raw': body};
+		}
+		return {};
+	}
+
+	Future<Map<String, String>> _headers({required bool json}) async {
+		final headers = <String, String>{
+			if (json) 'content-type': 'application/json',
+			'accept': 'application/json',
+		};
+		if (plugin != null) {
+			headers.addAll(await plugin!.requestHeaders());
+		}
+		for (final p in _plugins) {
+			headers.addAll(await p.buildRequestHeaders());
+		}
+		return headers;
+	}
+
+	Future<void> _notifyPlugins(Uri uri, http.Response response) async {
+		final headers = <String, String>{};
+		response.headers.forEach((key, value) {
+			headers[key.toLowerCase()] = value;
+		});
+
+		Object? body = response.body;
+		try {
+			body = jsonDecode(response.body);
+		} catch (_) {}
+
+		if (plugin != null) {
+			await plugin!.onResponse(
+				url: uri,
+				headers: headers,
+				body: response.body,
+			);
+		}
+		for (final p in _plugins) {
+			await p.handleResponse(
+				url: uri,
+				headers: headers,
+				statusCode: response.statusCode,
+				body: body,
+			);
+		}
+	}
+
+	AuthError _errorFromResponse(http.Response response) {
+		String message = response.reasonPhrase ?? 'Request failed';
+		String? code;
+		try {
+			final decoded = jsonDecode(response.body);
+			if (decoded is Map) {
+				message = decoded['message'] as String? ??
+						decoded['error'] as String? ??
+						message;
+				code = decoded['code'] as String?;
+			}
+		} catch (_) {}
+		return AuthError(
+			message: message,
+			code: code,
+			status: response.statusCode,
+			raw: response.body,
+		);
+	}
+
+	void _setSession(SessionData? data) {
+		_session = data;
+		if (!_sessionController.isClosed) {
+			_sessionController.add(data);
+		}
+	}
+
+	Future<void> dispose() async {
+		_refresh.stop();
+		await _sessionController.close();
+		_http.close();
+	}
+}

--- a/packages/flutter/dart/lib/src/cookies.dart
+++ b/packages/flutter/dart/lib/src/cookies.dart
@@ -1,0 +1,247 @@
+import 'dart:convert';
+
+import 'storage.dart';
+
+/// A single cookie entry stored by the client plugin.
+final class StoredCookie {
+	const StoredCookie({required this.value, this.expires});
+
+	final String value;
+	final String? expires;
+
+	Map<String, Object?> toJson() => {
+				'value': value,
+				'expires': expires,
+			};
+
+	factory StoredCookie.fromJson(Map<String, Object?> json) {
+		return StoredCookie(
+			value: json['value'] as String? ?? '',
+			expires: json['expires'] as String?,
+		);
+	}
+}
+
+/// Parses a `Set-Cookie` header into name → attribute map.
+///
+/// Mirrors the subset of cookie attributes needed by Better Auth clients
+/// (`Expires`, `Max-Age`). Multiple cookies may be comma-separated.
+Map<String, Map<String, String?>> parseSetCookieHeader(String header) {
+	final result = <String, Map<String, String?>>{};
+	if (header.trim().isEmpty) return result;
+
+	// Split on commas that precede a new cookie name=value (not date commas).
+	final parts = <String>[];
+	final buffer = StringBuffer();
+	var i = 0;
+	while (i < header.length) {
+		final char = header[i];
+		if (char == ',') {
+			final rest = header.substring(i + 1).trimLeft();
+			final looksLikeNextCookie = RegExp(r'^[A-Za-z0-9_\-.%]+=')
+					.hasMatch(rest);
+			if (looksLikeNextCookie) {
+				parts.add(buffer.toString().trim());
+				buffer.clear();
+				i++;
+				continue;
+			}
+		}
+		buffer.write(char);
+		i++;
+	}
+	final last = buffer.toString().trim();
+	if (last.isNotEmpty) parts.add(last);
+
+	for (final part in parts) {
+		final segments = part.split(';');
+		if (segments.isEmpty) continue;
+		final nameValue = segments.first.split('=');
+		if (nameValue.isEmpty) continue;
+		final name = nameValue.first.trim();
+		if (name.isEmpty) continue;
+		final value =
+				nameValue.length > 1 ? nameValue.sublist(1).join('=').trim() : '';
+		final attrs = <String, String?>{'value': value};
+		for (final segment in segments.skip(1)) {
+			final kv = segment.split('=');
+			final key = kv.first.trim().toLowerCase();
+			final attrValue =
+					kv.length > 1 ? kv.sublist(1).join('=').trim() : null;
+			attrs[key] = attrValue;
+		}
+		result[name] = attrs;
+	}
+	return result;
+}
+
+/// Merges [setCookieHeader] into previously stored cookie JSON.
+///
+/// Cookies with `Max-Age=0` or a past `Expires` are removed.
+String mergeSetCookie(String setCookieHeader, [String? prevCookieJson]) {
+	final parsed = parseSetCookieHeader(setCookieHeader);
+	Map<String, StoredCookie> toSet = {};
+	if (prevCookieJson != null && prevCookieJson.isNotEmpty) {
+		try {
+			final prev =
+					jsonDecode(prevCookieJson) as Map<String, Object?>? ?? {};
+			for (final entry in prev.entries) {
+				final value = entry.value;
+				if (value is Map<String, Object?>) {
+					toSet[entry.key] = StoredCookie.fromJson(value);
+				}
+			}
+		} catch (_) {
+			toSet = {};
+		}
+	}
+
+	for (final entry in parsed.entries) {
+		final attrs = entry.value;
+		final maxAgeRaw = attrs['max-age'];
+		final expiresRaw = attrs['expires'];
+		DateTime? expiresAt;
+		if (maxAgeRaw != null) {
+			final maxAge = int.tryParse(maxAgeRaw);
+			if (maxAge != null) {
+				if (maxAge <= 0) {
+					toSet.remove(entry.key);
+					continue;
+				}
+				expiresAt =
+						DateTime.now().toUtc().add(Duration(seconds: maxAge));
+			}
+		} else if (expiresRaw != null) {
+			expiresAt = DateTime.tryParse(expiresRaw)?.toUtc();
+			if (expiresAt != null && expiresAt.isBefore(DateTime.now().toUtc())) {
+				toSet.remove(entry.key);
+				continue;
+			}
+		}
+		toSet[entry.key] = StoredCookie(
+			value: attrs['value'] ?? '',
+			expires: expiresAt?.toIso8601String(),
+		);
+	}
+
+	return jsonEncode({
+		for (final e in toSet.entries) e.key: e.value.toJson(),
+	});
+}
+
+/// Builds a Cookie request header from stored cookie JSON.
+String buildCookieHeader(String cookieJson) {
+	Map<String, Object?> parsed = {};
+	try {
+		parsed = jsonDecode(cookieJson) as Map<String, Object?>? ?? {};
+	} catch (_) {
+		return '';
+	}
+	final parts = <String>[];
+	for (final entry in parsed.entries) {
+		final value = entry.value;
+		if (value is! Map<String, Object?>) continue;
+		final cookie = StoredCookie.fromJson(value);
+		if (cookie.expires != null) {
+			final exp = DateTime.tryParse(cookie.expires!);
+			if (exp != null && exp.isBefore(DateTime.now().toUtc())) {
+				continue;
+			}
+		}
+		parts.add('${entry.key}=${cookie.value}');
+	}
+	return parts.join('; ');
+}
+
+/// Replaces colons so Keys work with secure stores that reject `:`.
+String normalizeStorageKey(String name) => name.replaceAll(':', '_');
+
+/// Max characters written per `setItem`. Mirrors Expo / server chunking.
+const int storageValueLimit = 1800;
+
+/// Marker for values split across `<key>.0..N` chunks.
+const String chunkMarker = '\u0001ba-chunks:';
+
+/// Storage adapter that chunks oversized values (Keychain / EncryptedSharedPreferences limits).
+final class ChunkedAuthStorage implements AuthStorage {
+	ChunkedAuthStorage(this._inner);
+
+	final AuthStorage _inner;
+
+	@override
+	Future<String?> getItem(String key) async {
+		final normalized = normalizeStorageKey(key);
+		final stored = await _inner.getItem(normalized);
+		if (stored == null || !stored.startsWith(chunkMarker)) {
+			return stored;
+		}
+		final count = int.tryParse(stored.substring(chunkMarker.length));
+		if (count == null || count <= 0) return null;
+		final buffer = StringBuffer();
+		for (var i = 0; i < count; i++) {
+			final chunk = await _inner.getItem('$normalized.$i');
+			if (chunk == null) return null;
+			buffer.write(chunk);
+		}
+		return buffer.toString();
+	}
+
+	@override
+	Future<void> setItem(String key, String value) async {
+		final normalized = normalizeStorageKey(key);
+		if (value.length <= storageValueLimit) {
+			await _inner.setItem(normalized, value);
+			return;
+		}
+		await _inner.setItem(normalized, '');
+		final count = (value.length / storageValueLimit).ceil();
+		for (var i = 0; i < count; i++) {
+			final start = i * storageValueLimit;
+			final end = (start + storageValueLimit).clamp(0, value.length);
+			await _inner.setItem('$normalized.$i', value.substring(start, end));
+		}
+		await _inner.setItem(normalized, '$chunkMarker$count');
+	}
+
+	@override
+	Future<void> removeItem(String key) async {
+		final normalized = normalizeStorageKey(key);
+		final stored = await _inner.getItem(normalized);
+		if (stored != null && stored.startsWith(chunkMarker)) {
+			final count = int.tryParse(stored.substring(chunkMarker.length)) ?? 0;
+			for (var i = 0; i < count; i++) {
+				await _inner.removeItem('$normalized.$i');
+			}
+		}
+		await _inner.removeItem(normalized);
+	}
+}
+
+/// Returns true when [setCookieHeader] contains Better Auth session cookies.
+bool hasBetterAuthCookies(
+	String setCookieHeader, [
+	Object cookiePrefix = 'better-auth',
+]) {
+	final cookies = parseSetCookieHeader(setCookieHeader);
+	final prefixes = cookiePrefix is List<String>
+			? cookiePrefix
+			: [cookiePrefix as String];
+	const suffixes = ['session_token', 'session_data'];
+
+	for (final name in cookies.keys) {
+		var nameWithoutSecure = name;
+		if (nameWithoutSecure.startsWith('__Secure-')) {
+			nameWithoutSecure = nameWithoutSecure.substring('__Secure-'.length);
+		}
+		for (final prefix in prefixes) {
+			if (prefix.isNotEmpty) {
+				if (nameWithoutSecure.startsWith(prefix)) return true;
+			} else {
+				for (final suffix in suffixes) {
+					if (nameWithoutSecure.endsWith(suffix)) return true;
+				}
+			}
+		}
+	}
+	return false;
+}

--- a/packages/flutter/dart/lib/src/models.dart
+++ b/packages/flutter/dart/lib/src/models.dart
@@ -1,0 +1,184 @@
+/// User returned by Better Auth session endpoints.
+final class User {
+	const User({
+		required this.id,
+		required this.email,
+		required this.name,
+		this.emailVerified = false,
+		this.image,
+		this.createdAt,
+		this.updatedAt,
+		this.extra = const {},
+	});
+
+	final String id;
+	final String email;
+	final String name;
+	final bool emailVerified;
+	final String? image;
+	final DateTime? createdAt;
+	final DateTime? updatedAt;
+	final Map<String, Object?> extra;
+
+	factory User.fromJson(Map<String, Object?> json) {
+		final known = {
+			'id',
+			'email',
+			'name',
+			'emailVerified',
+			'image',
+			'createdAt',
+			'updatedAt',
+		};
+		return User(
+			id: json['id'] as String? ?? '',
+			email: json['email'] as String? ?? '',
+			name: json['name'] as String? ?? '',
+			emailVerified: json['emailVerified'] as bool? ?? false,
+			image: json['image'] as String?,
+			createdAt: _parseDate(json['createdAt']),
+			updatedAt: _parseDate(json['updatedAt']),
+			extra: {
+				for (final e in json.entries)
+					if (!known.contains(e.key)) e.key: e.value,
+			},
+		);
+	}
+
+	Map<String, Object?> toJson() => {
+				'id': id,
+				'email': email,
+				'name': name,
+				'emailVerified': emailVerified,
+				if (image != null) 'image': image,
+				if (createdAt != null) 'createdAt': createdAt!.toIso8601String(),
+				if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
+				...extra,
+			};
+}
+
+/// Session returned by Better Auth session endpoints.
+final class Session {
+	const Session({
+		required this.id,
+		required this.userId,
+		required this.token,
+		required this.expiresAt,
+		this.ipAddress,
+		this.userAgent,
+		this.createdAt,
+		this.updatedAt,
+		this.extra = const {},
+	});
+
+	final String id;
+	final String userId;
+	final String token;
+	final DateTime expiresAt;
+	final String? ipAddress;
+	final String? userAgent;
+	final DateTime? createdAt;
+	final DateTime? updatedAt;
+	final Map<String, Object?> extra;
+
+	factory Session.fromJson(Map<String, Object?> json) {
+		final known = {
+			'id',
+			'userId',
+			'token',
+			'expiresAt',
+			'ipAddress',
+			'userAgent',
+			'createdAt',
+			'updatedAt',
+		};
+		return Session(
+			id: json['id'] as String? ?? '',
+			userId: json['userId'] as String? ?? '',
+			token: json['token'] as String? ?? '',
+			expiresAt: _parseDate(json['expiresAt']) ??
+					DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+			ipAddress: json['ipAddress'] as String?,
+			userAgent: json['userAgent'] as String?,
+			createdAt: _parseDate(json['createdAt']),
+			updatedAt: _parseDate(json['updatedAt']),
+			extra: {
+				for (final e in json.entries)
+					if (!known.contains(e.key)) e.key: e.value,
+			},
+		);
+	}
+
+	Map<String, Object?> toJson() => {
+				'id': id,
+				'userId': userId,
+				'token': token,
+				'expiresAt': expiresAt.toIso8601String(),
+				if (ipAddress != null) 'ipAddress': ipAddress,
+				if (userAgent != null) 'userAgent': userAgent,
+				if (createdAt != null) 'createdAt': createdAt!.toIso8601String(),
+				if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
+				...extra,
+			};
+}
+
+/// Combined session + user payload from `/get-session`.
+final class SessionData {
+	const SessionData({required this.session, required this.user});
+
+	final Session session;
+	final User user;
+
+	factory SessionData.fromJson(Map<String, Object?> json) {
+		return SessionData(
+			session: Session.fromJson(
+				(json['session'] as Map?)?.cast<String, Object?>() ?? {},
+			),
+			user: User.fromJson(
+				(json['user'] as Map?)?.cast<String, Object?>() ?? {},
+			),
+		);
+	}
+
+	Map<String, Object?> toJson() => {
+				'session': session.toJson(),
+				'user': user.toJson(),
+			};
+}
+
+/// Result wrapper that mirrors the Better Auth client `{ data, error }` shape.
+final class AuthResponse<T> {
+	const AuthResponse({this.data, this.error});
+
+	final T? data;
+	final AuthError? error;
+
+	bool get isSuccess => error == null;
+}
+
+final class AuthError {
+	const AuthError({
+		required this.message,
+		this.code,
+		this.status,
+		this.raw,
+	});
+
+	final String message;
+	final String? code;
+	final int? status;
+	final Object? raw;
+
+	@override
+	String toString() => 'AuthError($status $code: $message)';
+}
+
+DateTime? _parseDate(Object? value) {
+	if (value == null) return null;
+	if (value is DateTime) return value.toUtc();
+	if (value is String) return DateTime.tryParse(value)?.toUtc();
+	if (value is int) {
+		return DateTime.fromMillisecondsSinceEpoch(value, isUtc: true);
+	}
+	return null;
+}

--- a/packages/flutter/dart/lib/src/plugins/flutter_client.dart
+++ b/packages/flutter/dart/lib/src/plugins/flutter_client.dart
@@ -1,0 +1,216 @@
+import 'dart:convert';
+
+import '../cookies.dart';
+import '../storage.dart';
+
+/// Opens an auth session in a browser / ASWebAuthenticationSession-style UI
+/// and returns the final redirect URL on success.
+///
+/// Wire this to `flutter_web_auth_2`, Chrome Custom Tabs, or a custom flow.
+typedef AuthSessionLauncher = Future<Uri?> Function({
+	required Uri authorizationUrl,
+	required Uri callbackUrl,
+});
+
+/// Options for [flutterClient].
+final class FlutterClientOptions {
+	const FlutterClientOptions({
+		required this.scheme,
+		required this.storage,
+		this.storagePrefix = 'better-auth',
+		this.cookiePrefix = 'better-auth',
+		this.disableCache = false,
+		this.sessionLauncher,
+	});
+
+	/// Custom URL scheme registered by the Flutter app (e.g. `myapp`).
+	final String scheme;
+
+	/// Injectable storage (typically secure storage on device).
+	final AuthStorage storage;
+
+	/// Prefix for local storage keys (cookie jar + session cache).
+	final String storagePrefix;
+
+	/// Prefix for server cookie names to filter Set-Cookie processing.
+	final String cookiePrefix;
+
+	/// When true, skip reading/writing the local session cache.
+	final bool disableCache;
+
+	/// Opens the OAuth / social browser session. Required for [AuthClient.signInSocial].
+	final AuthSessionLauncher? sessionLauncher;
+
+	String get origin => '$scheme://';
+}
+
+/// Client plugin that wires Flutter-specific cookie persistence and origin headers.
+///
+/// Mirrors `@better-auth/expo`'s `expoClient` contract:
+/// - Sends `Cookie` + `flutter-origin` on every request
+/// - Persists `Set-Cookie` values that belong to Better Auth
+/// - Caches session payloads locally
+/// - Handles OAuth proxy + deep-link cookie capture
+final class FlutterClientPlugin {
+	FlutterClientPlugin(this.options)
+			: storage = ChunkedAuthStorage(options.storage);
+
+	final FlutterClientOptions options;
+	final AuthStorage storage;
+
+	String get id => 'flutter';
+
+	String get _cookieName => '${options.storagePrefix}_cookie';
+	String get _sessionCacheName => '${options.storagePrefix}_session_data';
+
+	Future<String> getCookie() async {
+		final raw = await storage.getItem(_cookieName);
+		return buildCookieHeader(raw ?? '{}');
+	}
+
+	Future<String?> getCookieJson() => storage.getItem(_cookieName);
+
+	Future<void> clearSessionCache() async {
+		await storage.setItem(_cookieName, '{}');
+		await storage.setItem(_sessionCacheName, '{}');
+	}
+
+	/// Headers to attach to outgoing Better Auth requests.
+	Future<Map<String, String>> requestHeaders() async {
+		final cookie = await getCookie();
+		return {
+			if (cookie.isNotEmpty) 'cookie': cookie,
+			'flutter-origin': options.origin,
+			'x-skip-oauth-proxy': 'true',
+		};
+	}
+
+	/// Convert a relative callback path into a deep link for this scheme.
+	Uri resolveCallbackUrl(String callbackURL) {
+		if (callbackURL.startsWith('http://') ||
+				callbackURL.startsWith('https://') ||
+				callbackURL.contains('://')) {
+			return Uri.parse(callbackURL);
+		}
+		final path = callbackURL.startsWith('/') ? callbackURL : '/$callbackURL';
+		// Match Expo Linking.createURL: `<scheme>:///<path>`
+		return Uri.parse('${options.scheme}://$path');
+	}
+
+	/// Persist Set-Cookie from a successful response when relevant.
+	Future<void> onResponse({
+		required Uri url,
+		required Map<String, String> headers,
+		Object? body,
+	}) async {
+		final setCookie = headers['set-cookie'] ?? headers['Set-Cookie'];
+		if (setCookie != null &&
+				hasBetterAuthCookies(setCookie, options.cookiePrefix)) {
+			final prev = await storage.getItem(_cookieName);
+			final merged = mergeSetCookie(setCookie, prev);
+			await storage.setItem(_cookieName, merged);
+		}
+
+		final path = url.path;
+		if (!options.disableCache &&
+				path.contains('/get-session') &&
+				body != null) {
+			await storage.setItem(
+				_sessionCacheName,
+				body is String ? body : '$body',
+			);
+		}
+		if (path.contains('/sign-out')) {
+			await clearSessionCache();
+		}
+	}
+
+	Future<String?> readCachedSessionJson() async {
+		if (options.disableCache) return null;
+		return storage.getItem(_sessionCacheName);
+	}
+
+	Future<void> writeCachedSessionJson(String json) async {
+		if (options.disableCache) return;
+		await storage.setItem(_sessionCacheName, json);
+	}
+
+	/// Runs the OAuth authorization proxy flow and stores the returned cookie.
+	///
+	/// Returns `true` when a session cookie was captured from the redirect URL.
+	Future<bool> completeSocialRedirect({
+		required String signInUrl,
+		required String authBaseUrl,
+		required String callbackURL,
+	}) async {
+		final launcher = options.sessionLauncher;
+		if (launcher == null) {
+			throw StateError(
+				'sessionLauncher is required for social sign-in. '
+				'Pass an AuthSessionLauncher in FlutterClientOptions '
+				'(e.g. flutter_web_auth_2).',
+			);
+		}
+
+		final callbackUrl = resolveCallbackUrl(callbackURL);
+		final cookieJson = await getCookieJson();
+		final oauthState = getOAuthStateValue(cookieJson, options.cookiePrefix);
+
+		final proxy = Uri.parse('$authBaseUrl/flutter-authorization-proxy')
+				.replace(
+			queryParameters: {
+				'authorizationURL': signInUrl,
+				if (oauthState != null) 'oauthState': oauthState,
+			},
+		);
+
+		final resultUrl = await launcher(
+			authorizationUrl: proxy,
+			callbackUrl: callbackUrl,
+		);
+		if (resultUrl == null) return false;
+
+		final cookieParam = resultUrl.queryParameters['cookie'];
+		if (cookieParam == null || cookieParam.isEmpty) return false;
+
+		final prev = await storage.getItem(_cookieName);
+		final merged = mergeSetCookie(cookieParam, prev);
+		await storage.setItem(_cookieName, merged);
+		return true;
+	}
+}
+
+/// Creates a [FlutterClientPlugin] with the given options.
+FlutterClientPlugin flutterClient(FlutterClientOptions options) {
+	if (options.scheme.trim().isEmpty) {
+		throw ArgumentError(
+			'Scheme is required. Provide the Flutter app deep-link scheme.',
+		);
+	}
+	return FlutterClientPlugin(options);
+}
+
+/// Reads `oauth_state` from the stored cookie jar (Expo-compatible naming).
+String? getOAuthStateValue(String? cookieJson, String cookiePrefix) {
+	if (cookieJson == null || cookieJson.isEmpty) return null;
+	Map<String, Object?> parsed;
+	try {
+		parsed = jsonDecode(cookieJson) as Map<String, Object?>? ?? {};
+	} catch (_) {
+		return null;
+	}
+
+	const securePrefix = '__Secure-';
+	final candidates = [
+		'$securePrefix$cookiePrefix.oauth_state',
+		'$cookiePrefix.oauth_state',
+	];
+	for (final name in candidates) {
+		final entry = parsed[name];
+		if (entry is Map<String, Object?>) {
+			final value = entry['value'] as String?;
+			if (value != null && value.isNotEmpty) return value;
+		}
+	}
+	return null;
+}

--- a/packages/flutter/dart/lib/src/plugins/last_login_method.dart
+++ b/packages/flutter/dart/lib/src/plugins/last_login_method.dart
@@ -1,0 +1,75 @@
+import '../storage.dart';
+import 'plugin.dart';
+
+/// Options for [lastLoginMethodClient].
+final class LastLoginMethodOptions {
+	const LastLoginMethodOptions({
+		required this.storage,
+		this.storagePrefix = 'better-auth',
+		this.resolveMethod,
+	});
+
+	final AuthStorage storage;
+	final String storagePrefix;
+
+	/// Override how a request URL maps to a login-method label.
+	final String? Function(Uri url)? resolveMethod;
+}
+
+/// Persists the last successful login method (email, google, passkey, …).
+final class LastLoginMethodPlugin extends AuthClientPlugin {
+	LastLoginMethodPlugin(this.options);
+
+	final LastLoginMethodOptions options;
+
+	@override
+	String get id => 'last-login-method';
+
+	String get _key => '${options.storagePrefix}_last_login_method';
+
+	static const _tracked = [
+		'/callback/',
+		'/oauth2/callback/',
+		'/sign-in/email',
+		'/sign-up/email',
+	];
+
+	String? _defaultResolve(Uri url) {
+		final path = url.path;
+		if (_tracked.any(path.contains)) {
+			final segments = path.split('/').where((s) => s.isNotEmpty);
+			return segments.isEmpty ? null : segments.last;
+		}
+		if (path.contains('siwe')) return 'siwe';
+		if (path.contains('/passkey/verify-authentication')) return 'passkey';
+		if (path.contains('/sign-in/social')) return 'social';
+		return null;
+	}
+
+	@override
+	Future<void> handleResponse({
+		required Uri url,
+		required Map<String, String> headers,
+		required int statusCode,
+		Object? body,
+	}) async {
+		if (statusCode >= 400) return;
+		final resolve = options.resolveMethod ?? _defaultResolve;
+		final method = resolve(url);
+		if (method == null || method.isEmpty) return;
+		await options.storage.setItem(_key, method);
+	}
+
+	Future<String?> getLastUsedLoginMethod() => options.storage.getItem(_key);
+
+	Future<void> clearLastUsedLoginMethod() => options.storage.removeItem(_key);
+
+	Future<bool> isLastUsedLoginMethod(String method) async {
+		final last = await getLastUsedLoginMethod();
+		return last == method;
+	}
+}
+
+LastLoginMethodPlugin lastLoginMethodClient(LastLoginMethodOptions options) {
+	return LastLoginMethodPlugin(options);
+}

--- a/packages/flutter/dart/lib/src/plugins/organization.dart
+++ b/packages/flutter/dart/lib/src/plugins/organization.dart
@@ -1,0 +1,188 @@
+import '../models.dart';
+import 'plugin.dart';
+
+/// Client helpers for the server [organization] plugin.
+final class OrganizationPlugin extends AuthClientPlugin {
+	AuthRequestClient? _client;
+
+	@override
+	String get id => 'organization';
+
+	@override
+	void attach(Object client) {
+		if (client is AuthRequestClient) {
+			_client = client;
+		}
+	}
+
+	AuthRequestClient get _req {
+		final client = _client;
+		if (client == null) {
+			throw StateError('organizationClient is not attached to an AuthClient');
+		}
+		return client;
+	}
+
+	@override
+	bool triggersSessionRefresh(String path) {
+		return path == '/organization/set-active' ||
+				path == '/organization/create' ||
+				path == '/organization/delete' ||
+				path == '/organization/remove-member' ||
+				path == '/organization/leave' ||
+				path == '/organization/accept-invitation';
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> create({
+		required String name,
+		required String slug,
+		String? logo,
+		Map<String, Object?>? metadata,
+		bool? keepCurrentActiveOrganization,
+	}) {
+		return _req.postJson('/organization/create', {
+			'name': name,
+			'slug': slug,
+			if (logo != null) 'logo': logo,
+			if (metadata != null) 'metadata': metadata,
+			if (keepCurrentActiveOrganization != null)
+				'keepCurrentActiveOrganization': keepCurrentActiveOrganization,
+		}, refreshSession: true);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> list() {
+		return _req.getJson('/organization/list');
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> setActive({
+		String? organizationId,
+		String? organizationSlug,
+	}) {
+		return _req.postJson('/organization/set-active', {
+			if (organizationId != null) 'organizationId': organizationId,
+			if (organizationSlug != null) 'organizationSlug': organizationSlug,
+		}, refreshSession: true);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> getFullOrganization({
+		String? organizationId,
+		String? organizationSlug,
+	}) {
+		return _req.getJson('/organization/get-full-organization', query: {
+			if (organizationId != null) 'organizationId': organizationId,
+			if (organizationSlug != null) 'organizationSlug': organizationSlug,
+		});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> updateOrganization({
+		required Map<String, Object?> data,
+		String? organizationId,
+	}) {
+		return _req.postJson('/organization/update', {
+			'data': data,
+			if (organizationId != null) 'organizationId': organizationId,
+		});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> delete({
+		required String organizationId,
+	}) {
+		return _req.postJson('/organization/delete', {
+			'organizationId': organizationId,
+		}, refreshSession: true);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> checkSlug({required String slug}) {
+		return _req.postJson('/organization/check-slug', {'slug': slug});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> inviteMember({
+		required String email,
+		required String role,
+		String? organizationId,
+		String? resend,
+	}) {
+		return _req.postJson('/organization/invite-member', {
+			'email': email,
+			'role': role,
+			if (organizationId != null) 'organizationId': organizationId,
+			if (resend != null) 'resend': resend,
+		});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> acceptInvitation({
+		required String invitationId,
+	}) {
+		return _req.postJson('/organization/accept-invitation', {
+			'invitationId': invitationId,
+		}, refreshSession: true);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> rejectInvitation({
+		required String invitationId,
+	}) {
+		return _req.postJson('/organization/reject-invitation', {
+			'invitationId': invitationId,
+		});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> cancelInvitation({
+		required String invitationId,
+	}) {
+		return _req.postJson('/organization/cancel-invitation', {
+			'invitationId': invitationId,
+		});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> getActiveMember() {
+		return _req.getJson('/organization/get-active-member');
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> getActiveMemberRole() {
+		return _req.getJson('/organization/get-active-member-role');
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> leave({
+		required String organizationId,
+	}) {
+		return _req.postJson('/organization/leave', {
+			'organizationId': organizationId,
+		}, refreshSession: true);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> removeMember({
+		required String memberIdOrEmail,
+		String? organizationId,
+	}) {
+		return _req.postJson('/organization/remove-member', {
+			'memberIdOrEmail': memberIdOrEmail,
+			if (organizationId != null) 'organizationId': organizationId,
+		}, refreshSession: true);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> updateMemberRole({
+		required String role,
+		required String memberId,
+		String? organizationId,
+	}) {
+		return _req.postJson('/organization/update-member-role', {
+			'role': role,
+			'memberId': memberId,
+			if (organizationId != null) 'organizationId': organizationId,
+		});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> listMembers({
+		String? organizationId,
+		String? limit,
+		String? offset,
+	}) {
+		return _req.getJson('/organization/list-members', query: {
+			if (organizationId != null) 'organizationId': organizationId,
+			if (limit != null) 'limit': limit,
+			if (offset != null) 'offset': offset,
+		});
+	}
+}
+
+OrganizationPlugin organizationClient() => OrganizationPlugin();

--- a/packages/flutter/dart/lib/src/plugins/plugin.dart
+++ b/packages/flutter/dart/lib/src/plugins/plugin.dart
@@ -1,0 +1,43 @@
+import '../models.dart';
+
+/// Client-side plugin contract for the Dart Better Auth client.
+///
+/// Mirrors the conceptual surface of `BetterAuthClientPlugin` (headers,
+/// response hooks, session refresh triggers) without TypeScript/nanostores.
+abstract class AuthClientPlugin {
+	String get id;
+
+	/// Extra headers merged into every auth request.
+	Future<Map<String, String>> buildRequestHeaders() async => const {};
+
+	/// Called after each auth response is received.
+	Future<void> handleResponse({
+		required Uri url,
+		required Map<String, String> headers,
+		required int statusCode,
+		Object? body,
+	}) async {}
+
+	/// When true, [AuthClient] refetches the session after this path succeeds.
+	bool triggersSessionRefresh(String path) => false;
+
+	/// Called once when the plugin is attached to an [AuthClient].
+	void attach(Object client) {}
+}
+
+/// Narrow request surface plugins use to call Better Auth endpoints.
+abstract interface class AuthRequestClient {
+	Future<AuthResponse<Map<String, Object?>>> postJson(
+		String path,
+		Map<String, Object?> body, {
+		bool refreshSession = false,
+	});
+
+	Future<AuthResponse<Map<String, Object?>>> getJson(
+		String path, {
+		Map<String, String>? query,
+		bool refreshSession = false,
+	});
+
+	Future<void> refreshSession();
+}

--- a/packages/flutter/dart/lib/src/plugins/plugins.dart
+++ b/packages/flutter/dart/lib/src/plugins/plugins.dart
@@ -1,0 +1,5 @@
+export 'flutter_client.dart';
+export 'last_login_method.dart';
+export 'organization.dart';
+export 'plugin.dart';
+export 'two_factor.dart';

--- a/packages/flutter/dart/lib/src/plugins/two_factor.dart
+++ b/packages/flutter/dart/lib/src/plugins/two_factor.dart
@@ -1,0 +1,135 @@
+import '../models.dart';
+import 'plugin.dart';
+
+/// Options for [twoFactorClient].
+final class TwoFactorClientOptions {
+	const TwoFactorClientOptions({this.onTwoFactorRedirect});
+
+	/// Called when sign-in indicates a 2FA challenge is required.
+	final Future<void> Function({List<String>? twoFactorMethods})?
+			onTwoFactorRedirect;
+}
+
+/// Client helpers for the server [twoFactor] plugin.
+final class TwoFactorPlugin extends AuthClientPlugin {
+	TwoFactorPlugin({this.options = const TwoFactorClientOptions()});
+
+	final TwoFactorClientOptions options;
+	AuthRequestClient? _client;
+
+	@override
+	String get id => 'two-factor';
+
+	@override
+	void attach(Object client) {
+		if (client is AuthRequestClient) {
+			_client = client;
+		}
+	}
+
+	AuthRequestClient get _req {
+		final client = _client;
+		if (client == null) {
+			throw StateError('twoFactorClient is not attached to an AuthClient');
+		}
+		return client;
+	}
+
+	@override
+	bool triggersSessionRefresh(String path) => path.startsWith('/two-factor/');
+
+	@override
+	Future<void> handleResponse({
+		required Uri url,
+		required Map<String, String> headers,
+		required int statusCode,
+		Object? body,
+	}) async {
+		if (statusCode >= 400) return;
+		Map<String, Object?>? data;
+		if (body is Map<String, Object?>) {
+			data = body;
+		} else if (body is Map) {
+			data = body.cast<String, Object?>();
+		}
+		if (data?['twoFactorRedirect'] != true) return;
+		final callback = options.onTwoFactorRedirect;
+		if (callback == null) return;
+		final methodsRaw = data?['twoFactorMethods'];
+		List<String>? methods;
+		if (methodsRaw is List) {
+			methods = methodsRaw.map((e) => e.toString()).toList();
+		}
+		await callback(twoFactorMethods: methods);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> enable({
+		required String password,
+		String? issuer,
+	}) {
+		return _req.postJson('/two-factor/enable', {
+			'password': password,
+			if (issuer != null) 'issuer': issuer,
+		});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> disable({
+		required String password,
+	}) {
+		return _req.postJson('/two-factor/disable', {'password': password});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> getTotpUri({
+		required String password,
+	}) {
+		return _req.postJson('/two-factor/get-totp-uri', {'password': password});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> verifyTotp({
+		required String code,
+		bool? trustDevice,
+	}) {
+		return _req.postJson('/two-factor/verify-totp', {
+			'code': code,
+			if (trustDevice != null) 'trustDevice': trustDevice,
+		}, refreshSession: true);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> sendOtp() {
+		return _req.postJson('/two-factor/send-otp', {});
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> verifyOtp({
+		required String code,
+		bool? trustDevice,
+	}) {
+		return _req.postJson('/two-factor/verify-otp', {
+			'code': code,
+			if (trustDevice != null) 'trustDevice': trustDevice,
+		}, refreshSession: true);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> verifyBackupCode({
+		required String code,
+		bool? trustDevice,
+		bool? disableSession,
+	}) {
+		return _req.postJson('/two-factor/verify-backup-code', {
+			'code': code,
+			if (trustDevice != null) 'trustDevice': trustDevice,
+			if (disableSession != null) 'disableSession': disableSession,
+		}, refreshSession: true);
+	}
+
+	Future<AuthResponse<Map<String, Object?>>> generateBackupCodes({
+		required String password,
+	}) {
+		return _req.postJson('/two-factor/generate-backup-codes', {
+			'password': password,
+		});
+	}
+}
+
+TwoFactorPlugin twoFactorClient([TwoFactorClientOptions? options]) {
+	return TwoFactorPlugin(options: options ?? const TwoFactorClientOptions());
+}

--- a/packages/flutter/dart/lib/src/session_refresh.dart
+++ b/packages/flutter/dart/lib/src/session_refresh.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+/// Options controlling automatic / manual session refetch.
+final class SessionOptions {
+	const SessionOptions({
+		this.refetchInterval = Duration.zero,
+		this.refetchOnAppResume = true,
+		this.refetchWhenOffline = false,
+	});
+
+	/// Poll `/get-session` on this interval. [Duration.zero] disables polling.
+	final Duration refetchInterval;
+
+	/// Refetch when [AuthClient.onAppResumed] is called (app foreground).
+	final bool refetchOnAppResume;
+
+	/// When false (default), skip refetch while [AuthClient.isOnline] is false.
+	final bool refetchWhenOffline;
+}
+
+/// Manages interval polling and resume-triggered session refresh.
+final class SessionRefreshManager {
+	SessionRefreshManager({
+		required this.fetchSession,
+		required this.options,
+		this.isOnline = _alwaysOnline,
+	});
+
+	final Future<void> Function() fetchSession;
+	final SessionOptions options;
+	final bool Function() isOnline;
+
+	static bool _alwaysOnline() => true;
+
+	static const _focusRateLimit = Duration(seconds: 5);
+
+	DateTime _lastSessionRequest =
+			DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+	Timer? _pollTimer;
+
+	/// Starts periodic polling when [SessionOptions.refetchInterval] is set.
+	void start() {
+		stop();
+		final interval = options.refetchInterval;
+		if (interval <= Duration.zero) return;
+		_pollTimer = Timer.periodic(interval, (_) {
+			if (!_shouldRefetch()) return;
+			_lastSessionRequest = DateTime.now().toUtc();
+			unawaited(fetchSession());
+		});
+	}
+
+	void stop() {
+		_pollTimer?.cancel();
+		_pollTimer = null;
+	}
+
+	/// Call when the Flutter app returns to the foreground.
+	void onAppResumed() {
+		if (!options.refetchOnAppResume) return;
+		if (!_shouldRefetch()) return;
+		final since = DateTime.now().toUtc().difference(_lastSessionRequest);
+		if (since < _focusRateLimit) return;
+		_lastSessionRequest = DateTime.now().toUtc();
+		unawaited(fetchSession());
+	}
+
+	/// Marks that a session request just completed (rate-limit bookkeeping).
+	void markSessionFetched() {
+		_lastSessionRequest = DateTime.now().toUtc();
+	}
+
+	bool _shouldRefetch() => options.refetchWhenOffline || isOnline();
+}

--- a/packages/flutter/dart/lib/src/storage.dart
+++ b/packages/flutter/dart/lib/src/storage.dart
@@ -1,0 +1,30 @@
+/// Injectable key/value storage used by the Flutter client plugin.
+///
+/// Pass any backend (`flutter_secure_storage`, Hive, in-memory Map, etc.).
+abstract interface class AuthStorage {
+	Future<String?> getItem(String key);
+	Future<void> setItem(String key, String value);
+	Future<void> removeItem(String key);
+}
+
+/// Simple in-memory [AuthStorage] useful for tests and ephemeral sessions.
+final class MemoryAuthStorage implements AuthStorage {
+	final Map<String, String> _store = {};
+
+	@override
+	Future<String?> getItem(String key) async => _store[key];
+
+	@override
+	Future<void> setItem(String key, String value) async {
+		_store[key] = value;
+	}
+
+	@override
+	Future<void> removeItem(String key) async {
+		_store.remove(key);
+	}
+
+	void clear() => _store.clear();
+
+	Map<String, String> get snapshot => Map.unmodifiable(_store);
+}

--- a/packages/flutter/dart/pubspec.yaml
+++ b/packages/flutter/dart/pubspec.yaml
@@ -1,0 +1,18 @@
+name: better_auth
+description: Better Auth client SDK for Dart and Flutter applications.
+version: 0.1.0
+homepage: https://www.better-auth.com/docs/integrations/flutter
+repository: https://github.com/2keyapp/better-auth/tree/main/packages/flutter/dart
+# Consumed via GitHub (`git` + `path`); not published to pub.dev.
+publish_to: none
+
+environment:
+  sdk: ^3.5.0
+
+dependencies:
+  http: ^1.2.2
+  meta: ^1.15.0
+
+dev_dependencies:
+  lints: ^5.0.0
+  test: ^1.25.8

--- a/packages/flutter/dart/test/client_phase2_test.dart
+++ b/packages/flutter/dart/test/client_phase2_test.dart
@@ -1,0 +1,290 @@
+import 'dart:convert';
+
+import 'package:better_auth/better_auth.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+	group('cookies (phase 1)', () {
+		test('parses and merges set-cookie', () {
+			final merged = mergeSetCookie(
+				'better-auth.session_token=abc123; Max-Age=3600',
+			);
+			expect(
+				buildCookieHeader(merged),
+				contains('better-auth.session_token=abc123'),
+			);
+		});
+
+		test('chunked storage round-trip', () async {
+			final memory = MemoryAuthStorage();
+			final storage = ChunkedAuthStorage(memory);
+			final value = 'x' * (storageValueLimit * 2 + 50);
+			await storage.setItem('better-auth_cookie', value);
+			expect(await storage.getItem('better-auth_cookie'), value);
+		});
+	});
+
+	group('flutterClient social helpers', () {
+		test('resolveCallbackUrl builds deep links', () {
+			final plugin = flutterClient(
+				FlutterClientOptions(
+					scheme: 'myapp',
+					storage: MemoryAuthStorage(),
+				),
+			);
+			expect(
+				plugin.resolveCallbackUrl('/dashboard').toString(),
+				'myapp:///dashboard',
+			);
+			expect(
+				plugin.resolveCallbackUrl('https://example.com/cb').toString(),
+				'https://example.com/cb',
+			);
+		});
+
+		test('completeSocialRedirect stores cookie from callback', () async {
+			final memory = MemoryAuthStorage();
+			final plugin = flutterClient(
+				FlutterClientOptions(
+					scheme: 'myapp',
+					storage: memory,
+					sessionLauncher: ({
+						required authorizationUrl,
+						required callbackUrl,
+					}) async {
+						expect(
+							authorizationUrl.path,
+							contains('flutter-authorization-proxy'),
+						);
+						expect(
+							authorizationUrl.queryParameters['authorizationURL'],
+							'https://accounts.google.com/o/oauth2',
+						);
+						return Uri.parse(
+							'myapp:///dashboard?cookie=${Uri.encodeComponent('better-auth.session_token=tok; Max-Age=3600')}',
+						);
+					},
+				),
+			);
+
+			final ok = await plugin.completeSocialRedirect(
+				signInUrl: 'https://accounts.google.com/o/oauth2',
+				authBaseUrl: 'http://localhost/api/auth',
+				callbackURL: '/dashboard',
+			);
+			expect(ok, isTrue);
+			expect(await plugin.getCookie(), contains('session_token=tok'));
+		});
+
+		test('getOAuthStateValue reads stored oauth_state', () {
+			final json = jsonEncode({
+				'better-auth.oauth_state': {
+					'value': 'state-123',
+					'expires': null,
+				},
+			});
+			expect(getOAuthStateValue(json, 'better-auth'), 'state-123');
+		});
+	});
+
+	group('AuthClient social + OTT', () {
+		test('signInSocial with idToken skips browser launcher', () async {
+			var posts = 0;
+			final client = createAuthClient(
+				baseUrl: 'http://localhost',
+				httpClient: MockClient((request) async {
+					if (request.url.path.endsWith('/sign-in/social')) {
+						posts++;
+						return http.Response(
+							jsonEncode({
+								'user': {'id': '1', 'email': 'a@b.c', 'name': 'A'},
+								'session': {
+									'id': 's',
+									'userId': '1',
+									'token': 't',
+									'expiresAt': DateTime.now()
+											.add(const Duration(hours: 1))
+											.toUtc()
+											.toIso8601String(),
+								},
+							}),
+							200,
+							headers: {'content-type': 'application/json'},
+						);
+					}
+					if (request.url.path.endsWith('/get-session')) {
+						return http.Response(
+							jsonEncode({
+								'user': {'id': '1', 'email': 'a@b.c', 'name': 'A'},
+								'session': {
+									'id': 's',
+									'userId': '1',
+									'token': 't',
+									'expiresAt': DateTime.now()
+											.add(const Duration(hours: 1))
+											.toUtc()
+											.toIso8601String(),
+								},
+							}),
+							200,
+							headers: {'content-type': 'application/json'},
+						);
+					}
+					return http.Response('not found', 404);
+				}),
+				plugin: flutterClient(
+					FlutterClientOptions(
+						scheme: 'myapp',
+						storage: MemoryAuthStorage(),
+						sessionLauncher: ({
+							required authorizationUrl,
+							required callbackUrl,
+						}) async {
+							fail('launcher should not run for idToken flow');
+						},
+					),
+				),
+			);
+
+			final res = await client.signInSocial(
+				provider: 'google',
+				idToken: 'jwt-here',
+			);
+			expect(res.error, isNull);
+			expect(posts, 1);
+			await client.dispose();
+		});
+
+		test('signInSocial opens proxy and captures cookie', () async {
+			final memory = MemoryAuthStorage();
+			final client = createAuthClient(
+				baseUrl: 'http://localhost',
+				httpClient: MockClient((request) async {
+					if (request.url.path.endsWith('/sign-in/social')) {
+						return http.Response(
+							jsonEncode({
+								'redirect': true,
+								'url': 'https://accounts.google.com/o/oauth2',
+							}),
+							200,
+							headers: {
+								'content-type': 'application/json',
+								'set-cookie':
+										'better-auth.oauth_state=abc; Max-Age=600',
+							},
+						);
+					}
+					if (request.url.path.endsWith('/get-session')) {
+						return http.Response(
+							jsonEncode({
+								'user': {
+									'id': '1',
+									'email': 'a@b.c',
+									'name': 'A',
+								},
+								'session': {
+									'id': 's',
+									'userId': '1',
+									'token': 't',
+									'expiresAt': DateTime.now()
+											.add(const Duration(hours: 1))
+											.toUtc()
+											.toIso8601String(),
+								},
+							}),
+							200,
+							headers: {'content-type': 'application/json'},
+						);
+					}
+					return http.Response('not found', 404);
+				}),
+				plugin: flutterClient(
+					FlutterClientOptions(
+						scheme: 'myapp',
+						storage: memory,
+						sessionLauncher: ({
+							required authorizationUrl,
+							required callbackUrl,
+						}) async {
+							expect(
+								authorizationUrl.queryParameters['oauthState'],
+								'abc',
+							);
+							return Uri.parse(
+								'myapp:///dashboard?cookie=better-auth.session_token%3Dxyz%3B%20Max-Age%3D3600',
+							);
+						},
+					),
+				),
+			);
+
+			final res = await client.signInSocial(
+				provider: 'google',
+				callbackURL: '/dashboard',
+			);
+			expect(res.error, isNull);
+			expect(res.data?['cookieCaptured'], isTrue);
+			expect(await client.getCookie(), contains('session_token=xyz'));
+			expect(client.session?.user.email, 'a@b.c');
+			await client.dispose();
+		});
+
+		test('createSessionHandoffUrl appends token', () async {
+			final client = createAuthClient(
+				baseUrl: 'http://localhost',
+				httpClient: MockClient((request) async {
+					expect(
+						request.url.path.endsWith('/one-time-token/generate'),
+						isTrue,
+					);
+					return http.Response(
+						jsonEncode({'token': 'ott-secret'}),
+						200,
+						headers: {'content-type': 'application/json'},
+					);
+				}),
+				plugin: flutterClient(
+					FlutterClientOptions(
+						scheme: 'myapp',
+						storage: MemoryAuthStorage(),
+					),
+				),
+			);
+
+			final res = await client.createSessionHandoffUrl(
+				targetUrl: 'https://app.example.com/auth/handoff',
+			);
+			expect(res.error, isNull);
+			expect(
+				res.data.toString(),
+				'https://app.example.com/auth/handoff?token=ott-secret',
+			);
+			await client.dispose();
+		});
+	});
+
+	group('session refresh', () {
+		test('onAppResumed triggers getSession', () async {
+			var gets = 0;
+			final client = createAuthClient(
+				baseUrl: 'http://localhost',
+				sessionOptions: const SessionOptions(refetchOnAppResume: true),
+				httpClient: MockClient((request) async {
+					if (request.url.path.endsWith('/get-session')) {
+						gets++;
+						return http.Response('null', 200);
+					}
+					return http.Response('no', 404);
+				}),
+			);
+
+			// First call may be rate-limited against epoch — force mark old.
+			client.onAppResumed();
+			await Future<void>.delayed(const Duration(milliseconds: 20));
+			expect(gets, greaterThanOrEqualTo(1));
+			await client.dispose();
+		});
+	});
+}

--- a/packages/flutter/dart/test/plugins_phase3_test.dart
+++ b/packages/flutter/dart/test/plugins_phase3_test.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+
+import 'package:better_auth/better_auth.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+	group('lastLoginMethodClient', () {
+		test('stores method after successful sign-in', () async {
+			final memory = MemoryAuthStorage();
+			final lastLogin = lastLoginMethodClient(
+				LastLoginMethodOptions(storage: memory, storagePrefix: 'myapp'),
+			);
+			final client = createAuthClient(
+				baseUrl: 'http://localhost',
+				plugins: [lastLogin],
+				httpClient: MockClient((request) async {
+					if (request.url.path.endsWith('/sign-in/email')) {
+						return http.Response(
+							jsonEncode({'token': 'ok'}),
+							200,
+							headers: {'content-type': 'application/json'},
+						);
+					}
+					if (request.url.path.endsWith('/get-session')) {
+						return http.Response('null', 200);
+					}
+					return http.Response('no', 404);
+				}),
+			);
+
+			await client.signInEmail(email: 'a@b.c', password: 'x');
+			expect(await lastLogin.getLastUsedLoginMethod(), 'email');
+			expect(await lastLogin.isLastUsedLoginMethod('email'), isTrue);
+			await lastLogin.clearLastUsedLoginMethod();
+			expect(await lastLogin.getLastUsedLoginMethod(), isNull);
+			await client.dispose();
+		});
+	});
+
+	group('organizationClient', () {
+		test('list and create call expected endpoints', () async {
+			final paths = <String>[];
+			final client = createAuthClient(
+				baseUrl: 'http://localhost',
+				plugins: [organizationClient()],
+				httpClient: MockClient((request) async {
+					paths.add('${request.method} ${request.url.path}');
+					if (request.url.path.endsWith('/organization/list')) {
+						return http.Response(
+							jsonEncode([
+								{'id': 'org_1', 'name': 'Acme', 'slug': 'acme'},
+							]),
+							200,
+							headers: {'content-type': 'application/json'},
+						);
+					}
+					if (request.url.path.endsWith('/organization/create')) {
+						return http.Response(
+							jsonEncode({'id': 'org_1', 'name': 'Acme', 'slug': 'acme'}),
+							200,
+							headers: {'content-type': 'application/json'},
+						);
+					}
+					if (request.url.path.endsWith('/get-session')) {
+						return http.Response('null', 200);
+					}
+					return http.Response('no', 404);
+				}),
+			);
+
+			final list = await client.organization!.list();
+			expect(list.error, isNull);
+
+			final created = await client.organization!.create(
+				name: 'Acme',
+				slug: 'acme',
+			);
+			expect(created.error, isNull);
+			expect(paths, contains('GET /api/auth/organization/list'));
+			expect(paths, contains('POST /api/auth/organization/create'));
+			await client.dispose();
+		});
+	});
+
+	group('twoFactorClient', () {
+		test('invokes onTwoFactorRedirect', () async {
+			var redirected = false;
+			List<String>? methods;
+			final client = createAuthClient(
+				baseUrl: 'http://localhost',
+				plugins: [
+					twoFactorClient(
+						TwoFactorClientOptions(
+							onTwoFactorRedirect: ({twoFactorMethods}) async {
+								redirected = true;
+								methods = twoFactorMethods;
+							},
+						),
+					),
+				],
+				httpClient: MockClient((request) async {
+					if (request.url.path.endsWith('/sign-in/email')) {
+						return http.Response(
+							jsonEncode({
+								'twoFactorRedirect': true,
+								'twoFactorMethods': ['totp', 'otp'],
+							}),
+							200,
+							headers: {'content-type': 'application/json'},
+						);
+					}
+					if (request.url.path.endsWith('/get-session')) {
+						return http.Response('null', 200);
+					}
+					return http.Response('no', 404);
+				}),
+			);
+
+			await client.signInEmail(email: 'a@b.c', password: 'x');
+			expect(redirected, isTrue);
+			expect(methods, ['totp', 'otp']);
+
+			final verifyPath = <String>[];
+			final client2 = createAuthClient(
+				baseUrl: 'http://localhost',
+				plugins: [twoFactorClient()],
+				httpClient: MockClient((request) async {
+					verifyPath.add(request.url.path);
+					if (request.url.path.endsWith('/two-factor/verify-totp')) {
+						return http.Response(
+							jsonEncode({'status': true}),
+							200,
+							headers: {'content-type': 'application/json'},
+						);
+					}
+					if (request.url.path.endsWith('/get-session')) {
+						return http.Response('null', 200);
+					}
+					return http.Response('no', 404);
+				}),
+			);
+			await client2.twoFactor!.verifyTotp(code: '123456');
+			expect(verifyPath, contains('/api/auth/two-factor/verify-totp'));
+			await client.dispose();
+			await client2.dispose();
+		});
+	});
+}

--- a/packages/flutter/package.json
+++ b/packages/flutter/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@better-auth/flutter",
+  "version": "1.6.23",
+  "description": "Better Auth integration for Flutter and Dart applications.",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://www.better-auth.com/docs/integrations/flutter",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/2keyapp/better-auth.git",
+    "directory": "packages/flutter"
+  },
+  "keywords": [
+    "auth",
+    "flutter",
+    "dart",
+    "typescript",
+    "better-auth"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "lint:package": "publint run --strict --pack false",
+    "lint:types": "attw --profile esm-only --pack .",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest run --coverage --coverage.provider=istanbul"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@better-auth/core": "workspace:*",
+    "better-auth": "workspace:*",
+    "tsdown": "catalog:"
+  },
+  "peerDependencies": {
+    "@better-auth/core": "workspace:^",
+    "better-auth": "workspace:^"
+  }
+}

--- a/packages/flutter/src/index.ts
+++ b/packages/flutter/src/index.ts
@@ -94,7 +94,11 @@ export const flutter = (options?: FlutterOptions | undefined) => {
 						const isHttpRedirect =
 							redirectURL.protocol === "http:" ||
 							redirectURL.protocol === "https:";
-						if (isHttpRedirect) {
+						const isLoopbackHttpRedirect =
+							isHttpRedirect &&
+							(redirectURL.hostname === "localhost" ||
+								redirectURL.hostname === "127.0.0.1");
+						if (isHttpRedirect && !isLoopbackHttpRedirect) {
 							return;
 						}
 						const isTrustedOrigin = ctx.context.isTrustedOrigin(location);

--- a/packages/flutter/src/index.ts
+++ b/packages/flutter/src/index.ts
@@ -1,0 +1,119 @@
+import type { BetterAuthPlugin } from "@better-auth/core";
+import { createAuthMiddleware } from "@better-auth/core/api";
+import { flutterAuthorizationProxy } from "./routes";
+import { PACKAGE_VERSION } from "./version";
+
+export interface FlutterOptions {
+	/**
+	 * Disable origin override for Flutter API routes.
+	 * When set to true, the origin header will not be overridden from
+	 * the `flutter-origin` request header.
+	 */
+	disableOriginOverride?: boolean | undefined;
+}
+
+declare module "@better-auth/core" {
+	interface BetterAuthPluginRegistry<AuthOptions, Options> {
+		flutter: {
+			creator: typeof flutter;
+		};
+	}
+}
+
+/**
+ * Better Auth server plugin for Flutter / Dart clients.
+ *
+ * Adds trusted-origin helpers for custom URL schemes, copies
+ * `flutter-origin` into the request origin header (so CSRF/origin
+ * checks work without a browser Origin), and attaches session cookies
+ * to deep-link redirects after OAuth / magic-link / email verification.
+ */
+export const flutter = (options?: FlutterOptions | undefined) => {
+	return {
+		id: "flutter",
+		version: PACKAGE_VERSION,
+		init: () => {
+			return {
+				options: {
+					trustedOrigins: [],
+				},
+			};
+		},
+		async onRequest(request) {
+			if (options?.disableOriginOverride || request.headers.get("origin")) {
+				return;
+			}
+			/**
+			 * To bypass origin check from Flutter clients, set the origin
+			 * header from the flutter-origin header.
+			 */
+			const flutterOrigin = request.headers.get("flutter-origin");
+			if (!flutterOrigin) {
+				return;
+			}
+
+			try {
+				// Prefer in-place mutation (works on Bun, Node, Deno).
+				request.headers.set("origin", flutterOrigin);
+				return { request };
+			} catch {
+				// Cloudflare Workers has immutable headers on incoming requests,
+				// so fall back to constructing a new Request.
+				const newHeaders = new Headers(request.headers);
+				newHeaders.set("origin", flutterOrigin);
+				return { request: new Request(request, { headers: newHeaders }) };
+			}
+		},
+		hooks: {
+			after: [
+				{
+					matcher(context) {
+						return !!(
+							context.path?.startsWith("/callback") ||
+							context.path?.startsWith("/oauth2/callback") ||
+							context.path?.startsWith("/magic-link/verify") ||
+							context.path?.startsWith("/verify-email")
+						);
+					},
+					handler: createAuthMiddleware(async (ctx) => {
+						const headers = ctx.context.responseHeaders;
+						const location = headers?.get("location");
+						if (!location) {
+							return;
+						}
+						const isProxyURL = location.includes("/oauth-proxy-callback");
+						if (isProxyURL) {
+							return;
+						}
+						let redirectURL: URL;
+						try {
+							redirectURL = new URL(location);
+						} catch {
+							return;
+						}
+						const isHttpRedirect =
+							redirectURL.protocol === "http:" ||
+							redirectURL.protocol === "https:";
+						if (isHttpRedirect) {
+							return;
+						}
+						const isTrustedOrigin = ctx.context.isTrustedOrigin(location);
+						if (!isTrustedOrigin) {
+							return;
+						}
+						const cookie = headers?.get("set-cookie");
+						if (!cookie) {
+							return;
+						}
+						redirectURL.searchParams.set("cookie", cookie);
+						ctx.setHeader("location", redirectURL.toString());
+					}),
+				},
+			],
+		},
+		endpoints: {
+			flutterAuthorizationProxy,
+		},
+		options,
+	} satisfies BetterAuthPlugin;
+};

--- a/packages/flutter/src/routes.ts
+++ b/packages/flutter/src/routes.ts
@@ -1,0 +1,78 @@
+import { HIDE_METADATA } from "better-auth";
+import { APIError, createAuthEndpoint } from "better-auth/api";
+import * as z from "zod";
+
+export const flutterAuthorizationProxy = createAuthEndpoint(
+	"/flutter-authorization-proxy",
+	{
+		method: "GET",
+		query: z.object({
+			authorizationURL: z.string(),
+			oauthState: z.string().optional(),
+		}),
+		metadata: HIDE_METADATA,
+	},
+	async (ctx) => {
+		const { authorizationURL } = ctx.query;
+
+		// This endpoint sets an OAuth state cookie and redirects, so the target
+		// must be an external provider authorization endpoint. Reject malformed
+		// or non-https targets and any same-origin Better Auth URL: a same-origin
+		// target would allow a state cookie to be planted and a
+		// login-CSRF / session-fixation flow through the auth domain.
+		//
+		// A fragment is never part of a valid OAuth authorization endpoint, and a
+		// bare trailing "#" parses to an empty url.hash, so reject on the raw value.
+		if (authorizationURL.includes("#")) {
+			throw new APIError("BAD_REQUEST", {
+				message: "Invalid authorizationURL",
+			});
+		}
+		let url: URL;
+		try {
+			url = new URL(authorizationURL);
+		} catch {
+			throw new APIError("BAD_REQUEST", {
+				message: "Invalid authorizationURL",
+			});
+		}
+		if (
+			url.protocol !== "https:" ||
+			url.origin === new URL(ctx.context.baseURL).origin
+		) {
+			throw new APIError("BAD_REQUEST", {
+				message: "Invalid authorizationURL",
+			});
+		}
+
+		const { oauthState } = ctx.query;
+		if (oauthState) {
+			const oauthStateCookie = ctx.context.createAuthCookie("oauth_state", {
+				maxAge: 10 * 60, // 10 minutes
+			});
+			ctx.setCookie(
+				oauthStateCookie.name,
+				oauthState,
+				oauthStateCookie.attributes,
+			);
+			return ctx.redirect(authorizationURL);
+		}
+
+		const state = url.searchParams.get("state");
+		if (!state) {
+			throw new APIError("BAD_REQUEST", {
+				message: "Unexpected error",
+			});
+		}
+		const stateCookie = ctx.context.createAuthCookie("state", {
+			maxAge: 5 * 60, // 5 minutes
+		});
+		await ctx.setSignedCookie(
+			stateCookie.name,
+			state,
+			ctx.context.secret,
+			stateCookie.attributes,
+		);
+		return ctx.redirect(ctx.query.authorizationURL);
+	},
+);

--- a/packages/flutter/src/version.ts
+++ b/packages/flutter/src/version.ts
@@ -1,0 +1,3 @@
+import pkg from "../package.json" with { type: "json" };
+
+export const PACKAGE_VERSION = pkg.version;

--- a/packages/flutter/test/flutter.test.ts
+++ b/packages/flutter/test/flutter.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @see https://github.com/2keyapp/better-auth
+ */
+import { getTestInstance } from "better-auth/test";
+import { describe, expect, it } from "vitest";
+import { flutter } from "../src";
+
+describe("flutter server plugin", () => {
+	it("registers the flutter plugin id", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [flutter()],
+			trustedOrigins: ["myapp://"],
+		});
+		const ctx = await auth.$context;
+		expect(ctx.options.plugins?.some((p) => p.id === "flutter")).toBe(true);
+	});
+
+	it("overrides origin from flutter-origin when Origin is missing", async () => {
+		const { auth } = await getTestInstance({
+			emailAndPassword: { enabled: true },
+			plugins: [flutter()],
+			trustedOrigins: ["myapp://"],
+		});
+
+		const res = await auth.handler(
+			new Request("http://localhost:3000/api/auth/ok", {
+				method: "GET",
+				headers: {
+					"flutter-origin": "myapp://",
+				},
+			}),
+		);
+		expect(res.status).toBe(200);
+	});
+
+	it("does not override an existing Origin header", async () => {
+		const { auth } = await getTestInstance({
+			emailAndPassword: { enabled: true },
+			plugins: [flutter({ disableOriginOverride: false })],
+			trustedOrigins: ["https://example.com", "myapp://"],
+		});
+
+		const res = await auth.handler(
+			new Request("http://localhost:3000/api/auth/ok", {
+				method: "GET",
+				headers: {
+					origin: "https://example.com",
+					"flutter-origin": "myapp://",
+				},
+			}),
+		);
+		expect(res.status).toBe(200);
+	});
+
+	it("rejects same-origin authorizationURL on the proxy endpoint", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [flutter()],
+			trustedOrigins: ["myapp://"],
+		});
+		const ctx = await auth.$context;
+		const base = ctx.baseURL;
+		const res = await auth.handler(
+			new Request(
+				`${base}/flutter-authorization-proxy?authorizationURL=${encodeURIComponent(`${base}/sign-in`)}`,
+				{ method: "GET" },
+			),
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects non-https authorizationURL on the proxy endpoint", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [flutter()],
+			trustedOrigins: ["myapp://"],
+		});
+		const ctx = await auth.$context;
+		const res = await auth.handler(
+			new Request(
+				`${ctx.baseURL}/flutter-authorization-proxy?authorizationURL=${encodeURIComponent("http://evil.example/oauth")}`,
+				{ method: "GET" },
+			),
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it("rejects authorizationURL containing a fragment", async () => {
+		const { auth } = await getTestInstance({
+			plugins: [flutter()],
+			trustedOrigins: ["myapp://"],
+		});
+		const ctx = await auth.$context;
+		const res = await auth.handler(
+			new Request(
+				`${ctx.baseURL}/flutter-authorization-proxy?authorizationURL=${encodeURIComponent("https://accounts.google.com/o/oauth2?x=1#frag")}`,
+				{ method: "GET" },
+			),
+		);
+		expect(res.status).toBe(400);
+	});
+});

--- a/packages/flutter/tsconfig.json
+++ b/packages/flutter/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom", "dom.iterable"]
+  },
+  "include": ["./src", "./package.json"],
+  "references": [
+    {
+      "path": "../core/tsconfig.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
+    }
+  ]
+}

--- a/packages/flutter/tsconfig.test.json
+++ b/packages/flutter/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "outDir": "${configDir}/node_modules/.cache/ts/test-out",
+    "tsBuildInfoFile": "${configDir}/node_modules/.cache/ts/test-tsbuildinfo"
+  },
+  "include": ["./test", "./src", "./package.json"],
+  "references": [
+    {
+      "path": "../better-auth/tsconfig.json"
+    }
+  ]
+}

--- a/packages/flutter/tsdown.config.ts
+++ b/packages/flutter/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	dts: { build: true, incremental: true },
+	format: ["esm"],
+	entry: ["./src/index.ts"],
+	deps: {
+		neverBundle: ["better-call"],
+	},
+	platform: "neutral",
+	treeshake: true,
+});

--- a/packages/flutter/vitest.config.ts
+++ b/packages/flutter/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+	test: {
+		clearMocks: true,
+		restoreMocks: true,
+	},
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,9 @@
       "path": "./packages/expo/tsconfig.test.json"
     },
     {
+      "path": "./packages/flutter/tsconfig.json"
+    },
+    {
       "path": "./packages/i18n/tsconfig.json"
     },
     {


### PR DESCRIPTION
## Summary
- Add `@better-auth/flutter` server plugin and Dart `better_auth` client (cookie storage, social OAuth proxy, session refresh/handoff, org / 2FA / last-login plugins).
- Attach session cookie on loopback HTTP OAuth redirects (`localhost` / `127.0.0.1`) for desktop Flutter clients.
- Docs + CI path filters for Flutter/Dart changes.

## Test plan
- [ ] `packages/flutter` vitest passes
- [ ] Dart `dart analyze` / tests under `packages/flutter/dart`
- [ ] Manual: Flutter loopback OAuth redirect includes `?cookie=`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@better-auth/flutter` server plugin and a Dart `better_auth` client to support Flutter apps. When the plugin is enabled, loopback OAuth redirects to localhost now include the session via `?cookie=`, and requests without an `Origin` can use a `flutter-origin` header for CSRF/origin checks.

- New Features
  - Adds `@better-auth/flutter` plugin that accepts a `flutter-origin` header and attaches session cookies to deep-link redirects after OAuth/magic-link/email verification.
  - Introduces `/api/auth/flutter-authorization-proxy` (validates external HTTPS auth URLs and rejects same-origin targets) for provider redirects.
  - Adds Dart client (`packages/flutter/dart`) with cookie storage, session refresh, session handoff, and plugins for Flutter client, organizations, two-factor, and last-login method.
  - Appends `?cookie=` to `http://localhost` and `http://127.0.0.1` OAuth callbacks for desktop Flutter flows.
  - Documents setup in docs/integrations/flutter and adds sidebar entry.

- CI
  - Adds path-based filters to run focused Dart analyze/test for Flutter changes and skip Node/e2e/demo/preview when only `packages/flutter/**` changes.
  - Updates CODEOWNERS, labeler, PR analyzer scopes, and ignores `.dart_tool` in git and Biome.

<sup>Written for commit f60be538d967645e3c365842e634e7bab194c40c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

