### PR TITLE
fix(oauth-provider): return invalid_client for an unknown client at the token endpoint

### DIFF
--- a/.changeset/oauth-provider-invalid-client.md
+++ b/.changeset/oauth-provider-invalid-client.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Return `invalid_client` from the token endpoint for an unknown `client_id` on every grant type, resolving the client before the grant lookup as required by RFC 6749 §5.2.

--- a/docs/content/docs/plugins/oauth-provider.mdx
+++ b/docs/content/docs/plugins/oauth-provider.mdx
@@ -501,7 +501,7 @@ Important Notes:
 * With the JWT plugin enabled (default), sending `resource` results in a JWT access token with the selected resource in the `aud` claim.
 * With `disableJwtPlugin: true`, access tokens remain opaque. Requested resources are still bound to the token and surfaced through `/oauth2/introspect` and `customAccessTokenClaims` (via `resources`).
 
-Token endpoint errors follow the OAuth taxonomy: missing required request fields return `invalid_request`, failed client authentication returns `invalid_client`, and invalid or mismatched grants return `invalid_grant`. A confidential client must use its registered `token_endpoint_auth_method`. Failed `client_secret_post` authentication returns `400`; failed `client_secret_basic` authentication returns `401` with a Basic `WWW-Authenticate` challenge.
+Token endpoint errors follow the OAuth taxonomy: missing required request fields return `invalid_request`, failed client authentication returns `invalid_client`, and invalid or mismatched grants return `invalid_grant`. A confidential client must use its registered `token_endpoint_auth_method`. Failed `client_secret_post` authentication returns `400`; failed `client_secret_basic` authentication returns `401` with a Basic `WWW-Authenticate` challenge. The client is resolved and authenticated before the grant is looked up, so an unknown `client_id` returns `invalid_client` for every grant type rather than `invalid_grant`.
 
 #### DPoP sender-constrained tokens
 

--- a/packages/oauth-provider/src/device-code.ts
+++ b/packages/oauth-provider/src/device-code.ts
@@ -117,6 +117,11 @@ async function exchangeOAuthDeviceCode(
 	type ClientAuthorization = Awaited<
 		ReturnType<typeof provider.authenticateClient>
 	> & { scopes: string[] };
+	// RFC 6749 §5.2: an unknown or unauthenticated client is `invalid_client`,
+	// so resolve it before the device code lookup can report `invalid_grant`.
+	const authentication = await provider.authenticateClient({
+		requireCredentials: false,
+	});
 	const {
 		authorizationContext: { client, confirmation, scopes },
 		redemptionContext: resources,
@@ -139,9 +144,6 @@ async function exchangeOAuthDeviceCode(
 			}
 
 			const scopes = parseScopes(record.scope);
-			const authentication = await provider.authenticateClient({
-				requireCredentials: false,
-			});
 			if (record.oauthClientId !== authentication.client.clientId) {
 				tokenError("BAD_REQUEST", "invalid_grant", "Client ID mismatch");
 			}

--- a/packages/oauth-provider/src/token.test.ts
+++ b/packages/oauth-provider/src/token.test.ts
@@ -597,6 +597,33 @@ describe("oauth token - authorization_code", async () => {
 	 * redirect_uri (it delivers the code through it), so a headless code is
 	 * inserted the way authorize.ts persists one to exercise redemption directly.
 	 */
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11035
+	 */
+	it("returns invalid_client for an unknown client_id before checking the code", async () => {
+		const response = await client.$fetch<Record<string, unknown>>(
+			"/oauth2/token",
+			{
+				method: "POST",
+				body: new URLSearchParams({
+					grant_type: "authorization_code",
+					client_id: "unknown-client",
+					client_secret: "secret",
+					code: "not-a-real-code",
+					redirect_uri: redirectUri,
+				}),
+				headers: {
+					"content-type": "application/x-www-form-urlencoded",
+				},
+			},
+		);
+
+		expect(response.error?.status).toBe(400);
+		expect((response.error as { error?: string })?.error).toBe(
+			"invalid_client",
+		);
+	});
+
 	describe("redirect_uri conditional (RFC 6749 §4.1.3)", () => {
 		const tokenRequestHeaders = {
 			accept: "application/json",
@@ -944,6 +971,36 @@ describe("oauth token - refresh_token", async () => {
 		);
 	});
 
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11035
+	 */
+	it("returns invalid_client for an unknown client_id before looking up the refresh token", async () => {
+		let responseHeaders: Headers | undefined;
+		const response = await client.$fetch<Record<string, unknown>>(
+			"/oauth2/token",
+			{
+				method: "POST",
+				body: new URLSearchParams({
+					grant_type: "refresh_token",
+					refresh_token: "not-a-real-refresh-token",
+				}),
+				headers: {
+					"content-type": "application/x-www-form-urlencoded",
+					authorization: `Basic ${Buffer.from("unknown-client:secret").toString("base64")}`,
+				},
+				onError(context) {
+					responseHeaders = context.response.headers;
+				},
+			},
+		);
+
+		expect(response.error?.status).toBe(401);
+		expect((response.error as { error?: string })?.error).toBe(
+			"invalid_client",
+		);
+		expect(responseHeaders?.get("WWW-Authenticate")).toBe("Basic");
+	});
+
 	it("should refresh token with same scopes, opaque access token", async ({
 		expect,
 	}) => {
@@ -1005,6 +1062,7 @@ describe("oauth token - refresh_token", async () => {
 		const otherClient = await authorizationServer.api.adminCreateOAuthClient({
 			headers,
 			body: {
+				token_endpoint_auth_method: "client_secret_post",
 				grant_types: ["authorization_code", "refresh_token"],
 				redirect_uris: [otherRedirectUri],
 				application_type: "native",

--- a/packages/oauth-provider/src/token.ts
+++ b/packages/oauth-provider/src/token.ts
@@ -67,6 +67,7 @@ import {
 	toAudienceClaim,
 	toResourceList,
 	validateClientCredentials,
+	validateClientScopes,
 } from "./utils";
 
 // Seed the ID token with the standard UserInfo claim names set to `undefined`,
@@ -1524,6 +1525,20 @@ async function handleAuthorizationCodeGrant(
 		});
 	}
 
+	/** Verify Client (RFC 6749 §5.2: an unknown or unauthenticated client is
+	 * `invalid_client`, so resolve it before the code lookup can report
+	 * `invalid_grant` and before a one-time code is consumed). */
+	const client = await validateClientCredentials(
+		ctx,
+		opts,
+		client_id,
+		client_secret,
+		undefined,
+		preVerified,
+		"authorization_code",
+		authMethod,
+	);
+
 	/** Get and check Verification Value */
 	const {
 		verificationValue,
@@ -1545,18 +1560,7 @@ async function handleAuthorizationCodeGrant(
 			error: "invalid_scope",
 		});
 	}
-
-	/** Verify Client */
-	const client = await validateClientCredentials(
-		ctx,
-		opts,
-		client_id,
-		client_secret,
-		scopes,
-		preVerified,
-		"authorization_code",
-		authMethod,
-	);
+	validateClientScopes(client, scopes);
 
 	// Parse scopes from the authorization request
 	const requestedScopes =
@@ -1820,6 +1824,21 @@ async function handleRefreshTokenGrant(
 			error: "invalid_request",
 		});
 	}
+
+	/** Verify Client (RFC 6749 §5.2: an unknown or unauthenticated client is
+	 * `invalid_client`, so resolve it before the refresh token lookup can
+	 * report `invalid_grant`). */
+	const client = await validateClientCredentials(
+		ctx,
+		opts,
+		client_id,
+		client_secret, // Optional for refresh_grant but required on confidential clients
+		undefined,
+		preVerified,
+		"refresh_token",
+		authMethod,
+	);
+
 	const decodedRefresh = await decodeRefreshToken(opts, refresh_token);
 
 	const refreshToken = await ctx.context.adapter.findOne<
@@ -1884,16 +1903,7 @@ async function handleRefreshTokenGrant(
 		}
 	}
 
-	const client = await validateClientCredentials(
-		ctx,
-		opts,
-		client_id,
-		client_secret, // Optional for refresh_grant but required on confidential clients
-		requestedScopes ?? scopes,
-		preVerified,
-		"refresh_token",
-		authMethod,
-	);
+	validateClientScopes(client, requestedScopes ?? scopes);
 
 	if (refreshToken.revoked) {
 		if (isWithinRefreshTokenReuseInterval(refreshToken)) {


### PR DESCRIPTION
## Summary

The token endpoint answered a request carrying an unregistered `client_id` with `400 invalid_grant` for the `authorization_code`, `refresh_token`, and `device_code` grants. RFC 6749 §5.2 requires `invalid_client` for an unknown or unauthenticated client (`401` with a `WWW-Authenticate` challenge when the client attempted HTTP Basic authentication). MCP clients built on `@modelcontextprotocol/sdk` pick their recovery path from this code: `invalid_client` triggers re-registration, while `invalid_grant` leaves the client stuck.

## Root cause

`validateClientCredentials` already resolves the client and throws `invalid_client` (with the 401 / `WWW-Authenticate` handling) when it is missing, but in `handleAuthorizationCodeGrant` and `handleRefreshTokenGrant` it ran only after the grant lookup. An unknown `client_id` therefore failed on the code or refresh-token lookup first and surfaced as `invalid_grant`. The device-code grant had the same ordering: `redeemDeviceCode` looked up the record before `authorizeRedemption` called `provider.authenticateClient`. `client_credentials` already validated the client first.

## Fix

- `authorization_code`: call `validateClientCredentials` before `checkVerificationValue`, then apply the scope check with the existing `validateClientScopes` once the code's scopes are known. Authenticating first also means an unauthenticated caller can no longer consume a one-time code.
- `refresh_token`: call `validateClientCredentials` before the refresh-token lookup; keep the `requestedScopes ?? scopes` check via `validateClientScopes` at the original position.
- `device_code`: hoist `provider.authenticateClient({ requireCredentials: false })` above `redeemDeviceCode` and reuse the result inside `authorizeRedemption`.

The response for a known, authenticated client presenting a bad grant is unchanged (`invalid_grant`). The docs' token-endpoint error taxonomy notes the ordering.

## Tests

- New regression tests in `packages/oauth-provider/src/token.test.ts`: an unknown `client_id` with `grant_type=authorization_code` returns `400 invalid_client`; an unknown client using Basic auth with `grant_type=refresh_token` returns `401 invalid_client` with `WWW-Authenticate: Basic`.
- The existing "rejects refresh token use by a different client" test registered its second client without `token_endpoint_auth_method` (defaulting to `client_secret_basic`) while sending the secret in the body, so that client could never authenticate; it now registers as `client_secret_post` so the test exercises a valid different client and still asserts `invalid_grant`.
- `pnpm vitest run` in `packages/oauth-provider`: 40 files, 929 tests passed. `pnpm typecheck` passes.

Closes #11035