### PR TITLE
fix(cli): skip empty dependency installs

### DIFF
--- a/.changeset/calm-tools-skip-empty-installs.md
+++ b/.changeset/calm-tools-skip-empty-installs.md
@@ -1,0 +1,5 @@
+---
+"auth": patch
+---
+
+Allow `auth init` to finish when a generated setup has no dependencies in one of its install groups, and preserve useful package-manager output when an installation fails.

--- a/packages/cli/src/utils/install-dependencies.ts
+++ b/packages/cli/src/utils/install-dependencies.ts
@@ -76,12 +76,19 @@ export function installDependencies({
 			flags.push(flag);
 		}
 	}
-	const command = `${installCommand}${flags.length > 0 ? ` ${flags.join(" ")}` : ""} ${Array.isArray(dependencies) ? dependencies.join(" ") : dependencies}`;
+	const dependencyList = Array.isArray(dependencies)
+		? dependencies
+		: [dependencies];
+	if (dependencyList.length === 0) {
+		return Promise.resolve(true);
+	}
+	const command = `${installCommand}${flags.length > 0 ? ` ${flags.join(" ")}` : ""} ${dependencyList.join(" ")}`;
 
 	return new Promise((resolve, reject) => {
 		exec(command, { cwd }, (error, stdout, stderr) => {
 			if (error) {
-				reject(new Error(stderr));
+				const message = stderr.trim() || stdout.trim() || error.message;
+				reject(new Error(message, { cause: error }));
 				return;
 			}
 			resolve(true);

--- a/packages/cli/test/install-dependencies.test.ts
+++ b/packages/cli/test/install-dependencies.test.ts
@@ -131,6 +131,18 @@ describe("installDependencies", () => {
 		},
 	);
 
+	testWithTmpDir("should skip empty dependency lists", async ({ tmp }) => {
+		const result = await installDependencies({
+			dependencies: [],
+			packageManager: "pnpm",
+			cwd: tmp,
+			type: "dev",
+		});
+
+		expect(result).toBe(true);
+		expect(mockExec).not.toHaveBeenCalled();
+	});
+
 	testWithTmpDir(
 		"should run pnpm add with --save-catalog for catalog dependencies",
 		async ({ tmp }) => {
@@ -312,6 +324,26 @@ describe("installDependencies", () => {
 				cwd: tmp,
 			});
 			await expect(promise).rejects.toThrow("test error");
+		},
+	);
+
+	testWithTmpDir(
+		"should reject with stdout when stderr is empty",
+		async ({ tmp }) => {
+			const execError = Object.assign(new Error("Command failed"), { code: 1 });
+			mockExec.mockImplementation((_cmd, _opts, callback) => {
+				if (callback) {
+					callback(execError, "missing package name", "");
+				}
+				return {} as ReturnType<typeof exec>;
+			});
+
+			const promise = installDependencies({
+				dependencies: "invalid-package",
+				packageManager: "pnpm",
+				cwd: tmp,
+			});
+			await expect(promise).rejects.toThrow("missing package name");
 		},
 	);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the CLI dependency installer so `auth init` completes when a generated setup has no dependencies in an install group, instead of failing on an empty package-manager command. Also preserves useful output when an installation fails by falling back to stdout or the error message when stderr is empty.

<sup>Written for commit 1c23e10fa6707cbe60bef61ea22c88e5c3117175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

