### PR TITLE
ci(release): clarify preview boundaries

### DIFF
--- a/packages/release-tooling/src/release-notes/comment.ts
+++ b/packages/release-tooling/src/release-notes/comment.ts
@@ -79,20 +79,24 @@ export function wrapReleaseNotesComment(
 			: []),
 		`# Release preview: v${version}`,
 		"",
+		"---",
+		"",
 		bodyStartMarker,
 		"",
 		notes,
 		"",
 		bodyEndMarker,
 		"",
-		"Maintainers may edit the release notes above. Keep the hidden markers intact.",
+		"---",
+		"",
 		...(merged
 			? [
-					"This PR is already merged. Re-run the original failed Release workflow after reviewing these notes.",
+					"> [!IMPORTANT]",
+					"> **For maintainers:** This PR is already merged. Review and edit the notes above without changing the hidden markers. Re-run the original failed Release workflow when they are ready.",
 				]
 			: [
-					"Any head update returns this PR to Draft. Rerun `/release-notes` after it changes.",
-					"The release bot marks this PR ready. Merging it approves these release notes.",
+					"> [!TIP]",
+					"> **For maintainers:** You can edit the notes above, but keep the hidden markers intact. If the head changes, this PR returns to Draft. Rerun `/release-notes` after any update. Merging this PR approves the preview.",
 				]),
 	].join("\n");
 }

--- a/packages/release-tooling/test/release-notes-comment.test.ts
+++ b/packages/release-tooling/test/release-notes-comment.test.ts
@@ -20,6 +20,10 @@ describe("wrapReleaseNotesComment", () => {
 		expect(comment).toContain("<!-- release-body:start -->");
 		expect(comment).toContain(notes);
 		expect(comment).toContain("<!-- release-body:end -->");
+		expect(comment).toContain(
+			`# Release preview: v${version}\n\n---\n\n<!-- release-body:start -->`,
+		);
+		expect(comment).toContain("<!-- release-body:end -->\n\n---\n\n> [!TIP]");
 	});
 
 	it("rejects empty release notes", () => {
@@ -65,14 +69,17 @@ describe("wrapReleaseNotesComment", () => {
 
 		expect(comment).toContain("This PR is already merged");
 		expect(comment).toContain("Re-run the original failed Release workflow");
-		expect(comment).not.toContain("marks this PR ready");
+		expect(comment).toContain("> [!IMPORTANT]");
+		expect(comment).not.toContain("> [!TIP]");
 	});
 
 	it("explains the draft approval lifecycle", () => {
 		const comment = wrapReleaseNotesComment(version, head, notes);
 
-		expect(comment).toContain("Any head update returns this PR to Draft");
-		expect(comment).toContain("The release bot marks this PR ready");
+		expect(comment).toContain("> [!TIP]");
+		expect(comment).toContain("keep the hidden markers intact");
+		expect(comment).toContain("this PR returns to Draft");
+		expect(comment).toContain("Merging this PR approves the preview");
 	});
 
 	it("rejects malformed release identity markers", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies the release preview comment layout so maintainers can see at a glance what actions apply to merged vs. draft PRs.

- Separates the release notes body with horizontal rules so the editable preview is visually distinct.
- Replaces the old instruction lines with `> [!TIP]` and `> [!IMPORTANT]` GitHub alert blocks that explain the draft approval lifecycle and the re-run workflow for merged PRs.

<sup>Written for commit fa1d00c94c1c94f29ba70aad21072e714c25656c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

