### PR TITLE
docs: add @a77ay/better-auth-mikro-orm to community adapters list

### DIFF
--- a/docs/lib/community-adapters-data.ts
+++ b/docs/lib/community-adapters-data.ts
@@ -253,4 +253,15 @@ export const communityAdapters: CommunityAdapter[] = [
 			avatar: "https://github.com/ilbertt.png",
 		},
 	},
+	{
+		name: "@a77ay/better-auth-mikro-orm",
+		url: "https://www.npmjs.com/package/@a77ay/better-auth-mikro-orm",
+		database: "MikroORM",
+		databaseUrl: "https://mikro-orm.io/",
+		author: {
+			name: "A77AY",
+			url: "https://github.com/a77ay",
+			avatar: "https://github.com/a77ay.png",
+		},
+	},
 ];

--- a/docs/lib/community-adapters-data.ts
+++ b/docs/lib/community-adapters-data.ts
@@ -255,7 +255,7 @@ export const communityAdapters: CommunityAdapter[] = [
 	},
 	{
 		name: "@a77ay/better-auth-mikro-orm",
-		url: "https://www.npmjs.com/package/@a77ay/better-auth-mikro-orm",
+		url: "https://github.com/a77ay/better-auth-mikro-orm",
 		database: "MikroORM",
 		databaseUrl: "https://mikro-orm.io/",
 		author: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `@a77ay/better-auth-mikro-orm` to the community adapters list so it appears in the docs, linking to its GitHub repository.

<sup>Written for commit 21bfc4c00d47873f8934ecb8964401eb6f833353. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

