### PR TITLE
fix: avoid leaking Cloudflare types from D1 declarations

### DIFF
--- a/.changeset/fix-cloudflare-type-dependency.md
+++ b/.changeset/fix-cloudflare-type-dependency.md
@@ -1,0 +1,6 @@
+---
+"@better-auth/core": patch
+"@better-auth/kysely-adapter": patch
+---
+
+Avoid requiring Cloudflare Workers types from public D1 declarations.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -184,7 +184,6 @@
   "peerDependencies": {
     "@better-auth/utils": "catalog:",
     "@better-fetch/fetch": "catalog:",
-    "@cloudflare/workers-types": ">=4",
     "@opentelemetry/api": "^1.9.0",
     "better-call": "catalog:",
     "jose": "^6.1.0",
@@ -192,9 +191,6 @@
     "nanostores": "catalog:peer"
   },
   "peerDependenciesMeta": {
-    "@cloudflare/workers-types": {
-      "optional": true
-    },
     "@opentelemetry/api": {
       "optional": true
     }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -23,6 +23,7 @@ export type {
 	BetterAuthRateLimitOptions,
 	BetterAuthRateLimitRule,
 	BetterAuthRateLimitStorage,
+	D1Database,
 	DynamicBaseURLConfig,
 	GenerateIdFn,
 	StoreIdentifierOption,

--- a/packages/core/src/types/init-options.test.ts
+++ b/packages/core/src/types/init-options.test.ts
@@ -1,0 +1,13 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { describe, expectTypeOf, it } from "vitest";
+import type { BetterAuthOptions } from "./init-options";
+
+describe("BetterAuthOptions", () => {
+	it("accepts a Cloudflare D1 database structurally", () => {
+		function createOptions(database: D1Database) {
+			return { database } satisfies BetterAuthOptions;
+		}
+
+		expectTypeOf(createOptions).returns.toMatchTypeOf<BetterAuthOptions>();
+	});
+});

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1,6 +1,5 @@
 import type { Database as BunDatabase } from "bun:sqlite";
 import type { DatabaseSync } from "node:sqlite";
-import type { D1Database } from "@cloudflare/workers-types";
 import type { CookieOptions } from "better-call";
 import type {
 	Dialect,
@@ -32,6 +31,26 @@ import type { Awaitable, LiteralString, LiteralUnion } from "./helper";
 import type { BetterAuthPlugin } from "./plugin";
 
 type KyselyDatabaseType = "postgres" | "mysql" | "sqlite" | "mssql";
+
+interface D1Result<T = unknown> {
+	meta: {
+		changes?: number | undefined;
+		last_row_id?: number | undefined;
+	};
+	results: T[];
+}
+
+interface D1PreparedStatement {
+	bind(...values: unknown[]): D1PreparedStatement;
+	all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
+}
+
+export interface D1Database {
+	prepare(query: string): D1PreparedStatement;
+	batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
+	exec(query: string): Promise<unknown>;
+}
+
 type Optional<T> = {
 	[P in keyof T]?: T[P] | undefined;
 };

--- a/packages/kysely-adapter/src/d1-sqlite-dialect.ts
+++ b/packages/kysely-adapter/src/d1-sqlite-dialect.ts
@@ -1,4 +1,4 @@
-import type { D1Database } from "@cloudflare/workers-types";
+import type { D1Database } from "@better-auth/core";
 import type {
 	CompiledQuery,
 	DatabaseConnection,


### PR DESCRIPTION
## Summary

- replace the public `@cloudflare/workers-types` import with the minimal structural D1 contract Better Auth uses
- share that contract with the Kysely adapter while keeping Cloudflare types dev-only
- remove the now-unnecessary optional peer from core
- add a focused compatibility test and patch changesets

## Problem

`BetterAuthOptions` directly referenced Cloudflare's `D1Database`. That made the published core declaration import `@cloudflare/workers-types`, so non-Cloudflare consumers could fail with `TS2307` when the optional peer was absent. Making the type package mandatory would fix resolution but would also load Cloudflare global declarations for every consumer.

The local structural contract keeps real D1 bindings assignable without exposing or installing Cloudflare's global type package.

## Testing

- `pnpm --filter @better-auth/core exec vitest run src/types/init-options.test.ts`
- `pnpm --filter @better-auth/core typecheck`
- `pnpm --filter @better-auth/kysely-adapter typecheck`
- Biome check on all changed TypeScript and package manifest files
- built core declarations contain no `@cloudflare/workers-types` import