### PR TITLE
fix(two-factor): reject re-enrollment when TOTP is active

### DIFF
--- a/.changeset/calm-apples-verify.md
+++ b/.changeset/calm-apples-verify.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Require verification before completing TOTP re-enrollment.
+Prevent repeated TOTP enrollment from replacing an active authenticator and its backup codes.

--- a/.changeset/calm-apples-verify.md
+++ b/.changeset/calm-apples-verify.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Require verification before completing TOTP re-enrollment.

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -117,6 +117,10 @@ When `method` is `"totp"` (default):
 * Returns `{ method: "totp", totpURI, backupCodes }`. Use `totpURI` to display a QR code.
 * By default, `twoFactorEnabled` remains `false` until the user verifies a TOTP code. When the server plugin is configured with `skipVerificationOnEnable: true`, TOTP is enabled without enrollment-code verification. See [verifying TOTP](#totp).
 
+<Callout>
+  Calling `twoFactor.enable` when the user already has a verified TOTP authenticator returns `TOTP_ALREADY_ENABLED`. Disable the current authenticator before starting a new enrollment.
+</Callout>
+
 When `method` is `"otp"`:
 
 * Returns `{ method: "otp" }`. `twoFactorEnabled` is set to `true` immediately.

--- a/packages/better-auth/src/plugins/two-factor/error-code.ts
+++ b/packages/better-auth/src/plugins/two-factor/error-code.ts
@@ -5,6 +5,7 @@ export const TWO_FACTOR_ERROR_CODES = defineErrorCodes({
 	OTP_NOT_CONFIGURED: "OTP is not available",
 	OTP_HAS_EXPIRED: "OTP has expired",
 	TOTP_NOT_ENABLED: "TOTP not enabled",
+	TOTP_ALREADY_ENABLED: "TOTP is already enabled",
 	TOTP_NOT_CONFIGURED: "TOTP is not available",
 	TWO_FACTOR_NOT_ENABLED: "Two factor isn't enabled",
 	BACKUP_CODES_NOT_ENABLED: "Backup codes aren't enabled",

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -266,10 +266,7 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 					const totpData = {
 						secret: encryptedSecret,
 						backupCodes: backupCodes.encryptedBackupCodes,
-						verified:
-							(existingTwoFactor != null &&
-								existingTwoFactor.verified === true) ||
-							!!options?.skipVerificationOnEnable,
+						verified: !!options?.skipVerificationOnEnable,
 					};
 					if (existingTwoFactor) {
 						await ctx.context.adapter.update({

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -229,15 +229,21 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 						return ctx.json({ method: "otp" as const });
 					}
 
-					const backupCodes = await generateBackupCodes(
-						ctx.context.secretConfig,
-						backupCodeOptions,
-					);
 					const existingTwoFactor =
 						await ctx.context.adapter.findOne<TwoFactorTable>({
 							model: opts.twoFactorTable,
 							where: [{ field: "userId", value: user.id }],
 						});
+					if (existingTwoFactor && existingTwoFactor.verified !== false) {
+						throw APIError.from(
+							"BAD_REQUEST",
+							TWO_FACTOR_ERROR_CODES.TOTP_ALREADY_ENABLED,
+						);
+					}
+					const backupCodes = await generateBackupCodes(
+						ctx.context.secretConfig,
+						backupCodeOptions,
+					);
 					const secret = generateRandomString(32);
 					const encryptedSecret = await symmetricEncrypt({
 						key: ctx.context.secretConfig,

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -1832,7 +1832,7 @@ describe("pre-migration twoFactor rows (verified absent)", async () => {
 /**
  * @see https://github.com/better-auth/better-auth/issues/8627
  */
-describe("OTP-only account adding TOTP (issue #8627)", async () => {
+describe("TOTP enrollment verification", async () => {
 	it("should create twoFactor row with verified=false on enableTwoFactor", async () => {
 		const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
 			secret: DEFAULT_SECRET,
@@ -1907,74 +1907,50 @@ describe("OTP-only account adding TOTP (issue #8627)", async () => {
 		expect(updatedRecord?.verified).toBe(true);
 	});
 
-	it("should preserve verified state during re-enrollment", async () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10923
+	 */
+	it("requires verification for a new secret during re-enrollment", async () => {
 		const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
 			secret: DEFAULT_SECRET,
-			plugins: [
-				twoFactor({
-					otpOptions: {
-						sendOTP() {},
-					},
-				}),
-			],
+			plugins: [twoFactor()],
 		});
-		let { headers } = await signInWithTestUser();
+		const signedIn = await signInWithTestUser();
+		let headers = signedIn.headers;
+		const userId = signedIn.user.id;
 
-		// Enable and fully verify TOTP
 		await auth.api.enableTwoFactor({
 			body: { password: testUser.password },
 			headers,
 		});
-		const userId = (await auth.api.getSession({ headers }))?.user.id as string;
-		const record1 = await db.findOne<TwoFactorTable>({
+		const previousRecord = await db.findOne<TwoFactorTable>({
 			model: "twoFactor",
 			where: [{ field: "userId", value: userId }],
 		});
-		const decrypted = await symmetricDecrypt({
+		const decryptedSecret = await symmetricDecrypt({
 			key: DEFAULT_SECRET,
-			data: record1!.secret,
+			data: previousRecord!.secret,
 		});
-		const code = await createOTP(decrypted).totp();
-		const verifyEnrollRes = await auth.api.verifyTOTP({
+		const code = await createOTP(decryptedSecret).totp();
+		const verification = await auth.api.verifyTOTP({
 			body: { code },
 			headers,
 			asResponse: true,
 		});
-		headers = convertSetCookieToCookie(verifyEnrollRes.headers);
-		expect(verifyEnrollRes.status).toBe(200);
+		headers = convertSetCookieToCookie(verification.headers);
+		expect(verification.status).toBe(200);
 
-		// Re-enroll — verified should be preserved
 		await auth.api.enableTwoFactor({
 			body: { password: testUser.password },
 			headers,
-			asResponse: true,
 		});
-		const record2 = await db.findOne<TwoFactorTable>({
+		const newRecord = await db.findOne<TwoFactorTable>({
 			model: "twoFactor",
 			where: [{ field: "userId", value: userId }],
 		});
-		expect(record2?.verified).toBe(true);
 
-		// Sign in with the new secret should work
-		const signInRes = await auth.api.signInEmail({
-			body: {
-				email: testUser.email,
-				password: testUser.password,
-			},
-			asResponse: true,
-		});
-		const signInHeaders = convertSetCookieToCookie(signInRes.headers);
-		const decrypted2 = await symmetricDecrypt({
-			key: DEFAULT_SECRET,
-			data: record2!.secret,
-		});
-		const code2 = await createOTP(decrypted2).totp();
-		const verifyRes = await auth.api.verifyTOTP({
-			body: { code: code2 },
-			headers: signInHeaders,
-			asResponse: true,
-		});
-		expect(verifyRes.status).toBe(200);
+		expect(newRecord?.secret).not.toBe(previousRecord?.secret);
+		expect(newRecord?.verified).toBe(false);
 	});
 
 	it("should reject unverified TOTP during sign-in and allow OTP fallback", async () => {

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -1910,7 +1910,7 @@ describe("TOTP enrollment verification", async () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/10923
 	 */
-	it("requires verification for a new secret during re-enrollment", async () => {
+	it("rejects re-enrollment while a verified TOTP is active", async () => {
 		const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
 			secret: DEFAULT_SECRET,
 			plugins: [twoFactor()],
@@ -1923,13 +1923,16 @@ describe("TOTP enrollment verification", async () => {
 			body: { password: testUser.password },
 			headers,
 		});
-		const previousRecord = await db.findOne<TwoFactorTable>({
+		const enrollment = await db.findOne<TwoFactorTable>({
 			model: "twoFactor",
 			where: [{ field: "userId", value: userId }],
 		});
+		if (!enrollment) {
+			throw new Error("expected TOTP enrollment");
+		}
 		const decryptedSecret = await symmetricDecrypt({
 			key: DEFAULT_SECRET,
-			data: previousRecord!.secret,
+			data: enrollment.secret,
 		});
 		const code = await createOTP(decryptedSecret).totp();
 		const verification = await auth.api.verifyTOTP({
@@ -1940,17 +1943,72 @@ describe("TOTP enrollment verification", async () => {
 		headers = convertSetCookieToCookie(verification.headers);
 		expect(verification.status).toBe(200);
 
+		const activeFactor = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: userId }],
+		});
+		if (!activeFactor) {
+			throw new Error("expected active TOTP factor");
+		}
+		const response = await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { code: string };
+		expect(body.code).toBe(TWO_FACTOR_ERROR_CODES.TOTP_ALREADY_ENABLED.code);
+
+		const unchangedFactor = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: userId }],
+		});
+		expect(unchangedFactor).toMatchObject({
+			id: activeFactor.id,
+			secret: activeFactor.secret,
+			backupCodes: activeFactor.backupCodes,
+			verified: true,
+		});
+	});
+
+	it("allows restarting an unverified TOTP enrollment", async () => {
+		const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [twoFactor()],
+		});
+		const { headers, user } = await signInWithTestUser();
+
 		await auth.api.enableTwoFactor({
 			body: { password: testUser.password },
 			headers,
 		});
-		const newRecord = await db.findOne<TwoFactorTable>({
+		const firstEnrollment = await db.findOne<TwoFactorTable>({
 			model: "twoFactor",
-			where: [{ field: "userId", value: userId }],
+			where: [{ field: "userId", value: user.id }],
 		});
+		if (!firstEnrollment) {
+			throw new Error("expected initial TOTP enrollment");
+		}
 
-		expect(newRecord?.secret).not.toBe(previousRecord?.secret);
-		expect(newRecord?.verified).toBe(false);
+		const response = await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+		expect(response.status).toBe(200);
+		const restartedEnrollment = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: user.id }],
+		});
+		if (!restartedEnrollment) {
+			throw new Error("expected restarted TOTP enrollment");
+		}
+
+		expect(restartedEnrollment.secret).not.toBe(firstEnrollment.secret);
+		expect(restartedEnrollment.backupCodes).not.toBe(
+			firstEnrollment.backupCodes,
+		);
+		expect(restartedEnrollment.verified).toBe(false);
 	});
 
 	it("should reject unverified TOTP during sign-in and allow OTP fallback", async () => {

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -1910,7 +1910,12 @@ describe("TOTP enrollment verification", async () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/10923
 	 */
-	it("rejects re-enrollment while a verified TOTP is active", async () => {
+	it.for([
+		{ state: "verified", verified: true },
+		{ state: "legacy", verified: null as unknown as boolean },
+	])("rejects re-enrollment while a $state TOTP is active", async ({
+		verified,
+	}) => {
 		const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
 			secret: DEFAULT_SECRET,
 			plugins: [twoFactor()],
@@ -1943,6 +1948,11 @@ describe("TOTP enrollment verification", async () => {
 		headers = convertSetCookieToCookie(verification.headers);
 		expect(verification.status).toBe(200);
 
+		await db.update({
+			model: "twoFactor",
+			update: { verified },
+			where: [{ field: "id", value: enrollment.id }],
+		});
 		const activeFactor = await db.findOne<TwoFactorTable>({
 			model: "twoFactor",
 			where: [{ field: "userId", value: userId }],
@@ -1967,7 +1977,7 @@ describe("TOTP enrollment verification", async () => {
 			id: activeFactor.id,
 			secret: activeFactor.secret,
 			backupCodes: activeFactor.backupCodes,
-			verified: true,
+			verified,
 		});
 	});
 


### PR DESCRIPTION
Closes #10923

## Note

`enableTwoFactor` previously replaced the stored TOTP secret and backup codes when called for a user with an active authenticator.

This fix does not implement staged rotation. Instead, attempting to enroll TOTP while a verified authenticator is active returns `TOTP_ALREADY_ENABLED` without modifying the active credential. An unverified enrollment can still be restarted.

**Current behavior after this fix**

```text
twoFactor
 └─ Factor A
     ├─ secret: A
     ├─ backupCodes: A
     └─ verified: true

enableTwoFactor()
        │
        ▼

TOTP_ALREADY_ENABLED

twoFactor
 └─ Factor A
     ├─ secret: A
     ├─ backupCodes: A
     └─ verified: true
```

Replacing an active authenticator currently requires disabling it before starting a new enrollment.

A follow-up could separate verified credentials, incomplete enrollments, and authentication challenges:

- `Factor` represents a verified credential that can be used during sign-in.
- `Enrollment` represents a short-lived, unverified credential candidate.
- `Challenge` represents a short-lived request to verify a specific factor during sign-in.

**Possible foundation**

```text
twoFactor
 └─ Factor A
     ├─ id: A
     ├─ userId
     ├─ type: totp
     ├─ label
     └─ secret: A

twoFactorEnrollment
 └─ Enrollment B
     ├─ id: B
     ├─ userId
     ├─ type: totp
     ├─ intent: replace
     ├─ replacesFactorId: A
     ├─ secret: B
     └─ expiresAt

verification
 └─ Challenge C
     ├─ userId
     ├─ factorId
     ├─ attempts
     └─ expiresAt
```

Rows in `twoFactor` would represent verified factors only, making a separate `verified` field unnecessary. Pending secrets would remain in `twoFactorEnrollment` until verification succeeds.

`enableTwoFactor` would create an enrollment without modifying the active factor:

```text
enableTwoFactor()
  → enrollmentId: B
  → totpURI
```

After successful verification, the enrollment could atomically replace the active factor:

```text
verifyTOTPEnrollment({
  enrollmentId: B,
  code,
})
        │
        ▼

Factor B created
Factor A deleted
Enrollment B deleted
```

If enrollment is abandoned or expires, only Enrollment B would be removed and Factor A would remain usable.

The same foundation could support multiple authenticators by distinguishing between two enrollment intents:

```text
intent: replace
  → create Factor B and delete Factor A

intent: add
  → create Factor B and keep Factor A
```

Sign-in verification could then target a specific factor and challenge:

```text
challengeFactor({ factorId: B })
  → challengeId: C

verifyFactorChallenge({
  challengeId: C,
  code,
})
```

The existing `verification` table could continue to store challenge and attempt state, so the only new persistent model required for staged enrollment would be `twoFactorEnrollment`.

Recovery codes could also be managed independently from individual TOTP factors so rotating an authenticator does not invalidate account recovery credentials.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TOTP re-enrollment so an active authenticator can't be silently replaced. Re-enrollment now returns `TOTP_ALREADY_ENABLED` instead of swapping in a new unverified secret; users must disable the active authenticator first.

**Side effects**
- Unverified enrollments can still be restarted, replacing the pending secret and backup codes.
- Legacy TOTP rows without a `verified` field are treated as active and rejected.

<sup>Written for commit dffe5746c55208a57dd2b65b9a1f6753702b8835. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



