### PR TITLE
fix(cimd): answer Happy-Eyeballs lookup callback with array form

### DIFF
--- a/.changeset/curly-plums-yell.md
+++ b/.changeset/curly-plums-yell.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/cimd": patch
+---
+
+Fix `fetchClientMetadataResource`'s Node transport throwing `ERR_INVALID_IP_ADDRESS` for every request. `https.request`'s Happy Eyeballs connection path (`lookupAndConnectMultiple`) invokes the custom `lookup` option with `{ all: true }` and expects an array-style `(err, addresses[])` callback, but the pinned-address lookup always answered with the legacy `(err, address, family)` form, so every CIMD metadata fetch failed with a network error.

--- a/packages/cimd/src/node.test.ts
+++ b/packages/cimd/src/node.test.ts
@@ -226,4 +226,60 @@ describe("Node CIMD metadata transport", () => {
 		};
 		expect(options.servername).toBeUndefined();
 	});
+
+	it("answers the lookup callback in array form when invoked with { all: true }", async () => {
+		// https.request's Happy Eyeballs path (lookupAndConnectMultiple) invokes
+		// the custom `lookup` with `{ all: true }` and expects an array-style
+		// `(err, addresses[])` callback instead of the legacy `(err, address,
+		// family)` form. Every other test here calls `lookup` with `{}`, which
+		// never exercises this branch.
+		mocks.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+		let received: unknown;
+		mocks.request.mockImplementationOnce(
+			(
+				_url: URL,
+				requestOptions: {
+					lookup: (
+						hostname: string,
+						options: { all: boolean },
+						callback: (
+							error: Error | null,
+							addresses: { address: string; family: number }[],
+						) => void,
+					) => void;
+				},
+				onResponse: (response: Readable) => void,
+			) => {
+				const request = new EventEmitter() as EventEmitter & {
+					end: () => void;
+					destroy: (error?: Error) => void;
+				};
+				request.end = () => {
+					requestOptions.lookup(
+						"client.example.com",
+						{ all: true },
+						(_error, addresses) => {
+							received = addresses;
+							const response = Readable.from([
+								Buffer.from("ok"),
+							]) as Readable & {
+								headers: Record<string, string>;
+								statusCode: number;
+								statusMessage: string;
+							};
+							response.headers = { "content-type": "text/plain" };
+							response.statusCode = 200;
+							response.statusMessage = "OK";
+							onResponse(response);
+						},
+					);
+				};
+				request.destroy = () => {};
+				return request;
+			},
+		);
+
+		await fetchClientMetadataResource("https://client.example.com/client.json");
+		expect(received).toEqual([{ address: "93.184.216.34", family: 4 }]);
+	});
 });

--- a/packages/cimd/src/node.ts
+++ b/packages/cimd/src/node.ts
@@ -77,8 +77,12 @@ export const fetchClientMetadataResource: ClientMetadataResourceFetch = async (
 						? url.hostname
 						: undefined,
 				signal,
-				lookup: (_hostname, _options, callback) => {
-					callback(null, pinnedAddress.address, pinnedAddress.family);
+				lookup: (_hostname, options, callback) => {
+					if (options.all) {
+						callback(null, [pinnedAddress]);
+					} else {
+						callback(null, pinnedAddress.address, pinnedAddress.family);
+					}
 				},
 			},
 			(response) => {


### PR DESCRIPTION
## Summary

`fetchClientMetadataResource`'s Node transport (`packages/cimd/src/node.ts`) pins the resolved address for a CIMD metadata fetch via a custom `lookup` option passed to `https.request`. That callback always answers in the legacy `(err, address, family)` form.

`https.request`'s Happy Eyeballs connection path (`lookupAndConnectMultiple`) invokes this `lookup` option with `{ all: true }`, expecting the array-style `(err, addresses[])` callback instead. Because the legacy form is always used, every metadata fetch fails with:

```
TypeError [ERR_INVALID_IP_ADDRESS]: Invalid IP address: undefined
```

This reproduces on every request, on Node 22 and Node 25 alike (not version-specific), for any target host — so CIMD-based client discovery (e.g. an MCP client authenticating via a `client_id` that's a metadata URL) never actually succeeds.

## Fix

Branch on `options.all` and answer with the matching callback shape, same as `dns.lookup` itself does.

## How I found this

Wiring up `mcp()` + `cimd()` in a Next.js app and testing a real MCP client (Claude Code) connecting via its CIMD `client_id`, `/oauth2/authorize` consistently returned `invalid_client: Failed to fetch metadata document (network error or redirect blocked)`. Isolated `fetchClientMetadataResource` outside the app to get the underlying stack trace, which pointed at the `lookup` callback inside Node's `net.js` Happy Eyeballs path.

## Test plan

- Added a regression test (`node.test.ts`) that invokes the mocked `lookup` with `{ all: true }`, matching how `https.request` actually calls it — none of the existing tests exercise this path (they all call `lookup` with `{}`).
- Verified the new test fails without the fix and passes with it.
- `pnpm --filter @better-auth/cimd test` and `tsc --noEmit` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `fetchClientMetadataResource`'s Node transport so CIMD metadata fetches stop failing with `ERR_INVALID_IP_ADDRESS` when `https.request` uses its Happy Eyeballs connection path.

**Bug Fixes**
- `https.request` calls the custom `lookup` with `{ all: true }` and expects an array-style `(err, addresses[])` callback, but the transport always answered with the legacy `(err, address, family)` form.
- The callback now branches on `options.all` and returns `[pinnedAddress]` for the array form, matching `dns.lookup`.
- Adds a regression test for the `{ all: true }` path, which existing tests didn't cover.

<sup>Written for commit 14288856bf6a4064823c5bcf61c34c076fb22d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

