### PR TITLE
fix(core): do not double-pluralize model names ending in s

### DIFF
--- a/.changeset/jwks-plural.md
+++ b/.changeset/jwks-plural.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Stop double-pluralizing model names that already end in `s` when `usePlural` is enabled. The `jwks` table was generated with an extra trailing `s`.

--- a/packages/core/src/db/adapter/get-model-name.test.ts
+++ b/packages/core/src/db/adapter/get-model-name.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { initGetModelName } from "./get-model-name";
+
+const schema = {
+	user: { modelName: "user", fields: {} },
+	jwks: { modelName: "jwks", fields: {} },
+} as any;
+
+describe("getModelName usePlural", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10930
+	 */
+	it("does not double-pluralize a model that already ends in s", () => {
+		const getModelName = initGetModelName({ usePlural: true, schema });
+		expect(getModelName("jwks")).toBe("jwks");
+	});
+
+	it("still pluralizes singular models", () => {
+		const getModelName = initGetModelName({ usePlural: true, schema });
+		expect(getModelName("user")).toBe("users");
+	});
+
+	it("leaves names alone when usePlural is off", () => {
+		const getModelName = initGetModelName({ usePlural: false, schema });
+		expect(getModelName("jwks")).toBe("jwks");
+		expect(getModelName("user")).toBe("user");
+	});
+});

--- a/packages/core/src/db/adapter/get-model-name.ts
+++ b/packages/core/src/db/adapter/get-model-name.ts
@@ -1,6 +1,9 @@
 import type { BetterAuthDBSchema } from "../type";
 import { initGetDefaultModelName } from "./get-default-model-name";
 
+/** `jwks` is already plural, so appending another `s` would double it. */
+const pluralize = (name: string) => (name.endsWith("s") ? name : `${name}s`);
+
 export const initGetModelName = ({
 	usePlural,
 	schema,
@@ -26,11 +29,11 @@ export const initGetModelName = ({
 
 		if (useCustomModelName) {
 			return usePlural
-				? `${schema[defaultModelKey]!.modelName}s`
+				? pluralize(schema[defaultModelKey]!.modelName)
 				: schema[defaultModelKey]!.modelName;
 		}
 
-		return usePlural ? `${model}s` : model;
+		return usePlural ? pluralize(model) : model;
 	};
 	return getModelName;
 };


### PR DESCRIPTION
## Summary

With `usePlural` enabled, `getModelName` appended an `s` unconditionally, so the already-plural `jwks` table was generated with an extra trailing `s`. The same happened to any custom `modelName` ending in `s`.

Closes #10930

## The fix

```diff
+/** `jwks` is already plural, so appending another `s` gives `jwkss`. */
+const pluralize = (name: string) => (name.endsWith("s") ? name : `${name}s`);
```

Applied to both branches of `getModelName`, so it covers the built-in `jwks` model and user-supplied `modelName` overrides that are already plural.

Fixed at `getModelName` rather than special-casing `jwks` at the call sites, since every adapter and the schema generators route through it.

## Tests

New `get-model-name.test.ts`: an already-plural model stays unchanged, a singular model still pluralizes, and `usePlural: false` leaves both alone.

The first case fails on the unpatched code with `expected the doubled name to be `jwks``.

`packages/core` and `packages/better-auth/src/db` are 688 passing, and `pnpm typecheck` reports no new errors. The single failure (`preserve a forced UUID on postgres`) needs Docker and fails identically on a clean `main`.
