### PR TITLE
perf(organization): reuse role permission schema

### DIFF
--- a/.changeset/reuse-role-permission-schema.md
+++ b/.changeset/reuse-role-permission-schema.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Improve dynamic organization role permission check performance.

--- a/packages/better-auth/src/plugins/organization/has-permission.ts
+++ b/packages/better-auth/src/plugins/organization/has-permission.ts
@@ -7,6 +7,8 @@ import type { HasPermissionBaseInput } from "./permission";
 import { cacheAllRoles, hasPermissionFn } from "./permission";
 import type { OrganizationRole } from "./schema";
 
+const rolePermissionsSchema = z.record(z.string(), z.array(z.string()));
+
 export const hasPermission = async (
 	input: {
 		organizationId: string;
@@ -46,16 +48,13 @@ export const hasPermission = async (
 		});
 
 		for (const { role, permission: permissionsString } of roles) {
-			const result = z
-				.record(z.string(), z.array(z.string()))
-				.safeParse(JSON.parse(permissionsString));
+			const permissions: unknown = JSON.parse(permissionsString);
+			const result = rolePermissionsSchema.safeParse(permissions);
 
 			if (!result.success) {
 				ctx.context.logger.error(
 					"[hasPermission] Invalid permissions for role " + role,
-					{
-						permissions: JSON.parse(permissionsString),
-					},
+					{ permissions },
 				);
 				throw new APIError("INTERNAL_SERVER_ERROR", {
 					message: "Invalid permissions for role " + role,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reuses the role permission schema in organization role permission checks to avoid re-creating it on every validation. Validation behavior and error responses are unchanged.

- Hoists the schema to module scope so it's built once per process.
- Parses the permissions JSON once instead of twice on the invalid-permissions logging path.

<sup>Written for commit 9b432869b9abc5d7d1fecc2c8334f5007685ffe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

