### PR TITLE
fix(tiktok): authenticate token requests with client_key

### DIFF
--- a/.changeset/custom-token-auth.md
+++ b/.changeset/custom-token-auth.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Add a custom token endpoint authentication strategy for providers that require non-standard request parameters.

--- a/.changeset/fix-tiktok-token-auth.md
+++ b/.changeset/fix-tiktok-token-auth.md
@@ -1,0 +1,6 @@
+---
+---
+"@better-auth/core": patch
+---
+
+Fix TikTok sign-in and token refresh failing when configured with the documented `clientKey` and `clientSecret` options.

--- a/.changeset/fix-tiktok-token-auth.md
+++ b/.changeset/fix-tiktok-token-auth.md
@@ -1,5 +1,4 @@
 ---
----
 "@better-auth/core": patch
 ---
 

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -289,7 +289,7 @@ tokenEndpointAuth: {
 },
 ```
 
-`method: "custom"` preserves Better Auth's standard grant parameters, but replaces its built-in client authentication. The hook must add every credential parameter or header required by the provider.
+Better Auth builds the standard grant parameters, while `customizeRequest` adds the client authentication required by the provider.
 
 **scopes**: (Optional) An array of scopes to request from the provider (e.g., `["openid", "email", "profile"]`).
 

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -289,6 +289,8 @@ tokenEndpointAuth: {
 },
 ```
 
+`method: "custom"` preserves Better Auth's standard grant parameters, but replaces its built-in client authentication. The hook must add every credential parameter or header required by the provider.
+
 **scopes**: (Optional) An array of scopes to request from the provider (e.g., `["openid", "email", "profile"]`).
 
 **redirectURI**: (Optional) The redirect URI to use for the OAuth flow. If not set, a default is constructed based on your app's base URL. Must include the `:providerId` placeholder (e.g., `https://example.com/api/auth/callback/my-provider`).

--- a/docs/content/docs/plugins/generic-oauth.mdx
+++ b/docs/content/docs/plugins/generic-oauth.mdx
@@ -277,6 +277,18 @@ Provider configurations with the same `accountIssuer` and subject deduplicate on
 
 **tokenEndpointAuth**: (Optional) Client authentication configuration for token endpoint requests. Use `{ method: "private_key_jwt", getClientAssertion }` for RFC 7523 client assertions, `{ method: "client_secret_basic" }` or `{ method: "client_secret_post" }` for secret-based clients, and `{ method: "none" }` for public clients. Secret-based methods require `clientSecret`; do not combine `clientSecret` with `private_key_jwt` or `none`. If omitted, Better Auth sends secret-based token requests when `clientSecret` is configured and public-client token requests when it is not.
 
+For providers with non-standard token authentication, use `method: "custom"` to update the request after Better Auth sets the standard grant parameters:
+
+```ts
+tokenEndpointAuth: {
+  method: "custom",
+  customizeRequest({ body }) {
+    body.set("client_key", providerClientKey);
+    body.set("client_secret", providerClientSecret);
+  },
+},
+```
+
 **scopes**: (Optional) An array of scopes to request from the provider (e.g., `["openid", "email", "profile"]`).
 
 **redirectURI**: (Optional) The redirect URI to use for the OAuth flow. If not set, a default is constructed based on your app's base URL. Must include the `:providerId` placeholder (e.g., `https://example.com/api/auth/callback/my-provider`).

--- a/packages/core/src/oauth2/index.ts
+++ b/packages/core/src/oauth2/index.ts
@@ -80,6 +80,8 @@ export {
 export type {
 	TokenEndpointAuth,
 	TokenEndpointAuthMethod,
+	TokenEndpointRequestContext,
+	TokenEndpointRequestHook,
 	TokenEndpointSecretAuthentication,
 } from "./token-endpoint-auth";
 export {

--- a/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
+++ b/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
@@ -364,6 +364,30 @@ describe("private_key_jwt OAuth2 helpers", () => {
 		);
 	});
 
+	it("customizes token endpoint request authentication", async () => {
+		const { body } = await authorizationCodeRequest({
+			code: "auth-code",
+			redirectURI: "https://rp.example.com/callback",
+			options: {},
+			tokenEndpoint,
+			tokenEndpointAuth: {
+				method: "custom",
+				customizeRequest({ body }) {
+					body.set("client_key", "provider-client-key");
+					body.set("client_secret", "provider-client-secret");
+				},
+			},
+		});
+
+		expect(Object.fromEntries(body)).toEqual({
+			client_key: "provider-client-key",
+			client_secret: "provider-client-secret",
+			code: "auth-code",
+			grant_type: "authorization_code",
+			redirect_uri: "https://rp.example.com/callback",
+		});
+	});
+
 	it("uses configured clientId over additional token client_id parameters", async () => {
 		const { body } = await authorizationCodeRequest({
 			code: "auth-code",

--- a/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
+++ b/packages/core/src/oauth2/private-key-jwt-authentication.test.ts
@@ -388,6 +388,28 @@ describe("private_key_jwt OAuth2 helpers", () => {
 		});
 	});
 
+	it.each([
+		"client_assertion",
+		"client_assertion_type",
+	] as const)("rejects custom authentication with only %s", async (parameter) => {
+		await expect(
+			authorizationCodeRequest({
+				code: "auth-code",
+				redirectURI: "https://rp.example.com/callback",
+				options: {},
+				tokenEndpoint,
+				tokenEndpointAuth: {
+					method: "custom",
+					customizeRequest({ body }) {
+						body.set(parameter, "value");
+					},
+				},
+			}),
+		).rejects.toThrow(
+			"client_assertion and client_assertion_type must both be provided",
+		);
+	});
+
 	it("uses configured clientId over additional token client_id parameters", async () => {
 		const { body } = await authorizationCodeRequest({
 			code: "auth-code",

--- a/packages/core/src/oauth2/token-endpoint-auth.ts
+++ b/packages/core/src/oauth2/token-endpoint-auth.ts
@@ -17,6 +17,13 @@ export type TokenEndpointAuth =
 			method: "client_secret_post";
 	  }
 	| {
+			method: "custom";
+			/**
+			 * Customize the token request after standard grant parameters are set.
+			 */
+			customizeRequest: TokenEndpointRequestHook;
+	  }
+	| {
 			method: "private_key_jwt";
 			getClientAssertion: ClientAssertionGetter;
 	  };
@@ -24,6 +31,24 @@ export type TokenEndpointAuth =
 export type TokenEndpointAuthMethod = TokenEndpointAuth["method"];
 
 export type TokenEndpointSecretAuthentication = "basic" | "post";
+
+/**
+ * Mutable token request state passed to a custom authentication strategy.
+ */
+export interface TokenEndpointRequestContext {
+	body: URLSearchParams;
+	headers: Record<string, string>;
+	options: TokenEndpointClientOptions;
+	tokenEndpoint: string;
+	grantType: ClientAssertionGrantType;
+}
+
+/**
+ * Applies provider-specific authentication to a token request.
+ */
+export type TokenEndpointRequestHook = (
+	context: TokenEndpointRequestContext,
+) => void | Promise<void>;
 
 export interface TokenEndpointClientOptions {
 	clientId?: string | string[] | undefined;
@@ -171,6 +196,17 @@ export async function applyTokenEndpointAuth({
 
 	const auth =
 		tokenEndpointAuth ?? getDefaultTokenEndpointAuth(options, authentication);
+
+	if (auth.method === "custom") {
+		await auth.customizeRequest({
+			body,
+			headers,
+			options,
+			tokenEndpoint,
+			grantType,
+		});
+		return;
+	}
 
 	if (auth.method === "private_key_jwt") {
 		assertNoClientSecret(auth.method, options, body);

--- a/packages/core/src/oauth2/token-endpoint-auth.ts
+++ b/packages/core/src/oauth2/token-endpoint-auth.ts
@@ -201,6 +201,7 @@ export async function applyTokenEndpointAuth({
 			tokenEndpoint,
 			grantType,
 		});
+		assertCompleteManualClientAssertion(body);
 		return;
 	}
 

--- a/packages/core/src/oauth2/token-endpoint-auth.ts
+++ b/packages/core/src/oauth2/token-endpoint-auth.ts
@@ -17,15 +17,15 @@ export type TokenEndpointAuth =
 			method: "client_secret_post";
 	  }
 	| {
+			method: "private_key_jwt";
+			getClientAssertion: ClientAssertionGetter;
+	  }
+	| {
 			method: "custom";
 			/**
 			 * Customize the token request after standard grant parameters are set.
 			 */
 			customizeRequest: TokenEndpointRequestHook;
-	  }
-	| {
-			method: "private_key_jwt";
-			getClientAssertion: ClientAssertionGetter;
 	  };
 
 export type TokenEndpointAuthMethod = TokenEndpointAuth["method"];

--- a/packages/core/src/oauth2/token-endpoint-auth.ts
+++ b/packages/core/src/oauth2/token-endpoint-auth.ts
@@ -55,12 +55,8 @@ export interface TokenEndpointClientOptions {
 	clientSecret?: string | undefined;
 }
 
-export interface ApplyTokenEndpointAuthInput {
-	body: URLSearchParams;
-	headers: Record<string, string>;
-	options: TokenEndpointClientOptions;
-	tokenEndpoint: string;
-	grantType: ClientAssertionGrantType;
+export interface ApplyTokenEndpointAuthInput
+	extends TokenEndpointRequestContext {
 	tokenEndpointAuth?: TokenEndpointAuth | undefined;
 	authentication?: TokenEndpointSecretAuthentication | undefined;
 }

--- a/packages/core/src/social-providers/tiktok.test.ts
+++ b/packages/core/src/social-providers/tiktok.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock(import("@better-fetch/fetch"), () => ({
 	betterFetch: vi.fn(),
@@ -9,6 +9,78 @@ import { betterFetch } from "@better-fetch/fetch";
 import { tiktok } from "./tiktok";
 
 const mockedBetterFetch = vi.mocked(betterFetch);
+
+beforeEach(() => {
+	mockedBetterFetch.mockReset();
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10696
+ * @see https://developers.tiktok.com/docs/en/oauth-user-access-token-management
+ */
+describe("tiktok token requests", () => {
+	it("exchanges an authorization code with TikTok client credentials", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "access-token",
+				refresh_token: "refresh-token",
+				expires_in: 86400,
+				token_type: "Bearer",
+			},
+			error: null,
+		});
+
+		const tokens = await tiktok({
+			clientKey: "tiktok-client-key",
+			clientSecret: "tiktok-client-secret",
+		}).validateAuthorizationCode({
+			code: "authorization-code",
+			codeVerifier: "code-verifier",
+			redirectURI: "https://app.example.com/api/auth/callback/tiktok",
+		});
+
+		expect(tokens.accessToken).toBe("access-token");
+		const [url, init] = mockedBetterFetch.mock.calls[0] ?? [];
+		expect(url).toBe("https://open.tiktokapis.com/v2/oauth/token/");
+		expect(init?.body).toBeInstanceOf(URLSearchParams);
+		expect(Object.fromEntries(init?.body as URLSearchParams)).toEqual({
+			client_key: "tiktok-client-key",
+			client_secret: "tiktok-client-secret",
+			code: "authorization-code",
+			code_verifier: "code-verifier",
+			grant_type: "authorization_code",
+			redirect_uri: "https://app.example.com/api/auth/callback/tiktok",
+		});
+	});
+
+	it("refreshes an access token with TikTok client credentials", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "refreshed-access-token",
+				refresh_token: "rotated-refresh-token",
+				expires_in: 86400,
+				token_type: "Bearer",
+			},
+			error: null,
+		});
+
+		const tokens = await tiktok({
+			clientKey: "tiktok-client-key",
+			clientSecret: "tiktok-client-secret",
+		}).refreshAccessToken("refresh-token");
+
+		expect(tokens.accessToken).toBe("refreshed-access-token");
+		const [url, init] = mockedBetterFetch.mock.calls[0] ?? [];
+		expect(url).toBe("https://open.tiktokapis.com/v2/oauth/token/");
+		expect(init?.body).toBeInstanceOf(URLSearchParams);
+		expect(Object.fromEntries(init?.body as URLSearchParams)).toEqual({
+			client_key: "tiktok-client-key",
+			client_secret: "tiktok-client-secret",
+			grant_type: "refresh_token",
+			refresh_token: "refresh-token",
+		});
+	});
+});
 
 describe("tiktok.getUserInfo", () => {
 	it("uses the open id for the placeholder email", async () => {

--- a/packages/core/src/social-providers/tiktok.ts
+++ b/packages/core/src/social-providers/tiktok.ts
@@ -1,5 +1,9 @@
 import { betterFetch } from "@better-fetch/fetch";
-import type { OAuthProvider, ProviderOptions } from "../oauth2";
+import type {
+	OAuthProvider,
+	ProviderOptions,
+	TokenEndpointAuth,
+} from "../oauth2";
 import {
 	RESERVED_AUTHORIZATION_PARAMS_SET,
 	refreshAccessToken,
@@ -133,6 +137,13 @@ export interface TiktokOptions extends ProviderOptions<TiktokProfile> {
 
 export const tiktok = (options: TiktokOptions) => {
 	const tokenEndpoint = "https://open.tiktokapis.com/v2/oauth/token/";
+	const tokenEndpointAuth = {
+		method: "custom",
+		customizeRequest({ body }) {
+			body.set("client_key", options.clientKey);
+			body.set("client_secret", options.clientSecret);
+		},
+	} satisfies TokenEndpointAuth;
 	return {
 		id: "tiktok",
 		name: "TikTok",
@@ -159,15 +170,14 @@ export const tiktok = (options: TiktokOptions) => {
 			return url;
 		},
 
-		validateAuthorizationCode: async ({ code, redirectURI }) => {
+		validateAuthorizationCode: async ({ code, codeVerifier, redirectURI }) => {
 			return validateAuthorizationCode({
 				code,
+				codeVerifier,
 				redirectURI: options.redirectURI || redirectURI,
-				options: {
-					clientKey: options.clientKey,
-					clientSecret: options.clientSecret,
-				},
+				options: {},
 				tokenEndpoint,
+				tokenEndpointAuth,
 			});
 		},
 		refreshAccessToken: options.refreshAccessToken
@@ -175,14 +185,9 @@ export const tiktok = (options: TiktokOptions) => {
 			: async (refreshToken) => {
 					return refreshAccessToken({
 						refreshToken,
-						options: {
-							clientSecret: options.clientSecret,
-						},
+						options: {},
 						tokenEndpoint,
-						authentication: "post",
-						extraParams: {
-							client_key: options.clientKey,
-						},
+						tokenEndpointAuth,
 					});
 				},
 		async getUserInfo(token) {


### PR DESCRIPTION
- Closes #10696
- Supersedes #10699 (prefer following the official spec over the workaround in the PR)

Related to https://discord.com/channels/1288403910284935179/1544030454280101979

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TikTok sign-in and token refresh by authenticating token requests with `client_key` and `client_secret` per the official spec, replacing the previous workaround that only sent `client_key` as an extra param. Also forwards the `code_verifier` during authorization code exchange, which was previously omitted.

- Updates both authorization code exchange and token refresh to use the custom token endpoint auth method in `packages/core/src/social-providers/tiktok.ts`.
- Adds tests covering both token request flows with the new credentials payload.
- Includes a changeset marking this as a patch for `@better-auth/core`.

<sup>Written for commit 73ea8996398fbdf4f7be59ad39814410534d70fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



