### PR TITLE
fix(cli): report installed dependency versions

### DIFF
--- a/.changeset/report-installed-cli-versions.md
+++ b/.changeset/report-installed-cli-versions.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+`auth info` now reports installed package versions for catalog and workspace dependency specifiers.

--- a/.changeset/report-installed-cli-versions.md
+++ b/.changeset/report-installed-cli-versions.md
@@ -2,4 +2,4 @@
 "auth": patch
 ---
 
-`auth info` now reports installed package versions for catalog and workspace dependency specifiers.
+`auth info` now reports installed package versions instead of declared dependency specifiers, including catalog and workspace references.

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -526,14 +526,12 @@ export const info = new Command("info")
 		}
 
 		console.log(chalk.bold.white("\n🔐 Better Auth:"));
+		console.log(`  ${chalk.cyan("Version")}: ${betterAuthInfo.version}`);
 		if (betterAuthInfo.error) {
 			console.log(`  ${chalk.red("Error:")} ${betterAuthInfo.error}`);
-		} else {
-			console.log(`  ${chalk.cyan("Version")}: ${betterAuthInfo.version}`);
-			if (betterAuthInfo.config) {
-				console.log(`  ${chalk.cyan("Configuration")}:`);
-				console.log(formatOutput(betterAuthInfo.config, 4));
-			}
+		} else if (betterAuthInfo.config) {
+			console.log(`  ${chalk.cyan("Configuration")}:`);
+			console.log(formatOutput(betterAuthInfo.config, 4));
 		}
 
 		console.log(chalk.gray("\n" + "=".repeat(50)));

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -5,7 +5,36 @@ import path from "node:path";
 import chalk from "chalk";
 import { Command } from "commander";
 import { getConfig } from "../utils/get-config";
-import { getPackageInfo } from "../utils/get-package-info";
+import {
+	getInstalledPackageVersion,
+	getPackageInfo,
+} from "../utils/get-package-info";
+
+type ReportedDependency = {
+	name: string;
+	packageName: string;
+};
+
+function resolveReportedDependencies(
+	projectRoot: string,
+	dependencies: Record<string, string | undefined>,
+	reportedDependencies: readonly ReportedDependency[],
+) {
+	return reportedDependencies.flatMap(({ name, packageName }) => {
+		const declaredVersion = dependencies[packageName];
+		if (!declaredVersion) {
+			return [];
+		}
+		return [
+			{
+				name,
+				version:
+					getInstalledPackageVersion(packageName, projectRoot) ??
+					declaredVersion,
+			},
+		];
+	});
+}
 
 function getSystemInfo() {
 	const platform = os.platform();
@@ -73,25 +102,21 @@ function getFrameworkInfo(projectRoot: string) {
 			...packageJson.devDependencies,
 		};
 
-		const frameworks: Record<string, string | undefined> = {
-			next: deps["next"],
-			react: deps["react"],
-			vue: deps["vue"],
-			nuxt: deps["nuxt"],
-			svelte: deps["svelte"],
-			"@sveltejs/kit": deps["@sveltejs/kit"],
-			express: deps["express"],
-			fastify: deps["fastify"],
-			hono: deps["hono"],
-			"react-router": deps["react-router"],
-			astro: deps["astro"],
-			solid: deps["solid-js"],
-			qwik: deps["@builder.io/qwik"],
-		};
-
-		const installedFrameworks = Object.entries(frameworks)
-			.filter(([_, version]) => version)
-			.map(([name, version]) => ({ name, version }));
+		const installedFrameworks = resolveReportedDependencies(projectRoot, deps, [
+			{ name: "next", packageName: "next" },
+			{ name: "react", packageName: "react" },
+			{ name: "vue", packageName: "vue" },
+			{ name: "nuxt", packageName: "nuxt" },
+			{ name: "svelte", packageName: "svelte" },
+			{ name: "@sveltejs/kit", packageName: "@sveltejs/kit" },
+			{ name: "express", packageName: "express" },
+			{ name: "fastify", packageName: "fastify" },
+			{ name: "hono", packageName: "hono" },
+			{ name: "react-router", packageName: "react-router" },
+			{ name: "astro", packageName: "astro" },
+			{ name: "solid", packageName: "solid-js" },
+			{ name: "qwik", packageName: "@builder.io/qwik" },
+		]);
 
 		return installedFrameworks.length > 0 ? installedFrameworks : null;
 	} catch {
@@ -113,25 +138,30 @@ function getDatabaseInfo(projectRoot: string) {
 			...packageJson.devDependencies,
 		};
 
-		const databases: Record<string, string | undefined> = {
-			"better-sqlite3": deps["better-sqlite3"],
-			"@libsql/client": deps["@libsql/client"],
-			"@libsql/kysely-libsql": deps["@libsql/kysely-libsql"],
-			mysql2: deps["mysql2"],
-			pg: deps["pg"],
-			postgres: deps["postgres"],
-			"@prisma/client": deps["@prisma/client"],
-			drizzle: deps["drizzle-orm"],
-			kysely: deps["kysely"],
-			mongodb: deps["mongodb"],
-			"@neondatabase/serverless": deps["@neondatabase/serverless"],
-			"@vercel/postgres": deps["@vercel/postgres"],
-			"@planetscale/database": deps["@planetscale/database"],
-		};
-
-		const installedDatabases = Object.entries(databases)
-			.filter(([_, version]) => version)
-			.map(([name, version]) => ({ name, version }));
+		const installedDatabases = resolveReportedDependencies(projectRoot, deps, [
+			{ name: "better-sqlite3", packageName: "better-sqlite3" },
+			{ name: "@libsql/client", packageName: "@libsql/client" },
+			{
+				name: "@libsql/kysely-libsql",
+				packageName: "@libsql/kysely-libsql",
+			},
+			{ name: "mysql2", packageName: "mysql2" },
+			{ name: "pg", packageName: "pg" },
+			{ name: "postgres", packageName: "postgres" },
+			{ name: "@prisma/client", packageName: "@prisma/client" },
+			{ name: "drizzle", packageName: "drizzle-orm" },
+			{ name: "kysely", packageName: "kysely" },
+			{ name: "mongodb", packageName: "mongodb" },
+			{
+				name: "@neondatabase/serverless",
+				packageName: "@neondatabase/serverless",
+			},
+			{ name: "@vercel/postgres", packageName: "@vercel/postgres" },
+			{
+				name: "@planetscale/database",
+				packageName: "@planetscale/database",
+			},
+		]);
 
 		return installedDatabases.length > 0 ? installedDatabases : null;
 	} catch {
@@ -316,6 +346,21 @@ async function getBetterAuthInfo(
 	configPath?: string,
 	suppressLogs = false,
 ) {
+	let betterAuthVersion = "Unknown";
+	try {
+		const packageInfo = getPackageInfo(projectRoot);
+		const declaredVersion =
+			packageInfo.dependencies?.["better-auth"] ||
+			packageInfo.devDependencies?.["better-auth"] ||
+			packageInfo.peerDependencies?.["better-auth"] ||
+			packageInfo.optionalDependencies?.["better-auth"];
+		if (declaredVersion) {
+			betterAuthVersion =
+				getInstalledPackageVersion("better-auth", projectRoot) ??
+				declaredVersion;
+		}
+	} catch {}
+
 	try {
 		// Temporarily suppress console output if needed
 		const originalLog = console.log;
@@ -334,14 +379,6 @@ async function getBetterAuthInfo(
 				configPath,
 				shouldThrowOnError: true,
 			});
-			const packageInfo = await getPackageInfo();
-			const betterAuthVersion =
-				packageInfo.dependencies?.["better-auth"] ||
-				packageInfo.devDependencies?.["better-auth"] ||
-				packageInfo.peerDependencies?.["better-auth"] ||
-				packageInfo.optionalDependencies?.["better-auth"] ||
-				"Unknown";
-
 			return {
 				version: betterAuthVersion,
 				config: sanitizeBetterAuthConfig(config),
@@ -356,7 +393,7 @@ async function getBetterAuthInfo(
 		}
 	} catch (error) {
 		return {
-			version: "Unknown",
+			version: betterAuthVersion,
 			config: null,
 			error:
 				error instanceof Error

--- a/packages/cli/src/utils/get-package-info.ts
+++ b/packages/cli/src/utils/get-package-info.ts
@@ -1,13 +1,80 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
+import * as z from "zod";
 import { tryCatch } from "./helper";
+
+const packageManifestSchema = z.object({
+	name: z.string(),
+	version: z.string(),
+});
 
 export function getPackageInfo(cwd?: string) {
 	const packageJsonPath = cwd
 		? path.join(cwd, "package.json")
 		: path.join("package.json");
 	return JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+}
+
+function readPackageVersion(
+	packageJsonPath: string,
+	packageName: string,
+): string | null {
+	if (!existsSync(packageJsonPath)) {
+		return null;
+	}
+	try {
+		const result = packageManifestSchema.safeParse(
+			JSON.parse(readFileSync(packageJsonPath, "utf-8")),
+		);
+		return result.success && result.data.name === packageName
+			? result.data.version
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function findPackageVersion(
+	resolvedPath: string,
+	packageName: string,
+): string | null {
+	let currentDirectory = path.dirname(resolvedPath);
+	const rootDirectory = path.parse(currentDirectory).root;
+
+	while (true) {
+		const version = readPackageVersion(
+			path.join(currentDirectory, "package.json"),
+			packageName,
+		);
+		if (version) {
+			return version;
+		}
+		if (currentDirectory === rootDirectory) {
+			return null;
+		}
+		currentDirectory = path.dirname(currentDirectory);
+	}
+}
+
+export function getInstalledPackageVersion(
+	packageName: string,
+	projectDirectory: string,
+): string | null {
+	const resolve = createRequire(
+		path.join(path.resolve(projectDirectory), "package.json"),
+	).resolve;
+
+	for (const specifier of [`${packageName}/package.json`, packageName]) {
+		try {
+			const version = findPackageVersion(resolve(specifier), packageName);
+			if (version) {
+				return version;
+			}
+		} catch {}
+	}
+	return null;
 }
 
 export function getPrismaVersion(cwd?: string): number | null {

--- a/packages/cli/src/utils/get-package-info.ts
+++ b/packages/cli/src/utils/get-package-info.ts
@@ -58,6 +58,34 @@ function findPackageVersion(
 	}
 }
 
+function findPackageVersionInNodeModules(
+	packageName: string,
+	projectDirectory: string,
+): string | null {
+	let currentDirectory = path.resolve(projectDirectory);
+	const rootDirectory = path.parse(currentDirectory).root;
+	const packagePath = packageName.split("/");
+
+	while (true) {
+		const version = readPackageVersion(
+			path.join(
+				currentDirectory,
+				"node_modules",
+				...packagePath,
+				"package.json",
+			),
+			packageName,
+		);
+		if (version) {
+			return version;
+		}
+		if (currentDirectory === rootDirectory) {
+			return null;
+		}
+		currentDirectory = path.dirname(currentDirectory);
+	}
+}
+
 export function getInstalledPackageVersion(
 	packageName: string,
 	projectDirectory: string,
@@ -74,7 +102,7 @@ export function getInstalledPackageVersion(
 			}
 		} catch {}
 	}
-	return null;
+	return findPackageVersionInNodeModules(packageName, projectDirectory);
 }
 
 export function getPrismaVersion(cwd?: string): number | null {

--- a/packages/cli/src/utils/get-package-info.ts
+++ b/packages/cli/src/utils/get-package-info.ts
@@ -19,7 +19,7 @@ export function getPackageInfo(cwd?: string) {
 
 function readPackageVersion(
 	packageJsonPath: string,
-	packageName: string,
+	expectedPackageName: string,
 ): string | null {
 	if (!existsSync(packageJsonPath)) {
 		return null;
@@ -28,7 +28,7 @@ function readPackageVersion(
 		const result = packageManifestSchema.safeParse(
 			JSON.parse(readFileSync(packageJsonPath, "utf-8")),
 		);
-		return result.success && result.data.name === packageName
+		return result.success && result.data.name === expectedPackageName
 			? result.data.version
 			: null;
 	} catch {

--- a/packages/cli/test/info.test.ts
+++ b/packages/cli/test/info.test.ts
@@ -15,6 +15,19 @@ const runInfoCommand = (args: string[] = []) => {
 	});
 };
 
+const writeInstalledPackage = async (name: string, version: string) => {
+	const packageDirectory = path.join(
+		tmpDir,
+		"node_modules",
+		...name.split("/"),
+	);
+	await fs.mkdir(packageDirectory, { recursive: true });
+	await fs.writeFile(
+		path.join(packageDirectory, "package.json"),
+		JSON.stringify({ name, version }),
+	);
+};
+
 describe("info command", () => {
 	beforeEach(async () => {
 		const tmp = path.join(
@@ -70,6 +83,42 @@ describe("info command", () => {
 		// Better Auth config should have an error since no auth file exists
 		expect(output.betterAuth).toHaveProperty("version");
 		expect(output.betterAuth.config).toBeNull();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10997
+	 */
+	it("reports installed versions for protocol-based dependencies", async () => {
+		await fs.writeFile(
+			path.join(tmpDir, "package.json"),
+			JSON.stringify({
+				name: "test-project",
+				version: "1.0.0",
+				dependencies: {
+					"better-auth": "catalog:auth",
+					next: "catalog:frontend",
+					"drizzle-orm": "workspace:*",
+				},
+			}),
+		);
+		await Promise.all([
+			writeInstalledPackage("better-auth", "1.7.2"),
+			writeInstalledPackage("next", "16.1.0"),
+			writeInstalledPackage("drizzle-orm", "0.45.1"),
+		]);
+
+		const { stdout } = await runInfoCommand();
+		const output = JSON.parse(stdout);
+
+		expect(output.betterAuth.version).toBe("1.7.2");
+		expect(output.frameworks).toContainEqual({
+			name: "next",
+			version: "16.1.0",
+		});
+		expect(output.databases).toContainEqual({
+			name: "drizzle",
+			version: "0.45.1",
+		});
 	});
 
 	it("should load and sanitize auth configuration", async () => {
@@ -197,6 +246,12 @@ describe("info command", () => {
 				},
 			}),
 		);
+		await Promise.all([
+			writeInstalledPackage("next", "14.0.0"),
+			writeInstalledPackage("react", "18.0.0"),
+			writeInstalledPackage("@sveltejs/kit", "2.0.0"),
+			writeInstalledPackage("svelte", "4.0.0"),
+		]);
 
 		const { stdout } = await runInfoCommand();
 
@@ -205,19 +260,19 @@ describe("info command", () => {
 		// Check frameworks are detected
 		expect(output.frameworks).toContainEqual({
 			name: "next",
-			version: "^14.0.0",
+			version: "14.0.0",
 		});
 		expect(output.frameworks).toContainEqual({
 			name: "react",
-			version: "^18.0.0",
+			version: "18.0.0",
 		});
 		expect(output.frameworks).toContainEqual({
 			name: "@sveltejs/kit",
-			version: "^2.0.0",
+			version: "2.0.0",
 		});
 		expect(output.frameworks).toContainEqual({
 			name: "svelte",
-			version: "^4.0.0",
+			version: "4.0.0",
 		});
 	});
 
@@ -239,6 +294,12 @@ describe("info command", () => {
 				},
 			}),
 		);
+		await Promise.all([
+			writeInstalledPackage("@prisma/client", "5.0.0"),
+			writeInstalledPackage("kysely", "0.26.0"),
+			writeInstalledPackage("drizzle-orm", "0.29.0"),
+			writeInstalledPackage("better-sqlite3", "9.0.0"),
+		]);
 
 		const { stdout } = await runInfoCommand();
 
@@ -247,19 +308,19 @@ describe("info command", () => {
 		// Check database clients are detected
 		expect(output.databases).toContainEqual({
 			name: "@prisma/client",
-			version: "^5.0.0",
+			version: "5.0.0",
 		});
 		expect(output.databases).toContainEqual({
 			name: "kysely",
-			version: "^0.26.0",
+			version: "0.26.0",
 		});
 		expect(output.databases).toContainEqual({
 			name: "drizzle",
-			version: "^0.29.0",
+			version: "0.29.0",
 		});
 		expect(output.databases).toContainEqual({
 			name: "better-sqlite3",
-			version: "^9.0.0",
+			version: "9.0.0",
 		});
 	});
 

--- a/packages/cli/test/info.test.ts
+++ b/packages/cli/test/info.test.ts
@@ -15,6 +15,12 @@ const runInfoCommand = (args: string[] = []) => {
 	});
 };
 
+const runInfoTextCommand = (args: string[] = []) => {
+	return execFileAsync(process.execPath, [cliPath, "info", ...args], {
+		cwd: tmpDir,
+	});
+};
+
 const writeInstalledPackage = async (name: string, version: string) => {
 	const packageDirectory = path.join(
 		tmpDir,
@@ -119,6 +125,28 @@ describe("info command", () => {
 			name: "drizzle",
 			version: "0.45.1",
 		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/pull/11126#discussion_r3920527164
+	 */
+	it("reports the installed version when config loading fails", async () => {
+		await fs.writeFile(
+			path.join(tmpDir, "package.json"),
+			JSON.stringify({
+				name: "test-project",
+				dependencies: { "better-auth": "catalog:" },
+			}),
+		);
+		await writeInstalledPackage("better-auth", "1.7.2");
+
+		const { stdout } = await runInfoTextCommand([
+			"--config",
+			"missing-auth.ts",
+		]);
+
+		expect(stdout).toContain("Version: 1.7.2");
+		expect(stdout).toContain("Error:");
 	});
 
 	it("should load and sanitize auth configuration", async () => {

--- a/packages/cli/test/package-info.test.ts
+++ b/packages/cli/test/package-info.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { getInstalledPackageVersion } from "../src/utils/get-package-info";
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10997
+ */
+describe("getInstalledPackageVersion", () => {
+	const temporaryDirectories: string[] = [];
+
+	afterEach(async () => {
+		await Promise.all(
+			temporaryDirectories
+				.splice(0)
+				.map((directory) => fs.rm(directory, { recursive: true, force: true })),
+		);
+	});
+
+	test.for([
+		{ packageName: "example-package", version: "1.2.3" },
+		{ packageName: "@example/package", version: "4.5.6" },
+	])("resolves $packageName from an ancestor node_modules directory", async ({
+		packageName,
+		version,
+	}) => {
+		const workspaceRoot = await fs.mkdtemp(
+			path.join(os.tmpdir(), "better-auth-installed-version-"),
+		);
+		temporaryDirectories.push(workspaceRoot);
+		const projectDirectory = path.join(workspaceRoot, "apps", "web");
+		const packageDirectory = path.join(
+			workspaceRoot,
+			"node_modules",
+			...packageName.split("/"),
+		);
+		await fs.mkdir(projectDirectory, { recursive: true });
+		await fs.mkdir(packageDirectory, { recursive: true });
+		await fs.writeFile(
+			path.join(packageDirectory, "package.json"),
+			JSON.stringify({
+				name: packageName,
+				version,
+				exports: "./index.js",
+			}),
+		);
+		await fs.writeFile(path.join(packageDirectory, "index.js"), "");
+
+		expect(getInstalledPackageVersion(packageName, projectDirectory)).toBe(
+			version,
+		);
+	});
+
+	test("returns null when the package is not installed", async () => {
+		const projectDirectory = await fs.mkdtemp(
+			path.join(os.tmpdir(), "better-auth-missing-version-"),
+		);
+		temporaryDirectories.push(projectDirectory);
+
+		expect(
+			getInstalledPackageVersion("missing-package", projectDirectory),
+		).toBeNull();
+	});
+});

--- a/packages/cli/test/package-info.test.ts
+++ b/packages/cli/test/package-info.test.ts
@@ -19,9 +19,26 @@ describe("getInstalledPackageVersion", () => {
 	});
 
 	test.for([
-		{ packageName: "example-package", version: "1.2.3" },
-		{ packageName: "@example/package", version: "4.5.6" },
-	])("resolves $packageName from an ancestor node_modules directory", async ({
+		{
+			exports: { "./package.json": "./package.json" },
+			packageName: "example-package",
+			resolution: "its package manifest",
+			version: "1.2.3",
+		},
+		{
+			exports: "./index.js",
+			packageName: "@example/package",
+			resolution: "its package entry point",
+			version: "4.5.6",
+		},
+		{
+			exports: { ".": { import: "./index.js" } },
+			packageName: "esm-only-package",
+			resolution: "an import-only entry point",
+			version: "7.8.9",
+		},
+	])("resolves $packageName through $resolution", async ({
+		exports,
 		packageName,
 		version,
 	}) => {
@@ -42,7 +59,7 @@ describe("getInstalledPackageVersion", () => {
 			JSON.stringify({
 				name: packageName,
 				version,
-				exports: "./index.js",
+				exports,
 			}),
 		);
 		await fs.writeFile(path.join(packageDirectory, "index.js"), "");


### PR DESCRIPTION
> Thanks @davbrito for the detailed report and reproduction in #10997.

- Closes #10997


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`auth info` now reports the actual installed versions of detected frameworks, databases, and better-auth instead of the declared dependency specifiers. Previously, specifiers like `catalog:auth` or `workspace:*` were shown as-is; now the resolved installed version is reported, falling back to the declared specifier when a package is not installed. Closes #10997.

- Resolves installed versions by walking up from the project root through `node_modules`.
- Falls back to the declared version when the package is not installed.
- Refactors framework and database version resolution into a shared helper.
- Adds tests covering catalog and workspace specifiers, scoped packages, and hoisted `node_modules`.
- Reports the better-auth version even when config loading fails; previously it showed "Unknown".

<sup>Written for commit b441ecf7993dc988b4083ea6459d14ea7125b238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

