### PR TITLE
docs: establish social provider integration policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,37 @@ reproduction.
 
 New features start with discussion. Open a [feature request](https://github.com/better-auth/better-auth/issues/new?template=feature_request.yml) describing the problem, your proposed solution, and how it would benefit the project. This gives us room to align on scope and API shape before anyone writes code.
 
+### Social Provider Integrations
+
+New social providers that can be supported by the
+[Generic OAuth plugin](https://www.better-auth.com/docs/plugins/generic-oauth)
+default to a community-maintained helper. Better Auth prioritizes extensibility
+over maintaining the details of every provider integration.
+Adding a provider to this repository is an ongoing maintenance commitment and
+requires Better Auth to commit to maintaining it.
+
+| Integration | Criteria | Maintainer |
+| --- | --- | --- |
+| Built-in social provider | Broad use or provider-specific behavior beyond Generic OAuth | Better Auth |
+| Built-in provider helper | Broad demand and supported by Generic OAuth | Better Auth |
+| Community provider helper | Supported by Generic OAuth | Provider or community |
+
+When a missing capability is provider-agnostic, prefer improving Generic OAuth
+over adding provider-specific code.
+
+Open a feature request before implementing a built-in social provider or
+built-in provider helper. A vendor contribution or support in another auth
+library may demonstrate demand, but does not by itself determine whether Better
+Auth will maintain the integration.
+
+Community helpers can be developed and published independently. They may be
+submitted for listing in the
+[Other Social Providers](https://www.better-auth.com/docs/authentication/other-social-providers#community-provider-helpers)
+documentation. A listing must identify the package, repository, documentation,
+maintainer, supported Better Auth versions, and relevant tests. Helpers must use
+Better Auth's public APIs and document their callback URL, scopes, and token
+endpoint authentication.
+
 ### Security Reports
 
 Do not open a public issue for security vulnerabilities.

--- a/docs/content/docs/authentication/other-social-providers.mdx
+++ b/docs/content/docs/authentication/other-social-providers.mdx
@@ -4,7 +4,7 @@ title: Other Social Providers
 description: Other social providers setup and usage.
 ---
 
-Better Auth provides support for any social provider that implements the OAuth2 protocol or OpenID Connect (OIDC) flows through the [Generic OAuth Plugin](/docs/plugins/generic-oauth). You can use pre-configured helper functions for popular providers like Auth0, Keycloak, Okta, Microsoft Entra ID, and Slack, or manually configure any OAuth provider.
+Better Auth supports any social provider that implements OAuth 2.0 or OpenID Connect (OIDC) through the [Generic OAuth Plugin](/docs/plugins/generic-oauth). You can use a built-in provider helper, install a community provider helper, or configure a provider manually.
 
 ## Installation
 
@@ -50,7 +50,7 @@ Better Auth provides support for any social provider that implements the OAuth2 
 </Steps>
 
 <Callout>
-  Read more about installation and usage of the Generic Oauth plugin
+  Read more about installation and usage of the Generic OAuth plugin
   [Generic OAuth plugin documentation](/docs/plugins/generic-oauth#usage).
 </Callout>
 
@@ -78,9 +78,26 @@ export const auth = betterAuth({
 })
 ```
 
-## Using Pre-configured Providers
+## Provider Helpers
 
-Better Auth provides pre-configured helper functions for popular OAuth providers. Here's an example using Slack:
+Provider helpers package provider-specific endpoints, scopes, and profile mapping as reusable `GenericOAuthConfig` factories.
+
+### Built-in Provider Helpers
+
+Better Auth includes helpers for these providers:
+
+* **Auth0** - `auth0(options)`
+* **Gumroad** - `gumroad(options)`
+* **HubSpot** - `hubspot(options)`
+* **Keycloak** - `keycloak(options)`
+* **LINE** - `line(options)`
+* **Microsoft Entra ID (Azure AD)** - `microsoftEntraId(options)`
+* **Okta** - `okta(options)`
+* **Patreon** - `patreon(options)`
+* **Slack** - `slack(options)`
+* **Yandex** - `yandex(options)`
+
+Here's an example using Slack:
 
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth"
@@ -107,11 +124,101 @@ const response = await authClient.signIn.social({
 })
 ```
 
-For more pre-configured providers (Auth0, Keycloak, Okta, Microsoft Entra ID) and their configuration options, see the [Generic OAuth Plugin documentation](/docs/plugins/generic-oauth#pre-configured-provider-helpers).
+Each helper accepts common OAuth options through `BaseOAuthProviderOptions`, plus these provider-specific fields:
 
-## Manual Configuration Examples
+* **Auth0**: Requires `domain` (for example, `dev-xxx.eu.auth0.com`)
+* **HubSpot**: Accepts optional `scopes`, which default to `["oauth"]`
+* **Keycloak**: Requires `issuer` (for example, `https://my-domain/realms/MyRealm`)
+* **LINE**: Accepts an optional `providerId`. Call `line()` with different provider IDs and credentials to support multiple country-specific channels
+* **Microsoft Entra ID**: Requires a concrete tenant GUID. Use the built-in [Microsoft social provider](/docs/authentication/microsoft) for the multi-tenant `"common"`, `"organizations"`, or `"consumers"` authorities
+* **Okta**: Requires `issuer` (for example, `https://dev-xxxxx.okta.com/oauth2/default`)
 
-If you need to configure a provider that doesn't have a pre-configured helper, you can manually configure it:
+All helpers accept these common options:
+
+* `clientId`
+* `clientSecret`
+* `tokenEndpointAuth`
+* `scopes`
+* `redirectURI`
+* `pkce`
+* `disableImplicitSignUp`
+* `disableSignUp`
+* `overrideUserInfo`
+* `endSessionEndpoint`
+* `postLogoutRedirectURI`
+* `disableProviderLogout`
+
+### Community Provider Helpers
+
+Provider authors and community maintainers can publish reusable helpers that return a typed [`GenericOAuthConfig`](/docs/plugins/generic-oauth) for use with the Generic OAuth plugin.
+
+<Callout type="info">
+  Community provider helpers are not official or verified by the Better Auth
+  team. Use them at your own discretion and review their source code before
+  integrating them into your application.
+</Callout>
+
+{/*
+  | Provider                       | Package                | Repository                                                       | Maintainer                     |
+  | ------------------------------ | ---------------------- | ---------------------------------------------------------------- | ------------------------------ |
+  | [Example](https://example.com) | `@example/better-auth` | [example/better-auth](https://github.com/example/better-auth)    | [Example](https://example.com) |
+  */}
+
+*Community provider helper listings are coming soon.*
+
+#### Create a Provider Helper
+
+A provider helper accepts credentials and provider-specific options, then returns a `GenericOAuthConfig`.
+
+```ts title="provider.ts"
+import type {
+  BaseOAuthProviderOptions,
+  GenericOAuthConfig,
+} from "better-auth/plugins/generic-oauth";
+
+export interface ExampleOptions extends BaseOAuthProviderOptions {}
+
+export function example(
+  options: ExampleOptions,
+): GenericOAuthConfig<"example"> {
+  return {
+    providerId: "example",
+    discoveryUrl: "https://auth.example.com/.well-known/openid-configuration",
+    clientId: options.clientId,
+    clientSecret: options.clientSecret,
+    tokenEndpointAuth: options.tokenEndpointAuth,
+    scopes: options.scopes ?? ["openid", "email", "profile"],
+    redirectURI: options.redirectURI,
+  };
+}
+```
+
+Users install the helper from its author and pass it to Generic OAuth.
+
+```ts title="auth.ts"
+import { example } from "@example/better-auth";
+import { betterAuth } from "better-auth";
+import { genericOAuth } from "better-auth/plugins";
+
+export const auth = betterAuth({
+  plugins: [
+    genericOAuth({
+      config: [
+        example({
+          clientId: process.env.EXAMPLE_CLIENT_ID!,
+          clientSecret: process.env.EXAMPLE_CLIENT_SECRET!,
+        }),
+      ],
+    }),
+  ],
+});
+```
+
+To share a provider helper with the community, see the [contribution guidelines](/docs/reference/contributing#social-provider-integrations).
+
+## Configure a Provider Manually
+
+If you need to configure a provider that doesn't have a provider helper, you can configure it manually:
 
 ### Instagram Example
 

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -4,7 +4,7 @@ title: Generic OAuth
 description: Authenticate users with any OAuth provider
 ---
 
-The Generic OAuth plugin lets you add any OAuth 2.1 or OpenID Connect (OIDC) provider to your application. Providers are registered as first-class social providers and use the standard `signIn.social` flow, with PKCE and issuer validation enabled by default.
+The Generic OAuth plugin lets you add any OAuth 2.0 or OpenID Connect (OIDC) provider to your application. Providers are registered as first-class social providers and use the standard `signIn.social` flow, with PKCE and issuer validation enabled by default.
 
 ## When to Use This Plugin
 
@@ -189,133 +189,13 @@ genericOAuth({
 })
 ```
 
-## Pre-configured Provider Helpers
+## Provider Helpers
 
-Better Auth provides pre-configured helper functions for popular OAuth providers. These helpers handle the provider-specific configuration, including discovery URLs and user info endpoints.
-
-### Supported Providers
-
-* **Auth0** - `auth0(options)`
-* **HubSpot** - `hubspot(options)`
-* **Keycloak** - `keycloak(options)`
-* **LINE** - `line(options)`
-* **Microsoft Entra ID (Azure AD)** - `microsoftEntraId(options)`
-* **Okta** - `okta(options)`
-* **Slack** - `slack(options)`
-* **Patreon** - `patreon(options)`
-* **Yandex** - `yandex(options)`
-
-### Example: Using Pre-configured Providers
-
-```ts title="auth.ts"
-import { betterAuth } from 'better-auth';
-import {
-	// genericOAuth plugin
-	genericOAuth,
-	// providers
-	auth0,
-	gumroad,
-	hubspot,
-	keycloak,
-	line,
-	microsoftEntraId,
-	okta,
-	slack,
-	patreon,
-	yandex,
-} from 'better-auth/plugins';
-
-export const auth = betterAuth({
-	plugins: [
-		genericOAuth({
-			config: [
-				auth0({
-					clientId: process.env.AUTH0_CLIENT_ID,
-					clientSecret: process.env.AUTH0_CLIENT_SECRET,
-					domain: process.env.AUTH0_DOMAIN,
-				}),
-				gumroad({
-					clientId: process.env.GUMROAD_CLIENT_ID,
-					clientSecret: process.env.GUMROAD_CLIENT_SECRET,
-				}),
-				hubspot({
-					clientId: process.env.HUBSPOT_CLIENT_ID,
-					clientSecret: process.env.HUBSPOT_CLIENT_SECRET,
-					scopes: ['oauth', 'contacts'],
-				}),
-				keycloak({
-					clientId: process.env.KEYCLOAK_CLIENT_ID,
-					clientSecret: process.env.KEYCLOAK_CLIENT_SECRET,
-					issuer: process.env.KEYCLOAK_ISSUER,
-				}),
-				// LINE supports multiple channels (countries) - use different providerIds
-				line({
-					providerId: 'line-jp',
-					clientId: process.env.LINE_JP_CLIENT_ID,
-					clientSecret: process.env.LINE_JP_CLIENT_SECRET,
-				}),
-				line({
-					providerId: 'line-th',
-					clientId: process.env.LINE_TH_CLIENT_ID,
-					clientSecret: process.env.LINE_TH_CLIENT_SECRET,
-				}),
-				microsoftEntraId({
-					clientId: process.env.MS_APP_ID,
-					clientSecret: process.env.MS_CLIENT_SECRET,
-					tenantId: process.env.MS_TENANT_ID,
-				}),
-				okta({
-					clientId: process.env.OKTA_CLIENT_ID,
-					clientSecret: process.env.OKTA_CLIENT_SECRET,
-					issuer: process.env.OKTA_ISSUER,
-				}),
-				slack({
-					clientId: process.env.SLACK_CLIENT_ID,
-					clientSecret: process.env.SLACK_CLIENT_SECRET,
-				}),
-				patreon({
-					clientId: process.env.PATREON_CLIENT_ID,
-					clientSecret: process.env.PATREON_CLIENT_SECRET,
-				}),
-				yandex({
-					clientId: process.env.YANDEX_CLIENT_ID,
-					clientSecret: process.env.YANDEX_CLIENT_SECRET,
-				}),
-			],
-		}),
-	],
-});
-```
-
-Each provider helper accepts common OAuth options (extending `BaseOAuthProviderOptions`) plus provider-specific fields:
-
-* **Auth0**: Requires `domain` (e.g., `dev-xxx.eu.auth0.com`)
-* **HubSpot**: No additional required fields. Optional `scopes` (defaults to `["oauth"]`)
-* **Keycloak**: Requires `issuer` (e.g., `https://my-domain/realms/MyRealm`)
-* **LINE**: Optional `providerId` (defaults to `"line"`). LINE requires separate channels for different countries (Japan, Thailand, Taiwan, etc.), so you can call `line()` multiple times with different `providerId`s and credentials to support multiple countries
-* **Microsoft Entra ID**: Requires a concrete tenant GUID. Use the built-in [Microsoft social provider](/docs/authentication/microsoft) for the multi-tenant `"common"`, `"organizations"`, or `"consumers"` authorities; those authorities require ID-token claim validation to determine the account's actual issuer
-* **Okta**: Requires `issuer` (e.g., `https://dev-xxxxx.okta.com/oauth2/default`)
-* **Slack**: No additional required fields
-* **Patreon**: No additional required fields
-* **Yandex**: No additional required fields
-
-All providers support the same optional fields:
-
-* `clientSecret?: string` - OAuth client secret
-* `tokenEndpointAuth?: TokenEndpointAuth` - Client authentication configuration for token endpoint requests
-* `scopes?: string[]` - Array of OAuth scopes to request
-* `redirectURI?: string` - Custom redirect URI
-* `pkce?: boolean` - Enable PKCE (defaults to `true`)
-* `disableImplicitSignUp?: boolean` - Disable automatic sign-up for new users
-* `disableSignUp?: boolean` - Disable sign-up entirely
-* `overrideUserInfo?: boolean` - Override user info on sign in
-* `endSessionEndpoint?: string` - OIDC RP-Initiated Logout endpoint. Auto-discovered from `end_session_endpoint` when available
-* `postLogoutRedirectURI?: string` - Default URI to pass as `post_logout_redirect_uri` during provider logout
-* `disableProviderLogout?: boolean` - Disable automatic provider logout during `authClient.signOut()`
+For built-in and community-maintained provider helpers, see [Other Social Providers](/docs/authentication/other-social-providers#provider-helpers).
 
 ## Configuration
 
-When adding the plugin to your auth config, you can configure multiple OAuth providers. You can either use the pre-configured provider helpers (shown above) or create custom configurations manually.
+When adding the plugin to your auth config, you can register multiple OAuth providers using provider helpers or custom configurations.
 
 ### Manual Configuration
 

--- a/docs/content/docs/reference/contributing.mdx
+++ b/docs/content/docs/reference/contributing.mdx
@@ -127,6 +127,12 @@ We welcome contributions to support more frameworks:
 * Keep integrations minimal and maintainable
 * All integrations currently live in the main package
 
+### Social Provider Integrations
+
+Review the [social provider contribution policy](https://github.com/better-auth/better-auth/blob/main/CONTRIBUTING.md#social-provider-integrations) before proposing a built-in social provider or provider helper.
+
+Community helpers can be developed independently using the [Generic OAuth plugin](/docs/plugins/generic-oauth) and submitted for listing under [Other Social Providers](/docs/authentication/other-social-providers#community-provider-helpers).
+
 ### Plugin Development
 
 * For core plugins: Open an issue first to discuss your idea


### PR DESCRIPTION
We've received a growing number of requests to add social providers, but without clear contribution and ownership guidelines, these proposals have been difficult to evaluate consistently.

This PR establishes clear integration paths while allowing Better Auth to prioritize extensibility over maintaining every provider's implementation details.

| Integration | Criteria | Maintainer |
| --- | --- | --- |
| Built-in social provider | Broad use or provider-specific behavior beyond Generic OAuth | Better Auth |
| Built-in provider helper | Broad demand and supported by Generic OAuth | Better Auth |
| Community provider helper | Supported by Generic OAuth | Provider or community |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Establishes a social provider integration policy so maintainers can evaluate provider requests consistently and Better Auth can prioritize extensibility over maintaining every provider's implementation details.

- Defines three integration tiers — built-in social provider, built-in provider helper, and community provider helper — with adoption criteria and maintainer ownership for each.
- Moves provider helper documentation from the Generic OAuth plugin page into Other Social Providers and adds a community listing section with submission requirements.
- Adds a provider helper creation guide and links the contribution policy from the contributing docs.

<sup>Written for commit 599c85991843031153481d663bd9c41488baba5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

