### PR TITLE
fix(two-factor): make enabling two-factor safe under concurrent requests

### DIFF
--- a/.changeset/two-factor-enable-race.md
+++ b/.changeset/two-factor-enable-race.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Make enabling two-factor safe under concurrent requests by converging on a single `twoFactor` row per user.

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -286,6 +286,33 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 							data: { ...totpData, userId: user.id },
 						});
 					}
+					// `userId` is not unique, so concurrent enrollments can both pass the
+					// findOne above and both insert. Converge on one row that every racer
+					// picks identically (verified first, then lowest id) so a later findOne
+					// cannot return a factor the user never scanned. A racer whose row
+					// lost returned a URI that will fail verification; re-enabling
+					// updates the surviving unverified row.
+					const rows = await ctx.context.adapter.findMany<TwoFactorTable>({
+						model: opts.twoFactorTable,
+						where: [{ field: "userId", value: user.id }],
+					});
+					if (rows.length > 1) {
+						const [, ...duplicates] = rows.sort(
+							(a, b) =>
+								Number(b.verified !== false) - Number(a.verified !== false) ||
+								(String(a.id) < String(b.id) ? -1 : 1),
+						);
+						await ctx.context.adapter.deleteMany({
+							model: opts.twoFactorTable,
+							where: [
+								{
+									field: "id",
+									operator: "in",
+									value: duplicates.map((row) => row.id),
+								},
+							],
+						});
+					}
 					const totpURI = createOTP(secret, {
 						digits: options?.totpOptions?.digits || 6,
 						period: options?.totpOptions?.period,

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -2713,3 +2713,65 @@ describe("backup codes storage configurations", () => {
 		});
 	}
 });
+
+describe("two factor enable concurrency", async () => {
+	const { auth, db, signInWithTestUser, testUser } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [twoFactor()],
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/10561
+	 */
+	it("should keep a single usable factor when enable is called concurrently", async () => {
+		const { headers, user } = await signInWithTestUser();
+		const adapter = (await auth.$context).adapter;
+		const create = adapter.create.bind(adapter);
+		// Park every twoFactor insert until both requests have passed their
+		// findOne, so both observe "no existing factor" and both insert.
+		let arrived = 0;
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		vi.spyOn(adapter, "create").mockImplementation(async (input) => {
+			if (input.model === "twoFactor") {
+				arrived++;
+				if (arrived === 2) release();
+				await gate;
+			}
+			return create(input);
+		});
+
+		const results = await Promise.all([
+			auth.api.enableTwoFactor({
+				body: { password: testUser.password },
+				headers,
+			}),
+			auth.api.enableTwoFactor({
+				body: { password: testUser.password },
+				headers,
+			}),
+		]);
+		vi.restoreAllMocks();
+
+		const rows = await db.findMany<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: user.id }],
+		});
+		expect(rows).toHaveLength(1);
+		const storedSecret = await symmetricDecrypt({
+			key: DEFAULT_SECRET,
+			data: rows[0]!.secret,
+		});
+		const secretParam = (uri: string) =>
+			new URL(uri).searchParams.get("secret");
+		const returnedSecrets = results.map((res) => {
+			if (res.method !== "totp") throw new Error("expected totp");
+			return secretParam(res.totpURI);
+		});
+		expect(returnedSecrets).toContain(
+			secretParam(createOTP(storedSecret).url("test", user.email)),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Two concurrent `twoFactor.enable` calls for the same user could leave two `twoFactor` rows for that user. Because `findOne` on the table carries no ordering, later reads (sign-in method discovery, `verifyTOTP`, `verifyBackupCode`) could pick a row whose secret the user never scanned, locking the user out.

## Root cause

`enableTwoFactor` does `findOne` by `userId`, then `create` when no row exists. The `twoFactor.userId` column is indexed but not unique, so two first-time enrollments that both pass the `findOne` both insert. Sequential calls cannot produce this state (the second call finds the first row and updates it in place), so it only appears under concurrency.

## Fix

After the row write, `enableTwoFactor` reads all rows for the user and, if more than one exists, deletes every row except one chosen by a rule each racer evaluates identically: prefer a verified row, then the lowest `id`. Both concurrent calls therefore converge on the same single row without a lock or a schema change. The same pass also heals pre-existing duplicate rows (for example a `[verified, unverified]` pair) the next time the user enables, keeping the verified factor the user actually holds.

A racer whose row lost returns a TOTP URI that will not verify; re-running enable then updates the surviving unverified row, so no lockout is possible from the race. Unverified rows never gate sign-in.

## Tests

Added a regression test in `packages/better-auth/src/plugins/two-factor/two-factor.test.ts` that wraps the adapter's `create` so both enable requests park after their `findOne` and insert together, then asserts exactly one `twoFactor` row remains and that its secret is one of the two returned URIs. The test fails on `main` (2 rows) and passes with this change. `pnpm vitest run src/plugins/two-factor` passes (91 tests) and `pnpm typecheck` passes.

Closes #10561