### PR TITLE
chore: improve `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This is the Better Auth repository - a comprehensive authentication framework fo
 - ALWAYS use `pnpm` (never npm, yarn, or bun)
 - NEVER run `pnpm test` (runs all packages). Use `vitest path/to/test -t <pattern>`
 - Type check: `pnpm typecheck`
+- After changing a dependency in `package.json`, run `pnpm install --lockfile-only` to avoid unrelated lockfile updates, then verify with `pnpm install --frozen-lockfile`.
 - Formatting/linting runs automatically on commit (Lefthook + Biome). No need to run manually.
 
 ## Writing Code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ When a flow must synthesize an email, use `createPlaceholderEmail` with a stable
 - NEVER create separate clients with `createAuthClient()` in tests
 - Default test DB is SQLite in-memory; use `testWith` for other databases
 - Adapter tests need Docker: `docker compose up -d`
-- Regression tests: add `@see` comment with issue URL above `it()` or `describe()`:
+- Regression tests: use `@see` for relevant issues or authoritative sources. Do not reference the current pull request or its review comments:
   ```typescript
   /**
    * @see https://github.com/better-auth/better-auth/issues/{issue_number}
@@ -77,6 +77,7 @@ When a flow must synthesize an email, use `createPlaceholderEmail` with a stable
     // ...
   });
   ```
+- Put a shared `@see` above a focused `describe()` when multiple regression tests share the same reference. For a standalone regression test, put it above `it()`.
 
 ## Important Development Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This is the Better Auth repository - a comprehensive authentication framework fo
 - ALWAYS use `pnpm` (never npm, yarn, or bun)
 - NEVER run `pnpm test` (runs all packages). Use `vitest path/to/test -t <pattern>`
 - Type check: `pnpm typecheck`
-- After changing a dependency in `package.json`, run `pnpm install --lockfile-only` to avoid unrelated lockfile updates, then verify with `pnpm install --frozen-lockfile`.
+- After changing a dependency version in `package.json` or `pnpm-workspace.yaml`, run `pnpm install --lockfile-only` from the affected workspace root to avoid unrelated lockfile updates. Verify with `pnpm install --frozen-lockfile`. Nested `demo/*` workspaces have separate lockfiles.
 - Formatting/linting runs automatically on commit (Lefthook + Biome). No need to run manually.
 
 ## Writing Code


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves `AGENTS.md` with clearer dependency lockfile and regression test guidance.

- Documents the `pnpm install --lockfile-only` and frozen-lockfile verification workflow, noting nested `demo/*` workspaces have separate lockfiles.
- Clarifies how to reference issues or authoritative sources without linking to the current pull request.
- Explains where to place shared and standalone `@see` references.

<sup>Written for commit 6c734317ab98a3bf8ef1bf82a25e50090fd3c9e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

