### PR TITLE
feat(cookies): support the __Host- cookie prefix

### DIFF
--- a/.changeset/cookies-host-prefix.md
+++ b/.changeset/cookies-host-prefix.md
@@ -1,0 +1,8 @@
+---
+"better-auth": patch
+"@better-auth/core": patch
+"@better-auth/electron": patch
+"@better-auth/expo": patch
+---
+
+Add `advanced.useHostCookiePrefix` to name cookies with the `__Host-` prefix, reject configurations that are incompatible with it (`crossSubDomainCookies`, a custom cookie `path`, `useSecureCookies: false`), and offer an opt-in `migrateSecureCookies` that keeps existing `__Secure-` sessions alive by re-issuing them as `__Host-` cookies on their next request.

--- a/docs/content/docs/concepts/cookies.mdx
+++ b/docs/content/docs/concepts/cookies.mdx
@@ -105,6 +105,35 @@ export const auth = betterAuth({
 })
 ```
 
+### `__Host-` Prefix
+
+Secure cookies are named with the `__Secure-` prefix. Set `useHostCookiePrefix` to use the [`__Host-` prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#cookie_prefixes) instead. Browsers only accept a `__Host-` cookie when it is `Secure`, has `Path=/`, and carries no `Domain` attribute, so a cookie set by a sibling subdomain can never collide with your session cookie. Use it when tenants live on subdomains of one registrable domain.
+
+`useHostCookiePrefix` forces secure cookies and cannot be combined with `useSecureCookies: false`, `crossSubDomainCookies`, or a custom cookie `path`.
+
+```ts title="auth.ts"
+import { betterAuth } from "better-auth"
+
+export const auth = betterAuth({
+    advanced: {
+        useHostCookiePrefix: true
+    }
+})
+```
+
+Switching renames the cookies, so existing `__Secure-` sessions are no longer read and signed-in users sign in again once. For a seamless cutover, set `migrateSecureCookies: true`: existing `__Secure-` cookies are still accepted and are re-issued as `__Host-` cookies on their next request, with the old copies expired. While that migration is on, a visitor who has no `__Host-` cookie yet is still exposed to a `__Secure-` cookie planted by a sibling subdomain, so turn it off once existing sessions have rolled over (after `session.expiresIn`):
+
+```ts title="auth.ts"
+export const auth = betterAuth({
+    advanced: {
+        useHostCookiePrefix: {
+            enabled: true,
+            migrateSecureCookies: true // remove after session.expiresIn
+        }
+    }
+})
+```
+
 ## Safari, ITP, and Cross-Domain Setups
 
 Safari includes a privacy feature called Intelligent Tracking Prevention (ITP) that blocks third-party cookies.

--- a/docs/content/docs/concepts/plugins.mdx
+++ b/docs/content/docs/concepts/plugins.mdx
@@ -129,7 +129,7 @@ Create Auth endpoints wraps around `createEndpoint` from Better Call. Inside the
 * `db`: The Kysely instance used by Better Auth to interact with the database.
 * `adapter`: This is the same as db but it give you `orm` like functions to interact with the database. (we recommend using this over `db` unless you need raw sql queries or for performance reasons)
 * `internalAdapter`: These are internal db calls that are used by Better Auth. For example, you can use these calls to create a session instead of using `adapter` directly. `internalAdapter.createSession(userId)`
-* `createAuthCookie`: This is a helper function that lets you get a cookie `name` and `options` for either to `set` or `get` cookies. It implements things like `__Secure-` prefix for cookies based on whether the connection is secure (HTTPS) or the application is running in production mode.
+* `createAuthCookie`: This is a helper function that lets you get a cookie `name` and `options` for either to `set` or `get` cookies. It implements things like the `__Secure-` prefix for cookies based on whether the connection is secure (HTTPS) or the application is running in production mode, or the `__Host-` prefix when `advanced.useHostCookiePrefix` is enabled.
 * `trustedOrigins`: This is the list of trusted origins that you specified via `options.trustedOrigins`.
 * `isTrustedOrigin`: This is a helper function that allows you to quickly check whether a given url or path is trusted based on the trusted origins configuration.
 

--- a/docs/content/docs/reference/options.mdx
+++ b/docs/content/docs/reference/options.mdx
@@ -626,6 +626,7 @@ export const auth = betterAuth({
 			disableIpTracking: false
 		},
 		useSecureCookies: true,
+		useHostCookiePrefix: false,
 		disableCSRFCheck: false,
 		disableOriginCheck: false,
 		crossSubDomainCookies: {
@@ -675,6 +676,7 @@ export const auth = betterAuth({
   * `ipAddressHeaders`: Trusted header names to read client IP addresses from.
   * `trustedProxies`: Reverse-proxy IPs or CIDR ranges. The forwarded chain is walked right to left, trusted hops are skipped, and the first untrusted address is used as the client IP.
 * `useSecureCookies`: By default, cookies are secure in production environments. Set this to `true` to force the `Secure` cookie attribute in all environments.
+* `useHostCookiePrefix`: Name cookies with the `__Host-` prefix instead of `__Secure-`. Implies secure cookies and cannot be combined with `crossSubDomainCookies` or a custom cookie `path`. Enabling it alone renames the cookies, so existing sessions sign in again once; pass `{ enabled: true, migrateSecureCookies: true }` to keep accepting `__Secure-` cookies and re-issue them as `__Host-`, then remove it after `session.expiresIn`.
 * `disableCSRFCheck`: Disable all CSRF protection including origin header validation and Fetch Metadata checks (⚠️ security risk)
 * `disableOriginCheck`: Disable URL validation for `callbackURL`, `redirectTo`, and other redirect URLs (⚠️ security risk)
 * `crossSubDomainCookies`: Configure cookies to be shared across subdomains

--- a/packages/better-auth/src/context/helpers.ts
+++ b/packages/better-auth/src/context/helpers.ts
@@ -9,7 +9,12 @@ import { BetterAuthError } from "@better-auth/core/error";
 import { isLoopbackHost } from "@better-auth/core/utils/host";
 import type { EndpointContext, InputContext } from "better-call";
 import { defu } from "defu";
-import { createCookieGetter, getCookies } from "../cookies";
+import {
+	createCookieGetter,
+	getCookies,
+	shouldMigrateSecureCookies,
+} from "../cookies";
+import { secureCookieMigration } from "../cookies/migrate-secure-cookies";
 import { createInternalAdapter } from "../db";
 import { isPromise } from "../utils/is-promise";
 import {
@@ -101,6 +106,9 @@ export function getInternalPlugins(options: BetterAuthOptions) {
 	const plugins: BetterAuthPlugin[] = [];
 	if (options.advanced?.crossSubDomainCookies?.enabled) {
 		// TODO: add internal plugin
+	}
+	if (shouldMigrateSecureCookies(options)) {
+		plugins.push(secureCookieMigration());
 	}
 	return plugins;
 }

--- a/packages/better-auth/src/cookies/cookies.test.ts
+++ b/packages/better-auth/src/cookies/cookies.test.ts
@@ -4,6 +4,8 @@ import { runWithEndpointContext } from "@better-auth/core/context";
 import { createLogger } from "@better-auth/core/env";
 import type { GoogleProfile } from "@better-auth/core/social-providers";
 import { safeJSONParse } from "@better-auth/core/utils/json";
+import type { MemoryDB } from "@better-auth/memory-adapter";
+import { memoryAdapter } from "@better-auth/memory-adapter";
 import { base64Url } from "@better-auth/utils/base64";
 import { createHMAC } from "@better-auth/utils/hmac";
 import { serializeCookie } from "better-call";
@@ -38,6 +40,7 @@ import {
 	parseSetCookieHeader,
 	SECURE_COOKIE_PREFIX,
 	setRequestCookie,
+	splitSetCookieHeader,
 	stripSecureCookiePrefix,
 	toCookieOptions,
 } from "./cookie-utils";
@@ -2479,5 +2482,186 @@ describe("getCookieCache expiry (compact strategy)", () => {
 		);
 		const cache = await getCookieCache(requestWith(cookie), { secret: SECRET });
 		expect(cache).toBeNull();
+	});
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/11061
+ * @see https://github.com/better-auth/better-auth/issues/10806
+ */
+describe("useHostCookiePrefix", () => {
+	it("emits __Host- cookies that meet the prefix requirements and reads them back", async () => {
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			advanced: { useHostCookiePrefix: true },
+		});
+		const headers = new Headers();
+		let setCookie = "";
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{
+				onSuccess(context) {
+					setCookie = context.response.headers.get("set-cookie") || "";
+					cookieSetter(headers)(context);
+				},
+			},
+		);
+		const sessionCookie = splitSetCookieHeader(setCookie).find((c) =>
+			c.includes("session_token"),
+		);
+		expect(sessionCookie).toBeDefined();
+		expect(
+			sessionCookie!.startsWith(
+				`${HOST_COOKIE_PREFIX}better-auth.session_token=`,
+			),
+		).toBe(true);
+		expect(sessionCookie).toContain("Secure");
+		expect(sessionCookie).toContain("Path=/");
+		expect(sessionCookie).not.toContain("Domain=");
+		expect(setCookie).not.toContain(SECURE_COOKIE_PREFIX);
+
+		const { data } = await client.getSession({ fetchOptions: { headers } });
+		expect(data?.user.email).toBe(testUser.email);
+	});
+
+	it("rejects crossSubDomainCookies", () => {
+		expect(() =>
+			getCookies({
+				baseURL: "https://example.com",
+				advanced: {
+					useHostCookiePrefix: true,
+					crossSubDomainCookies: { enabled: true },
+				},
+			}),
+		).toThrow(/crossSubDomainCookies/);
+	});
+
+	it("rejects a Path other than /", () => {
+		expect(() =>
+			getCookies({
+				advanced: {
+					useHostCookiePrefix: true,
+					defaultCookieAttributes: { path: "/api" },
+				},
+			}),
+		).toThrow(/Path/);
+	});
+
+	it("rejects useSecureCookies: false", () => {
+		expect(() =>
+			getCookies({
+				advanced: { useHostCookiePrefix: true, useSecureCookies: false },
+			}),
+		).toThrow(/secure/i);
+	});
+
+	it("getSessionCookie prefers the __Host- cookie", () => {
+		const headers = new Headers();
+		headers.set(
+			"cookie",
+			"better-auth.session_token=stale; __Secure-better-auth.session_token=stale; __Host-better-auth.session_token=current",
+		);
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+		expect(getSessionCookie(request)).toBe("current");
+	});
+
+	it("getCookieCache reads the __Host- session_data cookie", async () => {
+		const { client, testUser, cookieSetter } = await getTestInstance({
+			secret: "better-auth.secret",
+			session: { cookieCache: { enabled: true } },
+			advanced: { useHostCookiePrefix: true },
+		});
+		const headers = new Headers();
+		await client.signIn.email(
+			{ email: testUser.email, password: testUser.password },
+			{ onSuccess: cookieSetter(headers) },
+		);
+		expect(headers.get("cookie")).toContain(
+			`${HOST_COOKIE_PREFIX}better-auth.session_data`,
+		);
+		const request = new Request("https://example.com/api/auth/session", {
+			headers,
+		});
+		const cache = await getCookieCache(request, {
+			secret: "better-auth.secret",
+		});
+		expect(cache?.user?.email).toEqual(testUser.email);
+	});
+
+	describe("migration from __Secure- cookies", () => {
+		async function signInLegacy() {
+			const database: MemoryDB = {
+				user: [],
+				account: [],
+				session: [],
+				verification: [],
+			};
+			const legacy = await getTestInstance({
+				database: memoryAdapter(database),
+				advanced: { useSecureCookies: true },
+			});
+			const headers = new Headers();
+			await legacy.client.signIn.email(
+				{ email: legacy.testUser.email, password: legacy.testUser.password },
+				{ onSuccess: legacy.cookieSetter(headers) },
+			);
+			expect(headers.get("cookie")).toContain(
+				`${SECURE_COOKIE_PREFIX}better-auth.session_token`,
+			);
+			return { database, headers, email: legacy.testUser.email };
+		}
+
+		it("keeps a __Secure- session alive and re-issues it as __Host- when migrateSecureCookies is on", async () => {
+			const { database, headers, email } = await signInLegacy();
+			const { auth } = await getTestInstance(
+				{
+					database: memoryAdapter(database),
+					advanced: {
+						useHostCookiePrefix: { enabled: true, migrateSecureCookies: true },
+					},
+				},
+				{ disableTestUser: true },
+			);
+
+			const res = await auth.api.getSession({ headers, returnHeaders: true });
+			expect(res.response?.user.email).toBe(email);
+
+			const setCookies = splitSetCookieHeader(
+				res.headers.get("set-cookie") ?? "",
+			);
+			const reissued = setCookies.find((c) =>
+				c.startsWith(`${HOST_COOKIE_PREFIX}better-auth.session_token=`),
+			);
+			expect(reissued).toBeDefined();
+			expect(reissued).not.toContain("Max-Age=0");
+			const expired = setCookies.find((c) =>
+				c.startsWith(`${SECURE_COOKIE_PREFIX}better-auth.session_token=`),
+			);
+			expect(expired).toContain("Max-Age=0");
+
+			// The migrated cookies work on their own, without the legacy one.
+			const migrated = new Headers();
+			// A browser drops the expired cookies, so only keep the live ones.
+			applySetCookies(
+				migrated,
+				setCookies.filter((c) => !c.includes("Max-Age=0")),
+			);
+			expect(migrated.get("cookie")).not.toContain(SECURE_COOKIE_PREFIX);
+			const again = await auth.api.getSession({ headers: migrated });
+			expect(again?.user.email).toBe(email);
+		});
+
+		it("does not read __Secure- sessions by default", async () => {
+			const { database, headers } = await signInLegacy();
+			const { auth } = await getTestInstance(
+				{
+					database: memoryAdapter(database),
+					advanced: { useHostCookiePrefix: true },
+				},
+				{ disableTestUser: true },
+			);
+			expect(await auth.api.getSession({ headers })).toBeNull();
+		});
 	});
 });

--- a/packages/better-auth/src/cookies/index.ts
+++ b/packages/better-auth/src/cookies/index.ts
@@ -29,6 +29,7 @@ import { sec } from "../utils/time";
 import { isDynamicBaseURLConfig } from "../utils/url";
 import { parseCompactCookieCache, parseCookieCachePayload } from "./cache";
 import {
+	HOST_COOKIE_PREFIX,
 	parseCookies,
 	SECURE_COOKIE_PREFIX,
 	splitSetCookieHeader,
@@ -40,6 +41,27 @@ import {
 	getAccountCookie,
 	setAccountCookie,
 } from "./session-store";
+
+/**
+ * Whether cookies are named with the `__Host-` prefix.
+ */
+function isHostCookiePrefixEnabled(options: BetterAuthOptions) {
+	const setting = options.advanced?.useHostCookiePrefix;
+	return typeof setting === "object" ? !!setting.enabled : !!setting;
+}
+
+/**
+ * Whether legacy `__Secure-` cookies are still accepted and re-issued as
+ * `__Host-` while the prefix is enabled. Off unless explicitly requested.
+ */
+export function shouldMigrateSecureCookies(options: BetterAuthOptions) {
+	const setting = options.advanced?.useHostCookiePrefix;
+	return (
+		typeof setting === "object" &&
+		!!setting.enabled &&
+		setting.migrateSecureCookies === true
+	);
+}
 
 export function createCookieGetter(options: BetterAuthOptions) {
 	const baseURLString =
@@ -62,8 +84,15 @@ export function createCookieGetter(options: BetterAuthOptions) {
 	 * protocol depends on each incoming request and is unknown at init time,
 	 * so we fall back to step 4.
 	 */
+	const useHostPrefix = isHostCookiePrefixEnabled(options);
+	if (useHostPrefix && options.advanced?.useSecureCookies === false) {
+		throw new BetterAuthError(
+			"useHostCookiePrefix requires secure cookies. Remove `useSecureCookies: false`.",
+		);
+	}
 	const secure =
-		options.advanced?.useSecureCookies !== undefined
+		useHostPrefix ||
+		(options.advanced?.useSecureCookies !== undefined
 			? options.advanced?.useSecureCookies
 			: dynamicProtocol === "https"
 				? true
@@ -71,10 +100,19 @@ export function createCookieGetter(options: BetterAuthOptions) {
 					? false
 					: baseURLString
 						? baseURLString.startsWith("https://")
-						: isProduction;
-	const secureCookiePrefix = secure ? SECURE_COOKIE_PREFIX : "";
+						: isProduction);
+	const secureCookiePrefix = useHostPrefix
+		? HOST_COOKIE_PREFIX
+		: secure
+			? SECURE_COOKIE_PREFIX
+			: "";
 	const crossSubdomainEnabled =
 		!!options.advanced?.crossSubDomainCookies?.enabled;
+	if (useHostPrefix && crossSubdomainEnabled) {
+		throw new BetterAuthError(
+			"useHostCookiePrefix cannot be combined with crossSubDomainCookies: `__Host-` cookies must not carry a Domain attribute.",
+		);
+	}
 	const domain = crossSubdomainEnabled
 		? options.advanced?.crossSubDomainCookies?.domain ||
 			(baseURLString ? new URL(baseURLString).hostname : undefined)
@@ -99,7 +137,7 @@ export function createCookieGetter(options: BetterAuthOptions) {
 		const attributes =
 			options.advanced?.cookies?.[cookieName]?.attributes ?? {};
 
-		return {
+		const cookie = {
 			name: `${secureCookiePrefix}${name}`,
 			attributes: {
 				secure: !!secureCookiePrefix,
@@ -112,6 +150,15 @@ export function createCookieGetter(options: BetterAuthOptions) {
 				...attributes,
 			},
 		} satisfies BetterAuthCookie;
+		if (
+			useHostPrefix &&
+			(cookie.attributes.domain || cookie.attributes.path !== "/")
+		) {
+			throw new BetterAuthError(
+				`Cookie "${cookie.name}" cannot use the __Host- prefix with a Domain attribute or a Path other than "/".`,
+			);
+		}
+		return cookie;
 	}
 	return createCookie;
 }
@@ -576,8 +623,9 @@ export const getSessionCookie = (
 	const { cookieName = "session_token", cookiePrefix = "better-auth" } =
 		config || {};
 	const parsedCookie = parseCookies(cookies);
-	// Prefer __Secure- (HTTPS-only) over a non-secure leftover.
+	// Prefer __Host-, then __Secure- (HTTPS-only), over a non-secure leftover.
 	const getCookie = (name: string) =>
+		parsedCookie.get(`${HOST_COOKIE_PREFIX}${name}`) ??
 		parsedCookie.get(`${SECURE_COOKIE_PREFIX}${name}`) ??
 		parsedCookie.get(name);
 
@@ -632,20 +680,21 @@ export const getCookieCache = async <
 	}
 	const { cookieName = "session_data", cookiePrefix = "better-auth" } =
 		config || {};
+	const baseName = `${cookiePrefix}.${cookieName}`;
 	const name =
 		config?.isSecure !== undefined
 			? config.isSecure
-				? `${SECURE_COOKIE_PREFIX}${cookiePrefix}.${cookieName}`
-				: `${cookiePrefix}.${cookieName}`
+				? `${SECURE_COOKIE_PREFIX}${baseName}`
+				: baseName
 			: isProduction
-				? `${SECURE_COOKIE_PREFIX}${cookiePrefix}.${cookieName}`
-				: `${cookiePrefix}.${cookieName}`;
+				? `${SECURE_COOKIE_PREFIX}${baseName}`
+				: baseName;
 	const parsedCookie = parseCookies(cookies);
 
-	// Check for chunked cookies
-	let sessionData = parsedCookie.get(name);
-	if (!sessionData) {
-		// Try to reconstruct from chunks
+	// Read a cookie, reconstructing it from `<name>.<index>` chunks if needed.
+	const readCookie = (name: string) => {
+		const value = parsedCookie.get(name);
+		if (value) return value;
 		const chunks: Array<{ index: number; value: string }> = [];
 		for (const [cookieName, value] of parsedCookie.entries()) {
 			if (cookieName.startsWith(name + ".")) {
@@ -657,13 +706,15 @@ export const getCookieCache = async <
 				}
 			}
 		}
+		if (chunks.length === 0) return undefined;
+		chunks.sort((a, b) => a.index - b.index);
+		return chunks.map((c) => c.value).join("");
+	};
 
-		if (chunks.length > 0) {
-			// Sort by index and join
-			chunks.sort((a, b) => a.index - b.index);
-			sessionData = chunks.map((c) => c.value).join("");
-		}
-	}
+	// A __Host- cookie is only ever written by a server configured with
+	// `useHostCookiePrefix`, so prefer it over the legacy name.
+	const sessionData =
+		readCookie(`${HOST_COOKIE_PREFIX}${baseName}`) ?? readCookie(name);
 
 	if (sessionData) {
 		const strategy = config?.strategy || "compact";

--- a/packages/better-auth/src/cookies/migrate-secure-cookies.ts
+++ b/packages/better-auth/src/cookies/migrate-secure-cookies.ts
@@ -1,0 +1,100 @@
+import type { BetterAuthCookie, BetterAuthPlugin } from "@better-auth/core";
+import { createAuthMiddleware } from "@better-auth/core/api";
+import { PACKAGE_VERSION } from "../version";
+import {
+	HOST_COOKIE_PREFIX,
+	parseCookies,
+	parseSetCookieHeader,
+	SECURE_COOKIE_PREFIX,
+	setRequestCookie,
+	stripSecureCookiePrefix,
+} from "./cookie-utils";
+import { expireCookie } from "./index";
+
+const toHostName = (legacyName: string) =>
+	`${HOST_COOKIE_PREFIX}${legacyName.slice(SECURE_COOKIE_PREFIX.length)}`;
+
+const hasLegacyCookie = (headers: Headers | undefined) =>
+	!!headers?.get("cookie")?.includes(SECURE_COOKIE_PREFIX);
+
+/**
+ * Keeps existing sessions alive when `useHostCookiePrefix` is turned on.
+ *
+ * A legacy `__Secure-` cookie with no `__Host-` twin is mirrored under its
+ * `__Host-` name for the duration of the request, so every read site sees
+ * it. On the response, the core cookies are re-issued under the `__Host-`
+ * name and the legacy copies are expired, so a session migrates on its
+ * first request after the upgrade.
+ */
+export const secureCookieMigration = (): BetterAuthPlugin => ({
+	id: "secure-cookie-migration",
+	version: PACKAGE_VERSION,
+	hooks: {
+		before: [
+			{
+				matcher: (c) => hasLegacyCookie(c.request?.headers ?? c.headers),
+				handler: createAuthMiddleware(async (c) => {
+					const existing = (c.request?.headers ?? c.headers) as
+						| Headers
+						| undefined;
+					const cookieHeader = existing?.get("cookie");
+					if (!cookieHeader) return;
+					const cookies = parseCookies(cookieHeader);
+					const headers = new Headers(existing);
+					let mirrored = false;
+					for (const [name, value] of cookies) {
+						if (!name.startsWith(SECURE_COOKIE_PREFIX)) continue;
+						const hostName = toHostName(name);
+						if (cookies.has(hostName)) continue;
+						setRequestCookie(headers, hostName, value);
+						mirrored = true;
+					}
+					if (!mirrored) return;
+					return { context: { headers } };
+				}),
+			},
+		],
+		after: [
+			{
+				matcher: (c) => hasLegacyCookie(c.headers),
+				handler: createAuthMiddleware(async (ctx) => {
+					const cookies = parseCookies(ctx.headers?.get("cookie") ?? "");
+					const alreadySet = parseSetCookieHeader(
+						ctx.context.responseHeaders?.get("set-cookie") ?? "",
+					);
+					const authCookies = Object.values(
+						ctx.context.authCookies,
+					) as BetterAuthCookie[];
+					const dontRemember = cookies.has(
+						ctx.context.authCookies.dontRememberToken.name,
+					);
+					for (const [name, value] of cookies) {
+						if (!name.startsWith(SECURE_COOKIE_PREFIX)) continue;
+						const hostName = toHostName(name);
+						// A real __Host- cookie with a different value is
+						// authoritative; only a mirrored (or absent) twin migrates.
+						const twin = cookies.get(hostName);
+						if (twin !== undefined && twin !== value) continue;
+						const base = stripSecureCookiePrefix(name);
+						const cookie = authCookies.find((c) => {
+							const coreBase = stripSecureCookiePrefix(c.name);
+							return base === coreBase || base.startsWith(`${coreBase}.`);
+						});
+						if (!cookie) continue;
+						if (!alreadySet.has(hostName)) {
+							const isSessionToken =
+								cookie.name === ctx.context.authCookies.sessionToken.name;
+							ctx.setCookie(hostName, value, {
+								...cookie.attributes,
+								...(isSessionToken && dontRemember
+									? { maxAge: undefined }
+									: {}),
+							});
+						}
+						expireCookie(ctx, { name, attributes: cookie.attributes });
+					}
+				}),
+			},
+		],
+	},
+});

--- a/packages/better-auth/src/plugins/multi-session/index.ts
+++ b/packages/better-auth/src/plugins/multi-session/index.ts
@@ -8,6 +8,7 @@ import { APIError, sessionMiddleware } from "../../api";
 import {
 	deleteSessionCookie,
 	expireCookie,
+	HOST_COOKIE_PREFIX,
 	parseCookies,
 	parseSetCookieHeader,
 	SECURE_COOKIE_PREFIX,
@@ -397,6 +398,10 @@ export const multiSession = (options?: MultiSessionConfig | undefined) => {
 												.replace(
 													SECURE_COOKIE_PREFIX.toLowerCase(),
 													SECURE_COOKIE_PREFIX,
+												)
+												.replace(
+													HOST_COOKIE_PREFIX.toLowerCase(),
+													HOST_COOKIE_PREFIX,
 												),
 											attributes:
 												ctx.context.authCookies.sessionToken.attributes,

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -348,6 +348,38 @@ export type BetterAuthAdvancedOptions = {
 	 */
 	useSecureCookies?: boolean | undefined;
 	/**
+	 * Name cookies with the `__Host-` prefix instead of `__Secure-`.
+	 *
+	 * Browsers only accept `__Host-` cookies that are `Secure`, use `Path=/`
+	 * and carry no `Domain` attribute, so a cookie set from a sibling
+	 * subdomain can never collide with the session cookie. Implies
+	 * `useSecureCookies` and cannot be combined with `crossSubDomainCookies`
+	 * or a custom cookie `path`.
+	 *
+	 * Switching renames the cookies, so existing `__Secure-` sessions are
+	 * no longer read and users sign in again once. Set
+	 * `migrateSecureCookies` for a seamless cutover instead.
+	 *
+	 * @default false
+	 */
+	useHostCookiePrefix?:
+		| boolean
+		| {
+				enabled: boolean;
+				/**
+				 * Keep accepting cookies written under the `__Secure-` prefix and
+				 * re-issue them as `__Host-` on the next request, so existing
+				 * sessions survive the switch. While this is on, a visitor
+				 * without a `__Host-` cookie is still exposed to a planted
+				 * `__Secure-` cookie, so turn it off once existing sessions have
+				 * expired (after `session.expiresIn`).
+				 *
+				 * @default false
+				 */
+				migrateSecureCookies?: boolean | undefined;
+		  }
+		| undefined;
+	/**
 	 * Disable all CSRF protection.
 	 *
 	 * When enabled, this disables:

--- a/packages/electron/src/cookies.ts
+++ b/packages/electron/src/cookies.ts
@@ -1,4 +1,8 @@
-import { cookieNameRegex, parseSetCookieHeader } from "better-auth/cookies";
+import {
+	cookieNameRegex,
+	parseSetCookieHeader,
+	stripSecureCookiePrefix,
+} from "better-auth/cookies";
 
 interface StoredCookie {
 	value: string;
@@ -121,10 +125,8 @@ export function hasBetterAuthCookies(
 
 	// Check if any cookie is a better-auth cookie
 	for (const name of cookies.keys()) {
-		// Remove __Secure- prefix if present for comparison
-		const nameWithoutSecure = name.startsWith("__Secure-")
-			? name.slice(9)
-			: name;
+		// Remove __Secure- / __Host- prefix if present for comparison
+		const nameWithoutSecure = stripSecureCookiePrefix(name);
 
 		// Check against all provided prefixes
 		for (const prefix of prefixes) {

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -6,6 +6,7 @@ import type {
 import type { Session, User } from "@better-auth/core/db";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import {
+	HOST_COOKIE_PREFIX,
 	parseSetCookieHeader,
 	SECURE_COOKIE_PREFIX,
 	stripSecureCookiePrefix,
@@ -138,6 +139,7 @@ function getOAuthStateValue(
 	for (const prefix of prefixes) {
 		// cookie strategy uses: <prefix>.oauth_state
 		const candidates = [
+			`${HOST_COOKIE_PREFIX}${prefix}.oauth_state`,
 			`${SECURE_COOKIE_PREFIX}${prefix}.oauth_state`,
 			`${prefix}.oauth_state`,
 		];


### PR DESCRIPTION
## Summary

Adds `advanced.useHostCookiePrefix` so Better Auth can name its cookies with the `__Host-` prefix instead of `__Secure-`, plus an opt-in `migrateSecureCookies` for a seamless cutover of existing `__Secure-` sessions.

## Root cause

`createCookieGetter` only ever emitted `""` or `__Secure-` as the cookie prefix. `HOST_COOKIE_PREFIX` was declared in `cookie-utils.ts` and stripped on the read side, but nothing on the emit path produced it. Putting `__Host-` into `advanced.cookiePrefix` therefore produced `__Secure-__Host-...`, which browsers reject because the name does not start with a valid prefix. `getSessionCookie`, `getCookieCache`, the multi-session plugin, and the Electron/Expo packages also only understood `__Secure-` names.

## Fix

- `advanced.useHostCookiePrefix?: boolean | { enabled, migrateSecureCookies? }` (`@better-auth/core`). When enabled, cookies are emitted as `__Host-<name>`, `Secure` is forced, and the getter throws at init on configurations that browsers would reject: `crossSubDomainCookies` (needs a `Domain`), a `path` other than `/`, a per-cookie `domain`, and an explicit `useSecureCookies: false`.
- Enabling it alone renames the cookies, so existing `__Secure-` sessions are no longer read and signed-in users sign in again once. This is the default: accepting `__Secure-` cookies is exactly the collision the prefix exists to prevent.
- `migrateSecureCookies: true` (default `false`) opts into a seamless cutover: an internal plugin mirrors `__Secure-*` request cookies to their `__Host-*` name for the request when no `__Host-` twin exists, then on the response re-issues them under the `__Host-` name and expires the `__Secure-` copies. Sessions migrate on their first request after the upgrade. The docs tell operators to remove it after `session.expiresIn`, since a visitor without a `__Host-` cookie is exposed to a planted `__Secure-` cookie while it is on.
- `getSessionCookie` and `getCookieCache` prefer a `__Host-` cookie (including chunked `session_data`) before the `__Secure-`/bare names.
- Multi-session restores `__Host-` casing when expiring per-session cookies; Electron uses `stripSecureCookiePrefix` instead of slicing `__Secure-` by hand; Expo checks the `__Host-` OAuth state cookie name.
- Docs: `concepts/cookies.mdx`, `reference/options.mdx`, `concepts/plugins.mdx`.

## Tests

`packages/better-auth/src/cookies/cookies.test.ts` (`useHostCookiePrefix` block):
- sign-in emits `__Host-better-auth.session_token` with `Secure`, `Path=/`, no `Domain`, and no `__Secure-` cookie; the session reads back
- `crossSubDomainCookies`, a non-`/` path, and `useSecureCookies: false` are rejected
- `getSessionCookie` prefers `__Host-` over `__Secure-` and bare names
- `getCookieCache` reads the `__Host-` `session_data` cookie
- by default, a session signed in under `__Secure-` is not read after switching
- with `migrateSecureCookies: true`, that session stays valid, is re-issued as `__Host-`, the `__Secure-` copy is expired, and the migrated cookies work on their own

Ran `pnpm vitest run src/cookies` (119 passed), `src/plugins/multi-session` (10 passed), `@better-auth/electron` (88 passed), `@better-auth/expo` (74 passed), and `pnpm typecheck` (passes).

Closes #11061
Closes #10806