### PR TITLE
feat(api): add enabledPaths option to restrict served paths

### DIFF
--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -961,6 +961,17 @@ export const auth = betterAuth({
 })
 ```
 
+## `enabledPaths`
+
+Serve only the listed auth paths and return `404 Not Found` for every other path. Entries match exactly, or as a wildcard pattern when they contain `*`. Server-side `auth.api` calls are not affected, and paths listed in `disabledPaths` stay disabled.
+
+```ts
+import { betterAuth } from "better-auth";
+export const auth = betterAuth({
+	enabledPaths: ["/sign-in/email", "/sign-out", "/get-session", "/callback/*"],
+})
+```
+
 ## `telemetry`
 
 Enable or disable Better Auth's telemetry collection. (default: `false`)

--- a/packages/better-auth/src/api/index.test.ts
+++ b/packages/better-auth/src/api/index.test.ts
@@ -290,3 +290,100 @@ describe("base path leading-prefix enforcement", () => {
 		expect(confused.status).toBe(404);
 	});
 });
+
+describe("enabledPaths", () => {
+	const signUpBody = JSON.stringify({
+		email: "user@example.com",
+		password: "password12345",
+		name: "Test User",
+	});
+
+	it("serves listed paths and returns 404 for every other path", async () => {
+		const { auth } = await getTestInstance({
+			enabledPaths: ["/sign-up/email"],
+		});
+
+		const allowed = await auth.handler(
+			new Request("http://localhost:3000/api/auth/sign-up/email", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: signUpBody,
+			}),
+		);
+		expect(allowed.status).toBe(200);
+
+		const blocked = await auth.handler(
+			new Request("http://localhost:3000/api/auth/ok", {
+				method: "GET",
+			}),
+		);
+		expect(blocked.status).toBe(404);
+	});
+
+	it("matches wildcard entries like rate-limit custom rules", async () => {
+		const { auth } = await getTestInstance({
+			enabledPaths: ["/sign-up/*"],
+		});
+
+		const allowed = await auth.handler(
+			new Request("http://localhost:3000/api/auth/sign-up/email", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: signUpBody,
+			}),
+		);
+		expect(allowed.status).toBe(200);
+
+		const blocked = await auth.handler(
+			new Request("http://localhost:3000/api/auth/sign-in/email", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					email: "user@example.com",
+					password: "password12345",
+				}),
+			}),
+		);
+		expect(blocked.status).toBe(404);
+	});
+
+	it("blocks every path when the list is empty", async () => {
+		const { auth } = await getTestInstance({
+			enabledPaths: [],
+		});
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/api/auth/ok", {
+				method: "GET",
+			}),
+		);
+		expect(response.status).toBe(404);
+	});
+
+	it("keeps paths from disabledPaths disabled even when listed", async () => {
+		const { auth } = await getTestInstance({
+			enabledPaths: ["/sign-up/email"],
+			disabledPaths: ["/sign-up/email"],
+		});
+
+		const response = await auth.handler(
+			new Request("http://localhost:3000/api/auth/sign-up/email", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: signUpBody,
+			}),
+		);
+		expect(response.status).toBe(404);
+	});
+
+	it("does not affect server-side api calls", async () => {
+		const { auth } = await getTestInstance({
+			enabledPaths: ["/sign-up/email"],
+		});
+
+		const session = await auth.api.getSession({
+			headers: new Headers(),
+		});
+		expect(session).toBeNull();
+	});
+});

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -17,6 +17,7 @@ import { normalizePathname } from "@better-auth/core/utils/url";
 import type { Endpoint, Middleware } from "better-call";
 import { createRouter } from "better-call";
 import type { OverrideMerge, UnionToIntersection } from "../types";
+import { isPathEnabled } from "../utils/enabled-paths";
 import { isAPIError } from "../utils/is-api-error";
 import { originCheckMiddleware } from "./middlewares";
 import { onRequestRateLimit } from "./rate-limiter";
@@ -297,6 +298,11 @@ export const router = <Option extends BetterAuthOptions>(
 			const disabledPaths = ctx.options.disabledPaths || [];
 			const normalizedPath = normalizePathname(req.url, basePath);
 			if (disabledPaths.includes(normalizedPath)) {
+				return new Response("Not Found", { status: 404 });
+			}
+
+			//handle enabled paths
+			if (!isPathEnabled(normalizedPath, ctx.options.enabledPaths)) {
 				return new Response("Not Found", { status: 404 });
 			}
 

--- a/packages/better-auth/src/plugins/open-api/generator.ts
+++ b/packages/better-auth/src/plugins/open-api/generator.ts
@@ -13,6 +13,7 @@ import type {
 import * as z from "zod";
 import { getEndpoints } from "../../api";
 import { getAuthTables } from "../../db";
+import { isPathEnabled } from "../../utils/enabled-paths";
 
 export interface Path {
 	get?: OpenAPIOperation | undefined;
@@ -939,7 +940,12 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 	const usedOperationIds = new Set<string>();
 
 	Object.entries(baseEndpoints.api).forEach(([_, value]) => {
-		if (!value.path || ctx.options.disabledPaths?.includes(value.path)) return;
+		if (
+			!value.path ||
+			ctx.options.disabledPaths?.includes(value.path) ||
+			!isPathEnabled(value.path, ctx.options.enabledPaths)
+		)
+			return;
 		const options = value.options as EndpointOptions;
 		if (options.metadata?.SERVER_ONLY) return;
 		const path = toOpenApiPath(value.path);
@@ -1040,7 +1046,11 @@ export async function generator(ctx: AuthContext, options: BetterAuthOptions) {
 			})
 			.filter((x) => x !== null) as Endpoint[];
 		Object.entries(api).forEach(([key, value]) => {
-			if (!value.path || ctx.options.disabledPaths?.includes(value.path))
+			if (
+				!value.path ||
+				ctx.options.disabledPaths?.includes(value.path) ||
+				!isPathEnabled(value.path, ctx.options.enabledPaths)
+			)
 				return;
 			const options = value.options as EndpointOptions;
 			if (options.metadata?.SERVER_ONLY) return;

--- a/packages/better-auth/src/plugins/open-api/open-api.test.ts
+++ b/packages/better-auth/src/plugins/open-api/open-api.test.ts
@@ -335,6 +335,16 @@ describe("open-api", async () => {
 		expect(schema).toMatchSnapshot("openAPISchema");
 	});
 
+	it("should omit paths outside enabledPaths", async () => {
+		const { auth: authWithEnabledPaths } = await getTestInstance({
+			plugins: [openAPI()],
+			enabledPaths: ["/sign-in/email"],
+		});
+		const schema = await authWithEnabledPaths.api.generateOpenAPISchema();
+		expect(schema.paths["/sign-in/email"]).toBeDefined();
+		expect(schema.paths["/sign-up/email"]).toBeUndefined();
+	});
+
 	it("should mark model id fields as required and read-only", async () => {
 		const schema = await auth.api.generateOpenAPISchema();
 		const schemas = schema.components.schemas as Record<

--- a/packages/better-auth/src/utils/enabled-paths.ts
+++ b/packages/better-auth/src/utils/enabled-paths.ts
@@ -1,0 +1,17 @@
+import { wildcardMatch } from "./wildcard";
+
+/**
+ * Checks whether a path is allowed by the `enabledPaths` option,
+ * using the same matching as rate-limit custom rules.
+ */
+export function isPathEnabled(
+	path: string,
+	enabledPaths: string[] | undefined,
+): boolean {
+	if (!enabledPaths) {
+		return true;
+	}
+	return enabledPaths.some((p) =>
+		p.includes("*") ? wildcardMatch(p)(path) : p === path,
+	);
+}

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1777,6 +1777,13 @@ export type BetterAuthOptions = {
 		  }
 		| undefined;
 	/**
+	 * Enabled paths
+	 *
+	 * When set, only these paths are served and every other path
+	 * returns `404`. Supports wildcards (e.g. `"/callback/*"`).
+	 */
+	enabledPaths?: string[] | undefined;
+	/**
 	 * Disabled paths
 	 *
 	 * Paths you want to disable.


### PR DESCRIPTION
Mounting better auth serves every core and plugin endpoint. Restricting an app that only uses a few of them with `disabledPaths` requires enumerating every other path across core and plugins, and re-checking the list on every update (#2622, #8015).

This PR adds `enabledPaths` as the allowlist counterpart:

```ts
export const auth = betterAuth({
	enabledPaths: ["/sign-in/email", "/sign-out", "/get-session", "/callback/*"],
});
```

## What changes

- When `enabledPaths` is set, only the listed paths are served; every other path returns `404 Not Found`. Leaving it unset keeps today's behavior, and an empty array blocks every path.
- Entries match exactly, or as a wildcard pattern when they contain `*` — the same matching rate-limit `customRules` already uses.
- `disabledPaths` keeps precedence: a path listed in both stays disabled.
- Server-side `auth.api` calls are not affected, same as `disabledPaths`.
- The OpenAPI generator omits paths outside the allowlist, mirroring its `disabledPaths` handling.

Closes #8015


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `enabledPaths` allowlist option so apps can restrict the auth endpoints they serve. With `disabledPaths`, keeping only a few endpoints meant enumerating every other path across core and plugins; now you can list the paths you want and everything else returns `404 Not Found`.

**New Features**
- Entries match exactly, or as a wildcard pattern when they contain `*`, using the same matching as rate-limit `customRules`.
- An empty array blocks every path.
- `disabledPaths` takes precedence over `enabledPaths`.
- Server-side `auth.api` calls are unaffected.
- The OpenAPI generator omits paths outside the allowlist.

<sup>Written for commit cbfb48b389df8cca06ce870245a89752e8b69650. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

