### PR TITLE
feat(cli): add Codex MCP target

### DIFF
--- a/.changeset/add-codex-mcp-target.md
+++ b/.changeset/add-codex-mcp-target.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+Add Codex as a supported target for configuring the Better Auth documentation MCP server.

--- a/docs/content/docs/ai-resources/mcp.mdx
+++ b/docs/content/docs/ai-resources/mcp.mdx
@@ -4,7 +4,7 @@ title: MCP
 description: Connect Better Auth documentation to MCP-capable clients via the remote documentation MCP server.
 ---
 
-Better Auth hosts a **remote MCP server** that exposes documentation search, examples, and setup help to any MCP-capable client (Cursor, Claude Code, Open Code, and others).
+Better Auth hosts a **remote MCP server** that exposes documentation search, examples, and setup help to any MCP-capable client (Cursor, Codex, Claude Code, Open Code, and others).
 
 **Endpoint:** `https://mcp.better-auth.com/mcp`
 
@@ -20,7 +20,7 @@ npx auth@latest mcp
 
 With no flags, the command lists supported targets. You can pass a target directly:
 
-<Tabs items={["Cursor", "Claude Code", "Open Code", "Manual"]}>
+<Tabs items={["Cursor", "Codex", "Claude Code", "Open Code", "Manual"]}>
   <Tab value="Cursor">
     ```bash title="terminal"
     npx auth@latest mcp --cursor
@@ -31,6 +31,16 @@ With no flags, the command lists supported targets. You can pass a target direct
     You can also use the one-click control on this site:
 
     <AddToCursor />
+  </Tab>
+
+  <Tab value="Codex">
+    ```bash title="terminal"
+    npx auth@latest mcp --codex
+    ```
+
+    This runs `codex mcp add` with the Better Auth URL. Codex stores the server in its MCP configuration, which is shared by ChatGPT desktop, Codex CLI, and the Codex IDE extension on the same host.
+
+    Run `codex mcp list` to verify the connection. ChatGPT web does not read local Codex configuration; use a ChatGPT plugin for hosted web chats.
   </Tab>
 
   <Tab value="Claude Code">

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -8,6 +8,7 @@ import { Command } from "commander";
 
 interface MCPOptions {
 	cursor?: boolean;
+	codex?: boolean;
 	claudeCode?: boolean;
 	openCode?: boolean;
 	manual?: boolean;
@@ -18,6 +19,8 @@ const REMOTE_MCP_URL = "https://mcp.better-auth.com/mcp";
 async function mcpAction(options: MCPOptions) {
 	if (options.cursor) {
 		await handleCursorAction();
+	} else if (options.codex) {
+		handleCodexAction();
 	} else if (options.claudeCode) {
 		handleClaudeCodeAction();
 	} else if (options.openCode) {
@@ -82,6 +85,32 @@ async function handleCursorAction() {
 			'• Try: "Set up Better Auth with Google login" or "Help me debug my auth"',
 		),
 	);
+}
+
+function handleCodexAction() {
+	console.log(chalk.bold.blue("🤖 Adding Better Auth MCP to Codex..."));
+
+	const command = `codex mcp add better-auth --url ${REMOTE_MCP_URL}`;
+
+	try {
+		execSync(command, { stdio: "inherit" });
+		console.log(chalk.green("\n✓ Codex MCP configured!"));
+	} catch {
+		console.log(
+			chalk.yellow(
+				"\n⚠ Could not automatically add to Codex. Please run this command manually:",
+			),
+		);
+		console.log(chalk.cyan(command));
+	}
+
+	console.log(chalk.bold.white("\n✨ Next Steps:"));
+	console.log(
+		chalk.gray(
+			"• Once configured, ChatGPT desktop, Codex CLI, and the IDE extension share this MCP server",
+		),
+	);
+	console.log(chalk.gray("• Run `codex mcp list` to verify the connection"));
 }
 
 function handleClaudeCodeAction() {
@@ -221,6 +250,7 @@ function showAllOptions() {
 
 	console.log(chalk.bold.white("MCP Clients:"));
 	console.log(chalk.cyan("  --cursor      ") + chalk.gray("Add to Cursor"));
+	console.log(chalk.cyan("  --codex       ") + chalk.gray("Add to Codex"));
 	console.log(
 		chalk.cyan("  --claude-code ") + chalk.gray("Add to Claude Code"),
 	);
@@ -242,6 +272,7 @@ function showAllOptions() {
 export const mcp = new Command("mcp")
 	.description("Add Better Auth MCP server to MCP Clients")
 	.option("--cursor", "Automatically open Cursor with the MCP configuration")
+	.option("--codex", "Add the MCP server to Codex")
 	.option("--claude-code", "Show Claude Code MCP configuration command")
 	.option("--open-code", "Show Open Code MCP configuration")
 	.option("--manual", "Show manual MCP configuration for mcp.json")


### PR DESCRIPTION
The order doesn't mean anything
I just arranged them this way because these pairs look visually nice:

`Cursor` / `Codex`  
`Claude Code` / `Open Code`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Codex as a supported target for configuring the Better Auth documentation MCP server via `npx auth@latest mcp --codex`.

- The command runs `codex mcp add` with the remote MCP URL and prints setup instructions if it fails.
- Docs now list Codex alongside Cursor, Claude Code, and Open Code, noting that Codex config is shared by ChatGPT desktop, Codex CLI, and the IDE extension.

<sup>Written for commit 3c936d98ce5ad1d97124d115f0d0cf4cf04bb0f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

