### PR TITLE
feat(oauth-provider): decouple public-client advertisement from unauthenticated DCR

### DIFF
--- a/.changeset/public-clients-supported.md
+++ b/.changeset/public-clients-supported.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": minor
+---
+
+Add `publicClientsSupported`, decoupling the advertised public-client support from how clients are registered. A provider with protected dynamic client registration (`allowUnauthenticatedClientRegistration: false`) previously advertised `token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post"]` even though its token endpoint accepts public clients, so conformant clients concluded public clients were unsupported. Unset, the option keeps the current derived behavior.

--- a/packages/oauth-provider/src/metadata.test.ts
+++ b/packages/oauth-provider/src/metadata.test.ts
@@ -132,6 +132,55 @@ describe("oauth metadata", async () => {
 		expect(oauthMetadata).toMatchObject(metadata ?? {});
 	});
 
+	it('should advertise "none" when publicClientsSupported is set, without opening dynamic client registration', async () => {
+		const { auth } = await createTestInstance({
+			oauthProviderConfig: {
+				allowUnauthenticatedClientRegistration: false,
+				publicClientsSupported: true,
+			},
+		});
+
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata?.token_endpoint_auth_methods_supported).toEqual([
+			"none",
+			"client_secret_basic",
+			"client_secret_post",
+			"private_key_jwt",
+		]);
+
+		// The introspection and revocation endpoints never accept public
+		// clients, so they must not gain "none" alongside the token endpoint.
+		expect(metadata?.introspection_endpoint_auth_methods_supported).toEqual([
+			"client_secret_basic",
+			"client_secret_post",
+			"private_key_jwt",
+		]);
+
+		// Registration stays authenticated: the option advertises what the
+		// token endpoint accepts, it does not open `/oauth2/register`.
+		const registration = await auth.api
+			.registerOAuthClient({
+				body: { redirect_uris: ["https://example.com/callback"] },
+			})
+			.catch((error: unknown) => error);
+		expect(registration).toBeInstanceOf(APIError);
+		expect((registration as APIError).status).toBe("UNAUTHORIZED");
+	});
+
+	it("should keep deriving public-client support from registration when publicClientsSupported is unset", async () => {
+		const { auth } = await createTestInstance({
+			oauthProviderConfig: { allowUnauthenticatedClientRegistration: true },
+		});
+
+		const metadata = await auth.api.getOpenIdConfig();
+		expect(metadata?.token_endpoint_auth_methods_supported).toEqual([
+			"none",
+			"client_secret_basic",
+			"client_secret_post",
+			"private_key_jwt",
+		]);
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/8343
 	 */

--- a/packages/oauth-provider/src/metadata.ts
+++ b/packages/oauth-provider/src/metadata.ts
@@ -122,8 +122,14 @@ function buildAuthServerMetadata(
 	// Any contributed `clientDiscovery` implicitly produces public clients
 	// (CIMD, wallet attestation, etc.), so it flips `public_client_supported`
 	// and the advertised `"none"` auth method alongside unauthenticated DCR.
+	// `publicClientsSupported` decouples the ADVERTISEMENT of public-client
+	// support from how clients are registered: a provider with protected DCR
+	// still accepts public clients at the token endpoint, and must be able to
+	// say so.
 	const publicClientSupported =
-		opts.allowUnauthenticatedClientRegistration || clientDiscoveries.length > 0;
+		opts.publicClientsSupported ??
+		(opts.allowUnauthenticatedClientRegistration ||
+			clientDiscoveries.length > 0);
 	const authMetadata = authServerMetadata(ctx, jwtPluginOptions, {
 		scopes_supported: opts.advertisedMetadata?.scopes_supported ?? opts.scopes,
 		dynamic_client_registration_supported: opts.allowDynamicClientRegistration,

--- a/packages/oauth-provider/src/types/index.ts
+++ b/packages/oauth-provider/src/types/index.ts
@@ -719,6 +719,29 @@ export interface OAuthOptions<
 	 */
 	allowUnauthenticatedClientRegistration?: boolean;
 	/**
+	 * Whether the token endpoint accepts PUBLIC clients — clients registered
+	 * with `token_endpoint_auth_method: "none"` that hold no client secret.
+	 *
+	 * Controls `public_client_supported` and, through it, the `"none"` entry
+	 * in the discovery documents' `token_endpoint_auth_methods_supported`.
+	 *
+	 * This is a separate concern from
+	 * {@link OAuthOptions.allowUnauthenticatedClientRegistration}, which
+	 * governs whether dynamic client registration requires an authenticated
+	 * caller. A provider may require a session (or an initial access token) to
+	 * REGISTER a client and still accept that client as a public one at the
+	 * token endpoint: `validateClientCredentials` demands a `client_secret`
+	 * only from a client that is not marked public, regardless of either
+	 * option. Leaving the two conflated makes a provider with protected DCR
+	 * advertise `["client_secret_basic", "client_secret_post"]`, which
+	 * RFC 8414 §2 gives a conformant client exactly one reading of: public
+	 * clients are not supported. Such a client then never attempts the
+	 * request that would have succeeded, and nothing errors anywhere.
+	 *
+	 * @default `allowUnauthenticatedClientRegistration || a contributed clientDiscovery`
+	 */
+	publicClientsSupported?: boolean;
+	/**
 	 * Allow dynamic client registration (RFC 7591) at `POST /oauth2/register`.
 	 *
 	 * Once enabled, a registration request is authorized through one of three


### PR DESCRIPTION
### The problem

`public_client_supported` — and through it the `"none"` entry in
`token_endpoint_auth_methods_supported` on both discovery documents — is
derived from how clients are *registered*:

```ts
// packages/oauth-provider/src/metadata.ts
const publicClientSupported =
  opts.allowUnauthenticatedClientRegistration || clientDiscoveries.length > 0;
```

Those are two different questions:

| Question | Answered by |
| --- | --- |
| May a caller with no session register a client? | `allowUnauthenticatedClientRegistration` |
| Does the **token endpoint** accept a client that holds no secret? | `validateClientCredentials` — which never consults either option |

A provider that requires a session (or an initial access token) to register a
client still accepts public clients at the token endpoint: `validateClientCredentials`
demands a `client_secret` only from a client that is **not** marked public, and
rejects a secret sent *by* a public client outright. An authenticated DCR caller
can already register `token_endpoint_auth_method: "none"`, and
`createOAuthClientEndpoint` stores `public: true` and mints no secret for it.

But such a provider advertises:

```json
"token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"]
```

RFC 8414 §2 gives a conformant client exactly one reading of that: public
clients are not supported. A stock `golang.org/x/oauth2` / `go-oidc` client
reads this field to pick its client-authentication method, so it never attempts
the request that would have succeeded — and nothing errors anywhere. The failure
is silent in both directions: no log line on the server, no error on the client.

Device-flow and native clients are public by definition, so this is the
configuration that hits it: protected DCR (which is the recommended posture)
plus public clients.

### The change

Adds `publicClientsSupported?: boolean` to `OAuthOptions`:

```ts
const publicClientSupported =
  opts.publicClientsSupported ??
  (opts.allowUnauthenticatedClientRegistration || clientDiscoveries.length > 0);
```

Left unset, the derived value is exactly what it is today, so this is additive
for every existing consumer. Set, it says what the token endpoint accepts,
independently of what registration requires.

### Tests

Two added to `packages/oauth-provider/src/metadata.test.ts`:

- `publicClientsSupported: true` with `allowUnauthenticatedClientRegistration: false`
  advertises `"none"` at the token endpoint, does **not** add it to the
  introspection/revocation lists (those never accept public clients), and
  `/oauth2/register` still rejects an unauthenticated caller with `UNAUTHORIZED`
  — the decoupling asserted in one body, since a test pinning only one half
  stays green while the other moves.
- With the option unset, `allowUnauthenticatedClientRegistration: true` still
  produces `"none"` — the no-regression half.

Verified red-without / green-with: reverting only the `metadata.ts` change fails
the first test with `expected [ 'client_secret_basic', …(2) ] to deeply equal [ 'none', … ]`.
`pnpm --filter @better-auth/oauth-provider exec vitest run src/metadata.test.ts` — 28 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `publicClientsSupported` option to `OAuthOptions` so the advertised public-client support matches what the token endpoint actually accepts, independent of how clients are registered.

Previously, the `"none"` entry in `token_endpoint_auth_methods_supported` was derived from `allowUnauthenticatedClientRegistration` (or contributed client discoveries). A provider with protected dynamic client registration still accepts public clients at the token endpoint, but advertised only `["client_secret_basic", "client_secret_post"]`. Per RFC 8414 §2, a conformant client reads that as "public clients unsupported" and never attempts the request that would have succeeded — no error anywhere.

With `publicClientsSupported` set, providers can advertise the `"none"` method without opening `/oauth2/register` to unauthenticated callers. Unset, the derived behavior is unchanged, so existing consumers are unaffected.

<sup>Written for commit 45d61863863ea5ecbc63ec29d9716536cbcecbdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

