### PR TITLE
fix(oauth-provider): backport CIMD grant intersection

### DIFF
--- a/.changeset/cimd-grant-intersection.md
+++ b/.changeset/cimd-grant-intersection.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Client ID Metadata Document clients that declare a grant the server does not offer (such as Claude's enterprise `jwt-bearer` grant) can now register. Only documents sharing no grant with the server are refused.

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -512,6 +512,84 @@ describe("oauth register", async () => {
 		});
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10660
+	 */
+	describe("client metadata document grant intersection", () => {
+		it("keeps a client metadata document whose grants intersect the supported set", async () => {
+			await expect(
+				checkOAuthClient(
+					{
+						client_id: "https://client.example.com/oauth/client-metadata",
+						client_name: "Claude",
+						redirect_uris: ["https://client.example.com/api/auth_callback"],
+						grant_types: [
+							"authorization_code",
+							"refresh_token",
+							"urn:ietf:params:oauth:grant-type:jwt-bearer",
+						],
+						response_types: ["code"],
+						token_endpoint_auth_method: "none",
+					},
+					{
+						loginPage: "/login",
+						consentPage: "/consent",
+					},
+					{ registrationSource: "clientMetadataDocument" },
+				),
+			).resolves.toBeUndefined();
+		});
+
+		it("rejects a client metadata document sharing no grant with the server", async () => {
+			await expect(
+				checkOAuthClient(
+					{
+						client_id: "https://client.example.com/oauth/client-metadata",
+						client_name: "Assertion Only",
+						redirect_uris: [],
+						grant_types: ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+						response_types: [],
+						token_endpoint_auth_method: "none",
+					},
+					{
+						loginPage: "/login",
+						consentPage: "/consent",
+					},
+					{ registrationSource: "clientMetadataDocument" },
+				),
+			).rejects.toMatchObject({
+				body: {
+					error_description: expect.stringContaining("no mutually supported"),
+				},
+			});
+		});
+
+		it("still rejects a dynamic registration declaring an unsupported grant", async () => {
+			await expect(
+				checkOAuthClient(
+					{
+						client_id: "dcr-client",
+						redirect_uris: [redirectUri],
+						grant_types: [
+							"authorization_code",
+							"urn:ietf:params:oauth:grant-type:jwt-bearer",
+						],
+						response_types: ["code"],
+					},
+					{
+						loginPage: "/login",
+						consentPage: "/consent",
+					},
+					{ registrationSource: "dynamic" },
+				),
+			).rejects.toMatchObject({
+				body: {
+					error_description: expect.stringContaining("unsupported grant_type"),
+				},
+			});
+		});
+	});
+
 	it("rejects a bare JWK array through managed registration", async () => {
 		await expect(
 			auth.api.adminCreateOAuthClient({

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -409,12 +409,24 @@ export async function checkOAuthClient(
 
 	// Validate correlation between grant_types and response_types
 	const supportedGrantTypes = new Set(getSupportedGrantTypes(opts));
-	for (const grantType of grantTypes) {
-		if (!supportedGrantTypes.has(grantType)) {
+	if (isClientMetadataDocument) {
+		// One metadata document serves every authorization server the client talks
+		// to, so it declares a grant union; require one mutual grant and let the
+		// token endpoint refuse the rest.
+		if (!grantTypes.some((grantType) => supportedGrantTypes.has(grantType))) {
 			throw new APIError("BAD_REQUEST", {
 				error: "invalid_client_metadata",
-				error_description: `unsupported grant_type ${grantType}`,
+				error_description: `no mutually supported grant_type among ${grantTypes.join(", ")}`,
 			});
+		}
+	} else {
+		for (const grantType of grantTypes) {
+			if (!supportedGrantTypes.has(grantType)) {
+				throw new APIError("BAD_REQUEST", {
+					error: "invalid_client_metadata",
+					error_description: `unsupported grant_type ${grantType}`,
+				});
+			}
 		}
 	}
 	if (


### PR DESCRIPTION
Backports #10731 to `main`.

It merged into `next` after the v1.7.0 promotion, shortly before v1.7.1 was released from `main`, so the fix did not enter the v1.7.x release line.

Not a breaking change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Client ID Metadata Document grant validation so clients that declare grants beyond the server's supported set (e.g., Claude's enterprise `jwt-bearer`) can register as long as at least one grant is mutually supported. Previously, any unsupported grant rejected the document. Dynamic registration still requires all grants to be supported.

Backports this fix into the v1.7.x release line, which missed it because it originally landed in `next` after the v1.7.0 promotion.

<sup>Written for commit c155d8032c0d39e33aae5ef3ced931ea472b6f53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

