### PR TITLE
feat(organizations): [WIP] Add support for roles in teams

### DIFF
--- a/packages/better-auth/src/plugins/access/access.ts
+++ b/packages/better-auth/src/plugins/access/access.ts
@@ -108,6 +108,7 @@ export function role<
 	TAuthorizeStatements extends Statements = TRoleStatements,
 >(
 	statements: TRoleStatements,
+	options?: { scope?: "organization" | "team" | "both" }
 ): Role<ExactRoleStatements<TRoleStatements>, TAuthorizeStatements> {
 	return {
 		authorize(
@@ -152,6 +153,7 @@ export function role<
 			};
 		},
 		statements,
+		scope: options?.scope
 	};
 }
 
@@ -161,8 +163,9 @@ export function createAccessControl<const TStatements extends Statements>(
 	return {
 		newRole<const TRoleStatements extends Statements>(
 			statements: RoleInput<TStatements, TRoleStatements>,
+			options?: { scope?: "organization" | "team" | "both" }
 		) {
-			return role<TRoleStatements, TStatements>(statements);
+			return role<TRoleStatements, TStatements>(statements, options);
 		},
 		statements: s,
 	};

--- a/packages/better-auth/src/plugins/access/types.ts
+++ b/packages/better-auth/src/plugins/access/types.ts
@@ -59,4 +59,5 @@ export type Role<
 		connector?: ("OR" | "AND") | undefined,
 	) => AuthorizeResponse;
 	statements: TRoleStatements;
+	scope?: "organization" | "team" | "both";
 };

--- a/packages/better-auth/src/plugins/organization/adapter.ts
+++ b/packages/better-auth/src/plugins/organization/adapter.ts
@@ -141,6 +141,7 @@ async function createTeamMemberWithKey(
 		teamId: string;
 		userId: string;
 		membershipKey: string;
+		role: string;
 	},
 ) {
 	try {
@@ -152,6 +153,7 @@ async function createTeamMemberWithKey(
 			data: {
 				teamId: data.teamId,
 				userId: data.userId,
+				role: data.role,
 				membershipKey: data.membershipKey,
 				createdAt: new Date(),
 			},
@@ -1059,6 +1061,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		findOrCreateTeamMember: async (data: {
 			teamId: string;
 			userId: string;
+			role: string;
 		}) => {
 			return runWithTransaction(baseAdapter, async () => {
 				const adapter = await getCurrentAdapter(baseAdapter);
@@ -1089,6 +1092,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 		addTeamMemberWithLimit: async (data: {
 			teamId: string;
 			userId: string;
+			role: string;
 			maximumMembersPerTeam: number;
 		}): Promise<
 			{ status: "added"; member: TeamMember } | { status: "limitReached" }
@@ -1115,8 +1119,7 @@ export const getOrgAdapter = <O extends OrganizationOptions>(
 				let result: Awaited<ReturnType<typeof createTeamMemberWithKey>>;
 				try {
 					result = await createTeamMemberWithKey(adapter, {
-						teamId: data.teamId,
-						userId: data.userId,
+						...data,
 						membershipKey,
 					});
 				} catch (error) {

--- a/packages/better-auth/src/plugins/organization/client.ts
+++ b/packages/better-auth/src/plugins/organization/client.ts
@@ -235,6 +235,8 @@ export const organizationClient = <CO extends OrganizationClientOptions>(
 		pathMethods: {
 			"/organization/get-full-organization": "GET",
 			"/organization/list-user-teams": "GET",
+			"/organization/list-roles": "GET",
+			"/organization/get-role": "GET",
 		},
 		atomListeners: [
 			{
@@ -270,6 +272,7 @@ export const organizationClient = <CO extends OrganizationClientOptions>(
 				matcher(path) {
 					return (
 						path.includes("/organization/update-member-role") ||
+						path.includes("/organization/update-team-member-role") ||
 						path.startsWith("/organization/set-active")
 					);
 				},
@@ -279,6 +282,7 @@ export const organizationClient = <CO extends OrganizationClientOptions>(
 				matcher(path) {
 					return (
 						path.includes("/organization/update-member-role") ||
+						path.includes("/organization/update-team-member-role") ||
 						path.startsWith("/organization/set-active")
 					);
 				},

--- a/packages/better-auth/src/plugins/organization/has-permission.ts
+++ b/packages/better-auth/src/plugins/organization/has-permission.ts
@@ -5,13 +5,19 @@ import type { Role } from "../access";
 import { defaultRoles } from "./access";
 import type { HasPermissionBaseInput } from "./permission";
 import { cacheAllRoles, hasPermissionFn } from "./permission";
-import type { OrganizationRole } from "./schema";
+import type { User } from "../../types";
+import { ORGANIZATION_ERROR_CODES } from "./error-codes";
+import type { Member, OrganizationRole, TeamMember } from "./schema";
+import type { OrganizationOptions } from "./types";
 
 const rolePermissionsSchema = z.record(z.string(), z.array(z.string()));
 
 export const hasPermission = async (
 	input: {
 		organizationId: string;
+		teamId?: string;
+		userId?: string;
+		teamRole?: string;
 		/**
 		 * If true, will use the in-memory cache of the roles.
 		 * Keep in mind to use this in a stateless mindset, the purpose of this is to avoid unnecessary database calls when running multiple
@@ -25,7 +31,39 @@ export const hasPermission = async (
 ) => {
 	let acRoles: {
 		[x: string]: Role<any> | undefined;
-	} = { ...(input.options.roles || defaultRoles) };
+	} = { 
+		...(input.options.roles || defaultRoles),
+		...(input.options.teams?.roles || {})
+	};
+
+	let role = input.role;
+	let teamRole = input.teamRole;
+
+	if (input.userId && (!role || (input.teamId && teamRole === undefined))) {
+		const [member, teamMember] = await Promise.all([
+			!role ? ctx.context.adapter.findOne<any>({
+				model: "member",
+				where: [
+					{ field: "organizationId", value: input.organizationId },
+					{ field: "userId", value: input.userId }
+				]
+			}) : null,
+			input.teamId && teamRole === undefined ? ctx.context.adapter.findOne<any>({
+				model: "teamMember",
+				where: [
+					{ field: "teamId", value: input.teamId },
+					{ field: "userId", value: input.userId }
+				]
+			}) : null
+		]);
+
+		if (!role && member) {
+			role = member.role;
+		}
+		if (input.teamId && teamRole === undefined && teamMember) {
+			teamRole = teamMember.role || "";
+		}
+	}
 
 	if (
 		ctx &&
@@ -74,5 +112,87 @@ export const hasPermission = async (
 	}
 	cacheAllRoles.set(input.organizationId, acRoles);
 
-	return hasPermissionFn(input, acRoles);
+	return hasPermissionFn({ ...input, role, teamRole }, acRoles);
 };
+
+export async function checkIfMemberHasPermission({
+	ctx,
+	permissionRequired: permission,
+	options,
+	organizationId,
+	teamId,
+	member,
+	teamMember,
+	user,
+	action,
+}: {
+	ctx: GenericEndpointContext;
+	permissionRequired: Record<string, string[]>;
+	options: OrganizationOptions;
+	organizationId: string;
+	teamId?: string;
+	member?: Member | null;
+	teamMember?: TeamMember | null;
+	user: User;
+	action: "create" | "update" | "delete" | "read" | "list" | "get";
+}) {
+	const hasNecessaryPermissions: {
+		resource: { [x: string]: string[] };
+		hasPermission: boolean;
+	}[] = [];
+	const permissionEntries = Object.entries(permission);
+	for await (const [resource, permissions] of permissionEntries) {
+		for await (const perm of permissions) {
+			hasNecessaryPermissions.push({
+				resource: { [resource]: [perm] },
+				hasPermission: await hasPermission(
+					{
+						options,
+						organizationId,
+						teamId,
+						permissions: { [resource]: [perm] },
+						useMemoryCache: true,
+						role: member?.role,
+						teamRole: teamMember?.role,
+					},
+					ctx,
+				),
+			});
+		}
+	}
+	const missingPermissions = hasNecessaryPermissions
+		.filter((x) => x.hasPermission === false)
+		.map((x) => {
+			const key = Object.keys(x.resource)[0]!;
+			return `${key}:${x.resource[key]![0]}` as const;
+		});
+	if (missingPermissions.length > 0) {
+		ctx.context.logger.error(
+			`[Dynamic Access Control] The user is missing permissions necessary to ${action} a role with those set of permissions.\n`,
+			{
+				userId: user.id,
+				organizationId,
+				role: member?.role,
+				teamRole: teamMember?.role,
+				missingPermissions,
+			},
+		);
+		let error: { code: string; message: string };
+		if (action === "create")
+			error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CREATE_A_ROLE;
+		else if (action === "update")
+			error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_UPDATE_A_ROLE;
+		else if (action === "delete")
+			error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_DELETE_A_ROLE;
+		else if (action === "read")
+			error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_READ_A_ROLE;
+		else if (action === "list")
+			error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_LIST_A_ROLE;
+		else error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_GET_A_ROLE;
+
+		throw APIError.fromStatus("FORBIDDEN", {
+			message: error.message,
+			code: error.code,
+		});
+	}
+}

--- a/packages/better-auth/src/plugins/organization/organization.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization.test.ts
@@ -2472,7 +2472,7 @@ describe("Additional Fields", async () => {
 
 	const orgOptions = {
 		teams: {
-			enabled: true,
+			enabled: true as const,
 		},
 		schema: {
 			organization: {
@@ -2770,6 +2770,7 @@ describe("Additional Fields", async () => {
 				createdAt: Date;
 				userId: string;
 				teamId?: string | undefined;
+				teamRole?: "member" | undefined;
 				user: {
 					id: string;
 					email: string;
@@ -2831,6 +2832,7 @@ describe("Additional Fields", async () => {
 			role: "member" | "admin" | "owner";
 			createdAt: Date;
 			teamId?: string | undefined;
+			teamRole?: "member" | undefined;
 			user: {
 				id: string;
 				email: string;
@@ -3066,6 +3068,7 @@ describe("Additional Fields", async () => {
 			createdAt: Date;
 			userId: string;
 			teamId?: string | undefined;
+			teamRole?: "member" | undefined;
 			user: {
 				id: string;
 				email: string;
@@ -3086,6 +3089,7 @@ describe("Additional Fields", async () => {
 			expiresAt: Date;
 			createdAt: Date;
 			teamId?: string | undefined;
+			teamRole?: "member" | undefined;
 			invitationRequiredField: string;
 			invitationOptionalField?: string | undefined;
 			invitationHiddenField?: string | undefined;
@@ -3186,6 +3190,7 @@ describe("Additional Fields", async () => {
 				createdAt: Date;
 				userId: string;
 				teamId?: string | undefined;
+				teamRole?: "member" | undefined;
 				user: {
 					id: string;
 					email: string;
@@ -3378,6 +3383,7 @@ describe("Additional Fields", async () => {
 			createdAt: Date;
 			expiresAt: Date;
 			teamId?: string | undefined;
+			teamRole?: "member" | undefined;
 			invitationRequiredField: string;
 			invitationOptionalField?: string | undefined;
 			invitationHiddenField?: string | undefined;
@@ -3412,6 +3418,7 @@ describe("Additional Fields", async () => {
 				createdAt: Date;
 				expiresAt: Date;
 				teamId?: string | undefined;
+				teamRole?: "member" | undefined;
 				invitationRequiredField: string;
 				invitationOptionalField?: string | undefined;
 				invitationHiddenField?: string | undefined;
@@ -3461,6 +3468,7 @@ describe("Additional Fields", async () => {
 			invitationOptionalField?: string | undefined;
 			invitationHiddenField?: string | undefined;
 			teamId?: string | undefined;
+			teamRole?: "member" | undefined;
 		}>();
 		expect(invitation.invitationRequiredField).toBe("hey");
 		expect(invitation.invitationOptionalField).toBe("hey2");

--- a/packages/better-auth/src/plugins/organization/organization.ts
+++ b/packages/better-auth/src/plugins/organization/organization.ts
@@ -58,6 +58,7 @@ import {
 	removeTeamMember,
 	setActiveTeam,
 	updateTeam,
+	updateTeamMemberRole,
 } from "./routes/crud-team";
 import type {
 	InferInvitation,
@@ -135,6 +136,7 @@ export type TeamEndpoints<O extends OrganizationOptions> = {
 	listUserTeams: ReturnType<typeof listUserTeams<O>>;
 	listTeamMembers: ReturnType<typeof listTeamMembers<O>>;
 	addTeamMember: ReturnType<typeof addTeamMember<O>>;
+	updateTeamMemberRole: ReturnType<typeof updateTeamMemberRole<O>>;
 	removeTeamMember: ReturnType<typeof removeTeamMember<O>>;
 };
 
@@ -913,6 +915,22 @@ export function organization<O extends OrganizationOptions>(options?: O) {
 		 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/organization#api-add-team-member)
 		 */
 		addTeamMember: addTeamMember(opts),
+		/**
+		 * ### Endpoint
+		 *
+		 * POST `/organization/update-team-member-role`
+		 *
+		 * ### API Methods
+		 *
+		 * **server:**
+		 * `auth.api.updateTeamMemberRole`
+		 *
+		 * **client:**
+		 * `authClient.organization.updateTeamMemberRole`
+		 *
+		 * @see [Read our docs to learn more.](https://better-auth.com/docs/plugins/organization#api-update-team-member-role)
+		 */
+		updateTeamMemberRole: updateTeamMemberRole(opts),
 		/**
 		 * ### Endpoint
 		 *

--- a/packages/better-auth/src/plugins/organization/permission.ts
+++ b/packages/better-auth/src/plugins/organization/permission.ts
@@ -2,27 +2,41 @@ import type { Role } from "../access";
 import type { OrganizationOptions } from "./types";
 
 export const hasPermissionFn = (
-	input: HasPermissionBaseInput,
+	input: HasPermissionBaseInput & { teamRole?: string },
 	acRoles: {
 		[x: string]: Role<any> | undefined;
 	},
 ) => {
 	if (!input.permissions) return false;
 
-	const roles = input.role.split(",");
+	const orgRoles = input.role ? input.role.split(",").map((r) => r.trim()).filter(Boolean) : [];
+	const teamRoles = input.teamRole !== undefined ? input.teamRole.split(",").map((r) => r.trim()).filter(Boolean) : undefined;
+	
 	const creatorRole = input.options.creatorRole || "owner";
-	const isCreator = roles.includes(creatorRole);
+	const isCreator = orgRoles.includes(creatorRole);
 
 	const allowCreatorsAllPermissions = input.allowCreatorAllPermissions || false;
 	if (isCreator && allowCreatorsAllPermissions) return true;
 
-	for (const role of roles) {
+	for (const role of orgRoles) {
 		const _role = acRoles[role as keyof typeof acRoles];
 		const result = _role?.authorize(input.permissions);
 		if (result?.success) {
 			return true;
 		}
 	}
+
+	if (teamRoles !== undefined) {
+		if (teamRoles.length === 0) return false;
+		for (const role of teamRoles) {
+			const _role = acRoles[role as keyof typeof acRoles];
+			const result = _role?.authorize(input.permissions);
+			if (result?.success) {
+				return true;
+			}
+		}
+	}
+
 	return false;
 };
 
@@ -38,7 +52,7 @@ export const cacheAllRoles = new Map<
 >();
 
 export type HasPermissionBaseInput = {
-	role: string;
+	role?: string;
 	options: OrganizationOptions;
 	allowCreatorAllPermissions?: boolean | undefined;
 } & PermissionExclusive;

--- a/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-access-control.ts
@@ -9,7 +9,7 @@ import type { User } from "../../../types";
 import type { AccessControl } from "../../access";
 import { orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
-import { hasPermission } from "../has-permission";
+import { checkIfMemberHasPermission, hasPermission } from "../has-permission";
 import type { Member, OrganizationRole } from "../schema";
 import type { OrganizationOptions } from "../types";
 
@@ -69,6 +69,9 @@ const baseCreateOrgRoleSchema = z.object({
 	permission: z.record(z.string(), z.array(z.string())).meta({
 		description: "The permission to assign to the role",
 	}),
+	scope: z.enum(["organization", "team", "both"]).optional().meta({
+		description: "The scope of the role (organization, team, or both)",
+	}),
 });
 
 export const createOrgRole = <O extends OrganizationOptions>(options: O) => {
@@ -92,6 +95,7 @@ export const createOrgRole = <O extends OrganizationOptions>(options: O) => {
 						organizationId?: string | undefined;
 						role: string;
 						permission: Record<string, string[]>;
+						scope?: "organization" | "team" | "both" | undefined;
 					} & (IsExactlyEmptyObject<AdditionalFields> extends true
 						? { additionalFields?: {} | undefined }
 						: { additionalFields: AdditionalFields }),
@@ -263,6 +267,7 @@ export const createOrgRole = <O extends OrganizationOptions>(options: O) => {
 					organizationId,
 					permission: JSON.stringify(permission),
 					role: roleName,
+					scope: ctx.body.scope || "organization",
 					...additionalFields,
 				},
 			});
@@ -270,7 +275,7 @@ export const createOrgRole = <O extends OrganizationOptions>(options: O) => {
 			const data = {
 				...newRoleInDB,
 				permission,
-			} as OrganizationRole & ReturnAdditionalFields;
+			} as unknown as OrganizationRole & ReturnAdditionalFields;
 			return ctx.json({
 				success: true,
 				roleData: data,
@@ -534,6 +539,9 @@ const listOrgRolesQuerySchema = z
 			description:
 				"The id of the organization to list roles for. If not provided, the user's active organization will be used.",
 		}),
+		scope: z.enum(["organization", "team", "both"]).optional().meta({
+			description: "The scope of the roles to list",
+		}),
 	})
 	.optional();
 
@@ -621,18 +629,29 @@ export const listOrgRoles = <O extends OrganizationOptions>(options: O) => {
 				);
 			}
 
+			const queryWhere = [
+				{
+					field: "organizationId",
+					value: organizationId,
+					operator: "eq" as const,
+					connector: "AND" as const,
+				},
+			];
+
+			if (ctx.query?.scope) {
+				queryWhere.push({
+					field: "scope",
+					value: ctx.query.scope,
+					operator: "eq" as const,
+					connector: "AND" as const,
+				});
+			}
+
 			let roles = await ctx.context.adapter.findMany<
 				OrganizationRole & ReturnAdditionalFields
 			>({
 				model: "organizationRole",
-				where: [
-					{
-						field: "organizationId",
-						value: organizationId,
-						operator: "eq",
-						connector: "AND",
-					},
-				],
+				where: queryWhere as any,
 			});
 
 			roles = roles.map((x) => ({
@@ -860,6 +879,9 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 						roleName: z.string().optional().meta({
 							description: "The name of the role to update",
 						}),
+						scope: z.enum(["organization", "team", "both"]).optional().meta({
+							description: "The scope of the role (organization, team, or both)",
+						}),
 						...additionalFieldsSchema.shape,
 					}),
 				})
@@ -871,6 +893,7 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 						data: {
 							permission?: Record<string, string[]> | undefined;
 							roleName?: string | undefined;
+							scope?: "organization" | "team" | "both" | undefined;
 						} & AdditionalFields;
 						roleName?: string | undefined;
 						roleId?: string | undefined;
@@ -1063,6 +1086,10 @@ export const updateOrgRole = <O extends OrganizationOptions>(options: O) => {
 				updateData.role = newRoleName;
 			}
 
+			if (ctx.body.data.scope) {
+				updateData.scope = ctx.body.data.scope;
+			}
+
 			// -----
 			// Apply the updates
 			const update = {
@@ -1127,82 +1154,6 @@ async function checkForInvalidResources({
 			"BAD_REQUEST",
 			ORGANIZATION_ERROR_CODES.INVALID_RESOURCE,
 		);
-	}
-}
-
-async function checkIfMemberHasPermission({
-	ctx,
-	permissionRequired: permission,
-	options,
-	organizationId,
-	member,
-	user,
-	action,
-}: {
-	ctx: GenericEndpointContext;
-	permissionRequired: Record<string, string[]>;
-	options: OrganizationOptions;
-	organizationId: string;
-	member: Member;
-	user: User;
-	action: "create" | "update" | "delete" | "read" | "list" | "get";
-}) {
-	const hasNecessaryPermissions: {
-		resource: { [x: string]: string[] };
-		hasPermission: boolean;
-	}[] = [];
-	const permissionEntries = Object.entries(permission);
-	for await (const [resource, permissions] of permissionEntries) {
-		for await (const perm of permissions) {
-			hasNecessaryPermissions.push({
-				resource: { [resource]: [perm] },
-				hasPermission: await hasPermission(
-					{
-						options,
-						organizationId,
-						permissions: { [resource]: [perm] },
-						useMemoryCache: true,
-						role: member.role,
-					},
-					ctx,
-				),
-			});
-		}
-	}
-	const missingPermissions = hasNecessaryPermissions
-		.filter((x) => x.hasPermission === false)
-		.map((x) => {
-			const key = Object.keys(x.resource)[0]!;
-			return `${key}:${x.resource[key]![0]}` as const;
-		});
-	if (missingPermissions.length > 0) {
-		ctx.context.logger.error(
-			`[Dynamic Access Control] The user is missing permissions necessary to ${action} a role with those set of permissions.\n`,
-			{
-				userId: user.id,
-				organizationId,
-				role: member.role,
-				missingPermissions,
-			},
-		);
-		let error: { code: string; message: string };
-		if (action === "create")
-			error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_CREATE_A_ROLE;
-		else if (action === "update")
-			error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_UPDATE_A_ROLE;
-		else if (action === "delete")
-			error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_DELETE_A_ROLE;
-		else if (action === "read")
-			error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_READ_A_ROLE;
-		else if (action === "list")
-			error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_LIST_A_ROLE;
-		else error = ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_GET_A_ROLE;
-
-		throw APIError.fromStatus("FORBIDDEN", {
-			message: error.message,
-			code: error.code,
-			missingPermissions,
-		});
 	}
 }
 

--- a/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-invites.ts
@@ -68,6 +68,18 @@ const baseInvitationSchema = z.object({
 			})
 			.optional(),
 	]),
+	teamRole: z.union([
+		z.string().meta({
+			description: "The team role to assign to the user",
+		}),
+		z.array(
+			z.string().meta({
+				description: "The team roles to assign to the user",
+			}),
+		),
+	]).optional().meta({
+		description: "The team role(s) to assign to the user in the team.",
+	}),
 });
 
 type DynamicOrganizationRole<O extends OrganizationOptions> = O extends {
@@ -140,10 +152,19 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 			method: "POST",
 			requireHeaders: true,
 			use: [orgMiddleware, orgSessionMiddleware],
-			body: z.object({
-				...baseInvitationSchema.shape,
-				...additionalFieldsSchema.shape,
-			}),
+			body: z
+				.object({
+					...baseInvitationSchema.shape,
+					...additionalFieldsSchema.shape,
+				})
+				.and(
+					option.teams?.enabled
+						? z.object({
+								teamId: z.union([z.string(), z.array(z.string())]).optional(),
+								teamRole: z.union([z.string(), z.array(z.string())]).optional(),
+						  })
+						: z.object({}),
+				),
 			metadata: {
 				$Infer: {
 					body: {} as {
@@ -175,6 +196,11 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 								 * being invited to.
 								 */
 								teamId?: (string | string[]) | undefined;
+								/**
+								 * The team role(s) to assign
+								 * in the team.
+								 */
+								teamRole?: string | string[] | undefined;
 							}
 						: {}) &
 						InferAdditionalFieldsFromPluginOptions<"invitation", O, false>,
@@ -283,6 +309,7 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 			const creatorRole = ctx.context.orgOptions.creatorRole || "owner";
 
 			const roles = parseRoles(ctx.body.role);
+			const teamRoles = (ctx.body as any).teamRole ? parseRoles((ctx.body as any).teamRole) : "";
 
 			const rolesArray = roles
 				.split(",")
@@ -333,6 +360,52 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 					"FORBIDDEN",
 					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_INVITE_USER_WITH_THIS_ROLE,
 				);
+			}
+
+			// Grant Ceiling enforcement for Organization Role
+			const { cacheAllRoles } = await import("../permission");
+			const { checkIfMemberHasPermission } = await import("../has-permission");
+			
+			let acRoles = cacheAllRoles.get(organizationId);
+			if (!acRoles) {
+				await hasPermission(
+					{
+						organizationId,
+						role: member.role,
+						options: ctx.context.orgOptions,
+						permissions: {},
+					},
+					ctx,
+				);
+				acRoles = cacheAllRoles.get(organizationId)!;
+			}
+
+			for (const r of rolesArray) {
+				const targetRole = acRoles[r];
+				if (!targetRole) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.ROLE_NOT_FOUND,
+					);
+				}
+
+				if (targetRole.scope === "team") {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.ROLE_NOT_FOUND,
+					);
+				}
+
+				const targetPermissions = targetRole.statements;
+				await checkIfMemberHasPermission({
+					ctx,
+					permissionRequired: targetPermissions as Record<string, string[]>,
+					options: ctx.context.orgOptions,
+					organizationId,
+					member: member,
+					user: session.user,
+					action: "create",
+				});
 			}
 
 			const alreadyMember = await adapter.findMemberByEmail({
@@ -482,6 +555,45 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 							ORGANIZATION_ERROR_CODES.TEAM_NOT_FOUND,
 						);
 					}
+
+					// Grant Ceiling enforcement for Team Role
+					if (teamRoles) {
+						const currentTeamMember = await adapter.findTeamMember({
+							userId: session.user.id,
+							teamId,
+						});
+
+						const teamRolesArray = teamRoles.split(",").map((r) => r.trim());
+						for (const r of teamRolesArray) {
+							const targetRole = acRoles[r];
+							if (!targetRole) {
+								throw APIError.from(
+									"BAD_REQUEST",
+									ORGANIZATION_ERROR_CODES.ROLE_NOT_FOUND,
+								);
+							}
+
+							if (targetRole.scope === "organization") {
+								throw APIError.from(
+									"BAD_REQUEST",
+									ORGANIZATION_ERROR_CODES.ROLE_NOT_FOUND,
+								);
+							}
+
+							const targetPermissions = targetRole.statements;
+							await checkIfMemberHasPermission({
+								ctx,
+								permissionRequired: targetPermissions as Record<string, string[]>,
+								options: ctx.context.orgOptions,
+								organizationId,
+								teamId,
+								member,
+								teamMember: currentTeamMember,
+								user: session.user,
+								action: "create",
+							});
+						}
+					}
 				}
 			}
 
@@ -547,6 +659,7 @@ export const createInvitation = <O extends OrganizationOptions>(option: O) => {
 
 			let invitationData = {
 				role: roles,
+				teamRole: teamRoles,
 				email: email,
 				organizationId: organizationId,
 				teamIds,
@@ -794,8 +907,9 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 									: ctx.context.orgOptions.teams.maximumMembersPerTeam;
 
 							const result = await adapter.addTeamMemberWithLimit({
-								teamId,
 								userId: session.user.id,
+								teamId: teamId as string,
+								role: (acceptedI as any).teamRole || ctx.context.orgOptions.teams?.defaultRole || "member",
 								maximumMembersPerTeam,
 							});
 							if (result.status === "limitReached") {
@@ -806,8 +920,9 @@ export const acceptInvitation = <O extends OrganizationOptions>(options: O) =>
 							}
 						} else {
 							await adapter.findOrCreateTeamMember({
-								teamId: teamId,
 								userId: session.user.id,
+								teamId: teamId as string,
+								role: (acceptedI as any).teamRole || ctx.context.orgOptions.teams?.defaultRole || "member",
 							});
 						}
 					}

--- a/packages/better-auth/src/plugins/organization/routes/crud-members.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-members.ts
@@ -222,7 +222,10 @@ export const addMember = <O extends OrganizationOptions>(option: O) => {
 						}
 						const result = await adapter.addTeamMemberWithLimit({
 							userId: user.id,
-							teamId,
+							teamId: teamId as string,
+							role: Array.isArray(ctx.context.orgOptions.teams?.defaultRole)
+								? ctx.context.orgOptions.teams.defaultRole.join(",")
+								: ctx.context.orgOptions.teams?.defaultRole || "member",
 							maximumMembersPerTeam,
 						});
 						if (result.status === "limitReached") {
@@ -234,7 +237,10 @@ export const addMember = <O extends OrganizationOptions>(option: O) => {
 					} else {
 						await adapter.findOrCreateTeamMember({
 							userId: user.id,
-							teamId,
+							teamId: teamId as string,
+							role: Array.isArray(ctx.context.orgOptions.teams?.defaultRole)
+								? ctx.context.orgOptions.teams.defaultRole.join(",")
+								: ctx.context.orgOptions.teams?.defaultRole || "member",
 						});
 					}
 				} catch (error) {

--- a/packages/better-auth/src/plugins/organization/routes/crud-org.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-org.ts
@@ -251,6 +251,9 @@ export const createOrganization = <O extends OrganizationOptions>(
 				teamMember = await adapter.findOrCreateTeamMember({
 					teamId: defaultTeam.id,
 					userId: user.id,
+					role: Array.isArray(options.teams?.defaultRole)
+						? options.teams.defaultRole.join(",")
+						: options.teams?.defaultRole || "member",
 				});
 
 				if (options?.organizationHooks?.afterCreateTeam) {

--- a/packages/better-auth/src/plugins/organization/routes/crud-team.ts
+++ b/packages/better-auth/src/plugins/organization/routes/crud-team.ts
@@ -13,7 +13,8 @@ import type { PrettifyDeep } from "../../../types/helper";
 import { getOrgAdapter } from "../adapter";
 import { orgMiddleware, orgSessionMiddleware } from "../call";
 import { ORGANIZATION_ERROR_CODES } from "../error-codes";
-import { hasPermission } from "../has-permission";
+import { hasPermission, checkIfMemberHasPermission } from "../has-permission";
+import { parseRoles } from "../utils";
 import type { TeamMember } from "../schema";
 import { teamSchema } from "../schema";
 import type { OrganizationOptions } from "../types";
@@ -1115,6 +1116,11 @@ const addTeamMemberBodySchema = z.object({
 			"The user Id which represents the user to be added as a member.",
 	}),
 
+	role: z.union([z.string(), z.array(z.string())]).optional().meta({
+		description:
+			"The role or roles to assign to the user in the team.",
+	}),
+
 	organizationId: z
 		.string()
 		.meta({
@@ -1259,12 +1265,70 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 				});
 			}
 
+			const currentTeamMember = await adapter.findTeamMember({
+				userId: session.user.id,
+				teamId: ctx.body.teamId,
+			});
+
+			const roleToSet = parseRoles(
+				ctx.body.role,
+				ctx.context.orgOptions.teams?.defaultRole,
+			);
+
+			// Grant Ceiling enforcement
+			const { cacheAllRoles } = await import("../permission");
+			let acRoles = cacheAllRoles.get(organizationId);
+			if (!acRoles) {
+				await hasPermission(
+					{
+						organizationId,
+						role: currentMember.role,
+						options: ctx.context.orgOptions,
+						permissions: {},
+					},
+					ctx,
+				);
+				acRoles = cacheAllRoles.get(organizationId)!;
+			}
+
+			const rolesArray = roleToSet.split(",").map((r) => r.trim());
+			for (const r of rolesArray) {
+				const targetRole = acRoles[r];
+				if (!targetRole) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.ROLE_NOT_FOUND,
+					);
+				}
+
+				if (targetRole.scope === "organization") {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.ROLE_NOT_FOUND,
+					);
+				}
+
+				const targetPermissions = targetRole.statements;
+				await checkIfMemberHasPermission({
+					ctx,
+					permissionRequired: targetPermissions as Record<string, string[]>,
+					options: ctx.context.orgOptions,
+					organizationId,
+					teamId: ctx.body.teamId,
+					member: currentMember,
+					teamMember: currentTeamMember,
+					user: session.user,
+					action: "create",
+				});
+			}
+
 			// Run beforeAddTeamMember hook
 			if (options?.organizationHooks?.beforeAddTeamMember) {
 				const response = await options?.organizationHooks.beforeAddTeamMember({
 					teamMember: {
 						teamId: ctx.body.teamId,
 						userId: ctx.body.userId,
+						role: roleToSet,
 					},
 					team,
 					user: userBeingAdded,
@@ -1292,6 +1356,7 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 				const result = await adapter.addTeamMemberWithLimit({
 					teamId: ctx.body.teamId,
 					userId: ctx.body.userId,
+					role: roleToSet,
 					maximumMembersPerTeam,
 				});
 				if (result.status === "limitReached") {
@@ -1305,6 +1370,7 @@ export const addTeamMember = <O extends OrganizationOptions>(options: O) =>
 				teamMember = await adapter.findOrCreateTeamMember({
 					teamId: ctx.body.teamId,
 					userId: ctx.body.userId,
+					role: roleToSet,
 				});
 			}
 
@@ -1401,35 +1467,103 @@ export const removeTeamMember = <O extends OrganizationOptions>(options: O) =>
 				);
 			}
 
-			const canDeleteMember = await hasPermission(
-				{
-					role: currentMember.role,
-					options: ctx.context.orgOptions,
-					permissions: {
-						member: ["delete"],
-					},
-					organizationId: organizationId,
-				},
-				ctx,
-			);
+			const currentTeamMember = await adapter.findTeamMember({
+				userId: session.user.id,
+				teamId: ctx.body.teamId,
+			});
 
-			if (!canDeleteMember) {
+			const { checkIfMemberHasPermission } = await import("../has-permission");
+			
+			// Basic permission check
+			const canDeleteTeamMember = await checkIfMemberHasPermission({
+				ctx,
+				permissionRequired: { teamMember: ["delete"] },
+				options: ctx.context.orgOptions,
+				organizationId,
+				teamId: ctx.body.teamId,
+				member: currentMember,
+				teamMember: currentTeamMember,
+				user: session.user,
+				action: "delete",
+			}).catch(() => false);
+
+			if (!canDeleteTeamMember) {
 				throw APIError.from(
 					"FORBIDDEN",
 					ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_REMOVE_A_TEAM_MEMBER,
 				);
 			}
 
-			const toBeAddedMember = await adapter.findMemberByOrgId({
+			const toBeRemovedMember = await adapter.findMemberByOrgId({
 				userId: ctx.body.userId,
 				organizationId: organizationId,
 			});
 
-			if (!toBeAddedMember) {
+			if (!toBeRemovedMember) {
 				throw APIError.from(
 					"BAD_REQUEST",
 					ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
 				);
+			}
+
+			const targetTeamMember = await adapter.findTeamMember({
+				teamId: ctx.body.teamId,
+				userId: ctx.body.userId,
+			});
+
+			if (!targetTeamMember) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_TEAM,
+				);
+			}
+
+			// Enforce Grant Ceiling for removal: You can only remove someone if you have permission to assign their current team roles
+			const { cacheAllRoles } = await import("../permission");
+			let acRoles = cacheAllRoles.get(organizationId);
+			if (!acRoles) {
+				await hasPermission(
+					{
+						organizationId,
+						role: currentMember.role,
+						options: ctx.context.orgOptions,
+						permissions: {},
+					},
+					ctx,
+				);
+				acRoles = cacheAllRoles.get(organizationId)!;
+			}
+
+			const targetRolesArray = (targetTeamMember.role || "member").split(",").map((r) => r.trim());
+			for (const r of targetRolesArray) {
+				const targetRole = acRoles[r];
+				if (targetRole) {
+					const targetPermissions = targetRole.statements;
+					await checkIfMemberHasPermission({
+						ctx,
+						permissionRequired: targetPermissions as Record<string, string[]>,
+						options: ctx.context.orgOptions,
+						organizationId,
+						teamId: ctx.body.teamId,
+						member: currentMember,
+						teamMember: currentTeamMember,
+						user: session.user,
+						action: "delete",
+					});
+				}
+			}
+
+			// No org owner removal via team unless the actor is also an org owner
+			const targetOrgRoles = toBeRemovedMember.role.split(",").map(r => r.trim());
+			const creatorRole = ctx.context.orgOptions.creatorRole || "owner";
+			if (targetOrgRoles.includes(creatorRole)) {
+				const actorOrgRoles = currentMember.role.split(",").map(r => r.trim());
+				if (!actorOrgRoles.includes(creatorRole)) {
+					throw APIError.from(
+						"FORBIDDEN",
+						ORGANIZATION_ERROR_CODES.YOU_ARE_NOT_ALLOWED_TO_REMOVE_A_TEAM_MEMBER,
+					);
+				}
 			}
 
 			const team = await adapter.findTeamById({
@@ -1461,17 +1595,7 @@ export const removeTeamMember = <O extends OrganizationOptions>(options: O) =>
 				});
 			}
 
-			const teamMember = await adapter.findTeamMember({
-				teamId: ctx.body.teamId,
-				userId: ctx.body.userId,
-			});
-
-			if (!teamMember) {
-				throw APIError.from(
-					"BAD_REQUEST",
-					ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_TEAM,
-				);
-			}
+			const teamMember = targetTeamMember;
 
 			// Run beforeRemoveTeamMember hook
 			if (options?.organizationHooks?.beforeRemoveTeamMember) {
@@ -1499,5 +1623,194 @@ export const removeTeamMember = <O extends OrganizationOptions>(options: O) =>
 			}
 
 			return ctx.json({ message: "Team member removed successfully." });
+		},
+	);
+
+const updateTeamMemberRoleBodySchema = z.object({
+	memberId: z.string().meta({
+		description: "The ID of the team member to update.",
+	}),
+	teamId: z.string().meta({
+		description: "The team the user is a member of.",
+	}),
+	role: z.union([z.string(), z.array(z.string())]).meta({
+		description: "The role or roles to assign to the user in the team.",
+	}),
+	organizationId: z.string().optional().meta({
+		description:
+			"The organization ID which the team falls under. If not provided, it will default to the user's active organization.",
+	}),
+});
+
+export const updateTeamMemberRole = <O extends OrganizationOptions>(
+	options: O,
+) =>
+	createAuthEndpoint(
+		"/organization/update-team-member-role",
+		{
+			method: "POST",
+			body: updateTeamMemberRoleBodySchema,
+			metadata: {
+				openapi: {
+					description: "Update the role of a team member",
+					responses: {
+						"200": {
+							description: "Team member updated successfully",
+							content: {
+								"application/json": {
+									schema: {
+										type: "object",
+										properties: {
+											member: {
+												type: "object",
+												properties: {
+													id: { type: "string" },
+													userId: { type: "string" },
+													teamId: { type: "string" },
+													role: { type: "string" },
+												},
+												required: ["id", "userId", "teamId", "role"],
+											},
+										},
+										required: ["member"],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requireHeaders: true,
+			use: [orgMiddleware, orgSessionMiddleware],
+		},
+		async (ctx) => {
+			const session = ctx.context.session;
+			const adapter = getOrgAdapter(ctx.context, ctx.context.orgOptions);
+
+			const organizationId =
+				ctx.body.organizationId || session.session.activeOrganizationId;
+
+			if (!organizationId) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.NO_ACTIVE_ORGANIZATION,
+				);
+			}
+
+			if (!ctx.body.role) {
+				throw APIError.fromStatus("BAD_REQUEST");
+			}
+
+			const currentMember = await adapter.findMemberByOrgId({
+				userId: session.user.id,
+				organizationId: organizationId,
+			});
+
+			if (!currentMember) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION,
+				);
+			}
+
+			const team = await adapter.findTeamById({
+				teamId: ctx.body.teamId,
+				organizationId: organizationId,
+			});
+
+			if (!team) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.TEAM_NOT_FOUND,
+				);
+			}
+
+			const currentTeamMember = await adapter.findTeamMember({
+				userId: session.user.id,
+				teamId: ctx.body.teamId,
+			});
+
+			const roleToSet = parseRoles(ctx.body.role, "");
+			if (!roleToSet) {
+				throw APIError.fromStatus("BAD_REQUEST");
+			}
+
+			const { cacheAllRoles } = await import("../permission");
+			let acRoles = cacheAllRoles.get(organizationId);
+			if (!acRoles) {
+				await hasPermission(
+					{
+						organizationId,
+						role: currentMember.role,
+						options: ctx.context.orgOptions,
+						permissions: {},
+					},
+					ctx,
+				);
+				acRoles = cacheAllRoles.get(organizationId)!;
+			}
+
+			const rolesArray = roleToSet.split(",").map((r) => r.trim());
+			for (const r of rolesArray) {
+				const targetRole = acRoles[r];
+				if (!targetRole) {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.ROLE_NOT_FOUND,
+					);
+				}
+
+				if (targetRole.scope === "organization") {
+					throw APIError.from(
+						"BAD_REQUEST",
+						ORGANIZATION_ERROR_CODES.ROLE_NOT_FOUND,
+					);
+				}
+
+				const targetPermissions = targetRole.statements;
+				await checkIfMemberHasPermission({
+					ctx,
+					permissionRequired: targetPermissions as Record<string, string[]>,
+					options: ctx.context.orgOptions,
+					organizationId,
+					teamId: ctx.body.teamId,
+					member: currentMember,
+					teamMember: currentTeamMember,
+					user: session.user,
+					action: "update",
+				});
+			}
+
+			const targetTeamMember = await ctx.context.adapter.findOne<TeamMember>({
+				model: "teamMember",
+				where: [
+					{
+						field: "id",
+						value: ctx.body.memberId,
+					},
+				],
+			});
+
+			if (!targetTeamMember || targetTeamMember.teamId !== ctx.body.teamId) {
+				throw APIError.from(
+					"BAD_REQUEST",
+					ORGANIZATION_ERROR_CODES.MEMBER_NOT_FOUND,
+				);
+			}
+
+			const updatedTeamMember = await ctx.context.adapter.update({
+				model: "teamMember",
+				where: [
+					{
+						field: "id",
+						value: ctx.body.memberId,
+					},
+				],
+				update: {
+					role: roleToSet,
+				},
+			});
+
+			return ctx.json({ member: updatedTeamMember });
 		},
 	);

--- a/packages/better-auth/src/plugins/organization/schema.ts
+++ b/packages/better-auth/src/plugins/organization/schema.ts
@@ -36,6 +36,19 @@ interface OrganizationRoleDefaultFields {
 		type: "string";
 		required: true;
 	};
+	scope: {
+		type: "string";
+		required: true;
+		defaultValue: "organization";
+	};
+	teamId: {
+		type: "string";
+		required: false;
+		references: {
+			model: "team";
+			field: "id";
+		};
+	};
 	permission: {
 		type: "string";
 		required: true;
@@ -97,6 +110,11 @@ interface TeamMemberDefaultFields {
 			model: "user";
 			field: "id";
 		};
+	};
+	role: {
+		type: "string";
+		required: true;
+		defaultValue: "member";
 	};
 	membershipKey: {
 		type: "string";
@@ -182,6 +200,11 @@ interface InvitationDefaultFields {
 	role: {
 		type: "string";
 		required: true;
+		sortable: true;
+	};
+	teamRole: {
+		type: "string";
+		required: false;
 		sortable: true;
 	};
 	status: {
@@ -332,6 +355,7 @@ export const invitationSchema = z.object({
 	role: roleSchema,
 	status: invitationStatus,
 	teamId: z.string().nullish(),
+	teamRole: z.string().nullish(),
 	inviterId: z.string(),
 	expiresAt: z.date(),
 	createdAt: z.date().default(() => new Date()),
@@ -349,13 +373,16 @@ export const teamMemberSchema = z.object({
 	id: z.string().default(generateId),
 	teamId: z.string(),
 	userId: z.string(),
+	role: roleSchema,
 	createdAt: z.date().default(() => new Date()),
 });
 
 export const organizationRoleSchema = z.object({
 	id: z.string().default(generateId),
 	organizationId: z.string(),
+	teamId: z.string().nullish(),
 	role: z.string(),
+	scope: z.string().default("organization"),
 	permission: z.record(z.string(), z.array(z.string())),
 	createdAt: z.date().default(() => new Date()),
 	updatedAt: z.date().optional(),
@@ -395,6 +422,14 @@ export type InferOrganizationRolesFromOption<
 		: "admin" | "member" | "owner"
 	: "admin" | "member" | "owner";
 
+export type InferTeamRolesFromOption<
+	O extends OrganizationOptions | undefined,
+> = O extends { teams: { roles: any } }
+	? keyof O["teams"]["roles"] extends infer K extends string
+		? K
+		: "member"
+	: "member";
+
 export type InvitationStatus = "pending" | "accepted" | "rejected" | "canceled";
 
 import type { DBFieldAttribute } from "@better-auth/core/db";
@@ -427,6 +462,7 @@ export type InferMember<
 				createdAt: Date;
 				userId: string;
 				teamId?: string | undefined;
+				teamRole?: InferTeamRolesFromOption<O> | undefined;
 				user: {
 					id: string;
 					email: string;
@@ -457,6 +493,13 @@ export type InferOrganization<
 	Organization & InferAdditionalFieldsOutput<"organization", O, isClientSide>
 >;
 
+export type InferTeamMember<
+	O extends OrganizationOptions,
+	isClientSide extends boolean = true,
+> = Prettify<
+	TeamMember & { role: InferTeamRolesFromOption<O> } & InferAdditionalFieldsOutput<"teamMember", O, isClientSide>
+>;
+
 export type InferTeam<
 	O extends OrganizationOptions,
 	isClientSide extends boolean = true,
@@ -479,6 +522,7 @@ export type InferInvitation<
 				expiresAt: Date;
 				createdAt: Date;
 				teamId?: string | undefined;
+				teamRole?: InferTeamRolesFromOption<O> | undefined;
 			}
 		: {
 				id: string;

--- a/packages/better-auth/src/plugins/organization/types.ts
+++ b/packages/better-auth/src/plugins/organization/types.ts
@@ -111,6 +111,20 @@ export interface OrganizationOptions {
 		 */
 		enabled: boolean;
 		/**
+		 * Custom permissions for team roles.
+		 */
+		roles?:
+			| {
+					[key in string]?: Role<any>;
+			  }
+			| undefined;
+		/**
+		 * Default role(s) for a team member
+		 *
+		 * @default "member"
+		 */
+		defaultRole?: string | string[];
+		/**
 		 * Default team configuration
 		 */
 		defaultTeam?: {

--- a/packages/better-auth/src/plugins/organization/utils.ts
+++ b/packages/better-auth/src/plugins/organization/utils.ts
@@ -1,0 +1,11 @@
+export const parseRoles = (
+	role?: string | string[],
+	defaultRole?: string | string[],
+) => {
+	const r = role ?? defaultRole ?? "member";
+	return (Array.isArray(r) ? r : [r])
+		.flatMap((x) => x.split(","))
+		.map((x) => x.trim())
+		.filter(Boolean)
+		.join(",");
+};


### PR DESCRIPTION
**PR is WIP, collaboration is more than welcome.**

---

Previously, role-based access control (RBAC) in the organization plugin are only granted on an organization level. This is suboptimal for many B2B SaaS setups, and I'm finding myself missing this feature in my own infrastructure.

This PR aligns the Teams feature with the organization plugin's core access control model by introducing:
- Team-level multi-role support (0..n roles per team member).
- Adds a scope to access control, including dynamic access control (scope: "organization" | "team" | "both").
- Privilege escalation protections between organization-level and team-level scopes.
- Permission statements stays flat, it's only roles that pertain to *either* teams or organizations - or both when relevant.

The objective is to allow providers to manage sub-resources within a single organization (tenant).

## Business case example: Expense app
In Business Expense App X, there's four main types of users;
- Finance Admins (organization owner, oversees and manages all)
- Department Manager (organization member, team owner)
- Department Approver (organization member, team member, specific permission of `expense-report:create-approval`)
- Employee (organization member, team member)

A given user may be an employee who's a member of several teams for expensing purposes, and then acts as an approver of specific teams' expenses, and as a department manager of another team.

I'm happy to elaborate on business use cases, if needed.

--- 

This PR would allow these permission to be natively managed through Better-Auth, ensuring that roles can be scoped specifically in their rightful context. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds team-level role support with scoped permissions and privilege escalation protection, extending the organization plugin's access control from organization-only to include team context.

- Roles now accept a `scope` of "organization", "team", or "both" via `role()` and `createAccessControl`.
- `teamMember` records now store a `role` field, replacing the implicit "member" default.
- New endpoints: `list-roles`, `get-role`, and `updateTeamMemberRole`.
- Invitations support `teamRole` to assign team roles on acceptance.
- Permission checks now consider both org and team roles, with team roles scoped accordingly.
- Privilege escalation checks prevent assigning roles with permissions the actor doesn't have.

**Migration**
- Schema changes: `organizationRole.scope` (default "organization"), `teamMember.role` (default "member"), `invitation.teamRole`. Requires migration for existing data.

<sup>Written for commit d8bdd5c6e8ed32bd0250537c89f1f2a24a279f85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

