### PR TITLE
fix(expo): serialize async secure-storage access so concurrent requests never read a torn cookie jar

### DIFF
--- a/.changeset/expo-storage-queue.md
+++ b/.changeset/expo-storage-queue.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/expo": patch
+---
+
+Serialize async secure-storage access in the Expo client so a request started while another response is rewriting the chunked cookie jar no longer reads an empty or torn value, logs `Error parsing JSON`, and goes out without a `Cookie` header.

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -298,7 +298,30 @@ function getStorageWrites(key: string, value: string): [string, string][] {
 	return writes;
 }
 
+/**
+ * Runs async storage operations one at a time, in call order. A chunked write
+ * is several native round-trips (clear the base key, write each chunk, set the
+ * marker), and any read that lands between them sees an empty or half-written
+ * jar. That is exactly what happens on app start, where several requests fire
+ * together and every response rewrites the cookie jar: one request's `init`
+ * reads while another's `onSuccess` is mid-write, gets `""`, logs
+ * "Error parsing JSON" and goes out without a Cookie header. Queueing the
+ * operations keeps every read either fully before or fully after a write, and
+ * keeps two concurrent writes from interleaving their chunks.
+ */
+function createQueue() {
+	let tail: Promise<unknown> = Promise.resolve();
+	return <T>(task: () => Promise<T>): Promise<T> => {
+		const run = tail.then(task, task);
+		// Swallow here only so a rejected task doesn't stall the queue; callers
+		// still get the original rejection through `run`.
+		tail = run.catch(() => {});
+		return run;
+	};
+}
+
 export function storageAdapter(storage: ExpoClientStorage) {
+	const enqueue = createQueue();
 	return {
 		/**
 		 * Reads a value, reassembling it if it was split across chunk keys. A value
@@ -325,33 +348,36 @@ export function storageAdapter(storage: ExpoClientStorage) {
 			}
 			return value;
 		},
-		getItemAsync: async (name: string): Promise<string | null> => {
-			const key = normalizeCookieName(name);
-			const stored = await storage.getItemAsync(key);
-			if (stored == null || !stored.startsWith(CHUNK_MARKER)) {
-				return stored;
-			}
-			const count = Number(stored.slice(CHUNK_MARKER.length));
-			if (!Number.isInteger(count) || count < 1) {
-				return null;
-			}
-			let value = "";
-			for (let i = 0; i < count; i++) {
-				const chunk = await storage.getItemAsync(`${key}.${i}`);
-				if (chunk == null) {
+		getItemAsync: (name: string): Promise<string | null> =>
+			enqueue(async () => {
+				const key = normalizeCookieName(name);
+				const stored = await storage.getItemAsync(key);
+				if (stored == null || !stored.startsWith(CHUNK_MARKER)) {
+					return stored;
+				}
+				const count = Number(stored.slice(CHUNK_MARKER.length));
+				if (!Number.isInteger(count) || count < 1) {
 					return null;
 				}
-				value += chunk;
-			}
-			return value;
-		},
+				let value = "";
+				for (let i = 0; i < count; i++) {
+					const chunk = await storage.getItemAsync(`${key}.${i}`);
+					if (chunk == null) {
+						return null;
+					}
+					value += chunk;
+				}
+				return value;
+			}),
 		/**
 		 * Stores `value`, splitting it across chunk keys when it exceeds the
 		 * per-write limit. The base key is cleared before the chunks are rewritten
 		 * and set to the marker last, as the commit point, so a write interrupted
 		 * partway through reads as absent rather than a mix of old and new chunks.
 		 * Failures are logged, not thrown: persistence is best-effort and must not
-		 * break the request.
+		 * break the request. The async variants additionally go through the
+		 * adapter's queue, so a concurrent read never observes the cleared base
+		 * key mid-write.
 		 */
 		setItem: (name: string, value: string): void => {
 			const key = normalizeCookieName(name);
@@ -366,19 +392,20 @@ export function storageAdapter(storage: ExpoClientStorage) {
 				);
 			}
 		},
-		setItemAsync: async (name: string, value: string): Promise<void> => {
-			const key = normalizeCookieName(name);
-			try {
-				for (const [writeKey, writeValue] of getStorageWrites(key, value)) {
-					await storage.setItemAsync(writeKey, writeValue);
+		setItemAsync: (name: string, value: string): Promise<void> =>
+			enqueue(async () => {
+				const key = normalizeCookieName(name);
+				try {
+					for (const [writeKey, writeValue] of getStorageWrites(key, value)) {
+						await storage.setItemAsync(writeKey, writeValue);
+					}
+				} catch (error) {
+					console.error(
+						`[better-auth/expo] failed to persist "${key}" to storage`,
+						error,
+					);
 				}
-			} catch (error) {
-				console.error(
-					`[better-auth/expo] failed to persist "${key}" to storage`,
-					error,
-				);
-			}
-		},
+			}),
 	};
 }
 

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -299,29 +299,39 @@ function getStorageWrites(key: string, value: string): [string, string][] {
 }
 
 /**
- * Runs async storage operations one at a time, in call order. A chunked write
- * is several native round-trips (clear the base key, write each chunk, set the
- * marker), and any read that lands between them sees an empty or half-written
- * jar. That is exactly what happens on app start, where several requests fire
- * together and every response rewrites the cookie jar: one request's `init`
- * reads while another's `onSuccess` is mid-write, gets `""`, logs
- * "Error parsing JSON" and goes out without a Cookie header. Queueing the
- * operations keeps every read either fully before or fully after a write, and
- * keeps two concurrent writes from interleaving their chunks.
+ * Runs async storage operations on the same key one at a time, in call order.
+ * A chunked write is several native round-trips (clear the base key, write
+ * each chunk, set the marker), and any read that lands between them sees an
+ * empty or half-written jar. That is exactly what happens on app start, where
+ * several requests fire together and every response rewrites the cookie jar:
+ * one request's `init` reads while another's `onSuccess` is mid-write, gets
+ * `""`, logs "Error parsing JSON" and goes out without a Cookie header.
+ * Queueing keeps every read either fully before or fully after a write on
+ * that key, and keeps two concurrent writes from interleaving their chunks.
+ * Keys are independent (the cookie jar and the session cache are separate
+ * values), so a write to one never delays a read of the other.
  */
-function createQueue() {
-	let tail: Promise<unknown> = Promise.resolve();
-	return <T>(task: () => Promise<T>): Promise<T> => {
+function createKeyedQueue() {
+	const tails = new Map<string, Promise<unknown>>();
+	return <T>(key: string, task: () => Promise<T>): Promise<T> => {
+		const tail = tails.get(key) ?? Promise.resolve();
 		const run = tail.then(task, task);
 		// Swallow here only so a rejected task doesn't stall the queue; callers
 		// still get the original rejection through `run`.
-		tail = run.catch(() => {});
+		const next = run
+			.catch(() => {})
+			.then(() => {
+				if (tails.get(key) === next) {
+					tails.delete(key);
+				}
+			});
+		tails.set(key, next);
 		return run;
 	};
 }
 
 export function storageAdapter(storage: ExpoClientStorage) {
-	const enqueue = createQueue();
+	const enqueue = createKeyedQueue();
 	return {
 		/**
 		 * Reads a value, reassembling it if it was split across chunk keys. A value
@@ -348,9 +358,9 @@ export function storageAdapter(storage: ExpoClientStorage) {
 			}
 			return value;
 		},
-		getItemAsync: (name: string): Promise<string | null> =>
-			enqueue(async () => {
-				const key = normalizeCookieName(name);
+		getItemAsync: (name: string): Promise<string | null> => {
+			const key = normalizeCookieName(name);
+			return enqueue(key, async () => {
 				const stored = await storage.getItemAsync(key);
 				if (stored == null || !stored.startsWith(CHUNK_MARKER)) {
 					return stored;
@@ -368,7 +378,8 @@ export function storageAdapter(storage: ExpoClientStorage) {
 					value += chunk;
 				}
 				return value;
-			}),
+			});
+		},
 		/**
 		 * Stores `value`, splitting it across chunk keys when it exceeds the
 		 * per-write limit. The base key is cleared before the chunks are rewritten
@@ -376,8 +387,8 @@ export function storageAdapter(storage: ExpoClientStorage) {
 		 * partway through reads as absent rather than a mix of old and new chunks.
 		 * Failures are logged, not thrown: persistence is best-effort and must not
 		 * break the request. The async variants additionally go through the
-		 * adapter's queue, so a concurrent read never observes the cleared base
-		 * key mid-write.
+		 * adapter's per-key queue, so a concurrent read never observes the
+		 * cleared base key mid-write.
 		 */
 		setItem: (name: string, value: string): void => {
 			const key = normalizeCookieName(name);
@@ -392,9 +403,9 @@ export function storageAdapter(storage: ExpoClientStorage) {
 				);
 			}
 		},
-		setItemAsync: (name: string, value: string): Promise<void> =>
-			enqueue(async () => {
-				const key = normalizeCookieName(name);
+		setItemAsync: (name: string, value: string): Promise<void> => {
+			const key = normalizeCookieName(name);
+			return enqueue(key, async () => {
 				try {
 					for (const [writeKey, writeValue] of getStorageWrites(key, value)) {
 						await storage.setItemAsync(writeKey, writeValue);
@@ -405,7 +416,8 @@ export function storageAdapter(storage: ExpoClientStorage) {
 						error,
 					);
 				}
-			}),
+			});
+		},
 	};
 }
 

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -1111,6 +1111,92 @@ describe("expo with cookieCache", async () => {
 		expect(error).toHaveBeenCalledTimes(2);
 		error.mockRestore();
 	});
+
+	/**
+	 * Native secure storage is one round-trip per key, so a chunked write is
+	 * several awaits long. Requests fire concurrently on app start and each
+	 * response rewrites the jar, so a read must never land between the base-key
+	 * clear and the marker write and come back empty or torn.
+	 */
+	describe("concurrent async access", () => {
+		// Every operation yields before touching the map so calls issued in the
+		// same tick genuinely interleave, the way native bridge calls do. A
+		// microtask, not a timer: this suite runs under fake timers.
+		function createAsyncStorage() {
+			const map = new Map<string, string>();
+			const tick = () =>
+				new Promise<void>((resolve) => queueMicrotask(resolve));
+			return {
+				map,
+				storage: storageAdapter({
+					getItem: (name) => map.get(name) ?? null,
+					setItem: (name, value) => map.set(name, value),
+					getItemAsync: async (name) => {
+						await tick();
+						return map.get(name) ?? null;
+					},
+					setItemAsync: async (name, value) => {
+						await tick();
+						map.set(name, value);
+					},
+				}),
+			};
+		}
+
+		it("should not read an empty or torn value while a chunked write is in flight", async () => {
+			const { storage } = createAsyncStorage();
+			const oldValue = "a".repeat(5_000);
+			await storage.setItemAsync("better-auth_cookie", oldValue);
+
+			const newValue = "b".repeat(5_000);
+			const write = storage.setItemAsync("better-auth_cookie", newValue);
+			// Issued while the write above is between its native round-trips.
+			const read = storage.getItemAsync("better-auth_cookie");
+
+			const [, result] = await Promise.all([write, read]);
+			expect(result).toBe(newValue);
+		});
+
+		it("should not interleave chunks of two concurrent writes", async () => {
+			const { storage } = createAsyncStorage();
+			const first = "a".repeat(5_000);
+			const second = "b".repeat(5_000);
+
+			await Promise.all([
+				storage.setItemAsync("better-auth_cookie", first),
+				storage.setItemAsync("better-auth_cookie", second),
+			]);
+
+			expect(await storage.getItemAsync("better-auth_cookie")).toBe(second);
+		});
+
+		it("should keep serving operations after one of them rejects", async () => {
+			const { storage } = createAsyncStorage();
+			let reads = 0;
+			const failing = storageAdapter({
+				getItem: () => null,
+				setItem: () => {},
+				getItemAsync: async () => {
+					if (reads++ === 0) {
+						throw new Error("keychain locked");
+					}
+					return "ok";
+				},
+				setItemAsync: async () => {},
+			});
+
+			await expect(failing.getItemAsync("better-auth_cookie")).rejects.toThrow(
+				"keychain locked",
+			);
+			await expect(failing.getItemAsync("better-auth_cookie")).resolves.toBe(
+				"ok",
+			);
+			// Unrelated adapters are not affected either way.
+			await expect(
+				storage.getItemAsync("better-auth_cookie"),
+			).resolves.toBeNull();
+		});
+	});
 });
 
 describe("expo with cookie storeStateStrategy", async () => {

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -1170,6 +1170,22 @@ describe("expo with cookieCache", async () => {
 			expect(await storage.getItemAsync("better-auth_cookie")).toBe(second);
 		});
 
+		it("should not let a chunked write on one key delay a read of another", async () => {
+			const { storage } = createAsyncStorage();
+			await storage.setItemAsync("better-auth_cookie", "cookie");
+
+			const order: string[] = [];
+			const write = storage
+				.setItemAsync("better-auth_session_data", "s".repeat(5_000))
+				.then(() => order.push("write"));
+			const read = storage
+				.getItemAsync("better-auth_cookie")
+				.then((value) => order.push(`read:${value}`));
+
+			await Promise.all([write, read]);
+			expect(order).toEqual(["read:cookie", "write"]);
+		});
+
 		it("should keep serving operations after one of them rejects", async () => {
 			const { storage } = createAsyncStorage();
 			let reads = 0;


### PR DESCRIPTION
## Summary

On native, `@better-auth/expo` stores the whole cookie jar under one secure-storage key and, since #10438 / v1.7, reads and writes it with the async SecureStore API, chunking values over 1800 chars (#9814). A chunked write is several native round-trips in a fixed order: clear the base key → write `<key>.0..N` → write the `ba-chunks:N` marker.

Nothing serializes those round-trips against other adapter calls. On app start several requests fire together (`useSession`, any `getSession()` the app makes, …) and, with `session.cookieCache` enabled, nearly every response re-sets `session_data` and rewrites the jar in `onSuccess`. A request whose `init` runs while another response is mid-write reads the cleared base key, gets `""`, and:

- `safeJSONParse("")` throws → `ERROR [Better Auth]: Error parsing JSON {"error":{}}` in the console (the 1.6 client swallowed this silently, 1.7 logs it), and
- `getCookie()` returns `""`, so that request goes out **without a `Cookie` header** and is handled as anonymous.

Two concurrent chunked writes can also interleave their chunk writes.

Any app whose jar exceeds 1800 chars hits this — with `cookieCache` on, a bare user with no extra fields is already at ~1750, so real accounts always take the chunked path.

## Fix

`storageAdapter` now runs `getItemAsync` / `setItemAsync` through a per-key FIFO queue, so every read of a key happens fully before or fully after a write to it and writes never interleave; the cookie jar and the session cache are independent keys and never wait on each other. The write order (clear → chunks → marker) is unchanged, so the existing fail-closed behaviour on an interrupted write is preserved. A rejected operation does not stall the queue; the rejection still reaches its caller. The sync `getItem` / `setItem` are untouched (the plugin itself no longer uses them).

## Tests

- read issued while a chunked write is in flight returns the new value, never `""` or a torn value (fails on `main`: returns `""`)
- two concurrent chunked writes leave the last value, not a mix
- a chunked write to one key does not delay a read of another
- a rejected operation doesn't block subsequent ones

## Changeset

`@better-auth/expo`: patch
