### PR TITLE
fix(oauth-provider): preserve assertion replay protection with uuid ids

### DIFF
--- a/.changeset/uuid-client-assertion-replays.md
+++ b/.changeset/uuid-client-assertion-replays.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Preserve private-key JWT replay protection when database IDs use UUIDs by encoding deterministic assertion IDs as UUIDs.

--- a/packages/oauth-provider/src/private-key-jwt.test.ts
+++ b/packages/oauth-provider/src/private-key-jwt.test.ts
@@ -17,6 +17,7 @@ import type {
 } from "./types";
 import type { OAuthClient } from "./types/oauth";
 import {
+	consumeClientAssertion,
 	isPrivateHostname,
 	verifyClientAssertion,
 } from "./utils/client-assertion";
@@ -768,6 +769,50 @@ describe("private_key_jwt authentication", async () => {
 
 		expect(result2.error?.status).toBeGreaterThanOrEqual(400);
 		expect(result2.error?.status).toBeLessThan(500);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10862
+	 */
+	it("should reject reused jti when database ids are uuids", async () => {
+		const uuidOptions = {
+			loginPage: "/login",
+			consentPage: "/consent",
+		} satisfies OAuthOptions<Scope[]>;
+		const uuidInstance = await getTestInstance({
+			baseURL: authServerBaseUrl,
+			advanced: { database: { generateId: "uuid" } },
+			plugins: [jwt(), oauthProvider(uuidOptions)],
+		});
+		const context = await uuidInstance.auth.$context;
+		const assertion = {
+			namespace: "private_key_jwt:uuid-client",
+			payload: {
+				aud: tokenEndpoint,
+				exp: Math.floor(Date.now() / 1000) + 120,
+				jti: crypto.randomUUID(),
+			},
+			expectedAudience: tokenEndpoint,
+		};
+
+		await consumeClientAssertion(
+			{ context } as unknown as GenericEndpointContext,
+			uuidOptions,
+			assertion,
+		);
+		await expect(
+			consumeClientAssertion(
+				{ context } as unknown as GenericEndpointContext,
+				uuidOptions,
+				assertion,
+			),
+		).rejects.toMatchObject({
+			statusCode: 400,
+			body: {
+				error: "invalid_client",
+				error_description: "client assertion jti has already been used",
+			},
+		});
 	});
 
 	it("should reject concurrent reuse of the same jti", async () => {

--- a/packages/oauth-provider/src/utils/client-assertion.ts
+++ b/packages/oauth-provider/src/utils/client-assertion.ts
@@ -38,6 +38,16 @@ const JWKS_FETCH_TIMEOUT_MS = 5_000;
 const MAX_JWKS_RESPONSE_BYTES = 64 * 1024;
 const JSON_CONTENT_TYPE = /^application\/(?:[-\w.]+\+)?json\s*(?:;|$)/i;
 
+function formatDigestAsUUID(digest: Uint8Array): string {
+	const bytes = digest.slice(0, 16);
+	bytes[6] = (bytes[6]! & 0x0f) | 0x50;
+	bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+	const hex = Array.from(bytes, (byte) =>
+		byte.toString(16).padStart(2, "0"),
+	).join("");
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 function setJwksCache(
 	jwksCache: JwksCache,
 	cacheKey: string,
@@ -408,12 +418,15 @@ export async function consumeClientAssertion(
 	// primary key, MongoDB `_id`), so concurrent requests across workers cannot
 	// both pass. A duplicate-key failure means the jti was already used (replay);
 	// any other failure is surfaced unchanged.
-	const jtiDigest = await createHash("SHA-256").digest(
-		new TextEncoder().encode(`${namespace}:${payload.jti}`),
+	const jtiDigest = new Uint8Array(
+		await createHash("SHA-256").digest(
+			new TextEncoder().encode(`${namespace}:${payload.jti}`),
+		),
 	);
-	const jtiId = base64Url.encode(new Uint8Array(jtiDigest).slice(0, 24), {
-		padding: false,
-	});
+	const jtiId =
+		ctx.context.options.advanced?.database?.generateId === "uuid"
+			? formatDigestAsUUID(jtiDigest)
+			: base64Url.encode(jtiDigest.slice(0, 24), { padding: false });
 	try {
 		await ctx.context.adapter.create({
 			model: "oauthClientAssertion",


### PR DESCRIPTION
Fixes `private_key_jwt` client authentication when `advanced.database.generateId` is `"uuid"`. The provider now formats deterministic assertion replay IDs as version-5 UUIDs, so adapters accept the ID and repeated `jti` values still collide.

Also, this pr adds regression coverage for UUID-backed assertion replay protection. This is the OAuth provider counterpart to #10826.

Closes #10862.

No breaking changes.

Written with AI assistance, reviewed and tested by me.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores private_key_jwt replay protection in `@better-auth/oauth-provider` when `advanced.database.generateId` is "uuid". Previously a reused jti could bypass detection because the stored assertion ID didn’t match UUID primary keys; now replays are rejected with invalid_client. Closes #10862.

**Bug Fixes**
- Generates a deterministic v5 UUID from namespace + jti for the replay ID when IDs are UUIDs.
- Adds regression tests for UUID-backed replay protection.
- No migrations or breaking changes.

<sup>Written for commit dfe9b0e10e9811b39b3c0b3742b7ca893a902069. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/10987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

