### PR TITLE
docs: add canonical Markdown routes

### DIFF
--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -82,3 +82,4 @@ pjpeg
 styl
 vbscript
 unvalidated
+describedby

--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -32,6 +32,7 @@ import {
 	resolveVersionFromSlug,
 	scopeDocsHref,
 } from "@/lib/docs-versions";
+import { getMarkdownPageUrl } from "@/lib/llm-text";
 import { createMetadata } from "@/lib/metadata";
 import { getSourceFor } from "@/lib/source";
 import { cn } from "@/lib/utils";
@@ -56,7 +57,7 @@ export default async function Page({
 	const versionSource = docsVersionSources[version.id];
 	const contentRef = versionSource.commitSha ?? versionSource.editBranch;
 	const githubBase = `https://github.com/better-auth/better-auth/blob/${contentRef}/docs/content/docs`;
-	const markdownUrl = `/llms.txt${page.url}.md`;
+	const markdownUrl = getMarkdownPageUrl(page.url);
 
 	// Keep every absolute /docs link scoped to the version being viewed.
 	const scope = (href: string | undefined) => scopeDocsHref(href, version);
@@ -236,6 +237,12 @@ export async function generateMetadata({
 	return createMetadata({
 		title,
 		description: page.data.description,
+		alternates: {
+			canonical: page.url,
+			types: {
+				"text/markdown": getMarkdownPageUrl(page.url),
+			},
+		},
 		openGraph: {
 			title,
 			description: page.data.description,

--- a/docs/app/docs/[version]/llms.txt/route.ts
+++ b/docs/app/docs/[version]/llms.txt/route.ts
@@ -1,0 +1,38 @@
+import { docsVersions, getVersionById } from "@/lib/docs-versions";
+import {
+	getDocsLLMsIndexUrl,
+	getLLMNotFound,
+	getLLMsIndex,
+} from "@/lib/llm-text";
+import { createMarkdownResponse } from "@/lib/markdown-response";
+import { getSourceFor } from "@/lib/source";
+
+export const dynamic = "force-static";
+
+export async function GET(
+	_request: Request,
+	{ params }: RouteContext<"/docs/[version]/llms.txt">,
+) {
+	const { version: versionId } = await params;
+	const version = getVersionById(versionId);
+	if (!version || version.id === "latest") {
+		return createMarkdownResponse(
+			getLLMNotFound(`/docs/${versionId}/llms.txt`),
+			{ status: 404 },
+		);
+	}
+	return createMarkdownResponse(
+		getLLMsIndex(getSourceFor(version.id), version),
+		{
+			headers: {
+				Link: `<${getDocsLLMsIndexUrl(version)}>; rel="canonical"`,
+			},
+		},
+	);
+}
+
+export function generateStaticParams() {
+	return docsVersions
+		.filter((version) => version.id !== "latest")
+		.map((version) => ({ version: version.id }));
+}

--- a/docs/app/docs/llms.txt/route.ts
+++ b/docs/app/docs/llms.txt/route.ts
@@ -1,0 +1,17 @@
+import { latestVersion } from "@/lib/docs-versions";
+import { getDocsLLMsIndexUrl, getLLMsIndex } from "@/lib/llm-text";
+import { createMarkdownResponse } from "@/lib/markdown-response";
+import { getSourceFor } from "@/lib/source";
+
+export const dynamic = "force-static";
+
+export function GET() {
+	return createMarkdownResponse(
+		getLLMsIndex(getSourceFor(latestVersion.id), latestVersion),
+		{
+			headers: {
+				Link: `<${getDocsLLMsIndexUrl(latestVersion)}>; rel="canonical"`,
+			},
+		},
+	);
+}

--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -1,0 +1,45 @@
+import { docsVersions, resolveVersionFromSlug } from "@/lib/docs-versions";
+import {
+	getDocsLLMsIndexUrl,
+	getLLMNotFound,
+	getLLMText,
+} from "@/lib/llm-text";
+import { createNegotiatedMarkdownResponse } from "@/lib/markdown-response";
+import { getSourceFor } from "@/lib/source";
+
+export const dynamic = "force-static";
+
+export async function GET(
+	_request: Request,
+	{ params }: RouteContext<"/llms.mdx/[[...slug]]">,
+) {
+	const slug = (await params).slug ?? [];
+	const { version, relSlug } = resolveVersionFromSlug(slug);
+	const page = getSourceFor(version.id).getPage(relSlug);
+
+	if (!page) {
+		const requestedPath = `/docs${slug.length > 0 ? `/${slug.join("/")}` : ""}.md`;
+		return createNegotiatedMarkdownResponse(getLLMNotFound(requestedPath), {
+			status: 404,
+		});
+	}
+
+	return createNegotiatedMarkdownResponse(await getLLMText(page, version), {
+		headers: {
+			Link: `<${page.url}>; rel="canonical", <${getDocsLLMsIndexUrl(version)}>; rel="describedby"`,
+		},
+	});
+}
+
+export function generateStaticParams() {
+	return docsVersions.flatMap((version) =>
+		getSourceFor(version.id)
+			.generateParams()
+			.map(({ slug }) => ({
+				slug:
+					version.id === "latest"
+						? (slug ?? [])
+						: [version.id, ...(slug ?? [])],
+			})),
+	);
+}

--- a/docs/app/llms.txt/[...slug]/route.ts
+++ b/docs/app/llms.txt/[...slug]/route.ts
@@ -1,63 +1,35 @@
-import { notFound } from "next/navigation";
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import {
-	docsVersions,
-	resolveVersionFromSlug,
-} from "../../../lib/docs-versions";
-import {
-	getLLMsIndex,
-	getLLMText,
-	LLM_TEXT_ERROR,
-	normalizeLLMsSlug,
-} from "../../../lib/llm-text";
-import { getSourceFor } from "../../../lib/source";
+import { getVersionById } from "@/lib/docs-versions";
+import { getLLMNotFound } from "@/lib/llm-text";
+import { createMarkdownResponse } from "@/lib/markdown-response";
 
-export const revalidate = false;
+// Redirect URLs published by the legacy `/llms.txt` index.
+function getLegacyMarkdownTarget(slug: string[]) {
+	if (slug.length === 1) {
+		const version = getVersionById(slug[0]);
+		if (version && version.id !== "latest") {
+			return `/docs/${version.id}/llms.txt`;
+		}
+	}
+
+	if (!slug.at(-1)?.endsWith(".md")) return null;
+
+	return slug[0] === "docs" ? `/${slug.join("/")}` : `/docs/${slug.join("/")}`;
+}
 
 export async function GET(
-	_req: NextRequest,
-	{ params }: { params: Promise<{ slug: string[] }> },
+	request: Request,
+	{ params }: RouteContext<"/llms.txt/[...slug]">,
 ) {
-	const slug = normalizeLLMsSlug((await params).slug);
-	const versionIndex = docsVersions.find(
-		(version) => version.id !== "latest" && version.id === slug[0],
-	);
-	if (versionIndex && slug.length === 1) {
-		return new NextResponse(
-			getLLMsIndex(getSourceFor(versionIndex.id), versionIndex),
-			{
-				status: 200,
-				headers: { "Content-Type": "text/markdown; charset=utf-8" },
-			},
+	const slug = (await params).slug;
+	const target = getLegacyMarkdownTarget(slug);
+	if (!target) {
+		return createMarkdownResponse(
+			getLLMNotFound(`/llms.txt/${slug.join("/")}`),
+			{ status: 404 },
 		);
 	}
 
-	const { version, relSlug } = resolveVersionFromSlug(slug);
-	const page = getSourceFor(version.id).getPage(relSlug);
-	if (!page) notFound();
-
-	try {
-		const content = await getLLMText(page, version);
-		return new NextResponse(content, {
-			status: 200,
-			headers: { "Content-Type": "text/markdown; charset=utf-8" },
-		});
-	} catch (error) {
-		console.error("Error generating LLM text:", error);
-		return new NextResponse(LLM_TEXT_ERROR, {
-			status: 500,
-			headers: { "Content-Type": "text/markdown; charset=utf-8" },
-		});
-	}
-}
-
-export function generateStaticParams() {
-	return docsVersions.flatMap((v) => {
-		const src = getSourceFor(v.id);
-		const pageParams = src.generateParams().map((p) => ({
-			slug: v.id !== "latest" ? [v.id, ...(p.slug ?? [])] : (p.slug ?? []),
-		}));
-		return v.id !== "latest" ? [{ slug: [v.id] }, ...pageParams] : pageParams;
-	});
+	const redirectUrl = new URL(request.url);
+	redirectUrl.pathname = target;
+	return Response.redirect(redirectUrl, 308);
 }

--- a/docs/app/llms.txt/[...slug]/route.ts
+++ b/docs/app/llms.txt/[...slug]/route.ts
@@ -1,20 +1,5 @@
-import { getVersionById } from "@/lib/docs-versions";
-import { getLLMNotFound } from "@/lib/llm-text";
+import { getLegacyMarkdownTarget, getLLMNotFound } from "@/lib/llm-text";
 import { createMarkdownResponse } from "@/lib/markdown-response";
-
-// Redirect URLs published by the legacy `/llms.txt` index.
-function getLegacyMarkdownTarget(slug: string[]) {
-	if (slug.length === 1) {
-		const version = getVersionById(slug[0]);
-		if (version && version.id !== "latest") {
-			return `/docs/${version.id}/llms.txt`;
-		}
-	}
-
-	if (!slug.at(-1)?.endsWith(".md")) return null;
-
-	return slug[0] === "docs" ? `/${slug.join("/")}` : `/docs/${slug.join("/")}`;
-}
 
 export async function GET(
 	request: Request,

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -1,21 +1,9 @@
 import { docsVersions } from "@/lib/docs-versions";
-import { getLLMsIndex } from "@/lib/llm-text";
-import { source } from "@/lib/source";
+import { getRootLLMsIndex } from "@/lib/llm-text";
+import { createMarkdownResponse } from "@/lib/markdown-response";
 
-export const revalidate = false;
+export const dynamic = "force-static";
 
 export function GET() {
-	const archivedVersions = docsVersions
-		.filter((version) => version.id !== "latest")
-		.map((version) => `- [${version.label}](/llms.txt/${version.id})`)
-		.join("\n");
-	const content = [
-		getLLMsIndex(source),
-		"## Other Versions",
-		archivedVersions,
-	].join("\n\n");
-
-	return new Response(content, {
-		headers: { "Content-Type": "text/markdown; charset=utf-8" },
-	});
+	return createMarkdownResponse(getRootLLMsIndex(docsVersions));
 }

--- a/docs/lib/llm-text.test.ts
+++ b/docs/lib/llm-text.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { docsVersions } from "./docs-versions";
 import {
+	getDocsLLMsIndexUrl,
+	getLLMNotFound,
 	getLLMsIndexTitle,
-	getLLMsPageUrl,
-	normalizeLLMsSlug,
+	getMarkdownPageUrl,
+	getRootLLMsIndex,
 } from "./llm-text";
 
 describe("LLM routes", () => {
 	it("uses the Better Auth product identity for latest docs", () => {
-		expect(getLLMsIndexTitle()).toBe("Better Auth");
+		expect(getLLMsIndexTitle()).toBe("Better Auth Documentation");
 	});
 
 	it("identifies archived documentation indexes", () => {
@@ -16,27 +18,41 @@ describe("LLM routes", () => {
 		expect(version).toBeDefined();
 		if (!version) return;
 
-		expect(getLLMsIndexTitle(version)).toBe("Better Auth — v1.6");
+		expect(getLLMsIndexTitle(version)).toBe("Better Auth Documentation — v1.6");
+		expect(getDocsLLMsIndexUrl(version)).toBe("/docs/1.6/llms.txt");
+	});
+
+	it("keeps the root index focused on discovery", () => {
+		const content = getRootLLMsIndex(docsVersions);
+
+		expect(content).toContain("https://better-auth.com/docs/llms.txt");
+		expect(content).toContain("https://better-auth.com/docs/1.6/llms.txt");
+		expect(content).toContain("https://mcp.better-auth.com/mcp");
+		expect(content).not.toContain("/llms.txt/docs/");
 	});
 
 	it("maps documentation pages to Markdown endpoints", () => {
-		expect(getLLMsPageUrl("/docs/introduction")).toBe(
-			"/llms.txt/docs/introduction.md",
+		expect(getMarkdownPageUrl("/docs/introduction")).toBe(
+			"/docs/introduction.md",
 		);
-		expect(getLLMsPageUrl("/docs/plugins/oauth?tab=server#usage")).toBe(
-			"/llms.txt/docs/plugins/oauth.md?tab=server#usage",
+		expect(getMarkdownPageUrl("/docs/plugins/oauth?tab=server#usage")).toBe(
+			"/docs/plugins/oauth.md?tab=server#usage",
 		);
-		expect(getLLMsPageUrl("/docs/foo(bar)/")).toBe(
-			"/llms.txt/docs/foo(bar).md",
-		);
-		expect(getLLMsPageUrl("/llms.txt")).toBe("/llms.txt");
+		expect(getMarkdownPageUrl("/docs/foo(bar)/")).toBe("/docs/foo(bar).md");
+		expect(
+			getMarkdownPageUrl(
+				"/docs/introduction",
+				new URL("https://better-auth.com"),
+			),
+		).toBe("https://better-auth.com/docs/introduction.md");
+		expect(getMarkdownPageUrl("/llms.txt")).toBe("/llms.txt");
 	});
 
-	it("normalizes Markdown version indexes before routing", () => {
-		expect(normalizeLLMsSlug(["1.6.md"])).toEqual(["1.6"]);
-		expect(normalizeLLMsSlug(["docs", "1.6", "introduction.md"])).toEqual([
-			"1.6",
-			"introduction",
-		]);
+	it("returns a useful Markdown not-found response", () => {
+		const content = getLLMNotFound("/docs/missing.md");
+
+		expect(content).toContain("# Documentation Page Not Found");
+		expect(content).toContain("/docs/missing.md");
+		expect(content).toContain("https://better-auth.com/docs/llms.txt");
 	});
 });

--- a/docs/lib/llm-text.test.ts
+++ b/docs/lib/llm-text.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { docsVersions } from "./docs-versions";
 import {
 	getDocsLLMsIndexUrl,
+	getLegacyMarkdownTarget,
 	getLLMNotFound,
 	getLLMsIndexTitle,
 	getMarkdownPageUrl,
@@ -46,6 +47,20 @@ describe("LLM routes", () => {
 			),
 		).toBe("https://better-auth.com/docs/introduction.md");
 		expect(getMarkdownPageUrl("/llms.txt")).toBe("/llms.txt");
+	});
+
+	it("redirects legacy Markdown paths to canonical endpoints", () => {
+		expect(getLegacyMarkdownTarget(["docs", "introduction"])).toBe(
+			"/docs/introduction.md",
+		);
+		expect(getLegacyMarkdownTarget(["docs", "introduction.md"])).toBe(
+			"/docs/introduction.md",
+		);
+		expect(getLegacyMarkdownTarget(["1.6", "plugins", "scim"])).toBe(
+			"/docs/1.6/plugins/scim.md",
+		);
+		expect(getLegacyMarkdownTarget(["1.6"])).toBe("/docs/1.6/llms.txt");
+		expect(getLegacyMarkdownTarget(["docs", "introduction.txt"])).toBeNull();
 	});
 
 	it("returns a useful Markdown not-found response", () => {

--- a/docs/lib/llm-text.ts
+++ b/docs/lib/llm-text.ts
@@ -2,6 +2,7 @@ import type { Item, Node } from "fumadocs-core/page-tree";
 import type { InferPageType } from "fumadocs-core/source";
 import { llms } from "fumadocs-core/source";
 import type { DocsVersion } from "./docs-versions";
+import { getVersionById } from "./docs-versions";
 import { scopeMarkdownLinks } from "./markdown-links";
 import type { source } from "./source";
 
@@ -322,6 +323,30 @@ export function getMarkdownPageUrl(url: string, baseUrl?: URL): string {
 	const pathname = parsed.pathname.replace(/\/+$/, "");
 	const markdownUrl = `${pathname}.md${parsed.search}${parsed.hash}`;
 	return baseUrl ? new URL(markdownUrl, baseUrl).toString() : markdownUrl;
+}
+
+export function getLegacyMarkdownTarget(slug: string[]): string | null {
+	if (slug.length === 1) {
+		const version = getVersionById(slug[0]);
+		if (version && version.id !== "latest") {
+			return `/docs/${version.id}/llms.txt`;
+		}
+	}
+
+	const lastSegment = slug.at(-1);
+	if (
+		!lastSegment ||
+		(!lastSegment.endsWith(".md") && lastSegment.includes("."))
+	) {
+		return null;
+	}
+
+	const markdownSlug = lastSegment.endsWith(".md")
+		? slug
+		: [...slug.slice(0, -1), `${lastSegment}.md`];
+	return markdownSlug[0] === "docs"
+		? `/${markdownSlug.join("/")}`
+		: `/docs/${markdownSlug.join("/")}`;
 }
 
 function withMarkdownPageUrl(node: Item): Item {

--- a/docs/lib/llm-text.ts
+++ b/docs/lib/llm-text.ts
@@ -2,6 +2,7 @@ import type { Item, Node } from "fumadocs-core/page-tree";
 import type { InferPageType } from "fumadocs-core/source";
 import { llms } from "fumadocs-core/source";
 import type { DocsVersion } from "./docs-versions";
+import { scopeMarkdownLinks } from "./markdown-links";
 import type { source } from "./source";
 
 type PropertyDefinition = {
@@ -15,6 +16,7 @@ type PropertyDefinition = {
 };
 
 const docsPathPattern = /^\/docs(?:\/|$)/;
+const productionUrl = new URL("https://better-auth.com");
 const llmsDescription =
 	"The most comprehensive authentication framework for TypeScript";
 
@@ -256,14 +258,16 @@ export async function getLLMText(
 		getText: (type: string) => Promise<string>;
 	};
 	const mdContent = await pageData.getText("processed");
-
-	// Extract APIMethod components & other nested wrapper before processing
-	const processedContent = extractAPIMethods(mdContent);
+	const renderedContent = extractAPIMethods(mdContent);
+	const processedContent =
+		version && version.id !== "latest"
+			? scopeMarkdownLinks(renderedContent, version)
+			: renderedContent;
 
 	const versionNote =
 		version && version.id !== "latest"
 			? `> You are reading Better Auth documentation for \`${version.label}\`. This is not the current stable release. APIs may differ from the latest stable version.\n\n`
-			: ""; // no version note for latest stable release
+			: "";
 
 	return `${versionNote}# ${docPage.data.title} (${docPage.url})
 
@@ -275,28 +279,62 @@ ${processedContent}
 
 export function getLLMsIndexTitle(version?: DocsVersion): string {
 	return version && version.id !== "latest"
-		? `Better Auth — ${version.label}`
-		: "Better Auth";
+		? `Better Auth Documentation — ${version.label}`
+		: "Better Auth Documentation";
 }
 
-export function getLLMsPageUrl(url: string): string {
+export function getDocsLLMsIndexUrl(
+	version: DocsVersion,
+	baseUrl?: URL,
+): string {
+	const path =
+		version.id === "latest" ? "/docs/llms.txt" : `/docs/${version.id}/llms.txt`;
+	return baseUrl ? new URL(path, baseUrl).toString() : path;
+}
+
+export function getRootLLMsIndex(versions: readonly DocsVersion[]): string {
+	const versionLinks = versions
+		.map(
+			(version) =>
+				`- [${version.label}](${getDocsLLMsIndexUrl(version, productionUrl)}): Documentation for the ${version.releaseLine}.x release line.`,
+		)
+		.join("\n");
+
+	return `# Better Auth
+
+> ${llmsDescription}
+
+Use the documentation version that matches the Better Auth version installed in the project. Find a relevant page in an index, then fetch its \`.md\` URL for clean Markdown. Cite the canonical URL without the \`.md\` suffix.
+
+## Documentation
+
+- [Current documentation index](https://better-auth.com/docs/llms.txt): All pages for the latest stable release.
+- [Documentation MCP server](https://mcp.better-auth.com/mcp): Search and retrieve Better Auth documentation from MCP-capable clients.
+
+## Versions
+
+${versionLinks}`;
+}
+
+export function getMarkdownPageUrl(url: string, baseUrl?: URL): string {
 	if (!docsPathPattern.test(url)) return url;
-	const parsed = new URL(url, "https://better-auth.com");
+	const parsed = new URL(url, productionUrl);
 	const pathname = parsed.pathname.replace(/\/+$/, "");
-	return `/llms.txt${pathname}.md${parsed.search}${parsed.hash}`;
+	const markdownUrl = `${pathname}.md${parsed.search}${parsed.hash}`;
+	return baseUrl ? new URL(markdownUrl, baseUrl).toString() : markdownUrl;
 }
 
-function withLLMsPageUrl(node: Item): Item {
-	return { ...node, url: getLLMsPageUrl(node.url) };
+function withMarkdownPageUrl(node: Item): Item {
+	return { ...node, url: getMarkdownPageUrl(node.url, productionUrl) };
 }
 
-function withLLMsPageUrls(node: Node): Node {
-	if (node.type === "page") return withLLMsPageUrl(node);
+function withMarkdownPageUrls(node: Node): Node {
+	if (node.type === "page") return withMarkdownPageUrl(node);
 	if (node.type === "separator") return node;
 	return {
 		...node,
-		index: node.index ? withLLMsPageUrl(node.index) : undefined,
-		children: node.children.map(withLLMsPageUrls),
+		index: node.index ? withMarkdownPageUrl(node.index) : undefined,
+		children: node.children.map(withMarkdownPageUrls),
 	};
 }
 
@@ -307,32 +345,31 @@ export function getLLMsIndex(
 	const formatter = llms(loader);
 	const pageTree = loader.getPageTree();
 	const body = pageTree.children
-		.map((node) => formatter.indexNode(withLLMsPageUrls(node)))
+		.map((node) => formatter.indexNode(withMarkdownPageUrls(node)))
 		.join("\n");
-	return [
+	const sections = [
 		`# ${getLLMsIndexTitle(version)}`,
 		"",
 		`> ${llmsDescription}`,
-		"",
-		body,
-	].join("\n");
-}
-
-export function normalizeLLMsSlug(input: readonly string[]): string[] {
-	const slug = [...input];
-	const lastSegment = slug.at(-1);
-	if (lastSegment?.endsWith(".md")) {
-		slug[slug.length - 1] = lastSegment.slice(0, -3);
+	];
+	if (version) {
+		sections.push(
+			"",
+			`This index covers the Better Auth ${version.releaseLine}.x documentation.`,
+		);
 	}
-	return slug[0] === "docs" ? slug.slice(1) : slug;
+	sections.push("", "## Documentation", "", body);
+	return sections.join("\n");
 }
 
-export const LLM_TEXT_ERROR = `# Documentation Not Available
+export function getLLMNotFound(path: string): string {
+	return `# Documentation Page Not Found
 
-The requested Better Auth documentation page could not be loaded at this time.
+The Markdown document \`${path}\` does not exist.
 
-**For AI Assistants:**  
-This page is temporarily unavailable. To help the user:  
-1. Check /llms.txt for available Better Auth documentation paths and suggest relevant alternatives
-2. Inform the user this specific page couldn't be loaded
-3. Offer to help with related Better Auth topics from available documentation`;
+## Find the correct page
+
+- [Current documentation index](https://better-auth.com/docs/llms.txt)
+- [Documentation versions](https://better-auth.com/llms.txt)
+- [Documentation MCP server](https://mcp.better-auth.com/mcp)`;
+}

--- a/docs/lib/markdown-response.ts
+++ b/docs/lib/markdown-response.ts
@@ -1,0 +1,17 @@
+export function createMarkdownResponse(
+	content: string,
+	init: ResponseInit = {},
+) {
+	const headers = new Headers(init.headers);
+	headers.set("Content-Type", "text/markdown; charset=utf-8");
+	return new Response(content, { ...init, headers });
+}
+
+export function createNegotiatedMarkdownResponse(
+	content: string,
+	init: ResponseInit = {},
+) {
+	const headers = new Headers(init.headers);
+	headers.set("Vary", "Accept");
+	return createMarkdownResponse(content, { ...init, headers });
+}

--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -1,0 +1,39 @@
+import { isMarkdownPreferred, rewritePath } from "fumadocs-core/negotiation";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+const { rewrite: rewriteMarkdownPath } = rewritePath(
+	"/docs{/*path}.md{x}",
+	"/llms.mdx{/*path}",
+);
+const { rewrite: rewriteDocsPath } = rewritePath(
+	"/docs/*path",
+	"/llms.mdx/*path",
+);
+
+function createRewriteUrl(request: NextRequest, pathname: string) {
+	const url = request.nextUrl.clone();
+	url.pathname = pathname;
+	return url;
+}
+
+export function proxy(request: NextRequest) {
+	const pathname = request.nextUrl.pathname;
+	const markdownPath = rewriteMarkdownPath(pathname);
+	if (markdownPath) {
+		return NextResponse.rewrite(createRewriteUrl(request, markdownPath));
+	}
+
+	if (!pathname.endsWith(".txt") && isMarkdownPreferred(request)) {
+		const rewrittenPath = rewriteDocsPath(pathname);
+		if (rewrittenPath) {
+			return NextResponse.rewrite(createRewriteUrl(request, rewrittenPath));
+		}
+	}
+
+	return NextResponse.next();
+}
+
+export const config = {
+	matcher: ["/docs/:path*"],
+};


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds canonical Markdown routes for docs pages via `/docs/*.md` URLs with content negotiation, so LLMs get clean Markdown while browsers see the HTML page. Legacy `/llms.txt/...` URLs now 308-redirect to the canonical locations, including extensionless paths.

**Details**
- Adds `Link` headers with `canonical` and `describedby` relations to Markdown responses, and declares the Markdown alternate on HTML pages.
- Rewrites `/docs/*` requests to Markdown based on the `Accept` header through a new proxy.
- Moves versioned doc indexes to `/docs/[version]/llms.txt` and lists all versions from the root index.
- Scopes internal links in versioned Markdown to the matching version.
- Returns Markdown 404 pages that point to the docs indexes and MCP server.

<sup>Written for commit 568d1bcc3600cd7f25cd372d91a2bdc89ddc85c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

