### PR TITLE
docs: list ThunderID as a community provider helper

### DIFF
--- a/docs/content/docs/authentication/other-social-providers.mdx
+++ b/docs/content/docs/authentication/other-social-providers.mdx
@@ -158,10 +158,11 @@ Provider authors and community maintainers can publish reusable helpers that ret
   integrating them into your application.
 </Callout>
 
-| Provider                                                          | Package                                  | Repository                                                                                        | Maintained by                                        |
-| ----------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| [AgentID](https://agentid.com)                                    | `@agentmail/agentid-better-auth`         | [agentmail-to/agentid-better-auth](https://github.com/agentmail-to/agentid-better-auth)           | [@agentmail-to](https://github.com/agentmail-to)     |
-| [EVE Online](https://developers.eveonline.com/docs/services/sso/) | `@localisprimary/better-auth-eve-online` | [localisprimary/better-auth-eve-online](https://github.com/localisprimary/better-auth-eve-online) | [@localisprimary](https://github.com/localisprimary) |
+| Provider                                                          | Package                                  | Repository                                                                                                 | Maintained by                                        |
+| ----------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| [AgentID](https://agentid.com)                                    | `@agentmail/agentid-better-auth`         | [agentmail-to/agentid-better-auth](https://github.com/agentmail-to/agentid-better-auth)                    | [@agentmail-to](https://github.com/agentmail-to)     |
+| [EVE Online](https://developers.eveonline.com/docs/services/sso/) | `@localisprimary/better-auth-eve-online` | [localisprimary/better-auth-eve-online](https://github.com/localisprimary/better-auth-eve-online)          | [@localisprimary](https://github.com/localisprimary) |
+| [ThunderID](https://thunderid.dev)                                | `@thunderid/better-auth`                 | [thunder-id/javascript-sdks](https://github.com/thunder-id/javascript-sdks/tree/main/packages/better-auth) | [@thunder-id](https://github.com/thunder-id)         |
 
 #### Create a Provider Helper
 


### PR DESCRIPTION
[ThunderID](https://thunderid.dev/) is a fully open source, OIDC-compliant identity platform initiated by [WSO2](https://wso2.com/) (the team behind [WSO2 Identity Server](https://wso2.com/identity-platform/identity-server/) and [Asgardeo](https://wso2.com/identity-platform/developer/)), which are widely used in enterprise IAM.

Following up on #10237, this is a docs-only PR listing ThunderID as a **community provider helper** for the Generic OAuth plugin, instead of a built-in provider.

The helper itself lives in [thunder-id/javascript-sdks](https://github.com/thunder-id/javascript-sdks/tree/main/packages/better-auth) as [@thunderid/better-auth](https://www.npmjs.com/package/@thunderid/better-auth). It returns a typed `GenericOAuthConfig` for a ThunderID issuer, with all OAuth 2.0 / OIDC handling performed by Better Auth itself.

This PR just adds the corresponding row to the Community Provider Helpers table in `docs/content/docs/authentication/other-social-providers.mdx`.

<img width="907" height="427" alt="Screenshot 2026-09-04 at 23 08 52" src="https://github.com/user-attachments/assets/0e19dc02-5db7-471a-8baa-a9a1f2ca73fe" />

Fixes https://github.com/better-auth/better-auth/issues/10238

## Related Issues

- thunder-id/thunderid#3559


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ThunderID to the Community Provider Helpers table in the Generic OAuth docs, per the social provider integration policy. The `@thunderid/better-auth` package returns a typed `GenericOAuthConfig` for a ThunderID issuer, with all OAuth 2.0 / OIDC handling performed by Better Auth itself.

<sup>Written for commit 482bbdac6b775a1fade998a3267dd4fcb86ff3ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

