### PR TITLE
test(sso): align mock IdP with SAML redirect binding

### DIFF
--- a/packages/sso/src/saml.test.ts
+++ b/packages/sso/src/saml.test.ts
@@ -566,19 +566,11 @@ const createMockSAMLIdP = (port: number, options: MockIdPOptions = {}) => {
 			};
 			const queryValue = (value: unknown) =>
 				typeof value === "string" ? value : undefined;
-			const templateOverrides: MockSAMLTemplateOverrides = {
-				audience: queryValue(req.query.audience),
-				destination: queryValue(req.query.destination),
-				inResponseTo:
-					req.query.idpInitiated === "true"
-						? ""
-						: req.query.echoAuthnRequest === "true"
-							? undefined
-							: "null",
-				subjectRecipient: queryValue(req.query.recipient),
-			};
+			const idpInitiated = req.query.idpInitiated === "true";
 			const parsedRequest =
-				req.query.echoAuthnRequest === "true"
+				!idpInitiated &&
+				!options.wantAuthnRequestsSigned &&
+				typeof req.query.SAMLRequest === "string"
 					? await idp.parseLoginRequest(sp, "redirect", {
 							query: req.query,
 						})
@@ -590,11 +582,17 @@ const createMockSAMLIdP = (port: number, options: MockIdPOptions = {}) => {
 						sigAlg: parsedRequest.sigAlg,
 					}
 				: { extract: {} };
-			if (req.query.echoAuthnRequest === "true") {
-				const requestId = requestInfo.extract.request?.id;
-				templateOverrides.inResponseTo =
-					typeof requestId === "string" ? requestId : "";
-			}
+			const requestId = requestInfo.extract.request?.id;
+			const templateOverrides: MockSAMLTemplateOverrides = {
+				audience: queryValue(req.query.audience),
+				destination: queryValue(req.query.destination),
+				inResponseTo: idpInitiated
+					? ""
+					: typeof requestId === "string"
+						? requestId
+						: "null",
+				subjectRecipient: queryValue(req.query.recipient),
+			};
 			const { context, entityEndpoint } = (await idp.createLoginResponse(
 				sp,
 				requestInfo,
@@ -6631,8 +6629,7 @@ describe("SAML user resolution HTTP", () => {
 	function persistedSAMLConfiguration() {
 		return {
 			issuer: "https://service.example.com/saml",
-			entryPoint:
-				"http://localhost:8081/api/sso/saml2/idp/post?echoAuthnRequest=true",
+			entryPoint: "http://localhost:8081/api/sso/saml2/idp/redirect",
 			cert: extractSigningCertificateFromMetadata(idpMetadata),
 			idpMetadata: {
 				entityID: "http://localhost:8081/api/sso/saml2/idp/metadata",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns the mock SAML IdP in `sso` tests with the SAML redirect binding, so the fixture no longer depends on a custom `echoAuthnRequest` query parameter. The mock now parses the redirect-bound `SAMLRequest` by default, except for IdP-initiated flows or when the SP requires signed AuthnRequests, and the test configuration points at the plain redirect endpoint instead of the POST endpoint with the flag.

<sup>Written for commit c5e533b73e2c90f9b4e3b5c6792fd485aad14260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

