### PR TITLE
chore(scim): ensure optional complex attributes accept null

### DIFF
--- a/.changeset/scim-strip-null-optional-attrs.md
+++ b/.changeset/scim-strip-null-optional-attrs.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/scim": patch
+---
+
+Accept Microsoft Entra User payloads that serialize unassigned optional nested attributes as JSON `null` by stripping those properties before validation, while preserving scalar PATCH `value: null` clearing semantics.

--- a/packages/scim/src/active-normalization.ts
+++ b/packages/scim/src/active-normalization.ts
@@ -1,33 +1,60 @@
 import { stripSCIMCoreAttributePrefix } from "./resource-schema-registry";
-import { SCIM_ENTERPRISE_USER_SCHEMA } from "./user-schemas";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Depth bound so attacker-controlled nesting cannot stack-overflow this middleware. */
+const SCIM_NULL_STRIP_MAX_DEPTH = 64;
+
 /**
- * Omit JSON `null` properties from a complex SCIM object (and nested objects
- * such as enterprise `manager`). Microsoft Entra serializes unassigned optional
- * complex subattributes as `null`; Zod optional strings reject that form.
- * Top-level User scalars are not passed through here.
+ * Keys whose JSON `null` must stay on a User resource root so invalid lifecycle
+ * values still fail validation instead of being omitted and defaulted.
  */
-function omitNullProperties(
-	value: Record<string, unknown>,
-): Record<string, unknown> {
+const SCIM_PRESERVED_RESOURCE_NULL_KEYS = new Set(["active"]);
+
+/**
+ * Drop JSON `null` object properties recursively. Microsoft Entra serializes
+ * unassigned optional attributes as `null`; Zod optional strings reject that
+ * form. Arrays are walked; scalar roots (including PATCH `value: null`) are
+ * left intact by callers. Optional `preserveNullKeys` keeps selected root
+ * nulls (e.g. `active`) distinguishable for validation.
+ */
+function stripNullProperties(
+	value: unknown,
+	options: {
+		depth?: number;
+		preserveNullKeys?: ReadonlySet<string>;
+	} = {},
+): unknown {
+	const depth = options.depth ?? 0;
+	if (depth > SCIM_NULL_STRIP_MAX_DEPTH) return value;
+
+	if (Array.isArray(value)) {
+		let changed = false;
+		const normalized = value.map((entry) => {
+			const result = stripNullProperties(entry, { depth: depth + 1 });
+			if (result !== entry) changed = true;
+			return result;
+		});
+		return changed ? normalized : value;
+	}
+	if (!isRecord(value)) return value;
+
 	let changed = false;
 	const normalized: Record<string, unknown> = {};
 	for (const [key, entry] of Object.entries(value)) {
 		if (entry === null) {
+			if (options.preserveNullKeys?.has(key)) {
+				normalized[key] = null;
+				continue;
+			}
 			changed = true;
 			continue;
 		}
-		if (isRecord(entry)) {
-			const nested = omitNullProperties(entry);
-			if (nested !== entry) changed = true;
-			normalized[key] = nested;
-			continue;
-		}
-		normalized[key] = entry;
+		const result = stripNullProperties(entry, { depth: depth + 1 });
+		if (result !== entry) changed = true;
+		normalized[key] = result;
 	}
 	return changed ? normalized : value;
 }
@@ -58,13 +85,9 @@ const SCIM_MULTI_VALUED_PRIMARY_ATTRIBUTES = [
 ] as const;
 
 function normalizeMultiValuedPrimaryEntry(entry: unknown): unknown {
-	if (!isRecord(entry)) return entry;
-	const withoutNulls = omitNullProperties(entry);
-	if (!Object.hasOwn(withoutNulls, "primary")) return withoutNulls;
-	const primary = normalizeSCIMStringBooleanValue(withoutNulls.primary);
-	return primary === withoutNulls.primary
-		? withoutNulls
-		: { ...withoutNulls, primary };
+	if (!isRecord(entry) || !Object.hasOwn(entry, "primary")) return entry;
+	const primary = normalizeSCIMStringBooleanValue(entry.primary);
+	return primary === entry.primary ? entry : { ...entry, primary };
 }
 
 function normalizeMultiValuedPrimaryValue(value: unknown): unknown {
@@ -93,20 +116,10 @@ function normalizeResourceMultiValuedPrimaries(
 function normalizeUserResourceEntraCompatibility(
 	value: Record<string, unknown>,
 ): Record<string, unknown> {
-	const updates: Record<string, unknown> = {};
-	if (isRecord(value.name)) {
-		const name = omitNullProperties(value.name);
-		if (name !== value.name) updates.name = name;
-	}
-	const enterpriseExtension = value[SCIM_ENTERPRISE_USER_SCHEMA];
-	if (isRecord(enterpriseExtension)) {
-		const enterprise = omitNullProperties(enterpriseExtension);
-		if (enterprise !== enterpriseExtension) {
-			updates[SCIM_ENTERPRISE_USER_SCHEMA] = enterprise;
-		}
-	}
-	const resource =
-		Object.keys(updates).length === 0 ? value : { ...value, ...updates };
+	const stripped = stripNullProperties(value, {
+		preserveNullKeys: SCIM_PRESERVED_RESOURCE_NULL_KEYS,
+	});
+	const resource = isRecord(stripped) ? stripped : value;
 	return normalizeResourceMultiValuedPrimaries(
 		normalizeActiveProperty(resource),
 	);
@@ -145,17 +158,6 @@ function isPathless(path: unknown): boolean {
 	);
 }
 
-function isEnterpriseComplexPath(path: unknown): boolean {
-	if (typeof path !== "string") return false;
-	const trimmed = path.trim();
-	return (
-		trimmed === SCIM_ENTERPRISE_USER_SCHEMA ||
-		trimmed
-			.toLowerCase()
-			.startsWith(`${SCIM_ENTERPRISE_USER_SCHEMA.toLowerCase()}:`)
-	);
-}
-
 function normalizePatchOperation(operation: unknown): unknown {
 	if (!isRecord(operation)) return operation;
 	if (isActivePath(operation.path)) {
@@ -164,17 +166,21 @@ function normalizePatchOperation(operation: unknown): unknown {
 	}
 	const primaryMatch = matchMultiValuedPrimaryPath(operation.path);
 	if (primaryMatch) {
-		const value = primaryMatch.targetsPrimary
-			? normalizeSCIMStringBooleanValue(operation.value)
-			: normalizeMultiValuedPrimaryValue(operation.value);
-		return value === operation.value ? operation : { ...operation, value };
-	}
-	if (isEnterpriseComplexPath(operation.path) && isRecord(operation.value)) {
-		const value = omitNullProperties(operation.value);
+		if (primaryMatch.targetsPrimary) {
+			const value = normalizeSCIMStringBooleanValue(operation.value);
+			return value === operation.value ? operation : { ...operation, value };
+		}
+		const withoutNulls = stripNullProperties(operation.value);
+		const value = normalizeMultiValuedPrimaryValue(withoutNulls);
 		return value === operation.value ? operation : { ...operation, value };
 	}
 	if (isPathless(operation.path) && isRecord(operation.value)) {
 		const value = normalizeUserResourceEntraCompatibility(operation.value);
+		return value === operation.value ? operation : { ...operation, value };
+	}
+	// Any other object/array PATCH value (name, enterprise, manager, …).
+	if (Array.isArray(operation.value) || isRecord(operation.value)) {
+		const value = stripNullProperties(operation.value);
 		return value === operation.value ? operation : { ...operation, value };
 	}
 	return operation;
@@ -183,8 +189,8 @@ function normalizePatchOperation(operation: unknown): unknown {
 /**
  * Normalize provider-compatible User request shapes from Microsoft Entra:
  * string Boolean `active` / multi-valued `primary` values, and JSON `null`
- * optional complex subattributes. Does not widen endpoint schemas or mutate
- * the caller's request body object.
+ * optional attributes. Does not widen endpoint schemas or mutate the caller's
+ * request body object.
  */
 export function normalizeSCIMUserEntraCompatibilityRequestBody(
 	method: string,

--- a/packages/scim/src/active-normalization.ts
+++ b/packages/scim/src/active-normalization.ts
@@ -4,6 +4,38 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Drop JSON `null` object properties recursively. Microsoft Entra serializes
+ * unassigned optional complex subattributes as `null`; Zod optional strings
+ * reject that form. Arrays and scalar roots (including PATCH `value: null`)
+ * are preserved so clearing semantics stay distinguishable.
+ */
+function stripNullProperties(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		let changed = false;
+		const normalized = value.map((entry) => {
+			const result = stripNullProperties(entry);
+			if (result !== entry) changed = true;
+			return result;
+		});
+		return changed ? normalized : value;
+	}
+	if (!isRecord(value)) return value;
+
+	let changed = false;
+	const normalized: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (entry === null) {
+			changed = true;
+			continue;
+		}
+		const result = stripNullProperties(entry);
+		if (result !== entry) changed = true;
+		normalized[key] = result;
+	}
+	return changed ? normalized : value;
+}
+
 /** Normalize the exact string Boolean forms accepted from SCIM providers. */
 function normalizeSCIMStringBooleanValue(value: unknown): unknown {
 	if (typeof value !== "string") return value;
@@ -61,7 +93,11 @@ function normalizeResourceMultiValuedPrimaries(
 function normalizeUserResourceEntraCompatibility(
 	value: Record<string, unknown>,
 ): Record<string, unknown> {
-	return normalizeResourceMultiValuedPrimaries(normalizeActiveProperty(value));
+	const withoutNulls = stripNullProperties(value);
+	const resource = isRecord(withoutNulls) ? withoutNulls : value;
+	return normalizeResourceMultiValuedPrimaries(
+		normalizeActiveProperty(resource),
+	);
 }
 
 function isActivePath(path: unknown): boolean {
@@ -97,30 +133,45 @@ function isPathless(path: unknown): boolean {
 	);
 }
 
+function normalizePatchOperationValue(value: unknown): unknown {
+	// Scalar roots (including `value: null`) stay intact so PATCH clearing
+	// remains distinguishable from an omitted optional property.
+	if (Array.isArray(value) || isRecord(value)) {
+		return stripNullProperties(value);
+	}
+	return value;
+}
+
 function normalizePatchOperation(operation: unknown): unknown {
 	if (!isRecord(operation)) return operation;
-	if (isActivePath(operation.path)) {
-		const value = normalizeSCIMStringBooleanValue(operation.value);
-		return value === operation.value ? operation : { ...operation, value };
+	let next: Record<string, unknown> = operation;
+	if (Object.hasOwn(operation, "value")) {
+		const value = normalizePatchOperationValue(operation.value);
+		if (value !== operation.value) next = { ...operation, value };
 	}
-	const primaryMatch = matchMultiValuedPrimaryPath(operation.path);
+	if (isActivePath(next.path)) {
+		const value = normalizeSCIMStringBooleanValue(next.value);
+		return value === next.value ? next : { ...next, value };
+	}
+	const primaryMatch = matchMultiValuedPrimaryPath(next.path);
 	if (primaryMatch) {
 		const value = primaryMatch.targetsPrimary
-			? normalizeSCIMStringBooleanValue(operation.value)
-			: normalizeMultiValuedPrimaryValue(operation.value);
-		return value === operation.value ? operation : { ...operation, value };
+			? normalizeSCIMStringBooleanValue(next.value)
+			: normalizeMultiValuedPrimaryValue(next.value);
+		return value === next.value ? next : { ...next, value };
 	}
-	if (isPathless(operation.path) && isRecord(operation.value)) {
-		const value = normalizeUserResourceEntraCompatibility(operation.value);
-		return value === operation.value ? operation : { ...operation, value };
+	if (isPathless(next.path) && isRecord(next.value)) {
+		const value = normalizeUserResourceEntraCompatibility(next.value);
+		return value === next.value ? next : { ...next, value };
 	}
-	return operation;
+	return next;
 }
 
 /**
- * Normalize provider-compatible User `active` and multi-valued `primary`
- * string Boolean values (Microsoft Entra) without widening the endpoint
- * schemas or mutating the parsed request body.
+ * Normalize provider-compatible User request shapes from Microsoft Entra:
+ * string Boolean `active` / multi-valued `primary` values, and JSON `null`
+ * optional object properties. Does not widen endpoint schemas or mutate the
+ * caller's request body object.
  */
 export function normalizeSCIMUserEntraCompatibilityRequestBody(
 	method: string,

--- a/packages/scim/src/active-normalization.ts
+++ b/packages/scim/src/active-normalization.ts
@@ -1,27 +1,19 @@
 import { stripSCIMCoreAttributePrefix } from "./resource-schema-registry";
+import { SCIM_ENTERPRISE_USER_SCHEMA } from "./user-schemas";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**
- * Drop JSON `null` object properties recursively. Microsoft Entra serializes
- * unassigned optional complex subattributes as `null`; Zod optional strings
- * reject that form. Arrays and scalar roots (including PATCH `value: null`)
- * are preserved so clearing semantics stay distinguishable.
+ * Omit JSON `null` properties from a complex SCIM object (and nested objects
+ * such as enterprise `manager`). Microsoft Entra serializes unassigned optional
+ * complex subattributes as `null`; Zod optional strings reject that form.
+ * Top-level User scalars are not passed through here.
  */
-function stripNullProperties(value: unknown): unknown {
-	if (Array.isArray(value)) {
-		let changed = false;
-		const normalized = value.map((entry) => {
-			const result = stripNullProperties(entry);
-			if (result !== entry) changed = true;
-			return result;
-		});
-		return changed ? normalized : value;
-	}
-	if (!isRecord(value)) return value;
-
+function omitNullProperties(
+	value: Record<string, unknown>,
+): Record<string, unknown> {
 	let changed = false;
 	const normalized: Record<string, unknown> = {};
 	for (const [key, entry] of Object.entries(value)) {
@@ -29,9 +21,13 @@ function stripNullProperties(value: unknown): unknown {
 			changed = true;
 			continue;
 		}
-		const result = stripNullProperties(entry);
-		if (result !== entry) changed = true;
-		normalized[key] = result;
+		if (isRecord(entry)) {
+			const nested = omitNullProperties(entry);
+			if (nested !== entry) changed = true;
+			normalized[key] = nested;
+			continue;
+		}
+		normalized[key] = entry;
 	}
 	return changed ? normalized : value;
 }
@@ -62,9 +58,13 @@ const SCIM_MULTI_VALUED_PRIMARY_ATTRIBUTES = [
 ] as const;
 
 function normalizeMultiValuedPrimaryEntry(entry: unknown): unknown {
-	if (!isRecord(entry) || !Object.hasOwn(entry, "primary")) return entry;
-	const primary = normalizeSCIMStringBooleanValue(entry.primary);
-	return primary === entry.primary ? entry : { ...entry, primary };
+	if (!isRecord(entry)) return entry;
+	const withoutNulls = omitNullProperties(entry);
+	if (!Object.hasOwn(withoutNulls, "primary")) return withoutNulls;
+	const primary = normalizeSCIMStringBooleanValue(withoutNulls.primary);
+	return primary === withoutNulls.primary
+		? withoutNulls
+		: { ...withoutNulls, primary };
 }
 
 function normalizeMultiValuedPrimaryValue(value: unknown): unknown {
@@ -93,8 +93,20 @@ function normalizeResourceMultiValuedPrimaries(
 function normalizeUserResourceEntraCompatibility(
 	value: Record<string, unknown>,
 ): Record<string, unknown> {
-	const withoutNulls = stripNullProperties(value);
-	const resource = isRecord(withoutNulls) ? withoutNulls : value;
+	const updates: Record<string, unknown> = {};
+	if (isRecord(value.name)) {
+		const name = omitNullProperties(value.name);
+		if (name !== value.name) updates.name = name;
+	}
+	const enterpriseExtension = value[SCIM_ENTERPRISE_USER_SCHEMA];
+	if (isRecord(enterpriseExtension)) {
+		const enterprise = omitNullProperties(enterpriseExtension);
+		if (enterprise !== enterpriseExtension) {
+			updates[SCIM_ENTERPRISE_USER_SCHEMA] = enterprise;
+		}
+	}
+	const resource =
+		Object.keys(updates).length === 0 ? value : { ...value, ...updates };
 	return normalizeResourceMultiValuedPrimaries(
 		normalizeActiveProperty(resource),
 	);
@@ -133,45 +145,46 @@ function isPathless(path: unknown): boolean {
 	);
 }
 
-function normalizePatchOperationValue(value: unknown): unknown {
-	// Scalar roots (including `value: null`) stay intact so PATCH clearing
-	// remains distinguishable from an omitted optional property.
-	if (Array.isArray(value) || isRecord(value)) {
-		return stripNullProperties(value);
-	}
-	return value;
+function isEnterpriseComplexPath(path: unknown): boolean {
+	if (typeof path !== "string") return false;
+	const trimmed = path.trim();
+	return (
+		trimmed === SCIM_ENTERPRISE_USER_SCHEMA ||
+		trimmed
+			.toLowerCase()
+			.startsWith(`${SCIM_ENTERPRISE_USER_SCHEMA.toLowerCase()}:`)
+	);
 }
 
 function normalizePatchOperation(operation: unknown): unknown {
 	if (!isRecord(operation)) return operation;
-	let next: Record<string, unknown> = operation;
-	if (Object.hasOwn(operation, "value")) {
-		const value = normalizePatchOperationValue(operation.value);
-		if (value !== operation.value) next = { ...operation, value };
+	if (isActivePath(operation.path)) {
+		const value = normalizeSCIMStringBooleanValue(operation.value);
+		return value === operation.value ? operation : { ...operation, value };
 	}
-	if (isActivePath(next.path)) {
-		const value = normalizeSCIMStringBooleanValue(next.value);
-		return value === next.value ? next : { ...next, value };
-	}
-	const primaryMatch = matchMultiValuedPrimaryPath(next.path);
+	const primaryMatch = matchMultiValuedPrimaryPath(operation.path);
 	if (primaryMatch) {
 		const value = primaryMatch.targetsPrimary
-			? normalizeSCIMStringBooleanValue(next.value)
-			: normalizeMultiValuedPrimaryValue(next.value);
-		return value === next.value ? next : { ...next, value };
+			? normalizeSCIMStringBooleanValue(operation.value)
+			: normalizeMultiValuedPrimaryValue(operation.value);
+		return value === operation.value ? operation : { ...operation, value };
 	}
-	if (isPathless(next.path) && isRecord(next.value)) {
-		const value = normalizeUserResourceEntraCompatibility(next.value);
-		return value === next.value ? next : { ...next, value };
+	if (isEnterpriseComplexPath(operation.path) && isRecord(operation.value)) {
+		const value = omitNullProperties(operation.value);
+		return value === operation.value ? operation : { ...operation, value };
 	}
-	return next;
+	if (isPathless(operation.path) && isRecord(operation.value)) {
+		const value = normalizeUserResourceEntraCompatibility(operation.value);
+		return value === operation.value ? operation : { ...operation, value };
+	}
+	return operation;
 }
 
 /**
  * Normalize provider-compatible User request shapes from Microsoft Entra:
  * string Boolean `active` / multi-valued `primary` values, and JSON `null`
- * optional object properties. Does not widen endpoint schemas or mutate the
- * caller's request body object.
+ * optional complex subattributes. Does not widen endpoint schemas or mutate
+ * the caller's request body object.
  */
 export function normalizeSCIMUserEntraCompatibilityRequestBody(
 	method: string,

--- a/packages/scim/src/scim-active-normalization.test.ts
+++ b/packages/scim/src/scim-active-normalization.test.ts
@@ -77,7 +77,6 @@ describe("SCIM User active ingress helper", () => {
 		"0",
 		1,
 		0,
-		null,
 		[],
 		[true],
 		{},
@@ -295,7 +294,6 @@ describe("SCIM User multi-valued primary ingress helper", () => {
 		"0",
 		1,
 		0,
-		null,
 		[],
 		{},
 	] as const)("leaves the rejected near-miss primary value unchanged at POST and PUT boundaries", (value) => {
@@ -310,6 +308,110 @@ describe("SCIM User multi-valued primary ingress helper", () => {
 				body,
 			);
 		}
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11015
+	 */
+	it("strips null optional object properties on POST and PUT without touching the input", () => {
+		for (const method of ["POST", "PUT"] as const) {
+			const body = {
+				schemas: [SCIM_USER_SCHEMA],
+				userName: "null-address@example.com",
+				title: null,
+				name: {
+					formatted: null,
+					givenName: "Ada",
+					familyName: null,
+				},
+				addresses: [
+					{
+						type: "work",
+						streetAddress: "44 Montgomery St",
+						locality: "San Francisco",
+						region: "CA",
+						postalCode: "94104",
+						formatted: null,
+						country: null,
+					},
+				],
+			};
+			const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
+				method,
+				body,
+			);
+
+			expect(normalized).not.toBe(body);
+			expect(normalized).toEqual({
+				schemas: [SCIM_USER_SCHEMA],
+				userName: "null-address@example.com",
+				name: { givenName: "Ada" },
+				addresses: [
+					{
+						type: "work",
+						streetAddress: "44 Montgomery St",
+						locality: "San Francisco",
+						region: "CA",
+						postalCode: "94104",
+					},
+				],
+			});
+			expect(body.title).toBeNull();
+			expect(body.addresses[0]?.formatted).toBeNull();
+			expect(body.addresses[0]?.country).toBeNull();
+		}
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11015
+	 */
+	it("strips nulls from nested PATCH object values but preserves scalar value null", () => {
+		const scalarNullOperation = {
+			op: "replace",
+			path: "active",
+			value: null,
+		};
+		const body = {
+			schemas: [SCIM_PATCH_SCHEMA],
+			Operations: [
+				scalarNullOperation,
+				{
+					op: "replace",
+					path: 'addresses[type eq "work"]',
+					value: {
+						type: "work",
+						streetAddress: "44 Montgomery St",
+						formatted: null,
+						country: null,
+					},
+				},
+				{
+					op: "replace",
+					value: {
+						title: null,
+						name: { givenName: "Ada", familyName: null },
+					},
+				},
+			],
+		};
+		const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
+			"PATCH",
+			body,
+		) as typeof body;
+
+		expect(normalized).not.toBe(body);
+		expect(normalized.Operations[0]).toBe(scalarNullOperation);
+		expect(normalized.Operations[0]?.value).toBeNull();
+		expect(normalized.Operations[1]?.value).toEqual({
+			type: "work",
+			streetAddress: "44 Montgomery St",
+		});
+		expect(normalized.Operations[2]?.value).toEqual({
+			name: { givenName: "Ada" },
+		});
+		expect(
+			(body.Operations[1]?.value as { formatted: null }).formatted,
+		).toBeNull();
 	});
 
 	it("copies only the multi-valued entries whose primary value changes", () => {

--- a/packages/scim/src/scim-active-normalization.test.ts
+++ b/packages/scim/src/scim-active-normalization.test.ts
@@ -316,12 +316,13 @@ describe("SCIM User multi-valued primary ingress helper", () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/11015
 	 */
-	it("omits null optional complex subattributes without touching top-level scalars", () => {
+	it("strips null optional attributes generally while preserving top-level active null", () => {
 		const body = {
 			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
 			userName: "null-address@example.com",
 			active: null,
-			name: { formatted: null, givenName: "Ada", familyName: null },
+			title: null,
+			name: null as string | null,
 			addresses: [
 				{
 					type: "work",
@@ -333,11 +334,13 @@ describe("SCIM User multi-valued primary ingress helper", () => {
 			[SCIM_ENTERPRISE_USER_SCHEMA]: {
 				department: "Engineering",
 				employeeNumber: null,
-				manager: {
-					value: "manager-1",
-					displayName: null,
-					$ref: null,
-				},
+				manager: [
+					{
+						value: "manager-1",
+						displayName: null,
+						$ref: null,
+					},
+				],
 			},
 		};
 		const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
@@ -349,59 +352,61 @@ describe("SCIM User multi-valued primary ingress helper", () => {
 			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
 			userName: "null-address@example.com",
 			active: null,
-			name: { givenName: "Ada" },
 			addresses: [{ type: "work", streetAddress: "44 Montgomery St" }],
 			[SCIM_ENTERPRISE_USER_SCHEMA]: {
 				department: "Engineering",
-				manager: { value: "manager-1" },
+				manager: [{ value: "manager-1" }],
 			},
 		});
 		expect(body.active).toBeNull();
+		expect(body.title).toBeNull();
+		expect(body.name).toBeNull();
 		expect(body.addresses[0]?.country).toBeNull();
-		expect(
-			(
-				body[SCIM_ENTERPRISE_USER_SCHEMA] as {
-					manager: { displayName: null };
-				}
-			).manager.displayName,
-		).toBeNull();
 	});
 
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/11015
 	 */
-	it("omits nulls from complex PATCH values and leaves scalar value null intact", () => {
+	it("strips nulls from any object PATCH value and leaves scalar value null intact", () => {
 		const activeNull = { op: "replace", path: "active", value: null };
-		const normalized = normalizeSCIMUserEntraCompatibilityRequestBody("PATCH", {
+		const addressValue = {
+			type: "work",
+			streetAddress: "44 Montgomery St",
+			formatted: null,
+			country: null,
+		};
+		const nameValue = { givenName: "Ada", familyName: null, formatted: null };
+		const body = {
 			schemas: [SCIM_PATCH_SCHEMA],
 			Operations: [
 				activeNull,
 				{
 					op: "replace",
 					path: 'addresses[type eq "work"]',
-					value: {
-						type: "work",
-						streetAddress: "44 Montgomery St",
-						formatted: null,
-						country: null,
-					},
+					value: addressValue,
 				},
+				{ op: "replace", path: "name", value: nameValue },
 				{
 					op: "replace",
-					path: `${SCIM_ENTERPRISE_USER_SCHEMA}:manager`,
-					value: { value: "manager-1", displayName: null, $ref: null },
+					path: "manager",
+					value: { value: "manager-1", displayName: null },
 				},
 			],
-		}) as {
-			Operations: { value: unknown }[];
 		};
+		const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
+			"PATCH",
+			body,
+		) as typeof body;
 
 		expect(normalized.Operations[0]).toBe(activeNull);
 		expect(normalized.Operations[1]?.value).toEqual({
 			type: "work",
 			streetAddress: "44 Montgomery St",
 		});
-		expect(normalized.Operations[2]?.value).toEqual({ value: "manager-1" });
+		expect(normalized.Operations[2]?.value).toEqual({ givenName: "Ada" });
+		expect(normalized.Operations[3]?.value).toEqual({ value: "manager-1" });
+		expect(addressValue.formatted).toBeNull();
+		expect(nameValue.familyName).toBeNull();
 	});
 
 	it("copies only the multi-valued entries whose primary value changes", () => {

--- a/packages/scim/src/scim-active-normalization.test.ts
+++ b/packages/scim/src/scim-active-normalization.test.ts
@@ -8,6 +8,8 @@ import { normalizeSCIMUserEntraCompatibilityRequestBody } from "./active-normali
 import type { SCIMProjectedUserState } from "./configuration";
 
 const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
+const SCIM_ENTERPRISE_USER_SCHEMA =
+	"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
 const SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
 const SCIM_MEDIA_TYPE = "application/scim+json";
 const SCIM_TOKEN = "active-normalization-token";
@@ -77,6 +79,7 @@ describe("SCIM User active ingress helper", () => {
 		"0",
 		1,
 		0,
+		null,
 		[],
 		[true],
 		{},
@@ -313,68 +316,66 @@ describe("SCIM User multi-valued primary ingress helper", () => {
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/11015
 	 */
-	it("strips null optional object properties on POST and PUT without touching the input", () => {
-		for (const method of ["POST", "PUT"] as const) {
-			const body = {
-				schemas: [SCIM_USER_SCHEMA],
-				userName: "null-address@example.com",
-				title: null,
-				name: {
+	it("omits null optional complex subattributes without touching top-level scalars", () => {
+		const body = {
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			userName: "null-address@example.com",
+			active: null,
+			name: { formatted: null, givenName: "Ada", familyName: null },
+			addresses: [
+				{
+					type: "work",
+					streetAddress: "44 Montgomery St",
 					formatted: null,
-					givenName: "Ada",
-					familyName: null,
+					country: null,
 				},
-				addresses: [
-					{
-						type: "work",
-						streetAddress: "44 Montgomery St",
-						locality: "San Francisco",
-						region: "CA",
-						postalCode: "94104",
-						formatted: null,
-						country: null,
-					},
-				],
-			};
-			const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
-				method,
-				body,
-			);
+			],
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				department: "Engineering",
+				employeeNumber: null,
+				manager: {
+					value: "manager-1",
+					displayName: null,
+					$ref: null,
+				},
+			},
+		};
+		const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
+			"POST",
+			body,
+		);
 
-			expect(normalized).not.toBe(body);
-			expect(normalized).toEqual({
-				schemas: [SCIM_USER_SCHEMA],
-				userName: "null-address@example.com",
-				name: { givenName: "Ada" },
-				addresses: [
-					{
-						type: "work",
-						streetAddress: "44 Montgomery St",
-						locality: "San Francisco",
-						region: "CA",
-						postalCode: "94104",
-					},
-				],
-			});
-			expect(body.title).toBeNull();
-			expect(body.addresses[0]?.formatted).toBeNull();
-			expect(body.addresses[0]?.country).toBeNull();
-		}
+		expect(normalized).toEqual({
+			schemas: [SCIM_USER_SCHEMA, SCIM_ENTERPRISE_USER_SCHEMA],
+			userName: "null-address@example.com",
+			active: null,
+			name: { givenName: "Ada" },
+			addresses: [{ type: "work", streetAddress: "44 Montgomery St" }],
+			[SCIM_ENTERPRISE_USER_SCHEMA]: {
+				department: "Engineering",
+				manager: { value: "manager-1" },
+			},
+		});
+		expect(body.active).toBeNull();
+		expect(body.addresses[0]?.country).toBeNull();
+		expect(
+			(
+				body[SCIM_ENTERPRISE_USER_SCHEMA] as {
+					manager: { displayName: null };
+				}
+			).manager.displayName,
+		).toBeNull();
 	});
 
 	/**
 	 * @see https://github.com/better-auth/better-auth/issues/11015
 	 */
-	it("strips nulls from nested PATCH object values but preserves scalar value null", () => {
-		const scalarNullOperation = {
-			op: "replace",
-			path: "active",
-			value: null,
-		};
-		const body = {
+	it("omits nulls from complex PATCH values and leaves scalar value null intact", () => {
+		const activeNull = { op: "replace", path: "active", value: null };
+		const normalized = normalizeSCIMUserEntraCompatibilityRequestBody("PATCH", {
 			schemas: [SCIM_PATCH_SCHEMA],
 			Operations: [
-				scalarNullOperation,
+				activeNull,
 				{
 					op: "replace",
 					path: 'addresses[type eq "work"]',
@@ -387,31 +388,20 @@ describe("SCIM User multi-valued primary ingress helper", () => {
 				},
 				{
 					op: "replace",
-					value: {
-						title: null,
-						name: { givenName: "Ada", familyName: null },
-					},
+					path: `${SCIM_ENTERPRISE_USER_SCHEMA}:manager`,
+					value: { value: "manager-1", displayName: null, $ref: null },
 				},
 			],
+		}) as {
+			Operations: { value: unknown }[];
 		};
-		const normalized = normalizeSCIMUserEntraCompatibilityRequestBody(
-			"PATCH",
-			body,
-		) as typeof body;
 
-		expect(normalized).not.toBe(body);
-		expect(normalized.Operations[0]).toBe(scalarNullOperation);
-		expect(normalized.Operations[0]?.value).toBeNull();
+		expect(normalized.Operations[0]).toBe(activeNull);
 		expect(normalized.Operations[1]?.value).toEqual({
 			type: "work",
 			streetAddress: "44 Montgomery St",
 		});
-		expect(normalized.Operations[2]?.value).toEqual({
-			name: { givenName: "Ada" },
-		});
-		expect(
-			(body.Operations[1]?.value as { formatted: null }).formatted,
-		).toBeNull();
+		expect(normalized.Operations[2]?.value).toEqual({ value: "manager-1" });
 	});
 
 	it("copies only the multi-valued entries whose primary value changes", () => {
@@ -1078,9 +1068,6 @@ describe("SCIM User active HTTP normalization", () => {
 		}
 	});
 });
-
-const SCIM_ENTERPRISE_USER_SCHEMA =
-	"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
 
 interface SCIMPrimaryNormalizationUserResponse {
 	id: string;

--- a/packages/scim/src/scim-entra-conformance.test.ts
+++ b/packages/scim/src/scim-entra-conformance.test.ts
@@ -180,6 +180,40 @@ describe("SCIM User PATCH against Microsoft Entra ID attribute mappings", () => 
 		expect(patched.addresses).toEqual([{ type: "work", postalCode: "94105" }]);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11015
+	 */
+	it("creates a user when optional address subattributes are JSON null", async () => {
+		const { auth } = createEntraFixture();
+		const user = await createUser(auth, {
+			userName: "member@example.com",
+			active: true,
+			addresses: [
+				{
+					type: "work",
+					streetAddress: "44 Montgomery St",
+					locality: "San Francisco",
+					region: "CA",
+					postalCode: "94104",
+					formatted: null,
+					country: null,
+				},
+			],
+		});
+
+		expect(user.addresses).toEqual([
+			{
+				type: "work",
+				streetAddress: "44 Montgomery St",
+				locality: "San Francisco",
+				region: "CA",
+				postalCode: "94104",
+			},
+		]);
+		expect(user.addresses?.[0]).not.toHaveProperty("formatted");
+		expect(user.addresses?.[0]).not.toHaveProperty("country");
+	});
+
 	it("creates filtered roles and entitlements", async () => {
 		const { auth } = createEntraFixture();
 		const user = await createUser(auth, {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Makes `@better-auth/scim` accept Microsoft Entra User payloads that serialize unassigned optional nested attributes as JSON `null`. Previously those payloads failed validation because Zod optional strings reject `null`; now null properties are stripped recursively from any object or array before validation, for POST, PUT, and PATCH.

**Bug Fixes**
- Recursively removes `null` properties from all object and array values in User resources and PATCH operation values.
- Preserves top-level `active: null` and scalar PATCH `value: null` so lifecycle validation and clearing semantics stay distinguishable.
- The caller's request body is never mutated.

<sup>Written for commit 7b78a965489bdad4570a18e8c99adc86b53805b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

