### PR TITLE
fix(session): skip cache cookie when disabled

### DIFF
--- a/.changeset/clean-rice-skip.md
+++ b/.changeset/clean-rice-skip.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Ignore retired session cache cookies when cookie caching is disabled so database-backed sessions can still be read.

--- a/.changeset/clean-rice-skip.md
+++ b/.changeset/clean-rice-skip.md
@@ -2,4 +2,4 @@
 "better-auth": patch
 ---
 
-Ignore retired session cache cookies when cookie caching is disabled so database-backed sessions can still be read.
+Prevent `getSession` from failing when cookie caching is disabled while clients still have cached session cookies.

--- a/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
+++ b/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { parseCookies } from "../../cookies";
+import { parseCookies, parseSetCookieHeader } from "../../cookies";
 import { symmetricEncodeJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 
@@ -24,9 +24,22 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/11119
 	 */
-	it("should ignore retired session_data when cookie caching is disabled", async () => {
+	it.each([
+		{
+			name: "disabled in configuration",
+			cookieCache: { enabled: false },
+			query: undefined,
+			expectedBaseMaxAge: 0,
+		},
+		{
+			name: "disabled for the request",
+			cookieCache: { enabled: true, strategy: "compact" as const },
+			query: { disableCookieCache: true },
+			expectedBaseMaxAge: 300,
+		},
+	])("should ignore retired session_data when caching is $name", async (test) => {
 		const { client, testUser, cookieSetter } = await getTestInstance({
-			session: { cookieCache: { enabled: false } },
+			session: { cookieCache: test.cookieCache },
 		});
 		const headers = new Headers();
 		await client.signIn.email(
@@ -39,13 +52,36 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 			"better-auth-secret-that-is-long-enough-for-validation-test",
 			"better-auth-session",
 		);
+		const sessionToken = parseCookies(headers.get("cookie") || "").get(
+			"better-auth.session_token",
+		);
 		headers.set(
 			"cookie",
-			`${headers.get("cookie")}; better-auth.session_data=${retiredCache}`,
+			`better-auth.session_data=${retiredCache}; better-auth.session_data.0=stale; better-auth.session_data.1=chunks; better-auth.session_token=${sessionToken}`,
 		);
 
-		const session = await client.getSession({ fetchOptions: { headers } });
+		let setCookieHeader = "";
+		const session = await client.getSession({
+			query: test.query,
+			fetchOptions: {
+				headers,
+				onSuccess(context) {
+					setCookieHeader = context.response.headers.get("set-cookie") || "";
+				},
+			},
+		});
 		expect(session.data?.user.email).toBe(testUser.email);
+
+		const responseCookies = parseSetCookieHeader(setCookieHeader);
+		expect(responseCookies.get("better-auth.session_data")?.["max-age"]).toBe(
+			test.expectedBaseMaxAge,
+		);
+		expect(responseCookies.get("better-auth.session_data.0")?.["max-age"]).toBe(
+			0,
+		);
+		expect(responseCookies.get("better-auth.session_data.1")?.["max-age"]).toBe(
+			0,
+		);
 	});
 
 	it("should fall through to session_token DB validation when session_data HMAC fails", async () => {

--- a/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
+++ b/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
@@ -81,6 +81,59 @@ describe("disabled cookie cache fallback", () => {
 		}
 		expect(responseCookies.has("custom.session_token")).toBe(false);
 	});
+
+	it.each([
+		{ state: "missing", sessionTokenCookie: "" },
+		{
+			state: "invalid",
+			sessionTokenCookie: "; custom.session_token=invalid",
+		},
+	])("clears retired session_data when session_token is $state", async ({
+		sessionTokenCookie,
+	}) => {
+		const { client } = await getTestInstance({
+			secret,
+			advanced: {
+				cookies: {
+					session_token: { name: "custom.session_token" },
+					session_data: { name: "custom.session" },
+				},
+			},
+			session: {
+				cookieCache: { enabled: false },
+			},
+		});
+		const retiredCache = await symmetricEncodeJWT(
+			{ retired: true },
+			secret,
+			"better-auth-session",
+		);
+		const headers = new Headers({
+			cookie:
+				`custom.session=${retiredCache}; custom.session.0=stale; custom.session.1=chunks` +
+				sessionTokenCookie,
+		});
+
+		let setCookieHeader = "";
+		const session = await client.getSession({
+			fetchOptions: {
+				headers,
+				onSuccess(context) {
+					setCookieHeader = context.response.headers.get("set-cookie") || "";
+				},
+			},
+		});
+
+		expect(session.data).toBeNull();
+		const responseCookies = parseSetCookieHeader(setCookieHeader);
+		for (const name of [
+			"custom.session",
+			"custom.session.0",
+			"custom.session.1",
+		]) {
+			expect(responseCookies.get(name)?.["max-age"]).toBe(0);
+		}
+	});
 });
 
 /**

--- a/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
+++ b/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseCookies } from "../../cookies";
+import { symmetricEncodeJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 
 /**
@@ -19,6 +20,34 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 	afterEach(() => {
 		vi.useRealTimers();
 	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11119
+	 */
+	it("should ignore retired session_data when cookie caching is disabled", async () => {
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			session: { cookieCache: { enabled: false } },
+		});
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+
+		const retiredCache = await symmetricEncodeJWT(
+			{ retired: true },
+			"better-auth-secret-that-is-long-enough-for-validation-test",
+			"better-auth-session",
+		);
+		headers.set(
+			"cookie",
+			`${headers.get("cookie")}; better-auth.session_data=${retiredCache}`,
+		);
+
+		const session = await client.getSession({ fetchOptions: { headers } });
+		expect(session.data?.user.email).toBe(testUser.email);
+	});
+
 	it("should fall through to session_token DB validation when session_data HMAC fails", async () => {
 		const { client, testUser, cookieSetter } = await getTestInstance({
 			session: {

--- a/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
+++ b/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
@@ -21,7 +21,14 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 		vi.useRealTimers();
 	});
 
-	it("ignores and clears retired session_data when cookie caching is disabled", async () => {
+	it.each([
+		{ mode: "in configuration", enabled: false, query: undefined },
+		{
+			mode: "for the request",
+			enabled: true,
+			query: { disableCookieCache: true },
+		},
+	])("ignores retired session_data when caching is disabled $mode", async (test) => {
 		const { client, testUser, cookieSetter } = await getTestInstance({
 			advanced: {
 				cookies: {
@@ -29,7 +36,9 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 					session_data: { name: "custom.session" },
 				},
 			},
-			session: { cookieCache: { enabled: false } },
+			session: {
+				cookieCache: { enabled: test.enabled, strategy: "compact" },
+			},
 		});
 		const headers = new Headers();
 		await client.signIn.email(
@@ -49,6 +58,7 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 
 		let setCookieHeader = "";
 		const session = await client.getSession({
+			query: test.query,
 			fetchOptions: {
 				headers,
 				onSuccess(context) {
@@ -59,11 +69,10 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 		expect(session.data?.user.email).toBe(testUser.email);
 
 		const responseCookies = parseSetCookieHeader(setCookieHeader);
-		for (const name of [
-			"custom.session",
-			"custom.session.0",
-			"custom.session.1",
-		]) {
+		expect(responseCookies.get("custom.session")?.["max-age"]).toBe(
+			test.enabled ? 300 : 0,
+		);
+		for (const name of ["custom.session.0", "custom.session.1"]) {
 			expect(responseCookies.get(name)?.["max-age"]).toBe(0);
 		}
 		expect(responseCookies.has("custom.session_token")).toBe(false);

--- a/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
+++ b/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
@@ -21,25 +21,9 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 		vi.useRealTimers();
 	});
 
-	/**
-	 * @see https://github.com/better-auth/better-auth/issues/11119
-	 */
-	it.each([
-		{
-			name: "disabled in configuration",
-			cookieCache: { enabled: false },
-			query: undefined,
-			expectedBaseMaxAge: 0,
-		},
-		{
-			name: "disabled for the request",
-			cookieCache: { enabled: true, strategy: "compact" as const },
-			query: { disableCookieCache: true },
-			expectedBaseMaxAge: 300,
-		},
-	])("should ignore retired session_data when caching is $name", async (test) => {
+	it("ignores and clears retired session_data when cookie caching is disabled", async () => {
 		const { client, testUser, cookieSetter } = await getTestInstance({
-			session: { cookieCache: test.cookieCache },
+			session: { cookieCache: { enabled: false } },
 		});
 		const headers = new Headers();
 		await client.signIn.email(
@@ -52,17 +36,13 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 			"better-auth-secret-that-is-long-enough-for-validation-test",
 			"better-auth-session",
 		);
-		const sessionToken = parseCookies(headers.get("cookie") || "").get(
-			"better-auth.session_token",
-		);
 		headers.set(
 			"cookie",
-			`better-auth.session_data=${retiredCache}; better-auth.session_data.0=stale; better-auth.session_data.1=chunks; better-auth.session_token=${sessionToken}`,
+			`${headers.get("cookie")}; better-auth.session_data=${retiredCache}; better-auth.session_data.0=stale; better-auth.session_data.1=chunks`,
 		);
 
 		let setCookieHeader = "";
 		const session = await client.getSession({
-			query: test.query,
 			fetchOptions: {
 				headers,
 				onSuccess(context) {
@@ -73,15 +53,13 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 		expect(session.data?.user.email).toBe(testUser.email);
 
 		const responseCookies = parseSetCookieHeader(setCookieHeader);
-		expect(responseCookies.get("better-auth.session_data")?.["max-age"]).toBe(
-			test.expectedBaseMaxAge,
-		);
-		expect(responseCookies.get("better-auth.session_data.0")?.["max-age"]).toBe(
-			0,
-		);
-		expect(responseCookies.get("better-auth.session_data.1")?.["max-age"]).toBe(
-			0,
-		);
+		for (const name of [
+			"better-auth.session_data",
+			"better-auth.session_data.0",
+			"better-auth.session_data.1",
+		]) {
+			expect(responseCookies.get(name)?.["max-age"]).toBe(0);
+		}
 	});
 
 	it("should fall through to session_token DB validation when session_data HMAC fails", async () => {

--- a/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
+++ b/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
@@ -23,6 +23,12 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 
 	it("ignores and clears retired session_data when cookie caching is disabled", async () => {
 		const { client, testUser, cookieSetter } = await getTestInstance({
+			advanced: {
+				cookies: {
+					session_token: { name: "custom.session_token" },
+					session_data: { name: "custom.session" },
+				},
+			},
 			session: { cookieCache: { enabled: false } },
 		});
 		const headers = new Headers();
@@ -38,7 +44,7 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 		);
 		headers.set(
 			"cookie",
-			`${headers.get("cookie")}; better-auth.session_data=${retiredCache}; better-auth.session_data.0=stale; better-auth.session_data.1=chunks`,
+			`${headers.get("cookie")}; custom.session=${retiredCache}; custom.session.0=stale; custom.session.1=chunks`,
 		);
 
 		let setCookieHeader = "";
@@ -54,12 +60,13 @@ describe("cookieCache HMAC verification failure fallback", async () => {
 
 		const responseCookies = parseSetCookieHeader(setCookieHeader);
 		for (const name of [
-			"better-auth.session_data",
-			"better-auth.session_data.0",
-			"better-auth.session_data.1",
+			"custom.session",
+			"custom.session.0",
+			"custom.session.1",
 		]) {
 			expect(responseCookies.get(name)?.["max-age"]).toBe(0);
 		}
+		expect(responseCookies.has("custom.session_token")).toBe(false);
 	});
 
 	it("should fall through to session_token DB validation when session_data HMAC fails", async () => {

--- a/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
+++ b/packages/better-auth/src/api/routes/cookie-cache-fallback.test.ts
@@ -4,6 +4,86 @@ import { symmetricEncodeJWT } from "../../crypto";
 import { getTestInstance } from "../../test-utils/test-instance";
 
 /**
+ * @see https://github.com/better-auth/better-auth/issues/11119
+ */
+describe("disabled cookie cache fallback", () => {
+	const secret = "better-auth-retired-cookie-cache-test-secret";
+	const cacheMaxAge = 5 * 60;
+
+	it.each([
+		{
+			mode: "in configuration",
+			cacheEnabled: false,
+			query: undefined,
+			expectedSessionDataMaxAge: 0,
+		},
+		{
+			mode: "for the request",
+			cacheEnabled: true,
+			query: { disableCookieCache: true },
+			expectedSessionDataMaxAge: cacheMaxAge,
+		},
+	])("ignores retired session_data when caching is disabled $mode", async ({
+		cacheEnabled,
+		query,
+		expectedSessionDataMaxAge,
+	}) => {
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			secret,
+			advanced: {
+				cookies: {
+					session_token: { name: "custom.session_token" },
+					session_data: { name: "custom.session" },
+				},
+			},
+			session: {
+				cookieCache: {
+					enabled: cacheEnabled,
+					strategy: "compact",
+					maxAge: cacheMaxAge,
+				},
+			},
+		});
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+
+		const retiredCache = await symmetricEncodeJWT(
+			{ retired: true },
+			secret,
+			"better-auth-session",
+		);
+		headers.set(
+			"cookie",
+			`${headers.get("cookie")}; custom.session=${retiredCache}; custom.session.0=stale; custom.session.1=chunks`,
+		);
+
+		let setCookieHeader = "";
+		const session = await client.getSession({
+			query,
+			fetchOptions: {
+				headers,
+				onSuccess(context) {
+					setCookieHeader = context.response.headers.get("set-cookie") || "";
+				},
+			},
+		});
+		expect(session.data?.user.email).toBe(testUser.email);
+
+		const responseCookies = parseSetCookieHeader(setCookieHeader);
+		expect(responseCookies.get("custom.session")?.["max-age"]).toBe(
+			expectedSessionDataMaxAge,
+		);
+		for (const name of ["custom.session.0", "custom.session.1"]) {
+			expect(responseCookies.get(name)?.["max-age"]).toBe(0);
+		}
+		expect(responseCookies.has("custom.session_token")).toBe(false);
+	});
+});
+
+/**
  * @see https://github.com/better-auth/better-auth/issues/9233
  *
  * When `crossSubDomainCookies` is enabled for the first time on a live deployment,
@@ -19,63 +99,6 @@ import { getTestInstance } from "../../test-utils/test-instance";
 describe("cookieCache HMAC verification failure fallback", async () => {
 	afterEach(() => {
 		vi.useRealTimers();
-	});
-
-	it.each([
-		{ mode: "in configuration", enabled: false, query: undefined },
-		{
-			mode: "for the request",
-			enabled: true,
-			query: { disableCookieCache: true },
-		},
-	])("ignores retired session_data when caching is disabled $mode", async (test) => {
-		const { client, testUser, cookieSetter } = await getTestInstance({
-			advanced: {
-				cookies: {
-					session_token: { name: "custom.session_token" },
-					session_data: { name: "custom.session" },
-				},
-			},
-			session: {
-				cookieCache: { enabled: test.enabled, strategy: "compact" },
-			},
-		});
-		const headers = new Headers();
-		await client.signIn.email(
-			{ email: testUser.email, password: testUser.password },
-			{ onSuccess: cookieSetter(headers) },
-		);
-
-		const retiredCache = await symmetricEncodeJWT(
-			{ retired: true },
-			"better-auth-secret-that-is-long-enough-for-validation-test",
-			"better-auth-session",
-		);
-		headers.set(
-			"cookie",
-			`${headers.get("cookie")}; custom.session=${retiredCache}; custom.session.0=stale; custom.session.1=chunks`,
-		);
-
-		let setCookieHeader = "";
-		const session = await client.getSession({
-			query: test.query,
-			fetchOptions: {
-				headers,
-				onSuccess(context) {
-					setCookieHeader = context.response.headers.get("set-cookie") || "";
-				},
-			},
-		});
-		expect(session.data?.user.email).toBe(testUser.email);
-
-		const responseCookies = parseSetCookieHeader(setCookieHeader);
-		expect(responseCookies.get("custom.session")?.["max-age"]).toBe(
-			test.enabled ? 300 : 0,
-		);
-		for (const name of ["custom.session.0", "custom.session.1"]) {
-			expect(responseCookies.get(name)?.["max-age"]).toBe(0);
-		}
-		expect(responseCookies.has("custom.session_token")).toBe(false);
 	});
 
 	it("should fall through to session_token DB validation when session_data HMAC fails", async () => {

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -11,6 +11,7 @@ import { APIError, BASE_ERROR_CODES } from "@better-auth/core/error";
 import * as z from "zod";
 import { hasServerSessionStore } from "../../context/store-capabilities";
 import {
+	createSessionStore,
 	decodeCookieCache,
 	deleteSessionCookie,
 	expireCookie,
@@ -18,10 +19,7 @@ import {
 	setCookieCache,
 	setSessionCookie,
 } from "../../cookies";
-import {
-	createSessionStore,
-	getSessionQuerySchema,
-} from "../../cookies/session-store";
+import { getSessionQuerySchema } from "../../cookies/session-store";
 import { parseSessionOutput, parseUserOutput } from "../../db";
 import type { Prettify, Session, User } from "../../types";
 import { getDate } from "../../utils/date";
@@ -95,15 +93,14 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 					return null;
 				}
 
-				const isCookieCacheEnabled =
-					ctx.context.options.session?.cookieCache?.enabled;
+				const cookieCache = ctx.context.options.session?.cookieCache;
 				const shouldUseCookieCache =
-					isCookieCacheEnabled && !ctx.query?.disableCookieCache;
+					cookieCache?.enabled && !ctx.query?.disableCookieCache;
 				const sessionDataCookie = getChunkedCookie(
 					ctx,
 					ctx.context.authCookies.sessionData.name,
 				);
-				if (sessionDataCookie && !isCookieCacheEnabled) {
+				if (sessionDataCookie && !cookieCache?.enabled) {
 					const sessionStore = createSessionStore(
 						ctx.context.authCookies.sessionData.name,
 						ctx.context.authCookies.sessionData.attributes,

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -84,19 +84,17 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 			}
 
 			try {
+				const cookieCacheEnabled =
+					ctx.context.options.session?.cookieCache?.enabled === true;
 				const sessionCookieToken = await ctx.getSignedCookie(
 					ctx.context.authCookies.sessionToken.name,
 					ctx.context.secret,
 				);
 
-				if (!sessionCookieToken) {
+				if (!sessionCookieToken && cookieCacheEnabled) {
 					return null;
 				}
 
-				const cookieCacheEnabled =
-					ctx.context.options.session?.cookieCache?.enabled === true;
-				const shouldUseCookieCache =
-					cookieCacheEnabled && !ctx.query?.disableCookieCache;
 				const sessionDataCookie = getChunkedCookie(
 					ctx,
 					ctx.context.authCookies.sessionData.name,
@@ -109,7 +107,12 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 					);
 					sessionStore.setCookies(sessionStore.clean());
 				}
+				if (!sessionCookieToken) {
+					return null;
+				}
 
+				const shouldUseCookieCache =
+					cookieCacheEnabled && !ctx.query?.disableCookieCache;
 				const sessionDataPayload =
 					shouldUseCookieCache && sessionDataCookie
 						? await decodeCookieCache(ctx, sessionDataCookie)

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -93,14 +93,15 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 					return null;
 				}
 
-				const cookieCache = ctx.context.options.session?.cookieCache;
+				const cookieCacheEnabled =
+					ctx.context.options.session?.cookieCache?.enabled === true;
 				const shouldUseCookieCache =
-					cookieCache?.enabled && !ctx.query?.disableCookieCache;
+					cookieCacheEnabled && !ctx.query?.disableCookieCache;
 				const sessionDataCookie = getChunkedCookie(
 					ctx,
 					ctx.context.authCookies.sessionData.name,
 				);
-				if (sessionDataCookie && !cookieCache?.enabled) {
+				if (sessionDataCookie && !cookieCacheEnabled) {
 					const sessionStore = createSessionStore(
 						ctx.context.authCookies.sessionData.name,
 						ctx.context.authCookies.sessionData.attributes,
@@ -125,7 +126,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 				/**
 				 * If session data is present in the cookie, check if it should be used or refreshed
 				 */
-				if (sessionDataPayload?.session && shouldUseCookieCache) {
+				if (sessionDataPayload?.session) {
 					const session = sessionDataPayload.session;
 
 					let shouldExpireCookieCache =

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -92,10 +92,10 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 					return null;
 				}
 
-				const sessionDataCookie = getChunkedCookie(
-					ctx,
-					ctx.context.authCookies.sessionData.name,
-				);
+				const sessionDataCookie = ctx.context.options.session?.cookieCache
+					?.enabled
+					? getChunkedCookie(ctx, ctx.context.authCookies.sessionData.name)
+					: null;
 
 				const sessionDataPayload = sessionDataCookie
 					? await decodeCookieCache(ctx, sessionDataCookie)

--- a/packages/better-auth/src/api/routes/session.ts
+++ b/packages/better-auth/src/api/routes/session.ts
@@ -18,7 +18,10 @@ import {
 	setCookieCache,
 	setSessionCookie,
 } from "../../cookies";
-import { getSessionQuerySchema } from "../../cookies/session-store";
+import {
+	createSessionStore,
+	getSessionQuerySchema,
+} from "../../cookies/session-store";
 import { parseSessionOutput, parseUserOutput } from "../../db";
 import type { Prettify, Session, User } from "../../types";
 import { getDate } from "../../utils/date";
@@ -92,15 +95,28 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 					return null;
 				}
 
-				const sessionDataCookie = ctx.context.options.session?.cookieCache
-					?.enabled
-					? getChunkedCookie(ctx, ctx.context.authCookies.sessionData.name)
-					: null;
+				const isCookieCacheEnabled =
+					ctx.context.options.session?.cookieCache?.enabled;
+				const shouldUseCookieCache =
+					isCookieCacheEnabled && !ctx.query?.disableCookieCache;
+				const sessionDataCookie = getChunkedCookie(
+					ctx,
+					ctx.context.authCookies.sessionData.name,
+				);
+				if (sessionDataCookie && !isCookieCacheEnabled) {
+					const sessionStore = createSessionStore(
+						ctx.context.authCookies.sessionData.name,
+						ctx.context.authCookies.sessionData.attributes,
+						ctx,
+					);
+					sessionStore.setCookies(sessionStore.clean());
+				}
 
-				const sessionDataPayload = sessionDataCookie
-					? await decodeCookieCache(ctx, sessionDataCookie)
-					: null;
-				if (sessionDataCookie && !sessionDataPayload) {
+				const sessionDataPayload =
+					shouldUseCookieCache && sessionDataCookie
+						? await decodeCookieCache(ctx, sessionDataCookie)
+						: null;
+				if (shouldUseCookieCache && sessionDataCookie && !sessionDataPayload) {
 					expireCookie(ctx, ctx.context.authCookies.sessionData);
 				}
 
@@ -112,11 +128,7 @@ export const getSession = <Option extends BetterAuthOptions>() =>
 				/**
 				 * If session data is present in the cookie, check if it should be used or refreshed
 				 */
-				if (
-					sessionDataPayload?.session &&
-					ctx.context.options.session?.cookieCache?.enabled &&
-					!ctx.query?.disableCookieCache
-				) {
+				if (sessionDataPayload?.session && shouldUseCookieCache) {
 					const session = sessionDataPayload.session;
 
 					let shouldExpireCookieCache =

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -2077,6 +2077,26 @@ describe("Cookie header without whitespace after semicolon", () => {
 	});
 });
 
+/**
+ * @see https://github.com/better-auth/better-auth/issues/11119
+ */
+describe("getChunkedCookie", () => {
+	it.each([
+		"better-auth.session_data.0junk",
+		"better-auth.session_data.nested.0",
+		"better-auth.session_data.01",
+		"better-auth.session_data.-1",
+	])("ignores non-canonical chunk name %s", (name) => {
+		const headers = new Headers({ cookie: `${name}=chunk` });
+		const ctx = {
+			getCookie: () => undefined,
+			headers,
+		} as unknown as Parameters<typeof getChunkedCookie>[0];
+
+		expect(getChunkedCookie(ctx, "better-auth.session_data")).toBeNull();
+	});
+});
+
 describe("parseCookies validation", () => {
 	it("returns empty map for empty header", () => {
 		expect(parseCookies("").size).toBe(0);

--- a/packages/better-auth/src/cookies/session-store.ts
+++ b/packages/better-auth/src/cookies/session-store.ts
@@ -54,7 +54,11 @@ function readExistingChunks(
 	const cookies = parseCookies(ctx.headers?.get("cookie") || "");
 
 	for (const [name, value] of cookies) {
-		if (name.startsWith(cookieName)) {
+		if (
+			name === cookieName ||
+			(name.startsWith(`${cookieName}.`) &&
+				/^\d+$/.test(name.slice(cookieName.length + 1)))
+		) {
 			chunks[name] = value;
 		}
 	}

--- a/packages/better-auth/src/cookies/session-store.ts
+++ b/packages/better-auth/src/cookies/session-store.ts
@@ -43,6 +43,22 @@ interface Cookie {
 
 type Chunks = Record<string, string>;
 
+function parseCookieChunkIndex(
+	cookieName: string,
+	name: string,
+): number | null {
+	const prefix = `${cookieName}.`;
+	if (!name.startsWith(prefix)) return null;
+
+	const suffix = name.slice(prefix.length);
+	const index = Number(suffix);
+	if (!Number.isSafeInteger(index) || index < 0 || String(index) !== suffix) {
+		return null;
+	}
+
+	return index;
+}
+
 /**
  * Read all existing chunks from cookies
  */
@@ -54,13 +70,9 @@ function readExistingChunks(
 	const cookies = parseCookies(ctx.headers?.get("cookie") || "");
 
 	for (const [name, value] of cookies) {
-		if (
-			name === cookieName ||
-			(name.startsWith(`${cookieName}.`) &&
-				/^\d+$/.test(name.slice(cookieName.length + 1)))
-		) {
-			chunks[name] = value;
-		}
+		if (name !== cookieName && parseCookieChunkIndex(cookieName, name) === null)
+			continue;
+		chunks[name] = value;
 	}
 
 	return chunks;
@@ -212,14 +224,9 @@ export function getChunkedCookie(
 	}
 
 	for (const [name, val] of parseCookies(cookieHeader)) {
-		if (name.startsWith(cookieName + ".")) {
-			const parts = name.split(".");
-			const indexStr = parts.at(-1);
-			const index = parseInt(indexStr || "0", 10);
-			if (!isNaN(index)) {
-				chunks.push({ index, value: val });
-			}
-		}
+		const index = parseCookieChunkIndex(cookieName, name);
+		if (index === null) continue;
+		chunks.push({ index, value: val });
 	}
 
 	if (chunks.length > 0) {


### PR DESCRIPTION
`getSession` now ignores retired `session_data` cookies when cookie caching is disabled, clears the base cookie and its chunks, and loads the session from the database-backed `session_token`. The request-level `disableCookieCache` option still refreshes the cache from the database.

Closes #11119.

Repro: https://github.com/onmax/repros/tree/repro/better-auth-disabled-cookie-cache/better-auth-11119

No breaking changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `getSession` so a retired `session_data` cache cookie no longer breaks database-backed sessions when cookie caching is disabled. The base cookie and its numbered chunks are now cleared, even when the session token is missing or invalid, and the session loads from the database-backed `session_token`. Previously a leftover cache cookie could cause a 500 after migrating off JWE cookie caching. Chunk matching only accepts canonical names like `session_data.0`, so lookalike cookies are ignored. The request-level `disableCookieCache` option still refreshes the cache from the database. Closes #11119. No breaking changes.

<sup>Written for commit ee3a9cf5e1fcd749d50dd893bbf27e902c0bc62e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

