### PR TITLE
refactor(oauth): use shared token flow for Reddit

### DIFF
--- a/.changeset/reddit-token-helpers.md
+++ b/.changeset/reddit-token-helpers.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Improve Reddit token requests with OAuth-compliant Basic authentication and redirect protection.

--- a/packages/core/src/social-providers/reddit.test.ts
+++ b/packages/core/src/social-providers/reddit.test.ts
@@ -21,6 +21,87 @@ function profileResponse(profile: Record<string, unknown>) {
 	>;
 }
 
+function formBody(body: unknown) {
+	if (body instanceof URLSearchParams) return body;
+	if (typeof body === "string") return new URLSearchParams(body);
+	throw new Error("Expected a URL-encoded form body");
+}
+
+/**
+ * @see https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1
+ */
+describe("reddit token requests", () => {
+	beforeEach(() => {
+		mockedBetterFetch.mockReset();
+	});
+
+	it("exchanges an authorization code with Basic authentication", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "access-token",
+				expires_in: 3600,
+				refresh_token: "refresh-token",
+				token_type: "bearer",
+			},
+			error: null,
+		});
+
+		const tokens = await reddit(options).validateAuthorizationCode({
+			code: "authorization-code",
+			redirectURI: "https://app.example.com/api/auth/callback/reddit",
+		});
+
+		expect(tokens?.accessToken).toBe("access-token");
+		const [url, init] = mockedBetterFetch.mock.calls[0] ?? [];
+		expect(url).toBe("https://www.reddit.com/api/v1/access_token");
+		const headers = new Headers(init?.headers as HeadersInit | undefined);
+		expect(headers.get("accept")).toBe("text/plain");
+		expect(headers.get("authorization")).toBe(
+			`Basic ${Buffer.from("reddit-app:reddit-secret").toString("base64")}`,
+		);
+		expect(headers.get("content-type")).toBe(
+			"application/x-www-form-urlencoded",
+		);
+		expect(headers.has("user-agent")).toBe(true);
+		expect(init?.redirect).toBe("manual");
+		expect(Object.fromEntries(formBody(init?.body))).toEqual({
+			code: "authorization-code",
+			grant_type: "authorization_code",
+			redirect_uri: "https://app.example.com/api/auth/callback/reddit",
+		});
+	});
+
+	it("refreshes an access token with Basic authentication", async () => {
+		mockedBetterFetch.mockResolvedValueOnce({
+			data: {
+				access_token: "refreshed-access-token",
+				expires_in: 3600,
+				token_type: "bearer",
+			},
+			error: null,
+		});
+
+		const tokens = await reddit(options).refreshAccessToken("refresh-token");
+
+		expect(tokens.accessToken).toBe("refreshed-access-token");
+		const [url, init] = mockedBetterFetch.mock.calls[0] ?? [];
+		expect(url).toBe("https://www.reddit.com/api/v1/access_token");
+		const headers = new Headers(init?.headers as HeadersInit | undefined);
+		expect(headers.get("accept")).toBe("application/json");
+		expect(headers.get("authorization")).toBe(
+			`Basic ${Buffer.from("reddit-app:reddit-secret").toString("base64")}`,
+		);
+		expect(headers.get("content-type")).toBe(
+			"application/x-www-form-urlencoded",
+		);
+		expect(init?.redirect).toBe("manual");
+		expect(Object.fromEntries(formBody(init?.body))).toEqual({
+			grant_type: "refresh_token",
+			refresh_token: "refresh-token",
+		});
+	});
+});
+
 describe("reddit.getUserInfo (no provider email)", () => {
 	beforeEach(() => {
 		mockedBetterFetch.mockReset();

--- a/packages/core/src/social-providers/reddit.ts
+++ b/packages/core/src/social-providers/reddit.ts
@@ -1,10 +1,13 @@
-import { base64 } from "@better-auth/utils/base64";
 import { betterFetch } from "@better-fetch/fetch";
-import type { OAuthProvider, ProviderOptions } from "../oauth2";
+import type {
+	OAuthProvider,
+	ProviderOptions,
+	TokenEndpointAuth,
+} from "../oauth2";
 import {
 	createAuthorizationURL,
-	getOAuth2Tokens,
 	refreshAccessToken,
+	validateAuthorizationCode,
 } from "../oauth2";
 import { createPlaceholderEmail } from "../utils/email";
 
@@ -23,6 +26,15 @@ export interface RedditOptions extends ProviderOptions<RedditProfile> {
 }
 
 export const reddit = (options: RedditOptions) => {
+	const tokenEndpoint = "https://www.reddit.com/api/v1/access_token";
+	const tokenRequestOptions = {
+		clientId: options.clientId,
+		clientSecret: options.clientSecret,
+	};
+	const tokenEndpointAuth = {
+		method: "client_secret_basic",
+	} satisfies TokenEndpointAuth;
+
 	return {
 		id: "reddit",
 		name: "Reddit",
@@ -43,34 +55,17 @@ export const reddit = (options: RedditOptions) => {
 			});
 		},
 		validateAuthorizationCode: async ({ code, redirectURI }) => {
-			const body = new URLSearchParams({
-				grant_type: "authorization_code",
+			return validateAuthorizationCode({
 				code,
-				redirect_uri: options.redirectURI || redirectURI,
-			});
-			const headers = {
-				"content-type": "application/x-www-form-urlencoded",
-				accept: "text/plain",
-				"user-agent": "better-auth",
-				Authorization: `Basic ${base64.encode(
-					`${options.clientId}:${options.clientSecret}`,
-				)}`,
-			};
-
-			const { data, error } = await betterFetch<object>(
-				"https://www.reddit.com/api/v1/access_token",
-				{
-					method: "POST",
-					headers,
-					body: body.toString(),
+				redirectURI: options.redirectURI || redirectURI,
+				options: tokenRequestOptions,
+				tokenEndpoint,
+				tokenEndpointAuth,
+				headers: {
+					accept: "text/plain",
+					"user-agent": "better-auth",
 				},
-			);
-
-			if (error) {
-				throw error;
-			}
-
-			return getOAuth2Tokens(data);
+			});
 		},
 
 		refreshAccessToken: options.refreshAccessToken
@@ -78,13 +73,9 @@ export const reddit = (options: RedditOptions) => {
 			: async (refreshToken) => {
 					return refreshAccessToken({
 						refreshToken,
-						options: {
-							clientId: options.clientId,
-							clientKey: options.clientKey,
-							clientSecret: options.clientSecret,
-						},
-						authentication: "basic",
-						tokenEndpoint: "https://www.reddit.com/api/v1/access_token",
+						options: tokenRequestOptions,
+						tokenEndpoint,
+						tokenEndpointAuth,
 					});
 				},
 		async getUserInfo(token) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors Reddit OAuth token exchanges to use the shared OAuth2 flow instead of provider-specific request handling. Authorization-code and refresh requests now use OAuth-compliant client-secret Basic authentication and disable automatic redirects, preventing credentials from being forwarded while preserving the provider API.

- Adds tests for request headers, form payloads, token endpoint URLs, and redirect handling.
- Adds a patch changeset for `@better-auth/core`.

<sup>Written for commit 3dcfdf0ece912b5c8c432e90a7826a1d7dd16c91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

