### PR TITLE
docs: add `@better-geetest/better-auth-plugin-gt4` to community plugins

### DIFF
--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -353,4 +353,15 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/lapluviosilla.png",
 		},
 	},
+	{
+		name: "@better-geetest/better-auth-plugin-gt4",
+		url: "https://github.com/typed-sigterm/better-geetest/tree/main/packages/better-auth-plugin-gt4",
+		description:
+			"Integrate GeeTest gt4 bot protection by adding captcha verification for key endpoints.",
+		author: {
+			name: "Typed SIGTERM",
+			github: "typed-sigterm",
+			avatar: "https://github.com/typed-sigterm.png",
+		},
+	},
 ];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `@better-geetest/better-auth-plugin-gt4` to the community plugins list.

- Lists GeeTest gt4 bot protection, which adds captcha verification for key endpoints.

<sup>Written for commit 014693d193426b9a5ccdff86d27f8821372cce22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

