### PR TITLE
fix(cli): depend on better-auth as a peer, not a bundled copy

### DIFF
--- a/.changeset/quiet-pianos-repeat.md
+++ b/.changeset/quiet-pianos-repeat.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+Schema generation now uses the better-auth version installed in your project rather than a copy bundled with the CLI. Previously the generated schema could omit columns your installed version requires, and the mismatch only surfaced later as a database error on first sign up instead of as a migration failure.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,6 @@
     "@better-auth/utils": "catalog:",
     "@clack/prompts": "^1.6.0",
     "@mrleebo/prisma-ast": "^0.16.0",
-    "better-auth": "workspace:*",
     "c12": "^4.0.0-beta.5",
     "chalk": "^5.6.2",
     "commander": "^15.0.0",
@@ -78,6 +77,9 @@
     "yocto-spinner": "^1.2.0",
     "zod": "^4.3.6"
   },
+  "peerDependencies": {
+    "better-auth": "workspace:^"
+  },
   "devDependencies": {
     "@better-auth/oauth-provider": "workspace:*",
     "@better-auth/passkey": "workspace:*",
@@ -85,6 +87,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/prompts": "^2.4.9",
     "@types/semver": "^7.7.1",
+    "better-auth": "workspace:*",
     "better-auth-1-6-30": "npm:better-auth@1.6.30",
     "better-auth-scim-1-6-30": "npm:@better-auth/scim@1.6.30",
     "better-sqlite3": "^12.11.1",


### PR DESCRIPTION
Fixes #11048

## The problem

`@better-auth/cli` declares `better-auth` in `dependencies` as `workspace:*`, which publishes as an exact pin of whatever version was current at release. Package managers install that as a nested copy:

```
node_modules/@better-auth/cli/node_modules/better-auth   # 1.4.21
node_modules/better-auth                                 # 1.7.2  (the project's)
```

The CLI's schema generation imports statically:

```ts
// packages/cli/src/generators/kysely.ts
import { getMigrations } from "better-auth/db/migration";
```

which resolves to the nested copy. So `generate` always emits the schema of the version the CLI shipped with, not the version the project runs.

## What that does today

`@better-auth/cli@latest` is 1.4.21 while `better-auth@latest` is 1.7.2. A project on 1.7.x gets an `account` table with no `issuer` column, added in 1.7:

```
better-auth 1.7.2                       -> 3 files under dist/db mention issuer
better-auth 1.4.21 (bundled in the CLI) -> 0
```

Both `generate` and `migrate` report success. The failure appears later, on the first sign up:

```
table account has no column named issuer
  at withReturning (@better-auth/kysely-adapter/dist/index.mjs:241)
```

which points at the database rather than at the tool that produced the schema. Calling the installed library's own `getMigrations` directly produces the correct DDL, including `issuer` and the `account_issuer_accountId` unique index, which is the workaround I ended up shipping.

## The change

Move `better-auth` from `dependencies` to `peerDependencies`, and add it to `devDependencies` for local builds.

This is safe because the CLI loads the user's own auth config, which imports `better-auth`, so a project using the CLI always has it installed already. The bundled copy is redundant and actively harmful.

It also matches what every other package in this repo already does. `packages/stripe`, `packages/passkey` and `packages/sso` all use:

```json
"peerDependencies": { "better-auth": "workspace:^" },
"devDependencies":  { "better-auth": "workspace:*" }
```

The CLI was the only outlier.

## Alternative considered

Resolving `better-auth` from the user's `cwd` at runtime with `createRequire` and warning on mismatch. That keeps a standalone `npx` invocation working without any local install, but it is more code, and a standalone invocation cannot generate a schema anyway since it has no config to load. The dependency change fixes the root cause; happy to switch approaches if you would rather keep the bundled copy and warn instead.

## Verification

- `better-auth` no longer appears in the CLI's `dependencies`.
- `packages/cli/package.json` remains valid JSON; key order preserved and the devDependency inserted in sort position.
- Diff is 4 added lines and 1 removed line, no reformatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11048 by making `@better-auth/cli` resolve `better-auth` from the project instead of its bundled copy, so generated schemas match the project's installed version.

- Old behavior: the CLI's pinned copy (1.4.21) generated schemas even when the project ran 1.7.2, and the mismatch only surfaced later as a database error on first sign-up.
- `better-auth` moved from `dependencies` to `peerDependencies` plus a `devDependency` for local builds; safe because the CLI loads the user's config, which imports `better-auth`.
- Adds a changeset for the patch.

<sup>Written for commit 193f24f67fc68855d897f051f3bcbe5ebd9d8d05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

