### PR TITLE
test(e2e): track typecheck with skipLibCheck disabled

### DIFF
--- a/e2e/smoke/test/fixtures/cloudflare/package.json
+++ b/e2e/smoke/test/fixtures/cloudflare/package.json
@@ -16,6 +16,7 @@
     "e2e:smoke": "pnpm run check && vitest run",
     "dev": "wrangler dev",
     "cf-typegen": "wrangler types --env-interface CloudflareBindings",
-    "typecheck:consumer": "tsc --noEmit --project tsconfig.json"
+    "typecheck:consumer": "tsc --noEmit --project tsconfig.json",
+    "typecheck:skip-lib-check-false": "tsc --noEmit --project tsconfig.skip-lib-check-false.json"
   }
 }

--- a/e2e/smoke/test/fixtures/cloudflare/tsconfig.skip-lib-check-false.json
+++ b/e2e/smoke/test/fixtures/cloudflare/tsconfig.skip-lib-check-false.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": false,
+    "types": []
+  }
+}

--- a/e2e/smoke/test/typecheck.spec.ts
+++ b/e2e/smoke/test/typecheck.spec.ts
@@ -33,3 +33,27 @@ const typecheckTimeoutMilliseconds = 60 * 1000;
 		);
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/11013
+ */
+test("typecheck cloudflare with skipLibCheck disabled", {
+	skip: "Blocked by #11013",
+}, () => {
+	const cwd = resolve(fixturesDir, "cloudflare");
+	const output = spawnSync("pnpm", ["run", "typecheck:skip-lib-check-false"], {
+		stdio: "inherit",
+		cwd,
+		timeout: typecheckTimeoutMilliseconds,
+	});
+	assert.equal(
+		output.error,
+		undefined,
+		`Running typecheck in ${cwd} should not throw an error`,
+	);
+	assert.equal(
+		output.status,
+		0,
+		`Running typecheck in ${cwd} should exit with status 0`,
+	);
+});


### PR DESCRIPTION
We designed Better Auth to support the following DX:

```ts
betterAuth({ database: db })
```

To keep this API type-safe while adding Bun SQLite, Node.js SQLite, and D1 support, we referenced their official types directly. This unintentionally exposed runtime-specific type dependencies through `@better-auth/core`.

It does not affect runtime behavior, but type checking fails with `skipLibCheck: false` when unused runtime types are unavailable.

A patch-level fix is difficult because:

- Replacing official types with structural types weakens the public contract and requires manual synchronization.
- Bundling upstream declarations risks ambient type conflicts.
- Moving integrations to runtime-specific adapters or entry points is cleaner but may require breaking API changes.

For now, this patch adds a skipped E2E test for `skipLibCheck: false`, linked to the issue, so the expected behavior remains tracked.

### Possible Design (not final)

```ts
betterAuth({
  database: nodeSqlite(db),
})
```

Instead of inferring the database implementation at runtime from the shape of the provided instance, we could use an explicit adapter function. This would make runtime selection declarative and keep runtime-specific types outside of core.


### Related

- #11013
- #1550
- #5465 — previous `better-sqlite3` case

### Adjacent Work

- #9934 : makes Kysely optional but does not remove the runtime-specific type imports
- #10318 : changes `AsyncLocalStorage` runtime resolution but does not address declaration leakage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a skipped E2E test that typechecks the Cloudflare fixture with `skipLibCheck: false`, tracking the known issue where `@better-auth/core` leaks runtime-specific type dependencies. The test is skipped until #11013 is fixed, so there's no runtime behavior change.

<sup>Written for commit c5d79248ff59187500dea679de7afc27496a6200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

