### PR TITLE
fix(email-otp): surface sendVerificationOTP errors when not deferred

### DIFF
--- a/docs/content/docs/concepts/hooks.mdx
+++ b/docs/content/docs/concepts/hooks.mdx
@@ -303,6 +303,8 @@ export const auth = betterAuth({
 
 Defers the task when a handler is configured, otherwise awaits it. Use for operations that must complete (e.g. sending emails) but benefit from not blocking when a handler exists. Configure the handler in [advanced.backgroundTasks](/docs/reference/options#backgroundtasks).
 
+Without a handler, a rejected promise is logged and then rethrown so the caller (and HTTP response) can surface the original error. With a handler, failures are logged on the background promise and do not block the request.
+
 ```ts title="auth.ts"
 import { betterAuth } from "better-auth";
 import { createAuthMiddleware } from "better-auth/api";

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -132,20 +132,18 @@ export const requestPasswordReset = createAuthEndpoint(
 		});
 		const callbackURL = redirectTo ? encodeURIComponent(redirectTo) : "";
 		const url = `${ctx.context.baseURL}/reset-password/${verificationToken}?callbackURL=${callbackURL}`;
-		try {
-			await ctx.context.runInBackgroundOrAwait(
-				Promise.resolve().then(() =>
-					ctx.context.options.emailAndPassword.sendResetPassword(
-						{
-							user: user.user,
-							url,
-							token: verificationToken,
-						},
-						ctx.request,
-					),
+		ctx.context.runInBackground(
+			Promise.resolve().then(() =>
+				ctx.context.options.emailAndPassword.sendResetPassword?.(
+					{
+						user: user.user,
+						url,
+						token: verificationToken,
+					},
+					ctx.request,
 				),
-			);
-		} catch {}
+			),
+		);
 		return ctx.json({
 			status: true,
 			message:

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -132,16 +132,21 @@ export const requestPasswordReset = createAuthEndpoint(
 		});
 		const callbackURL = redirectTo ? encodeURIComponent(redirectTo) : "";
 		const url = `${ctx.context.baseURL}/reset-password/${verificationToken}?callbackURL=${callbackURL}`;
-		await ctx.context.runInBackgroundOrAwait(
-			ctx.context.options.emailAndPassword.sendResetPassword(
-				{
-					user: user.user,
-					url,
-					token: verificationToken,
-				},
-				ctx.request,
-			),
-		);
+		try {
+			await ctx.context.runInBackgroundOrAwait(
+				ctx.context.options.emailAndPassword.sendResetPassword(
+					{
+						user: user.user,
+						url,
+						token: verificationToken,
+					},
+					ctx.request,
+				),
+			);
+		} catch {
+			// Already logged by runInBackgroundOrAwait. Do not leak send
+			// failures — they would distinguish registered emails.
+		}
 		return ctx.json({
 			status: true,
 			message:

--- a/packages/better-auth/src/api/routes/password.ts
+++ b/packages/better-auth/src/api/routes/password.ts
@@ -134,19 +134,18 @@ export const requestPasswordReset = createAuthEndpoint(
 		const url = `${ctx.context.baseURL}/reset-password/${verificationToken}?callbackURL=${callbackURL}`;
 		try {
 			await ctx.context.runInBackgroundOrAwait(
-				ctx.context.options.emailAndPassword.sendResetPassword(
-					{
-						user: user.user,
-						url,
-						token: verificationToken,
-					},
-					ctx.request,
+				Promise.resolve().then(() =>
+					ctx.context.options.emailAndPassword.sendResetPassword(
+						{
+							user: user.user,
+							url,
+							token: verificationToken,
+						},
+						ctx.request,
+					),
 				),
 			);
-		} catch {
-			// Already logged by runInBackgroundOrAwait. Do not leak send
-			// failures — they would distinguish registered emails.
-		}
+		} catch {}
 		return ctx.json({
 			status: true,
 			message:

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -408,20 +408,21 @@ Most of the features of Better Auth will not work correctly.`,
 		async runInBackgroundOrAwait(
 			promise: Promise<unknown> | Promise<void> | void | unknown,
 		) {
-			try {
-				if (options.advanced?.backgroundTasks?.handler) {
-					if (promise instanceof Promise) {
-						options.advanced.backgroundTasks.handler(
-							promise.catch((e) => {
-								logger.error("Failed to run background task:", e);
-							}),
-						);
-					}
-				} else {
-					await promise;
+			if (options.advanced?.backgroundTasks?.handler) {
+				if (promise instanceof Promise) {
+					options.advanced.backgroundTasks.handler(
+						promise.catch((e) => {
+							logger.error("Failed to run background task:", e);
+						}),
+					);
 				}
+				return;
+			}
+			try {
+				await promise;
 			} catch (e) {
 				logger.error("Failed to run background task:", e);
+				throw e;
 			}
 		},
 		getPlugin: getPluginFn,

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -410,11 +410,15 @@ Most of the features of Better Auth will not work correctly.`,
 		) {
 			if (options.advanced?.backgroundTasks?.handler) {
 				if (promise instanceof Promise) {
-					options.advanced.backgroundTasks.handler(
-						promise.catch((e) => {
-							logger.error("Failed to run background task:", e);
-						}),
-					);
+					try {
+						options.advanced.backgroundTasks.handler(
+							promise.catch((e) => {
+								logger.error("Failed to run background task:", e);
+							}),
+						);
+					} catch (e) {
+						logger.error("Failed to run background task:", e);
+					}
 				}
 				return;
 			}

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -1,3 +1,4 @@
+import { APIError } from "@better-auth/core/error";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAuthClient } from "../../client";
 import { getCookieCache } from "../../cookies";
@@ -2711,5 +2712,74 @@ describe("email-otp send origin/CSRF protection", async () => {
 		const response = await auth.handler(legitimateRequest);
 		expect(response.status).toBe(200);
 		expect(sendVerificationOTP).toHaveBeenCalledTimes(1);
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/11107
+ */
+describe("email-otp sendVerificationOTP error surfacing", () => {
+	it("surfaces sendVerificationOTP errors when no backgroundTasks handler is configured", async () => {
+		const { auth, testUser } = await getTestInstance({
+			plugins: [
+				emailOTP({
+					async sendVerificationOTP() {
+						throw APIError.from("TOO_MANY_REQUESTS", {
+							code: "RATE_LIMIT_EXCEEDED",
+							message: "Too many requests. Please try again later.",
+						});
+					},
+				}),
+			],
+		});
+
+		try {
+			await auth.api.sendVerificationOTP({
+				body: {
+					email: testUser.email,
+					type: "email-verification",
+				},
+			});
+			expect.fail("Expected sendVerificationOTP to throw");
+		} catch (error) {
+			expect(error).toBeInstanceOf(APIError);
+			if (error instanceof APIError) {
+				expect(error.status).toBe("TOO_MANY_REQUESTS");
+				expect(error.body?.code).toBe("RATE_LIMIT_EXCEEDED");
+			}
+		}
+	});
+
+	it("does not block the request when a backgroundTasks handler is configured", async () => {
+		const backgroundTasks: Promise<unknown>[] = [];
+		const { auth, testUser } = await getTestInstance({
+			advanced: {
+				backgroundTasks: {
+					handler: (promise) => {
+						backgroundTasks.push(promise);
+					},
+				},
+			},
+			plugins: [
+				emailOTP({
+					async sendVerificationOTP() {
+						throw APIError.from("TOO_MANY_REQUESTS", {
+							code: "RATE_LIMIT_EXCEEDED",
+							message: "Too many requests. Please try again later.",
+						});
+					},
+				}),
+			],
+		});
+
+		const result = await auth.api.sendVerificationOTP({
+			body: {
+				email: testUser.email,
+				type: "email-verification",
+			},
+		});
+		expect(result).toEqual({ success: true });
+		expect(backgroundTasks.length).toBeGreaterThan(0);
+		await Promise.all(backgroundTasks);
 	});
 });

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -2733,21 +2733,104 @@ describe("email-otp sendVerificationOTP error surfacing", () => {
 			],
 		});
 
-		try {
-			await auth.api.sendVerificationOTP({
+		await expect(
+			auth.api.sendVerificationOTP({
 				body: {
 					email: testUser.email,
 					type: "email-verification",
 				},
-			});
-			expect.fail("Expected sendVerificationOTP to throw");
-		} catch (error) {
-			expect(error).toBeInstanceOf(APIError);
-			if (error instanceof APIError) {
-				expect(error.status).toBe("TOO_MANY_REQUESTS");
-				expect(error.body?.code).toBe("RATE_LIMIT_EXCEEDED");
-			}
-		}
+			}),
+		).rejects.toMatchObject({
+			status: "TOO_MANY_REQUESTS",
+			body: { code: "RATE_LIMIT_EXCEEDED" },
+		});
+	});
+
+	it("keeps generic success when forget-password sendVerificationOTP fails", async () => {
+		const { auth, testUser } = await getTestInstance({
+			plugins: [
+				emailOTP({
+					async sendVerificationOTP() {
+						throw new Error("SMTP provider error");
+					},
+				}),
+			],
+		});
+
+		const result = await auth.api.sendVerificationOTP({
+			body: {
+				email: testUser.email,
+				type: "forget-password",
+			},
+		});
+		expect(result).toEqual({ success: true });
+	});
+
+	it("keeps generic success when request-password-reset OTP send fails", async () => {
+		const { auth, testUser } = await getTestInstance({
+			plugins: [
+				emailOTP({
+					async sendVerificationOTP() {
+						throw new Error("SMTP provider error");
+					},
+				}),
+			],
+		});
+
+		const registered = await auth.api.requestPasswordResetEmailOTP({
+			body: { email: testUser.email },
+		});
+		const unknown = await auth.api.requestPasswordResetEmailOTP({
+			body: { email: "unknown-user@example.com" },
+		});
+		expect(registered).toEqual({ success: true });
+		expect(unknown).toEqual({ success: true });
+	});
+
+	it("keeps generic success when deprecated forget-password email OTP send fails", async () => {
+		const { auth, testUser } = await getTestInstance({
+			plugins: [
+				emailOTP({
+					async sendVerificationOTP() {
+						throw new Error("SMTP provider error");
+					},
+				}),
+			],
+		});
+
+		const registered = await auth.api.forgetPasswordEmailOTP({
+			body: { email: testUser.email },
+		});
+		const unknown = await auth.api.forgetPasswordEmailOTP({
+			body: { email: "unknown-user@example.com" },
+		});
+		expect(registered).toEqual({ success: true });
+		expect(unknown).toEqual({ success: true });
+	});
+
+	it("keeps generic success when change-email OTP send fails", async () => {
+		const { auth, testUser, signInWithTestUser } = await getTestInstance({
+			plugins: [
+				emailOTP({
+					changeEmail: { enabled: true },
+					async sendVerificationOTP() {
+						throw new Error("SMTP provider error");
+					},
+				}),
+			],
+		});
+		const { headers } = await signInWithTestUser();
+
+		const available = await auth.api.requestEmailChangeEmailOTP({
+			body: { newEmail: "available-change@example.com" },
+			headers,
+		});
+		const taken = await auth.api.requestEmailChangeEmailOTP({
+			body: { newEmail: testUser.email },
+			headers,
+		});
+		expect(available).toEqual({ success: true });
+		expect(taken).toEqual({ success: true });
 	});
 
 	it("does not block the request when a backgroundTasks handler is configured", async () => {

--- a/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
+++ b/packages/better-auth/src/plugins/email-otp/email-otp.test.ts
@@ -1,5 +1,5 @@
-import { APIError } from "@better-auth/core/error";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { APIError } from "../../api";
 import { createAuthClient } from "../../client";
 import { getCookieCache } from "../../cookies";
 import { parseSetCookieHeader } from "../../cookies/cookie-utils";

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -159,9 +159,15 @@ export const sendVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 				return ctx.json({ success: true });
 			}
 
-			await ctx.context.runInBackgroundOrAwait(
-				opts.sendVerificationOTP({ email, otp, type: ctx.body.type }, ctx),
-			);
+			try {
+				await ctx.context.runInBackgroundOrAwait(
+					opts.sendVerificationOTP({ email, otp, type: ctx.body.type }, ctx),
+				);
+			} catch (error) {
+				if (ctx.body.type !== "forget-password") {
+					throw error;
+				}
+			}
 			return ctx.json({ success: true });
 		},
 	);
@@ -778,16 +784,21 @@ export const requestPasswordResetEmailOTP = (opts: RequiredEmailOTPOptions) =>
 					success: true,
 				});
 			}
-			await ctx.context.runInBackgroundOrAwait(
-				opts.sendVerificationOTP(
-					{
-						email,
-						otp,
-						type: "forget-password",
-					},
-					ctx,
-				),
-			);
+			try {
+				await ctx.context.runInBackgroundOrAwait(
+					opts.sendVerificationOTP(
+						{
+							email,
+							otp,
+							type: "forget-password",
+						},
+						ctx,
+					),
+				);
+			} catch {
+				// Already logged. Keep the generic success payload so send
+				// failures cannot enumerate registered emails.
+			}
 			return ctx.json({
 				success: true,
 			});
@@ -870,16 +881,21 @@ export const forgetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) => {
 					success: true,
 				});
 			}
-			await ctx.context.runInBackgroundOrAwait(
-				opts.sendVerificationOTP(
-					{
-						email,
-						otp,
-						type: "forget-password",
-					},
-					ctx,
-				),
-			);
+			try {
+				await ctx.context.runInBackgroundOrAwait(
+					opts.sendVerificationOTP(
+						{
+							email,
+							otp,
+							type: "forget-password",
+						},
+						ctx,
+					),
+				);
+			} catch {
+				// Already logged. Keep the generic success payload so send
+				// failures cannot enumerate registered emails.
+			}
 			return ctx.json({
 				success: true,
 			});
@@ -1131,16 +1147,21 @@ export const requestEmailChangeEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				});
 			}
 
-			await ctx.context.runInBackgroundOrAwait(
-				opts.sendVerificationOTP(
-					{
-						email: newEmail,
-						otp,
-						type: "change-email",
-					},
-					ctx,
-				),
-			);
+			try {
+				await ctx.context.runInBackgroundOrAwait(
+					opts.sendVerificationOTP(
+						{
+							email: newEmail,
+							otp,
+							type: "change-email",
+						},
+						ctx,
+					),
+				);
+			} catch {
+				// Already logged. A send failure on an available email must
+				// not differ from the generic success used for taken emails.
+			}
 			return ctx.json({
 				success: true,
 			});

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -161,7 +161,12 @@ export const sendVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 
 			try {
 				await ctx.context.runInBackgroundOrAwait(
-					opts.sendVerificationOTP({ email, otp, type: ctx.body.type }, ctx),
+					Promise.resolve().then(() =>
+						opts.sendVerificationOTP(
+							{ email, otp, type: ctx.body.type },
+							ctx,
+						),
+					),
 				);
 			} catch (error) {
 				if (ctx.body.type !== "forget-password") {
@@ -786,19 +791,18 @@ export const requestPasswordResetEmailOTP = (opts: RequiredEmailOTPOptions) =>
 			}
 			try {
 				await ctx.context.runInBackgroundOrAwait(
-					opts.sendVerificationOTP(
-						{
-							email,
-							otp,
-							type: "forget-password",
-						},
-						ctx,
+					Promise.resolve().then(() =>
+						opts.sendVerificationOTP(
+							{
+								email,
+								otp,
+								type: "forget-password",
+							},
+							ctx,
+						),
 					),
 				);
-			} catch {
-				// Already logged. Keep the generic success payload so send
-				// failures cannot enumerate registered emails.
-			}
+			} catch {}
 			return ctx.json({
 				success: true,
 			});
@@ -883,19 +887,18 @@ export const forgetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) => {
 			}
 			try {
 				await ctx.context.runInBackgroundOrAwait(
-					opts.sendVerificationOTP(
-						{
-							email,
-							otp,
-							type: "forget-password",
-						},
-						ctx,
+					Promise.resolve().then(() =>
+						opts.sendVerificationOTP(
+							{
+								email,
+								otp,
+								type: "forget-password",
+							},
+							ctx,
+						),
 					),
 				);
-			} catch {
-				// Already logged. Keep the generic success payload so send
-				// failures cannot enumerate registered emails.
-			}
+			} catch {}
 			return ctx.json({
 				success: true,
 			});
@@ -1149,19 +1152,18 @@ export const requestEmailChangeEmailOTP = (opts: RequiredEmailOTPOptions) =>
 
 			try {
 				await ctx.context.runInBackgroundOrAwait(
-					opts.sendVerificationOTP(
-						{
-							email: newEmail,
-							otp,
-							type: "change-email",
-						},
-						ctx,
+					Promise.resolve().then(() =>
+						opts.sendVerificationOTP(
+							{
+								email: newEmail,
+								otp,
+								type: "change-email",
+							},
+							ctx,
+						),
 					),
 				);
-			} catch {
-				// Already logged. A send failure on an available email must
-				// not differ from the generic success used for taken emails.
-			}
+			} catch {}
 			return ctx.json({
 				success: true,
 			});

--- a/packages/better-auth/src/plugins/email-otp/routes.ts
+++ b/packages/better-auth/src/plugins/email-otp/routes.ts
@@ -159,8 +159,8 @@ export const sendVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 				return ctx.json({ success: true });
 			}
 
-			try {
-				await ctx.context.runInBackgroundOrAwait(
+			if (ctx.body.type === "forget-password") {
+				ctx.context.runInBackground(
 					Promise.resolve().then(() =>
 						opts.sendVerificationOTP(
 							{ email, otp, type: ctx.body.type },
@@ -168,10 +168,10 @@ export const sendVerificationOTP = (opts: RequiredEmailOTPOptions) =>
 						),
 					),
 				);
-			} catch (error) {
-				if (ctx.body.type !== "forget-password") {
-					throw error;
-				}
+			} else {
+				await ctx.context.runInBackgroundOrAwait(
+					opts.sendVerificationOTP({ email, otp, type: ctx.body.type }, ctx),
+				);
 			}
 			return ctx.json({ success: true });
 		},
@@ -789,20 +789,18 @@ export const requestPasswordResetEmailOTP = (opts: RequiredEmailOTPOptions) =>
 					success: true,
 				});
 			}
-			try {
-				await ctx.context.runInBackgroundOrAwait(
-					Promise.resolve().then(() =>
-						opts.sendVerificationOTP(
-							{
-								email,
-								otp,
-								type: "forget-password",
-							},
-							ctx,
-						),
+			ctx.context.runInBackground(
+				Promise.resolve().then(() =>
+					opts.sendVerificationOTP(
+						{
+							email,
+							otp,
+							type: "forget-password",
+						},
+						ctx,
 					),
-				);
-			} catch {}
+				),
+			);
 			return ctx.json({
 				success: true,
 			});
@@ -885,20 +883,18 @@ export const forgetPasswordEmailOTP = (opts: RequiredEmailOTPOptions) => {
 					success: true,
 				});
 			}
-			try {
-				await ctx.context.runInBackgroundOrAwait(
-					Promise.resolve().then(() =>
-						opts.sendVerificationOTP(
-							{
-								email,
-								otp,
-								type: "forget-password",
-							},
-							ctx,
-						),
+			ctx.context.runInBackground(
+				Promise.resolve().then(() =>
+					opts.sendVerificationOTP(
+						{
+							email,
+							otp,
+							type: "forget-password",
+						},
+						ctx,
 					),
-				);
-			} catch {}
+				),
+			);
 			return ctx.json({
 				success: true,
 			});
@@ -1150,20 +1146,18 @@ export const requestEmailChangeEmailOTP = (opts: RequiredEmailOTPOptions) =>
 				});
 			}
 
-			try {
-				await ctx.context.runInBackgroundOrAwait(
-					Promise.resolve().then(() =>
-						opts.sendVerificationOTP(
-							{
-								email: newEmail,
-								otp,
-								type: "change-email",
-							},
-							ctx,
-						),
+			ctx.context.runInBackground(
+				Promise.resolve().then(() =>
+					opts.sendVerificationOTP(
+						{
+							email: newEmail,
+							otp,
+							type: "change-email",
+						},
+						ctx,
 					),
-				);
-			} catch {}
+				),
+			);
 			return ctx.json({
 				success: true,
 			});

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -404,6 +404,57 @@ describe("phone-number send otp background handler failures", async () => {
 	});
 });
 
+describe("phone-number password reset send failures", async () => {
+	let otp = "";
+	const sendPasswordResetOTP = vi.fn(async () => {
+		throw new Error("SMS provider error");
+	});
+
+	const { client } = await getTestInstance(
+		{
+			plugins: [
+				phoneNumber({
+					async sendOTP({ code }) {
+						otp = code;
+					},
+					sendPasswordResetOTP,
+					signUpOnVerification: {
+						getTempEmail(phoneNumber) {
+							return `temp-${phoneNumber}`;
+						},
+					},
+				}),
+			],
+		},
+		{
+			clientOptions: {
+				plugins: [phoneNumberClient()],
+			},
+		},
+	);
+
+	it("keeps generic success when sendPasswordResetOTP fails", async () => {
+		const phone = "+251900111222";
+		await client.phoneNumber.sendOtp({ phoneNumber: phone });
+		await client.phoneNumber.verify({
+			phoneNumber: phone,
+			code: otp,
+		});
+
+		const registered = await client.phoneNumber.requestPasswordReset({
+			phoneNumber: phone,
+		});
+		const unknown = await client.phoneNumber.requestPasswordReset({
+			phoneNumber: "+251900000000",
+		});
+
+		expect(registered.error).toBe(null);
+		expect(registered.data?.status).toBe(true);
+		expect(unknown.error).toBe(null);
+		expect(unknown.data?.status).toBe(true);
+	});
+});
+
 describe("phone auth flow", async () => {
 	let otp = "";
 

--- a/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
+++ b/packages/better-auth/src/plugins/phone-number/phone-number.test.ts
@@ -436,17 +436,20 @@ describe("phone-number password reset send failures", async () => {
 	it("keeps generic success when sendPasswordResetOTP fails", async () => {
 		const phone = "+251900111222";
 		await client.phoneNumber.sendOtp({ phoneNumber: phone });
-		await client.phoneNumber.verify({
+		const verifyRes = await client.phoneNumber.verify({
 			phoneNumber: phone,
 			code: otp,
 		});
+		expect(verifyRes.error).toBe(null);
 
 		const registered = await client.phoneNumber.requestPasswordReset({
 			phoneNumber: phone,
 		});
+		expect(sendPasswordResetOTP).toHaveBeenCalledOnce();
 		const unknown = await client.phoneNumber.requestPasswordReset({
 			phoneNumber: "+251900000000",
 		});
+		expect(sendPasswordResetOTP).toHaveBeenCalledOnce();
 
 		expect(registered.error).toBe(null);
 		expect(registered.data?.status).toBe(true);

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -726,20 +726,17 @@ export const requestPasswordResetPhoneNumber = (
 				});
 			}
 			if (opts.sendPasswordResetOTP) {
-				const sendPasswordResetOTP = opts.sendPasswordResetOTP;
-				try {
-					await ctx.context.runInBackgroundOrAwait(
-						Promise.resolve().then(() =>
-							sendPasswordResetOTP(
-								{
-									phoneNumber: ctx.body.phoneNumber,
-									code,
-								},
-								ctx,
-							),
+				ctx.context.runInBackground(
+					Promise.resolve().then(() =>
+						opts.sendPasswordResetOTP?.(
+							{
+								phoneNumber: ctx.body.phoneNumber,
+								code,
+							},
+							ctx,
 						),
-					);
-				} catch {}
+					),
+				);
 			}
 			return ctx.json({
 				status: true,

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -726,20 +726,20 @@ export const requestPasswordResetPhoneNumber = (
 				});
 			}
 			if (opts.sendPasswordResetOTP) {
+				const sendPasswordResetOTP = opts.sendPasswordResetOTP;
 				try {
 					await ctx.context.runInBackgroundOrAwait(
-						opts.sendPasswordResetOTP(
-							{
-								phoneNumber: ctx.body.phoneNumber,
-								code,
-							},
-							ctx,
+						Promise.resolve().then(() =>
+							sendPasswordResetOTP(
+								{
+									phoneNumber: ctx.body.phoneNumber,
+									code,
+								},
+								ctx,
+							),
 						),
 					);
-				} catch {
-					// Already logged. Do not leak SMS send failures — they
-					// would distinguish registered phone numbers.
-				}
+				} catch {}
 			}
 			return ctx.json({
 				status: true,

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -726,15 +726,20 @@ export const requestPasswordResetPhoneNumber = (
 				});
 			}
 			if (opts.sendPasswordResetOTP) {
-				await ctx.context.runInBackgroundOrAwait(
-					opts.sendPasswordResetOTP(
-						{
-							phoneNumber: ctx.body.phoneNumber,
-							code,
-						},
-						ctx,
-					),
-				);
+				try {
+					await ctx.context.runInBackgroundOrAwait(
+						opts.sendPasswordResetOTP(
+							{
+								phoneNumber: ctx.body.phoneNumber,
+								code,
+							},
+							ctx,
+						),
+					);
+				} catch {
+					// Already logged. Do not leak SMS send failures — they
+					// would distinguish registered phone numbers.
+				}
 			}
 			return ctx.json({
 				status: true,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -490,6 +490,11 @@ export type AuthContext<Options extends BetterAuthOptions = BetterAuthOptions> =
 			 * This is useful for operations like sending emails where we want
 			 * to avoid blocking the response when possible (for timing attack
 			 * mitigation), but still ensure the operation completes.
+			 *
+			 * When no background handler is configured, rejections from the
+			 * awaited promise propagate to the caller (after being logged).
+			 * When a handler is configured, failures are logged on the
+			 * background promise and do not block the current request.
 			 */
 			runInBackgroundOrAwait: (
 				promise: Promise<unknown> | void,


### PR DESCRIPTION
Fixes #11107.

runInBackgroundOrAwait logged and swallowed awaited promise rejections whenever advanced.backgroundTasks.handler was not configured. sendVerificationOTP then returned success even when the send callback failed.

This change rethrows the original error after logging when no background handler is set, so callers see the original status and payload. Fire-and-forget behavior is unchanged when a handler is configured. Regression tests cover both paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11107: OTP send errors were logged and swallowed when no background handler was configured, so `sendVerificationOTP` returned success on failure. `runInBackgroundOrAwait` now rethrows rejections when no handler is set, so callers see the original error status and payload.

**Behavior**

- Password-reset, forget-password, change-email, and phone password-reset sends are fire-and-forget via `runInBackground`, so registered vs unknown requests aren't distinguishable by latency and still return generic success.
- Send callbacks are deferred through `Promise.resolve` so synchronous throws are logged the same way as rejections.
- Fire-and-forget behavior is unchanged when a handler is configured; failures are logged and don't block the request.
- Adds regression tests for email and phone routes and documents the propagation behavior in the hooks guide and `AuthContext` type comments.

<sup>Written for commit a1dc65b4c786a56cbc090ac22e748b45c44164c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

