### PR TITLE
fix(scim): restore inactive SCIM user on Okta reprovision POST

### DIFF
--- a/packages/scim/src/scim-okta-reprovision.test.ts
+++ b/packages/scim/src/scim-okta-reprovision.test.ts
@@ -1,0 +1,260 @@
+import { DatabaseSync } from "node:sqlite";
+import { NodeSqliteDialect } from "@better-auth/kysely-adapter/node-sqlite-dialect";
+import { getMigrations } from "better-auth/db/migration";
+import { getHttpTestInstance } from "better-auth/test";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { scim } from ".";
+
+const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+const SCIM_ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error";
+const SCIM_MEDIA_TYPE = "application/scim+json";
+const SCIM_TOKEN = "okta-reprovision-token";
+
+interface SCIMUserResponse {
+	schemas: string[];
+	id: string;
+	userName: string;
+	externalId?: string;
+	displayName?: string;
+	active: boolean;
+}
+
+interface SCIMErrorResponse {
+	schemas: string[];
+	status: string;
+	detail?: string;
+	scimType?: string;
+}
+
+async function readJSON<T>(response: Response): Promise<T> {
+	return (await response.json()) as T;
+}
+
+function createSCIMHeaders(
+	authorization = `Bearer ${SCIM_TOKEN}`,
+): HeadersInit {
+	return {
+		accept: SCIM_MEDIA_TYPE,
+		authorization,
+		"content-type": SCIM_MEDIA_TYPE,
+	};
+}
+
+async function createTestInstance() {
+	const sqlite = new DatabaseSync(":memory:");
+	const instance = await getHttpTestInstance(
+		{
+			database: {
+				dialect: new NodeSqliteDialect({ database: sqlite }),
+				type: "sqlite",
+				transaction: true,
+			},
+			plugins: [
+				scim({
+					connections: [
+						{
+							id: "okta-reprovision",
+							credentials: [
+								{
+									type: "bearer",
+									id: "okta-reprovision-token",
+									token: SCIM_TOKEN,
+								},
+							],
+						},
+					],
+				}),
+			],
+		},
+		{ disableTestUser: true, testWith: "sqlite" },
+	);
+	await (await getMigrations(instance.auth.options)).runMigrations();
+	return { instance, sqlite };
+}
+
+/**
+ * Okta's account deactivation/reactivation lifecycle removes the user's app
+ * assignment on deactivate and sends a fresh `POST /scim/v2/Users` with the
+ * same stable externalId when the account is re-assigned. The retained
+ * inactive SCIM User must be restored (same SCIM id) instead of rejected
+ * with a uniqueness conflict.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/11111
+ */
+describe("Okta deprovision/reprovision lifecycle", () => {
+	let instance: Awaited<ReturnType<typeof createTestInstance>>["instance"];
+	let sqlite: Awaited<ReturnType<typeof createTestInstance>>["sqlite"];
+	let usersURL: string;
+
+	const externalId = "okta-external-id-11111";
+	const userName = "reprovision.case@example.com";
+
+	beforeAll(async () => {
+		const created = await createTestInstance();
+		instance = created.instance;
+		sqlite = created.sqlite;
+		usersURL = `${instance.baseURL}/api/auth/scim/v2/Users`;
+	});
+
+	afterAll(async () => {
+		await instance.server.close();
+		sqlite.close();
+	});
+
+	it("restores the inactive SCIM User on re-POST, preserving its SCIM id", async () => {
+		const createResponse = await fetch(usersURL, {
+			method: "POST",
+			headers: createSCIMHeaders(),
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName,
+				externalId,
+				name: { givenName: "Reprovision", familyName: "Case" },
+				emails: [{ value: userName, type: "work", primary: true }],
+				displayName: "Reprovision Case",
+				active: true,
+			}),
+		});
+		expect(createResponse.status).toBe(201);
+		const created = await readJSON<SCIMUserResponse>(createResponse);
+		expect(created.active).toBe(true);
+
+		// Okta deactivates the account: SCIM update marking the user inactive.
+		const deactivateResponse = await fetch(`${usersURL}/${created.id}`, {
+			method: "PATCH",
+			headers: createSCIMHeaders(),
+			body: JSON.stringify({
+				schemas: [SCIM_PATCH_SCHEMA],
+				Operations: [{ op: "replace", path: "active", value: false }],
+			}),
+		});
+		expect(deactivateResponse.status).toBe(200);
+		expect((await readJSON<SCIMUserResponse>(deactivateResponse)).active).toBe(
+			false,
+		);
+
+		// Okta reactivates the account: a fresh POST with the same externalId.
+		const reprovisionResponse = await fetch(usersURL, {
+			method: "POST",
+			headers: createSCIMHeaders(),
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName,
+				externalId,
+				name: { givenName: "Reprovisioned", familyName: "Case" },
+				emails: [{ value: userName, type: "work", primary: true }],
+				displayName: "Reprovisioned Case",
+				active: true,
+			}),
+		});
+		expect(reprovisionResponse.status).toBe(200);
+		const restored = await readJSON<SCIMUserResponse>(reprovisionResponse);
+		expect(restored.id).toBe(created.id);
+		expect(restored.externalId).toBe(externalId);
+		expect(restored.active).toBe(true);
+		expect(restored.displayName).toBe("Reprovisioned Case");
+
+		const getResponse = await fetch(`${usersURL}/${created.id}`, {
+			headers: createSCIMHeaders(),
+		});
+		expect(getResponse.status).toBe(200);
+		expect((await readJSON<SCIMUserResponse>(getResponse)).active).toBe(true);
+	});
+
+	it("still returns 409 when the matching SCIM User is active", async () => {
+		const activeExternalId = "okta-external-id-active";
+		const activeUserName = "active.collision@example.com";
+		const firstResponse = await fetch(usersURL, {
+			method: "POST",
+			headers: createSCIMHeaders(),
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName: activeUserName,
+				externalId: activeExternalId,
+				emails: [{ value: activeUserName, type: "work", primary: true }],
+				displayName: "Active Collision",
+				active: true,
+			}),
+		});
+		expect(firstResponse.status).toBe(201);
+
+		const duplicateResponse = await fetch(usersURL, {
+			method: "POST",
+			headers: createSCIMHeaders(),
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName: activeUserName,
+				externalId: activeExternalId,
+				emails: [{ value: activeUserName, type: "work", primary: true }],
+				displayName: "Active Collision",
+				active: true,
+			}),
+		});
+		expect(duplicateResponse.status).toBe(409);
+		const error = await readJSON<SCIMErrorResponse>(duplicateResponse);
+		expect(error.schemas).toContain(SCIM_ERROR_SCHEMA);
+		expect(error.scimType).toBe("uniqueness");
+	});
+
+	it("still returns 409 when an inactive row's userName collides with another user", async () => {
+		const sharedExternalId = "okta-external-id-username-collision";
+		const firstUserName = "username.collision.first@example.com";
+		const secondUserName = "username.collision.second@example.com";
+
+		// First user is provisioned, then deactivated.
+		const firstResponse = await fetch(usersURL, {
+			method: "POST",
+			headers: createSCIMHeaders(),
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName: firstUserName,
+				externalId: sharedExternalId,
+				emails: [{ value: firstUserName, type: "work", primary: true }],
+				displayName: "First Collision",
+				active: true,
+			}),
+		});
+		expect(firstResponse.status).toBe(201);
+		const first = await readJSON<SCIMUserResponse>(firstResponse);
+		const deactivateResponse = await fetch(`${usersURL}/${first.id}`, {
+			method: "PATCH",
+			headers: createSCIMHeaders(),
+			body: JSON.stringify({
+				schemas: [SCIM_PATCH_SCHEMA],
+				Operations: [{ op: "replace", path: "active", value: false }],
+			}),
+		});
+		expect(deactivateResponse.status).toBe(200);
+
+		// A second active user now owns the userName the re-POST will carry.
+		const secondResponse = await fetch(usersURL, {
+			method: "POST",
+			headers: createSCIMHeaders(),
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName: secondUserName,
+				emails: [{ value: secondUserName, type: "work", primary: true }],
+				displayName: "Second Collision",
+				active: true,
+			}),
+		});
+		expect(secondResponse.status).toBe(201);
+
+		// Re-POST with the inactive row's externalId but the second user's
+		// userName must still conflict instead of restoring.
+		const collisionResponse = await fetch(usersURL, {
+			method: "POST",
+			headers: createSCIMHeaders(),
+			body: JSON.stringify({
+				schemas: [SCIM_USER_SCHEMA],
+				userName: secondUserName,
+				externalId: sharedExternalId,
+				emails: [{ value: secondUserName, type: "work", primary: true }],
+				displayName: "Second Collision",
+				active: true,
+			}),
+		});
+		expect(collisionResponse.status).toBe(409);
+	});
+});

--- a/packages/scim/src/user-provisioning.ts
+++ b/packages/scim/src/user-provisioning.ts
@@ -1334,4 +1334,4 @@ export function deleteSCIMUser(
 			return;
 		},
 	);
-							}
+}

--- a/packages/scim/src/user-provisioning.ts
+++ b/packages/scim/src/user-provisioning.ts
@@ -403,6 +403,130 @@ export function createSCIMUser(
 				ctx.body.externalId,
 			);
 			await assertUserConnectionDomainStable(adapter, connection);
+			// Okta deprovision/reprovision lifecycle: when Okta reactivates an
+			// account it sends a fresh POST with the same stable externalId the
+			// now-inactive SCIM User was provisioned with. That retained inactive
+			// row must be restored in place (preserving its SCIM id) instead of
+			// rejected as a uniqueness conflict; an ACTIVE row with the same
+			// externalId remains a conflict and falls through to the assertion
+			// below.
+			const existingByExternalId = externalIdKey
+				? await adapter.findOne<SCIMUser>({
+						model: "scimUser",
+						where: [
+							{ field: "connectionId", value: connection.id },
+							{ field: "externalIdKey", value: externalIdKey },
+						],
+					})
+				: null;
+			if (existingByExternalId && existingByExternalId.active === false) {
+				const restoredSCIMUser = await runIdentityMutationTransaction(
+					adapter,
+					async (trx) => {
+						const currentSource = await findSCIMUser(
+							trx,
+							connection,
+							existingByExternalId.id,
+						);
+						if (!currentSource) {
+							throw createSCIMError("NOT_FOUND", {
+								detail: "SCIM User not found",
+							});
+						}
+						if (currentSource.active) {
+							// Raced with another re-provision that already restored the
+							// row; surface the original uniqueness conflict.
+							throw createSCIMError("CONFLICT", {
+								detail: "SCIM User externalId already exists",
+								scimType: "uniqueness",
+							});
+						}
+						await assertSCIMUserKeysAvailable(trx, {
+							connectionId: connection.id,
+							userNameKey,
+							externalIdKey,
+							excludeSCIMUserId: currentSource.id,
+						});
+						const updatedAt = new Date();
+						const subject = await identity.acquireSubject(
+							trx,
+							currentSource.userId,
+							updatedAt,
+						);
+						if (subject.profileSourceId === currentSource.id) {
+							await updateManagedBetterAuthUser(
+								trx,
+								ctx.context.internalAdapter,
+								{
+									userId: currentSource.userId,
+									email: profile.primaryEmail,
+									name: profile.displayName,
+									updatedAt,
+								},
+							);
+						}
+						const restoredSource = await trx.update<SCIMUser>({
+							model: "scimUser",
+							where: [
+								{ field: "id", value: currentSource.id },
+								{ field: "connectionId", value: connection.id },
+							],
+							update: {
+								userName: profile.userName,
+								userNameKey,
+								primaryEmail: profile.primaryEmail,
+								workEmailValueIndex: createSCIMEmailValueIndex(
+									profile.emails,
+									"work",
+								),
+								emailValueIndex: createSCIMEmailValueIndex(profile.emails),
+								displayName: profile.displayName,
+								formattedName: profile.formattedName,
+								givenName: profile.name.givenName ?? null,
+								familyName: profile.name.familyName ?? null,
+								serializedEmails: serializeSCIMEmails(profile.emails),
+								serializedAttributes: serializeSCIMUserAttributes(
+									profile.attributes,
+								),
+								externalId: ctx.body.externalId ?? null,
+								externalIdKey: externalIdKey ?? null,
+								active,
+								updatedAt,
+							},
+						});
+						if (!restoredSource) {
+							throw createSCIMError("NOT_FOUND", {
+								detail: "SCIM User not found",
+							});
+						}
+						await projection.reconcileUser({
+							database: trx,
+							auth: ctx.context,
+							provisioningDomainId: connection.provisioningDomainId,
+							scimUserId: restoredSource.id,
+						});
+						await identity.reconcileUser({
+							database: trx,
+							auth: ctx.context,
+							subject,
+						});
+						await fenceActiveSCIMConnection(trx, connection.id);
+						return restoredSource;
+					},
+				);
+				const completeResource = createUserResource(
+					ctx.context.baseURL,
+					restoredSCIMUser,
+				);
+				const resource = projectSCIMResourceAttributes(
+					completeResource,
+					attributeProjection,
+				);
+				ctx.setStatus(200);
+				ctx.setHeader("location", completeResource.meta.location);
+				ctx.setHeader("content-location", completeResource.meta.location);
+				return ctx.json(resource);
+			}
 			await assertSCIMUserKeysAvailable(adapter, {
 				connectionId: connection.id,
 				userNameKey,
@@ -1210,4 +1334,4 @@ export function deleteSCIMUser(
 			return;
 		},
 	);
-}
+							}


### PR DESCRIPTION
> Built by breken, your AI support engineer - breken.ai - this one's on us.

**Fixes #11111.**

## The problem in plain words

When someone leaves a company, Okta deactivates their account, and the SCIM user in Better Auth is kept but marked inactive. When that person comes back, Okta sends a brand-new "create user" request with the same externalId it always used. Better Auth answers "409: that externalId is taken" - taken by the person's own old, inactive record. Okta can't reprovision them, and every retry fails the same way, so the user stays locked out of every app behind that connection.

## Root cause

`createSCIMUser` in `packages/scim/src/user-provisioning.ts` calls `assertSCIMUserKeysAvailable` before identity resolution. That check matches the retained inactive `scimUser` row on `externalIdKey` and throws a uniqueness conflict. It never distinguishes "this externalId belongs to an active user" (a real conflict) from "this externalId belongs to an inactive user the IdP is trying to bring back" (a restore).

## The fix

When an incoming POST matches an **inactive** SCIM user on the same connection + externalId, restore that row in place instead of rejecting it:

- the SCIM id is preserved, so Okta keeps its mapping;
- the submitted profile is refreshed (same field update as `replaceSCIMUser` / PUT);
- `active` reflects the request (Okta sends `active: true` on reprovision);
- the linked Better Auth user's email/name is updated when this SCIM user is the profile source;
- projection and identity reconciliation rerun, exactly like a PUT;
- the endpoint returns 200 with the resource, since no new resource was created.

An **active** row with the same externalId still returns 409, and a userName now owned by a different user still returns 409 - both enforced inside the restore transaction, so two racing reprovision POSTs degrade to the same conflict as before.

## Behavior change worth knowing about

`POST /scim/v2/Users` with a connection-scoped externalId that belongs to an inactive user now succeeds (200) and revives that user instead of failing with 409. Everything else about the endpoint is unchanged.

## Reproduction and evidence

New test file `packages/scim/src/scim-okta-reprovision.test.ts` replays Okta's lifecycle over real HTTP against a sqlite-backed instance:

1. POST create with an externalId -> 201
2. PATCH `active: false` (deprovision) -> 200
3. POST again with the same externalId (reprovision)
   - before this change: 409 `SCIM User externalId already exists` (the reported bug)
   - after: 200, same SCIM id, `active: true`, refreshed profile
4. Two guard tests: the same externalId on an ACTIVE user still 409s, and an inactive row whose userName is now owned by another user still 409s.

## Verified vs. not verified

- ✅ The restore test fails on master and passes with this change (before/after confirmed).
- ✅ Full `@better-auth/scim` suite passes locally: 334 tests across 33 files, including create-uniqueness, okta-conformance, user-patch, and user-concurrency.
- ⚠️ 3 suite files (scim-http-e2e, scim-sso-http-e2e, scim-sso-registration) could not run in my environment because `@better-auth/test-utils` does not build there; they fail at import resolution, unrelated to this change.
- ⚠️ Not exercised against a live Okta tenant; the lifecycle is modeled from Okta's documented deactivation/reassignment behavior and the reporter's trace.
- ⚠️ Deliberate choice: restore returns 200 rather than 201 because no new resource is created - happy to switch if you prefer create semantics.

Happy to iterate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Okta reprovisioning (issue #11111) by restoring inactive SCIM users on POST instead of returning a 409 conflict.

**Behavior change**
- `POST /scim/v2/Users` now returns 200 and revives the inactive user when the externalId matches an inactive row on the same connection.
- The SCIM id is preserved and the profile is refreshed like a PUT.
- Active rows with the same externalId still return 409, and userName collisions are still enforced.
- Returns 200 instead of 201 because no new resource is created.

<sup>Written for commit d35a855fb7334ec113a96041e071bae5b1e5aa43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

