### PR TITLE
fix(magic-link): stop double-decoding callback URLs on verify

### DIFF
--- a/.changeset/magic-link-decode.md
+++ b/.changeset/magic-link-decode.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Stop double-decoding `callbackURL`, `newUserCallbackURL` and `errorCallbackURL` on magic link verify so percent-encoded characters in callback query params are preserved.

--- a/packages/better-auth/src/plugins/magic-link/index.ts
+++ b/packages/better-auth/src/plugins/magic-link/index.ts
@@ -301,21 +301,9 @@ export const magicLink = (options: MagicLinkOptions) => {
 					method: "GET",
 					query: magicLinkVerifyQuerySchema,
 					use: [
-						originCheck((ctx) => {
-							return ctx.query.callbackURL
-								? decodeURIComponent(ctx.query.callbackURL)
-								: "/";
-						}),
-						originCheck((ctx) => {
-							return ctx.query.newUserCallbackURL
-								? decodeURIComponent(ctx.query.newUserCallbackURL)
-								: "/";
-						}),
-						originCheck((ctx) => {
-							return ctx.query.errorCallbackURL
-								? decodeURIComponent(ctx.query.errorCallbackURL)
-								: "/";
-						}),
+						originCheck((ctx) => ctx.query.callbackURL || "/"),
+						originCheck((ctx) => ctx.query.newUserCallbackURL || "/"),
+						originCheck((ctx) => ctx.query.errorCallbackURL || "/"),
 					],
 					requireHeaders: true,
 					metadata: {
@@ -351,15 +339,11 @@ export const magicLink = (options: MagicLinkOptions) => {
 					// new URL("http://localhost:3001/hello", "http://localhost:3000").toString()
 					// Returns http://localhost:3001/hello
 					const callbackURL = new URL(
-						ctx.query.callbackURL
-							? decodeURIComponent(ctx.query.callbackURL)
-							: "/",
+						ctx.query.callbackURL || "/",
 						ctx.context.baseURL,
 					).toString();
 					const errorCallbackURL = new URL(
-						ctx.query.errorCallbackURL
-							? decodeURIComponent(ctx.query.errorCallbackURL)
-							: callbackURL,
+						ctx.query.errorCallbackURL || callbackURL,
 						ctx.context.baseURL,
 					);
 
@@ -378,9 +362,7 @@ export const magicLink = (options: MagicLinkOptions) => {
 					}
 
 					const newUserCallbackURL = new URL(
-						ctx.query.newUserCallbackURL
-							? decodeURIComponent(ctx.query.newUserCallbackURL)
-							: callbackURL,
+						ctx.query.newUserCallbackURL || callbackURL,
 						ctx.context.baseURL,
 					).toString();
 					const storedToken = await storeToken(ctx, token);

--- a/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
+++ b/packages/better-auth/src/plugins/magic-link/magic-link.test.ts
@@ -926,3 +926,67 @@ describe("magic link send origin/CSRF protection", async () => {
 		expect(sendMagicLink).toHaveBeenCalledTimes(1);
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10916
+ */
+describe("magic link callback URL encoding", async () => {
+	let sent: VerificationEmail = { email: "", token: "", url: "" };
+	const { auth, testUser } = await getTestInstance({
+		plugins: [
+			magicLink({
+				async sendMagicLink(data) {
+					sent = data;
+				},
+			}),
+		],
+	});
+	const signIn = (body: Record<string, string>) =>
+		auth.handler(
+			new Request("http://localhost:3000/api/auth/sign-in/magic-link", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(body),
+			}),
+		);
+	const verifyAndGetLocation = async (url: string) => {
+		const res = await auth.handler(new Request(url));
+		expect(res.status).toBe(302);
+		return new URL(res.headers.get("location")!);
+	};
+
+	it("should not double-decode callbackURL on verify", async () => {
+		await signIn({
+			email: testUser.email,
+			callbackURL: "http://localhost:3000/cb?sig=a%2Bb",
+		});
+		const location = await verifyAndGetLocation(sent.url);
+		expect(location.pathname).toBe("/cb");
+		expect(location.searchParams.get("sig")).toBe("a+b");
+	});
+
+	it("should not double-decode newUserCallbackURL on verify", async () => {
+		await signIn({
+			email: "new-user-10916@email.com",
+			callbackURL: "http://localhost:3000/cb",
+			newUserCallbackURL: "http://localhost:3000/welcome?sig=a%2Bb",
+		});
+		const location = await verifyAndGetLocation(sent.url);
+		expect(location.pathname).toBe("/welcome");
+		expect(location.searchParams.get("sig")).toBe("a+b");
+	});
+
+	it("should not double-decode errorCallbackURL on verify", async () => {
+		await signIn({
+			email: testUser.email,
+			callbackURL: "http://localhost:3000/cb",
+			errorCallbackURL: "http://localhost:3000/error?sig=a%2Bb",
+		});
+		const url = new URL(sent.url);
+		url.searchParams.set("token", "invalid-token");
+		const location = await verifyAndGetLocation(url.toString());
+		expect(location.pathname).toBe("/error");
+		expect(location.searchParams.get("sig")).toBe("a+b");
+		expect(location.searchParams.get("error")).toBe("INVALID_TOKEN");
+	});
+});


### PR DESCRIPTION
## Summary

`GET /magic-link/verify` corrupted percent-encoded characters inside `callbackURL`, `newUserCallbackURL` and `errorCallbackURL`. A callback like `https://app.example.com/cb?sig=abc%2Bdef` was redirected to as `...?sig=abc+def`, which downstream query parsers read as `abc def`. Base64 values (signatures, tokens) carried in callback query params were silently broken whenever they contained `+`, `/` or `=`.

## Root cause

better-call builds `ctx.query` from `url.searchParams.forEach(...)` (`router.mjs`), so every query value is already percent-decoded once when the handler sees it. The verify endpoint then called `decodeURIComponent` on each of the three callback params again, in six places (three `originCheck` getters and three `new URL(...)` calls in the handler body). The second decode spent any `%xx` escape that belonged to the callback URL's own query string.

`/sign-in/magic-link` encodes the callback params exactly once via `url.searchParams.set(...)`, so the extra decode on verify was never needed for the documented flow. It is a leftover from when the verify URL was built by string concatenation.

## Fix

Remove the six redundant `decodeURIComponent` calls in `packages/better-auth/src/plugins/magic-link/index.ts` and pass `ctx.query.*` straight through. The `|| "/"` / `|| callbackURL` fallbacks are unchanged, so empty values behave as before. Origin checking is unaffected: it only needs the origin, which never contained a nested escape.

No other plugin or route uses the `decodeURIComponent(ctx.query...)` pattern. The remaining `decodeURIComponent` in `auth/trusted-origins.ts` is a deliberate defense-in-depth normalization on a path segment before traversal checks, not a query decode, and is left as is.

## Tests

- Added `magic link callback URL encoding` in `packages/better-auth/src/plugins/magic-link/magic-link.test.ts`: signs in with `callbackURL`, `newUserCallbackURL` and `errorCallbackURL` each carrying `sig=a%2Bb`, follows the emailed verify link through `auth.handler`, and asserts the 302 `Location` decodes `sig` to `a+b` (previously `a b`). All three failed before the fix.
- `pnpm vitest run src/plugins/magic-link`: 26 passed.
- `pnpm typecheck`: passes.

Closes #10916