### PR TITLE
fix: prevent slow custom scheme URL parsing

### DIFF
--- a/.changeset/bright-paths-parse.md
+++ b/.changeset/bright-paths-parse.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Handle malformed custom-scheme callback URLs without excessive processing.

--- a/packages/better-auth/src/auth/trusted-origins.test.ts
+++ b/packages/better-auth/src/auth/trusted-origins.test.ts
@@ -407,6 +407,16 @@ describe("trusted origins", () => {
 			);
 		});
 
+		it("should reject control characters in custom-scheme URLs", async () => {
+			const { isTrustedOrigin } = await createAuthTestInstance({
+				trustedOrigins: ["myapp://callback"],
+			});
+
+			await expect(
+				isTrustedOrigin(`myapp://callback?${"#".repeat(10_000)}\n\n`),
+			).resolves.toBe(false);
+		});
+
 		it("should match custom-scheme with empty host (myapp:/)", async () => {
 			const { isTrustedOrigin } = await createAuthTestInstance({
 				trustedOrigins: ["myapp:/"],

--- a/packages/better-auth/src/auth/trusted-origins.ts
+++ b/packages/better-auth/src/auth/trusted-origins.ts
@@ -1,6 +1,10 @@
 import { getHost, getOrigin, getProtocol } from "../utils/url";
 import { wildcardMatch } from "../utils/wildcard";
 
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/;
+const RELATIVE_URL_PARSER_ORIGIN = "https://better-auth.invalid";
+const ENCODED_PATH_SEPARATOR_PATTERN = /%2[fF]|%5[cC]/;
+
 /**
  * Resolves `.` and `..` segments in a path after percent-decoding so a
  * path-pinned pattern cannot be bypassed with traversal: e.g.
@@ -39,6 +43,10 @@ const normalizePath = (path: string): string => {
  * a path-pinned pattern.
  */
 const parseCustomSchemeOrigin = (value: string) => {
+	if (CONTROL_CHARACTER_PATTERN.test(value)) {
+		return null;
+	}
+
 	const schemeEnd = value.indexOf(":");
 	if (schemeEnd <= 0) {
 		return null;
@@ -59,14 +67,10 @@ const parseCustomSchemeOrigin = (value: string) => {
 			rest = rest.slice(authorityEnd);
 		}
 	}
-	const path = normalizePath(rest.replace(/[?#].*$/, ""));
+	const pathEnd = rest.search(/[?#]/);
+	const path = normalizePath(pathEnd === -1 ? rest : rest.slice(0, pathEnd));
 	return { scheme, authority: authority.toLowerCase(), path };
 };
-
-const RELATIVE_URL_PARSER_ORIGIN = "https://better-auth.invalid";
-const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/;
-const ENCODED_PATH_SEPARATOR_PATTERN = /%2[fF]|%5[cC]/;
-
 /**
  * Validates root-relative redirects against ambiguous browser and router parsing.
  *


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speeds up trusted-origin checks by rejecting custom-scheme URLs that contain control characters before parsing, so malformed callback URLs like `myapp://callback?####...` no longer trigger slow processing. Path extraction now stops at the first `?` or `#` instead of using a regex replace.

<sup>Written for commit e7d955329c80f5d400195e9825d4d1cbf5255591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

