### PR TITLE
fix(last-login-method): support Google One Tap

### DIFF
--- a/.changeset/google-one-tap-last-login.md
+++ b/.changeset/google-one-tap-last-login.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Track Google One Tap callbacks as the Google last login method.

--- a/packages/better-auth/src/plugins/last-login-method/index.ts
+++ b/packages/better-auth/src/plugins/last-login-method/index.ts
@@ -82,6 +82,9 @@ export const lastLoginMethod = <O extends LastLoginMethodOptions>(
 		if (path.startsWith("/callback/")) {
 			return ctx.params?.id || path.split("/").pop();
 		}
+		if (path === "/one-tap/callback") {
+			return "google";
+		}
 		// Check for email sign-in/sign-up
 		if (path === "/sign-in/email" || path === "/sign-up/email") {
 			return "email";

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -370,6 +370,34 @@ describe("lastLoginMethod", async () => {
 		});
 	});
 
+	it("should set the last login method cookie for Google One Tap", async () => {
+		const plugin = lastLoginMethod();
+		const handler = plugin.hooks?.after?.[0]?.handler;
+
+		const result = (await handler?.({
+			path: "/one-tap/callback",
+			returnHeaders: true,
+			context: {
+				responseHeaders: new Headers({
+					"set-cookie": "better-auth.session_token=session-token",
+				}),
+				authCookies: {
+					sessionToken: {
+						name: "better-auth.session_token",
+						attributes: {},
+					},
+				},
+			},
+		} as any)) as unknown as { headers: Headers } | undefined;
+
+		const cookies = parseSetCookieHeader(
+			result?.headers.get("set-cookie") || "",
+		);
+		expect(cookies.get("better-auth.last_used_login_method")?.value).toBe(
+			"google",
+		);
+	});
+
 	it("should ignore missing path in after hooks", async () => {
 		const plugin = lastLoginMethod();
 		const handler = plugin.hooks?.after?.[0]?.handler;

--- a/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
+++ b/packages/better-auth/src/plugins/last-login-method/last-login-method.test.ts
@@ -344,6 +344,32 @@ describe("lastLoginMethod", async () => {
 		expect(cookies.get("better-auth.last_used_login_method")).toBeUndefined();
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10995
+	 */
+	it("should resolve Google One Tap callbacks as google", async () => {
+		const updateUser = vi.fn();
+		const plugin = lastLoginMethod({ storeInDatabase: true });
+		const initResult = await plugin.init?.({
+			internalAdapter: { updateUser },
+			logger: { error: vi.fn() },
+		} as unknown as Parameters<NonNullable<typeof plugin.init>>[0]);
+		const sessionCreateAfter =
+			initResult?.options?.databaseHooks?.session?.create?.after;
+		if (!sessionCreateAfter) throw new Error("Expected a session create hook");
+
+		await sessionCreateAfter(
+			{ userId: "user-123" } as Parameters<typeof sessionCreateAfter>[0],
+			{
+				path: "/one-tap/callback",
+			} as Parameters<typeof sessionCreateAfter>[1],
+		);
+
+		expect(updateUser).toHaveBeenCalledWith("user-123", {
+			lastLoginMethod: "google",
+		});
+	});
+
 	it("should ignore missing path in after hooks", async () => {
 		const plugin = lastLoginMethod();
 		const handler = plugin.hooks?.after?.[0]?.handler;


### PR DESCRIPTION
## Summary

Closes #10995.

The last-login-method resolver handled redirect-based OAuth callbacks through `/callback/:provider`, but Google One Tap completes through `/one-tap/callback`. As a result, successful One Tap sessions did not resolve a login method.

Map the One Tap callback to `google`, which matches the provider used by the One Tap plugin. The shared resolver now updates both cookie-backed and database-backed last login tracking for this flow.

## Testing

- `pnpm --filter better-auth exec vitest src/plugins/last-login-method/last-login-method.test.ts --run`
- `pnpm --filter better-auth typecheck`
- `pnpm typecheck`
- Biome and cspell pre-commit checks

The regression tests cover both storage paths: the database hook updates `lastLoginMethod` to `google`, and the cookie hook writes `better-auth.last_used_login_method=google` after a successful One Tap session.

A patch changeset is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the last-login-method resolver so Google One Tap sessions now track `google` instead of leaving the login method unset.

- Maps the `/one-tap/callback` path to `google` for both cookie-backed and database-backed tracking.
- Adds regression tests covering the database hook and the cookie header for the One Tap callback path.
- Includes a patch changeset and closes #10995.

<sup>Written for commit 1865710d9394005869de7d97f5bf7fddb02e8fdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


