### PR TITLE
chore(scim): ensure inactive SCIM user resources can be reactivated

### DIFF
--- a/.changeset/scim-okta-inactive-reprovision.md
+++ b/.changeset/scim-okta-inactive-reprovision.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": patch
+---
+
+Restore an inactive SCIM User when `POST /scim/v2/Users` reuses the same connection-scoped `externalId`, so Okta-style deprovision and reassignment no longer fails with a uniqueness conflict.

--- a/docs/content/docs/plugins/scim/index.mdx
+++ b/docs/content/docs/plugins/scim/index.mdx
@@ -172,6 +172,8 @@ You can configure several connections. Their credentials remain isolated, while 
 
 When a directory creates a SCIM User, Better Auth creates a User by default, or links one when `identity.resolveUser` returns `link`. The directory can then update the profile, set `active`, or delete the SCIM resource. A SCIM User does not create an authentication account, so the user still needs SSO, a passkey, credentials, or another sign-in method.
 
+If a directory deactivates a user and later creates them again with the same `externalId`, Better Auth restores the inactive SCIM User instead of rejecting the create.
+
 By default, the SCIM source manages the Better Auth User's email and name. The plugin never links an incoming resource to an existing user by email.
 
 ### Link an existing Better Auth User

--- a/docs/content/docs/plugins/scim/reference.mdx
+++ b/docs/content/docs/plugins/scim/reference.mdx
@@ -215,14 +215,14 @@ The plugin passes Microsoft's [Entra SCIM Validator](https://learn.microsoft.com
 
 ## Users
 
-| Method   | Path                     | Result                                                                                 |
-| -------- | ------------------------ | -------------------------------------------------------------------------------------- |
-| `POST`   | `/scim/v2/Users`         | Creates a SCIM User and creates or explicitly links a Better Auth User. Returns `201`. |
-| `GET`    | `/scim/v2/Users`         | Returns the connection's Users in a SCIM `ListResponse`.                               |
-| `GET`    | `/scim/v2/Users/:userId` | Returns one User owned by the connection.                                              |
-| `PUT`    | `/scim/v2/Users/:userId` | Replaces the writable profile while preserving the resource ID. Returns `200`.         |
-| `PATCH`  | `/scim/v2/Users/:userId` | Applies ordered, atomic changes. Returns `200` with the updated resource.              |
-| `DELETE` | `/scim/v2/Users/:userId` | Deletes the SCIM resource while preserving the Better Auth User. Returns `204`.        |
+| Method   | Path                     | Result                                                                                        |
+| -------- | ------------------------ | --------------------------------------------------------------------------------------------- |
+| `POST`   | `/scim/v2/Users`         | Creates a SCIM User (`201`), or restores an inactive User with the same `externalId` (`200`). |
+| `GET`    | `/scim/v2/Users`         | Returns the connection's Users in a SCIM `ListResponse`.                                      |
+| `GET`    | `/scim/v2/Users/:userId` | Returns one User owned by the connection.                                                     |
+| `PUT`    | `/scim/v2/Users/:userId` | Replaces the writable profile while preserving the resource ID. Returns `200`.                |
+| `PATCH`  | `/scim/v2/Users/:userId` | Applies ordered, atomic changes. Returns `200` with the updated resource.                     |
+| `DELETE` | `/scim/v2/Users/:userId` | Deletes the SCIM resource while preserving the Better Auth User. Returns `204`.               |
 
 Deleting a User also removes its direct Group memberships and projected grants, updates the affected Groups, and reconciles lifecycle and access state. When `externalId` is present, the plugin preserves the link needed to attach a later reprovisioned resource to the same Better Auth User.
 

--- a/packages/scim/src/identity.ts
+++ b/packages/scim/src/identity.ts
@@ -186,7 +186,7 @@ interface IdentityMutationTransactionOptions {
 	subjectCreationUserId?: string;
 }
 
-function concurrentIdentityMutation(): never {
+export function concurrentIdentityMutation(): never {
 	const error = createSCIMError("CONFLICT", {
 		detail: "The SCIM identity changed concurrently; retry the request",
 	}) as SCIMIdentityMutationConflict;

--- a/packages/scim/src/scim-identity-resolution.test.ts
+++ b/packages/scim/src/scim-identity-resolution.test.ts
@@ -615,6 +615,162 @@ describe("SCIM explicit identity resolution", () => {
 		expect(data.scimIdentityTombstone).toEqual([]);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11111
+	 */
+	it("restores an inactive SCIM User when POST reuses its externalId", async () => {
+		const { auth, data } = createIdentityFixture();
+		const first = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "inactive-restore@example.com",
+				externalId: "okta-soft-deactivated-subject",
+				name: { givenName: "Before", familyName: "Restore" },
+				displayName: "Before Restore",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		const original = data.scimUser.find((source) => source.id === first.id);
+		if (!original) throw new Error("Expected the original SCIM source");
+
+		await auth.api.patchSCIMUser({
+			params: { userId: first.id },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [{ op: "replace", path: "active", value: false }],
+			},
+			headers: authorization("connection-a-token"),
+		});
+		expect(data.scimUser.find((source) => source.id === first.id)?.active).toBe(
+			false,
+		);
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "okta-soft-deactivated-subject",
+			}),
+		).resolves.toBeNull();
+
+		const restored = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "inactive-restored@example.com",
+				externalId: "okta-soft-deactivated-subject",
+				name: { givenName: "After", familyName: "Restore" },
+				displayName: "After Restore",
+			},
+			headers: authorization("connection-a-token"),
+		});
+
+		expect(restored.id).toBe(first.id);
+		expect(restored.active).toBe(true);
+		expect(restored.userName).toBe("inactive-restored@example.com");
+		expect(restored.displayName).toBe("After Restore");
+		expect(data.scimUser).toHaveLength(1);
+		expect(data.user).toHaveLength(1);
+		expect(data.scimUser[0]?.userId).toBe(original.userId);
+		expect(data.user[0]).toMatchObject({
+			email: "inactive-restored@example.com",
+			name: "After Restore",
+		});
+		expect(data.scimIdentityTombstone).toEqual([]);
+		await expect(
+			acquireUserLink(auth, {
+				connectionId: CONNECTION_A.id,
+				externalId: "okta-soft-deactivated-subject",
+			}),
+		).resolves.toEqual({
+			scimUserId: first.id,
+			userId: original.userId,
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11111
+	 */
+	it("still rejects POST when the matching externalId belongs to an active SCIM User", async () => {
+		const { auth } = createIdentityFixture();
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "active-collision@example.com",
+				externalId: "active-external-id",
+			},
+			headers: authorization("connection-a-token"),
+		});
+
+		await expect(
+			auth.api.createSCIMUser({
+				body: {
+					schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+					userName: "active-collision-other@example.com",
+					externalId: "active-external-id",
+				},
+				headers: authorization("connection-a-token"),
+			}),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				statusCode: 409,
+				body: expect.objectContaining({
+					detail: "SCIM User externalId already exists",
+					scimType: "uniqueness",
+				}),
+			}),
+		);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11111
+	 */
+	it("still rejects inactive externalId restore when userName belongs to another user", async () => {
+		const { auth, data } = createIdentityFixture();
+		const inactive = await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "username-collision-first@example.com",
+				externalId: "username-collision-subject",
+			},
+			headers: authorization("connection-a-token"),
+		});
+		await auth.api.patchSCIMUser({
+			params: { userId: inactive.id },
+			body: {
+				schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+				Operations: [{ op: "replace", path: "active", value: false }],
+			},
+			headers: authorization("connection-a-token"),
+		});
+		await auth.api.createSCIMUser({
+			body: {
+				schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+				userName: "username-collision-second@example.com",
+			},
+			headers: authorization("connection-a-token"),
+		});
+
+		await expect(
+			auth.api.createSCIMUser({
+				body: {
+					schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+					userName: "username-collision-second@example.com",
+					externalId: "username-collision-subject",
+				},
+				headers: authorization("connection-a-token"),
+			}),
+		).rejects.toThrowError(
+			expect.objectContaining({
+				statusCode: 409,
+				body: expect.objectContaining({
+					detail: "SCIM User userName already exists",
+					scimType: "uniqueness",
+				}),
+			}),
+		);
+		expect(
+			data.scimUser.find((source) => source.id === inactive.id)?.active,
+		).toBe(false);
+	});
+
 	it("revokes sessions only when the final linked source becomes inactive", async () => {
 		const target = createBackingUser();
 		const session = createSession(target.id);

--- a/packages/scim/src/user-provisioning.ts
+++ b/packages/scim/src/user-provisioning.ts
@@ -206,6 +206,139 @@ async function findSCIMUser(
 	return scimUser;
 }
 
+async function findSCIMUserByExternalIdKey(
+	adapter: Pick<DBAdapter, "findOne">,
+	connection: SCIMConnection,
+	externalIdKey: string,
+) {
+	const scimUser = await adapter.findOne<SCIMUser>({
+		model: "scimUser",
+		where: [
+			{ field: "connectionId", value: connection.id },
+			{ field: "externalIdKey", value: externalIdKey },
+		],
+	});
+	if (
+		scimUser &&
+		scimUser.provisioningDomainId !== connection.provisioningDomainId
+	) {
+		throw createSCIMError("CONFLICT", {
+			detail:
+				"The connection provisioningDomainId changed after resources were created",
+		});
+	}
+	return scimUser;
+}
+
+async function restoreInactiveSCIMUserByExternalId(input: {
+	adapter: DBAdapter;
+	auth: AuthContext;
+	connection: SCIMConnection;
+	identity: SCIMIdentityCoordinator;
+	projection: SCIMProjectionCoordinator;
+	profile: ReturnType<typeof createCanonicalSCIMUserProfile>;
+	userNameKey: string;
+	externalIdKey: string;
+	externalId: string | undefined;
+	active: boolean;
+}): Promise<SCIMUser | null> {
+	const {
+		adapter,
+		auth,
+		connection,
+		identity,
+		projection,
+		profile,
+		userNameKey,
+		externalIdKey,
+		externalId,
+		active,
+	} = input;
+
+	return runIdentityMutationTransaction(adapter, async (trx) => {
+		const currentSource = await findSCIMUserByExternalIdKey(
+			trx,
+			connection,
+			externalIdKey,
+		);
+		if (!currentSource) {
+			return null;
+		}
+		if (currentSource.active) {
+			throw createSCIMError("CONFLICT", {
+				detail: "SCIM User externalId already exists",
+				scimType: "uniqueness",
+			});
+		}
+
+		await assertSCIMUserKeysAvailable(trx, {
+			connectionId: connection.id,
+			userNameKey,
+			externalIdKey,
+			excludeSCIMUserId: currentSource.id,
+		});
+
+		const updatedAt = new Date();
+		const subject = await identity.acquireSubject(
+			trx,
+			currentSource.userId,
+			updatedAt,
+		);
+		if (subject.profileSourceId === currentSource.id) {
+			await updateManagedBetterAuthUser(trx, auth.internalAdapter, {
+				userId: currentSource.userId,
+				email: profile.primaryEmail,
+				name: profile.displayName,
+				updatedAt,
+			});
+		}
+
+		const restoredSource = await trx.update<SCIMUser>({
+			model: "scimUser",
+			where: [
+				{ field: "id", value: currentSource.id },
+				{ field: "connectionId", value: connection.id },
+				{ field: "externalIdKey", value: externalIdKey },
+				{ field: "active", value: false },
+			],
+			update: {
+				userName: profile.userName,
+				userNameKey,
+				primaryEmail: profile.primaryEmail,
+				workEmailValueIndex: createSCIMEmailValueIndex(profile.emails, "work"),
+				emailValueIndex: createSCIMEmailValueIndex(profile.emails),
+				displayName: profile.displayName,
+				formattedName: profile.formattedName,
+				givenName: profile.name.givenName ?? null,
+				familyName: profile.name.familyName ?? null,
+				serializedEmails: serializeSCIMEmails(profile.emails),
+				serializedAttributes: serializeSCIMUserAttributes(profile.attributes),
+				externalId: externalId ?? null,
+				externalIdKey,
+				active,
+				updatedAt,
+			},
+		});
+		if (!restoredSource) {
+			return null;
+		}
+
+		await projection.reconcileUser({
+			database: trx,
+			auth,
+			provisioningDomainId: connection.provisioningDomainId,
+			scimUserId: restoredSource.id,
+		});
+		await identity.reconcileUser({
+			database: trx,
+			auth,
+			subject,
+		});
+		await fenceActiveSCIMConnection(trx, connection.id);
+		return restoredSource;
+	});
+}
+
 async function requireSCIMSubject(
 	adapter: Pick<DBAdapter, "findOne">,
 	userId: string,
@@ -376,6 +509,11 @@ export function createSCIMUser(
 				openapi: {
 					summary: "Create SCIM User",
 					responses: {
+						"200": {
+							description:
+								"Restored inactive SCIM User matched by connection-scoped externalId",
+							content: createSCIMOpenAPIContent(OpenAPIUserResourceSchema),
+						},
 						"201": {
 							description: "SCIM User resource",
 							content: createSCIMOpenAPIContent(OpenAPIUserResourceSchema),
@@ -403,6 +541,43 @@ export function createSCIMUser(
 				ctx.body.externalId,
 			);
 			await assertUserConnectionDomainStable(adapter, connection);
+
+			if (externalIdKey) {
+				const existingByExternalId = await findSCIMUserByExternalIdKey(
+					adapter,
+					connection,
+					externalIdKey,
+				);
+				if (existingByExternalId && existingByExternalId.active === false) {
+					const restoredSCIMUser = await restoreInactiveSCIMUserByExternalId({
+						adapter,
+						auth: ctx.context,
+						connection,
+						identity,
+						projection,
+						profile,
+						userNameKey,
+						externalIdKey,
+						externalId: ctx.body.externalId,
+						active,
+					});
+					if (restoredSCIMUser) {
+						const completeResource = createUserResource(
+							ctx.context.baseURL,
+							restoredSCIMUser,
+						);
+						const resource = projectSCIMResourceAttributes(
+							completeResource,
+							attributeProjection,
+						);
+						ctx.setStatus(200);
+						ctx.setHeader("location", completeResource.meta.location);
+						ctx.setHeader("content-location", completeResource.meta.location);
+						return ctx.json(resource);
+					}
+				}
+			}
+
 			await assertSCIMUserKeysAvailable(adapter, {
 				connectionId: connection.id,
 				userNameKey,

--- a/packages/scim/src/user-provisioning.ts
+++ b/packages/scim/src/user-provisioning.ts
@@ -23,7 +23,10 @@ import {
 	throwConcurrentSCIMGroupMutation,
 } from "./group-state";
 import type { SCIMIdentityCoordinator } from "./identity";
-import { runIdentityMutationTransaction } from "./identity";
+import {
+	concurrentIdentityMutation,
+	runIdentityMutationTransaction,
+} from "./identity";
 import type {
 	SCIMGroup,
 	SCIMGroupMember,
@@ -320,7 +323,7 @@ async function restoreInactiveSCIMUserByExternalId(input: {
 			},
 		});
 		if (!restoredSource) {
-			return null;
+			concurrentIdentityMutation();
 		}
 
 		await projection.reconcileUser({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores inactive SCIM User resources when a directory recreates them with the same `externalId`, instead of rejecting the create with a 409.

- `POST /scim/v2/Users` now returns 200 and reactivates the inactive resource when `externalId` matches; active matches still return 409.
- The restored resource keeps its existing Better Auth User link and refreshes the managed profile.
- Restores run in a transaction and fail with a conflict if the resource changes concurrently.
- `userName` collisions with another user still return 409.
- Updates the SCIM plugin docs to describe the restore behavior and adds a changeset.

<sup>Written for commit 4026bcfb58d974a72cff95ee3f13d4b32b147a26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

