### PR TITLE
docs: add canonical Markdown routes

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -31,6 +31,7 @@ import {
 	resolveVersionFromSlug,
 	scopeDocsHref,
 } from "@/lib/docs-versions";
+import { getMarkdownPageUrl } from "@/lib/llm-text";
 import { createMetadata } from "@/lib/metadata";
 import { getSourceFor } from "@/lib/source";
 import { cn } from "@/lib/utils";
@@ -55,7 +56,7 @@ export default async function Page({
 	// Upstream content always lives at docs/content/docs on each branch;
 	// `content/_generated` only contains local sync targets, not repo paths.
 	const githubBase = `https://github.com/better-auth/better-auth/blob/${version.branch}/docs/content/docs`;
-	const markdownUrl = `/llms.txt${page.url}.md`;
+	const markdownUrl = getMarkdownPageUrl(page.url);
 
 	// Keep every absolute /docs link scoped to the version being viewed.
 	const scope = (href: string | undefined) => scopeDocsHref(href, version);

--- a/docs/lib/llm-text.test.ts
+++ b/docs/lib/llm-text.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { docsVersions } from "./docs-versions";
 import {
 	getLLMsIndexTitle,
-	getLLMsPageUrl,
+	getMarkdownPageUrl,
 	normalizeLLMsSlug,
 } from "./llm-text";
 
@@ -20,20 +20,27 @@ describe("LLM routes", () => {
 	});
 
 	it("maps documentation pages to Markdown endpoints", () => {
-		expect(getLLMsPageUrl("/docs/introduction")).toBe(
-			"/llms.txt/docs/introduction.md",
+		expect(getMarkdownPageUrl("/docs/introduction")).toBe(
+			"/docs/introduction.md",
 		);
-		expect(getLLMsPageUrl("/docs/plugins/oauth?tab=server#usage")).toBe(
-			"/llms.txt/docs/plugins/oauth.md?tab=server#usage",
+		expect(getMarkdownPageUrl("/docs/plugins/oauth?tab=server#usage")).toBe(
+			"/docs/plugins/oauth.md?tab=server#usage",
 		);
-		expect(getLLMsPageUrl("/docs/foo(bar)/")).toBe(
-			"/llms.txt/docs/foo(bar).md",
-		);
-		expect(getLLMsPageUrl("/llms.txt")).toBe("/llms.txt");
+		expect(getMarkdownPageUrl("/docs/foo(bar)/")).toBe("/docs/foo(bar).md");
+		expect(
+			getMarkdownPageUrl(
+				"/docs/introduction",
+				new URL("https://better-auth.com"),
+			),
+		).toBe("https://better-auth.com/docs/introduction.md");
+		expect(getMarkdownPageUrl("/llms.txt")).toBe("/llms.txt");
 	});
 
 	it("normalizes Markdown version indexes before routing", () => {
 		expect(normalizeLLMsSlug(["1.6.md"])).toEqual(["1.6"]);
+		expect(normalizeLLMsSlug(["docs", "introduction.md"])).toEqual([
+			"introduction",
+		]);
 		expect(normalizeLLMsSlug(["docs", "1.6", "introduction.md"])).toEqual([
 			"1.6",
 			"introduction",

--- a/docs/lib/llm-text.ts
+++ b/docs/lib/llm-text.ts
@@ -15,6 +15,7 @@ type PropertyDefinition = {
 };
 
 const docsPathPattern = /^\/docs(?:\/|$)/;
+const productionUrl = new URL("https://better-auth.com");
 const llmsDescription =
 	"The most comprehensive authentication framework for TypeScript";
 
@@ -279,24 +280,25 @@ export function getLLMsIndexTitle(version?: DocsVersion): string {
 		: "Better Auth";
 }
 
-export function getLLMsPageUrl(url: string): string {
+export function getMarkdownPageUrl(url: string, baseUrl?: URL): string {
 	if (!docsPathPattern.test(url)) return url;
-	const parsed = new URL(url, "https://better-auth.com");
+	const parsed = new URL(url, productionUrl);
 	const pathname = parsed.pathname.replace(/\/+$/, "");
-	return `/llms.txt${pathname}.md${parsed.search}${parsed.hash}`;
+	const markdownUrl = `${pathname}.md${parsed.search}${parsed.hash}`;
+	return baseUrl ? new URL(markdownUrl, baseUrl).toString() : markdownUrl;
 }
 
-function withLLMsPageUrl(node: Item): Item {
-	return { ...node, url: getLLMsPageUrl(node.url) };
+function withMarkdownPageUrl(node: Item): Item {
+	return { ...node, url: getMarkdownPageUrl(node.url, productionUrl) };
 }
 
-function withLLMsPageUrls(node: Node): Node {
-	if (node.type === "page") return withLLMsPageUrl(node);
+function withMarkdownPageUrls(node: Node): Node {
+	if (node.type === "page") return withMarkdownPageUrl(node);
 	if (node.type === "separator") return node;
 	return {
 		...node,
-		index: node.index ? withLLMsPageUrl(node.index) : undefined,
-		children: node.children.map(withLLMsPageUrls),
+		index: node.index ? withMarkdownPageUrl(node.index) : undefined,
+		children: node.children.map(withMarkdownPageUrls),
 	};
 }
 
@@ -307,7 +309,7 @@ export function getLLMsIndex(
 	const formatter = llms(loader);
 	const pageTree = loader.getPageTree();
 	const body = pageTree.children
-		.map((node) => formatter.indexNode(withLLMsPageUrls(node)))
+		.map((node) => formatter.indexNode(withMarkdownPageUrls(node)))
 		.join("\n");
 	return [
 		`# ${getLLMsIndexTitle(version)}`,

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -25,6 +25,14 @@ const nextConfig = {
 			},
 		],
 	},
+	async rewrites() {
+		return [
+			{
+				source: "/docs/:path*\\.md",
+				destination: "/llms.txt/docs/:path*.md",
+			},
+		];
+	},
 	async redirects() {
 		return [
 			// Infrastructure backwards compatibility redirects


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds canonical Markdown routes for docs pages. The docs now link to `/docs/... .md` instead of `/llms.txt/docs/...`, and the `llms.txt` index now uses absolute URLs. A rewrite keeps the old `/llms.txt/docs/...` URLs working.

<sup>Written for commit d617302aefdff2409e4bec9145657f7be1b48d54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

