### PR TITLE
ci(release): show fallback review feedback

### DIFF
--- a/packages/release-tooling/src/release-notes/comment.ts
+++ b/packages/release-tooling/src/release-notes/comment.ts
@@ -67,7 +67,7 @@ function formatFallbackWarning(fallbacks: ReleaseRewriteFallback[]): string[] {
 		">",
 		...fallbacks.map((fallback) => {
 			const reference = fallback.prNumber ? `#${fallback.prNumber}: ` : "";
-			return `> - ${reference}${formatUntrustedInlineMarkdown(fallback.title)}`;
+			return `> - ${reference}${formatUntrustedInlineMarkdown(fallback.title)}<br><sub>${formatUntrustedInlineMarkdown(fallback.reason)}</sub>`;
 		}),
 		">",
 		"> Review or edit the original wording before merging.",

--- a/packages/release-tooling/src/release-notes/comment.ts
+++ b/packages/release-tooling/src/release-notes/comment.ts
@@ -63,7 +63,7 @@ function formatFallbackWarning(fallbacks: ReleaseRewriteFallback[]): string[] {
 		"> [!WARNING]",
 		`> **${count} release ${count === 1 ? "note needs" : "notes need"} a closer look.**`,
 		">",
-		"> I took a second pass, but the copy below still needs human review, so I kept the original wording.",
+		"> I couldn't confidently improve the copy below, so I kept the original wording.",
 		">",
 		...fallbacks.map((fallback) => {
 			const reference = fallback.prNumber ? `#${fallback.prNumber}: ` : "";

--- a/packages/release-tooling/src/release-notes/rewrite.ts
+++ b/packages/release-tooling/src/release-notes/rewrite.ts
@@ -22,8 +22,9 @@ const maxBatchCharacters = 60_000;
 const maxContextCharacters = 500_000;
 const maxOutputTokensPerBatch = 32_000;
 const maxReviewOutputTokensPerBatch = 8_000;
-const defaultFallbackReason =
-	"The rewrite could not be approved after a second pass.";
+const defaultFallbackReason = "The rewrite was not approved by review.";
+const invalidCopyFallbackReason =
+	"The rewrite did not pass deterministic copy validation.";
 
 const rewriteInstructions = readFileSync(
 	new URL("./rewrite.prompt.md", import.meta.url),
@@ -142,6 +143,16 @@ function validationFeedback(
 	}
 }
 
+function fallbackReason(
+	reviewFeedback: string | null,
+	copyFeedback: string | null,
+): string {
+	return (
+		reviewFeedback ??
+		(copyFeedback ? invalidCopyFallbackReason : defaultFallbackReason)
+	);
+}
+
 export async function rewriteReleaseNotes(
 	contextPath: string,
 	outputPath: string,
@@ -202,10 +213,11 @@ export async function rewriteReleaseNotes(
 				const feedback = review.feedback ?? copyFeedback;
 				if (feedback) {
 					feedbackById.set(review.id, feedback);
-					fallbackReasons.set(review.id, feedback);
-				} else {
-					fallbackReasons.set(review.id, defaultFallbackReason);
 				}
+				fallbackReasons.set(
+					review.id,
+					fallbackReason(review.feedback, copyFeedback),
+				);
 			}
 		}
 
@@ -260,7 +272,7 @@ export async function rewriteReleaseNotes(
 				} else {
 					fallbackReasons.set(
 						review.id,
-						review.feedback ?? copyFeedback ?? defaultFallbackReason,
+						fallbackReason(review.feedback, copyFeedback),
 					);
 				}
 			}

--- a/packages/release-tooling/src/release-notes/rewrite.ts
+++ b/packages/release-tooling/src/release-notes/rewrite.ts
@@ -22,6 +22,8 @@ const maxBatchCharacters = 60_000;
 const maxContextCharacters = 500_000;
 const maxOutputTokensPerBatch = 32_000;
 const maxReviewOutputTokensPerBatch = 8_000;
+const defaultFallbackReason =
+	"The rewrite could not be approved after a second pass.";
 
 const rewriteInstructions = readFileSync(
 	new URL("./rewrite.prompt.md", import.meta.url),
@@ -161,6 +163,7 @@ export async function rewriteReleaseNotes(
 		`Invalid release rewrite context ${contextPath}`,
 	);
 	const acceptedRewrites = new Map<string, GeneratedReleaseRewrites[number]>();
+	const fallbackReasons = new Map<string, string>();
 	for (const batch of buildBatches(context)) {
 		const generated = await generate({
 			model: models.releaseNotes,
@@ -194,9 +197,15 @@ export async function rewriteReleaseNotes(
 			const copyFeedback = validationFeedback(batch, rewrite);
 			if (review.approved && !review.feedback && !copyFeedback) {
 				acceptedRewrites.set(review.id, rewrite);
+				fallbackReasons.delete(review.id);
 			} else {
 				const feedback = review.feedback ?? copyFeedback;
-				if (feedback) feedbackById.set(review.id, feedback);
+				if (feedback) {
+					feedbackById.set(review.id, feedback);
+					fallbackReasons.set(review.id, feedback);
+				} else {
+					fallbackReasons.set(review.id, defaultFallbackReason);
+				}
 			}
 		}
 
@@ -242,11 +251,17 @@ export async function rewriteReleaseNotes(
 				repairedRewrites.map((rewrite) => [rewrite.id, rewrite]),
 			);
 			for (const review of repairReviews) {
-				if (!review.approved) continue;
 				const rewrite = repairedById.get(review.id);
 				if (!rewrite) throw new Error(`AI repair ${review.id} is missing`);
-				if (!validationFeedback(repairContext, rewrite)) {
+				const copyFeedback = validationFeedback(repairContext, rewrite);
+				if (review.approved && !review.feedback && !copyFeedback) {
 					acceptedRewrites.set(review.id, rewrite);
+					fallbackReasons.delete(review.id);
+				} else {
+					fallbackReasons.set(
+						review.id,
+						review.feedback ?? copyFeedback ?? defaultFallbackReason,
+					);
 				}
 			}
 		} catch (error) {
@@ -263,7 +278,13 @@ export async function rewriteReleaseNotes(
 	const fallbacks = Object.entries(context).flatMap(([id, entry]) =>
 		acceptedRewrites.has(id)
 			? []
-			: [{ title: entry.title, prNumber: entry.prNumber }],
+			: [
+					{
+						title: entry.title,
+						prNumber: entry.prNumber,
+						reason: fallbackReasons.get(id) ?? defaultFallbackReason,
+					},
+				],
 	);
 	if (fallbacks.length > 0) {
 		console.warn(

--- a/packages/release-tooling/src/release-notes/schema.ts
+++ b/packages/release-tooling/src/release-notes/schema.ts
@@ -98,6 +98,7 @@ export const releaseRewriteFallbacksSchema = z
 		z.strictObject({
 			title: releaseTitleSchema,
 			prNumber: z.int().positive().nullable(),
+			reason: z.string().trim().min(1).max(500),
 		}),
 	)
 	.max(250);

--- a/packages/release-tooling/test/release-notes-comment.test.ts
+++ b/packages/release-tooling/test/release-notes-comment.test.ts
@@ -109,14 +109,13 @@ describe("wrapReleaseNotesComment", () => {
 				{
 					prNumber: 42,
 					title: "fix: preserve safe copy",
-					reason:
-						"See [the migration](https://example.com) and notify @maintainers.",
+					reason: '</sub><a href="https://example.com">unsafe</a>@maintainers',
 				},
 			],
 		});
 
 		expect(comment).toContain(
-			"<sub>`See [the migration](https://example.com) and notify @maintainers.`</sub>",
+			'<sub>`</sub><a href="https://example.com">unsafe</a>@maintainers`</sub>',
 		);
 	});
 

--- a/packages/release-tooling/test/release-notes-comment.test.ts
+++ b/packages/release-tooling/test/release-notes-comment.test.ts
@@ -68,13 +68,15 @@ describe("wrapReleaseNotesComment", () => {
 				{
 					prNumber: 10907,
 					title: "fix(client): preserve plugin assignability",
+					reason:
+						"State that assignability was restored for clients using additional plugins.",
 				},
 			],
 		});
 
 		expect(comment).toContain("**1 release note needs a closer look.**");
 		expect(comment).toContain(
-			"> - #10907: fix(client): preserve plugin assignability",
+			"> - #10907: fix(client): preserve plugin assignability<br><sub>State that assignability was restored for clients using additional plugins.</sub>",
 		);
 		expect(comment.indexOf("> [!WARNING]")).toBeLessThan(
 			comment.indexOf(`# Release preview: v${version}`),
@@ -85,12 +87,37 @@ describe("wrapReleaseNotesComment", () => {
 	it("uses plural copy for multiple partial fallbacks", () => {
 		const comment = wrapReleaseNotesComment(version, head, notes, {
 			fallbacks: [
-				{ prNumber: 42, title: "fix: first change" },
-				{ prNumber: 43, title: "fix: second change" },
+				{
+					prNumber: 42,
+					title: "fix: first change",
+					reason: "Preserve the first behavior.",
+				},
+				{
+					prNumber: 43,
+					title: "fix: second change",
+					reason: "Preserve the second behavior.",
+				},
 			],
 		});
 
 		expect(comment).toContain("**2 release notes need a closer look.**");
+	});
+
+	it("neutralizes unsupported Markdown in review reasons", () => {
+		const comment = wrapReleaseNotesComment(version, head, notes, {
+			fallbacks: [
+				{
+					prNumber: 42,
+					title: "fix: preserve safe copy",
+					reason:
+						"See [the migration](https://example.com) and notify @maintainers.",
+				},
+			],
+		});
+
+		expect(comment).toContain(
+			"<sub>`See [the migration](https://example.com) and notify @maintainers.`</sub>",
+		);
 	});
 
 	it("instructs merged release PRs to rerun the failed release", () => {

--- a/packages/release-tooling/test/release-rewrite.test.ts
+++ b/packages/release-tooling/test/release-rewrite.test.ts
@@ -431,6 +431,8 @@ describe("release-note rewriting", () => {
 			{
 				title: "fix: preserve redirect validation",
 				prNumber: 42,
+				reason:
+					"Preserve both standard path support and open-redirect protection.",
 			},
 		]);
 	});

--- a/packages/release-tooling/test/release-rewrite.test.ts
+++ b/packages/release-tooling/test/release-rewrite.test.ts
@@ -10,6 +10,7 @@ import { rewriteReleaseNotes } from "../src/release-notes/rewrite.ts";
 import {
 	parseSchema,
 	releaseRewriteContextSchema,
+	releaseRewriteFallbacksSchema,
 	releaseRewritesSchema,
 } from "../src/release-notes/schema.ts";
 
@@ -338,7 +339,7 @@ describe("release-note rewriting", () => {
 		});
 	});
 
-	test("omits copy that remains rejected after one repair", async ({
+	test("returns reasons for copy rejected before and after repair", async ({
 		releaseFiles,
 	}) => {
 		writeFileSync(
@@ -356,6 +357,13 @@ describe("release-note rewriting", () => {
 					title: "fix: prevent duplicate refreshes",
 					changesetDescription: "Prevent duplicate session refreshes.",
 					prNumber: 43,
+					packageNames: ["better-auth"],
+					changeType: "fix",
+				},
+				"pr-44": {
+					title: "fix: preserve account linking",
+					changesetDescription: "Preserve account linking behavior.",
+					prNumber: 44,
 					packageNames: ["better-auth"],
 					changeType: "fix",
 				},
@@ -377,6 +385,11 @@ describe("release-note rewriting", () => {
 							{
 								id: "pr-43",
 								title: "Prevented duplicate session refreshes",
+								migration: null,
+							},
+							{
+								id: "pr-44",
+								title: "Preserved account linking behavior",
 								migration: null,
 							},
 						],
@@ -403,6 +416,7 @@ describe("release-note rewriting", () => {
 										"Preserve both standard path support and open-redirect protection.",
 								},
 								{ id: "pr-43", approved: true, feedback: null },
+								{ id: "pr-44", approved: false, feedback: null },
 							],
 						}
 					: {
@@ -433,6 +447,64 @@ describe("release-note rewriting", () => {
 				prNumber: 42,
 				reason:
 					"Preserve both standard path support and open-redirect protection.",
+			},
+			{
+				title: "fix: preserve account linking",
+				prNumber: 44,
+				reason: "The rewrite was not approved by review.",
+			},
+		]);
+	});
+
+	test("bounds fallback reasons from deterministic validation", async ({
+		releaseFiles,
+	}) => {
+		const id = "x".repeat(600);
+		writeFileSync(
+			releaseFiles.contextPath,
+			JSON.stringify({
+				[id]: {
+					title: "fix: preserve safe output",
+					changesetDescription: "Preserve safe output.",
+					prNumber: 42,
+					packageNames: ["better-auth"],
+					changeType: "fix",
+				},
+			}),
+		);
+
+		const fallbacks = await rewriteReleaseNotes(
+			releaseFiles.contextPath,
+			releaseFiles.outputPath,
+			generatorFor((request) =>
+				request.name === "release_note_rewrites" ||
+				request.name === "release_note_repairs"
+					? {
+							rewrites: [
+								{
+									id,
+									title: "Preserved safe output",
+									migration: "Change an unrelated setting.",
+								},
+							],
+						}
+					: {
+							reviews: [{ id, approved: true, feedback: null }],
+						},
+			),
+		);
+
+		expect(
+			parseSchema(
+				releaseRewriteFallbacksSchema,
+				fallbacks,
+				"Invalid test fallbacks",
+			),
+		).toEqual([
+			{
+				title: "fix: preserve safe output",
+				prNumber: 42,
+				reason: "The rewrite did not pass deterministic copy validation.",
 			},
 		]);
 	});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shows the reason a release note fell back to its original wording in the release comment. Previously fallback items only listed the PR number and title; they now also show the review feedback that blocked the rewrite, or a default reason when none was provided.

**Migration**
- Fallback entries in the release tooling schema now require a `reason` (`1–500` characters).

<sup>Written for commit c7393ee726300217aabe138e698baf97b0517ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

