### PR TITLE
ci: adopt shared CI tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      - uses: better-auth/shared-workflows/.github/actions/setup-pnpm@08e5520e7a829b03bee1152913682b67d2ba44b1
 
       - name: Reject stale release merge groups
         if: github.event_name == 'merge_group'
@@ -123,16 +114,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      - uses: better-auth/shared-workflows/.github/actions/setup-pnpm@08e5520e7a829b03bee1152913682b67d2ba44b1
 
       - name: Typecheck
         run: pnpm typecheck
@@ -174,16 +156,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: better-auth/shared-workflows/.github/actions/setup-pnpm@08e5520e7a829b03bee1152913682b67d2ba44b1
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
 
       - name: Test release tooling
         if: matrix.node-version == '24.x'

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -41,16 +41,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - name: Install workspace dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: better-auth/shared-workflows/.github/actions/setup-pnpm@08e5520e7a829b03bee1152913682b67d2ba44b1
 
       - name: Build workspace packages
         run: pnpm build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,19 +43,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: better-auth/shared-workflows/.github/actions/setup-pnpm@08e5520e7a829b03bee1152913682b67d2ba44b1
         with:
           node-version: ${{ matrix.node-version }}
-          # Use the latest patch per major: the smoke specs run `node --test` on .ts,
-          # which needs native type-stripping (default-on at 22.18+/24), not the cached 22.13.0.
-          check-latest: true
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install
 
       - name: Build
         run: pnpm build
@@ -110,16 +100,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install
+      - uses: better-auth/shared-workflows/.github/actions/setup-pnpm@08e5520e7a829b03bee1152913682b67d2ba44b1
 
       - name: Install Next.js demo
         run: pnpm --dir demo/nextjs install --frozen-lockfile
@@ -211,16 +192,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install
+      - uses: better-auth/shared-workflows/.github/actions/setup-pnpm@08e5520e7a829b03bee1152913682b67d2ba44b1
 
       - name: Reset Docker Containers
         run: docker compose down --volumes --remove-orphans

--- a/.github/workflows/lint-github-actions.yml
+++ b/.github/workflows/lint-github-actions.yml
@@ -1,0 +1,23 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/**"
+  push:
+    branches:
+      - main
+      - next
+      - "release/**"
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/**"
+
+permissions: {}
+
+jobs:
+  lint:
+    permissions:
+      contents: read
+    uses: better-auth/shared-workflows/.github/workflows/lint-github-actions.yml@08e5520e7a829b03bee1152913682b67d2ba44b1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,18 +32,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-      
-      - name: Install
-        run: pnpm install
+      - uses: better-auth/shared-workflows/.github/actions/setup-pnpm@08e5520e7a829b03bee1152913682b67d2ba44b1
 
       - name: Build
         run: pnpm build
           
-      - run: pnpm dlx pkg-pr-new publish --pnpm './packages/*'
+      - run: pnpm exec pkg-pr-new publish --pnpm './packages/*'

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -30,14 +30,7 @@ jobs:
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: better-auth/shared-workflows/.github/actions/setup-pnpm@08e5520e7a829b03bee1152913682b67d2ba44b1
 
       - name: Exit pre-release and version
         env:
@@ -83,6 +76,7 @@ jobs:
             echo "Promote PR #$EXISTING already exists"
           else
             BODY_FILE=$(mktemp)
+            # shellcheck disable=SC2016
             printf '%s\n' \
               '> [!IMPORTANT]' \
               '> Keep this PR in Draft. Run `/release-notes` to generate and review the release notes.' \

--- a/.github/workflows/release-notes-command.yml
+++ b/.github/workflows/release-notes-command.yml
@@ -146,11 +146,13 @@ jobs:
             exit 1
           fi
 
-          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
-          echo "merged=$MERGED" >> "$GITHUB_OUTPUT"
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "base_ref=$BASE_REF"
+            echo "head_sha=$HEAD_SHA"
+            echo "head_ref=$HEAD_REF"
+            echo "merged=$MERGED"
+          } >> "$GITHUB_OUTPUT"
 
       # issue_comment runs from the default branch. Execute that trusted code
       # and read the release head only as git data.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,9 +173,11 @@ jobs:
             echo "::error::Current commit does not match the approved release commit"
             exit 1
           fi
-          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "release_commit=$RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
-          echo "notes_path=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "release_commit=$RELEASE_COMMIT"
+            echo "notes_path=$NOTES_FILE"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Reject release commits with pending changesets
         if: steps.guard.outputs.skip != 'true' && steps.release-candidate.outputs.release == 'true'
@@ -190,7 +192,7 @@ jobs:
             echo ""
             echo "This release commit still contains changesets that were not included in the approved Version PR. Publishing it would ship unapproved changes under the current version."
             echo ""
-            echo "Revert this release merge, let Changesets regenerate the Version PR, then run `/release-notes` again."
+            echo "Revert this release merge, let Changesets regenerate the Version PR, then run \`/release-notes\` again."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::error::Release commit contains unconsumed changesets"
           exit 1
@@ -226,6 +228,7 @@ jobs:
 
           BODY=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json body --jq '.body')
           if ! printf '%s' "$BODY" | grep -qF '<!-- release-notes-draft -->'; then
+            # shellcheck disable=SC2016
             NOTICE='<!-- release-notes-draft -->
           > [!IMPORTANT]
           > Keep this PR in Draft. Run `/release-notes` to generate and review the release notes.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "knip": "^6.17.1",
     "lefthook": "^2.1.9",
     "nyc": "^18.0.0",
+    "pkg-pr-new": "0.0.88",
     "publint": "^0.3.21",
     "turbo": "^2.9.18",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       nyc:
         specifier: ^18.0.0
         version: 18.0.0
+      pkg-pr-new:
+        specifier: 0.0.88
+        version: 0.0.88
       publint:
         specifier: ^0.3.21
         version: 0.3.21
@@ -12560,6 +12563,10 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  pkg-pr-new@0.0.88:
+    resolution: {integrity: sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==}
+    hasBin: true
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -27246,6 +27253,8 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  pkg-pr-new@0.0.88: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adopts shared CI tooling from `better-auth/shared-workflows`, replacing manual pnpm and Node.js setup steps with a single `setup-pnpm` action and adding a new workflow to lint GitHub Actions files.

- All workflows now use the shared `setup-pnpm` action for consistent Node and pnpm setup.
- Adds a `lint-github-actions.yml` workflow that runs on changes to workflow and action files.
- Fixes shellcheck warnings in `promote.yml`, `release.yml`, and `release-notes-command.yml`.
- Adds `pkg-pr-new` as a dev dependency and uses `pnpm exec` instead of `pnpm dlx` in `preview.yml`.

<sup>Written for commit ee7559a5686616b9921a5e5d0be4bac67adfa631. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

