### PR TITLE
fix(mongo-adapter): don't abort a transaction after commit was attempted

### DIFF
--- a/.changeset/mongo-abort-after-commit.md
+++ b/.changeset/mongo-abort-after-commit.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/mongo-adapter": patch
+---
+
+Fix `unable_to_create_user` on fresh databases with transactions enabled. The adapter no longer calls `abortTransaction` after `commitTransaction` has been attempted, so a genuine commit failure surfaces its real error instead of the driver's "Cannot call abortTransaction after calling commitTransaction" guard error.

--- a/packages/mongo-adapter/src/mongodb-adapter.test.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.test.ts
@@ -12,6 +12,37 @@ describe("mongodb-adapter", () => {
 		expect(adapter).toBeDefined();
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10925
+	 */
+	it("does not call abortTransaction when commitTransaction itself throws, so the real commit error propagates", async () => {
+		const commitError = new Error("commit failed: write conflict");
+		const abortTransaction = vi
+			.fn()
+			.mockRejectedValue(
+				new Error(
+					"Cannot call abortTransaction after calling commitTransaction",
+				),
+			);
+		const session = {
+			startTransaction: vi.fn(),
+			commitTransaction: vi.fn().mockRejectedValue(commitError),
+			abortTransaction,
+			endSession: vi.fn().mockResolvedValue(undefined),
+		};
+		const client = { startSession: vi.fn(() => session) } as any;
+		const db = { collection: vi.fn() } as any;
+
+		const adapter = mongodbAdapter(db, { client })({});
+		const transaction = adapter.options!.adapterConfig.transaction as (
+			cb: (adapter: unknown) => Promise<unknown>,
+		) => Promise<unknown>;
+
+		await expect(transaction(async () => "ok")).rejects.toThrow(commitError);
+		expect(abortTransaction).not.toHaveBeenCalled();
+		expect(session.endSession).toHaveBeenCalledOnce();
+	});
+
 	it("creates configured compound indexes before the first write", async () => {
 		let resolveIndexSetup: (indexName: string) => void = () => {};
 		const indexSetup = new Promise<string>((resolve) => {

--- a/packages/mongo-adapter/src/mongodb-adapter.ts
+++ b/packages/mongo-adapter/src/mongodb-adapter.ts
@@ -760,6 +760,7 @@ export const mongodbAdapter = (
 							}
 
 							const session = config.client.startSession();
+							let commitAttempted = false;
 
 							try {
 								session.startTransaction();
@@ -774,10 +775,18 @@ export const mongodbAdapter = (
 
 								const result = await cb(adapter);
 
+								commitAttempted = true;
 								await session.commitTransaction();
 								return result;
 							} catch (err) {
-								await session.abortTransaction();
+								// Once commitTransaction has been called, the driver marks the
+								// session as committed even if the call itself threw, and a
+								// subsequent abortTransaction throws "Cannot call abortTransaction
+								// after calling commitTransaction" instead of the real error.
+								// @see https://github.com/better-auth/better-auth/issues/10925
+								if (!commitAttempted) {
+									await session.abortTransaction();
+								}
 								throw err;
 							} finally {
 								await session.endSession();


### PR DESCRIPTION
## What was broken
On a fresh database with transactions enabled, if commitTransaction throws, the MongoDB driver has already marked the client session as committed internally. The adapter's catch block unconditionally called abortTransaction anyway, which throws "Cannot call abortTransaction after calling commitTransaction" and masks the real commit error, surfacing to users as unable_to_create_user.

## What changed
Track whether commitTransaction was attempted and skip the abortTransaction call in that case, so the real underlying error propagates.

## How it's tested
Added a regression test that simulates commitTransaction throwing and asserts abortTransaction is never called and the original error propagates. Full mongo-adapter suite passes (16/16), typecheck clean.

Note: #9701 touches this same catch block for an unrelated reason (standalone-server fallback) and would incidentally also fix this via a broader `.catch(() => {})` around abortTransaction. Flagging the overlap in case these need to be reconciled.

Fixes #10925

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mongo adapter masking a real commit failure with the driver's "Cannot call abortTransaction after calling commitTransaction" guard error, which surfaced as `unable_to_create_user` on fresh databases with transactions enabled.

- Tracks whether `commitTransaction` was attempted and skips `abortTransaction` in that case so the original error propagates.
- Adds a regression test simulating a commit failure and asserting `abortTransaction` is never called.
- Fixes #10925.
- Note: #9701 touches the same catch block for unrelated reasons and may also fix this incidentially.

<sup>Written for commit 8749994c593441380a8e82b2f9055b2d809d31f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

