### PR TITLE
fix(oauth-provider): detect adapter-wrapped unique violations when seeding resources

### DIFF
--- a/.changeset/oauth-provider-wrapped-unique-violation.md
+++ b/.changeset/oauth-provider-wrapped-unique-violation.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Recognise unique-constraint and missing-table errors that adapters wrap in `error.cause`. The Drizzle adapter reports the failed SQL as the error message and puts the Postgres SQLSTATE on `cause`, so `seedResources` did not detect a lost insert race and rethrew — aborting the plugin's `init` before it returned the back-channel-logout session hooks.

--- a/packages/oauth-provider/src/oauthResource/endpoints.ts
+++ b/packages/oauth-provider/src/oauthResource/endpoints.ts
@@ -8,6 +8,7 @@ import type {
 	OAuthResourceInput,
 	Scope,
 } from "../types";
+import { isUniqueConstraintError } from "../utils/db-errors";
 
 /**
  * Action types passed to {@link OAuthOptions.resourcePrivileges}. Mirrors
@@ -145,8 +146,7 @@ export async function createResourceEndpoint(
 			data: buildResourceRow(input, now),
 		});
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		if (/unique|duplicate|UNIQUE/i.test(message)) {
+		if (isUniqueConstraintError(err)) {
 			throw new APIError("BAD_REQUEST", {
 				error: "invalid_request",
 				error_description: `resource ${input.identifier} already exists`,
@@ -347,8 +347,7 @@ export async function linkClientResourceEndpoint(
 			} as never,
 		});
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		if (/unique|duplicate|UNIQUE/i.test(message)) {
+		if (isUniqueConstraintError(err)) {
 			return ctx.json({ linked: true, alreadyLinked: true });
 		}
 		throw err;

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -33,6 +33,7 @@ import type {
 import type { GrantType, OAuthClient } from "./types/oauth";
 import { parseClientMetadata, storeClientSecret } from "./utils";
 import { isPrivateHostname } from "./utils/client-assertion";
+import { isUniqueConstraintError } from "./utils/db-errors";
 import { authorizeInitialAccessToken } from "./utils/initial-access-token";
 
 const DEFAULT_REGISTRATION_GRANT_TYPES = [
@@ -1127,36 +1128,6 @@ export async function registerClientMetadataDocument(
 			throw retryError;
 		}
 	}
-}
-
-function isUniqueConstraintError(error: unknown): boolean {
-	if (!error || typeof error !== "object") return false;
-	const candidate = error as {
-		code?: unknown;
-		errno?: unknown;
-		name?: unknown;
-		message?: unknown;
-	};
-	const code = String(candidate.code ?? candidate.errno ?? "");
-	if (
-		[
-			"1062",
-			"11000",
-			"23505",
-			"ER_DUP_ENTRY",
-			"P2002",
-			"SQLITE_CONSTRAINT_UNIQUE",
-		].includes(code)
-	) {
-		return true;
-	}
-	if (candidate.name === "MongoServerError" && candidate.code === 11000) {
-		return true;
-	}
-	return (
-		typeof candidate.message === "string" &&
-		/(?:duplicate|unique constraint|unique key)/i.test(candidate.message)
-	);
 }
 
 export function createOAuthClientEndpoint(

--- a/packages/oauth-provider/src/resources.test.ts
+++ b/packages/oauth-provider/src/resources.test.ts
@@ -260,6 +260,97 @@ describe("seedResources (integration via plugin init)", () => {
 			allowedScopes: null, // cleared
 		});
 	});
+
+	/**
+	 * `drizzle-orm` throws an `Error` whose `message` is the failed SQL and
+	 * whose `cause` carries the Postgres SQLSTATE. Reported as
+	 * better-auth#11034.
+	 */
+	const drizzleUniqueViolation = () =>
+		Object.assign(
+			new Error(
+				'Failed query: insert into "oauthResource" ("id", "identifier") values ($1, $2) returning "id"',
+			),
+			{
+				cause: Object.assign(
+					new Error(
+						'duplicate key value violates unique constraint "oauthResource_identifier_unique"',
+					),
+					{ code: "23505", constraint: "oauthResource_identifier_unique" },
+				),
+			},
+		);
+
+	it("treats a Drizzle-wrapped unique violation as a lost insert race", async () => {
+		const identifier = "https://api.example.com/wrapped-race";
+		const instance = await bootWithResourcesOption({});
+		const ctx = (await instance.auth.$context) as unknown as AuthContext;
+		const debugSpy = vi
+			.spyOn(logger, "debug")
+			.mockImplementation(() => undefined);
+		const createSpy = vi
+			.spyOn(ctx.adapter, "create")
+			.mockRejectedValue(drizzleUniqueViolation());
+
+		try {
+			await expect(
+				seedResources(ctx, {
+					loginPage: "/login",
+					consentPage: "/consent",
+					resources: [{ identifier }],
+				} as OAuthOptions<Scope[]>),
+			).resolves.toBeUndefined();
+			expect(createSpy).toHaveBeenCalledTimes(1);
+			expect(
+				debugSpy.mock.calls.map((call: unknown[]) => String(call[0] ?? "")).join("\n"),
+			).toContain("already inserted by a concurrent process");
+		} finally {
+			createSpy.mockRestore();
+			debugSpy.mockRestore();
+		}
+	});
+
+	it("still rethrows an unrelated wrapped adapter failure", async () => {
+		const instance = await bootWithResourcesOption({});
+		const ctx = (await instance.auth.$context) as unknown as AuthContext;
+		const wrapped = Object.assign(new Error("Failed query: insert into \"oauthResource\""), {
+			cause: Object.assign(new Error("deadlock detected"), { code: "40P01" }),
+		});
+		const createSpy = vi.spyOn(ctx.adapter, "create").mockRejectedValue(wrapped);
+
+		try {
+			await expect(
+				seedResources(ctx, {
+					loginPage: "/login",
+					consentPage: "/consent",
+					resources: [{ identifier: "https://api.example.com/wrapped-deadlock" }],
+				} as OAuthOptions<Scope[]>),
+			).rejects.toBe(wrapped);
+		} finally {
+			createSpy.mockRestore();
+		}
+	});
+
+	it("defers seeding when a wrapped error reports the table is missing", async () => {
+		const instance = await bootWithResourcesOption({});
+		const ctx = (await instance.auth.$context) as unknown as AuthContext;
+		const wrapped = Object.assign(new Error('Failed query: select from "oauthResource"'), {
+			cause: new Error('relation "oauthResource" does not exist'),
+		});
+		const findOneSpy = vi.spyOn(ctx.adapter, "findOne").mockRejectedValue(wrapped);
+
+		try {
+			await expect(
+				seedResources(ctx, {
+					loginPage: "/login",
+					consentPage: "/consent",
+					resources: [{ identifier: "https://api.example.com/wrapped-missing-table" }],
+				} as OAuthOptions<Scope[]>),
+			).resolves.toBeUndefined();
+		} finally {
+			findOneSpy.mockRestore();
+		}
+	});
 });
 
 describe("getResource + cache", () => {

--- a/packages/oauth-provider/src/resources.test.ts
+++ b/packages/oauth-provider/src/resources.test.ts
@@ -415,3 +415,53 @@ describe("getResource + cache", () => {
 		expect(third?.name).toBe("Mutated externally");
 	});
 });
+
+describe("oauthProvider init resilience to a lost seed race", () => {
+	let debugSpy: ReturnType<typeof vi.spyOn>;
+	let infoSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => undefined);
+		infoSpy = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		debugSpy.mockRestore();
+		infoSpy.mockRestore();
+	});
+
+	/**
+	 * Minimal AuthContext stand-in reproducing production ordering: the table
+	 * exists, `findOne` finds nothing, and `create` loses the race with a
+	 * concurrent boot. `disableJwtPlugin` keeps init off the issuer-validation
+	 * branch, which needs a full plugin registry.
+	 */
+	const stubContext = (createError: unknown) =>
+		({
+			options: {},
+			baseURL: "http://localhost:3000",
+			adapter: {
+				findOne: async () => null,
+				create: async () => {
+					throw createError;
+				},
+			},
+		}) as unknown as AuthContext;
+
+	it("returns the session databaseHooks when the seed insert loses the race", async () => {
+		const plugin = oauthProvider({
+			loginPage: "/login",
+			consentPage: "/consent",
+			disableJwtPlugin: true,
+			resources: ["https://api.example.com/init-race"],
+		} as OAuthOptions<Scope[]>);
+		const wrapped = Object.assign(
+			new Error('Failed query: insert into "oauthResource" ("id", "identifier") values ($1, $2)'),
+			{ cause: Object.assign(new Error("duplicate key value"), { code: "23505" }) },
+		);
+
+		const result = await plugin.init?.(stubContext(wrapped));
+
+		expect(result?.options?.databaseHooks?.session?.delete).toBeDefined();
+	});
+});

--- a/packages/oauth-provider/src/resources.ts
+++ b/packages/oauth-provider/src/resources.ts
@@ -9,6 +9,7 @@ import type {
 	OAuthResourceInput,
 	Scope,
 } from "./types";
+import { isMissingTableError, isUniqueConstraintError } from "./utils/db-errors";
 
 /**
  * Source-of-truth list of asymmetric JWS algorithms supported by the JWT
@@ -802,18 +803,6 @@ function buildSeedUpdate(
 	return update;
 }
 
-/**
- * Pattern matched against adapter errors to detect the "table not yet
- * created" case — i.e. migrations haven't been run. When matched, the
- * caller treats the seed as deferred (will retry on first resource access).
- *
- * Covers SQLite ("no such table"), Postgres ("relation X does not exist"),
- * and MySQL ("Table X does not exist" / contracted form).
- */
-// cspell:ignore-next-line doesn
-const MISSING_TABLE_PATTERN =
-	/no such table|relation.*does not exist|table.*does(?: not|n[''']?t) exist/i;
-
 interface SeedState {
 	completed: boolean;
 	promise: Promise<void> | null;
@@ -922,8 +911,7 @@ export async function seedResources(
 				where: [{ field: "identifier", value: input.identifier }],
 			});
 		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			if (MISSING_TABLE_PATTERN.test(message)) {
+			if (isMissingTableError(err)) {
 				logger.debug(
 					"oauth-provider: oauthResource table not yet created; deferring resource seed to first access.",
 				);
@@ -940,17 +928,25 @@ export async function seedResources(
 					data: buildSeedRow(input, now),
 				});
 			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				// Race with a concurrent boot — another process inserted between
-				// our findOne and create. The UNIQUE constraint protects us; treat
-				// the conflict as a no-op so init doesn't fail.
-				if (/unique|duplicate|UNIQUE/i.test(message)) {
+				// Race with a concurrent boot — another process inserted
+				// between our findOne and create. The UNIQUE constraint
+				// protects us; treat the conflict as a no-op so init
+				// doesn't fail.
+				//
+				// Skipping is correct in every seed mode, not just
+				// insertOnly: a race can only happen when findOne saw no
+				// row, so the winner just inserted a row built by
+				// buildSeedRow from the same config. buildSeedUpdate in
+				// "overwrite" mode is that same row minus identifier and
+				// createdAt, and "merge" writes a subset of it, so the
+				// update we skip would rewrite what is already there.
+				if (isUniqueConstraintError(err)) {
 					logger.debug(
 						`oauth-provider: resource ${input.identifier} already inserted by a concurrent process — skipping.`,
 					);
 					continue;
 				}
-				if (MISSING_TABLE_PATTERN.test(message)) {
+				if (isMissingTableError(err)) {
 					logger.debug(
 						"oauth-provider: oauthResource table not yet created; deferring resource seed to first access.",
 					);

--- a/packages/oauth-provider/src/utils/db-errors.test.ts
+++ b/packages/oauth-provider/src/utils/db-errors.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { isMissingTableError, isUniqueConstraintError } from "./db-errors";
+
+/**
+ * The shape `drizzle-orm` throws: `message` is the failed SQL text, and the
+ * driver error carrying the SQLSTATE is on `cause`. Reported upstream as
+ * better-auth#11034.
+ */
+const drizzleWrapped = (driverError: unknown) =>
+	Object.assign(
+		new Error(
+			'Failed query: insert into "oauthResource" ("id", "identifier") values ($1, $2) returning "id"',
+		),
+		{ cause: driverError },
+	);
+
+describe("isUniqueConstraintError", () => {
+	it("matches a bare Postgres unique violation by SQLSTATE", () => {
+		const error = Object.assign(
+			new Error('duplicate key value violates unique constraint "oauthResource_identifier_unique"'),
+			{ code: "23505" },
+		);
+		expect(isUniqueConstraintError(error)).toBe(true);
+	});
+
+	it("matches a Drizzle-wrapped unique violation via the cause chain", () => {
+		const cause = Object.assign(
+			new Error('duplicate key value violates unique constraint "oauthResource_identifier_unique"'),
+			{ code: "23505", constraint: "oauthResource_identifier_unique" },
+		);
+		expect(isUniqueConstraintError(drizzleWrapped(cause))).toBe(true);
+	});
+
+	it("matches when only the wrapped cause carries the code and no message text", () => {
+		expect(isUniqueConstraintError(drizzleWrapped({ code: "23505" }))).toBe(true);
+	});
+
+	it.each([
+		["1062", "MySQL"],
+		["11000", "MongoDB"],
+		["2067", "SQLite extended"],
+		["2601", "SQL Server"],
+		["2627", "SQL Server"],
+		["ER_DUP_ENTRY", "MySQL symbolic"],
+		["P2002", "Prisma"],
+		["SQLITE_CONSTRAINT_UNIQUE", "better-sqlite3"],
+	])("matches driver identifier %s (%s)", (code) => {
+		expect(isUniqueConstraintError({ code })).toBe(true);
+	});
+
+	it("matches identifiers reported as errno, errcode, or number", () => {
+		expect(isUniqueConstraintError({ errno: 1062 })).toBe(true);
+		expect(isUniqueConstraintError({ errcode: "23505" })).toBe(true);
+		expect(isUniqueConstraintError({ number: 2627 })).toBe(true);
+	});
+
+	it("falls back to message text for adapters that expose no code", () => {
+		expect(isUniqueConstraintError(new Error("UNIQUE constraint failed: oauthResource.identifier"))).toBe(true);
+		expect(isUniqueConstraintError(new Error("Duplicate entry 'x' for key 'identifier'"))).toBe(true);
+	});
+
+	it("does not match unrelated failures", () => {
+		expect(isUniqueConstraintError(new Error("connection terminated unexpectedly"))).toBe(false);
+		expect(isUniqueConstraintError(Object.assign(new Error("not null violation"), { code: "23502" }))).toBe(false);
+		expect(isUniqueConstraintError(drizzleWrapped(Object.assign(new Error("deadlock detected"), { code: "40P01" })))).toBe(false);
+	});
+
+	it("tolerates non-object throwables", () => {
+		expect(isUniqueConstraintError(undefined)).toBe(false);
+		expect(isUniqueConstraintError(null)).toBe(false);
+		expect(isUniqueConstraintError("duplicate key value")).toBe(true);
+		expect(isUniqueConstraintError("connection refused")).toBe(false);
+	});
+
+	it("terminates on a cyclic cause chain", () => {
+		const first = new Error("outer") as Error & { cause?: unknown };
+		const second = new Error("inner") as Error & { cause?: unknown };
+		first.cause = second;
+		second.cause = first;
+		expect(isUniqueConstraintError(first)).toBe(false);
+	});
+
+	it("stops walking past the depth cap", () => {
+		let error: { message: string; cause?: unknown } = { message: "duplicate key" };
+		for (let i = 0; i < 20; i += 1) error = { message: "wrapper", cause: error };
+		expect(isUniqueConstraintError(error)).toBe(false);
+	});
+});
+
+describe("isMissingTableError", () => {
+	it("matches SQLite, Postgres, and MySQL wording", () => {
+		expect(isMissingTableError(new Error("no such table: oauthResource"))).toBe(true);
+		expect(isMissingTableError(new Error('relation "oauthResource" does not exist'))).toBe(true);
+		expect(isMissingTableError(new Error("Table 'db.oauthResource' doesn't exist"))).toBe(true);
+	});
+
+	it("matches a Drizzle-wrapped missing-table error via the cause chain", () => {
+		expect(isMissingTableError(drizzleWrapped(new Error('relation "oauthResource" does not exist')))).toBe(true);
+	});
+
+	it("does not match unrelated failures", () => {
+		expect(isMissingTableError(new Error("permission denied for table oauthResource"))).toBe(false);
+		expect(isMissingTableError(null)).toBe(false);
+	});
+});

--- a/packages/oauth-provider/src/utils/db-errors.test.ts
+++ b/packages/oauth-provider/src/utils/db-errors.test.ts
@@ -65,6 +65,13 @@ describe("isUniqueConstraintError", () => {
 		expect(isUniqueConstraintError(drizzleWrapped(Object.assign(new Error("deadlock detected"), { code: "40P01" })))).toBe(false);
 	});
 
+	it("does not misclassify an unconstrained mention of the word 'unique'", () => {
+		// A bare "unique" match would swallow this unrelated failure and
+		// misreport it as a lost insert race (flagged in PR #11087 review).
+		expect(isUniqueConstraintError(new Error("could not uniquely identify row for update"))).toBe(false);
+		expect(isUniqueConstraintError(new Error("column values are not unique across shards"))).toBe(false);
+	});
+
 	it("tolerates non-object throwables", () => {
 		expect(isUniqueConstraintError(undefined)).toBe(false);
 		expect(isUniqueConstraintError(null)).toBe(false);

--- a/packages/oauth-provider/src/utils/db-errors.ts
+++ b/packages/oauth-provider/src/utils/db-errors.ts
@@ -32,9 +32,14 @@ const UNIQUE_CONSTRAINT_ERROR_IDENTIFIERS = new Set([
 
 /**
  * Message fallback for adapters that surface no machine-readable code.
- * Wording differs per engine, hence the alternation.
+ * Wording differs per engine, hence the alternation — SQLite says "UNIQUE
+ * constraint failed", MySQL/MongoDB say "Duplicate entry"/"duplicate key".
+ *
+ * Deliberately narrower than a bare `unique`/`duplicate` match: an
+ * unconstrained "unique" (e.g. "could not uniquely identify row") would
+ * misclassify an unrelated failure as a lost insert race and swallow it.
  */
-const UNIQUE_CONSTRAINT_MESSAGE_PATTERN = /unique|duplicate/i;
+const UNIQUE_CONSTRAINT_MESSAGE_PATTERN = /duplicate|unique constraint|unique key/i;
 
 /**
  * Matched against adapter errors to detect the "table not yet created" case —

--- a/packages/oauth-provider/src/utils/db-errors.ts
+++ b/packages/oauth-provider/src/utils/db-errors.ts
@@ -1,0 +1,124 @@
+/**
+ * Adapter error classification.
+ *
+ * Adapters wrap driver errors rather than rethrowing them. `drizzle-orm`, for
+ * example, throws an `Error` whose `message` is the failed SQL text and whose
+ * `cause` is the driver error carrying the SQLSTATE. Matching only the
+ * top-level `message` therefore misses real unique violations and missing
+ * tables (better-auth#11034), so every predicate here walks the `cause` chain.
+ *
+ * @internal
+ */
+
+/**
+ * Driver identifiers denoting a unique-constraint violation, matched against
+ * `code`, `errno`, `errcode`, and `number`.
+ *
+ * `23505` Postgres, `1062`/`ER_DUP_ENTRY` MySQL, `11000` MongoDB,
+ * `2067`/`SQLITE_CONSTRAINT_UNIQUE` SQLite, `2601`/`2627` SQL Server,
+ * `P2002` Prisma.
+ */
+const UNIQUE_CONSTRAINT_ERROR_IDENTIFIERS = new Set([
+	"11000",
+	"1062",
+	"2067",
+	"23505",
+	"2601",
+	"2627",
+	"ER_DUP_ENTRY",
+	"P2002",
+	"SQLITE_CONSTRAINT_UNIQUE",
+]);
+
+/**
+ * Message fallback for adapters that surface no machine-readable code.
+ * Wording differs per engine, hence the alternation.
+ */
+const UNIQUE_CONSTRAINT_MESSAGE_PATTERN = /unique|duplicate/i;
+
+/**
+ * Matched against adapter errors to detect the "table not yet created" case —
+ * i.e. migrations haven't been run.
+ *
+ * Covers SQLite ("no such table"), Postgres ("relation X does not exist"),
+ * and MySQL ("Table X does not exist" / contracted form).
+ */
+// cspell:ignore-next-line doesn
+const MISSING_TABLE_PATTERN =
+	/no such table|relation.*does not exist|table.*does(?: not|n['’´]?t) exist/i;
+
+/**
+ * Bounds the `cause` walk. Chains can be cyclic, and a pathologically deep
+ * chain should not become a hot loop.
+ */
+const MAX_CAUSE_DEPTH = 8;
+
+/**
+ * Yields each link of an error's `cause` chain, starting with the error
+ * itself. Terminates on a repeat (cycle) or at {@link MAX_CAUSE_DEPTH}.
+ */
+function* causeChain(error: unknown): Generator<unknown> {
+	const seen = new Set<unknown>();
+	let current = error;
+	for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+		if (current == null) return;
+		if (typeof current === "object") {
+			if (seen.has(current)) return;
+			seen.add(current);
+		}
+		yield current;
+		if (typeof current !== "object") return;
+		current = (current as { cause?: unknown }).cause;
+	}
+}
+
+/** Reads the error's message as a string, whatever the throwable's shape. */
+function messageOf(error: unknown): string {
+	if (typeof error === "string") return error;
+	if (typeof error === "object" && error !== null) {
+		const { message } = error as { message?: unknown };
+		if (typeof message === "string") return message;
+	}
+	return "";
+}
+
+/**
+ * True when `error`, or anything in its `cause` chain, is a unique-constraint
+ * violation. Checks driver identifiers first, then falls back to message text
+ * so adapters exposing no code keep working.
+ */
+export function isUniqueConstraintError(error: unknown): boolean {
+	for (const link of causeChain(error)) {
+		if (typeof link === "object" && link !== null) {
+			const details = link as Record<string, unknown>;
+			const identifiers = [
+				details.code,
+				details.errcode,
+				details.errno,
+				details.number,
+			];
+			if (
+				identifiers.some(
+					(identifier) =>
+						identifier != null &&
+						UNIQUE_CONSTRAINT_ERROR_IDENTIFIERS.has(String(identifier)),
+				)
+			) {
+				return true;
+			}
+		}
+		if (UNIQUE_CONSTRAINT_MESSAGE_PATTERN.test(messageOf(link))) return true;
+	}
+	return false;
+}
+
+/**
+ * True when `error`, or anything in its `cause` chain, reports that the target
+ * table does not exist yet — i.e. migrations have not run.
+ */
+export function isMissingTableError(error: unknown): boolean {
+	for (const link of causeChain(error)) {
+		if (MISSING_TABLE_PATTERN.test(messageOf(link))) return true;
+	}
+	return false;
+}

--- a/packages/oauth-provider/src/utils/db-errors.ts
+++ b/packages/oauth-provider/src/utils/db-errors.ts
@@ -45,7 +45,7 @@ const UNIQUE_CONSTRAINT_MESSAGE_PATTERN = /unique|duplicate/i;
  */
 // cspell:ignore-next-line doesn
 const MISSING_TABLE_PATTERN =
-	/no such table|relation.*does not exist|table.*does(?: not|n['’´]?t) exist/i;
+	/no such table|relation.*does not exist|table.*does(?: not|n[''']?t) exist/i;
 
 /**
  * Bounds the `cause` walk. Chains can be cyclic, and a pathologically deep


### PR DESCRIPTION
Closes #11034

## Root cause

`seedResources` detects a lost insert-race by testing `err.message` against a unique-constraint regex. The Drizzle adapter wraps driver errors: the thrown error's `message` is the failed SQL text, and the Postgres SQLSTATE lives on `err.cause`. The regex never matches, so `throw err` runs and the plugin's `init` aborts before its final `return` — which is what registers the back-channel-logout `databaseHooks` on session deletion.

## Fix

Added one internal module, `isUniqueConstraintError`/`isMissingTableError` in `packages/oauth-provider/src/utils/db-errors.ts`, that walks the error's `cause` chain checking driver identifiers (`code`/`errno`/`errcode`/`number` against `23505`, `1062`, `11000`, `2067`, `2601`, `2627`, `ER_DUP_ENTRY`, `P2002`, `SQLITE_CONSTRAINT_UNIQUE`) before falling back to the existing message regex, so adapters exposing no code keep working unchanged. Every inline `err.message` check in the package (`resources.ts`, `oauthResource/endpoints.ts`, `register.ts`) now goes through these two functions, and `register.ts`'s duplicated private helper is removed.

`packages/better-auth/src/plugins/device-authorization/routes.ts` has the same latent gap but lives in a different package — left out of scope here, happy to follow up separately.

## Behavior notes

- No public API change; the module is internal to `oauth-provider`.
- The seed loop keeps `continue` on a detected unique violation in every `resourceSeedMode` (`insertOnly`, `merge`, `overwrite`). This is safe by construction, not just for the default mode: a race can only happen when `findOne` found no row, meaning the winner just inserted a row built by `buildSeedRow` from the same config. `buildSeedUpdate` in `"overwrite"` mode is `buildSeedRow` minus `identifier`/`createdAt`, and `"merge"` writes a subset of those same values — so the update the loser skips would only rewrite what the winner already wrote.

## Tests

- `packages/oauth-provider/src/utils/db-errors.test.ts` (new): both predicates against bare driver errors, Drizzle-wrapped errors, message-only adapters, cyclic `cause` chains, a depth cap, and non-object throwables.
- `packages/oauth-provider/src/resources.test.ts`: a regression test with a Drizzle-shaped wrapped error that fails on `main` today (rejects instead of resolving), plus a negative case confirming an unrelated wrapped failure still rethrows, and a wrapped missing-table case.
- Also in `resources.test.ts`: `oauthProvider`'s `init` is called directly against a stub `AuthContext` (table exists, `create` throws the wrapped error) to prove the actual consequence — `init` still returns `options.databaseHooks.session.delete` after losing the race. This can't be shown through the existing `getTestInstance` harness, since it runs `runMigrations()` after plugin init and seeding always defers there before reaching `create`.

## End-to-end reproduction (Postgres + Drizzle)

The repo has no Drizzle test infrastructure, so here's a standalone reproduction instead of an in-tree e2e test:

```ts
import { betterAuth } from "better-auth";
import { drizzleAdapter } from "better-auth/adapters/drizzle";
import { oauthProvider } from "@better-auth/oauth-provider";
import { drizzle } from "drizzle-orm/node-postgres";
import { Pool } from "pg";

const pool = new Pool({ connectionString: process.env.DATABASE_URL });
const db = drizzle(pool);

await db.execute(`delete from "oauthResource"`);

function makeAuth() {
  return betterAuth({
    database: drizzleAdapter(db, { provider: "pg" }),
    plugins: [oauthProvider({ resources: ["http://localhost:3000/api/mcp"] })],
  });
}

const [a, b] = [makeAuth(), makeAuth()];
const results = await Promise.allSettled([a.$context, b.$context]);

console.log(results.map((r) => r.status));
// On main:  [ 'fulfilled', 'rejected' ]  — the loser's init throws
// Fixed:    [ 'fulfilled', 'fulfilled' ] — both settle, both get their hooks
```

## Interim workaround

For anyone hitting this before a release with the fix: pre-insert the `oauthResource` row (`insert ... on conflict do nothing`) in a migration before replicas start, so `findOne` finds it and `create` is never attempted. There's no configuration escape hatch — the adapter API has no `upsert`, no option disables seeding, and with the `mcp` plugin `resources` is never empty (it unconditionally injects the MCP resource), so the seed always runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `oauth-provider`'s seed logic so a wrapped unique-constraint error no longer aborts plugin init. The Drizzle adapter stores the SQLSTATE on `error.cause` instead of the message, so the old regex never matched and `init` threw before registering the back-channel-logout session hooks.

- Adds internal `isUniqueConstraintError`/`isMissingTableError` helpers that walk the `cause` chain and check driver codes (`23505`, `ER_DUP_ENTRY`, etc.) before falling back to message text.
- The message fallback matches "duplicate", "unique constraint", and "unique key" phrases rather than a bare "unique" word, so unrelated errors like "could not uniquely identify row" still rethrow.
- Replaces every inline error-message check in the package with these helpers and removes a duplicated private predicate.
- Adds regression tests proving `init` still returns the session delete hook after losing an insert race, and that unrelated wrapped failures still rethrow.

<sup>Written for commit 962a7b0527e57f88a14282d6cee3ec83c582385d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

