### PR TITLE
fix(oauth-provider): detach inactive sessions on refresh

### DIFF
--- a/.changeset/calm-cats-refresh.md
+++ b/.changeset/calm-cats-refresh.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Omit inactive issuance-session IDs from tokens created by OAuth refresh grants.

--- a/.changeset/calm-cats-refresh.md
+++ b/.changeset/calm-cats-refresh.md
@@ -2,4 +2,4 @@
 "@better-auth/oauth-provider": patch
 ---
 
-Omit inactive issuance-session IDs from tokens created by OAuth refresh grants.
+Omit inactive issuance-session IDs from tokens created by OAuth refresh grants, and reject cached session-bound rotation replays after that session becomes inactive.

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -1,6 +1,10 @@
 import { clientCredentialsTokenRequest } from "@better-auth/core/oauth2";
 import { createAuthClient } from "better-auth/client";
-import { generateRandomString } from "better-auth/crypto";
+import {
+	generateRandomString,
+	symmetricDecrypt,
+	symmetricEncrypt,
+} from "better-auth/crypto";
 import type { ProviderOptions } from "better-auth/oauth2";
 import {
 	authorizationCodeRequest,
@@ -1897,6 +1901,86 @@ describe("oauth token - refresh_token reuse interval", async () => {
 		});
 	}
 
+	async function expectInactiveSessionReplayRejected(
+		originalRefreshToken: string,
+		rotatedRefreshToken: string,
+	) {
+		if (!oauthClient?.client_id || !oauthClient.client_secret) {
+			throw Error("OAuth client unavailable");
+		}
+		const replay = await refresh(originalRefreshToken);
+		expect((replay.error as { error?: string } | null)?.error).toBe(
+			"invalid_grant",
+		);
+
+		const next = await refresh(rotatedRefreshToken);
+		expect(next.error).toBeNull();
+		expect(next.data?.access_token).toBeDefined();
+		const introspection = await client.$fetch<{
+			active?: boolean;
+			sid?: string;
+		}>("/oauth2/introspect", {
+			method: "POST",
+			body: new URLSearchParams({
+				client_id: oauthClient.client_id,
+				client_secret: oauthClient.client_secret,
+				token: next.data!.access_token!,
+				token_type_hint: "access_token",
+			}),
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+		});
+		expect(introspection.error).toBeNull();
+		expect(introspection.data).toMatchObject({ active: true });
+		expect(introspection.data?.sid).toBeUndefined();
+
+		const detachedReplay = await refresh(rotatedRefreshToken);
+		expect(detachedReplay.error).toBeNull();
+		expect(detachedReplay.data).toMatchObject({
+			access_token: next.data?.access_token,
+			expires_at: next.data?.expires_at,
+			id_token: next.data?.id_token,
+			refresh_token: next.data?.refresh_token,
+			scope: next.data?.scope,
+			token_type: next.data?.token_type,
+		});
+		expect(detachedReplay.data?.expires_in).toBeLessThanOrEqual(
+			next.data!.expires_in!,
+		);
+	}
+
+	async function removeReplaySessionMetadata() {
+		if (!oauthClient?.client_id) throw Error("OAuth client unavailable");
+		const context = await authorizationServer.$context;
+		const rows = await context.adapter.findMany<{
+			id: string;
+			rotationReplayResponse?: string | null;
+		}>({
+			model: "oauthRefreshToken",
+			where: [{ field: "clientId", value: oauthClient.client_id }],
+		});
+		const replayRow = rows.find((row) => row.rotationReplayResponse);
+		if (!replayRow?.rotationReplayResponse) {
+			throw Error("Rotation replay unavailable");
+		}
+		const replay = JSON.parse(
+			await symmetricDecrypt({
+				data: replayRow.rotationReplayResponse,
+				key: context.secretConfig,
+			}),
+		) as Record<string, unknown>;
+		const legacyReplay = { request: replay.request, response: replay.response };
+		await context.adapter.update({
+			model: "oauthRefreshToken",
+			where: [{ field: "id", value: replayRow.id }],
+			update: {
+				rotationReplayResponse: await symmetricEncrypt({
+					data: JSON.stringify(legacyReplay),
+					key: context.secretConfig,
+				}),
+			},
+		});
+	}
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/8512
 	 */
@@ -1938,6 +2022,25 @@ describe("oauth token - refresh_token reuse interval", async () => {
 		);
 	});
 
+	it("replays a legacy cached response while its session remains live", async () => {
+		oauthClient = await createOAuthClient();
+		const tokens = await authorizeForRefreshToken([
+			"openid",
+			"profile",
+			"offline_access",
+		]);
+		const firstRefresh = await refresh(tokens.refresh_token!);
+		expect(firstRefresh.error).toBeNull();
+		await removeReplaySessionMetadata();
+
+		const replay = await refresh(tokens.refresh_token!);
+		expect(replay.error).toBeNull();
+		expect(replay.data).toMatchObject({
+			access_token: firstRefresh.data?.access_token,
+			refresh_token: firstRefresh.data?.refresh_token,
+		});
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/11132
 	 */
@@ -1962,36 +2065,69 @@ describe("oauth token - refresh_token reuse interval", async () => {
 				update: { expiresAt: new Date() },
 			});
 
-			const replay = await refresh(tokens.refresh_token!);
-			expect((replay.error as { error?: string } | null)?.error).toBe(
-				"invalid_grant",
+			await expectInactiveSessionReplayRejected(
+				tokens.refresh_token!,
+				firstRefresh.data!.refresh_token!,
 			);
-
-			const next = await refresh(firstRefresh.data!.refresh_token!);
-			expect(next.error).toBeNull();
-			expect(next.data?.access_token).toBeDefined();
-			const introspection = await client.$fetch<{
-				active?: boolean;
-				sid?: string;
-			}>("/oauth2/introspect", {
-				method: "POST",
-				body: new URLSearchParams({
-					client_id: oauthClient.client_id,
-					client_secret: oauthClient.client_secret!,
-					token: next.data!.access_token!,
-					token_type_hint: "access_token",
-				}),
-				headers: { "content-type": "application/x-www-form-urlencoded" },
-			});
-			expect(introspection.error).toBeNull();
-			expect(introspection.data).toMatchObject({ active: true });
-			expect(introspection.data?.sid).toBeUndefined();
 		} finally {
 			await context.adapter.update({
 				model: "session",
 				where: [{ field: "id", value: session.session.id }],
 				update: { expiresAt: session.session.expiresAt },
 			});
+		}
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11132
+	 */
+	it.each([
+		["current", false],
+		["legacy", true],
+	] as const)("rejects a %s cached session-bound response after the session is deleted", async (_format, legacyEnvelope) => {
+		oauthClient = await createOAuthClient();
+		const session = await authorizationServer.api.getSession({ headers });
+		if (!session) throw new Error("test session unavailable");
+		const tokens = await authorizeForRefreshToken([
+			"openid",
+			"profile",
+			"offline_access",
+		]);
+
+		const firstRefresh = await refresh(tokens.refresh_token!);
+		expect(firstRefresh.error).toBeNull();
+		expect(firstRefresh.data?.refresh_token).toBeDefined();
+		if (legacyEnvelope) await removeReplaySessionMetadata();
+		const context = await authorizationServer.$context;
+		let sessionDeleted = false;
+		try {
+			await context.adapter.delete({
+				model: "session",
+				where: [{ field: "id", value: session.session.id }],
+			});
+			sessionDeleted = true;
+			const refreshRows = await context.adapter.findMany<{
+				rotationReplayResponse?: string | null;
+				sessionId?: string | null;
+			}>({
+				model: "oauthRefreshToken",
+				where: [{ field: "clientId", value: oauthClient.client_id }],
+			});
+			expect(
+				refreshRows.find((row) => row.rotationReplayResponse)?.sessionId,
+			).toBeNull();
+			await expectInactiveSessionReplayRejected(
+				tokens.refresh_token!,
+				firstRefresh.data!.refresh_token!,
+			);
+		} finally {
+			if (sessionDeleted) {
+				await context.adapter.create({
+					model: "session",
+					data: session.session,
+					forceAllowId: true,
+				});
+			}
 		}
 	});
 

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -1939,6 +1939,63 @@ describe("oauth token - refresh_token reuse interval", async () => {
 	});
 
 	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11132
+	 */
+	it("rejects a cached session-bound response after the session expires", async () => {
+		oauthClient = await createOAuthClient();
+		const session = await authorizationServer.api.getSession({ headers });
+		if (!session) throw new Error("test session unavailable");
+		const tokens = await authorizeForRefreshToken([
+			"openid",
+			"profile",
+			"offline_access",
+		]);
+
+		const firstRefresh = await refresh(tokens.refresh_token!);
+		expect(firstRefresh.error).toBeNull();
+		expect(firstRefresh.data?.refresh_token).toBeDefined();
+		const context = await authorizationServer.$context;
+		try {
+			await context.adapter.update({
+				model: "session",
+				where: [{ field: "id", value: session.session.id }],
+				update: { expiresAt: new Date() },
+			});
+
+			const replay = await refresh(tokens.refresh_token!);
+			expect((replay.error as { error?: string } | null)?.error).toBe(
+				"invalid_grant",
+			);
+
+			const next = await refresh(firstRefresh.data!.refresh_token!);
+			expect(next.error).toBeNull();
+			expect(next.data?.access_token).toBeDefined();
+			const introspection = await client.$fetch<{
+				active?: boolean;
+				sid?: string;
+			}>("/oauth2/introspect", {
+				method: "POST",
+				body: new URLSearchParams({
+					client_id: oauthClient.client_id,
+					client_secret: oauthClient.client_secret!,
+					token: next.data!.access_token!,
+					token_type_hint: "access_token",
+				}),
+				headers: { "content-type": "application/x-www-form-urlencoded" },
+			});
+			expect(introspection.error).toBeNull();
+			expect(introspection.data).toMatchObject({ active: true });
+			expect(introspection.data?.sid).toBeUndefined();
+		} finally {
+			await context.adapter.update({
+				model: "session",
+				where: [{ field: "id", value: session.session.id }],
+				update: { expiresAt: session.session.expiresAt },
+			});
+		}
+	});
+
+	/**
 	 * @see https://github.com/better-auth/better-auth/issues/8512
 	 */
 	it("replays equivalent requests when scope and resource order differ", async () => {

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -2041,6 +2041,42 @@ describe("oauth token - refresh_token reuse interval", async () => {
 		});
 	});
 
+	it("does not revoke the refresh family when replay session lookup fails", async () => {
+		oauthClient = await createOAuthClient();
+		const tokens = await authorizeForRefreshToken([
+			"openid",
+			"profile",
+			"offline_access",
+		]);
+		const firstRefresh = await refresh(tokens.refresh_token!);
+		expect(firstRefresh.error).toBeNull();
+		expect(firstRefresh.data?.refresh_token).toBeDefined();
+
+		const context = await authorizationServer.$context;
+		const findOne = context.adapter.findOne;
+		let rejectSessionLookup = true;
+		context.adapter.findOne = async (options) => {
+			if (options.model === "session" && rejectSessionLookup) {
+				rejectSessionLookup = false;
+				throw new Error("synthetic session storage outage");
+			}
+			return findOne.call(context.adapter, options);
+		};
+		try {
+			const replay = await refresh(tokens.refresh_token!);
+			expect(replay.error?.status).toBe(500);
+			expect((replay.error as { error?: string } | null)?.error).not.toBe(
+				"invalid_grant",
+			);
+
+			const next = await refresh(firstRefresh.data!.refresh_token!);
+			expect(next.error).toBeNull();
+			expect(next.data?.refresh_token).toBeDefined();
+		} finally {
+			context.adapter.findOne = findOne;
+		}
+	});
+
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/11132
 	 */

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -862,13 +862,17 @@ describe("oauth token - refresh_token", async () => {
 	}
 
 	/** Initial authorization */
-	async function authorizeForRefreshToken(scopes: string[]) {
+	async function authorizeForRefreshToken(
+		scopes: string[],
+		authorizationHeaders = headers,
+	) {
 		const { url: authUrl, codeVerifier } = await createAuthUrl({
 			scopes,
 		});
 
 		let callbackRedirectUrl = "";
 		await client.$fetch(authUrl.toString(), {
+			headers: authorizationHeaders,
 			onError(context) {
 				callbackRedirectUrl = context.response.headers.get("Location") || "";
 			},
@@ -896,6 +900,89 @@ describe("oauth token - refresh_token", async () => {
 
 		return tokens.data;
 	}
+
+	async function issueSessionBoundRefreshToken() {
+		const { headers: sessionHeaders } = await signInWithTestUser();
+		const session = await authorizationServer.api.getSession({
+			headers: sessionHeaders,
+		});
+		if (!session) throw new Error("test session unavailable");
+
+		const tokens = await authorizeForRefreshToken(
+			["openid", "profile", "offline_access"],
+			sessionHeaders,
+		);
+		if (!tokens?.refresh_token) throw new Error("refresh token unavailable");
+
+		return {
+			refreshToken: tokens.refresh_token,
+			sessionId: session.session.id,
+		};
+	}
+
+	async function refreshWithJwtAccessToken(refreshToken: string) {
+		if (!oauthClient?.client_id || !oauthClient.client_secret) {
+			throw Error("beforeAll not run properly");
+		}
+		const { body, headers } = await refreshAccessTokenRequest({
+			refreshToken,
+			options: {
+				clientId: oauthClient.client_id,
+				clientSecret: oauthClient.client_secret,
+				redirectURI: redirectUri,
+			},
+			resource: validResource,
+		});
+		return client.$fetch<OAuthTokenResponse>("/oauth2/token", {
+			method: "POST",
+			body,
+			headers,
+		});
+	}
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11132
+	 */
+	describe("refresh token issuance-session liveness", () => {
+		it("preserves sid while the issuance session is live", async () => {
+			const issued = await issueSessionBoundRefreshToken();
+			const refreshed = await refreshWithJwtAccessToken(issued.refreshToken);
+
+			expect(refreshed.error).toBeNull();
+			expect(decodeJwt(refreshed.data!.access_token!).sid).toBe(
+				issued.sessionId,
+			);
+		});
+
+		it("omits sid after the issuance session expires", async () => {
+			const issued = await issueSessionBoundRefreshToken();
+			const context = await authorizationServer.$context;
+			await context.adapter.update({
+				model: "session",
+				where: [{ field: "id", value: issued.sessionId }],
+				update: { expiresAt: new Date(Date.now() - 60_000) },
+			});
+
+			const refreshed = await refreshWithJwtAccessToken(issued.refreshToken);
+
+			expect(refreshed.error).toBeNull();
+			expect(decodeJwt(refreshed.data!.access_token!).sid).toBeUndefined();
+		});
+
+		it("omits sid after the issuance session is deleted", async () => {
+			const issued = await issueSessionBoundRefreshToken();
+			const context = await authorizationServer.$context;
+			await context.adapter.delete({
+				model: "session",
+				where: [{ field: "id", value: issued.sessionId }],
+			});
+
+			const refreshed = await refreshWithJwtAccessToken(issued.refreshToken);
+
+			expect(refreshed.error).toBeNull();
+			expect(decodeJwt(refreshed.data!.access_token!).sid).toBeUndefined();
+		});
+	});
 
 	it("returns invalid_request when refresh_token omits client_id", async () => {
 		const response = await client.$fetch<Record<string, unknown>>(

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -841,6 +841,7 @@ type RefreshTokenRotationReplayRequest = {
 type RefreshTokenRotationReplay = {
 	request: RefreshTokenRotationReplayRequest;
 	response: OAuthTokenResponse;
+	sessionId?: string | null;
 };
 
 function normalizeReplayValues(values: string[] | undefined) {
@@ -934,7 +935,10 @@ function isRefreshTokenRotationReplay(
 				))) &&
 		(request.confirmation === undefined ||
 			isConfirmation(request.confirmation)) &&
-		isOAuthTokenResponse(replay.response)
+		isOAuthTokenResponse(replay.response) &&
+		(replay.sessionId === undefined ||
+			replay.sessionId === null ||
+			typeof replay.sessionId === "string")
 	);
 }
 
@@ -1003,6 +1007,7 @@ async function storeRefreshTokenRotationReplay(
 	refreshToken: OAuthRefreshToken<Scope[]> & { id: string },
 	request: RefreshTokenRotationReplayRequest,
 	response: OAuthTokenResponse,
+	sessionId: string | undefined,
 ) {
 	if ((opts.refreshTokenReuseInterval ?? 0) <= 0) {
 		return;
@@ -1014,6 +1019,7 @@ async function storeRefreshTokenRotationReplay(
 			rotationReplayResponse: await encryptRefreshTokenRotationReplay(ctx, {
 				request,
 				response,
+				sessionId: sessionId ?? null,
 			}),
 		},
 	});
@@ -1039,6 +1045,17 @@ async function getRefreshTokenRotationReplay(
 		if (
 			!replay ||
 			!sameRefreshTokenRotationReplayRequest(replay.request, request)
+		) {
+			return undefined;
+		}
+		const replaySessionId =
+			replay.sessionId === undefined
+				? refreshToken.sessionId
+				: replay.sessionId;
+		if (
+			(replay.sessionId === undefined && !replaySessionId) ||
+			(replaySessionId &&
+				!(await resolveActiveRefreshSessionId(ctx, replaySessionId)))
 		) {
 			return undefined;
 		}
@@ -1346,6 +1363,7 @@ async function createUserTokens(
 					confirmation,
 				}),
 				responseBody,
+				sessionId,
 			);
 		} catch (error) {
 			ctx.context.logger.error(
@@ -1910,15 +1928,6 @@ async function handleRefreshTokenGrant(
 
 	if (refreshToken.revoked) {
 		if (isWithinRefreshTokenReuseInterval(refreshToken)) {
-			if (
-				refreshToken.sessionId &&
-				!(await resolveActiveRefreshSessionId(ctx, refreshToken.sessionId))
-			) {
-				throw new APIError("BAD_REQUEST", {
-					error_description: "invalid refresh token",
-					error: "invalid_grant",
-				});
-			}
 			const replayRequest = await resolveRefreshTokenRotationReplayRequest(
 				ctx,
 				opts,

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -1941,6 +1941,16 @@ async function handleRefreshTokenGrant(
 		refreshToken.authTime != null
 			? normalizeTimestampValue(refreshToken.authTime)
 			: undefined;
+	let sessionId = refreshToken.sessionId ?? undefined;
+	if (sessionId) {
+		const session = await ctx.context.adapter.findOne<Session>({
+			model: "session",
+			where: [{ field: "id", value: sessionId }],
+		});
+		if (!session || session.expiresAt < new Date()) {
+			sessionId = undefined;
+		}
+	}
 
 	// Generate new tokens
 	return createUserTokens(ctx, opts, {
@@ -1950,7 +1960,7 @@ async function handleRefreshTokenGrant(
 		grantType: "refresh_token",
 		referenceId: refreshToken.referenceId,
 		authorizationCodeId: refreshToken.authorizationCodeId,
-		sessionId: refreshToken.sessionId,
+		sessionId,
 		refreshToken,
 		resources: resources ?? refreshToken.resources,
 		authTime,

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -1037,33 +1037,32 @@ async function getRefreshTokenRotationReplay(
 		return undefined;
 	}
 
+	let replay: RefreshTokenRotationReplay | undefined;
 	try {
-		const replay = await decryptRefreshTokenRotationReplay(
+		replay = await decryptRefreshTokenRotationReplay(
 			ctx,
 			refreshToken.rotationReplayResponse,
 		);
-		if (
-			!replay ||
-			!sameRefreshTokenRotationReplayRequest(replay.request, request)
-		) {
-			return undefined;
-		}
-		const replaySessionId =
-			replay.sessionId === undefined
-				? refreshToken.sessionId
-				: replay.sessionId;
-		if (
-			(replay.sessionId === undefined && !replaySessionId) ||
-			(replaySessionId &&
-				!(await resolveActiveRefreshSessionId(ctx, replaySessionId)))
-		) {
-			return undefined;
-		}
-		return replay.response;
 	} catch (error) {
 		ctx.context.logger.error("refresh token rotation replay failed", error);
 		return undefined;
 	}
+	if (
+		!replay ||
+		!sameRefreshTokenRotationReplayRequest(replay.request, request)
+	) {
+		return undefined;
+	}
+	const replaySessionId =
+		replay.sessionId === undefined ? refreshToken.sessionId : replay.sessionId;
+	if (
+		(replay.sessionId === undefined && !replaySessionId) ||
+		(replaySessionId &&
+			!(await resolveActiveRefreshSessionId(ctx, replaySessionId)))
+	) {
+		return undefined;
+	}
+	return replay.response;
 }
 
 async function resolveRefreshTokenRotationReplayRequest(

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -1779,6 +1779,19 @@ async function handleClientCredentialsGrant(
  * Refresh tokens will only allow the same or lesser scopes as the initial authorize request.
  * To add scopes, you must restart the authorize process again.
  */
+async function resolveActiveRefreshSessionId(
+	ctx: GenericEndpointContext,
+	sessionId: string | null | undefined,
+): Promise<string | undefined> {
+	if (!sessionId) return undefined;
+	const session = await ctx.context.adapter.findOne<Session>({
+		model: "session",
+		where: [{ field: "id", value: sessionId }],
+	});
+	if (!session || session.expiresAt <= new Date()) return undefined;
+	return sessionId;
+}
+
 async function handleRefreshTokenGrant(
 	ctx: GenericEndpointContext,
 	opts: OAuthOptions<Scope[]>,
@@ -1897,6 +1910,15 @@ async function handleRefreshTokenGrant(
 
 	if (refreshToken.revoked) {
 		if (isWithinRefreshTokenReuseInterval(refreshToken)) {
+			if (
+				refreshToken.sessionId &&
+				!(await resolveActiveRefreshSessionId(ctx, refreshToken.sessionId))
+			) {
+				throw new APIError("BAD_REQUEST", {
+					error_description: "invalid refresh token",
+					error: "invalid_grant",
+				});
+			}
 			const replayRequest = await resolveRefreshTokenRotationReplayRequest(
 				ctx,
 				opts,
@@ -1941,16 +1963,10 @@ async function handleRefreshTokenGrant(
 		refreshToken.authTime != null
 			? normalizeTimestampValue(refreshToken.authTime)
 			: undefined;
-	let sessionId = refreshToken.sessionId ?? undefined;
-	if (sessionId) {
-		const session = await ctx.context.adapter.findOne<Session>({
-			model: "session",
-			where: [{ field: "id", value: sessionId }],
-		});
-		if (!session || session.expiresAt < new Date()) {
-			sessionId = undefined;
-		}
-	}
+	const sessionId = await resolveActiveRefreshSessionId(
+		ctx,
+		refreshToken.sessionId,
+	);
 
 	// Generate new tokens
 	return createUserTokens(ctx, opts, {


### PR DESCRIPTION
## Summary

- resolve an OAuth refresh token's issuance session against current session storage
- preserve `sid` only while that session exists and remains unexpired
- normalize deleted-session foreign keys to an omitted `sid`
- propagate replay-time session storage failures without revoking a healthy refresh family

## Testing

- `pnpm --filter @better-auth/oauth-provider test -- token.test.ts`
- `pnpm typecheck`
- targeted Biome check

Closes #11132
