### PR TITLE
refactor(oauth): use shared token flow for PayPal

### DIFF
--- a/.changeset/paypal-token-helpers.md
+++ b/.changeset/paypal-token-helpers.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Improve PayPal authorization code and refresh token requests, including PKCE parameter handling.

--- a/packages/core/src/social-providers/paypal.test.ts
+++ b/packages/core/src/social-providers/paypal.test.ts
@@ -45,6 +45,88 @@ async function idToken(subject: string) {
 		.sign(signingKey);
 }
 
+function formBody(body: unknown) {
+	if (body instanceof URLSearchParams) return body;
+	if (typeof body === "string") return new URLSearchParams(body);
+	throw new Error("Expected a URL-encoded form body");
+}
+
+describe("paypal token requests", () => {
+	beforeEach(() => {
+		mockedBetterFetch.mockReset();
+	});
+
+	it("exchanges an authorization code with Basic authentication", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "access-token",
+				expires_in: 3600,
+				refresh_token: "refresh-token",
+				token_type: "Bearer",
+			},
+			error: null,
+		});
+
+		const tokens = await paypal(options).validateAuthorizationCode({
+			code: "authorization-code",
+			codeVerifier: "code-verifier",
+			redirectURI: "https://app.example.com/api/auth/callback/paypal",
+		});
+
+		expect(tokens.accessToken).toBe("access-token");
+		const [url, init] = mockedBetterFetch.mock.calls[0] ?? [];
+		expect(url).toBe("https://api-m.paypal.com/v1/oauth2/token");
+		const headers = new Headers(init?.headers as HeadersInit | undefined);
+		expect(headers.get("accept")).toBe("application/json");
+		expect(headers.get("authorization")).toBe(
+			`Basic ${Buffer.from("paypal-client-id:paypal-client-secret").toString(
+				"base64",
+			)}`,
+		);
+		expect(headers.get("content-type")).toBe(
+			"application/x-www-form-urlencoded",
+		);
+		expect(Object.fromEntries(formBody(init?.body))).toEqual({
+			code: "authorization-code",
+			code_verifier: "code-verifier",
+			grant_type: "authorization_code",
+			redirect_uri: "https://app.example.com/api/auth/callback/paypal",
+		});
+	});
+
+	it("refreshes an access token with Basic authentication", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "refreshed-access-token",
+				expires_in: 3600,
+				refresh_token: "rotated-refresh-token",
+				token_type: "Bearer",
+			},
+			error: null,
+		});
+
+		const tokens = await paypal(options).refreshAccessToken("refresh-token");
+
+		expect(tokens.accessToken).toBe("refreshed-access-token");
+		const [url, init] = mockedBetterFetch.mock.calls[0] ?? [];
+		expect(url).toBe("https://api-m.paypal.com/v1/oauth2/token");
+		const headers = new Headers(init?.headers as HeadersInit | undefined);
+		expect(headers.get("accept")).toBe("application/json");
+		expect(headers.get("authorization")).toBe(
+			`Basic ${Buffer.from("paypal-client-id:paypal-client-secret").toString(
+				"base64",
+			)}`,
+		);
+		expect(headers.get("content-type")).toBe(
+			"application/x-www-form-urlencoded",
+		);
+		expect(Object.fromEntries(formBody(init?.body))).toEqual({
+			grant_type: "refresh_token",
+			refresh_token: "refresh-token",
+		});
+	});
+});
+
 describe("paypal.getUserInfo", () => {
 	beforeEach(() => {
 		mockedBetterFetch.mockReset();

--- a/packages/core/src/social-providers/paypal.ts
+++ b/packages/core/src/social-providers/paypal.ts
@@ -1,10 +1,17 @@
-import { base64 } from "@better-auth/utils/base64";
 import { betterFetch } from "@better-fetch/fetch";
 import { decodeJwt } from "jose";
 import { logger } from "../env";
 import { BetterAuthError } from "../error";
-import type { OAuthProvider, ProviderOptions } from "../oauth2";
-import { createAuthorizationURL } from "../oauth2";
+import type {
+	OAuthProvider,
+	ProviderOptions,
+	TokenEndpointAuth,
+} from "../oauth2";
+import {
+	createAuthorizationURL,
+	refreshAccessToken,
+	validateAuthorizationCode,
+} from "../oauth2";
 
 export interface PayPalProfile {
 	sub?: string | undefined;
@@ -75,6 +82,13 @@ export const paypal = (options: PayPalOptions) => {
 	const userInfoEndpoint = isSandbox
 		? "https://api-m.sandbox.paypal.com/v1/identity/oauth2/userinfo"
 		: "https://api-m.paypal.com/v1/identity/oauth2/userinfo";
+	const tokenRequestOptions = {
+		clientId: options.clientId,
+		clientSecret: options.clientSecret,
+	};
+	const tokenEndpointAuth = {
+		method: "client_secret_basic",
+	} satisfies TokenEndpointAuth;
 
 	return {
 		id: "paypal",
@@ -115,47 +129,16 @@ export const paypal = (options: PayPalOptions) => {
 			return url;
 		},
 
-		validateAuthorizationCode: async ({ code, redirectURI }) => {
-			/**
-			 * PayPal requires Basic Auth for token exchange
-			 **/
-
-			const credentials = base64.encode(
-				`${options.clientId}:${options.clientSecret}`,
-			);
-
+		validateAuthorizationCode: async ({ code, codeVerifier, redirectURI }) => {
 			try {
-				const response = await betterFetch(tokenEndpoint, {
-					method: "POST",
-					headers: {
-						Authorization: `Basic ${credentials}`,
-						Accept: "application/json",
-						"Accept-Language": "en_US",
-						"Content-Type": "application/x-www-form-urlencoded",
-					},
-					body: new URLSearchParams({
-						grant_type: "authorization_code",
-						code: code,
-						redirect_uri: redirectURI,
-					}).toString(),
+				return await validateAuthorizationCode({
+					code,
+					codeVerifier,
+					redirectURI: options.redirectURI || redirectURI,
+					options: tokenRequestOptions,
+					tokenEndpoint,
+					tokenEndpointAuth,
 				});
-
-				if (!response.data) {
-					throw new BetterAuthError("FAILED_TO_GET_ACCESS_TOKEN");
-				}
-
-				const data = response.data as PayPalTokenResponse;
-
-				const result = {
-					accessToken: data.access_token,
-					refreshToken: data.refresh_token,
-					accessTokenExpiresAt: data.expires_in
-						? new Date(Date.now() + data.expires_in * 1000)
-						: undefined,
-					idToken: data.id_token,
-				};
-
-				return result;
 			} catch (error) {
 				logger.error("PayPal token exchange failed:", error);
 				throw new BetterAuthError("FAILED_TO_GET_ACCESS_TOKEN");
@@ -165,37 +148,13 @@ export const paypal = (options: PayPalOptions) => {
 		refreshAccessToken: options.refreshAccessToken
 			? options.refreshAccessToken
 			: async (refreshToken) => {
-					const credentials = base64.encode(
-						`${options.clientId}:${options.clientSecret}`,
-					);
-
 					try {
-						const response = await betterFetch(tokenEndpoint, {
-							method: "POST",
-							headers: {
-								Authorization: `Basic ${credentials}`,
-								Accept: "application/json",
-								"Accept-Language": "en_US",
-								"Content-Type": "application/x-www-form-urlencoded",
-							},
-							body: new URLSearchParams({
-								grant_type: "refresh_token",
-								refresh_token: refreshToken,
-							}).toString(),
+						return await refreshAccessToken({
+							refreshToken,
+							options: tokenRequestOptions,
+							tokenEndpoint,
+							tokenEndpointAuth,
 						});
-
-						if (!response.data) {
-							throw new BetterAuthError("FAILED_TO_REFRESH_ACCESS_TOKEN");
-						}
-
-						const data = response.data as any;
-						return {
-							accessToken: data.access_token,
-							refreshToken: data.refresh_token,
-							accessTokenExpiresAt: data.expires_in
-								? new Date(Date.now() + data.expires_in * 1000)
-								: undefined,
-						};
 					} catch (error) {
 						logger.error("PayPal token refresh failed:", error);
 						throw new BetterAuthError("FAILED_TO_REFRESH_ACCESS_TOKEN");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors PayPal's token exchange and refresh to use the shared OAuth2 token helpers instead of PayPal-specific code. The authorization code flow now includes the PKCE `code_verifier` parameter and prefers `options.redirectURI` when set.

**Behavior changes**
- Authorization code exchange now sends `code_verifier` for PKCE.
- Redirect URI falls back to `options.redirectURI` before the callback-provided URI.
- Token responses are mapped by shared helpers with the same error handling.

<sup>Written for commit 1ab173087ea7f4a86910ef9d189c16c857eccfc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

