### PR TITLE
fix(drizzle-adapter): read serial insert ids from the INSERT response on MySQL

### DIFF
--- a/.changeset/drizzle-mysql-serial-insert-id.md
+++ b/.changeset/drizzle-mysql-serial-insert-id.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/drizzle-adapter": patch
+---
+
+Fix `create` returning `null` on MySQL with `generateId: "serial"` when the driver does not keep one connection between queries (for example `@planetscale/database`). The adapter now reads the auto-increment id from the `INSERT` response instead of `LAST_INSERT_ID()`.

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -596,4 +596,155 @@ describe("drizzle-adapter", () => {
 			expect(result).toBeNull();
 		});
 	});
+
+	describe("MySQL serial inserts", () => {
+		const defaultSecret = "test-secret-that-is-at-least-32-chars-long!!";
+		const userRow = {
+			id: 7,
+			name: "Test",
+			email: "test@example.com",
+			emailVerified: false,
+			image: null,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+		const userTable = {
+			id: { name: "id" },
+			name: { name: "name" },
+			email: { name: "email" },
+			emailVerified: { name: "emailVerified" },
+			image: { name: "image" },
+			createdAt: { name: "createdAt" },
+			updatedAt: { name: "updatedAt" },
+		};
+
+		/**
+		 * Builds a mock MySQL db. `returningIdRows` is what the Drizzle insert
+		 * builder's `$returningId()` resolves to (omit it to model a builder
+		 * without `$returningId`). Every `select().from().where()` resolves to
+		 * `userRow`; the `where` predicates are recorded for inspection.
+		 */
+		function createSerialDb(returningIdRows?: unknown[]) {
+			const whereCalls: unknown[] = [];
+			const where = vi.fn((predicate: unknown) => {
+				whereCalls.push(predicate);
+				return {
+					limit: vi.fn().mockReturnValue({
+						execute: vi.fn().mockResolvedValue([userRow]),
+					}),
+				};
+			});
+			const select = vi.fn().mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where,
+					limit: vi.fn().mockReturnValue({
+						// What PlanetScale returns for `SELECT LAST_INSERT_ID()` on a
+						// fresh connection: UINT64 is returned uncast, as a string.
+						execute: vi.fn().mockResolvedValue([{ id: "0" }]),
+					}),
+				}),
+			});
+			const execute = vi.fn().mockResolvedValue(undefined);
+			const builder: Record<string, unknown> = {
+				config: { values: [{ name: { value: "Test" } }] },
+				execute,
+			};
+			if (returningIdRows) {
+				builder.$returningId = vi.fn().mockResolvedValue(returningIdRows);
+			}
+			const txProxy = new Proxy(
+				{},
+				{
+					get(_target, prop) {
+						if (prop === "select") return select;
+						return undefined;
+					},
+				},
+			);
+			const db = {
+				_: { fullSchema: { user: userTable } },
+				insert: vi.fn().mockReturnValue({
+					values: vi.fn().mockReturnValue(builder),
+				}),
+				select,
+				transaction: vi.fn().mockImplementation((fn: any) => fn(txProxy)),
+			} as any;
+			return { db, builder, execute, select, whereCalls };
+		}
+
+		function createSerialAdapter(db: any) {
+			return drizzleAdapter(db, { provider: "mysql" })({
+				secret: defaultSecret,
+				advanced: { database: { generateId: "serial" } },
+			});
+		}
+
+		/** Flattens the recorded `where` predicate into its raw query chunks. */
+		function chunksOf(predicate: unknown): unknown[] {
+			return is(predicate, SQL) ? predicate.queryChunks : [];
+		}
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/8867
+		 */
+		it("reads the inserted id from $returningId() and re-selects the row", async () => {
+			const { db, builder, execute, whereCalls } = createSerialDb([{ id: 7 }]);
+			const adapter = createSerialAdapter(db);
+
+			const result = await adapter.create({
+				model: "user",
+				data: { name: "Test", email: "test@example.com" },
+			});
+
+			expect(result).toEqual({ ...userRow, id: "7" });
+			expect(builder.$returningId).toHaveBeenCalledTimes(1);
+			// The INSERT must run exactly once: $returningId() executes it.
+			expect(execute).not.toHaveBeenCalled();
+			// No LAST_INSERT_ID() probe and no extra transaction are needed.
+			expect(db.select).not.toHaveBeenCalledWith(expect.anything());
+			expect(db.transaction).not.toHaveBeenCalled();
+			expect(whereCalls).toHaveLength(1);
+			expect(chunksOf(whereCalls[0])).toContain(userTable.id);
+			expect(chunksOf(whereCalls[0])).toContain(7);
+		});
+
+		it("falls through to the unique-column lookup when $returningId() yields no usable id", async () => {
+			// Drivers that do not report `insertId` yield `0`; PlanetScale-style
+			// drivers may yield it as the string `"0"`, which is truthy.
+			for (const noId of [[{ id: "0" }], [{ id: 0 }], [{}], []]) {
+				const { db, execute, whereCalls } = createSerialDb(noId);
+				const adapter = createSerialAdapter(db);
+
+				const result = await adapter.create({
+					model: "user",
+					data: { name: "Test", email: "test@example.com" },
+				});
+
+				expect(result).toEqual({ ...userRow, id: "7" });
+				expect(execute).not.toHaveBeenCalled();
+				expect(db.select).not.toHaveBeenCalledWith(expect.anything());
+				// The row must never be looked up by a bogus id.
+				for (const predicate of whereCalls) {
+					expect(chunksOf(predicate)).not.toContain(userTable.id);
+				}
+				expect(chunksOf(whereCalls[0])).toContain(userTable.email);
+				expect(chunksOf(whereCalls[0])).toContain("test@example.com");
+			}
+		});
+
+		it("executes the insert and uses the fallbacks when the builder has no $returningId", async () => {
+			const { db, execute, whereCalls } = createSerialDb();
+			const adapter = createSerialAdapter(db);
+
+			const result = await adapter.create({
+				model: "user",
+				data: { name: "Test", email: "test@example.com" },
+			});
+
+			expect(result).toEqual({ ...userRow, id: "7" });
+			expect(execute).toHaveBeenCalledTimes(1);
+			expect(db.select).not.toHaveBeenCalledWith(expect.anything());
+			expect(chunksOf(whereCalls[0])).toContain(userTable.email);
+		});
+	});
 });

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -227,9 +227,43 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 					const c = await builder.returning();
 					return c[0];
 				}
-				await builder.execute();
 				const schemaModel = getSchema(model);
 				const builderVal = builder.config?.values;
+
+				// Serial auto-increment inserts read the generated id from the
+				// driver's response to the INSERT itself (Drizzle `$returningId()`).
+				// `LAST_INSERT_ID()` must not be used for this: it is connection
+				// scoped, and drivers without connection affinity (for example
+				// `@planetscale/database`, which opens a new connection for each
+				// request and for each transaction) return `0` for it. PlanetScale
+				// returns that `0` as the string `"0"`, which is truthy and used to
+				// short-circuit the safe fallbacks below with `WHERE id = '0'`.
+				if (
+					!where?.length &&
+					options.advanced?.database?.generateId === "serial" &&
+					schemaModel.id &&
+					typeof builder.$returningId === "function"
+				) {
+					const returned: { id?: unknown }[] = await builder.$returningId();
+					const insertedId = returned[0]?.id;
+					// Drivers that do not report `insertId` yield `0` or `undefined`.
+					// Check numerically: `"0"` is truthy.
+					if (
+						Number.isSafeInteger(Number(insertedId)) &&
+						Number(insertedId) > 0
+					) {
+						const res = await db
+							.select()
+							.from(schemaModel)
+							.where(eq(schemaModel.id, insertedId))
+							.limit(1)
+							.execute();
+						return res[0] ?? null;
+					}
+				} else {
+					await builder.execute();
+				}
+
 				if (where?.length) {
 					const updatedWhere = where.map((w) => {
 						if (data[w.field] !== undefined) {
@@ -270,29 +304,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						return res[0] ?? null;
 					}
 
-					// 3. Serial auto-increment: LAST_INSERT_ID() is connection-scoped
-					if (
-						options.advanced?.database?.generateId === "serial" &&
-						schemaModel.id
-					) {
-						const lastInsertId = await tx
-							.select({ id: sql`LAST_INSERT_ID()` })
-							.from(schemaModel)
-							.limit(1)
-							.execute();
-						const lastId = lastInsertId[0]?.id;
-						if (lastId) {
-							const res = await tx
-								.select()
-								.from(schemaModel)
-								.where(eq(schemaModel.id, lastId))
-								.limit(1)
-								.execute();
-							return res[0] ?? null;
-						}
-					}
-
-					// 4. Unique column lookup via Better Auth schema
+					// 3. Unique column lookup via Better Auth schema
 					const modelSchema = baSchema[getDefaultModelName(model)]?.fields;
 					if (modelSchema) {
 						for (const [fieldKey, fieldAttr] of Object.entries(modelSchema)) {
@@ -314,7 +326,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						}
 					}
 
-					// 5. Full-field match (last resort) — LIMIT 2 to detect ambiguity
+					// 4. Full-field match (last resort) — LIMIT 2 to detect ambiguity
 					const conditions: SQL<unknown>[] = [];
 					for (const [key, val] of Object.entries(data)) {
 						if (val === undefined || !schemaModel[key]) continue;


### PR DESCRIPTION
## Summary

`@better-auth/drizzle-adapter` returns `null` from `create()` on MySQL when `advanced.database.generateId` is `"serial"` and the driver does not keep one connection between queries. `@planetscale/database` is one such driver. `signUpEmail` then throws `FAILED_TO_CREATE_USER`, and `signInEmail` throws `FAILED_TO_CREATE_SESSION`. The `INSERT` succeeds and the row exists in the database.

### Cause

`withReturning` runs the `INSERT`, opens `db.transaction()`, and reads `SELECT LAST_INSERT_ID()` inside that transaction (added in #9665).

1. `LAST_INSERT_ID()` is connection-scoped. `@planetscale/database` opens a new connection for each request and for each transaction (`Client.execute()` and `Client.transaction()` both call `new Connection()`). The value is `0`.
2. PlanetScale returns `UINT64` values as strings. The value is `"0"`.
3. The adapter tests `if (lastId)`. `"0"` is truthy. The adapter runs `WHERE id = '0'`, finds no row, and returns `null`. The unique-column and full-field fallbacks are not reached.

The same failure occurs with any pool where the transaction receives a different connection than the `INSERT`. In that case `LAST_INSERT_ID()` can also return the id of an unrelated row that the other connection inserted earlier.

### Change

- On the `"serial"` insert path, execute the `INSERT` with Drizzle's `$returningId()` and read the auto-increment id from the driver's response to the `INSERT` itself. This value is per request. It does not depend on connection affinity. The adapter then selects the row by that id on the same `db` handle. No extra transaction is opened for this path.
- Validate the id numerically (`Number.isSafeInteger(Number(id)) && Number(id) > 0`). Drivers that do not report `insertId` yield `0` or `undefined`, and the adapter falls through to the existing fallbacks (unique column, full-field match). This removes the truthiness trap for `"0"`.
- Remove the `LAST_INSERT_ID()` step. It cannot be made reliable on drivers without connection affinity, and when it is wrong it short-circuits the safe fallbacks.
- Builders without `$returningId()` keep the previous behavior: `execute()`, then the fallbacks.

`$returningId()` exists in `drizzle-orm` 0.45 and 1.0 (both peer ranges). Both map the driver's `insertId` to `[{ id }]`, keyed by the primary column's TypeScript key. `drizzle-orm/mysql2` reads `insertId` from the `ResultSetHeader`. `drizzle-orm/planetscale-serverless` reads `Number.parseFloat(res.insertId)`.

### Not changed

- `@better-auth/kysely-adapter` has the same `LAST_INSERT_ID()` step (`packages/kysely-adapter/src/kysely-adapter.ts`). This PR does not change it. Kysely exposes `insertId` on the result of `executeTakeFirst()`, so the same approach applies there. I can open a follow-up PR.
- The MySQL warnings that recommend `generateId: "serial"` are unchanged. With this fix, that recommendation is correct.

Related: #8867, #8971 (proposes `$returningId()`; opened before #9665 added the `LAST_INSERT_ID()` step), #9665.

## Reproduction

Reproduction repository: <!-- TODO: link -->

It runs without a PlanetScale account. A `mysql2` client that opens a new connection for each statement and for each transaction, with `bigNumberStrings: true`, has the same two properties as `@planetscale/database`. The repository also contains a script for a real PlanetScale database.

Output with `better-auth@1.7.2` and `@better-auth/drizzle-adapter@1.7.2` against MySQL 8.4:

```
--- Mechanism
  $returningId() after INSERT:               {"id":3}
  LAST_INSERT_ID() inside db.transaction():  "0" (typeof string)
--- signUpEmail
  FAIL: signUpEmail threw BAD_REQUEST FAILED_TO_CREATE_USER
  The INSERT itself succeeded: 1 user row(s) exist with email user-1787859169544@example.com (id 3). The adapter returned null after the insert.
Result: bug reproduced. The adapter returned null for an insert that succeeded.
```

Output with the adapter built from this branch:

```
--- signUpEmail
  PASS: signUpEmail returned user id 4
Result: no bug. The adapter returned the inserted row.
```

## Testing

- `pnpm vitest run packages/drizzle-adapter/src/drizzle-adapter.test.ts`: 3 new unit tests in `MySQL serial inserts`. They fail on `main` and pass with this change. The other 25 tests pass.
- `pnpm vitest run e2e/adapter/test/drizzle-adapter/adapter.drizzle.mysql.test.ts` (Docker MySQL, `mysql2` pool): 460 passed, 1 skipped. This includes `numberIdTestSuite` (`generateId: "serial"`).
- The reproduction above, with the released 1.7.2 packages (fails) and with this branch (passes).
- `tsc --noEmit` for the package passes. Biome is clean.

A patch changeset for `@better-auth/drizzle-adapter` is included.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `@better-auth/drizzle-adapter` returning `null` from `create()` on MySQL with `generateId: "serial"` when the driver does not keep one connection between queries, which made `signUpEmail` and `signInEmail` throw even though the INSERT succeeded.

- Reads the auto-increment id from the driver's INSERT response via Drizzle's `$returningId()` instead of `LAST_INSERT_ID()`, which is connection-scoped and unreliable on pools like `@planetscale/database`.
- Validates the id numerically so a string `"0"` no longer short-circuits the unique-column and full-field fallbacks.
- Builders without `$returningId()` keep the previous `execute()` + fallback behavior; no extra transaction is opened on the new path.

<sup>Written for commit 7b5008c25b660e87304070fc5f8499f836450670. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

