### PR TITLE
feat(captcha): add Vercel BotID provider

### DIFF
--- a/.cspell/third-party.txt
+++ b/.cspell/third-party.txt
@@ -49,3 +49,4 @@ elif
 zitadel
 anthropics
 nextjs
+botid

--- a/docs/content/docs/plugins/captcha.mdx
+++ b/docs/content/docs/plugins/captcha.mdx
@@ -10,6 +10,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 * [Cloudflare Turnstile](https://www.cloudflare.com/application-services/products/turnstile/)
 * [hCaptcha](https://www.hcaptcha.com/)
 * [CaptchaFox](https://captchafox.com/)
+* [Vercel BotID](https://vercel.com/docs/botid)
 
 <Callout type="info">
   This plugin works out of the box with <Link href="/docs/authentication/email-password">Email & Password</Link> authentication. To use it with other authentication methods, you will need to configure the <Link href="/docs/plugins/captcha#plugin-options">endpoints</Link> array in the plugin options.
@@ -19,7 +20,21 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 
 <Steps>
   <Step>
+    ### Install dependencies (Optional)
+
+    If you are using **Vercel BotID** as your provider, you need to install the `botid` library:
+
+    ```package-install
+    npm install botid
+    ```
+  </Step>
+
+  <Step>
     ### Add the plugin to your **auth** config
+
+    <Callout type="info">
+      **Vercel BotID** doesn't require a `secretKey`. You can omit it from the plugin options.
+    </Callout>
 
     ```ts title="auth.ts"
     import { betterAuth } from "better-auth";
@@ -28,7 +43,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     export const auth = betterAuth({
         plugins: [
             captcha({ // [!code highlight]
-                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha, captchafox // [!code highlight]
+                provider: "cloudflare-turnstile", // or google-recaptcha, hcaptcha, captchafox, vercel-botid // [!code highlight]
                 secretKey: process.env.TURNSTILE_SECRET_KEY!, // [!code highlight]
             }), // [!code highlight]
         ],
@@ -41,6 +56,10 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 
     <Callout type="warning">
       The `x-captcha-user-remote-ip` header is no longer required—IP is now auto-detected server-side.
+    </Callout>
+
+    <Callout type="info">
+      Using **Vercel BotID**? You don't need a captcha token header or a `secretKey`. Install the BotID library (`npm install botid`) and set `provider: "vercel-botid"` in the plugin options.
     </Callout>
 
     Add the captcha token to your request headers for all protected endpoints. This example shows how to include it in a `signIn` request:
@@ -63,6 +82,7 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
     * To implement Google reCAPTCHA on the client side, follow the official [Google reCAPTCHA documentation](https://developers.google.com/recaptcha/intro) or use libraries like [react-google-recaptcha](https://www.npmjs.com/package/react-google-recaptcha) (v2) and [react-google-recaptcha-v3](https://www.npmjs.com/package/react-google-recaptcha-v3) (v3).
     * To implement hCaptcha on the client side, follow the official [hCaptcha documentation](https://docs.hcaptcha.com/#add-the-hcaptcha-widget-to-your-webpage) or use libraries like [@hcaptcha/react-hcaptcha](https://www.npmjs.com/package/@hcaptcha/react-hcaptcha)
     * To implement CaptchaFox on the client side, follow the official [CaptchaFox documentation](https://docs.captchafox.com/getting-started) or use libraries like [@captchafox/react](https://www.npmjs.com/package/@captchafox/react)
+    * To implement Vercel BotID, follow the official [Vercel BotID documentation](https://vercel.com/docs/botid/get-started)
   </Step>
 </Steps>
 
@@ -88,8 +108,10 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 ## Plugin Options
 
 * **`provider` (required)**: your captcha provider.
-* **`secretKey` (required)**: your provider's secret key used for the server-side validation.
+* **`secretKey` (required for all providers except `vercel-botid`)**: your provider's secret key used for the server-side validation.
 * `endpoints` (optional): replaces the default array of paths where captcha verification is enforced. If set, only the specified paths will be protected. Paths match exactly unless they include wildcards, such as `/sign-in/*` for one segment or `/sign-in/**` for nested routes. Default is `["/sign-up/email", "/sign-in/email", "/request-password-reset"]`.
 * `minScore` (optional - only *Google ReCAPTCHA v3*): minimum score threshold. Default is `0.5`.
 * `siteKey` (optional - only *hCaptcha* and *CaptchaFox*): prevents tokens issued on one sitekey from being redeemed elsewhere.
 * `siteVerifyURLOverride` (optional): overrides endpoint URL for the captcha verification request.
+* `validateRequest` (optional - only *Vercel BotID*): custom validation logic. Return `true` to allow the request, `false` to reject it.
+* `checkBotIdOptions` (optional - only *Vercel BotID*): options passed to `checkBotId` from the BotID library.

--- a/docs/content/docs/plugins/captcha.mdx
+++ b/docs/content/docs/plugins/captcha.mdx
@@ -96,12 +96,17 @@ The **Captcha Plugin** integrates bot protection into your Better Auth system by
 
   <Step>
     it validates the captcha token on the server, by calling the captcha provider's `/siteverify`.
+
+    <Callout type="info">
+      **Vercel BotID** is the exception: it never calls `/siteverify` or reads an `x-captcha-response` header. It runs its own server-side check (`checkBotId` from the `botid` library) before any other captcha logic.
+    </Callout>
   </Step>
 
   <Step>
     * if the token is missing, gets rejected by the captcha provider, or if the `/siteverify` endpoint is
       unavailable, the plugin returns an error and interrupts the request.
     * if the token is accepted by the captcha provider, the middleware returns `undefined`, meaning the request is allowed to proceed.
+    * for **Vercel BotID**, the request is rejected when `checkBotId` (or your custom `validateRequest`) determines it's a bot, and allowed to proceed otherwise.
   </Step>
 </Steps>
 

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -504,6 +504,7 @@
     "@types/pg": "^8.20.0",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
+    "botid": "^1.5.10",
     "happy-dom": "^20.8.9",
     "msw": "^2.14.6",
     "next": "^16.2.11",
@@ -524,6 +525,7 @@
     "@tanstack/react-start": "^1.0.0",
     "@tanstack/solid-start": "^1.0.0",
     "better-sqlite3": "^12.0.0",
+    "botid": "^1.0.0",
     "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1",
     "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0",
     "mongodb": "^6.0.0 || ^7.0.0",
@@ -552,6 +554,9 @@
       "optional": true
     },
     "@tanstack/solid-start": {
+      "optional": true
+    },
+    "botid": {
       "optional": true
     },
     "next": {

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -525,7 +525,7 @@
     "@tanstack/react-start": "^1.0.0",
     "@tanstack/solid-start": "^1.0.0",
     "better-sqlite3": "^12.0.0",
-    "botid": "^1.0.0",
+    "botid": "^1.5.10",
     "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1",
     "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0",
     "mongodb": "^6.0.0 || ^7.0.0",

--- a/packages/better-auth/src/plugins/captcha/captcha.test.ts
+++ b/packages/better-auth/src/plugins/captcha/captcha.test.ts
@@ -864,6 +864,30 @@ describe("captcha", async () => {
 
 			expect(res.error?.status).toBe(403);
 		});
+
+		it("fails closed when the BotID verification call never resolves", async () => {
+			vi.useFakeTimers();
+			vi.doMock("botid/server", () => ({
+				checkBotId: () => new Promise(() => {}),
+			}));
+
+			try {
+				const { vercelBotId } = await import("./verify-handlers/vercel-botid");
+				const resultPromise = vercelBotId({
+					request: new Request("http://localhost/sign-in/email"),
+				});
+				// Attach the rejection assertion before advancing timers so the
+				// rejection is handled synchronously and doesn't surface as unhandled.
+				const assertion = expect(resultPromise).rejects.toThrow();
+
+				await vi.advanceTimersByTimeAsync(CAPTCHA_VERIFY_TIMEOUT_MS);
+
+				await assertion;
+			} finally {
+				vi.useRealTimers();
+				vi.doUnmock("botid/server");
+			}
+		});
 	});
 
 	describe("action and hostname binding", async () => {

--- a/packages/better-auth/src/plugins/captcha/captcha.test.ts
+++ b/packages/better-auth/src/plugins/captcha/captcha.test.ts
@@ -808,6 +808,64 @@ describe("captcha", async () => {
 		});
 	});
 
+	describe("vercel-botid", async () => {
+		const { client: badBotClient } = await getTestInstance({
+			plugins: [
+				captcha({
+					provider: "vercel-botid",
+					checkBotIdOptions: { developmentOptions: { bypass: "BAD-BOT" } },
+				}),
+			],
+		});
+
+		const { client: humanClient, testUser } = await getTestInstance({
+			plugins: [
+				captcha({
+					provider: "vercel-botid",
+					checkBotIdOptions: { developmentOptions: { bypass: "HUMAN" } },
+				}),
+			],
+		});
+
+		it("should reject the request when BotID reports a bot", async () => {
+			const res = await badBotClient.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+			});
+
+			expect(res.error?.status).toBe(403);
+		});
+
+		it("should allow the request when BotID reports a human", async () => {
+			const res = await humanClient.signIn.email({
+				email: testUser.email,
+				password: testUser.password,
+			});
+
+			expect(res.error).toBeNull();
+			expect(res.data?.user).toBeDefined();
+		});
+
+		it("should use a custom validateRequest function when provided", async () => {
+			const { client } = await getTestInstance({
+				plugins: [
+					captcha({
+						provider: "vercel-botid",
+						checkBotIdOptions: { developmentOptions: { bypass: "HUMAN" } },
+						validateRequest: () => false,
+					}),
+				],
+			});
+
+			const res = await client.signIn.email({
+				email: "test@test.com",
+				password: "test123456",
+			});
+
+			expect(res.error?.status).toBe(403);
+		});
+	});
+
 	describe("action and hostname binding", async () => {
 		it("rejects a Turnstile token whose action does not match expectedAction", async () => {
 			const { client } = await getTestInstance({

--- a/packages/better-auth/src/plugins/captcha/constants.ts
+++ b/packages/better-auth/src/plugins/captcha/constants.ts
@@ -19,9 +19,13 @@ export const Providers = {
 	GOOGLE_RECAPTCHA: "google-recaptcha",
 	HCAPTCHA: "hcaptcha",
 	CAPTCHAFOX: "captchafox",
+	VERCEL_BOTID: "vercel-botid",
 } as const;
 
-export const siteVerifyMap: Record<Provider, string> = {
+export const siteVerifyMap: Record<
+	Exclude<Provider, typeof Providers.VERCEL_BOTID>,
+	string
+> = {
 	[Providers.CLOUDFLARE_TURNSTILE]:
 		"https://challenges.cloudflare.com/turnstile/v0/siteverify",
 	[Providers.GOOGLE_RECAPTCHA]:

--- a/packages/better-auth/src/plugins/captcha/index.ts
+++ b/packages/better-auth/src/plugins/captcha/index.ts
@@ -58,6 +58,16 @@ export const captcha = (options: CaptchaOptions) =>
 					return undefined;
 				}
 
+				// BotId does not require a secret key to be provided, nor a captcha response header
+				// as it uses its own internal verification method, so we handle it first
+				if (options.provider === Providers.VERCEL_BOTID) {
+					return await verifyHandlers.vercelBotId({
+						request,
+						checkBotIdOptions: options.checkBotIdOptions,
+						validateRequest: options.validateRequest,
+					});
+				}
+
 				if (!options.secretKey) {
 					throw new Error(INTERNAL_ERROR_CODES.MISSING_SECRET_KEY.message);
 				}

--- a/packages/better-auth/src/plugins/captcha/types.ts
+++ b/packages/better-auth/src/plugins/captcha/types.ts
@@ -1,4 +1,8 @@
 import type { Providers } from "./constants";
+import type {
+	CheckBotIdOptions,
+	ValidateRequestContext,
+} from "./verify-handlers/vercel-botid";
 
 export type Provider = (typeof Providers)[keyof typeof Providers];
 
@@ -52,8 +56,29 @@ export interface CaptchaFoxOptions extends BaseCaptchaOptions {
 	siteKey?: string | undefined;
 }
 
+export interface VercelBotIdOptions
+	extends Pick<BaseCaptchaOptions, "endpoints"> {
+	provider: typeof Providers.VERCEL_BOTID;
+
+	/**
+	 * If you want custom logic to validate the request, you can use this function.
+	 * Return `false` to invalidate the request, and `true` to allow the request to proceed.
+	 *
+	 * Note: Any requests which are invalidated by the `endpoints` will not be checked by this function.
+	 *
+	 * @example
+	 * ```ts
+	 * ({ request, verification }) => {
+	 * 	return verification.isBot === false;
+	 * }
+	 */
+	validateRequest?: (ctx: ValidateRequestContext) => boolean | Promise<boolean>;
+	checkBotIdOptions?: CheckBotIdOptions;
+}
+
 export type CaptchaOptions =
 	| GoogleRecaptchaOptions
 	| CloudflareTurnstileOptions
 	| HCaptchaOptions
-	| CaptchaFoxOptions;
+	| CaptchaFoxOptions
+	| VercelBotIdOptions;

--- a/packages/better-auth/src/plugins/captcha/utils.ts
+++ b/packages/better-auth/src/plugins/captcha/utils.ts
@@ -1,3 +1,5 @@
+import type { IncomingHttpHeaders } from "node:http";
+
 export const encodeToURLParams = (obj: Record<string, any>): string => {
 	if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
 		throw new Error("Input must be a non-null object.");
@@ -12,4 +14,49 @@ export const encodeToURLParams = (obj: Record<string, any>): string => {
 	}
 
 	return params.toString();
+};
+
+/**
+ * Rejects with an `AbortError` if `promise` doesn't settle within `timeoutMs`.
+ * The original promise keeps running; only the returned promise is bound by
+ * the timeout.
+ */
+export const withTimeout = <T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+): Promise<T> => {
+	let timer: ReturnType<typeof setTimeout>;
+	const timeout = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(() => {
+			reject(new DOMException("The operation was aborted.", "AbortError"));
+		}, timeoutMs);
+	});
+
+	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+};
+
+/**
+ * Builds `IncomingHttpHeaders` from a Fetch `Request`, so provider libraries
+ * that expect Node-style request headers (rather than the `Request` object
+ * itself) can classify the current request instead of relying on ambient
+ * context that may not exist outside of specific frameworks/runtimes.
+ *
+ * `overrides` take precedence per header name, with keys normalized to
+ * lowercase. Array values (e.g. `set-cookie`) are kept as-is rather than
+ * joined, since joining them would change their meaning.
+ */
+export const requestToIncomingHeaders = (
+	request: Request,
+	overrides?: IncomingHttpHeaders,
+): IncomingHttpHeaders => {
+	// The Fetch `Headers` iterator already yields lowercase names with
+	// duplicate headers combined into a single comma-separated value.
+	const headers: IncomingHttpHeaders = Object.fromEntries(request.headers);
+
+	for (const [key, value] of Object.entries(overrides ?? {})) {
+		if (value === undefined) continue;
+		headers[key.toLowerCase()] = value;
+	}
+
+	return headers;
 };

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/index.ts
@@ -2,3 +2,4 @@ export { captchaFox } from "./captchafox";
 export { cloudflareTurnstile } from "./cloudflare-turnstile";
 export { googleRecaptcha } from "./google-recaptcha";
 export { hCaptcha } from "./h-captcha";
+export { vercelBotId } from "./vercel-botid";

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/vercel-botid.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/vercel-botid.ts
@@ -41,23 +41,28 @@ export const vercelBotId = async ({
 	checkBotIdOptions,
 	validateRequest = defaultValidateRequest,
 }: Params) => {
-	let verification: BotIdVerification;
+	let isValid: boolean;
 	try {
-		const { checkBotId } = await import("botid/server"); // botid is an optional dependency
-		verification = await withTimeout(
-			checkBotId({
-				...checkBotIdOptions,
-				advancedOptions: {
-					...checkBotIdOptions?.advancedOptions,
-					// Forward the current request's headers so BotID can classify it
-					// in runtimes where it can't recover ambient request context on its own.
-					// Explicit overrides in checkBotIdOptions still win per header name.
-					headers: requestToIncomingHeaders(
-						request,
-						checkBotIdOptions?.advancedOptions?.headers,
-					),
-				},
-			}),
+		isValid = await withTimeout(
+			(async () => {
+				const { checkBotId } = await import("botid/server"); // botid is an optional dependency
+				const verification = await checkBotId({
+					...checkBotIdOptions,
+					advancedOptions: {
+						...checkBotIdOptions?.advancedOptions,
+						// Forward the current request's headers so BotID can classify it
+						// in runtimes where it can't recover ambient request context on its own.
+						// Explicit overrides in checkBotIdOptions still win per header name.
+						headers: requestToIncomingHeaders(
+							request,
+							checkBotIdOptions?.advancedOptions?.headers,
+						),
+					},
+				});
+				return validateRequest({ request, verification });
+			})(),
+			// Bounds checkBotId and validateRequest together, so a slow custom
+			// validateRequest can't hold the request open past the deadline either.
 			CAPTCHA_VERIFY_TIMEOUT_MS,
 		);
 	} catch (error) {
@@ -65,7 +70,6 @@ export const vercelBotId = async ({
 			cause: error,
 		});
 	}
-	const isValid = await validateRequest({ request, verification });
 
 	if (isValid) return undefined;
 

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/vercel-botid.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/vercel-botid.ts
@@ -1,0 +1,60 @@
+import type * as BotIdServer from "botid/server";
+import { middlewareResponse } from "../../../utils/middleware-response";
+import { EXTERNAL_ERROR_CODES, INTERNAL_ERROR_CODES } from "../error-codes";
+
+export type BotIdVerification = Awaited<
+	ReturnType<typeof BotIdServer.checkBotId>
+>;
+export type CheckBotIdOptions = Parameters<typeof BotIdServer.checkBotId>[0];
+
+export type ValidateRequestContext = {
+	request: Request;
+	verification: BotIdVerification;
+};
+
+type Params = {
+	request: Request;
+	/**
+	 * If you want custom logic to validate the request, you can use this function.
+	 * Return `false` to invalidate the request, and `true` to allow the request to proceed.
+	 *
+	 * Note: Any requests which are invalidated by the `endpoints` will not be checked by this function.
+	 *
+	 * @example
+	 * ```ts
+	 * ({ request, verification }) => {
+	 * 	return verification.isBot === false;
+	 * }
+	 */
+	validateRequest?: (ctx: ValidateRequestContext) => boolean | Promise<boolean>;
+	checkBotIdOptions?: CheckBotIdOptions;
+};
+
+function defaultValidateRequest({ verification }: ValidateRequestContext) {
+	return !verification.isBot;
+}
+
+export const vercelBotId = async ({
+	request,
+	checkBotIdOptions,
+	validateRequest = defaultValidateRequest,
+}: Params) => {
+	let verification: BotIdVerification;
+	try {
+		const { checkBotId } = await import("botid/server"); // botid is an optional dependency
+		verification = await checkBotId(checkBotIdOptions);
+	} catch (error) {
+		throw new Error(INTERNAL_ERROR_CODES.SERVICE_UNAVAILABLE.message, {
+			cause: error,
+		});
+	}
+	const isValid = await validateRequest({ request, verification });
+
+	if (isValid) return undefined;
+
+	return middlewareResponse({
+		message: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.message,
+		code: EXTERNAL_ERROR_CODES.VERIFICATION_FAILED.code,
+		status: 403,
+	});
+};

--- a/packages/better-auth/src/plugins/captcha/verify-handlers/vercel-botid.ts
+++ b/packages/better-auth/src/plugins/captcha/verify-handlers/vercel-botid.ts
@@ -1,6 +1,8 @@
 import type * as BotIdServer from "botid/server";
 import { middlewareResponse } from "../../../utils/middleware-response";
+import { CAPTCHA_VERIFY_TIMEOUT_MS } from "../constants";
 import { EXTERNAL_ERROR_CODES, INTERNAL_ERROR_CODES } from "../error-codes";
+import { requestToIncomingHeaders, withTimeout } from "../utils";
 
 export type BotIdVerification = Awaited<
 	ReturnType<typeof BotIdServer.checkBotId>
@@ -42,7 +44,22 @@ export const vercelBotId = async ({
 	let verification: BotIdVerification;
 	try {
 		const { checkBotId } = await import("botid/server"); // botid is an optional dependency
-		verification = await checkBotId(checkBotIdOptions);
+		verification = await withTimeout(
+			checkBotId({
+				...checkBotIdOptions,
+				advancedOptions: {
+					...checkBotIdOptions?.advancedOptions,
+					// Forward the current request's headers so BotID can classify it
+					// in runtimes where it can't recover ambient request context on its own.
+					// Explicit overrides in checkBotIdOptions still win per header name.
+					headers: requestToIncomingHeaders(
+						request,
+						checkBotIdOptions?.advancedOptions?.headers,
+					),
+				},
+			}),
+			CAPTCHA_VERIFY_TIMEOUT_MS,
+		);
 	} catch (error) {
 		throw new Error(INTERNAL_ERROR_CODES.SERVICE_UNAVAILABLE.message, {
 			cause: error,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1171,6 +1171,9 @@ importers:
       '@types/react-dom':
         specifier: catalog:react19
         version: 19.2.3(@types/react@19.2.17)
+      botid:
+        specifier: ^1.5.10
+        version: 1.5.11(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@25.9.4)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       happy-dom:
         specifier: '>=20.8.9 <21'
         version: 20.8.9
@@ -8344,6 +8347,17 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
+
+  botid@1.5.11:
+    resolution: {integrity: sha512-KOO1A3+/vFVJk5aFoG3sNwiogKFPVR+x4aw4gQ1b2e0XoE+i5xp48/EZn+WqR07jRHeDGwHWQUOtV5WVm7xiww==}
+    peerDependencies:
+      next: '*'
+      react: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      next:
+        optional: true
+      react:
+        optional: true
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -22340,6 +22354,11 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  botid@1.5.11(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@25.9.4)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+    optionalDependencies:
+      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@25.9.4)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
 
   boxen@8.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Adds [Vercel BotID](https://vercel.com/docs/botid) as a new captcha provider on the `captcha` plugin, alongside the existing Cloudflare Turnstile, Google reCAPTCHA, hCaptcha, and CaptchaFox providers.

BotID uses its own server-side verification (`botid/server`'s `checkBotId`) rather than a `/siteverify` HTTP call, so it doesn't require a `secretKey` or an `x-captcha-response` header. The plugin handles `vercel-botid` as a special case before the shared `secretKey` check.

- New provider constant `Providers.VERCEL_BOTID` ("vercel-botid") and `VercelBotIdOptions` (a distinct branch of the `CaptchaOptions` union — it only picks `endpoints` from `BaseCaptchaOptions` since it needs no secret key / siteVerify URL).
- New `validateRequest` and `checkBotIdOptions` options for custom validation logic and `checkBotId` configuration.
- `botid` added as an optional peer dependency (dynamically imported at call time, matching the pattern used by other truly-optional runtime deps in this repo).
- Docs and tests updated accordingly.

## Background

This reworks the implementation originally proposed in #7566 (itself based on the earlier #3214) to resolve #7535. That PR was never reviewed, and the repo has since gone through a significant restructuring of the captcha plugin (error codes split out, a shared verify timeout, wildcard endpoint matching with base-path normalization, and anti-replay `expectedAction`/`allowedHostnames` options for Turnstile/reCAPTCHA). Rather than rebase the stale branch through 1000+ commits of unrelated history, I rebuilt the BotID feature from scratch on top of the current `main`, reusing the original verify-handler logic where it still applied.

Resolves #7535
Based on #7566 (mine) and #3214 (@ping-maxwell)

## Test plan

- [x] `pnpm --filter better-auth typecheck` passes
- [x] `vitest packages/better-auth/src/plugins/captcha/captcha.test.ts` — 42/42 passing, including new `vercel-botid` cases using `botid`'s real `developmentOptions.bypass` test hook (bot rejected, human allowed, custom `validateRequest` override)
- [x] Docs reviewed for accuracy (`docs/content/docs/plugins/captcha.mdx`) — verified locally via `pnpm --filter docs dev`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Vercel BotID as a captcha provider for protected auth routes. Unlike token-based providers, it uses `checkBotId` instead of `/siteverify`, so it needs no `secretKey` or captcha response header; rejected requests return 403, while errors and timeouts fail closed.

- Adds endpoint configuration, custom validation, and trusted verified-bot policies.
- Runs `checkBotId` and custom validation under the shared timeout.
- Documents the `botid` setup, client-side route protection, Vercel deployment, and local-development behavior.
- Adds tests for accepted and rejected verdicts, custom policies, unprotected routes, errors, and timeouts.

<sup>Written for commit f8807c858975e72783895d40ddbdb2e798fa459c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

