### PR TITLE
fix(react): return the pending session as the server snapshot during hydration

### DIFF
--- a/.changeset/react-server-snapshot.md
+++ b/.changeset/react-server-snapshot.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Return the pending session as the React server snapshot during hydration so `useSession` no longer causes hydration mismatches when the session resolves before a subtree hydrates.

--- a/packages/better-auth/src/client/react/index.ts
+++ b/packages/better-auth/src/client/react/index.ts
@@ -92,7 +92,14 @@ export function createAuthClient<Option extends BetterAuthClientOptions>(
 	} = getClientConfig(options);
 	const resolvedHooks: Record<string, any> = {};
 	for (const [key, value] of Object.entries(pluginsAtoms)) {
-		resolvedHooks[getAtomKey(key)] = () => useStore(value);
+		// Nothing mounts an atom during SSR, so the server rendered its initial
+		// value. Hand React that same value while hydrating; the live value may
+		// already have resolved. Computed stores have no `init` and keep the
+		// live value.
+		const getServerSnapshot =
+			value.init === undefined ? undefined : () => value.init;
+		resolvedHooks[getAtomKey(key)] = () =>
+			useStore(value, { getServerSnapshot });
 	}
 
 	const routes = {

--- a/packages/better-auth/src/client/react/react-store.test.ts
+++ b/packages/better-auth/src/client/react/react-store.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { act, createElement } from "react";
+import type { Root } from "react-dom/client";
+import { hydrateRoot } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, expect, it, vi } from "vitest";
+import { createAuthClient } from "./index";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10972
+ */
+it("hydrates useSession with the pending state the server rendered", async () => {
+	vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+	const client = createAuthClient({
+		baseURL: "http://localhost:3000",
+		fetchOptions: {
+			customFetchImpl: () => new Promise<Response>(() => {}),
+		},
+	});
+	const rendered: boolean[] = [];
+	const SaveButton = () => {
+		const { isPending } = client.useSession();
+		rendered.push(isPending);
+		return createElement(
+			"button",
+			{ "aria-disabled": isPending },
+			isPending ? "loading" : "save",
+		);
+	};
+
+	const html = renderToString(createElement(SaveButton));
+	expect(html).toContain('aria-disabled="true"');
+
+	// A subscriber higher in the tree already resolved the session before this
+	// subtree hydrates.
+	const now = new Date();
+	client.hydrateSession({
+		user: {
+			id: "user-id",
+			name: "Test User",
+			email: "test@example.com",
+			emailVerified: true,
+			createdAt: now,
+			updatedAt: now,
+		},
+		session: {
+			id: "session-id",
+			userId: "user-id",
+			token: "token",
+			expiresAt: now,
+			createdAt: now,
+			updatedAt: now,
+		},
+	});
+	expect(client.$store.atoms.session!.get().isPending).toBe(false);
+
+	const container = document.createElement("div");
+	container.innerHTML = html;
+	const onRecoverableError = vi.fn();
+	const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+	rendered.length = 0;
+	let root: Root | undefined;
+	await act(async () => {
+		root = hydrateRoot(container, createElement(SaveButton), {
+			onRecoverableError,
+		});
+	});
+
+	expect(onRecoverableError).not.toHaveBeenCalled();
+	expect(consoleError).not.toHaveBeenCalled();
+	// The hydration render matches the server, then the live value lands.
+	expect(rendered[0]).toBe(true);
+	const button = container.querySelector("button");
+	expect(button?.getAttribute("aria-disabled")).toBe("false");
+	expect(button?.textContent).toBe("save");
+
+	await act(async () => root?.unmount());
+});

--- a/packages/better-auth/src/client/react/react-store.ts
+++ b/packages/better-auth/src/client/react/react-store.ts
@@ -20,6 +20,13 @@ export interface UseStoreOptions<SomeStore> {
 	 * Will re-render components only on specific key changes.
 	 */
 	keys?: StoreKeys<SomeStore>[] | undefined;
+
+	/**
+	 * Returns the value rendered on the server and during hydration. It must
+	 * return the same stable reference in both places, otherwise React reports
+	 * a hydration mismatch. Defaults to the live store value.
+	 */
+	getServerSnapshot?: (() => StoreValue<SomeStore>) | undefined;
 }
 
 /**
@@ -51,7 +58,7 @@ export function useStore<SomeStore extends Store>(
 ): StoreValue<SomeStore> {
 	const snapshotRef = useRef<StoreValue<SomeStore>>(store.get());
 
-	const { keys, deps = [store, keys] } = options;
+	const { keys, deps = [store, keys], getServerSnapshot } = options;
 
 	const subscribe = useCallback((onChange: () => void) => {
 		const emitChange = (value: StoreValue<SomeStore>) => {
@@ -69,5 +76,5 @@ export function useStore<SomeStore extends Store>(
 
 	const get = () => snapshotRef.current as StoreValue<SomeStore>;
 
-	return useSyncExternalStore(subscribe, get, get);
+	return useSyncExternalStore(subscribe, get, getServerSnapshot ?? get);
 }


### PR DESCRIPTION
## Summary

Client components that server-render on `authClient.useSession()` (or any other React atom hook) could hydrate against different markup than the server produced, logging a React hydration mismatch. The failure was intermittent because it depended on whether the session store resolved before that particular subtree hydrated.

## Root cause

`useStore` in `packages/better-auth/src/client/react/react-store.ts` passed its live `getSnapshot` as the third argument to `useSyncExternalStore`, which is `getServerSnapshot`. React calls `getServerSnapshot` on the server and again during client hydration and expects both to return the same value. The server rendered the atom's initial pending state, but by the time a lower subtree hydrated, a subscriber higher in the tree (or `hydrateSession`) could already have resolved the store, so the live getter returned `isPending: false` against server markup rendered with `isPending: true`.

## Fix

- `useStore` accepts an optional `getServerSnapshot` and passes it to `useSyncExternalStore`, falling back to the live getter as before.
- `createAuthClient` in `packages/better-auth/src/client/react/index.ts` passes the atom's `init` (nanostores' stable initial-value reference) for every generated hook. Nothing mounts an atom during SSR, so `init` is exactly what the server rendered. Computed stores have no `init` and keep the previous behavior.

Hydration now renders the initial state and React re-renders with the live value immediately after commit. Client-only rendering is unaffected since React never calls `getServerSnapshot` outside SSR and hydration. `init` is read instead of `get()` because `get()` on an unmounted nanostores atom mounts it and would start the session fetch at client creation.

## Tests

- `packages/better-auth/src/client/react/react-store.test.ts`: renders `useSession` with `renderToString`, resolves the store via `hydrateSession`, hydrates with `hydrateRoot`, and asserts no recoverable error or console error, that the hydration render used the pending state, and that the DOM then reflects the live value. Fails on `main` with the exact `aria-disabled` and text mismatch from the issue.
- `pnpm vitest run src/client` in `packages/better-auth`: 10 files, 119 tests passed.
- `pnpm typecheck` passes.

Closes #10972