### PR TITLE
feat(haveibeenpwned): expose password compromise check

### DIFF
--- a/.changeset/fresh-cats-check-passwords.md
+++ b/.changeset/fresh-cats-check-passwords.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Add `isPasswordCompromised` for checking passwords against Have I Been Pwned in custom server-side flows, while ignoring padded response entries with zero occurrences.

--- a/docs/content/docs/plugins/have-i-been-pwned.mdx
+++ b/docs/content/docs/plugins/have-i-been-pwned.mdx
@@ -32,6 +32,21 @@ When a user attempts to create an account or update their password with a compro
 }
 ```
 
+### Custom password flows
+
+Use `isPasswordCompromised` to check passwords in server-side flows that do not use Better Auth endpoints.
+
+```ts
+import { isPasswordCompromised } from "better-auth/plugins/haveibeenpwned"
+
+const compromised = await isPasswordCompromised(password)
+if (compromised) {
+    throw new Error("Please choose a password that has not been compromised")
+}
+```
+
+The function only sends the first five characters of the password's SHA-1 hash to Have I Been Pwned. It throws an `APIError` if the service cannot complete the check.
+
 ## Options
 
 ### `enabled`

--- a/packages/better-auth/src/plugins/haveibeenpwned/haveibeenpwned.test.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/haveibeenpwned.test.ts
@@ -299,6 +299,9 @@ describe("have-i-been-pwned", async () => {
 	});
 });
 
+/**
+ * @see https://haveibeenpwned.com/API/v3#PwnedPasswords
+ */
 describe("isPasswordCompromised", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -331,6 +334,18 @@ describe("isPasswordCompromised", () => {
 		);
 
 		await expect(isPasswordCompromised(password)).resolves.toBe(false);
+	});
+
+	it("should match lowercase hash suffixes in CRLF responses", async () => {
+		const password = "compromised-password";
+		const hash = (
+			await createHash("SHA-1", "hex").digest(password)
+		).toUpperCase();
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(`${hash.slice(5).toLowerCase()}:1\r\n`, { status: 200 }),
+		);
+
+		await expect(isPasswordCompromised(password)).resolves.toBe(true);
 	});
 
 	it("should not query the service for an empty password", async () => {
@@ -366,13 +381,17 @@ describe("isPasswordCompromised", () => {
 		});
 	});
 
-	it("should reject an invalid compromise count", async () => {
+	it.each([
+		"",
+		"   ",
+		"invalid",
+	])("should reject an invalid compromise count %#", async (compromiseCount) => {
 		const password = "password";
 		const hash = (
 			await createHash("SHA-1", "hex").digest(password)
 		).toUpperCase();
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(`${hash.slice(5)}:invalid\n`, { status: 200 }),
+			new Response(`${hash.slice(5)}:${compromiseCount}\n`, { status: 200 }),
 		);
 
 		await expect(isPasswordCompromised(password)).rejects.toMatchObject({

--- a/packages/better-auth/src/plugins/haveibeenpwned/haveibeenpwned.test.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/haveibeenpwned.test.ts
@@ -348,11 +348,10 @@ describe("isPasswordCompromised", () => {
 		await expect(isPasswordCompromised(password)).resolves.toBe(true);
 	});
 
-	it("should not query the service for an empty password", async () => {
-		const fetch = vi.spyOn(globalThis, "fetch");
+	it("should check an empty password", async () => {
+		await mockBreached("");
 
-		await expect(isPasswordCompromised("")).resolves.toBe(false);
-		expect(fetch).not.toHaveBeenCalled();
+		await expect(isPasswordCompromised("")).resolves.toBe(true);
 	});
 
 	it("should throw an API error when the service cannot complete the check", async () => {

--- a/packages/better-auth/src/plugins/haveibeenpwned/haveibeenpwned.test.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/haveibeenpwned.test.ts
@@ -7,7 +7,7 @@ import { emailOTP } from "../email-otp";
 import { emailOTPClient } from "../email-otp/client";
 import { phoneNumber } from "../phone-number";
 import { phoneNumberClient } from "../phone-number/client";
-import { haveIBeenPwned } from "./index";
+import { haveIBeenPwned, isPasswordCompromised } from "./index";
 
 /**
  * Stubs the Have I Been Pwned range API so the given password is reported as
@@ -295,6 +295,91 @@ describe("have-i-been-pwned", async () => {
 
 			expect(result.error?.status).toBe(400);
 			expect(result.error?.code).toBe("PASSWORD_COMPROMISED");
+		});
+	});
+});
+
+describe("isPasswordCompromised", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("should report a compromised password", async () => {
+		const password = "breached-password";
+		await mockBreached(password);
+
+		await expect(isPasswordCompromised(password)).resolves.toBe(true);
+	});
+
+	it("should report a safe password", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("00000000000000000000000000000000000:1\n", {
+				status: 200,
+			}),
+		);
+
+		await expect(isPasswordCompromised("unique-password")).resolves.toBe(false);
+	});
+
+	it("should ignore padded entries with a zero count", async () => {
+		const password = "padded-password";
+		const hash = (
+			await createHash("SHA-1", "hex").digest(password)
+		).toUpperCase();
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(`${hash.slice(5)}:0\n`, { status: 200 }),
+		);
+
+		await expect(isPasswordCompromised(password)).resolves.toBe(false);
+	});
+
+	it("should not query the service for an empty password", async () => {
+		const fetch = vi.spyOn(globalThis, "fetch");
+
+		await expect(isPasswordCompromised("")).resolves.toBe(false);
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("should throw an API error when the service cannot complete the check", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(null, { status: 503 }),
+		);
+
+		await expect(isPasswordCompromised("password")).rejects.toMatchObject({
+			status: "INTERNAL_SERVER_ERROR",
+			body: {
+				message: "Failed to check password. Status: 503",
+			},
+		});
+	});
+
+	it("should hide unexpected service errors", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error("network unavailable"),
+		);
+
+		await expect(isPasswordCompromised("password")).rejects.toMatchObject({
+			status: "INTERNAL_SERVER_ERROR",
+			body: {
+				message: "Failed to check password. Please try again later.",
+			},
+		});
+	});
+
+	it("should reject an invalid compromise count", async () => {
+		const password = "password";
+		const hash = (
+			await createHash("SHA-1", "hex").digest(password)
+		).toUpperCase();
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(`${hash.slice(5)}:invalid\n`, { status: 200 }),
+		);
+
+		await expect(isPasswordCompromised(password)).rejects.toMatchObject({
+			status: "INTERNAL_SERVER_ERROR",
+			body: {
+				message: "Failed to check password. Please try again later.",
+			},
 		});
 	});
 });

--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -21,16 +21,24 @@ const ERROR_CODES = defineErrorCodes({
 });
 
 function getPasswordCompromiseCount(response: string, hashSuffix: string) {
-	const matchingEntryPrefix = `${hashSuffix}:`;
-	for (const line of response.split("\n")) {
-		if (!line.startsWith(matchingEntryPrefix)) continue;
+	const matchingEntryPrefix = `${hashSuffix.toUpperCase()}:`;
 
-		const compromiseCount = Number(line.slice(matchingEntryPrefix.length));
-		if (!Number.isSafeInteger(compromiseCount) || compromiseCount < 0) {
+	for (const line of response.split(/\r?\n/)) {
+		const entryPrefix = line.slice(0, matchingEntryPrefix.length).toUpperCase();
+		if (entryPrefix !== matchingEntryPrefix) continue;
+
+		const compromiseCountText = line.slice(matchingEntryPrefix.length);
+		const compromiseCount = Number(compromiseCountText);
+		const validCompromiseCount =
+			Number.isSafeInteger(compromiseCount) &&
+			compromiseCount >= 0 &&
+			String(compromiseCount) === compromiseCountText;
+		if (!validCompromiseCount) {
 			throw new Error("Invalid password compromise count");
 		}
 		return compromiseCount;
 	}
+
 	return 0;
 }
 

--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -52,7 +52,6 @@ function getPasswordCompromiseCount(response: string, hashSuffix: string) {
 export async function isPasswordCompromised(
 	password: string,
 ): Promise<boolean> {
-	if (!password) return false;
 	try {
 		const sha1Hash = (
 			await createHash("SHA-1", "hex").digest(password)

--- a/packages/better-auth/src/plugins/haveibeenpwned/index.ts
+++ b/packages/better-auth/src/plugins/haveibeenpwned/index.ts
@@ -20,18 +20,37 @@ const ERROR_CODES = defineErrorCodes({
 		"The password you entered has been compromised. Please choose a different password.",
 });
 
-async function checkPasswordCompromise(
-	password: string,
-	customMessage?: string | undefined,
-) {
-	if (!password) return;
+function getPasswordCompromiseCount(response: string, hashSuffix: string) {
+	const matchingEntryPrefix = `${hashSuffix}:`;
+	for (const line of response.split("\n")) {
+		if (!line.startsWith(matchingEntryPrefix)) continue;
 
-	const sha1Hash = (
-		await createHash("SHA-1", "hex").digest(password)
-	).toUpperCase();
-	const prefix = sha1Hash.substring(0, 5);
-	const suffix = sha1Hash.substring(5);
+		const compromiseCount = Number(line.slice(matchingEntryPrefix.length));
+		if (!Number.isSafeInteger(compromiseCount) || compromiseCount < 0) {
+			throw new Error("Invalid password compromise count");
+		}
+		return compromiseCount;
+	}
+	return 0;
+}
+
+/**
+ * Checks whether a password appears in the Have I Been Pwned password corpus.
+ * Only the first five characters of its SHA-1 hash are sent to the service.
+ *
+ * @returns Whether the password has been compromised.
+ * @throws {APIError} When the password could not be checked.
+ */
+export async function isPasswordCompromised(
+	password: string,
+): Promise<boolean> {
+	if (!password) return false;
 	try {
+		const sha1Hash = (
+			await createHash("SHA-1", "hex").digest(password)
+		).toUpperCase();
+		const prefix = sha1Hash.substring(0, 5);
+		const suffix = sha1Hash.substring(5);
 		const { data, error } = await betterFetch<string>(
 			`https://api.pwnedpasswords.com/range/${prefix}`,
 			{
@@ -47,21 +66,25 @@ async function checkPasswordCompromise(
 				message: `Failed to check password. Status: ${error.status}`,
 			});
 		}
-		const lines = data.split("\n");
-		const found = lines.some(
-			(line) => line.split(":")[0]!.toUpperCase() === suffix.toUpperCase(),
-		);
-
-		if (found) {
-			throw APIError.from("BAD_REQUEST", {
-				message: customMessage || ERROR_CODES.PASSWORD_COMPROMISED.message,
-				code: ERROR_CODES.PASSWORD_COMPROMISED.code,
-			});
-		}
+		const compromiseCount = getPasswordCompromiseCount(data, suffix);
+		return compromiseCount > 0;
 	} catch (error) {
 		if (isAPIError(error)) throw error;
 		throw new APIError("INTERNAL_SERVER_ERROR", {
 			message: "Failed to check password. Please try again later.",
+		});
+	}
+}
+
+async function rejectCompromisedPassword(
+	password: string,
+	customMessage?: string | undefined,
+) {
+	const compromised = await isPasswordCompromised(password);
+	if (compromised) {
+		throw APIError.from("BAD_REQUEST", {
+			message: customMessage || ERROR_CODES.PASSWORD_COMPROMISED.message,
+			code: ERROR_CODES.PASSWORD_COMPROMISED.code,
 		});
 	}
 }
@@ -112,7 +135,7 @@ export const haveIBeenPwned = (options?: HaveIBeenPwnedOptions | undefined) => {
 							if (!c.path || !paths.includes(c.path)) {
 								return originalHash(password);
 							}
-							await checkPasswordCompromise(
+							await rejectCompromisedPassword(
 								password,
 								options?.customPasswordCompromisedMessage,
 							);


### PR DESCRIPTION
Supersedes #10268

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports `isPasswordCompromised` from the `haveibeenpwned` plugin for checking passwords against Have I Been Pwned in custom server-side flows, while preserving existing endpoint behavior.

**New Features**
- `isPasswordCompromised` returns a boolean instead of throwing, so custom flows decide how to handle compromised passwords.
- The check ignores padded response entries with zero occurrences, rejects invalid compromise counts, and now checks empty passwords instead of skipping them.

<sup>Written for commit 3c9d16d757d125d12ac8a88867f227af3ed6a2d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

