### PR TITLE
ci(release): replace command acknowledgement with status

### DIFF
--- a/.github/workflows/release-notes-command.yml
+++ b/.github/workflows/release-notes-command.yml
@@ -471,8 +471,8 @@ jobs:
   finalize-command:
     needs: [acknowledge, generate, publish-comment]
     if: >-
-      !cancelled() &&
-      contains(fromJSON('["success", "failure"]'), needs.generate.result)
+      always() &&
+      contains(fromJSON('["success", "failure", "cancelled"]'), needs.generate.result)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/release-notes-command.yml
+++ b/.github/workflows/release-notes-command.yml
@@ -24,10 +24,14 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       startsWith(github.event.comment.body, '/release-notes')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 1
+    continue-on-error: true
     permissions:
       issues: write
       pull-requests: write
+    outputs:
+      reaction_id: ${{ steps.reaction.outputs.reaction_id }}
+      token_source: ${{ steps.reaction.outputs.token_source }}
     steps:
       - name: Generate scoped App token
         id: app-token
@@ -41,8 +45,10 @@ jobs:
           permission-pull-requests: write
 
       - name: Acknowledge command
+        id: reaction
         continue-on-error: true
         env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
@@ -50,8 +56,19 @@ jobs:
             echo "::error::Comment ID is invalid"
             exit 1
           fi
-          gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
-            -f content='eyes' >/dev/null
+          REACTION_ID=$(gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content='eyes' --jq '.id')
+          if [[ ! "$REACTION_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::Reaction ID is invalid"
+            exit 1
+          fi
+          echo "reaction_id=$REACTION_ID" >> "$GITHUB_OUTPUT"
+          if [ -n "$APP_TOKEN" ]; then
+            echo "token_source=app" >> "$GITHUB_OUTPUT"
+          else
+            echo "token_source=github" >> "$GITHUB_OUTPUT"
+          fi
 
   generate:
     if: >-
@@ -451,19 +468,11 @@ jobs:
             exit 1
           fi
 
-      - name: Mark command as complete
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-        run: |
-          gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
-            -f content='+1' >/dev/null
-
-  mark-failure:
-    needs: [generate, publish-comment]
+  finalize-command:
+    needs: [acknowledge, generate, publish-comment]
     if: >-
       !cancelled() &&
-      (needs.generate.result == 'failure' || needs.publish-comment.result == 'failure')
+      contains(fromJSON('["success", "failure"]'), needs.generate.result)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -481,15 +490,35 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
 
-      - name: Mark command as failed
+      - name: Set command status
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ needs.acknowledge.outputs.token_source == 'github' && secrets.GITHUB_TOKEN || steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           COMMENT_ID: ${{ github.event.comment.id }}
+          REACTION_ID: ${{ needs.acknowledge.outputs.reaction_id }}
+          GENERATE_RESULT: ${{ needs.generate.result }}
+          PUBLISH_RESULT: ${{ needs.publish-comment.result }}
         run: |
           if [[ ! "$COMMENT_ID" =~ ^[0-9]+$ ]]; then
             echo "::error::Comment ID is invalid"
             exit 1
           fi
+
+          if [ -n "$REACTION_ID" ]; then
+            if [[ ! "$REACTION_ID" =~ ^[0-9]+$ ]]; then
+              echo "::error::Reaction ID is invalid"
+              exit 1
+            fi
+            if ! gh api --method DELETE \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions/${REACTION_ID}"; then
+              echo "::warning::Could not clear the command acknowledgement"
+            fi
+          fi
+
+          CONTENT='-1'
+          if [ "$GENERATE_RESULT" = 'success' ] && \
+             [ "$PUBLISH_RESULT" = 'success' ]; then
+            CONTENT='+1'
+          fi
           gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
-            -f content='-1' >/dev/null
+            -f content="$CONTENT" >/dev/null

--- a/.github/workflows/release-notes-command.yml
+++ b/.github/workflows/release-notes-command.yml
@@ -471,8 +471,8 @@ jobs:
   finalize-command:
     needs: [acknowledge, generate, publish-comment]
     if: >-
-      always() &&
-      contains(fromJSON('["success", "failure", "cancelled"]'), needs.generate.result)
+      !cancelled() &&
+      contains(fromJSON('["success", "failure"]'), needs.generate.result)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -293,7 +293,7 @@ describe("release notes command security", () => {
 			"publish-comment",
 		]);
 		expect(finalize.if?.replace(/\s+/g, " ")).toBe(
-			'!cancelled() && contains(fromJSON(\'["success", "failure"]\'), needs.generate.result)',
+			'always() && contains(fromJSON(\'["success", "failure", "cancelled"]\'), needs.generate.result)',
 		);
 		expect(appTokenPermissions(token)).toEqual({
 			"permission-issues": "write",

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -27,7 +27,9 @@ const workflowStepSchema = z.looseObject({
 });
 
 const workflowJobSchema = z.looseObject({
+	"continue-on-error": z.union([z.boolean(), z.string()]).optional(),
 	if: z.string().optional(),
+	outputs: z.record(z.string(), workflowValueSchema).optional(),
 	permissions: z.record(z.string(), z.string()).optional(),
 	steps: z.array(workflowStepSchema),
 	"timeout-minutes": z.number().positive().optional(),
@@ -137,6 +139,12 @@ describe("release notes command security", () => {
 			issues: "write",
 			"pull-requests": "write",
 		});
+		expect(acknowledge["continue-on-error"]).toBe(true);
+		expect(acknowledge["timeout-minutes"]).toBe(1);
+		expect(acknowledge.outputs).toEqual({
+			reaction_id: "${{ steps.reaction.outputs.reaction_id }}",
+			token_source: "${{ steps.reaction.outputs.token_source }}",
+		});
 		expect(appTokenPermissions(token)).toEqual({
 			"permission-issues": "write",
 			"permission-pull-requests": "write",
@@ -147,6 +155,9 @@ describe("release notes command security", () => {
 		);
 		expect(reaction["continue-on-error"]).toBe(true);
 		expect(reaction.run).toContain("content='eyes'");
+		expect(reaction.run).toContain("reaction_id=$REACTION_ID");
+		expect(reaction.run).toContain("token_source=app");
+		expect(reaction.run).toContain("token_source=github");
 		expect(generate).not.toHaveProperty("needs");
 	});
 
@@ -267,28 +278,43 @@ describe("release notes command security", () => {
 		);
 	});
 
-	it("reacts to failed release-note commands", () => {
-		const failure = getJob(commandWorkflow, "mark-failure");
-		const token = getStep(failure, "Generate scoped App token");
-		const reaction = getStep(failure, "Mark command as failed");
+	it("replaces command acknowledgement with the final status", () => {
+		const finalize = getJob(commandWorkflow, "finalize-command");
+		const token = getStep(finalize, "Generate scoped App token");
+		const status = getStep(finalize, "Set command status");
 
-		expect(failure.permissions).toEqual({
+		expect(finalize.permissions).toEqual({
 			issues: "write",
 			"pull-requests": "write",
 		});
-		expect(failure.if?.replace(/\s+/g, " ")).toBe(
-			"!cancelled() && (needs.generate.result == 'failure' || needs.publish-comment.result == 'failure')",
+		expect(finalize).toHaveProperty("needs", [
+			"acknowledge",
+			"generate",
+			"publish-comment",
+		]);
+		expect(finalize.if?.replace(/\s+/g, " ")).toBe(
+			'!cancelled() && contains(fromJSON(\'["success", "failure"]\'), needs.generate.result)',
 		);
 		expect(appTokenPermissions(token)).toEqual({
 			"permission-issues": "write",
 			"permission-pull-requests": "write",
 		});
-		expect(reaction.env).toHaveProperty(
+		expect(status.env).toHaveProperty(
 			"GH_TOKEN",
-			expect.stringContaining("steps.app-token.outputs.token"),
+			expect.stringContaining("needs.acknowledge.outputs.token_source"),
 		);
-		expect(reaction["continue-on-error"]).toBe(true);
-		expect(reaction.run).toContain("content='-1'");
+		expect(status.env).toHaveProperty(
+			"REACTION_ID",
+			expect.stringContaining("needs.acknowledge.outputs.reaction_id"),
+		);
+		expect(status["continue-on-error"]).toBe(true);
+		expect(status.run).toContain("--method DELETE");
+		expect(status.run).toContain('content="$CONTENT"');
+		expect(status.run).toContain("CONTENT='+1'");
+		expect(status.run).toContain("CONTENT='-1'");
+		expect(status.run?.indexOf("--method DELETE")).toBeLessThan(
+			status.run?.indexOf('content="$CONTENT"') ?? 0,
+		);
 	});
 
 	it("returns release carriers to draft without pull_request_target", () => {

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -293,7 +293,7 @@ describe("release notes command security", () => {
 			"publish-comment",
 		]);
 		expect(finalize.if?.replace(/\s+/g, " ")).toBe(
-			'always() && contains(fromJSON(\'["success", "failure", "cancelled"]\'), needs.generate.result)',
+			'!cancelled() && contains(fromJSON(\'["success", "failure"]\'), needs.generate.result)',
 		);
 		expect(appTokenPermissions(token)).toEqual({
 			"permission-issues": "write",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Makes the `/release-notes` command leave only the final status reaction on the comment, replacing the temporary eyes acknowledgement with a +1 or -1.

- Captures the acknowledgement reaction ID and token source so the finalize job can delete it before posting the result.
- Replaces the separate `mark-failure` job with a single `finalize-command` job that runs after generate and publish-comment regardless of their individual results.
- Shrinks the acknowledge step timeout to 1 minute and lets it fail without blocking the rest of the workflow.

<sup>Written for commit 1ccd4ec0e8fbcb1536126e480e90a60aa25a01f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

