### PR TITLE
docs: show the account issuer/accountId unique index

### DIFF
--- a/docs/content/docs/concepts/database.mdx
+++ b/docs/content/docs/concepts/database.mdx
@@ -506,6 +506,19 @@ export const accountTableFields = [
 
 The database requires `issuer` and `accountId` and enforces a unique compound index across them for every account identity strategy. Newly generated configurations explicitly use [`account.identityStrategy: "provider-id"`](/docs/reference/options#identitystrategy), so `issuer` contains a deterministic `local:oauth:<encoded providerId>` namespace, or `local:credential` for credential accounts. An omitted strategy remains a v1.7 compatibility mode that stores the verified authority and warns once; explicit `"issuer"` selects the same namespace without a warning. The selected strategy changes the stored namespace value, not the generated schema.
 
+<Callout type="info">
+  The CLI creates this index for you as `account_issuer_accountId_uidx`. If you
+  manage the schema by hand, add it yourself over the columns mapped to `issuer`
+  and `accountId`:
+
+  ```sql
+  CREATE UNIQUE INDEX account_issuer_accountId_uidx ON account (issuer, account_id);
+  ```
+
+  Substitute the physical table and column names your adapter maps these fields
+  to.
+</Callout>
+
 ### Verification
 
 Table Name: `verification`


### PR DESCRIPTION
## Summary

The Account section of [Database](https://better-auth.com/docs/concepts/database#account) states:

> The database requires `issuer` and `accountId` and enforces a unique compound index across them for every account identity strategy.

It never shows what that index looks like. The Core Schema section explicitly supports adding tables by hand ("If you prefer adding tables manually, you can do that as well"), and those readers currently have no way to know the constraint's shape or the name the CLI generates for it.

This adds a short callout after that paragraph with the DDL and the generated index name.

## Details

The index name comes from `getDatabaseIndexName()` in `packages/core/src/db/database-index.ts`, applied to the table-level index declared for `account` in `packages/core/src/db/get-tables.ts`:

```ts
indexes: mergeTableIndexes(
    [
        {
            fields: ["issuer", "accountId"],
            unique: true,
        },
    ],
    account?.indexes,
),
```

With no explicit `name`, that resolves to `account_issuer_accountId_uidx`, which matches what the Drizzle generator emits.

The callout notes that physical table and column identifiers depend on the adapter's mapping, so the SQL is an illustration rather than a literal statement to paste.

## Scope

Docs only. No package changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the DDL and generated index name for the `account` unique compound index to the Account section of the database docs, so readers who manage schemas by hand know the constraint's shape.

- The callout shows `account_issuer_accountId_uidx` and an example `CREATE UNIQUE INDEX` statement.
- Notes that physical table and column names depend on the adapter's mapping.
- Docs-only change, so no changeset or migration steps.

<sup>Written for commit da5845e14c4cb747f668f0fec88f17fa5c508530. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

