### PR TITLE
fix(cli): handle pnpm catalog dependencies in auth upgrade

### DIFF
--- a/.changeset/fix-cli-upgrade-pnpm-catalog.md
+++ b/.changeset/fix-cli-upgrade-pnpm-catalog.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+`auth upgrade` no longer crashes on pnpm `catalog:` dependency specs. The command resolves catalog versions from `pnpm-workspace.yaml`, compares them to the running CLI version, updates catalog entries while preserving range prefixes, and runs `pnpm install` at the workspace root.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -75,6 +75,7 @@
     "prettier": "^3.8.1",
     "prompts": "^2.4.2",
     "semver": "^7.8.4",
+    "yaml": "^2.9.0",
     "yocto-spinner": "^1.2.0",
     "zod": "catalog:"
   },

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -18,6 +18,7 @@ import {
 	formatCatalogTargetVersion,
 	getPnpmCatalogVersion,
 	getPnpmWorkspaceYamlPath,
+	isWildcardCatalogVersion,
 	parseCatalogSpec,
 	resolveCatalogDependencyVersion,
 	setPnpmCatalogVersion,
@@ -122,6 +123,10 @@ export async function upgradeAction(opts: unknown) {
 				catalogWarnings.push(
 					`Could not resolve ${name} (${current}) from pnpm-workspace.yaml`,
 				);
+				continue;
+			}
+
+			if (isWildcardCatalogVersion(resolved.version)) {
 				continue;
 			}
 

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import chalk from "chalk";
 import { Command } from "commander";
@@ -10,10 +10,11 @@ import changesetConfig from "../../../../.changeset/config.json" with {
 	type: "json",
 };
 import { detectPackageManager } from "../utils/check-package-managers";
-import { findMonorepoRoot, getPackageInfo } from "../utils/get-package-info";
+import { getPackageInfo } from "../utils/get-package-info";
 import { spawnCommand } from "../utils/helper";
 import { installDependencies } from "../utils/install-dependencies";
 import {
+	findPnpmWorkspaceRoot,
 	formatCatalogTargetVersion,
 	getPnpmCatalogVersion,
 	getPnpmWorkspaceYamlPath,
@@ -199,8 +200,8 @@ export async function upgradeAction(opts: unknown) {
 
 	try {
 		if (catalogUpgrades.length > 0) {
-			const monorepoRoot = await findMonorepoRoot(cwd);
-			if (!monorepoRoot) {
+			const workspaceRoot = await findPnpmWorkspaceRoot(cwd);
+			if (!workspaceRoot) {
 				installSpinner.stop();
 				console.error(
 					"Could not find a pnpm workspace root to update catalog dependencies.",
@@ -208,27 +209,34 @@ export async function upgradeAction(opts: unknown) {
 				process.exit(1);
 			}
 
-			const workspaceYamlPath = getPnpmWorkspaceYamlPath(monorepoRoot);
-			for (const upgrade of catalogUpgrades) {
-				const currentCatalogVersion = getPnpmCatalogVersion(
-					workspaceYamlPath,
-					upgrade.name,
-					upgrade.catalogName,
-				);
-				if (!currentCatalogVersion) {
-					throw new Error(
-						`Could not find ${upgrade.name} in pnpm-workspace.yaml`,
+			const workspaceYamlPath = getPnpmWorkspaceYamlPath(workspaceRoot);
+			const originalWorkspaceYaml = readFileSync(workspaceYamlPath, "utf-8");
+
+			try {
+				for (const upgrade of catalogUpgrades) {
+					const currentCatalogVersion = getPnpmCatalogVersion(
+						workspaceYamlPath,
+						upgrade.name,
+						upgrade.catalogName,
+					);
+					if (!currentCatalogVersion) {
+						throw new Error(
+							`Could not find ${upgrade.name} in pnpm-workspace.yaml`,
+						);
+					}
+					setPnpmCatalogVersion(
+						workspaceYamlPath,
+						upgrade.name,
+						formatCatalogTargetVersion(currentCatalogVersion, upgrade.target),
+						upgrade.catalogName,
 					);
 				}
-				setPnpmCatalogVersion(
-					workspaceYamlPath,
-					upgrade.name,
-					formatCatalogTargetVersion(currentCatalogVersion, upgrade.target),
-					upgrade.catalogName,
-				);
-			}
 
-			await spawnCommand("pnpm install", monorepoRoot);
+				await spawnCommand("pnpm install", workspaceRoot);
+			} catch (error) {
+				writeFileSync(workspaceYamlPath, originalWorkspaceYaml);
+				throw error;
+			}
 		}
 
 		if (semverUpgrades.length > 0) {

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -10,8 +10,17 @@ import changesetConfig from "../../../../.changeset/config.json" with {
 	type: "json",
 };
 import { detectPackageManager } from "../utils/check-package-managers";
-import { getPackageInfo } from "../utils/get-package-info";
+import { findMonorepoRoot, getPackageInfo } from "../utils/get-package-info";
+import { spawnCommand } from "../utils/helper";
 import { installDependencies } from "../utils/install-dependencies";
+import {
+	formatCatalogTargetVersion,
+	getPnpmCatalogVersion,
+	getPnpmWorkspaceYamlPath,
+	parseCatalogSpec,
+	resolveCatalogDependencyVersion,
+	setPnpmCatalogVersion,
+} from "../utils/pnpm-catalog";
 import { cliVersion } from "../version";
 
 const fixedReleaseGroup = changesetConfig.fixed.find((group) =>
@@ -34,6 +43,9 @@ interface UpgradeEntry {
 	current: string;
 	target: string;
 	depType: "prod" | "dev";
+	source: "semver" | "catalog";
+	catalogName?: string;
+	resolvedVersion?: string;
 }
 
 /** @internal */
@@ -95,14 +107,55 @@ export async function upgradeAction(opts: unknown) {
 	const spinner = yoctoSpinner({ text: "checking for updates..." }).start();
 
 	const upgrades: UpgradeEntry[] = [];
+	const catalogWarnings: string[] = [];
+
 	for (const { name, current, depType } of candidates) {
+		const catalogSpec = parseCatalogSpec(current);
+		if (catalogSpec) {
+			const resolved = await resolveCatalogDependencyVersion(
+				cwd,
+				name,
+				current,
+			);
+			if (!resolved) {
+				catalogWarnings.push(
+					`Could not resolve ${name} (${current}) from pnpm-workspace.yaml`,
+				);
+				continue;
+			}
+
+			const currentVersion = semver.minVersion(resolved.version);
+			if (currentVersion && semver.lt(currentVersion, cliVersion)) {
+				upgrades.push({
+					name,
+					current,
+					target: cliVersion,
+					depType,
+					source: "catalog",
+					catalogName: resolved.catalogName,
+					resolvedVersion: resolved.version,
+				});
+			}
+			continue;
+		}
+
 		const currentVersion = semver.minVersion(current);
 		if (currentVersion && semver.lt(currentVersion, cliVersion)) {
-			upgrades.push({ name, current, target: cliVersion, depType });
+			upgrades.push({
+				name,
+				current,
+				target: cliVersion,
+				depType,
+				source: "semver",
+			});
 		}
 	}
 
 	spinner.stop();
+
+	for (const warning of catalogWarnings) {
+		console.warn(chalk.yellow(warning));
+	}
 
 	if (upgrades.length === 0) {
 		console.log("All better-auth packages are up to date.");
@@ -111,8 +164,12 @@ export async function upgradeAction(opts: unknown) {
 
 	console.log(`\nThe following packages can be upgraded:\n`);
 	for (const u of upgrades) {
+		const currentLabel =
+			u.source === "catalog" && u.resolvedVersion
+				? `${u.current} (${u.resolvedVersion} in pnpm-workspace.yaml)`
+				: u.current;
 		console.log(
-			`  ${chalk.cyan(u.name)}  ${chalk.gray(u.current)} ${chalk.white("→")} ${chalk.green(u.target)}`,
+			`  ${chalk.cyan(u.name)}  ${chalk.gray(currentLabel)} ${chalk.white("→")} ${chalk.green(u.target)}`,
 		);
 	}
 	console.log();
@@ -133,36 +190,75 @@ export async function upgradeAction(opts: unknown) {
 		return;
 	}
 
-	const { packageManager } = await detectPackageManager(cwd, packageJson);
-
-	const prodUpgrades = upgrades
-		.filter((u) => u.depType === "prod")
-		.map((u) => `${u.name}@${u.target}`);
-	const devUpgrades = upgrades
-		.filter((u) => u.depType === "dev")
-		.map((u) => `${u.name}@${u.target}`);
+	const catalogUpgrades = upgrades.filter((u) => u.source === "catalog");
+	const semverUpgrades = upgrades.filter((u) => u.source === "semver");
 
 	const installSpinner = yoctoSpinner({
 		text: "installing updates...",
 	}).start();
 
 	try {
-		if (prodUpgrades.length > 0) {
-			await installDependencies({
-				dependencies: prodUpgrades,
-				packageManager,
-				cwd,
-				type: "prod",
-			});
+		if (catalogUpgrades.length > 0) {
+			const monorepoRoot = await findMonorepoRoot(cwd);
+			if (!monorepoRoot) {
+				installSpinner.stop();
+				console.error(
+					"Could not find a pnpm workspace root to update catalog dependencies.",
+				);
+				process.exit(1);
+			}
+
+			const workspaceYamlPath = getPnpmWorkspaceYamlPath(monorepoRoot);
+			for (const upgrade of catalogUpgrades) {
+				const currentCatalogVersion = getPnpmCatalogVersion(
+					workspaceYamlPath,
+					upgrade.name,
+					upgrade.catalogName,
+				);
+				if (!currentCatalogVersion) {
+					throw new Error(
+						`Could not find ${upgrade.name} in pnpm-workspace.yaml`,
+					);
+				}
+				setPnpmCatalogVersion(
+					workspaceYamlPath,
+					upgrade.name,
+					formatCatalogTargetVersion(currentCatalogVersion, upgrade.target),
+					upgrade.catalogName,
+				);
+			}
+
+			await spawnCommand("pnpm install", monorepoRoot);
 		}
-		if (devUpgrades.length > 0) {
-			await installDependencies({
-				dependencies: devUpgrades,
-				packageManager,
-				cwd,
-				type: "dev",
-			});
+
+		if (semverUpgrades.length > 0) {
+			const { packageManager } = await detectPackageManager(cwd, packageJson);
+
+			const prodUpgrades = semverUpgrades
+				.filter((u) => u.depType === "prod")
+				.map((u) => `${u.name}@${u.target}`);
+			const devUpgrades = semverUpgrades
+				.filter((u) => u.depType === "dev")
+				.map((u) => `${u.name}@${u.target}`);
+
+			if (prodUpgrades.length > 0) {
+				await installDependencies({
+					dependencies: prodUpgrades,
+					packageManager,
+					cwd,
+					type: "prod",
+				});
+			}
+			if (devUpgrades.length > 0) {
+				await installDependencies({
+					dependencies: devUpgrades,
+					packageManager,
+					cwd,
+					type: "dev",
+				});
+			}
 		}
+
 		installSpinner.stop();
 		console.log(chalk.green("Successfully upgraded better-auth packages."));
 	} catch (error) {

--- a/packages/cli/src/utils/pnpm-catalog.ts
+++ b/packages/cli/src/utils/pnpm-catalog.ts
@@ -1,7 +1,6 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { parse, stringify } from "yaml";
-import { findMonorepoRoot } from "./get-package-info";
+import { parse, parseDocument } from "yaml";
 
 export function parseCatalogSpec(
 	version: string,
@@ -13,8 +12,28 @@ export function parseCatalogSpec(
 	return catalogName ? { catalogName } : {};
 }
 
-export function getPnpmWorkspaceYamlPath(monorepoRoot: string): string {
-	return path.join(monorepoRoot, "pnpm-workspace.yaml");
+export function getPnpmWorkspaceYamlPath(workspaceRoot: string): string {
+	return path.join(workspaceRoot, "pnpm-workspace.yaml");
+}
+
+export async function findPnpmWorkspaceRoot(
+	startDir: string,
+): Promise<string | null> {
+	let currentDir = path.resolve(startDir);
+	const root = path.parse(currentDir).root;
+
+	while (currentDir !== root) {
+		if (existsSync(getPnpmWorkspaceYamlPath(currentDir))) {
+			return currentDir;
+		}
+		const parentDir = path.dirname(currentDir);
+		if (parentDir === currentDir) {
+			break;
+		}
+		currentDir = parentDir;
+	}
+
+	return null;
 }
 
 type WorkspaceYaml = {
@@ -42,11 +61,27 @@ export function formatCatalogTargetVersion(
 	currentCatalogVersion: string,
 	target: string,
 ): string {
-	if (currentCatalogVersion.startsWith("^")) {
+	const trimmed = currentCatalogVersion.trim();
+	if (trimmed.startsWith("^")) {
 		return `^${target}`;
 	}
-	if (currentCatalogVersion.startsWith("~")) {
+	if (trimmed.startsWith("~")) {
 		return `~${target}`;
+	}
+	if (trimmed.startsWith(">=")) {
+		return `>=${target}`;
+	}
+	if (trimmed.startsWith("<=")) {
+		return `<=${target}`;
+	}
+	if (trimmed.startsWith(">")) {
+		return `>${target}`;
+	}
+	if (trimmed.startsWith("<")) {
+		return `<${target}`;
+	}
+	if (trimmed === "*") {
+		return trimmed;
 	}
 	return target;
 }
@@ -57,16 +92,16 @@ export function setPnpmCatalogVersion(
 	newVersion: string,
 	catalogName?: string,
 ): void {
-	const workspace = readWorkspaceYaml(workspaceYamlPath);
+	const content = readFileSync(workspaceYamlPath, "utf-8");
+	const doc = parseDocument(content);
+
 	if (catalogName) {
-		workspace.catalogs ??= {};
-		workspace.catalogs[catalogName] ??= {};
-		workspace.catalogs[catalogName][packageName] = newVersion;
+		doc.setIn(["catalogs", catalogName, packageName], newVersion);
 	} else {
-		workspace.catalog ??= {};
-		workspace.catalog[packageName] = newVersion;
+		doc.setIn(["catalog", packageName], newVersion);
 	}
-	writeFileSync(workspaceYamlPath, stringify(workspace));
+
+	writeFileSync(workspaceYamlPath, String(doc));
 }
 
 export async function resolveCatalogDependencyVersion(
@@ -79,12 +114,12 @@ export async function resolveCatalogDependencyVersion(
 		return null;
 	}
 
-	const monorepoRoot = await findMonorepoRoot(cwd);
-	if (!monorepoRoot) {
+	const workspaceRoot = await findPnpmWorkspaceRoot(cwd);
+	if (!workspaceRoot) {
 		return null;
 	}
 
-	const workspaceYamlPath = getPnpmWorkspaceYamlPath(monorepoRoot);
+	const workspaceYamlPath = getPnpmWorkspaceYamlPath(workspaceRoot);
 	const catalogVersion = getPnpmCatalogVersion(
 		workspaceYamlPath,
 		packageName,

--- a/packages/cli/src/utils/pnpm-catalog.ts
+++ b/packages/cli/src/utils/pnpm-catalog.ts
@@ -62,6 +62,15 @@ export function formatCatalogTargetVersion(
 	target: string,
 ): string {
 	const trimmed = currentCatalogVersion.trim();
+	if (trimmed === "*") {
+		return trimmed;
+	}
+	if (trimmed.includes("||")) {
+		return trimmed.replace(
+			/(\^|~|>=|<=|>|<)?(\d+\.\d+\.\d+[^\s|]*)/g,
+			(_match, operator: string | undefined) => `${operator ?? ""}${target}`,
+		);
+	}
 	if (trimmed.startsWith("^")) {
 		return `^${target}`;
 	}
@@ -80,10 +89,11 @@ export function formatCatalogTargetVersion(
 	if (trimmed.startsWith("<")) {
 		return `<${target}`;
 	}
-	if (trimmed === "*") {
-		return trimmed;
-	}
 	return target;
+}
+
+export function isWildcardCatalogVersion(catalogVersion: string): boolean {
+	return catalogVersion.trim() === "*";
 }
 
 export function setPnpmCatalogVersion(

--- a/packages/cli/src/utils/pnpm-catalog.ts
+++ b/packages/cli/src/utils/pnpm-catalog.ts
@@ -1,0 +1,101 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { parse, stringify } from "yaml";
+import { findMonorepoRoot } from "./get-package-info";
+
+export function parseCatalogSpec(
+	version: string,
+): { catalogName?: string } | null {
+	if (!version.startsWith("catalog:")) {
+		return null;
+	}
+	const catalogName = version.slice("catalog:".length);
+	return catalogName ? { catalogName } : {};
+}
+
+export function getPnpmWorkspaceYamlPath(monorepoRoot: string): string {
+	return path.join(monorepoRoot, "pnpm-workspace.yaml");
+}
+
+type WorkspaceYaml = {
+	catalog?: Record<string, string>;
+	catalogs?: Record<string, Record<string, string>>;
+};
+
+function readWorkspaceYaml(workspaceYamlPath: string): WorkspaceYaml {
+	return parse(readFileSync(workspaceYamlPath, "utf-8")) as WorkspaceYaml;
+}
+
+export function getPnpmCatalogVersion(
+	workspaceYamlPath: string,
+	packageName: string,
+	catalogName?: string,
+): string | null {
+	const workspace = readWorkspaceYaml(workspaceYamlPath);
+	if (catalogName) {
+		return workspace.catalogs?.[catalogName]?.[packageName] ?? null;
+	}
+	return workspace.catalog?.[packageName] ?? null;
+}
+
+export function formatCatalogTargetVersion(
+	currentCatalogVersion: string,
+	target: string,
+): string {
+	if (currentCatalogVersion.startsWith("^")) {
+		return `^${target}`;
+	}
+	if (currentCatalogVersion.startsWith("~")) {
+		return `~${target}`;
+	}
+	return target;
+}
+
+export function setPnpmCatalogVersion(
+	workspaceYamlPath: string,
+	packageName: string,
+	newVersion: string,
+	catalogName?: string,
+): void {
+	const workspace = readWorkspaceYaml(workspaceYamlPath);
+	if (catalogName) {
+		workspace.catalogs ??= {};
+		workspace.catalogs[catalogName] ??= {};
+		workspace.catalogs[catalogName][packageName] = newVersion;
+	} else {
+		workspace.catalog ??= {};
+		workspace.catalog[packageName] = newVersion;
+	}
+	writeFileSync(workspaceYamlPath, stringify(workspace));
+}
+
+export async function resolveCatalogDependencyVersion(
+	cwd: string,
+	packageName: string,
+	versionSpec: string,
+): Promise<{ version: string; catalogName?: string } | null> {
+	const catalogSpec = parseCatalogSpec(versionSpec);
+	if (!catalogSpec) {
+		return null;
+	}
+
+	const monorepoRoot = await findMonorepoRoot(cwd);
+	if (!monorepoRoot) {
+		return null;
+	}
+
+	const workspaceYamlPath = getPnpmWorkspaceYamlPath(monorepoRoot);
+	const catalogVersion = getPnpmCatalogVersion(
+		workspaceYamlPath,
+		packageName,
+		catalogSpec.catalogName,
+	);
+	if (!catalogVersion) {
+		return null;
+	}
+
+	return {
+		version: catalogVersion,
+		catalogName: catalogSpec.catalogName,
+	};
+}

--- a/packages/cli/test/pnpm-catalog.test.ts
+++ b/packages/cli/test/pnpm-catalog.test.ts
@@ -8,10 +8,12 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
+import { findMonorepoRoot } from "../src/utils/get-package-info";
 import {
 	findPnpmWorkspaceRoot,
 	formatCatalogTargetVersion,
 	getPnpmCatalogVersion,
+	isWildcardCatalogVersion,
 	parseCatalogSpec,
 	resolveCatalogDependencyVersion,
 	setPnpmCatalogVersion,
@@ -132,15 +134,23 @@ describe("pnpm-catalog", () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/11072
 	 */
-	it("finds the pnpm workspace root past nearer generic monorepo markers", async () => {
+	it("resolves catalog via pnpm workspace root instead of generic monorepo markers", async () => {
 		const { appDir, root } = createWorkspace({
 			catalog: { "better-auth": "^1.6.26" },
-			packageJson: { name: "web" },
+			packageJson: {
+				name: "web",
+				dependencies: {
+					"better-auth": "catalog:",
+				},
+			},
 			extraFiles: {
 				"apps/turbo.json": "{}\n",
 			},
 		});
 
+		await expect(findMonorepoRoot(appDir)).resolves.toBe(
+			path.join(root, "apps"),
+		);
 		await expect(findPnpmWorkspaceRoot(appDir)).resolves.toBe(root);
 		await expect(
 			resolveCatalogDependencyVersion(appDir, "better-auth", "catalog:"),
@@ -155,6 +165,15 @@ describe("pnpm-catalog", () => {
 		expect(formatCatalogTargetVersion(">=1.6.26", "1.7.2")).toBe(">=1.7.2");
 		expect(formatCatalogTargetVersion("*", "1.7.2")).toBe("*");
 		expect(formatCatalogTargetVersion("1.6.26", "1.7.2")).toBe("1.7.2");
+		expect(formatCatalogTargetVersion("^0.28.17 || ^0.29.0", "1.7.2")).toBe(
+			"^1.7.2 || ^1.7.2",
+		);
+	});
+
+	it("detects wildcard catalog versions", () => {
+		expect(isWildcardCatalogVersion("*")).toBe(true);
+		expect(isWildcardCatalogVersion(" ^* ")).toBe(false);
+		expect(isWildcardCatalogVersion("^1.6.26")).toBe(false);
 	});
 
 	it("preserves comments when updating catalog entries", () => {

--- a/packages/cli/test/pnpm-catalog.test.ts
+++ b/packages/cli/test/pnpm-catalog.test.ts
@@ -1,8 +1,15 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import {
+	findPnpmWorkspaceRoot,
 	formatCatalogTargetVersion,
 	getPnpmCatalogVersion,
 	parseCatalogSpec,
@@ -13,16 +20,24 @@ import {
 describe("pnpm-catalog", () => {
 	const tempDirs: string[] = [];
 
+	afterAll(() => {
+		for (const dir of tempDirs) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	function createWorkspace({
 		catalog,
 		catalogs,
 		packageJson,
 		subdir = "apps/web",
+		extraFiles,
 	}: {
 		catalog?: Record<string, string>;
 		catalogs?: Record<string, Record<string, string>>;
 		packageJson: Record<string, unknown>;
 		subdir?: string;
+		extraFiles?: Record<string, string>;
 	}) {
 		const root = mkdtempSync(path.join(os.tmpdir(), "better-auth-catalog-"));
 		tempDirs.push(root);
@@ -51,6 +66,12 @@ describe("pnpm-catalog", () => {
 			path.join(appDir, "package.json"),
 			`${JSON.stringify(packageJson, null, 2)}\n`,
 		);
+
+		for (const [filePath, contents] of Object.entries(extraFiles ?? {})) {
+			const absolutePath = path.join(root, filePath);
+			mkdirSync(path.dirname(absolutePath), { recursive: true });
+			writeFileSync(absolutePath, contents);
+		}
 
 		return { root, appDir, workspacePath };
 	}
@@ -90,7 +111,7 @@ describe("pnpm-catalog", () => {
 		);
 	});
 
-	it("resolves catalog dependency versions from the monorepo root", async () => {
+	it("resolves catalog dependency versions from the pnpm workspace root", async () => {
 		const { appDir } = createWorkspace({
 			catalog: { "better-auth": "^1.6.26" },
 			packageJson: {
@@ -108,9 +129,52 @@ describe("pnpm-catalog", () => {
 		});
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11072
+	 */
+	it("finds the pnpm workspace root past nearer generic monorepo markers", async () => {
+		const { appDir, root } = createWorkspace({
+			catalog: { "better-auth": "^1.6.26" },
+			packageJson: { name: "web" },
+			extraFiles: {
+				"apps/turbo.json": "{}\n",
+			},
+		});
+
+		await expect(findPnpmWorkspaceRoot(appDir)).resolves.toBe(root);
+		await expect(
+			resolveCatalogDependencyVersion(appDir, "better-auth", "catalog:"),
+		).resolves.toEqual({
+			version: "^1.6.26",
+		});
+	});
+
 	it("preserves range prefixes when formatting catalog targets", () => {
 		expect(formatCatalogTargetVersion("^1.6.26", "1.7.2")).toBe("^1.7.2");
 		expect(formatCatalogTargetVersion("~1.6.26", "1.7.2")).toBe("~1.7.2");
+		expect(formatCatalogTargetVersion(">=1.6.26", "1.7.2")).toBe(">=1.7.2");
+		expect(formatCatalogTargetVersion("*", "1.7.2")).toBe("*");
 		expect(formatCatalogTargetVersion("1.6.26", "1.7.2")).toBe("1.7.2");
+	});
+
+	it("preserves comments when updating catalog entries", () => {
+		const root = mkdtempSync(path.join(os.tmpdir(), "better-auth-catalog-"));
+		tempDirs.push(root);
+		const workspacePath = path.join(root, "pnpm-workspace.yaml");
+		writeFileSync(
+			workspacePath,
+			`packages:
+  - apps/**
+# managed versions
+catalog:
+  better-auth: ^1.6.26
+`,
+		);
+
+		setPnpmCatalogVersion(workspacePath, "better-auth", "^1.7.2");
+
+		const workspace = readFileSync(workspacePath, "utf-8");
+		expect(workspace).toContain("# managed versions");
+		expect(workspace).toContain("better-auth: ^1.7.2");
 	});
 });

--- a/packages/cli/test/pnpm-catalog.test.ts
+++ b/packages/cli/test/pnpm-catalog.test.ts
@@ -1,0 +1,116 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	formatCatalogTargetVersion,
+	getPnpmCatalogVersion,
+	parseCatalogSpec,
+	resolveCatalogDependencyVersion,
+	setPnpmCatalogVersion,
+} from "../src/utils/pnpm-catalog";
+
+describe("pnpm-catalog", () => {
+	const tempDirs: string[] = [];
+
+	function createWorkspace({
+		catalog,
+		catalogs,
+		packageJson,
+		subdir = "apps/web",
+	}: {
+		catalog?: Record<string, string>;
+		catalogs?: Record<string, Record<string, string>>;
+		packageJson: Record<string, unknown>;
+		subdir?: string;
+	}) {
+		const root = mkdtempSync(path.join(os.tmpdir(), "better-auth-catalog-"));
+		tempDirs.push(root);
+		const appDir = path.join(root, subdir);
+		mkdirSync(appDir, { recursive: true });
+
+		const workspacePath = path.join(root, "pnpm-workspace.yaml");
+		const lines = ["packages:", "  - apps/**"];
+		if (catalog) {
+			lines.push("catalog:");
+			for (const [name, version] of Object.entries(catalog)) {
+				lines.push(`  ${name}: ${version}`);
+			}
+		}
+		if (catalogs) {
+			lines.push("catalogs:");
+			for (const [catalogName, entries] of Object.entries(catalogs)) {
+				lines.push(`  ${catalogName}:`);
+				for (const [name, version] of Object.entries(entries)) {
+					lines.push(`    ${name}: ${version}`);
+				}
+			}
+		}
+		writeFileSync(workspacePath, `${lines.join("\n")}\n`);
+		writeFileSync(
+			path.join(appDir, "package.json"),
+			`${JSON.stringify(packageJson, null, 2)}\n`,
+		);
+
+		return { root, appDir, workspacePath };
+	}
+
+	it("parses default and named catalog specs", () => {
+		expect(parseCatalogSpec("catalog:")).toEqual({});
+		expect(parseCatalogSpec("catalog:vitest")).toEqual({
+			catalogName: "vitest",
+		});
+		expect(parseCatalogSpec("^1.6.26")).toBeNull();
+	});
+
+	it("reads and writes default catalog entries", () => {
+		const { workspacePath } = createWorkspace({
+			catalog: { "better-auth": "^1.6.26" },
+			packageJson: { name: "web" },
+		});
+
+		expect(getPnpmCatalogVersion(workspacePath, "better-auth")).toBe("^1.6.26");
+
+		setPnpmCatalogVersion(workspacePath, "better-auth", "^1.7.2");
+		expect(getPnpmCatalogVersion(workspacePath, "better-auth")).toBe("^1.7.2");
+	});
+
+	it("reads named catalog entries", () => {
+		const { workspacePath } = createWorkspace({
+			catalogs: {
+				vitest: {
+					vitest: "^4.1.10",
+				},
+			},
+			packageJson: { name: "web" },
+		});
+
+		expect(getPnpmCatalogVersion(workspacePath, "vitest", "vitest")).toBe(
+			"^4.1.10",
+		);
+	});
+
+	it("resolves catalog dependency versions from the monorepo root", async () => {
+		const { appDir } = createWorkspace({
+			catalog: { "better-auth": "^1.6.26" },
+			packageJson: {
+				name: "web",
+				dependencies: {
+					"better-auth": "catalog:",
+				},
+			},
+		});
+
+		await expect(
+			resolveCatalogDependencyVersion(appDir, "better-auth", "catalog:"),
+		).resolves.toEqual({
+			version: "^1.6.26",
+		});
+	});
+
+	it("preserves range prefixes when formatting catalog targets", () => {
+		expect(formatCatalogTargetVersion("^1.6.26", "1.7.2")).toBe("^1.7.2");
+		expect(formatCatalogTargetVersion("~1.6.26", "1.7.2")).toBe("~1.7.2");
+		expect(formatCatalogTargetVersion("1.6.26", "1.7.2")).toBe("1.7.2");
+	});
+});

--- a/packages/cli/test/upgrade-catalog.test.ts
+++ b/packages/cli/test/upgrade-catalog.test.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { upgradeAction } from "../src/commands/upgrade";
+import { spawnCommand } from "../src/utils/helper";
+
+vi.mock(import("../src/version"), () => ({
+	cliVersion: "1.7.2",
+}));
+vi.mock(import("../src/utils/helper"), async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/utils/helper")>();
+	return {
+		...actual,
+		spawnCommand: vi.fn().mockResolvedValue(undefined),
+	};
+});
+vi.mock(import("yocto-spinner"), () => ({
+	default: vi.fn(() => ({
+		start: vi.fn().mockReturnThis(),
+		stop: vi.fn().mockReturnThis(),
+	})),
+}));
+
+const mockSpawnCommand = vi.mocked(spawnCommand);
+
+describe("upgradeAction catalog support", () => {
+	afterEach(() => {
+		mockSpawnCommand.mockClear();
+		vi.spyOn(console, "log").mockRestore();
+		vi.spyOn(console, "warn").mockRestore();
+	});
+
+	function createCatalogProject() {
+		const root = mkdtempSync(
+			path.join(os.tmpdir(), "better-auth-upgrade-catalog-"),
+		);
+		const appDir = path.join(root, "apps", "web");
+		mkdirSync(appDir, { recursive: true });
+		writeFileSync(
+			path.join(root, "pnpm-workspace.yaml"),
+			`packages:
+  - apps/**
+catalog:
+  better-auth: ^1.6.26
+  "@better-auth/passkey": ^1.6.26
+`,
+		);
+		writeFileSync(
+			path.join(appDir, "package.json"),
+			`${JSON.stringify(
+				{
+					name: "web",
+					dependencies: {
+						"better-auth": "catalog:",
+					},
+					devDependencies: {
+						"@better-auth/passkey": "catalog:",
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		return {
+			root,
+			appDir,
+			workspacePath: path.join(root, "pnpm-workspace.yaml"),
+		};
+	}
+
+	it("upgrades catalog dependencies via pnpm-workspace.yaml", async () => {
+		const { appDir, root, workspacePath } = createCatalogProject();
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await upgradeAction({ cwd: appDir, yes: true });
+
+		const workspace = readFileSync(workspacePath, "utf-8");
+		expect(workspace).toContain("better-auth: ^1.7.2");
+		expect(workspace).toContain('"@better-auth/passkey": ^1.7.2');
+		expect(mockSpawnCommand).toHaveBeenCalledWith("pnpm install", root);
+	});
+});

--- a/packages/cli/test/upgrade-catalog.test.ts
+++ b/packages/cli/test/upgrade-catalog.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -25,16 +31,24 @@ vi.mock(import("yocto-spinner"), () => ({
 const mockSpawnCommand = vi.mocked(spawnCommand);
 
 describe("upgradeAction catalog support", () => {
+	const tempDirs: string[] = [];
+
 	afterEach(() => {
 		mockSpawnCommand.mockClear();
+		mockSpawnCommand.mockResolvedValue(undefined);
 		vi.spyOn(console, "log").mockRestore();
 		vi.spyOn(console, "warn").mockRestore();
+		vi.spyOn(console, "error").mockRestore();
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	function createCatalogProject() {
 		const root = mkdtempSync(
 			path.join(os.tmpdir(), "better-auth-upgrade-catalog-"),
 		);
+		tempDirs.push(root);
 		const appDir = path.join(root, "apps", "web");
 		mkdirSync(appDir, { recursive: true });
 		writeFileSync(
@@ -69,6 +83,9 @@ catalog:
 		};
 	}
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11072
+	 */
 	it("upgrades catalog dependencies via pnpm-workspace.yaml", async () => {
 		const { appDir, root, workspacePath } = createCatalogProject();
 		vi.spyOn(console, "log").mockImplementation(() => {});
@@ -79,5 +96,21 @@ catalog:
 		expect(workspace).toContain("better-auth: ^1.7.2");
 		expect(workspace).toContain('"@better-auth/passkey": ^1.7.2');
 		expect(mockSpawnCommand).toHaveBeenCalledWith("pnpm install", root);
+	});
+
+	it("restores pnpm-workspace.yaml when pnpm install fails", async () => {
+		mockSpawnCommand.mockRejectedValueOnce(new Error("install failed"));
+		const { appDir, workspacePath } = createCatalogProject();
+		const before = readFileSync(workspacePath, "utf-8");
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		const exitSpy = vi
+			.spyOn(process, "exit")
+			.mockImplementation((() => undefined) as never);
+
+		await upgradeAction({ cwd: appDir, yes: true });
+
+		expect(readFileSync(workspacePath, "utf-8")).toBe(before);
+		exitSpy.mockRestore();
 	});
 });

--- a/packages/cli/test/upgrade-catalog.test.ts
+++ b/packages/cli/test/upgrade-catalog.test.ts
@@ -98,6 +98,40 @@ catalog:
 		expect(mockSpawnCommand).toHaveBeenCalledWith("pnpm install", root);
 	});
 
+	it("does not offer wildcard catalog entries for upgrade", async () => {
+		const { appDir, workspacePath } = createCatalogProject();
+		writeFileSync(
+			workspacePath,
+			`packages:
+  - apps/**
+catalog:
+  better-auth: "*"
+`,
+		);
+		writeFileSync(
+			path.join(appDir, "package.json"),
+			`${JSON.stringify(
+				{
+					name: "web",
+					dependencies: {
+						"better-auth": "catalog:",
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await upgradeAction({ cwd: appDir, yes: true });
+
+		expect(readFileSync(workspacePath, "utf-8")).toContain('better-auth: "*"');
+		expect(mockSpawnCommand).not.toHaveBeenCalled();
+		expect(logSpy).toHaveBeenCalledWith(
+			"All better-auth packages are up to date.",
+		);
+	});
+
 	it("restores pnpm-workspace.yaml when pnpm install fails", async () => {
 		mockSpawnCommand.mockRejectedValueOnce(new Error("install failed"));
 		const { appDir, workspacePath } = createCatalogProject();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1320,6 +1320,9 @@ importers:
       semver:
         specifier: ^7.8.4
         version: 7.8.4
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       yocto-spinner:
         specifier: ^1.2.0
         version: 1.2.0


### PR DESCRIPTION
## Summary

- Fix `auth upgrade` crashing with `TypeError: Invalid comparator: catalog:` when Better Auth packages use pnpm `catalog:` dependency specs
- Resolve catalog versions from `pnpm-workspace.yaml`, compare them against the running CLI version, and upgrade catalog entries in place while preserving `^` / `~` prefixes
- Run `pnpm install` at the workspace root for catalog upgrades instead of replacing `catalog:` specs with literal versions via `pnpm add`

## Related issues

- Fixes #11072
- Related to #10997 (`auth info` reporting raw `catalog:` strings)

## Test plan

- [x] `pnpm exec vitest run test/pnpm-catalog.test.ts test/upgrade-catalog.test.ts test/upgrade.test.ts` in `packages/cli`
- [x] Verified locally against a minimal pnpm catalog monorepo repro from #11072

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11072 so `auth upgrade` no longer crashes on pnpm `catalog:` specs. Catalog versions are now resolved from `pnpm-workspace.yaml`, catalog entries are updated in place, and `pnpm install` runs at the workspace root.

**Bug Fixes**
- Handles default and named catalog specs and preserves `^`, `~`, and compound ranges; wildcard entries are skipped.
- Restores `pnpm-workspace.yaml` if `pnpm install` fails and preserves existing YAML comments.
- Adds `yaml` as a CLI dependency for parsing `pnpm-workspace.yaml`.

<sup>Written for commit e86b87efc11f4632942a5a45d6bb0c7249098f15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

