### PR TITLE
test(sso): cover wantAssertionsSigned absent-to-true policy flip

### DIFF
--- a/packages/sso/src/providers.test.ts
+++ b/packages/sso/src/providers.test.ts
@@ -2045,6 +2045,116 @@ kBGIJYs=
 			);
 		});
 
+		/**
+		 * Regression: a provider registered without wantAssertionsSigned (the only
+		 * shape that existed before @better-auth/infra 0.4.3) stores the field as
+		 * absent and treats it as false. An explicit update to true is a signing-
+		 * policy change and must be classified as an authentication-boundary change
+		 * so that callers can gate or log it.
+		 * @see https://github.com/better-auth/better-auth/issues/11054
+		 */
+		it("classifies upgrading wantAssertionsSigned from absent to true as an authentication-boundary change", async () => {
+			let isAuthenticationBoundaryChange: boolean | undefined;
+			const { auth, getAuthHeaders, data } = createTestAuth(false, false, {
+				guardProviderMutation(input) {
+					if (input.action === "update") {
+						isAuthenticationBoundaryChange =
+							input.isAuthenticationBoundaryChange;
+					}
+				},
+			});
+			const headers = await getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "absent-signing-policy",
+					issuer: "https://idp.example.com",
+					domain: "example.com",
+					samlConfig: {
+						entryPoint: "https://idp.example.com/sso",
+						cert: TEST_CERT,
+						idpMetadata: { entityID: "https://idp.example.com" },
+					},
+				},
+				headers,
+			});
+
+			const storedBefore = safeJsonParse<SAMLConfig>(
+				data.ssoProvider[0]!.samlConfig!,
+			);
+			expect(storedBefore?.wantAssertionsSigned).toBeUndefined();
+
+			await auth.api.updateSSOProvider({
+				body: {
+					providerId: "absent-signing-policy",
+					samlConfig: { wantAssertionsSigned: true },
+				},
+				headers,
+			});
+
+			expect(isAuthenticationBoundaryChange).toBe(true);
+
+			const storedAfter = safeJsonParse<SAMLConfig>(
+				data.ssoProvider[0]!.samlConfig!,
+			);
+			expect(storedAfter?.wantAssertionsSigned).toBe(true);
+		});
+
+		/**
+		 * Regression: the absent → true policy flip must be blocked when a linked
+		 * account already exists. Without this guard, existing users whose IdP signs
+		 * only the Response (not the Assertion) would silently stop being able to
+		 * sign in after an unrelated provider update.
+		 * @see https://github.com/better-auth/better-auth/issues/11054
+		 */
+		it("rejects upgrading wantAssertionsSigned from absent to true when linked accounts exist", async () => {
+			const { auth, getAuthHeaders, data } = createTestAuth(false);
+			const headers = await getAuthHeaders({
+				email: "owner@example.com",
+				password: "password123",
+				name: "Owner",
+			});
+
+			await auth.api.registerSSOProvider({
+				body: {
+					providerId: "absent-policy-linked",
+					issuer: "https://idp.example.com",
+					domain: "example.com",
+					samlConfig: {
+						entryPoint: "https://idp.example.com/sso",
+						cert: TEST_CERT,
+						idpMetadata: { entityID: "https://idp.example.com" },
+					},
+				},
+				headers,
+			});
+
+			const user = (data.user as { id: string; email: string }[]).find(
+				(u) => u.email === "owner@example.com",
+			);
+			data.account.push({
+				id: "linked-absent-policy-account",
+				userId: user!.id,
+				providerId: "absent-policy-linked",
+				accountId: "saml-name-id",
+			});
+
+			const response = await auth.api.updateSSOProvider({
+				body: {
+					providerId: "absent-policy-linked",
+					samlConfig: { wantAssertionsSigned: true },
+				},
+				headers,
+				asResponse: true,
+			});
+
+			expect(response.status).toBe(409);
+		});
+
 		it.each(
 			INVALID_CUSTOM_SP_METADATA,
 		)("rejects custom SP metadata with $name before updating the provider", async ({

--- a/packages/sso/src/routes/helpers.test.ts
+++ b/packages/sso/src/routes/helpers.test.ts
@@ -343,4 +343,28 @@ describe("createSP assertion-signing metadata", () => {
 			),
 		).toThrow("Invalid SAML service provider metadata");
 	});
+
+	/**
+	 * When wantAssertionsSigned is absent (the only shape available before
+	 * @better-auth/infra 0.4.3), the SP must advertise WantAssertionsSigned="false"
+	 * so that IdPs configured to sign only the Response continue to work.
+	 * @see https://github.com/better-auth/better-auth/issues/11054
+	 */
+	it("defaults to WantAssertionsSigned=false when wantAssertionsSigned is absent", () => {
+		const config: SAMLConfig = {
+			issuer: "https://service.example.com/saml",
+			entryPoint: "https://idp.example.com/sso",
+			idpMetadata: { entityID: "https://idp.example.com/metadata" },
+		};
+
+		const provider = createSP(
+			config,
+			"https://service.example.com/api/auth",
+			"workforce",
+		);
+		expect(provider.getMetadata()).toContain('WantAssertionsSigned="false"');
+		expect(deriveSAMLServiceProviderPolicy(config)).toEqual({
+			wantAssertionsSigned: false,
+		});
+	});
 });


### PR DESCRIPTION
## What

Adds 3 regression tests for #11054.

## Why

A SAML provider registered without `wantAssertionsSigned` (the only shape
that existed before `@better-auth/infra` 0.4.3) has an effective policy of
`false` — the SP advertises `WantAssertionsSigned="false"` and the ACS does
not require assertion-level signatures.

When `@better-auth/infra` 0.4.3 introduced `wantAssertionsSigned ?? true` in
`resolveSAMLConfig`, any subsequent update sent by infra carries the field
explicitly as `true`. That silently flips the stored policy and causes
`SAML_ASSERTION_SIGNATURE_REQUIRED` for IdPs that sign only the Response —
with no configuration change on either side.

## Tests added

| File | Test |
|---|---|
| `routes/helpers.test.ts` | `defaults to WantAssertionsSigned=false when wantAssertionsSigned is absent` — proves the SP contract for omitted field |
| `providers.test.ts` | `classifies upgrading wantAssertionsSigned from absent to true as an authentication-boundary change` — verifies `guardProviderMutation` callers are notified |
| `providers.test.ts` | `rejects upgrading wantAssertionsSigned from absent to true when linked accounts exist` — verifies the CONFLICT guard fires to protect existing users |

## Notes

- No production code changed — tests only
- The root cause is in `@better-auth/infra` (private); these tests document
  and lock the existing SSO contract so a future infra fix has coverage
- No changeset needed (test-only change)

Related to #11054

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests for the SAML `wantAssertionsSigned` policy flip caused by `@better-auth/infra` 0.4.3's new `?? true` default. Providers registered without the field previously advertised `WantAssertionsSigned="false"`; now any update flips it to `true`, breaking IdPs that sign only the Response. These tests lock the intended contract, and no production code changes.

- `routes/helpers.test.ts` asserts the SP metadata advertises `WantAssertionsSigned="false"` when the field is omitted.
- `providers.test.ts` asserts an absent-to-true update is classified as an authentication-boundary change and rejected with a conflict when linked accounts exist.

Related to #11054.

<sup>Written for commit b68849d56ffdc6a1e9364fdd7d9616e6a3947977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

