### PR TITLE
docs: restore Typesense search indexing

### DIFF
--- a/docs/scripts/sync-typesense.ts
+++ b/docs/scripts/sync-typesense.ts
@@ -2,7 +2,32 @@ import "dotenv/config";
 import * as fs from "node:fs";
 import { Client } from "typesense";
 import type { DocumentRecord } from "typesense-fumadocs-adapter";
-import { sync } from "typesense-fumadocs-adapter";
+import { getDefaultCollectionFields, sync } from "typesense-fumadocs-adapter";
+
+const typesenseCollectionName = "better-auth-docs";
+const typesenseLocale = "en";
+
+// The adapter types tags as strings but creates a string[] field, which rejects imports.
+const typesenseCollectionFields = getDefaultCollectionFields(
+	typesenseLocale,
+).map((field): typeof field =>
+	field.name === "tag" ? { ...field, type: "string" } : field,
+);
+
+export function getTypesenseSyncOptions(documents: DocumentRecord[]) {
+	return {
+		typesenseCollectionName,
+		documents: documents.map((document) => ({
+			...document,
+			locale: typesenseLocale,
+		})),
+		customLocaleCollectionSettings: {
+			[typesenseLocale]: {
+				field_definitions: typesenseCollectionFields,
+			},
+		},
+	};
+}
 
 export function getTypesenseSyncSkipReason(env: NodeJS.ProcessEnv) {
 	const url = env.NEXT_PUBLIC_TYPESENSE_SERVER_URL;
@@ -49,37 +74,39 @@ async function main() {
 
 	const filePath = ".next/server/app/api/docs/static.json.body";
 	if (!fs.existsSync(filePath)) {
-		console.log("[Typesense] build output not found, skipping sync.");
-		return;
+		throw new Error("Typesense build output was not found.");
 	}
 
-	try {
-		const serverUrl = new URL(url);
-		const content = fs.readFileSync(filePath, "utf8");
-		const records = JSON.parse(content) as DocumentRecord[];
-
-		const client = new Client({
-			nodes: [
-				{
-					host: serverUrl.hostname,
-					port:
-						Number(serverUrl.port) ||
-						(serverUrl.protocol === "https:" ? 443 : 80),
-					protocol: serverUrl.protocol.replace(":", ""),
-				},
-			],
-			apiKey: adminKey,
-			connectionTimeoutSeconds: 30,
-		});
-
-		await sync(client, {
-			typesenseCollectionName: "better-auth-docs",
-			documents: records,
-		});
-		console.log(`[Typesense] search updated: ${records.length} records`);
-	} catch (error) {
-		console.warn("[Typesense] failed to sync index, continuing build:", error);
+	const serverUrl = new URL(url);
+	const content = fs.readFileSync(filePath, "utf8");
+	const records = JSON.parse(content) as DocumentRecord[];
+	if (records.length === 0) {
+		throw new Error("Typesense build output contains no records.");
 	}
+
+	const client = new Client({
+		nodes: [
+			{
+				host: serverUrl.hostname,
+				port:
+					Number(serverUrl.port) ||
+					(serverUrl.protocol === "https:" ? 443 : 80),
+				protocol: serverUrl.protocol.replace(":", ""),
+			},
+		],
+		apiKey: adminKey,
+		connectionTimeoutSeconds: 30,
+	});
+
+	await sync(client, getTypesenseSyncOptions(records));
+	const collection = await client
+		.collections(typesenseCollectionName)
+		.retrieve();
+	if (collection.num_documents === 0) {
+		throw new Error("Typesense search index is empty after sync.");
+	}
+
+	console.log(`[Typesense] search updated: ${records.length} records`);
 }
 
 if (import.meta.main) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores Typesense search indexing for the docs site after a schema mismatch and silent failures caused the index to break.

- Fixes the `tag` field type mismatch (`string[]` vs `string`) that rejected imports.
- Removes the try/catch that swallowed sync errors; missing build output, empty records, or failed syncs now fail the build.
- Adds document locale metadata and matching collection field definitions.
- Verifies the collection is non-empty after syncing and throws if it isn't.

<sup>Written for commit 4e032c2f73298fffb3db48b75698e15208c72597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

