### PR TITLE
fix(haveibeenpwned): bound the HIBP breach-check fetch with a timeout

### DIFF
--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -39,6 +39,9 @@ async function checkPasswordCompromise(
 					"Add-Padding": "true",
 					"User-Agent": "BetterAuth Password Checker",
 				},
+				// Bound the outbound HIBP request so a hung upstream cannot stall
+				// the /sign-up/email and /reset-password flows this hook runs in.
+				timeout: 5000,
 			},
 		);
 


### PR DESCRIPTION
### Problem

The HaveIBeenPwned plugin calls the range API without a timeout:

```ts
const { data, error } = await betterFetch<string>(
  `https://api.pwnedpasswords.com/range/${prefix}`,
  { headers: { "Add-Padding": "true", "User-Agent": "BetterAuth Password Checker" } },
);
```

This runs inside the password `hash` hook, whose default `paths` include `/sign-up/email` and `/reset-password`. If `api.pwnedpasswords.com` hangs (slow network, upstream incident), those flows hang with it — there is no bound on the outbound request.

### Fix

Add a 5s `timeout` to the `betterFetch` call so a stalled upstream fails fast instead of blocking sign-up / password-reset. The existing `error` branch already surfaces a clean 500.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 5-second timeout to the HaveIBeenPwned breach-check fetch so a hung upstream no longer stalls the `/sign-up/email` and `/reset-password` flows. The existing error branch still returns a clean 500 when the request times out.

<sup>Written for commit a78f4b9896f10f0cdfe57db732f57d5f3e60237e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

