### PR TITLE
fix(passkey): respect authenticatorSelection.userVerification in auth options and verifiers

### DIFF
--- a/packages/passkey/src/passkey.test.ts
+++ b/packages/passkey/src/passkey.test.ts
@@ -504,6 +504,110 @@ describe("passkey", async () => {
 		expect(options).toHaveProperty("userVerification");
 	});
 
+	it("should respect authenticatorSelection.userVerification for auth options and verifiers", async () => {
+		const {
+			auth: uvAuth,
+			client: uvClient,
+			cookieSetter,
+			signInWithTestUser: uvSignIn,
+		} = await getTestInstance({
+			plugins: [
+				passkey({
+					authenticatorSelection: {
+						userVerification: "required",
+					},
+				}),
+			],
+		});
+
+		const { headers, user } = await uvSignIn();
+		headers.set("origin", "http://localhost:3000");
+		const setCookie = cookieSetter(headers);
+
+		const authOptions = await uvAuth.api.generatePasskeyAuthenticationOptions({
+			headers,
+		});
+		expect(authOptions.userVerification).toBe("required");
+
+		const registerOptions = await uvAuth.api.generatePasskeyRegistrationOptions(
+			{
+				headers,
+			},
+		);
+		expect(registerOptions.authenticatorSelection?.userVerification).toBe(
+			"required",
+		);
+
+		await uvClient.$fetch("/passkey/generate-register-options", {
+			method: "GET",
+			headers,
+			onResponse: setCookie,
+		});
+		serverMocks.verifyRegistrationResponse.mockResolvedValue(
+			mockRegistrationVerification,
+		);
+		await uvAuth.api.verifyPasskeyRegistration({
+			headers,
+			body: {
+				response: mockRegistrationResponse,
+			},
+		});
+		expect(serverMocks.verifyRegistrationResponse).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requireUserVerification: true,
+			}),
+		);
+
+		const context = await uvAuth.$context;
+		await context.adapter.create<Omit<Passkey, "id">, Passkey>({
+			model: "passkey",
+			data: {
+				userId: user.id,
+				publicKey: "bW9ja1B1YmxpY0tleQ==",
+				name: "uv-required",
+				counter: 0,
+				deviceType: "singleDevice",
+				credentialID: "uv-required-credential",
+				createdAt: new Date(),
+				backedUp: false,
+				transports: "internal",
+				aaguid: "mockAAGUID",
+			} satisfies Omit<Passkey, "id">,
+		});
+
+		await uvClient.$fetch("/passkey/generate-authenticate-options", {
+			method: "GET",
+			headers,
+			onResponse: setCookie,
+		});
+		serverMocks.verifyAuthenticationResponse.mockResolvedValue({
+			verified: true,
+			authenticationInfo: { newCounter: 1 },
+		});
+		await uvAuth.api.verifyPasskeyAuthentication({
+			headers,
+			body: {
+				response: {
+					id: "uv-required-credential",
+					rawId: "uv-required-credential",
+					response: {
+						clientDataJSON: "mockClientDataJSON",
+						authenticatorData: "mockAuthenticatorData",
+						signature: "mockSignature",
+						userHandle: "mockUserHandle",
+					},
+					type: "public-key",
+					clientExtensionResults: {},
+				},
+			},
+		});
+		expect(serverMocks.verifyAuthenticationResponse).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requireUserVerification: true,
+			}),
+		);
+	});
+
 	it("should list user passkeys", async () => {
 		const { headers, user } = await signInWithTestUser();
 		const context = await auth.$context;

--- a/packages/passkey/src/routes.ts
+++ b/packages/passkey/src/routes.ts
@@ -485,7 +485,8 @@ export const generatePasskeyAuthenticationOptions = (
 			);
 			const options = await generateAuthenticationOptions({
 				rpID: getRpID(opts, baseURLString),
-				userVerification: "preferred",
+				userVerification:
+					opts.authenticatorSelection?.userVerification ?? "preferred",
 				extensions: authenticationExtensions,
 				...(userPasskeys.length
 					? {
@@ -655,7 +656,8 @@ export const verifyPasskeyRegistration = (options: RequiredPassKeyOptions) => {
 					expectedChallenge,
 					expectedOrigin: origin,
 					expectedRPID: getRpID(options, verifyBaseURL),
-					requireUserVerification: false,
+					requireUserVerification:
+						options.authenticatorSelection?.userVerification === "required",
 				});
 				const { verified, registrationInfo } = verification;
 				if (!verified || !registrationInfo) {
@@ -906,7 +908,8 @@ export const verifyPasskeyAuthentication = (options: RequiredPassKeyOptions) =>
 							",",
 						) as AuthenticatorTransportFuture[],
 					},
-					requireUserVerification: false,
+					requireUserVerification:
+						options.authenticatorSelection?.userVerification === "required",
 				});
 				const { verified } = verification;
 				if (!verified)


### PR DESCRIPTION
## Summary

When configuring the passkey plugin with `authenticatorSelection: { userVerification: "required" }`, authentication challenges still always used `"preferred"`, and both registration and authentication verifiers hardcoded `requireUserVerification: false`. That meant a configured `"required"` policy was not enforced on the server side.

This change:

- Uses `opts.authenticatorSelection?.userVerification ?? "preferred"` when generating authentication options
- Sets `requireUserVerification: true` in both `verifyRegistrationResponse` and `verifyAuthenticationResponse` when `authenticatorSelection.userVerification === "required"`

Registration option generation already merged `authenticatorSelection` into the WebAuthn options; only the authentication challenge path and both verifiers needed updating.

## Test plan

- [x] Added a test that configures `authenticatorSelection: { userVerification: "required" }` and asserts:
  - generated authentication options expose `userVerification: "required"`
  - registration options reflect the configured `userVerification`
  - registration and authentication verifiers are called with `requireUserVerification: true`
- [x] `pnpm --filter @better-auth/passkey test -- --run` passes (51 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the passkey plugin ignoring the configured `authenticatorSelection.userVerification` value. Authentication options now use the configured value (defaulting to `preferred`), and both registration and authentication verifiers set `requireUserVerification: true` when the policy is `required`.

<sup>Written for commit 9952f3d1ff9f4605d51089549e118cc375404b4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

