### PR TITLE
fix(drizzle-adapter): fix schema generation for drizzle v1 does not include ".notNull()"

### DIFF
--- a/packages/drizzle-adapter/src/relations-v2/generate-drizzle-schema.test.ts
+++ b/packages/drizzle-adapter/src/relations-v2/generate-drizzle-schema.test.ts
@@ -77,6 +77,36 @@ describe("relations-v2 schema generator", () => {
 		expect(typeErrors(code)).toEqual([]);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10947
+	 */
+	it("treats fields with omitted required as not null", async () => {
+		const { code = "" } = await generate({
+			plugins: [
+				{
+					id: "required-fields-test",
+					schema: {
+						testTable: {
+							fields: {
+								implicitRequired: { type: "string" },
+								explicitRequired: { type: "string", required: true },
+								explicitOptional: { type: "string", required: false },
+							},
+						},
+					},
+				},
+			],
+		});
+
+		expect(code).toContain(
+			"implicitRequired: text('implicit_required').notNull()",
+		);
+		expect(code).toContain(
+			"explicitRequired: text('explicit_required').notNull()",
+		);
+		expect(code).not.toMatch(/explicitOptional:.*\.notNull\(\)/);
+	});
+
 	test("generates compound indexes with physical field names", async () => {
 		const { code = "" } = await generateFor("mysql", {
 			plugins: [

--- a/packages/drizzle-adapter/src/relations-v2/generate-drizzle-schema.ts
+++ b/packages/drizzle-adapter/src/relations-v2/generate-drizzle-schema.ts
@@ -400,7 +400,7 @@ export const generateDrizzleSchema: SchemaGenerator = async ({
 								}
 							}
 
-							return `${fieldName}: ${type}${attr.required ? ".notNull()" : ""}${
+							return `${fieldName}: ${type}${attr.required !== false ? ".notNull()" : ""}${
 								attr.unique ? ".unique()" : ""
 							}${
 								attr.references


### PR DESCRIPTION
Fixes #10947 

during https://github.com/better-auth/better-auth/pull/9489 missed the extra guard to check if `attr.required !== false` rather than just truthy. This caused a regression which lead to generated auth schemas to be missing `.notNull()`.  check #10947  for more info

I have copied over the fixed which was previously applied to drizzle pre-1.0. https://github.com/better-auth/better-auth/pull/8614.