### PR TITLE
feat(cli): add fx as an mcp target

### DIFF
--- a/docs/content/docs/ai-resources/mcp.mdx
+++ b/docs/content/docs/ai-resources/mcp.mdx
@@ -20,7 +20,7 @@ npx auth@latest mcp
 
 With no flags, the command lists supported targets. You can pass a target directly:
 
-<Tabs items={["Cursor", "Claude Code", "Open Code", "Manual"]}>
+<Tabs items={["Cursor", "Claude Code", "Open Code", "fx", "Manual"]}>
   <Tab value="Cursor">
     ```bash title="terminal"
     npx auth@latest mcp --cursor
@@ -47,6 +47,16 @@ With no flags, the command lists supported targets. You can pass a target direct
     ```
 
     This merges a `better-auth` entry into `opencode.json` in the current directory (remote transport, URL above).
+  </Tab>
+
+  <Tab value="fx">
+    ```bash title="terminal"
+    npx auth@latest mcp --fx
+    ```
+
+    This runs `fx mcp add` with the Better Auth URL, saving the server to `~/.fx/mcp.json` so it is available in every project. If that fails, the CLI prints the exact command to run yourself.
+
+    Run `fx mcp list --connect` to verify the connection.
   </Tab>
 
   <Tab value="Manual">

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -137,7 +137,7 @@ function handleFxAction() {
 	console.log(chalk.bold.white("\n✨ Next Steps:"));
 	console.log(
 		chalk.gray(
-			"• The server is saved to ~/.fx/mcp.json and available in every project",
+			"• Once configured, the server is saved to ~/.fx/mcp.json and available in every project",
 		),
 	);
 	console.log(

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -10,6 +10,7 @@ interface MCPOptions {
 	cursor?: boolean;
 	claudeCode?: boolean;
 	openCode?: boolean;
+	fx?: boolean;
 	manual?: boolean;
 }
 
@@ -22,6 +23,8 @@ async function mcpAction(options: MCPOptions) {
 		handleClaudeCodeAction();
 	} else if (options.openCode) {
 		handleOpenCodeAction();
+	} else if (options.fx) {
+		handleFxAction();
 	} else if (options.manual) {
 		handleManualAction();
 	} else {
@@ -111,6 +114,34 @@ function handleClaudeCodeAction() {
 		chalk.gray(
 			"• You can now use Better Auth features directly in Claude Code",
 		),
+	);
+}
+
+function handleFxAction() {
+	console.log(chalk.bold.blue("⚡ Adding Better Auth MCP to fx..."));
+
+	const command = `fx mcp add --transport http better-auth ${REMOTE_MCP_URL}`;
+
+	try {
+		execSync(command, { stdio: "inherit" });
+		console.log(chalk.green("\n✓ fx MCP configured!"));
+	} catch {
+		console.log(
+			chalk.yellow(
+				"\n⚠ Could not automatically add to fx. Please run this command manually:",
+			),
+		);
+		console.log(chalk.cyan(command));
+	}
+
+	console.log(chalk.bold.white("\n✨ Next Steps:"));
+	console.log(
+		chalk.gray(
+			"• The server is saved to ~/.fx/mcp.json and available in every project",
+		),
+	);
+	console.log(
+		chalk.gray("• Run `fx mcp list --connect` to verify the connection"),
 	);
 }
 
@@ -225,6 +256,7 @@ function showAllOptions() {
 		chalk.cyan("  --claude-code ") + chalk.gray("Add to Claude Code"),
 	);
 	console.log(chalk.cyan("  --open-code   ") + chalk.gray("Add to Open Code"));
+	console.log(chalk.cyan("  --fx          ") + chalk.gray("Add to fx"));
 	console.log(
 		chalk.cyan("  --manual      ") + chalk.gray("Manual configuration"),
 	);
@@ -244,5 +276,6 @@ export const mcp = new Command("mcp")
 	.option("--cursor", "Automatically open Cursor with the MCP configuration")
 	.option("--claude-code", "Show Claude Code MCP configuration command")
 	.option("--open-code", "Show Open Code MCP configuration")
+	.option("--fx", "Add the MCP server to fx")
 	.option("--manual", "Show manual MCP configuration for mcp.json")
 	.action(mcpAction);


### PR DESCRIPTION
Adds [fx](https://fx.sh) as an MCP target, so `npx auth@latest mcp --fx` configures the Better Auth docs server the same way `--claude-code` does.

- `packages/cli/src/commands/mcp.ts`: new `--fx` option and `handleFxAction`, which shells out to `fx mcp add --transport http better-auth <url>` and falls back to printing the command, mirroring the Claude Code handler.
- `docs/content/docs/ai-resources/mcp.mdx`: an `fx` tab alongside Cursor, Claude Code and Open Code.

fx is an open source coding agent for the terminal. It stores MCP servers in `~/.fx/mcp.json`, so a server added once is available in every project.

Verified against `https://mcp.better-auth.com/mcp` with fx v0.0.7:

```
better-auth  transport=http  state=ready  protocol=2026-07-28
negotiated_name=better-auth  version=0.0.1  tools=2  discovery=completed
```

Biome is clean on the changed file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `fx` as an MCP target so `npx auth@latest mcp --fx` configures Better Auth's docs server for fx, mirroring how `--claude-code` works.

- Adds the `--fx` flag, which runs `fx mcp add` and falls back to printing the command if execution fails.
- Updates the MCP docs with an `fx` tab alongside Cursor, Claude Code, and Open Code.

<sup>Written for commit b77f1ef62eb666925a32eceb09d4cf46f261dace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

