### PR TITLE
docs: add `better-auth-evp` community plugin

### DIFF
--- a/docs/lib/community-plugins-data.ts
+++ b/docs/lib/community-plugins-data.ts
@@ -364,4 +364,15 @@ export const communityPlugins: CommunityPlugin[] = [
 			avatar: "https://github.com/typed-sigterm.png",
 		},
 	},
+	{
+		name: "better-auth-evp",
+		url: "https://github.com/qamarq/better-auth-evp",
+		description:
+			"Email Verification Protocol (Chrome origin trial) plugin - lets a supporting browser verify mailbox ownership in the background and sign the user in, with automatic fallback to any other sign-in method when unsupported.",
+		author: {
+			name: "qamarq",
+			github: "qamarq",
+			avatar: "https://github.com/qamarq.png",
+		},
+	},
 ];


### PR DESCRIPTION
Adds `better-auth-evp` to the community plugins list.

[`better-auth-evp`](https://github.com/qamarq/better-auth-evp) implements Chrome's experimental [Email Verification Protocol](https://developer.chrome.com/blog/email-verification-protocol-origin-trial) (currently gated behind an origin trial): a supporting browser verifies mailbox ownership in the background and the plugin signs the user in directly - no OTP, no magic link. It's pure progressive enhancement and falls back to whatever sign-in method the app already has whenever the browser/mailbox provider doesn't support it (which is most of them today, since this is a very new capability).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `better-auth-evp` to the community plugins list so it appears in the docs. The plugin implements Chrome's Email Verification Protocol origin trial and falls back to existing sign-in methods when the browser or mailbox provider doesn't support it.

<sup>Written for commit 049c9de2be32536ed7f9943d430cb2a6ac468d4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

