### PR TITLE
fix(oauth-provider): drop unsupported grant types from dynamic registration instead of rejecting it

### DIFF
--- a/.changeset/oauth-provider-dcr-grants.md
+++ b/.changeset/oauth-provider-dcr-grants.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Narrow dynamic client registration `grant_types` to the grants the server supports instead of rejecting the whole registration when an unsupported grant accompanies supported ones.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -1318,6 +1318,8 @@ oauthProvider({
 
 Dynamic registration allows for authorized registration of both public and confidential clients.
 
+Requested `grant_types` are narrowed to the grants this server supports and the effective list is returned in the registration response ([RFC 7591 §3.2.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1)). A registration sharing no grant with the server is rejected with `invalid_client_metadata`.
+
 ```ts title="auth.ts"
 oauthProvider({
   allowDynamicClientRegistration: true, // [!code highlight]

--- a/packages/oauth-provider/src/register.test.ts
+++ b/packages/oauth-provider/src/register.test.ts
@@ -537,7 +537,13 @@ describe("oauth register", async () => {
 					},
 					{ registrationSource: "clientMetadataDocument" },
 				),
-			).resolves.toBeUndefined();
+			).resolves.toEqual({
+				grant_types: [
+					"authorization_code",
+					"refresh_token",
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+				],
+			});
 		});
 
 		it("rejects a client metadata document sharing no grant with the server", async () => {
@@ -563,12 +569,92 @@ describe("oauth register", async () => {
 				},
 			});
 		});
+	});
 
-		it("still rejects a dynamic registration declaring an unsupported grant", async () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11081
+	 */
+	describe("dynamic registration grant narrowing", () => {
+		it("registers a client declaring a supported grant next to an unsupported one", async () => {
+			const response = await serverClient.oauth2.register({
+				redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+				token_endpoint_auth_method: "none",
+				grant_types: [
+					"authorization_code",
+					"refresh_token",
+					"urn:ietf:params:oauth:grant-type:jwt-bearer",
+				],
+				response_types: ["code"],
+			});
+			expect(response.error).toBeNull();
+			expect(response.data?.grant_types).toEqual([
+				"authorization_code",
+				"refresh_token",
+			]);
+			const context = await auth.$context;
+			const stored = await context.adapter.findOne<{ grantTypes: string[] }>({
+				model: "oauthClient",
+				where: [{ field: "clientId", value: response.data!.client_id }],
+			});
+			expect(stored?.grantTypes).toEqual([
+				"authorization_code",
+				"refresh_token",
+			]);
+		});
+
+		it("rejects a dynamic registration sharing no grant with the server", async () => {
 			await expect(
 				checkOAuthClient(
 					{
 						client_id: "dcr-client",
+						redirect_uris: [],
+						grant_types: ["urn:ietf:params:oauth:grant-type:jwt-bearer"],
+						response_types: [],
+						token_endpoint_auth_method: "none",
+					},
+					{
+						loginPage: "/login",
+						consentPage: "/consent",
+					},
+					{ registrationSource: "dynamic" },
+				),
+			).rejects.toMatchObject({
+				body: {
+					error_description: expect.stringContaining("no mutually supported"),
+				},
+			});
+		});
+
+		it("checks response_types against the narrowed grants", async () => {
+			await expect(
+				checkOAuthClient(
+					{
+						client_id: "dcr-client",
+						redirect_uris: [redirectUri],
+						grant_types: ["authorization_code", "client_credentials"],
+						response_types: ["code"],
+					},
+					{
+						loginPage: "/login",
+						consentPage: "/consent",
+						grantTypes: ["client_credentials"],
+					},
+					{ registrationSource: "dynamic" },
+				),
+			).rejects.toMatchObject({
+				body: {
+					error_description: expect.stringContaining(
+						"'authorization_code' grant type must be included",
+					),
+				},
+			});
+		});
+
+		it("keeps managed registration strict about unsupported grants", async () => {
+			await expect(
+				checkOAuthClient(
+					{
+						client_id: "managed-client",
 						redirect_uris: [redirectUri],
 						grant_types: [
 							"authorization_code",
@@ -580,7 +666,7 @@ describe("oauth register", async () => {
 						loginPage: "/login",
 						consentPage: "/consent",
 					},
-					{ registrationSource: "dynamic" },
+					{ registrationSource: "managed" },
 				),
 			).rejects.toMatchObject({
 				body: {

--- a/packages/oauth-provider/src/register.ts
+++ b/packages/oauth-provider/src/register.ts
@@ -368,7 +368,37 @@ export async function checkOAuthClient(
 		});
 	}
 
-	const grantTypes = clientWithDefaults.grant_types ?? [];
+	const requestedGrantTypes = clientWithDefaults.grant_types ?? [];
+	const isDynamicRegistration = settings?.registrationSource === "dynamic";
+	const supportedGrantTypes = new Set(getSupportedGrantTypes(opts));
+	const mutualGrantTypes = requestedGrantTypes.filter((grantType) =>
+		supportedGrantTypes.has(grantType),
+	);
+	if (isClientMetadataDocument || isDynamicRegistration) {
+		// A metadata document serves every authorization server the client talks
+		// to, and DCR clients such as MCP connectors send that same grant union, so
+		// require one mutual grant. Dynamic registration replaces the rest with the
+		// supported subset (RFC 7591 §3.2.1); a metadata document keeps its union
+		// and the token endpoint refuses the unsupported grants.
+		if (mutualGrantTypes.length === 0) {
+			throw new APIError("BAD_REQUEST", {
+				error: "invalid_client_metadata",
+				error_description: `no mutually supported grant_type among ${requestedGrantTypes.join(", ")}`,
+			});
+		}
+	} else {
+		for (const grantType of requestedGrantTypes) {
+			if (!supportedGrantTypes.has(grantType)) {
+				throw new APIError("BAD_REQUEST", {
+					error: "invalid_client_metadata",
+					error_description: `unsupported grant_type ${grantType}`,
+				});
+			}
+		}
+	}
+	const grantTypes = isDynamicRegistration
+		? mutualGrantTypes
+		: requestedGrantTypes;
 	const responseTypes = clientWithDefaults.response_types;
 	const applicationType = clientWithDefaults.application_type as unknown;
 	if (
@@ -408,27 +438,6 @@ export async function checkOAuthClient(
 	}
 
 	// Validate correlation between grant_types and response_types
-	const supportedGrantTypes = new Set(getSupportedGrantTypes(opts));
-	if (isClientMetadataDocument) {
-		// One metadata document serves every authorization server the client talks
-		// to, so it declares a grant union; require one mutual grant and let the
-		// token endpoint refuse the rest.
-		if (!grantTypes.some((grantType) => supportedGrantTypes.has(grantType))) {
-			throw new APIError("BAD_REQUEST", {
-				error: "invalid_client_metadata",
-				error_description: `no mutually supported grant_type among ${grantTypes.join(", ")}`,
-			});
-		}
-	} else {
-		for (const grantType of grantTypes) {
-			if (!supportedGrantTypes.has(grantType)) {
-				throw new APIError("BAD_REQUEST", {
-					error: "invalid_client_metadata",
-					error_description: `unsupported grant_type ${grantType}`,
-				});
-			}
-		}
-	}
 	if (
 		grantTypes.includes("authorization_code") &&
 		!responseTypes?.includes("code")
@@ -659,6 +668,8 @@ export async function checkOAuthClient(
 			});
 		}
 	}
+
+	return { grant_types: grantTypes };
 }
 
 interface CreateOAuthClientRegistrationBaseInput {
@@ -773,7 +784,7 @@ async function persistOAuthClientRegistration(
 	);
 
 	// Check if client parameters are valid combination
-	await checkOAuthClient(body, opts, {
+	const { grant_types: grantTypes } = await checkOAuthClient(body, opts, {
 		registrationSource: input.registrationSource,
 		ctx,
 	});
@@ -818,6 +829,7 @@ async function persistOAuthClientRegistration(
 				};
 	const schema = oauthToSchema({
 		...persistableBody,
+		grant_types: grantTypes,
 		redirect_uris: body.redirect_uris ?? [],
 		// Dynamic registration should not have disabled defined
 		disabled: undefined,


### PR DESCRIPTION
## Summary

Dynamic client registration now narrows the requested `grant_types` to the grants the server supports and returns the effective list in the registration response, instead of rejecting the whole registration because one unsupported grant accompanies supported ones. A registration that shares no grant with the server is still rejected with `invalid_client_metadata`.

## Root cause

`checkOAuthClient` in `packages/oauth-provider/src/register.ts` required every requested grant to be supported for non-CIMD registrations. Claude's MCP client registers via DCR with `["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"]`, so the `jwt-bearer` entry made the whole request fail and the connection never completed. #10731 relaxed the same check for Client ID Metadata Documents but deliberately left DCR strict.

## Fix

- Dynamic registration and CIMD share one check: at least one requested grant must be supported. Dynamic registration then replaces the requested set with the supported subset (RFC 7591 §3.2.1); CIMD keeps its union as before and the token endpoint refuses unsupported grants.
- The supported-grant check moved ahead of the redirect URI and `authorization_code`/`code` correlation checks so they run against the narrowed set. A `code` response type left over after `authorization_code` is dropped is still rejected.
- `checkOAuthClient` returns the effective `grant_types`; `persistOAuthClientRegistration` stores them so the registration response reflects what was registered.
- Managed (administrator) registration and client updates remain strict about unsupported grants.
- Docs: noted the narrowing behavior in the Dynamic Client Registration section.

## Tests

`packages/oauth-provider/src/register.test.ts`:
- registering with a supported grant next to an unsupported one succeeds, and both the response and the stored client list only the supported grants
- a dynamic registration with only unsupported grants is rejected
- `response_types` is validated against the narrowed grants
- managed registration still rejects an unsupported grant
- the CIMD intersection test now asserts the returned union

`pnpm vitest run` in `packages/oauth-provider`: 40 files, 930 tests passed. `pnpm typecheck` passes.

Closes #11081