### PR TITLE
feat(oauth): support custom token request authentication

### DIFF
--- a/.changeset/custom-token-auth.md
+++ b/.changeset/custom-token-auth.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Add a custom token endpoint authentication strategy for providers that require non-standard request parameters.

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -289,7 +289,7 @@ tokenEndpointAuth: {
 },
 ```
 
-`method: "custom"` preserves Better Auth's standard grant parameters, but replaces its built-in client authentication. The hook must add every credential parameter or header required by the provider.
+Better Auth builds the standard grant parameters, while `customizeRequest` adds the client authentication required by the provider.
 
 **scopes**: (Optional) An array of scopes to request from the provider (e.g., `["openid", "email", "profile"]`).
 

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -289,6 +289,8 @@ tokenEndpointAuth: {
 },
 ```
 
+`method: "custom"` preserves Better Auth's standard grant parameters, but replaces its built-in client authentication. The hook must add every credential parameter or header required by the provider.
+
 **scopes**: (Optional) An array of scopes to request from the provider (e.g., `["openid", "email", "profile"]`).
 
 **redirectURI**: (Optional) The redirect URI to use for the OAuth flow. If not set, a default is constructed based on your app's base URL. Must include the `:providerId` placeholder (e.g., `https://example.com/api/auth/callback/my-provider`).

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -277,6 +277,18 @@ Provider configurations with the same `accountIssuer` and subject deduplicate on
 
 **tokenEndpointAuth**: (Optional) Client authentication configuration for token endpoint requests. Use `{ method: "private_key_jwt", getClientAssertion }` for RFC 7523 client assertions, `{ method: "client_secret_basic" }` or `{ method: "client_secret_post" }` for secret-based clients, and `{ method: "none" }` for public clients. Secret-based methods require `clientSecret`; do not combine `clientSecret` with `private_key_jwt` or `none`. If omitted, Better Auth sends secret-based token requests when `clientSecret` is configured and public-client token requests when it is not.
 
+For providers with non-standard token authentication, use `method: "custom"` to update the request after Better Auth sets the standard grant parameters:
+
+```ts
+tokenEndpointAuth: {
+  method: "custom",
+  customizeRequest({ body }) {
+    body.set("client_key", providerClientKey);
+    body.set("client_secret", providerClientSecret);
+  },
+},
+```
+
 **scopes**: (Optional) An array of scopes to request from the provider (e.g., `["openid", "email", "profile"]`).
 
 **redirectURI**: (Optional) The redirect URI to use for the OAuth flow. If not set, a default is constructed based on your app's base URL. Must include the `:providerId` placeholder (e.g., `https://example.com/api/auth/callback/my-provider`).

--- a/packages/core/src/oauth2/index.ts
+++ b/packages/core/src/oauth2/index.ts
@@ -80,6 +80,8 @@ export {
 export type {
 	TokenEndpointAuth,
 	TokenEndpointAuthMethod,
+	TokenEndpointRequestContext,
+	TokenEndpointRequestHook,
 	TokenEndpointSecretAuthentication,
 } from "./token-endpoint-auth";
 export {

--- a/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
+++ b/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
@@ -364,6 +364,30 @@ describe("private_key_jwt OAuth2 helpers", () => {
 		);
 	});
 
+	it("customizes token endpoint request authentication", async () => {
+		const { body } = await authorizationCodeRequest({
+			code: "auth-code",
+			redirectURI: "https://rp.example.com/callback",
+			options: {},
+			tokenEndpoint,
+			tokenEndpointAuth: {
+				method: "custom",
+				customizeRequest({ body }) {
+					body.set("client_key", "provider-client-key");
+					body.set("client_secret", "provider-client-secret");
+				},
+			},
+		});
+
+		expect(Object.fromEntries(body)).toEqual({
+			client_key: "provider-client-key",
+			client_secret: "provider-client-secret",
+			code: "auth-code",
+			grant_type: "authorization_code",
+			redirect_uri: "https://rp.example.com/callback",
+		});
+	});
+
 	it("uses configured clientId over additional token client_id parameters", async () => {
 		const { body } = await authorizationCodeRequest({
 			code: "auth-code",

--- a/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
+++ b/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
@@ -388,6 +388,28 @@ describe("private_key_jwt OAuth2 helpers", () => {
 		});
 	});
 
+	it.each([
+		"client_assertion",
+		"client_assertion_type",
+	] as const)("rejects custom authentication with only %s", async (parameter) => {
+		await expect(
+			authorizationCodeRequest({
+				code: "auth-code",
+				redirectURI: "https://rp.example.com/callback",
+				options: {},
+				tokenEndpoint,
+				tokenEndpointAuth: {
+					method: "custom",
+					customizeRequest({ body }) {
+						body.set(parameter, "value");
+					},
+				},
+			}),
+		).rejects.toThrow(
+			"client_assertion and client_assertion_type must both be provided",
+		);
+	});
+
 	it("uses configured clientId over additional token client_id parameters", async () => {
 		const { body } = await authorizationCodeRequest({
 			code: "auth-code",

--- a/packages/core/src/oauth2/token-endpoint-auth.ts
+++ b/packages/core/src/oauth2/token-endpoint-auth.ts
@@ -17,6 +17,13 @@ export type TokenEndpointAuth =
 			method: "client_secret_post";
 	  }
 	| {
+			method: "custom";
+			/**
+			 * Customize the token request after standard grant parameters are set.
+			 */
+			customizeRequest: TokenEndpointRequestHook;
+	  }
+	| {
 			method: "private_key_jwt";
 			getClientAssertion: ClientAssertionGetter;
 	  };
@@ -24,6 +31,24 @@ export type TokenEndpointAuth =
 export type TokenEndpointAuthMethod = TokenEndpointAuth["method"];
 
 export type TokenEndpointSecretAuthentication = "basic" | "post";
+
+/**
+ * Mutable token request state passed to a custom authentication strategy.
+ */
+export interface TokenEndpointRequestContext {
+	body: URLSearchParams;
+	headers: Record<string, string>;
+	options: TokenEndpointClientOptions;
+	tokenEndpoint: string;
+	grantType: ClientAssertionGrantType;
+}
+
+/**
+ * Applies provider-specific authentication to a token request.
+ */
+export type TokenEndpointRequestHook = (
+	context: TokenEndpointRequestContext,
+) => void | Promise<void>;
 
 export interface TokenEndpointClientOptions {
 	clientId?: string | string[] | undefined;
@@ -171,6 +196,17 @@ export async function applyTokenEndpointAuth({
 
 	const auth =
 		tokenEndpointAuth ?? getDefaultTokenEndpointAuth(options, authentication);
+
+	if (auth.method === "custom") {
+		await auth.customizeRequest({
+			body,
+			headers,
+			options,
+			tokenEndpoint,
+			grantType,
+		});
+		return;
+	}
 
 	if (auth.method === "private_key_jwt") {
 		assertNoClientSecret(auth.method, options, body);

--- a/packages/core/src/oauth2/token-endpoint-auth.ts
+++ b/packages/core/src/oauth2/token-endpoint-auth.ts
@@ -201,6 +201,7 @@ export async function applyTokenEndpointAuth({
 			tokenEndpoint,
 			grantType,
 		});
+		assertCompleteManualClientAssertion(body);
 		return;
 	}
 

--- a/packages/core/src/oauth2/token-endpoint-auth.ts
+++ b/packages/core/src/oauth2/token-endpoint-auth.ts
@@ -17,15 +17,15 @@ export type TokenEndpointAuth =
 			method: "client_secret_post";
 	  }
 	| {
+			method: "private_key_jwt";
+			getClientAssertion: ClientAssertionGetter;
+	  }
+	| {
 			method: "custom";
 			/**
 			 * Customize the token request after standard grant parameters are set.
 			 */
 			customizeRequest: TokenEndpointRequestHook;
-	  }
-	| {
-			method: "private_key_jwt";
-			getClientAssertion: ClientAssertionGetter;
 	  };
 
 export type TokenEndpointAuthMethod = TokenEndpointAuth["method"];

--- a/packages/core/src/oauth2/token-endpoint-auth.ts
+++ b/packages/core/src/oauth2/token-endpoint-auth.ts
@@ -55,12 +55,8 @@ export interface TokenEndpointClientOptions {
 	clientSecret?: string | undefined;
 }
 
-export interface ApplyTokenEndpointAuthInput {
-	body: URLSearchParams;
-	headers: Record<string, string>;
-	options: TokenEndpointClientOptions;
-	tokenEndpoint: string;
-	grantType: ClientAssertionGrantType;
+export interface ApplyTokenEndpointAuthInput
+	extends TokenEndpointRequestContext {
 	tokenEndpointAuth?: TokenEndpointAuth | undefined;
 	authentication?: TokenEndpointSecretAuthentication | undefined;
 }


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `custom` token endpoint authentication method so providers with non-standard token request requirements can alter the request after Better Auth sets standard grant parameters.

- The `custom` method's `customizeRequest` hook gets a mutable context with body, headers, options, tokenEndpoint, and grantType.
- Existing auth methods (`private_key_jwt`, `client_secret_basic`, `client_secret_post`, `none`) are unchanged and remain the default when `custom` is not used.
- Rejects custom requests that set only one of `client_assertion` or `client_assertion_type`.

<sup>Written for commit 9259fcd156924ba25b9dc9c23eb09b6b957aad1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

