### PR TITLE
fix(expo): prevent torn cookie storage writes

### DIFF
--- a/.changeset/calm-taxis-store-cookies.md
+++ b/.changeset/calm-taxis-store-cookies.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/expo": patch
+---
+
+Prevent Expo apps from sending unauthenticated requests while large stored cookies are being updated, and recover the previous cookie value when an update is interrupted or incomplete.

--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -485,7 +485,7 @@ export function TRPCProvider(props: { children: React.ReactNode }) {
 
 ### Expo Client
 
-**storage**: the SecureStore-compatible storage used to cache session data and cookies.
+**storage**: the SecureStore-compatible storage used to cache session data and cookies. Write coordination is scoped to the provided object, so reuse it when configuring multiple clients that access the same stored data.
 
 ```ts title="lib/auth-client.ts"
 import { createAuthClient } from "better-auth/react";

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -272,6 +272,7 @@ export function normalizeCookieName(name: string) {
  * @see https://github.com/better-auth/better-auth/issues/9151
  */
 const STORAGE_VALUE_LIMIT = 1800;
+const MAX_STORAGE_CHUNKS = 100;
 
 /**
  * Marks a base key whose value is split across multiple storage keys. Legacy
@@ -295,7 +296,10 @@ function parseChunkCount(value: string | undefined): number | null {
 		return null;
 	}
 	const count = Number(value);
-	return Number.isInteger(count) && count > 0 ? count : null;
+	if (!Number.isInteger(count) || count < 1 || count > MAX_STORAGE_CHUNKS) {
+		return null;
+	}
+	return count;
 }
 
 function parseChunkMarker(baseValue: string): ChunkMarker | null {
@@ -378,6 +382,52 @@ async function readChunksAsync(
 	return value;
 }
 
+function readStoredValue(
+	storage: Pick<ExpoClientStorage, "getItem">,
+	key: string,
+	baseValue: string | null,
+): string | null {
+	if (baseValue == null || !baseValue.startsWith(CHUNK_MARKER)) {
+		return baseValue;
+	}
+	const marker = parseChunkMarker(baseValue);
+	if (!marker) {
+		return null;
+	}
+	const value = readChunks(storage, key, marker);
+	if (value !== null || marker.slot === null || marker.fallbackCount === null) {
+		return value;
+	}
+	return readChunks(storage, key, {
+		count: marker.fallbackCount,
+		slot: getOtherSlot(marker.slot),
+		fallbackCount: null,
+	});
+}
+
+async function readStoredValueAsync(
+	storage: Pick<ExpoClientStorage, "getItemAsync">,
+	key: string,
+	baseValue: string | null,
+): Promise<string | null> {
+	if (baseValue == null || !baseValue.startsWith(CHUNK_MARKER)) {
+		return baseValue;
+	}
+	const marker = parseChunkMarker(baseValue);
+	if (!marker) {
+		return null;
+	}
+	const value = await readChunksAsync(storage, key, marker);
+	if (value !== null || marker.slot === null || marker.fallbackCount === null) {
+		return value;
+	}
+	return readChunksAsync(storage, key, {
+		count: marker.fallbackCount,
+		slot: getOtherSlot(marker.slot),
+		fallbackCount: null,
+	});
+}
+
 function getStorageWrites(
 	key: string,
 	value: string,
@@ -388,6 +438,11 @@ function getStorageWrites(
 	}
 
 	const count = Math.ceil(value.length / STORAGE_VALUE_LIMIT);
+	if (count > MAX_STORAGE_CHUNKS) {
+		throw new Error(
+			`Storage value requires ${count} chunks, exceeding the limit of ${MAX_STORAGE_CHUNKS}`,
+		);
+	}
 	const currentMarker = currentBaseValue?.startsWith(CHUNK_MARKER)
 		? parseChunkMarker(currentBaseValue)
 		: null;
@@ -419,130 +474,167 @@ function getStorageWrites(
 
 function createKeyedWriteQueue() {
 	const tails = new Map<string, Promise<unknown>>();
-	return <Result>(
-		key: string,
-		operation: () => Promise<Result>,
-	): Promise<Result> => {
-		const previous = tails.get(key) ?? Promise.resolve();
-		const queued = previous.then(operation, operation);
-		tails.set(key, queued);
+	return {
+		pending(key: string): boolean {
+			return tails.has(key);
+		},
+		enqueue<Result>(
+			key: string,
+			operation: () => Promise<Result>,
+		): Promise<Result> {
+			const previous = tails.get(key) ?? Promise.resolve();
+			const queued = previous.then(operation, operation);
+			tails.set(key, queued);
 
-		const cleanup = () => {
-			if (tails.get(key) === queued) {
-				tails.delete(key);
-			}
-		};
-		void queued.then(cleanup, cleanup);
-		return queued;
+			const cleanup = () => {
+				if (tails.get(key) === queued) {
+					tails.delete(key);
+				}
+			};
+			void queued.then(cleanup, cleanup);
+			return queued;
+		},
 	};
 }
 
-export function storageAdapter(storage: ExpoClientStorage) {
-	const enqueueWrite = createKeyedWriteQueue();
-	return {
-		/**
-		 * Reads a value, reassembling it if it was split across chunk keys. A value
-		 * that fit is returned as-is. If the active slot is incomplete, the previous
-		 * slot is used as a fallback.
-		 */
-		getItem: (name: string): string | null => {
-			const key = normalizeCookieName(name);
-			const stored = storage.getItem(key);
-			if (stored == null || !stored.startsWith(CHUNK_MARKER)) {
-				return stored;
-			}
-			const marker = parseChunkMarker(stored);
-			if (!marker) {
-				return null;
-			}
-			const value = readChunks(storage, key, marker);
-			if (
-				value !== null ||
-				marker.slot === null ||
-				marker.fallbackCount === null
-			) {
-				return value;
-			}
-			return readChunks(storage, key, {
-				count: marker.fallbackCount,
-				slot: getOtherSlot(marker.slot),
-				fallbackCount: null,
-			});
-		},
-		getItemAsync: async (name: string): Promise<string | null> => {
-			const key = normalizeCookieName(name);
-			const stored = await storage.getItemAsync(key);
-			if (stored == null || !stored.startsWith(CHUNK_MARKER)) {
-				return stored;
-			}
-			const marker = parseChunkMarker(stored);
-			if (!marker) {
-				return null;
-			}
-			const value = await readChunksAsync(storage, key, marker);
-			if (
-				value !== null ||
-				marker.slot === null ||
-				marker.fallbackCount === null
-			) {
-				return value;
-			}
-			return readChunksAsync(storage, key, {
-				count: marker.fallbackCount,
-				slot: getOtherSlot(marker.slot),
-				fallbackCount: null,
-			});
-		},
-		/**
-		 * Stores `value`, splitting it across chunk keys when it exceeds the
-		 * per-write limit. Chunked writes fill the inactive slot before changing the
-		 * base marker, so readers see either the previous value or the new value. A
-		 * fallback is temporarily removed while its slot is being overwritten.
-		 * Failures are logged, not thrown: persistence is best-effort and must not
-		 * break the request.
-		 */
-		setItem: (name: string, value: string): void => {
-			const key = normalizeCookieName(name);
+const storageWriteQueues = new WeakMap<
+	ExpoClientStorage,
+	ReturnType<typeof createKeyedWriteQueue>
+>();
+
+function getStorageWriteQueue(storage: ExpoClientStorage) {
+	const existing = storageWriteQueues.get(storage);
+	if (existing) {
+		return existing;
+	}
+	const queue = createKeyedWriteQueue();
+	storageWriteQueues.set(storage, queue);
+	return queue;
+}
+
+interface ExpoStorageAdapter {
+	getItem(name: string): string | null;
+	getItemAsync(name: string): Promise<string | null>;
+	setItem(name: string, value: string): void;
+	setItemAsync(name: string, value: string): Promise<void>;
+}
+
+interface StoredUpdate {
+	previousValue: string | null;
+	value: string;
+}
+
+function createManagedStorage(storage: ExpoClientStorage) {
+	const writeQueue = getStorageWriteQueue(storage);
+	const logWriteError = (key: string, error: unknown) => {
+		console.error(
+			`[better-auth/expo] failed to persist "${key}" to storage`,
+			error,
+		);
+	};
+	const getItem = (name: string): string | null => {
+		const key = normalizeCookieName(name);
+		return readStoredValue(storage, key, storage.getItem(key));
+	};
+	const getItemAsync = async (name: string): Promise<string | null> => {
+		const key = normalizeCookieName(name);
+		const baseValue = await storage.getItemAsync(key);
+		return readStoredValueAsync(storage, key, baseValue);
+	};
+	const writeItem = (
+		key: string,
+		value: string,
+		currentBaseValue: string | null,
+	) => {
+		for (const [writeKey, writeValue] of getStorageWrites(
+			key,
+			value,
+			currentBaseValue,
+		)) {
+			storage.setItem(writeKey, writeValue);
+		}
+	};
+	const writeItemAsync = async (
+		key: string,
+		value: string,
+		currentBaseValue: string | null,
+	) => {
+		for (const [writeKey, writeValue] of getStorageWrites(
+			key,
+			value,
+			currentBaseValue,
+		)) {
+			await storage.setItemAsync(writeKey, writeValue);
+		}
+	};
+	const setItem = (name: string, value: string): void => {
+		const key = normalizeCookieName(name);
+		if (writeQueue.pending(key)) {
+			logWriteError(
+				key,
+				new Error("Cannot write synchronously while an async write is pending"),
+			);
+			return;
+		}
+		try {
+			const currentBaseValue =
+				value.length > STORAGE_VALUE_LIMIT ? storage.getItem(key) : null;
+			writeItem(key, value, currentBaseValue);
+		} catch (error) {
+			logWriteError(key, error);
+		}
+	};
+	const setItemAsync = (name: string, value: string): Promise<void> => {
+		const key = normalizeCookieName(name);
+		return writeQueue.enqueue(key, async () => {
 			try {
 				const currentBaseValue =
-					value.length > STORAGE_VALUE_LIMIT ? storage.getItem(key) : null;
-				for (const [writeKey, writeValue] of getStorageWrites(
-					key,
-					value,
-					currentBaseValue,
-				)) {
-					storage.setItem(writeKey, writeValue);
-				}
+					value.length > STORAGE_VALUE_LIMIT
+						? await storage.getItemAsync(key)
+						: null;
+				await writeItemAsync(key, value, currentBaseValue);
 			} catch (error) {
-				console.error(
-					`[better-auth/expo] failed to persist "${key}" to storage`,
-					error,
-				);
+				logWriteError(key, error);
 			}
-		},
-		setItemAsync: (name: string, value: string): Promise<void> => {
-			const key = normalizeCookieName(name);
-			return enqueueWrite(key, async () => {
-				try {
-					const currentBaseValue =
-						value.length > STORAGE_VALUE_LIMIT
-							? await storage.getItemAsync(key)
-							: null;
-					for (const [writeKey, writeValue] of getStorageWrites(
-						key,
-						value,
-						currentBaseValue,
-					)) {
-						await storage.setItemAsync(writeKey, writeValue);
-					}
-				} catch (error) {
-					console.error(
-						`[better-auth/expo] failed to persist "${key}" to storage`,
-						error,
-					);
-				}
-			});
-		},
+		});
+	};
+	const updateItemAsync = (
+		name: string,
+		update: (currentValue: string | null) => string,
+	): Promise<StoredUpdate | null> => {
+		const key = normalizeCookieName(name);
+		return writeQueue.enqueue(key, async () => {
+			try {
+				const currentBaseValue = await storage.getItemAsync(key);
+				const previousValue = await readStoredValueAsync(
+					storage,
+					key,
+					currentBaseValue,
+				);
+				const value = update(previousValue);
+				await writeItemAsync(key, value, currentBaseValue);
+				return { previousValue, value };
+			} catch (error) {
+				logWriteError(key, error);
+				return null;
+			}
+		});
+	};
+
+	return { getItem, getItemAsync, setItem, setItemAsync, updateItemAsync };
+}
+
+/**
+ * Wraps Expo storage with chunking, recoverable writes, and serialized async
+ * updates.
+ */
+export function storageAdapter(storage: ExpoClientStorage): ExpoStorageAdapter {
+	const managedStorage = createManagedStorage(storage);
+	return {
+		getItem: managedStorage.getItem,
+		getItemAsync: managedStorage.getItemAsync,
+		setItem: managedStorage.setItem,
+		setItemAsync: managedStorage.setItemAsync,
 	};
 }
 
@@ -551,7 +643,7 @@ export const expoClient = (opts: ExpoClientOptions) => {
 	const storagePrefix = opts?.storagePrefix || "better-auth";
 	const cookieName = `${storagePrefix}_cookie`;
 	const localCacheName = `${storagePrefix}_session_data`;
-	const storage = storageAdapter(opts.storage);
+	const storage = createManagedStorage(opts.storage);
 	const isWeb = Platform.OS === "web";
 	const cookiePrefix = opts?.cookiePrefix || "better-auth";
 	let sessionCacheHydration: Promise<void> | undefined;
@@ -652,19 +744,18 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							// Only process and notify if the Set-Cookie header contains better-auth cookies
 							// This prevents infinite refetching when other cookies (like Cloudflare's __cf_bm) are present
 							if (hasBetterAuthCookies(setCookie, cookiePrefix)) {
-								const prevCookie = await storage.getItemAsync(cookieName);
-								const toSetCookie = getSetCookie(
-									setCookie || "",
-									prevCookie ?? undefined,
+								const update = await storage.updateItemAsync(
+									cookieName,
+									(currentValue) =>
+										getSetCookie(setCookie, currentValue ?? undefined),
 								);
 								// Only notify $sessionSignal if the session cookie values actually changed
 								// This prevents infinite refetching when the server sends the same cookie with updated expiry
-								if (hasSessionCookieChanged(prevCookie, toSetCookie)) {
-									await storage.setItemAsync(cookieName, toSetCookie);
+								if (
+									update &&
+									hasSessionCookieChanged(update.previousValue, update.value)
+								) {
 									store?.notify("$sessionSignal");
-								} else {
-									// Still update the storage to refresh expiry times, but don't trigger refetch
-									await storage.setItemAsync(cookieName, toSetCookie);
 								}
 							}
 						}
@@ -732,10 +823,14 @@ export const expoClient = (opts: ExpoClientOptions) => {
 							const url = new URL(result.url);
 							const cookie = url.searchParams.get("cookie");
 							if (!cookie) return;
-							const prevCookie = await storage.getItemAsync(cookieName);
-							const toSetCookie = getSetCookie(cookie, prevCookie ?? undefined);
-							await storage.setItemAsync(cookieName, toSetCookie);
-							store?.notify("$sessionSignal");
+							const update = await storage.updateItemAsync(
+								cookieName,
+								(currentValue) =>
+									getSetCookie(cookie, currentValue ?? undefined),
+							);
+							if (update) {
+								store?.notify("$sessionSignal");
+							}
 						}
 					},
 				},

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -274,36 +274,176 @@ export function normalizeCookieName(name: string) {
 const STORAGE_VALUE_LIMIT = 1800;
 
 /**
- * Marks a base key whose value is split across `<key>.0..N` chunks. The leading
- * control char can't start a JSON value (so it never collides) and, unlike NUL,
- * survives the native storage bridge without C-string truncation.
+ * Marks a base key whose value is split across multiple storage keys. Legacy
+ * markers contain only the chunk count. Current markers also identify the
+ * active slot and retain the previous slot's chunk count for recovery.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/11082
  */
 const CHUNK_MARKER = "\u0001ba-chunks:";
 
-function getStorageWrites(key: string, value: string): [string, string][] {
+type ChunkSlot = 0 | 1;
+
+interface ChunkMarker {
+	count: number;
+	slot: ChunkSlot | null;
+	fallbackCount: number | null;
+}
+
+function parseChunkCount(value: string | undefined): number | null {
+	if (value === undefined) {
+		return null;
+	}
+	const count = Number(value);
+	return Number.isInteger(count) && count > 0 ? count : null;
+}
+
+function parseChunkMarker(baseValue: string): ChunkMarker | null {
+	const parts = baseValue.slice(CHUNK_MARKER.length).split(":");
+	if (parts.length > 3) {
+		return null;
+	}
+	const [countValue, slotValue, fallbackCountValue] = parts;
+	const count = parseChunkCount(countValue);
+	if (count === null) {
+		return null;
+	}
+	if (slotValue === undefined) {
+		return fallbackCountValue === undefined
+			? { count, slot: null, fallbackCount: null }
+			: null;
+	}
+	if (slotValue !== "0" && slotValue !== "1") {
+		return null;
+	}
+	const fallbackCount = parseChunkCount(fallbackCountValue);
+	if (fallbackCountValue !== undefined && fallbackCount === null) {
+		return null;
+	}
+	return {
+		count,
+		slot: slotValue === "0" ? 0 : 1,
+		fallbackCount,
+	};
+}
+
+function getChunkKey(key: string, marker: ChunkMarker, index: number) {
+	return marker.slot === null
+		? `${key}.${index}`
+		: `${key}.${marker.slot}.${index}`;
+}
+
+function getOtherSlot(slot: ChunkSlot): ChunkSlot {
+	return slot === 0 ? 1 : 0;
+}
+
+function serializeChunkMarker(marker: ChunkMarker) {
+	if (marker.slot === null) {
+		return `${CHUNK_MARKER}${marker.count}`;
+	}
+	const fallback =
+		marker.fallbackCount === null ? "" : `:${marker.fallbackCount}`;
+	return `${CHUNK_MARKER}${marker.count}:${marker.slot}${fallback}`;
+}
+
+function readChunks(
+	storage: Pick<ExpoClientStorage, "getItem">,
+	key: string,
+	marker: ChunkMarker,
+): string | null {
+	let value = "";
+	for (let i = 0; i < marker.count; i++) {
+		const chunk = storage.getItem(getChunkKey(key, marker, i));
+		if (chunk == null) {
+			return null;
+		}
+		value += chunk;
+	}
+	return value;
+}
+
+async function readChunksAsync(
+	storage: Pick<ExpoClientStorage, "getItemAsync">,
+	key: string,
+	marker: ChunkMarker,
+): Promise<string | null> {
+	let value = "";
+	for (let i = 0; i < marker.count; i++) {
+		const chunk = await storage.getItemAsync(getChunkKey(key, marker, i));
+		if (chunk == null) {
+			return null;
+		}
+		value += chunk;
+	}
+	return value;
+}
+
+function getStorageWrites(
+	key: string,
+	value: string,
+	currentBaseValue: string | null,
+): [string, string][] {
 	if (value.length <= STORAGE_VALUE_LIMIT) {
 		return [[key, value]];
 	}
 
 	const count = Math.ceil(value.length / STORAGE_VALUE_LIMIT);
-	const writes: [string, string][] = [[key, ""]];
+	const currentMarker = currentBaseValue?.startsWith(CHUNK_MARKER)
+		? parseChunkMarker(currentBaseValue)
+		: null;
+	const slot: ChunkSlot = currentMarker?.slot === 0 ? 1 : 0;
+	const marker: ChunkMarker = {
+		count,
+		slot,
+		fallbackCount: currentMarker?.slot == null ? null : currentMarker.count,
+	};
+	const writes: [string, string][] = [];
+	if (currentMarker?.slot != null && currentMarker.fallbackCount !== null) {
+		// The fallback slot becomes the next write target.
+		// Stop readers from using it until the new value is complete.
+		writes.push([
+			key,
+			serializeChunkMarker({ ...currentMarker, fallbackCount: null }),
+		]);
+	}
 	for (let i = 0; i < count; i++) {
 		const start = i * STORAGE_VALUE_LIMIT;
 		writes.push([
-			`${key}.${i}`,
+			getChunkKey(key, marker, i),
 			value.slice(start, start + STORAGE_VALUE_LIMIT),
 		]);
 	}
-	writes.push([key, `${CHUNK_MARKER}${count}`]);
+	writes.push([key, serializeChunkMarker(marker)]);
 	return writes;
 }
 
+function createKeyedWriteQueue() {
+	const tails = new Map<string, Promise<unknown>>();
+	return <Result>(
+		key: string,
+		operation: () => Promise<Result>,
+	): Promise<Result> => {
+		const previous = tails.get(key) ?? Promise.resolve();
+		const queued = previous.then(operation, operation);
+		tails.set(key, queued);
+
+		const cleanup = () => {
+			if (tails.get(key) === queued) {
+				tails.delete(key);
+			}
+		};
+		void queued.then(cleanup, cleanup);
+		return queued;
+	};
+}
+
 export function storageAdapter(storage: ExpoClientStorage) {
+	const enqueueWrite = createKeyedWriteQueue();
 	return {
 		/**
 		 * Reads a value, reassembling it if it was split across chunk keys. A value
-		 * that fit is returned as-is (values written before chunking still read
-		 * back); a missing chunk returns `null` so a torn write fails closed.
+		 * that fit is returned as-is. If the active slot is incomplete, the previous
+		 * slot is used as a fallback.
 		 */
 		getItem: (name: string): string | null => {
 			const key = normalizeCookieName(name);
@@ -311,19 +451,23 @@ export function storageAdapter(storage: ExpoClientStorage) {
 			if (stored == null || !stored.startsWith(CHUNK_MARKER)) {
 				return stored;
 			}
-			const count = Number(stored.slice(CHUNK_MARKER.length));
-			if (!Number.isInteger(count) || count < 1) {
+			const marker = parseChunkMarker(stored);
+			if (!marker) {
 				return null;
 			}
-			let value = "";
-			for (let i = 0; i < count; i++) {
-				const chunk = storage.getItem(`${key}.${i}`);
-				if (chunk == null) {
-					return null;
-				}
-				value += chunk;
+			const value = readChunks(storage, key, marker);
+			if (
+				value !== null ||
+				marker.slot === null ||
+				marker.fallbackCount === null
+			) {
+				return value;
 			}
-			return value;
+			return readChunks(storage, key, {
+				count: marker.fallbackCount,
+				slot: getOtherSlot(marker.slot),
+				fallbackCount: null,
+			});
 		},
 		getItemAsync: async (name: string): Promise<string | null> => {
 			const key = normalizeCookieName(name);
@@ -331,32 +475,42 @@ export function storageAdapter(storage: ExpoClientStorage) {
 			if (stored == null || !stored.startsWith(CHUNK_MARKER)) {
 				return stored;
 			}
-			const count = Number(stored.slice(CHUNK_MARKER.length));
-			if (!Number.isInteger(count) || count < 1) {
+			const marker = parseChunkMarker(stored);
+			if (!marker) {
 				return null;
 			}
-			let value = "";
-			for (let i = 0; i < count; i++) {
-				const chunk = await storage.getItemAsync(`${key}.${i}`);
-				if (chunk == null) {
-					return null;
-				}
-				value += chunk;
+			const value = await readChunksAsync(storage, key, marker);
+			if (
+				value !== null ||
+				marker.slot === null ||
+				marker.fallbackCount === null
+			) {
+				return value;
 			}
-			return value;
+			return readChunksAsync(storage, key, {
+				count: marker.fallbackCount,
+				slot: getOtherSlot(marker.slot),
+				fallbackCount: null,
+			});
 		},
 		/**
 		 * Stores `value`, splitting it across chunk keys when it exceeds the
-		 * per-write limit. The base key is cleared before the chunks are rewritten
-		 * and set to the marker last, as the commit point, so a write interrupted
-		 * partway through reads as absent rather than a mix of old and new chunks.
+		 * per-write limit. Chunked writes fill the inactive slot before changing the
+		 * base marker, so readers see either the previous value or the new value. A
+		 * fallback is temporarily removed while its slot is being overwritten.
 		 * Failures are logged, not thrown: persistence is best-effort and must not
 		 * break the request.
 		 */
 		setItem: (name: string, value: string): void => {
 			const key = normalizeCookieName(name);
 			try {
-				for (const [writeKey, writeValue] of getStorageWrites(key, value)) {
+				const currentBaseValue =
+					value.length > STORAGE_VALUE_LIMIT ? storage.getItem(key) : null;
+				for (const [writeKey, writeValue] of getStorageWrites(
+					key,
+					value,
+					currentBaseValue,
+				)) {
 					storage.setItem(writeKey, writeValue);
 				}
 			} catch (error) {
@@ -366,18 +520,28 @@ export function storageAdapter(storage: ExpoClientStorage) {
 				);
 			}
 		},
-		setItemAsync: async (name: string, value: string): Promise<void> => {
+		setItemAsync: (name: string, value: string): Promise<void> => {
 			const key = normalizeCookieName(name);
-			try {
-				for (const [writeKey, writeValue] of getStorageWrites(key, value)) {
-					await storage.setItemAsync(writeKey, writeValue);
+			return enqueueWrite(key, async () => {
+				try {
+					const currentBaseValue =
+						value.length > STORAGE_VALUE_LIMIT
+							? await storage.getItemAsync(key)
+							: null;
+					for (const [writeKey, writeValue] of getStorageWrites(
+						key,
+						value,
+						currentBaseValue,
+					)) {
+						await storage.setItemAsync(writeKey, writeValue);
+					}
+				} catch (error) {
+					console.error(
+						`[better-auth/expo] failed to persist "${key}" to storage`,
+						error,
+					);
 				}
-			} catch (error) {
-				console.error(
-					`[better-auth/expo] failed to persist "${key}" to storage`,
-					error,
-				);
-			}
+			});
 		},
 	};
 }

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -497,20 +497,7 @@ function createKeyedWriteQueue() {
 	};
 }
 
-const storageWriteQueues = new WeakMap<
-	ExpoClientStorage,
-	ReturnType<typeof createKeyedWriteQueue>
->();
-
-function getStorageWriteQueue(storage: ExpoClientStorage) {
-	const existing = storageWriteQueues.get(storage);
-	if (existing) {
-		return existing;
-	}
-	const queue = createKeyedWriteQueue();
-	storageWriteQueues.set(storage, queue);
-	return queue;
-}
+const storageWriteQueue = createKeyedWriteQueue();
 
 interface ExpoStorageAdapter {
 	getItem(name: string): string | null;
@@ -525,7 +512,6 @@ interface StoredUpdate {
 }
 
 function createManagedStorage(storage: ExpoClientStorage) {
-	const writeQueue = getStorageWriteQueue(storage);
 	const logWriteError = (key: string, error: unknown) => {
 		console.error(
 			`[better-auth/expo] failed to persist "${key}" to storage`,
@@ -569,7 +555,7 @@ function createManagedStorage(storage: ExpoClientStorage) {
 	};
 	const setItem = (name: string, value: string): void => {
 		const key = normalizeCookieName(name);
-		if (writeQueue.pending(key)) {
+		if (storageWriteQueue.pending(key)) {
 			logWriteError(
 				key,
 				new Error("Cannot write synchronously while an async write is pending"),
@@ -586,7 +572,7 @@ function createManagedStorage(storage: ExpoClientStorage) {
 	};
 	const setItemAsync = (name: string, value: string): Promise<void> => {
 		const key = normalizeCookieName(name);
-		return writeQueue.enqueue(key, async () => {
+		return storageWriteQueue.enqueue(key, async () => {
 			try {
 				const currentBaseValue =
 					value.length > STORAGE_VALUE_LIMIT
@@ -603,7 +589,7 @@ function createManagedStorage(storage: ExpoClientStorage) {
 		update: (currentValue: string | null) => string,
 	): Promise<StoredUpdate | null> => {
 		const key = normalizeCookieName(name);
-		return writeQueue.enqueue(key, async () => {
+		return storageWriteQueue.enqueue(key, async () => {
 			try {
 				const currentBaseValue = await storage.getItemAsync(key);
 				const previousValue = await readStoredValueAsync(

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -25,6 +25,8 @@ if (Platform.OS !== "web") {
 
 /**
  * Storage used by the Expo client for cookies and cached session data.
+ * Write coordination is scoped to the provided object, so reuse it across
+ * clients that access the same stored data.
  */
 export type ExpoClientStorage = Pick<
 	typeof SecureStore,
@@ -497,7 +499,20 @@ function createKeyedWriteQueue() {
 	};
 }
 
-const storageWriteQueue = createKeyedWriteQueue();
+const storageWriteQueues = new WeakMap<
+	ExpoClientStorage,
+	ReturnType<typeof createKeyedWriteQueue>
+>();
+
+function getStorageWriteQueue(storage: ExpoClientStorage) {
+	const existing = storageWriteQueues.get(storage);
+	if (existing) {
+		return existing;
+	}
+	const queue = createKeyedWriteQueue();
+	storageWriteQueues.set(storage, queue);
+	return queue;
+}
 
 interface ExpoStorageAdapter {
 	getItem(name: string): string | null;
@@ -512,6 +527,7 @@ interface StoredUpdate {
 }
 
 function createManagedStorage(storage: ExpoClientStorage) {
+	const writeQueue = getStorageWriteQueue(storage);
 	const logWriteError = (key: string, error: unknown) => {
 		console.error(
 			`[better-auth/expo] failed to persist "${key}" to storage`,
@@ -555,7 +571,7 @@ function createManagedStorage(storage: ExpoClientStorage) {
 	};
 	const setItem = (name: string, value: string): void => {
 		const key = normalizeCookieName(name);
-		if (storageWriteQueue.pending(key)) {
+		if (writeQueue.pending(key)) {
 			logWriteError(
 				key,
 				new Error("Cannot write synchronously while an async write is pending"),
@@ -572,7 +588,7 @@ function createManagedStorage(storage: ExpoClientStorage) {
 	};
 	const setItemAsync = (name: string, value: string): Promise<void> => {
 		const key = normalizeCookieName(name);
-		return storageWriteQueue.enqueue(key, async () => {
+		return writeQueue.enqueue(key, async () => {
 			try {
 				const currentBaseValue =
 					value.length > STORAGE_VALUE_LIMIT
@@ -589,7 +605,7 @@ function createManagedStorage(storage: ExpoClientStorage) {
 		update: (currentValue: string | null) => string,
 	): Promise<StoredUpdate | null> => {
 		const key = normalizeCookieName(name);
-		return storageWriteQueue.enqueue(key, async () => {
+		return writeQueue.enqueue(key, async () => {
 			try {
 				const currentBaseValue = await storage.getItemAsync(key);
 				const previousValue = await readStoredValueAsync(

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -1018,8 +1018,12 @@ describe("expo with cookieCache", async () => {
 		);
 	});
 
-	it("should fail closed when a chunk is missing", () => {
-		const map = new Map<string, string>();
+	it("should read values written with the legacy chunk marker", async () => {
+		const map = new Map<string, string>([
+			["better-auth_cookie", "\u0001ba-chunks:2"],
+			["better-auth_cookie.0", "legacy-"],
+			["better-auth_cookie.1", "value"],
+		]);
 		const storage = storageAdapter({
 			getItem: (name) => map.get(name) ?? null,
 			setItem: (name, value) => map.set(name, value),
@@ -1029,49 +1033,207 @@ describe("expo with cookieCache", async () => {
 			},
 		});
 
-		storage.setItem("better-auth_cookie", "y".repeat(5_000));
-		// Simulate a torn write: drop one data chunk.
-		map.delete("better-auth_cookie.1");
-
-		expect(storage.getItem("better-auth_cookie")).toBeNull();
+		expect(storage.getItem("better-auth_cookie")).toBe("legacy-value");
+		await expect(storage.getItemAsync("better-auth_cookie")).resolves.toBe(
+			"legacy-value",
+		);
 	});
 
-	it("should not return mixed old/new data when a chunked overwrite is interrupted", () => {
-		const map = new Map<string, string>();
-		let failAfter = Number.POSITIVE_INFINITY;
-		let writes = 0;
+	it("should fail closed when a chunk is missing", async () => {
+		const map = new Map<string, string>([
+			["better-auth_cookie", "\u0001ba-chunks:2:0"],
+			["better-auth_cookie.0.0", "first chunk"],
+		]);
 		const storage = storageAdapter({
 			getItem: (name) => map.get(name) ?? null,
-			setItem: (name, value) => {
-				if (writes++ >= failAfter) {
-					throw new Error("interrupted");
-				}
-				map.set(name, value);
-			},
+			setItem: (name, value) => map.set(name, value),
 			getItemAsync: async (name) => map.get(name) ?? null,
 			setItemAsync: async (name, value) => {
-				if (writes++ >= failAfter) {
-					throw new Error("interrupted");
-				}
 				map.set(name, value);
 			},
 		});
+		expect(storage.getItem("better-auth_cookie")).toBeNull();
+		await expect(
+			storage.getItemAsync("better-auth_cookie"),
+		).resolves.toBeNull();
+	});
 
-		const oldValue = "a".repeat(5_000);
-		storage.setItem("better-auth_cookie", oldValue);
-		expect(storage.getItem("better-auth_cookie")).toBe(oldValue);
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11082
+	 */
+	describe("chunked storage consistency", () => {
+		function createAsyncStorage() {
+			const map = new Map<string, string>();
+			const nextTask = () =>
+				new Promise<void>((resolve) => queueMicrotask(resolve));
+			return storageAdapter({
+				getItem: (name) => map.get(name) ?? null,
+				setItem: (name, value) => map.set(name, value),
+				getItemAsync: async (name) => {
+					await nextTask();
+					return map.get(name) ?? null;
+				},
+				setItemAsync: async (name, value) => {
+					await nextTask();
+					map.set(name, value);
+				},
+			});
+		}
 
-		// Overwrite with another large value, failing after the marker clear and
-		// the first chunk so the remaining chunks keep their old data.
-		const error = vi.spyOn(console, "error").mockImplementation(() => {});
-		writes = 0;
-		failAfter = 2;
-		storage.setItem("better-auth_cookie", "b".repeat(5_000));
-		error.mockRestore();
+		it("should preserve the previous value when a sync overwrite fails", () => {
+			const map = new Map<string, string>();
+			let failAfter = Number.POSITIVE_INFINITY;
+			let writes = 0;
+			const storage = storageAdapter({
+				getItem: (name) => map.get(name) ?? null,
+				setItem: (name, value) => {
+					if (writes++ >= failAfter) {
+						throw new Error("interrupted");
+					}
+					map.set(name, value);
+				},
+				getItemAsync: async (name) => map.get(name) ?? null,
+				setItemAsync: async (name, value) => {
+					if (writes++ >= failAfter) {
+						throw new Error("interrupted");
+					}
+					map.set(name, value);
+				},
+			});
 
-		// The reassembled value must never splice old "a" chunks into the new write.
-		const result = storage.getItem("better-auth_cookie");
-		expect(result ?? "").not.toContain("a");
+			storage.setItem("better-auth_cookie", "a".repeat(3_000));
+			const previousValue = "b".repeat(5_000);
+			storage.setItem("better-auth_cookie", previousValue);
+			expect(storage.getItem("better-auth_cookie")).toBe(previousValue);
+
+			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+			writes = 0;
+			failAfter = 2;
+			storage.setItem("better-auth_cookie", "c".repeat(5_000));
+
+			expect(error).toHaveBeenCalledTimes(1);
+			expect(storage.getItem("better-auth_cookie")).toBe(previousValue);
+		});
+
+		it.for([
+			{ failedWrite: 1 },
+			{ failedWrite: 2 },
+			{ failedWrite: 3 },
+			{ failedWrite: 4 },
+			{ failedWrite: 5 },
+		])("should preserve the previous value when async write $failedWrite fails", async ({
+			failedWrite,
+		}) => {
+			const map = new Map<string, string>();
+			let writeIndex = 0;
+			let failing = false;
+			const storage = storageAdapter({
+				getItem: (name) => map.get(name) ?? null,
+				setItem: (name, value) => map.set(name, value),
+				getItemAsync: async (name) => map.get(name) ?? null,
+				setItemAsync: async (name, value) => {
+					if (failing && ++writeIndex === failedWrite) {
+						throw new Error("interrupted");
+					}
+					map.set(name, value);
+				},
+			});
+			await storage.setItemAsync("better-auth_cookie", "a".repeat(3_000));
+			const previousValue = "b".repeat(5_000);
+			await storage.setItemAsync("better-auth_cookie", previousValue);
+			writeIndex = 0;
+			failing = true;
+			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			await storage.setItemAsync("better-auth_cookie", "c".repeat(5_000));
+
+			expect(error).toHaveBeenCalledTimes(1);
+			await expect(storage.getItemAsync("better-auth_cookie")).resolves.toBe(
+				previousValue,
+			);
+		});
+
+		it("should disable fallback while its slot is being overwritten", async () => {
+			const map = new Map<string, string>();
+			let writeIndex = 0;
+			let failing = false;
+			const storage = storageAdapter({
+				getItem: (name) => map.get(name) ?? null,
+				setItem: (name, value) => map.set(name, value),
+				getItemAsync: async (name) => map.get(name) ?? null,
+				setItemAsync: async (name, value) => {
+					if (failing && ++writeIndex === 3) {
+						throw new Error("interrupted");
+					}
+					map.set(name, value);
+				},
+			});
+			await storage.setItemAsync("better-auth_cookie", "a".repeat(3_000));
+			await storage.setItemAsync("better-auth_cookie", "b".repeat(5_000));
+			writeIndex = 0;
+			failing = true;
+			vi.spyOn(console, "error").mockImplementation(() => {});
+
+			await storage.setItemAsync("better-auth_cookie", "c".repeat(5_000));
+			map.delete("better-auth_cookie.1.1");
+
+			expect(storage.getItem("better-auth_cookie")).toBeNull();
+			await expect(
+				storage.getItemAsync("better-auth_cookie"),
+			).resolves.toBeNull();
+		});
+
+		it("should fall back when the active slot is incomplete", async () => {
+			const map = new Map<string, string>();
+			const storage = storageAdapter({
+				getItem: (name) => map.get(name) ?? null,
+				setItem: (name, value) => map.set(name, value),
+				getItemAsync: async (name) => map.get(name) ?? null,
+				setItemAsync: async (name, value) => {
+					map.set(name, value);
+				},
+			});
+			const previousValue = "a".repeat(3_000);
+			await storage.setItemAsync("better-auth_cookie", previousValue);
+			await storage.setItemAsync("better-auth_cookie", "b".repeat(5_000));
+			map.delete("better-auth_cookie.1.1");
+
+			expect(storage.getItem("better-auth_cookie")).toBe(previousValue);
+			await expect(storage.getItemAsync("better-auth_cookie")).resolves.toBe(
+				previousValue,
+			);
+		});
+
+		it("should read the previous value during a chunked overwrite", async () => {
+			const storage = createAsyncStorage();
+			await storage.setItemAsync("better-auth_cookie", "a".repeat(3_000));
+			const previousValue = "b".repeat(5_000);
+			await storage.setItemAsync("better-auth_cookie", previousValue);
+			const newValue = "c".repeat(5_000);
+
+			const write = storage.setItemAsync("better-auth_cookie", newValue);
+			const read = storage.getItemAsync("better-auth_cookie");
+			const [stored] = await Promise.all([read, write]);
+
+			expect(stored).toBe(previousValue);
+		});
+
+		it("should serialize concurrent chunked overwrites", async () => {
+			const storage = createAsyncStorage();
+			const firstValue = "a".repeat(5_000);
+			const secondValue = "b".repeat(5_000);
+			const thirdValue = "c".repeat(5_000);
+
+			await Promise.all([
+				storage.setItemAsync("better-auth_cookie", firstValue),
+				storage.setItemAsync("better-auth_cookie", secondValue),
+				storage.setItemAsync("better-auth_cookie", thirdValue),
+			]);
+
+			await expect(storage.getItemAsync("better-auth_cookie")).resolves.toBe(
+				thirdValue,
+			);
+		});
 	});
 
 	it("should shrink from chunked to a single value without bleeding stale chunks", () => {

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -1249,11 +1249,11 @@ describe("expo with cookieCache", async () => {
 			);
 		});
 
-		it("should serialize writes across wrappers sharing storage", async () => {
+		it("should serialize writes across adapters sharing storage", async () => {
 			const map = new Map<string, string>();
 			let activeWrites = 0;
 			let peakWrites = 0;
-			const createStorage = () => ({
+			const backingStorage = {
 				getItem: (name: string) => map.get(name) ?? null,
 				setItem: (name: string, value: string) => map.set(name, value),
 				getItemAsync: async (name: string) => map.get(name) ?? null,
@@ -1264,9 +1264,9 @@ describe("expo with cookieCache", async () => {
 					map.set(name, value);
 					activeWrites--;
 				},
-			});
-			const first = storageAdapter(createStorage());
-			const second = storageAdapter(createStorage());
+			};
+			const first = storageAdapter(backingStorage);
+			const second = storageAdapter(backingStorage);
 
 			await Promise.all([
 				first.setItemAsync("better-auth_cookie", "a".repeat(5_000)),
@@ -1284,9 +1284,41 @@ describe("expo with cookieCache", async () => {
 			expect(peakWrites).toBe(2);
 		});
 
+		it("should not coordinate independent storage backends", async () => {
+			const firstMap = new Map<string, string>();
+			const secondMap = new Map<string, string>();
+			const first = storageAdapter({
+				getItem: (name) => firstMap.get(name) ?? null,
+				setItem: (name, value) => firstMap.set(name, value),
+				getItemAsync: async (name) => firstMap.get(name) ?? null,
+				setItemAsync: async (name, value) => {
+					await new Promise<void>((resolve) => queueMicrotask(resolve));
+					firstMap.set(name, value);
+				},
+			});
+			const second = storageAdapter({
+				getItem: (name) => secondMap.get(name) ?? null,
+				setItem: (name, value) => secondMap.set(name, value),
+				getItemAsync: async (name) => secondMap.get(name) ?? null,
+				setItemAsync: async (name, value) => {
+					secondMap.set(name, value);
+				},
+			});
+			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			const write = first.setItemAsync("better-auth_cookie", "a".repeat(5_000));
+			second.setItem("better-auth_cookie", "independent");
+			await write;
+			const errorCalls = error.mock.calls.length;
+			error.mockRestore();
+
+			expect(errorCalls).toBe(0);
+			expect(second.getItem("better-auth_cookie")).toBe("independent");
+		});
+
 		it("should not mix a sync write into a pending async write", async () => {
 			const map = new Map<string, string>();
-			const createStorage = () => ({
+			const backingStorage = {
 				getItem: (name: string) => map.get(name) ?? null,
 				setItem: (name: string, value: string) => map.set(name, value),
 				getItemAsync: async (name: string) => map.get(name) ?? null,
@@ -1294,9 +1326,9 @@ describe("expo with cookieCache", async () => {
 					await new Promise<void>((resolve) => queueMicrotask(resolve));
 					map.set(name, value);
 				},
-			});
-			const asyncStorage = storageAdapter(createStorage());
-			const syncStorage = storageAdapter(createStorage());
+			};
+			const asyncStorage = storageAdapter(backingStorage);
+			const syncStorage = storageAdapter(backingStorage);
 			const asyncValue = "a".repeat(5_000);
 			const error = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -1312,7 +1344,7 @@ describe("expo with cookieCache", async () => {
 
 		it("should update a value without losing concurrent changes", async () => {
 			const map = new Map<string, string>();
-			const createStorage = () => ({
+			const backingStorage = {
 				getItem: (name: string) => map.get(name) ?? null,
 				setItem: (name: string, value: string) => map.set(name, value),
 				getItemAsync: async (name: string) => map.get(name) ?? null,
@@ -1320,18 +1352,17 @@ describe("expo with cookieCache", async () => {
 					await new Promise<void>((resolve) => queueMicrotask(resolve));
 					map.set(name, value);
 				},
-			});
-			const first = expoClient({ scheme: "test", storage: createStorage() });
-			const second = expoClient({ scheme: "test", storage: createStorage() });
+			};
+			const first = expoClient({ scheme: "test", storage: backingStorage });
+			const second = expoClient({ scheme: "test", storage: backingStorage });
 
 			await Promise.all([
 				applyCookieResponse(first, "better-auth.first=value; Path=/"),
 				applyCookieResponse(second, "better-auth.second=value; Path=/"),
 			]);
 
-			const stored = await storageAdapter(createStorage()).getItemAsync(
-				"better-auth_cookie",
-			);
+			const stored =
+				await storageAdapter(backingStorage).getItemAsync("better-auth_cookie");
 			expect(JSON.parse(stored ?? "{}")).toMatchObject({
 				"better-auth.first": { value: "value" },
 				"better-auth.second": { value: "value" },

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -1249,11 +1249,11 @@ describe("expo with cookieCache", async () => {
 			);
 		});
 
-		it("should serialize writes across adapters sharing storage", async () => {
+		it("should serialize writes across wrappers sharing storage", async () => {
 			const map = new Map<string, string>();
 			let activeWrites = 0;
 			let peakWrites = 0;
-			const backingStorage = {
+			const createStorage = () => ({
 				getItem: (name: string) => map.get(name) ?? null,
 				setItem: (name: string, value: string) => map.set(name, value),
 				getItemAsync: async (name: string) => map.get(name) ?? null,
@@ -1264,9 +1264,9 @@ describe("expo with cookieCache", async () => {
 					map.set(name, value);
 					activeWrites--;
 				},
-			};
-			const first = storageAdapter(backingStorage);
-			const second = storageAdapter(backingStorage);
+			});
+			const first = storageAdapter(createStorage());
+			const second = storageAdapter(createStorage());
 
 			await Promise.all([
 				first.setItemAsync("better-auth_cookie", "a".repeat(5_000)),
@@ -1286,7 +1286,7 @@ describe("expo with cookieCache", async () => {
 
 		it("should not mix a sync write into a pending async write", async () => {
 			const map = new Map<string, string>();
-			const backingStorage = {
+			const createStorage = () => ({
 				getItem: (name: string) => map.get(name) ?? null,
 				setItem: (name: string, value: string) => map.set(name, value),
 				getItemAsync: async (name: string) => map.get(name) ?? null,
@@ -1294,9 +1294,9 @@ describe("expo with cookieCache", async () => {
 					await new Promise<void>((resolve) => queueMicrotask(resolve));
 					map.set(name, value);
 				},
-			};
-			const asyncStorage = storageAdapter(backingStorage);
-			const syncStorage = storageAdapter(backingStorage);
+			});
+			const asyncStorage = storageAdapter(createStorage());
+			const syncStorage = storageAdapter(createStorage());
 			const asyncValue = "a".repeat(5_000);
 			const error = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -1312,7 +1312,7 @@ describe("expo with cookieCache", async () => {
 
 		it("should update a value without losing concurrent changes", async () => {
 			const map = new Map<string, string>();
-			const backingStorage = {
+			const createStorage = () => ({
 				getItem: (name: string) => map.get(name) ?? null,
 				setItem: (name: string, value: string) => map.set(name, value),
 				getItemAsync: async (name: string) => map.get(name) ?? null,
@@ -1320,17 +1320,18 @@ describe("expo with cookieCache", async () => {
 					await new Promise<void>((resolve) => queueMicrotask(resolve));
 					map.set(name, value);
 				},
-			};
-			const first = expoClient({ scheme: "test", storage: backingStorage });
-			const second = expoClient({ scheme: "test", storage: backingStorage });
+			});
+			const first = expoClient({ scheme: "test", storage: createStorage() });
+			const second = expoClient({ scheme: "test", storage: createStorage() });
 
 			await Promise.all([
 				applyCookieResponse(first, "better-auth.first=value; Path=/"),
 				applyCookieResponse(second, "better-auth.second=value; Path=/"),
 			]);
 
-			const stored =
-				await storageAdapter(backingStorage).getItemAsync("better-auth_cookie");
+			const stored = await storageAdapter(createStorage()).getItemAsync(
+				"better-auth_cookie",
+			);
 			expect(JSON.parse(stored ?? "{}")).toMatchObject({
 				"better-auth.first": { value: "value" },
 				"better-auth.second": { value: "value" },

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -1062,6 +1062,20 @@ describe("expo with cookieCache", async () => {
 	 * @see https://github.com/better-auth/better-auth/issues/11082
 	 */
 	describe("chunked storage consistency", () => {
+		function applyCookieResponse(
+			plugin: ReturnType<typeof expoClient>,
+			setCookie: string,
+		) {
+			const onSuccess = plugin.fetchPlugins[0]?.hooks?.onSuccess;
+			if (!onSuccess) {
+				throw new Error("Expo response hook is unavailable");
+			}
+			return onSuccess({
+				request: { url: "https://example.com/api/auth/test" },
+				response: new Response(null, { headers: { "set-cookie": setCookie } }),
+			} as Parameters<typeof onSuccess>[0]);
+		}
+
 		function createAsyncStorage() {
 			const map = new Map<string, string>();
 			const nextTask = () =>
@@ -1233,6 +1247,167 @@ describe("expo with cookieCache", async () => {
 			await expect(storage.getItemAsync("better-auth_cookie")).resolves.toBe(
 				thirdValue,
 			);
+		});
+
+		it("should serialize writes across adapters sharing storage", async () => {
+			const map = new Map<string, string>();
+			let activeWrites = 0;
+			let peakWrites = 0;
+			const backingStorage = {
+				getItem: (name: string) => map.get(name) ?? null,
+				setItem: (name: string, value: string) => map.set(name, value),
+				getItemAsync: async (name: string) => map.get(name) ?? null,
+				setItemAsync: async (name: string, value: string) => {
+					activeWrites++;
+					peakWrites = Math.max(peakWrites, activeWrites);
+					await new Promise<void>((resolve) => queueMicrotask(resolve));
+					map.set(name, value);
+					activeWrites--;
+				},
+			};
+			const first = storageAdapter(backingStorage);
+			const second = storageAdapter(backingStorage);
+
+			await Promise.all([
+				first.setItemAsync("better-auth_cookie", "a".repeat(5_000)),
+				second.setItemAsync("better-auth_cookie", "b".repeat(5_000)),
+			]);
+
+			expect(peakWrites).toBe(1);
+
+			peakWrites = 0;
+			await Promise.all([
+				first.setItemAsync("first_cookie", "a".repeat(5_000)),
+				second.setItemAsync("second_cookie", "b".repeat(5_000)),
+			]);
+
+			expect(peakWrites).toBe(2);
+		});
+
+		it("should not mix a sync write into a pending async write", async () => {
+			const map = new Map<string, string>();
+			const backingStorage = {
+				getItem: (name: string) => map.get(name) ?? null,
+				setItem: (name: string, value: string) => map.set(name, value),
+				getItemAsync: async (name: string) => map.get(name) ?? null,
+				setItemAsync: async (name: string, value: string) => {
+					await new Promise<void>((resolve) => queueMicrotask(resolve));
+					map.set(name, value);
+				},
+			};
+			const asyncStorage = storageAdapter(backingStorage);
+			const syncStorage = storageAdapter(backingStorage);
+			const asyncValue = "a".repeat(5_000);
+			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			const write = asyncStorage.setItemAsync("better-auth_cookie", asyncValue);
+			syncStorage.setItem("better-auth_cookie", "b".repeat(5_000));
+			await write;
+
+			expect(error).toHaveBeenCalledTimes(1);
+			await expect(
+				asyncStorage.getItemAsync("better-auth_cookie"),
+			).resolves.toBe(asyncValue);
+		});
+
+		it("should update a value without losing concurrent changes", async () => {
+			const map = new Map<string, string>();
+			const backingStorage = {
+				getItem: (name: string) => map.get(name) ?? null,
+				setItem: (name: string, value: string) => map.set(name, value),
+				getItemAsync: async (name: string) => map.get(name) ?? null,
+				setItemAsync: async (name: string, value: string) => {
+					await new Promise<void>((resolve) => queueMicrotask(resolve));
+					map.set(name, value);
+				},
+			};
+			const first = expoClient({ scheme: "test", storage: backingStorage });
+			const second = expoClient({ scheme: "test", storage: backingStorage });
+
+			await Promise.all([
+				applyCookieResponse(first, "better-auth.first=value; Path=/"),
+				applyCookieResponse(second, "better-auth.second=value; Path=/"),
+			]);
+
+			const stored =
+				await storageAdapter(backingStorage).getItemAsync("better-auth_cookie");
+			expect(JSON.parse(stored ?? "{}")).toMatchObject({
+				"better-auth.first": { value: "value" },
+				"better-auth.second": { value: "value" },
+			});
+		});
+
+		it("should keep atomic updates internal to the Expo client", () => {
+			const storage = storageAdapter({
+				getItem: () => null,
+				setItem: () => {},
+				getItemAsync: async () => null,
+				setItemAsync: async () => {},
+			});
+
+			expect(storage).not.toHaveProperty("updateItemAsync");
+		});
+
+		it("should not notify when a cookie update cannot be stored", async () => {
+			const previousValue = JSON.stringify({
+				"better-auth.session_token": { value: "previous", expires: null },
+			});
+			const plugin = expoClient({
+				scheme: "test",
+				storage: {
+					getItem: () => previousValue,
+					setItem: () => {},
+					getItemAsync: async () => previousValue,
+					setItemAsync: async () => {
+						throw new Error("keychain rejected write");
+					},
+				},
+			});
+			const notify = vi.fn();
+			plugin.getActions(undefined, { notify } as unknown as Parameters<
+				typeof plugin.getActions
+			>[1]);
+			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			await applyCookieResponse(
+				plugin,
+				"better-auth.session_token=next; Path=/",
+			);
+
+			expect(error).toHaveBeenCalledTimes(1);
+			expect(notify).not.toHaveBeenCalled();
+		});
+
+		it("should reject excessive chunk counts", async () => {
+			const map = new Map<string, string>([["better-auth_cookie", "previous"]]);
+			const getItem = vi.fn((name: string) => map.get(name) ?? null);
+			const getItemAsync = vi.fn(async (name: string) => map.get(name) ?? null);
+			const storage = storageAdapter({
+				getItem,
+				setItem: (name, value) => map.set(name, value),
+				getItemAsync,
+				setItemAsync: async (name, value) => {
+					map.set(name, value);
+				},
+			});
+			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			await storage.setItemAsync("better-auth_cookie", "x".repeat(180_001));
+
+			expect(error).toHaveBeenCalledTimes(1);
+			await expect(storage.getItemAsync("better-auth_cookie")).resolves.toBe(
+				"previous",
+			);
+
+			map.set("better-auth_cookie", "\u0001ba-chunks:101:0");
+			getItem.mockClear();
+			getItemAsync.mockClear();
+			expect(storage.getItem("better-auth_cookie")).toBeNull();
+			await expect(
+				storage.getItemAsync("better-auth_cookie"),
+			).resolves.toBeNull();
+			expect(getItem).toHaveBeenCalledTimes(1);
+			expect(getItemAsync).toHaveBeenCalledTimes(1);
 		});
 	});
 


### PR DESCRIPTION
- Closes #11082
- Supersedes #11057

Following the concurrency analysis in [#11057](https://github.com/better-auth/better-auth/pull/11057), this PR serializes asynchronous writes per storage key. Reads remain lock-free because clear-first chunk writes are replaced with recoverable copy-on-write storage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the Expo storage adapter that sent unauthenticated requests while chunked cookie updates were in progress (closes #11082). Updates now use copy-on-write and per-key write serialization so reads always see a complete value, and interrupted updates recover the previous cookie value.

- Writes chunked cookies to an inactive slot first, then switches the base marker, instead of clearing the old value up front.
- Async writes are serialized per key across adapters sharing the same storage object; independent storage objects keep separate queues.
- Cookie updates run as atomic read-modify-write operations inside the queue.
- If the active slot is incomplete, reads fall back to the previous slot's chunks.
- Legacy chunk markers (no slot info) still read back correctly.
- Values requiring more than 100 chunks are rejected.

<sup>Written for commit 85e7886e6d8b8b9e3c0d5f5a73ee18fc061c7b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

