### PR TITLE
fix(db): never write the active-sessions list with a zero ttl

### DIFF
--- a/.changeset/active-sessions-ttl-floor.md
+++ b/.changeset/active-sessions-ttl-floor.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Gate the `active-sessions` list write on the whole-second ttl instead of the millisecond expiry. A list whose furthest session was under a second from expiring floored to a ttl of `0`, which secondary storage implementations read as "no expiry", so the list was stored permanently instead of being reclaimed.

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -2464,3 +2464,63 @@ describe("internal adapter test", async () => {
 		});
 	});
 });
+
+describe("active-sessions list ttl", () => {
+	it("never writes the list with a zero ttl", async () => {
+		// The list write is gated on a millisecond comparison but the ttl is
+		// whole seconds, so a remaining session under a second from expiry
+		// floors to 0. Secondary storage reads a zero ttl as "no expiry", so
+		// the list would be stored permanently.
+		const data = new Map<string, string>();
+		const ttls: Record<string, number | undefined> = {};
+		const opts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				set(key: string, value: string, ttl?: number) {
+					data.set(key, value);
+					ttls[key] = ttl;
+				},
+				get: (key: string) => data.get(key) ?? null,
+				delete: (key: string) => {
+					data.delete(key);
+					delete ttls[key];
+				},
+				getAndDelete: (key: string) => {
+					const value = data.get(key) ?? null;
+					data.delete(key);
+					return value;
+				},
+				increment: () => 1,
+			},
+		} satisfies BetterAuthOptions;
+		(await getMigrations(opts)).runMigrations();
+		const ctx = await init(opts);
+
+		const now = Date.now();
+		const userId = "user-ttl-floor";
+		const keep = "token-expiring-soon";
+		const drop = "token-to-delete";
+
+		data.set(
+			drop,
+			JSON.stringify({
+				session: { token: drop, userId },
+				user: { id: userId },
+			}),
+		);
+		data.set(
+			`active-sessions-${userId}`,
+			JSON.stringify([
+				{ token: keep, expiresAt: now + 300 },
+				{ token: drop, expiresAt: now + 3_600_000 },
+			]),
+		);
+
+		await ctx.internalAdapter.deleteSession(drop);
+
+		const listKey = `active-sessions-${userId}`;
+		if (data.has(listKey)) {
+			expect(ttls[listKey]).toBeGreaterThan(0);
+		}
+	});
+});

--- a/packages/better-auth/src/db/internal-adapter.test.ts
+++ b/packages/better-auth/src/db/internal-adapter.test.ts
@@ -2488,6 +2488,7 @@ describe("active-sessions list ttl", () => {
 				getAndDelete: (key: string) => {
 					const value = data.get(key) ?? null;
 					data.delete(key);
+					delete ttls[key];
 					return value;
 				},
 				increment: () => 1,
@@ -2518,9 +2519,63 @@ describe("active-sessions list ttl", () => {
 
 		await ctx.internalAdapter.deleteSession(drop);
 
+		// The remaining entry floors to a ttl of 0, so the list must be dropped
+		// rather than written without an expiry. Unpatched, the key survives
+		// with ttl 0 and never expires.
+		expect(data.has(`active-sessions-${userId}`)).toBe(false);
+	});
+
+	it("rewrites the list with a positive ttl when a session outlives a second", async () => {
+		const data = new Map<string, string>();
+		const ttls: Record<string, number | undefined> = {};
+		const opts = {
+			database: new DatabaseSync(":memory:"),
+			secondaryStorage: {
+				set(key: string, value: string, ttl?: number) {
+					data.set(key, value);
+					ttls[key] = ttl;
+				},
+				get: (key: string) => data.get(key) ?? null,
+				delete: (key: string) => {
+					data.delete(key);
+					delete ttls[key];
+				},
+				getAndDelete: (key: string) => {
+					const value = data.get(key) ?? null;
+					data.delete(key);
+					delete ttls[key];
+					return value;
+				},
+				increment: () => 1,
+			},
+		} satisfies BetterAuthOptions;
+		(await getMigrations(opts)).runMigrations();
+		const ctx = await init(opts);
+
+		const now = Date.now();
+		const userId = "user-ttl-kept";
+		const keep = "token-hour-out";
+		const drop = "token-expiring-soon";
+
+		data.set(
+			drop,
+			JSON.stringify({
+				session: { token: drop, userId },
+				user: { id: userId },
+			}),
+		);
+		data.set(
+			`active-sessions-${userId}`,
+			JSON.stringify([
+				{ token: drop, expiresAt: now + 300 },
+				{ token: keep, expiresAt: now + 3_600_000 },
+			]),
+		);
+
+		await ctx.internalAdapter.deleteSession(drop);
+
 		const listKey = `active-sessions-${userId}`;
-		if (data.has(listKey)) {
-			expect(ttls[listKey]).toBeGreaterThan(0);
-		}
+		expect(data.has(listKey)).toBe(true);
+		expect(ttls[listKey]).toBeGreaterThan(0);
 	});
 });

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -169,11 +169,17 @@ export const createInternalAdapter = (
 		remainingSessionReferences.sort((a, b) => a.expiresAt - b.expiresAt);
 		const furthestExpiration = remainingSessionReferences.at(-1)?.expiresAt;
 
-		if (furthestExpiration) {
+		// Gate on the whole-second ttl, not the millisecond expiry: a list under
+		// a second from expiry floors to 0, which secondary storage reads as
+		// "no expiry" and would keep the list forever.
+		const listTTL = furthestExpiration
+			? getTTLSeconds(furthestExpiration, now)
+			: 0;
+		if (listTTL > 0) {
 			await secondaryStorage.set(
 				activeSessionsKey,
 				JSON.stringify(remainingSessionReferences),
-				getTTLSeconds(furthestExpiration, now),
+				listTTL,
 			);
 			return;
 		}
@@ -827,11 +833,14 @@ export const createInternalAdapter = (
 									);
 									const furthestSessionExp = sorted.at(-1)?.expiresAt;
 
-									if (furthestSessionExp && furthestSessionExp > now) {
+									const listTTL = furthestSessionExp
+										? getTTLSeconds(furthestSessionExp, now)
+										: 0;
+									if (listTTL > 0) {
 										await secondaryStorage.set(
 											listKey,
 											JSON.stringify(sorted),
-											getTTLSeconds(furthestSessionExp, now),
+											listTTL,
 										);
 									} else {
 										await secondaryStorage.delete(listKey);
@@ -876,15 +885,14 @@ export const createInternalAdapter = (
 						const sorted = filtered.sort((a, b) => a.expiresAt - b.expiresAt);
 						const furthestSessionExp = sorted.at(-1)?.expiresAt;
 
-						if (
-							filtered.length > 0 &&
-							furthestSessionExp &&
-							furthestSessionExp > Date.now()
-						) {
+						const listTTL = furthestSessionExp
+							? getTTLSeconds(furthestSessionExp, now)
+							: 0;
+						if (filtered.length > 0 && listTTL > 0) {
 							await secondaryStorage.set(
 								`active-sessions-${userId}`,
 								JSON.stringify(filtered),
-								getTTLSeconds(furthestSessionExp, now),
+								listTTL,
 							);
 						} else {
 							await secondaryStorage.delete(`active-sessions-${userId}`);


### PR DESCRIPTION
## Summary

Three secondary-storage writes gated the `active-sessions` list on a millisecond expiry while passing a ttl in whole seconds. A list whose furthest remaining session is under a second from expiry passes the gate but floors to a ttl of `0`, and secondary storage reads a zero ttl as "no expiry", so the key is stored permanently.

Closes #10992

## The inconsistency

`getTTLSeconds` floors to whole seconds and clamps at zero, so these three gates are checking the wrong unit:

- `deleteCachedUserSessions`: `if (furthestExpiration)` (truthy only)
- `updateSession`: `if (furthestSessionExp && furthestSessionExp > now)`
- `deleteSession`: `if (filtered.length > 0 && furthestSessionExp && furthestSessionExp > Date.now())`

The session write in the same file already does it correctly:

```ts
const furthestSessionTTL = getTTLSeconds(furthestSessionExp, now);
if (furthestSessionTTL > 0) { ... }
```

## The fix

Each site now computes the ttl once and gates on it, so a zero never reaches `set()` and the existing `else` branch deletes the key instead.

```diff
-		if (furthestExpiration) {
+		const listTTL = furthestExpiration
+			? getTTLSeconds(furthestExpiration, now)
+			: 0;
+		if (listTTL > 0) {
 			await secondaryStorage.set(
 				activeSessionsKey,
 				JSON.stringify(remainingSessionReferences),
-				getTTLSeconds(furthestExpiration, now),
+				listTTL,
 			);
```

No new helper: this reuses the pattern already present in the file.

## Tests

One test on the `deleteSession` path, which is the most commonly reached of the three: seed the list with one entry 300ms out and one an hour out, delete the hour-out token, and assert the rewritten list carries a positive ttl.

It fails on the unpatched code with `expected 0 to be greater than 0`, which is the bug.

`internal-adapter.test.ts` is 68/68 and `pnpm typecheck` reports no new errors. The one failing test in `db.test.ts` (`preserve a forced UUID on postgres`) needs Docker and fails identically on a clean `main`.
