### PR TITLE
fix(cli): skip unsupported upgrade specifiers

### DIFF
--- a/.changeset/upgrade-pnpm-catalog-dependencies.md
+++ b/.changeset/upgrade-pnpm-catalog-dependencies.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+`auth upgrade` no longer crashes on pnpm catalog dependencies and directs users to update the catalog entry in `pnpm-workspace.yaml`.

--- a/.changeset/upgrade-pnpm-catalog-dependencies.md
+++ b/.changeset/upgrade-pnpm-catalog-dependencies.md
@@ -2,4 +2,4 @@
 "auth": patch
 ---
 
-`auth upgrade` no longer crashes on unsupported dependency specifiers such as pnpm catalogs and reports that automatic upgrades require a semver range.
+`auth upgrade` now skips non-semver dependency specifiers, including pnpm catalogs, with a clear warning instead of crashing.

--- a/.changeset/upgrade-pnpm-catalog-dependencies.md
+++ b/.changeset/upgrade-pnpm-catalog-dependencies.md
@@ -2,4 +2,4 @@
 "auth": patch
 ---
 
-`auth upgrade` no longer crashes on pnpm catalog dependencies and directs users to update the catalog entry in `pnpm-workspace.yaml`.
+`auth upgrade` no longer crashes on unsupported dependency specifiers such as pnpm catalogs and reports that automatic upgrades require a semver range.

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import { Command } from "commander";
 import prompts from "prompts";
 import * as semver from "semver";
+import type { PackageJson } from "type-fest";
 import yoctoSpinner from "yocto-spinner";
 import * as z from "zod";
 import changesetConfig from "../../../../.changeset/config.json" with {
@@ -13,6 +14,8 @@ import { detectPackageManager } from "../utils/check-package-managers";
 import { getPackageInfo } from "../utils/get-package-info";
 import { installDependencies } from "../utils/install-dependencies";
 import { cliVersion } from "../version";
+
+const dependencyMapSchema = z.record(z.string(), z.string()).catch({});
 
 const fixedReleaseGroup = changesetConfig.fixed.find((group) =>
 	group.includes("better-auth"),
@@ -51,7 +54,7 @@ export async function upgradeAction(opts: unknown) {
 		process.exit(1);
 	}
 
-	let packageJson: Record<string, any>;
+	let packageJson: PackageJson;
 	try {
 		packageJson = getPackageInfo(cwd);
 	} catch {
@@ -61,8 +64,8 @@ export async function upgradeAction(opts: unknown) {
 		process.exit(1);
 	}
 
-	const deps = packageJson.dependencies ?? {};
-	const devDeps = packageJson.devDependencies ?? {};
+	const deps = dependencyMapSchema.parse(packageJson.dependencies);
+	const devDeps = dependencyMapSchema.parse(packageJson.devDependencies);
 
 	const candidates: {
 		name: string;
@@ -70,7 +73,7 @@ export async function upgradeAction(opts: unknown) {
 		depType: "prod" | "dev";
 	}[] = [];
 
-	for (const [name, version] of Object.entries(deps) as [string, string][]) {
+	for (const [name, version] of Object.entries(deps)) {
 		if (
 			isSynchronizedBetterAuthPackage(name) &&
 			!version.startsWith("workspace:")
@@ -78,7 +81,7 @@ export async function upgradeAction(opts: unknown) {
 			candidates.push({ name, current: version, depType: "prod" });
 		}
 	}
-	for (const [name, version] of Object.entries(devDeps) as [string, string][]) {
+	for (const [name, version] of Object.entries(devDeps)) {
 		if (
 			isSynchronizedBetterAuthPackage(name) &&
 			!version.startsWith("workspace:")
@@ -95,17 +98,44 @@ export async function upgradeAction(opts: unknown) {
 	const spinner = yoctoSpinner({ text: "checking for updates..." }).start();
 
 	const upgrades: UpgradeEntry[] = [];
+	const warnings: string[] = [];
 	for (const { name, current, depType } of candidates) {
-		const currentVersion = semver.minVersion(current);
+		if (current.startsWith("catalog:")) {
+			warnings.push(
+				`Skipped ${name} (${current}). Update its catalog entry in pnpm-workspace.yaml.`,
+			);
+			continue;
+		}
+
+		const currentRange = semver.validRange(current);
+		if (!currentRange) {
+			warnings.push(
+				`Skipped ${name} because '${current}' is not a semver range.`,
+			);
+			continue;
+		}
+		const currentVersion = semver.minVersion(currentRange);
 		if (currentVersion && semver.lt(currentVersion, cliVersion)) {
-			upgrades.push({ name, current, target: cliVersion, depType });
+			upgrades.push({
+				name,
+				current,
+				target: cliVersion,
+				depType,
+			});
 		}
 	}
 
 	spinner.stop();
+	for (const warning of warnings) {
+		console.warn(chalk.yellow(warning));
+	}
 
 	if (upgrades.length === 0) {
-		console.log("All better-auth packages are up to date.");
+		console.log(
+			warnings.length > 0
+				? "No supported Better Auth package upgrades were found."
+				: "All better-auth packages are up to date.",
+		);
 		return;
 	}
 
@@ -134,7 +164,6 @@ export async function upgradeAction(opts: unknown) {
 	}
 
 	const { packageManager } = await detectPackageManager(cwd, packageJson);
-
 	const prodUpgrades = upgrades
 		.filter((u) => u.depType === "prod")
 		.map((u) => `${u.name}@${u.target}`);

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -102,17 +102,10 @@ export async function upgradeAction(opts: unknown) {
 	const upgrades: UpgradeEntry[] = [];
 	const warnings: string[] = [];
 	for (const { name, current, depType } of candidates) {
-		if (current.startsWith("catalog:")) {
-			warnings.push(
-				`Skipped ${name} (${current}). Update its catalog entry in pnpm-workspace.yaml.`,
-			);
-			continue;
-		}
-
 		const currentRange = semver.validRange(current);
 		if (!currentRange) {
 			warnings.push(
-				`Skipped ${name} because '${current}' is not a semver range.`,
+				`Skipped ${name} (${current}). Automatic upgrades require a semver range.`,
 			);
 			continue;
 		}

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -15,7 +15,9 @@ import { getPackageInfo } from "../utils/get-package-info";
 import { installDependencies } from "../utils/install-dependencies";
 import { cliVersion } from "../version";
 
-const dependencyMapSchema = z.record(z.string(), z.string()).catch({});
+const dependencyMapSchema = z
+	.record(z.string(), z.string().catch(""))
+	.catch({});
 
 const fixedReleaseGroup = changesetConfig.fixed.find((group) =>
 	group.includes("better-auth"),

--- a/packages/cli/test/upgrade.test.ts
+++ b/packages/cli/test/upgrade.test.ts
@@ -139,22 +139,21 @@ describe("upgradeAction", () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/11072
 	 */
-	it("skips pnpm catalog dependencies with an actionable warning", async () => {
+	it.each([
+		"catalog:",
+		"file:../better-auth",
+	])("skips unsupported dependency specifier %s", async (specifier) => {
 		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
 		mockGetPackageInfo.mockReturnValue({
 			dependencies: {
-				"better-auth": "catalog:",
+				"better-auth": specifier,
 			},
 		});
 
-		await expect(
-			upgradeAction({ cwd: process.cwd(), yes: true }),
-		).resolves.toBeUndefined();
+		await upgradeAction({ cwd: process.cwd(), yes: true });
 
 		expect(warning).toHaveBeenCalledWith(
-			expect.stringContaining(
-				"Update its catalog entry in pnpm-workspace.yaml",
-			),
+			expect.stringContaining("Automatic upgrades require a semver range"),
 		);
 		expect(mockDetectPackageManager).not.toHaveBeenCalled();
 		expect(mockInstallDependencies).not.toHaveBeenCalled();

--- a/packages/cli/test/upgrade.test.ts
+++ b/packages/cli/test/upgrade.test.ts
@@ -71,6 +71,27 @@ describe("upgradeAction", () => {
 	});
 
 	/**
+	 * @see https://github.com/better-auth/better-auth/pull/11127#discussion_r3920511930
+	 */
+	it("keeps valid dependencies when another entry is malformed", async () => {
+		mockGetPackageInfo.mockReturnValue({
+			dependencies: {
+				"better-auth": "^1.6.26",
+				invalid: 123,
+			},
+		});
+
+		await upgradeAction({ cwd: process.cwd(), yes: true });
+
+		expect(mockInstallDependencies).toHaveBeenCalledWith({
+			dependencies: ["better-auth@1.7.0-rc.4"],
+			packageManager: "pnpm",
+			cwd: process.cwd(),
+			type: "prod",
+		});
+	});
+
+	/**
 	 * @see https://github.com/better-auth/better-auth/pull/10760
 	 */
 	it("upgrades every package in the Changesets fixed release group", async () => {

--- a/packages/cli/test/upgrade.test.ts
+++ b/packages/cli/test/upgrade.test.ts
@@ -116,6 +116,30 @@ describe("upgradeAction", () => {
 	});
 
 	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11072
+	 */
+	it("skips pnpm catalog dependencies with an actionable warning", async () => {
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		mockGetPackageInfo.mockReturnValue({
+			dependencies: {
+				"better-auth": "catalog:",
+			},
+		});
+
+		await expect(
+			upgradeAction({ cwd: process.cwd(), yes: true }),
+		).resolves.toBeUndefined();
+
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"Update its catalog entry in pnpm-workspace.yaml",
+			),
+		);
+		expect(mockDetectPackageManager).not.toHaveBeenCalled();
+		expect(mockInstallDependencies).not.toHaveBeenCalled();
+	});
+
+	/**
 	 * @see https://github.com/better-auth/better-auth/pull/10760
 	 */
 	it("does not align independently versioned Better Auth packages", async () => {


### PR DESCRIPTION
> Thanks @scs0209 for the reproduction in #11072 and the investigation in #11112.

- Closes #11072

### Before
<img width="511" height="111" alt="before" src="https://github.com/user-attachments/assets/f66b353a-8947-4c8e-813a-58c03832674a" />


### After
<img width="510" height="110" alt="after" src="https://github.com/user-attachments/assets/baaa614f-a4d0-4c13-8b42-bb1dd635e08b" />


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
