### PR TITLE
feat(cli): offer the Nuxt module during init

### DIFF
--- a/.changeset/quiet-ravens-init.md
+++ b/.changeset/quiet-ravens-init.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+Offer the Nuxt module setup when `auth init` detects a Nuxt project.

--- a/docs/content/docs/concepts/cli.mdx
+++ b/docs/content/docs/concepts/cli.mdx
@@ -125,6 +125,8 @@ The `init` command allows you to initialize Better Auth in your project.
 npx auth@latest init
 ```
 
+In a Nuxt project, the command offers to install `@nuxtjs/better-auth` with Nuxt CLI. Decline the prompt to use the manual Better Auth setup instead.
+
 ### Options
 
 * `--name` - The name of your application. (defaults to the `name` property in your `package.json`).

--- a/docs/content/docs/integrations/nuxt.mdx
+++ b/docs/content/docs/integrations/nuxt.mdx
@@ -5,9 +5,27 @@ title: Nuxt Integration
 description: Integrate Better Auth with Nuxt.
 ---
 
-Before you start, make sure you have a Better Auth instance configured. If you haven't done that yet, check out the [installation](/docs/installation).
+## Install the Nuxt module
 
-## Mount the handler
+The [`@nuxtjs/better-auth`](https://better-auth.nuxt.dev) module is the recommended way to use Better Auth with Nuxt. It mounts the auth handler and adds Nuxt composables for accessing the current session during SSR and on the client.
+
+<Callout type="info">
+  The Nuxt module is maintained by the Nuxt Modules team outside the Better Auth repository. Report module-specific issues in the [`nuxt-modules/better-auth`](https://github.com/nuxt-modules/better-auth/issues) repository.
+</Callout>
+
+{/* cspell:ignore nuxi */}
+
+```package-install title="Terminal"
+npx nuxi module add @nuxtjs/better-auth
+```
+
+The command adds the module to `nuxt.config` and creates server and client configuration files. Continue with the [Nuxt module installation guide](https://better-auth.nuxt.dev/getting-started/installation) to configure your secret, authentication methods, and database.
+
+<Accordions>
+  <Accordion id="manual-setup" title="Manual setup">
+    Use this setup if you don't want to install the Nuxt module. Before you start, configure a Better Auth instance by following the [installation guide](/docs/installation).
+
+### Mount the handler
 
 Mount the Better Auth handler to a catch-all Nitro route. Create a file at `server/api/auth/[...all].ts`:
 
@@ -23,7 +41,7 @@ export default defineEventHandler((event) => {
   You can change the mount path in your Better Auth configuration, but keeping it as `/api/auth/[...all]` is recommended.
 </Callout>
 
-## Create a client
+### Create a client
 
 Create an auth client using `better-auth/vue` so `useSession` returns Vue refs:
 
@@ -34,7 +52,7 @@ export const authClient = createAuthClient();
 export const { signIn, signUp, signOut, useSession } = authClient;
 ```
 
-## Use the session
+### Use the session
 
 Use `authClient.useSession(useFetch)` inside a page `setup()` to load the session on the server and hydrate it on the client. Pass Nuxt's `useFetch` so the request is made with the incoming cookies and the payload is reused during hydration:
 
@@ -58,7 +76,7 @@ const { data: session } = await authClient.useSession(useFetch);
 
 For client-only widgets like popovers or menus, call `authClient.useSession()` without an argument. It returns a reactive ref that updates on sign-in and sign-out.
 
-## Protect pages
+### Protect pages
 
 Create a named route middleware and opt pages into it with `definePageMeta`:
 
@@ -81,7 +99,7 @@ definePageMeta({ middleware: "auth" });
 
 Rename the file to `app/middleware/auth.global.ts` to run it on every route. Always `return` the `navigateTo(...)` call, since calling it without `return` is a no-op.
 
-## Protect server routes
+### Protect server routes
 
 Call `auth.api.getSession` with the incoming `event.headers` and guard the route with `createError`:
 
@@ -99,7 +117,7 @@ export default defineEventHandler(async (event) => {
 
 If you need to reuse this across many routes, factor the check into your own `server/utils/` helper.
 
-## Use the client during SSR
+### Use the client during SSR
 
 Aside from `useSession(useFetch)`, `authClient` actions don't forward cookies during SSR by default, so they return as unauthenticated. Two ways to handle this:
 
@@ -141,7 +159,7 @@ const { data: accounts } = await useAsyncData("accounts", () =>
 </script>
 ```
 
-## Reuse with a Nuxt layer
+### Reuse with a Nuxt layer
 
 When you want to reuse the same auth setup across multiple Nuxt apps (for example a marketing site and a dashboard), extract `lib/auth.ts`, `server/`, `app/middleware/`, and `app/composables/` into a [Nuxt layer](https://nuxt.com/docs/4.x/getting-started/layers) and extend it from each app:
 
@@ -151,12 +169,15 @@ export default defineNuxtConfig({
 });
 ```
 
+  </Accordion>
+</Accordions>
+
 ## Resources & examples
 
 {/* cspell:disable */}
 
 * [`nuxt-modules/better-auth`](https://github.com/nuxt-modules/better-auth)
-* [`atinux/nuxthub-better-auth`](https://github.com/atinux/nuxthub-better-auth)
+* [NuxtHub database integration](https://better-auth.nuxt.dev/integrations/nuxthub)
 * [`leamsigc/nuxt-better-auth-drizzle`](https://github.com/leamsigc/nuxt-better-auth-drizzle)
 * [`nuxtone/nuxt-one`](https://github.com/nuxtone/nuxt-one)
 

--- a/docs/content/docs/integrations/nuxt.mdx
+++ b/docs/content/docs/integrations/nuxt.mdx
@@ -13,13 +13,13 @@ The [`@nuxtjs/better-auth`](https://better-auth.nuxt.dev) module is the recommen
   The Nuxt module is maintained by the Nuxt Modules team outside the Better Auth repository. Report module-specific issues in the [`nuxt-modules/better-auth`](https://github.com/nuxt-modules/better-auth/issues) repository.
 </Callout>
 
-{/* cspell:ignore nuxi */}
+Run Better Auth's CLI from your Nuxt project:
 
 ```package-install title="Terminal"
-npx nuxi module add @nuxtjs/better-auth
+npx auth@latest init
 ```
 
-The command adds the module to `nuxt.config` and creates server and client configuration files. Continue with the [Nuxt module installation guide](https://better-auth.nuxt.dev/getting-started/installation) to configure your secret, authentication methods, and database.
+The CLI detects Nuxt and asks to install the module. The module install updates `nuxt.config` and creates server and client configuration files. Continue with the [Nuxt module installation guide](https://better-auth.nuxt.dev/getting-started/installation) to configure your secret, authentication methods, and database.
 
 <Accordions>
   <Accordion id="manual-setup" title="Manual setup">

--- a/packages/cli/src/commands/init/configs/frameworks.config.ts
+++ b/packages/cli/src/commands/init/configs/frameworks.config.ts
@@ -97,6 +97,11 @@ export const { GET, POST } = toNextJsHandler(auth.handler);`,
 		name: "Nuxt",
 		id: "nuxt",
 		dependency: "nuxt",
+		setup: {
+			name: "@nuxtjs/better-auth",
+			executable: "nuxi",
+			args: ["module", "add", "@nuxtjs/better-auth"],
+		},
 		authClient: {
 			importPath: "better-auth/vue",
 		},
@@ -226,6 +231,11 @@ export const Route = createFileRoute('/api/auth/$')({
 	name: string;
 	id: string;
 	dependency: string;
+	setup?: {
+		name: string;
+		executable: string;
+		args: readonly string[];
+	};
 	authClient: {
 		importPath: string;
 	} | null;

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { exec, spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import chalk from "chalk";
@@ -415,6 +415,49 @@ export async function initAction(opts: any) {
 	>();
 	const filesToWrite: (() => Promise<unknown>)[] = [];
 
+	// Let frameworks with a dedicated integration own their setup.
+	const detectedFramework = await detectFramework(cwd, packageJson);
+	if (detectedFramework && "setup" in detectedFramework) {
+		const shouldUseFrameworkSetup = await confirm({
+			message: `Would you like to set up Better Auth with ${chalk.cyan(detectedFramework.setup.name)}?`,
+			initial: true,
+		});
+		if (isCancel(shouldUseFrameworkSetup)) {
+			cancel("✋ Operation cancelled.");
+			process.exit(0);
+		}
+
+		if (shouldUseFrameworkSetup) {
+			await nextStep(`Install ${detectedFramework.setup.name}`);
+			const setupCommand = pm === "npm" ? "npx" : pm;
+			const setupArgs = [
+				...(pm === "bun" ? ["x"] : []),
+				detectedFramework.setup.executable,
+				...detectedFramework.setup.args,
+			];
+			await new Promise<void>((resolve, reject) => {
+				const child = spawn(setupCommand, setupArgs, {
+					cwd,
+					stdio: "inherit",
+					shell: process.platform === "win32",
+				});
+				child.once("error", reject);
+				child.once("close", (code) => {
+					if (code === 0) {
+						resolve();
+						return;
+					}
+					reject(
+						new Error(
+							`${detectedFramework.setup.name} setup exited with code ${code ?? "unknown"}.`,
+						),
+					);
+				});
+			});
+			return;
+		}
+	}
+
 	// Install Better Auth
 	await (async () => {
 		const hasBetterAuth = await hasDependency(packageJson, "better-auth");
@@ -579,7 +622,6 @@ export async function initAction(opts: any) {
 	})();
 
 	// Auto-detect framework silently
-	const detectedFramework = await detectFramework(cwd, packageJson);
 	let framework: Framework =
 		detectedFramework || FRAMEWORKS.find((f) => f.id === "next")!;
 	const frameworkWasDetected = !!detectedFramework;

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -1,4 +1,4 @@
-import { exec as execMock } from "node:child_process";
+import { exec as execMock, spawn as spawnMock } from "node:child_process";
 import path from "node:path";
 import { vol } from "memfs";
 import prompts from "prompts";
@@ -31,6 +31,7 @@ vi.mock("prompts", () => ({
 }));
 vi.mock("node:child_process", () => ({
 	exec: vi.fn(),
+	spawn: vi.fn(),
 }));
 vi.mock("../src/utils/get-package-info", () => {
 	const mockGetPackageInfo = vi.fn();
@@ -67,12 +68,83 @@ vi.mock("../src/generators/drizzle", () => ({
 // Type the mocked functions
 const mockPrompts = vi.mocked(prompts);
 const mockExec = vi.mocked(execMock);
+const mockSpawn = vi.mocked(spawnMock);
 const mockGetPackageInfo = vi.mocked(getPackageInfo);
 const mockHasDependency = vi.mocked(hasDependency);
 const mockDetectPackageManager = vi.mocked(detectPackageManager);
 const mockInstallDependencies = vi.mocked(installDependencies);
 const mockGeneratePrismaSchema = vi.mocked(generatePrismaSchema);
 const mockGenerateDrizzleSchema = vi.mocked(generateDrizzleSchema);
+
+const setupNuxtProject = async (
+	tmp: string,
+	{ includeBetterAuth = false }: { includeBetterAuth?: boolean } = {},
+) => {
+	const packageJson = {
+		name: "nuxt-project",
+		version: "1.0.0",
+		dependencies: {
+			...(includeBetterAuth ? { "better-auth": "latest" } : {}),
+			nuxt: "latest",
+		},
+	};
+	await fs.writeFile(
+		path.join(tmp, "package.json"),
+		JSON.stringify(packageJson),
+	);
+	mockGetPackageInfo.mockReturnValue(packageJson);
+	mockHasDependency.mockImplementation(
+		(_packageJson, dependency) => dependency in packageJson.dependencies,
+	);
+};
+
+const mockManualNuxtSetupPrompts = () => {
+	mockPrompts.mockImplementation(async (questions: any) => {
+		const question = Array.isArray(questions) ? questions[0] : questions;
+
+		if (question.message?.includes("@nuxtjs/better-auth")) {
+			return { value: false };
+		}
+		if (question.message?.includes("set environment variables")) {
+			return { value: false };
+		}
+		if (question.message?.includes("auth instance")) {
+			return { filePath: "lib/auth.ts" };
+		}
+		if (question.message?.includes("configure a database")) {
+			return { value: "skip" };
+		}
+		if (
+			question.message?.includes("email & password") ||
+			question.message?.includes("setup social providers") ||
+			question.message?.includes("auth client configuration")
+		) {
+			return { value: false };
+		}
+		if (question.message?.includes("route handler")) {
+			return { filePath: "server/api/auth/[...all].ts" };
+		}
+		if (question.name === "connect") {
+			return { connect: false };
+		}
+
+		return {};
+	});
+};
+
+const mockFrameworkSetupExit = (exitCode: number) => {
+	mockSpawn.mockImplementation(() => {
+		const child = {
+			once: (event: string, listener: (value: number | null) => void) => {
+				if (event === "close") {
+					queueMicrotask(() => listener(exitCode));
+				}
+				return child;
+			},
+		};
+		return child as unknown as ReturnType<typeof spawnMock>;
+	});
+};
 
 describe("initAction", () => {
 	let originalExit: typeof process.exit;
@@ -119,6 +191,68 @@ describe("initAction", () => {
 		process.exit = originalExit;
 		vi.restoreAllMocks();
 	});
+
+	for (const [packageManager, command, prefix] of [
+		["npm", "npx", []],
+		["pnpm", "pnpm", []],
+		["yarn", "yarn", []],
+		["bun", "bun", ["x"]],
+	] as const) {
+		testWithTmpDir(
+			`should delegate Nuxt setup with ${packageManager}`,
+			async ({ tmp }) => {
+				await setupNuxtProject(tmp);
+				mockDetectPackageManager.mockResolvedValue({ packageManager });
+				mockPrompts.mockResolvedValue({ value: true });
+				mockFrameworkSetupExit(0);
+
+				await initAction({ cwd: tmp });
+
+				expect(mockSpawn).toHaveBeenCalledWith(
+					command,
+					[...prefix, "nuxi", "module", "add", "@nuxtjs/better-auth"],
+					expect.objectContaining({
+						cwd: path.resolve(tmp),
+						stdio: "inherit",
+					}),
+				);
+				expect(mockPrompts).toHaveBeenCalledOnce();
+				expect(mockInstallDependencies).not.toHaveBeenCalled();
+			},
+		);
+	}
+
+	testWithTmpDir(
+		"should report a failed Nuxt module setup",
+		async ({ tmp }) => {
+			await setupNuxtProject(tmp);
+			mockPrompts.mockResolvedValue({ value: true });
+			mockFrameworkSetupExit(1);
+
+			await expect(initAction({ cwd: tmp })).rejects.toThrow(
+				"@nuxtjs/better-auth setup exited with code 1.",
+			);
+			expect(mockInstallDependencies).not.toHaveBeenCalled();
+		},
+	);
+
+	testWithTmpDir(
+		"should keep the manual Nuxt setup when the module is declined",
+		async ({ tmp }) => {
+			await setupNuxtProject(tmp, { includeBetterAuth: true });
+			mockManualNuxtSetupPrompts();
+
+			await initAction({ cwd: tmp });
+
+			expect(mockSpawn).not.toHaveBeenCalled();
+			expect(
+				await fs.readFile(
+					path.join(tmp, "server/api/auth/[...all].ts"),
+					"utf-8",
+				),
+			).toContain("auth.handler");
+		},
+	);
 
 	testWithTmpDir(
 		"should complete full init flow with database setup",


### PR DESCRIPTION
Updates `auth init` to offer the Nuxt module and run Nuxi with the detected package manager. Declining keeps the manual setup.

Builds on #11123 and closes #10896.

## Tests

- `pnpm --filter auth exec vitest run test/init.test.ts`
- `pnpm --filter auth typecheck`
- `pnpm --filter docs build`
- Tested accept and decline paths in `/tmp`