### PR TITLE
docs: upgrade Typesense Fumadocs adapter

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -106,7 +106,7 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "catalog:tailwind",
     "typesense": "^3.0.6",
-    "typesense-fumadocs-adapter": "^0.4.1",
+    "typesense-fumadocs-adapter": "^0.4.2",
     "unist-util-visit": "^5.1.0",
     "vaul": "^1.1.2",
     "zod": "catalog:"

--- a/docs/scripts/sync-typesense.ts
+++ b/docs/scripts/sync-typesense.ts
@@ -2,32 +2,9 @@ import "dotenv/config";
 import * as fs from "node:fs";
 import { Client } from "typesense";
 import type { DocumentRecord } from "typesense-fumadocs-adapter";
-import { getDefaultCollectionFields, sync } from "typesense-fumadocs-adapter";
+import { sync } from "typesense-fumadocs-adapter";
 
 const typesenseCollectionName = "better-auth-docs";
-const typesenseLocale = "en";
-
-// The adapter types tags as strings but creates a string[] field, which rejects imports.
-const typesenseCollectionFields = getDefaultCollectionFields(
-	typesenseLocale,
-).map((field): typeof field =>
-	field.name === "tag" ? { ...field, type: "string" } : field,
-);
-
-export function getTypesenseSyncOptions(documents: DocumentRecord[]) {
-	return {
-		typesenseCollectionName,
-		documents: documents.map((document) => ({
-			...document,
-			locale: typesenseLocale,
-		})),
-		customLocaleCollectionSettings: {
-			[typesenseLocale]: {
-				field_definitions: typesenseCollectionFields,
-			},
-		},
-	};
-}
 
 export function getTypesenseSyncSkipReason(env: NodeJS.ProcessEnv) {
 	const url = env.NEXT_PUBLIC_TYPESENSE_SERVER_URL;
@@ -98,7 +75,10 @@ async function main() {
 		connectionTimeoutSeconds: 30,
 	});
 
-	await sync(client, getTypesenseSyncOptions(records));
+	await sync(client, {
+		typesenseCollectionName,
+		documents: records,
+	});
 	const collection = await client
 		.collections(typesenseCollectionName)
 		.retrieve();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,8 +435,8 @@ importers:
         specifier: ^3.0.6
         version: 3.0.6(@babel/runtime@7.29.2)
       typesense-fumadocs-adapter:
-        specifier: ^0.4.1
-        version: 0.4.1(f8cd0429ca9c88ff7de5886f478169dd)
+        specifier: ^0.4.2
+        version: 0.4.2(f8cd0429ca9c88ff7de5886f478169dd)
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -15076,8 +15076,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typesense-fumadocs-adapter@0.4.1:
-    resolution: {integrity: sha512-yKF+T5aFzevLPlyqX6OA4PUvTnr1BMa5CWIn5vC6/UqKW0bg8L5xpu3sb0AqsOcPxciuUzd6cRMfMVmcfDE/YA==}
+  typesense-fumadocs-adapter@0.4.2:
+    resolution: {integrity: sha512-KmctDfcAdm7C+HS9zYNMYULuShZJDetKLO9mTyWw1EWGIjPjIRmnWyRsD41aErzEwDIN6TguUBjomp2Lx7klGg==}
     peerDependencies:
       fumadocs-core: ^16.0.0
       fumadocs-ui: ^16.0.0
@@ -32290,7 +32290,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  typesense-fumadocs-adapter@0.4.1(f8cd0429ca9c88ff7de5886f478169dd):
+  typesense-fumadocs-adapter@0.4.2(f8cd0429ca9c88ff7de5886f478169dd):
     dependencies:
       fumadocs-core: 16.12.0(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@25.9.4)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.5.4)
       fumadocs-ui: 16.12.0(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.12.0(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@25.9.4)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.5.4))(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@25.9.4)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)


### PR DESCRIPTION
Related:
- https://github.com/typesense/typesense-fumadocs-adapter/issues/2
- https://github.com/typesense/typesense-fumadocs-adapter/issues/3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `typesense-fumadocs-adapter` from 0.4.1 to 0.4.2, which fixes the tag field type mismatch and default locale handling. This lets us remove the custom sync options workaround and call `sync` directly with just the collection name and documents.

<sup>Written for commit f2e96f17e52ad643505fccc0c39e93e678166cb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

