### PR TITLE
docs: make header dropdown menus keyboard accessible

### DIFF
--- a/docs/components/landing/staggered-nav-files.tsx
+++ b/docs/components/landing/staggered-nav-files.tsx
@@ -320,6 +320,18 @@ const mobileMenuSections: MobileMenuSection[] = [
 	{ name: "enterprise", href: "/enterprise" },
 ];
 
+function closeOnBlurOutside(close: () => void) {
+	return (event: React.FocusEvent<HTMLElement>) => {
+		if (!event.currentTarget.contains(event.relatedTarget)) close();
+	};
+}
+
+function closeOnEscape(close: () => void) {
+	return (event: React.KeyboardEvent<HTMLElement>) => {
+		if (event.key === "Escape") close();
+	};
+}
+
 export function StaggeredNavFiles() {
 	const pathname = usePathname() || "/";
 	const mobileNavigationView = useMobileNavigationView();
@@ -579,9 +591,14 @@ export function StaggeredNavFiles() {
 						className="relative flex-1"
 						onMouseEnter={openProducts}
 						onMouseLeave={closeProducts}
+						onFocus={openProducts}
+						onBlur={closeOnBlurOutside(() => setProductsOpen(false))}
+						onKeyDown={closeOnEscape(() => setProductsOpen(false))}
 					>
-						<div
-							className={`group/tab flex items-center justify-center gap-1.5 px-2 xl:px-4 py-3 h-full cursor-pointer border-r ${tabDividerClass} transition-colors duration-150 ${
+						<button
+							type="button"
+							aria-expanded={productsOpen}
+							className={`group/tab flex w-full items-center justify-center gap-1.5 px-2 xl:px-4 py-3 h-full cursor-pointer border-r ${tabDividerClass} transition-colors duration-150 ${
 								isProductsPage
 									? `bg-background border-b-2 ${activeTabBorderClass}`
 									: productsOpen
@@ -606,6 +623,7 @@ export function StaggeredNavFiles() {
 								}`}
 								viewBox="0 0 10 6"
 								fill="none"
+								aria-hidden="true"
 							>
 								<path
 									d="M1 1L5 5L9 1"
@@ -613,7 +631,7 @@ export function StaggeredNavFiles() {
 									strokeWidth="1.2"
 								/>
 							</svg>
-						</div>
+						</button>
 
 						<AnimatePresence>
 							{productsOpen && (
@@ -703,9 +721,14 @@ export function StaggeredNavFiles() {
 						className="relative flex-1"
 						onMouseEnter={openResources}
 						onMouseLeave={closeResources}
+						onFocus={openResources}
+						onBlur={closeOnBlurOutside(() => setResourcesOpen(false))}
+						onKeyDown={closeOnEscape(() => setResourcesOpen(false))}
 					>
-						<div
-							className={`group/tab flex items-center justify-center gap-1.5 px-2 xl:px-4 py-3 h-full cursor-pointer transition-colors duration-150 ${
+						<button
+							type="button"
+							aria-expanded={resourcesOpen}
+							className={`group/tab flex w-full items-center justify-center gap-1.5 px-2 xl:px-4 py-3 h-full cursor-pointer transition-colors duration-150 ${
 								isResourcePage
 									? `bg-background border-b-2 ${activeTabBorderClass}`
 									: resourcesOpen
@@ -730,6 +753,7 @@ export function StaggeredNavFiles() {
 								}`}
 								viewBox="0 0 10 6"
 								fill="none"
+								aria-hidden="true"
 							>
 								<path
 									d="M1 1L5 5L9 1"
@@ -737,7 +761,7 @@ export function StaggeredNavFiles() {
 									strokeWidth="1.2"
 								/>
 							</svg>
-						</div>
+						</button>
 
 						<AnimatePresence>
 							{resourcesOpen && (

--- a/docs/components/landing/staggered-nav-files.tsx
+++ b/docs/components/landing/staggered-nav-files.tsx
@@ -326,9 +326,16 @@ function closeOnBlurOutside(close: () => void) {
 	};
 }
 
-function closeOnEscape(close: () => void) {
+function dismissOnEscape(
+	close: () => void,
+	triggerRef: React.RefObject<HTMLButtonElement | null>,
+) {
 	return (event: React.KeyboardEvent<HTMLElement>) => {
-		if (event.key === "Escape") close();
+		if (event.key !== "Escape") return;
+
+		event.preventDefault();
+		triggerRef.current?.focus();
+		close();
 	};
 }
 
@@ -339,6 +346,8 @@ export function StaggeredNavFiles() {
 	const [productsOpen, setProductsOpen] = useState(false);
 	const resourcesTimeout = useRef<NodeJS.Timeout>(undefined);
 	const productsTimeout = useRef<NodeJS.Timeout>(undefined);
+	const resourcesTriggerRef = useRef<HTMLButtonElement>(null);
+	const productsTriggerRef = useRef<HTMLButtonElement>(null);
 
 	useEffect(() => {
 		document.body.style.overflow =
@@ -593,11 +602,16 @@ export function StaggeredNavFiles() {
 						onMouseLeave={closeProducts}
 						onFocus={openProducts}
 						onBlur={closeOnBlurOutside(() => setProductsOpen(false))}
-						onKeyDown={closeOnEscape(() => setProductsOpen(false))}
+						onKeyDown={dismissOnEscape(
+							() => setProductsOpen(false),
+							productsTriggerRef,
+						)}
 					>
 						<button
+							ref={productsTriggerRef}
 							type="button"
 							aria-expanded={productsOpen}
+							onClick={() => setProductsOpen((open) => !open)}
 							className={`group/tab flex w-full items-center justify-center gap-1.5 px-2 xl:px-4 py-3 h-full cursor-pointer border-r ${tabDividerClass} transition-colors duration-150 ${
 								isProductsPage
 									? `bg-background border-b-2 ${activeTabBorderClass}`
@@ -723,11 +737,16 @@ export function StaggeredNavFiles() {
 						onMouseLeave={closeResources}
 						onFocus={openResources}
 						onBlur={closeOnBlurOutside(() => setResourcesOpen(false))}
-						onKeyDown={closeOnEscape(() => setResourcesOpen(false))}
+						onKeyDown={dismissOnEscape(
+							() => setResourcesOpen(false),
+							resourcesTriggerRef,
+						)}
 					>
 						<button
+							ref={resourcesTriggerRef}
 							type="button"
 							aria-expanded={resourcesOpen}
+							onClick={() => setResourcesOpen((open) => !open)}
 							className={`group/tab flex w-full items-center justify-center gap-1.5 px-2 xl:px-4 py-3 h-full cursor-pointer transition-colors duration-150 ${
 								isResourcePage
 									? `bg-background border-b-2 ${activeTabBorderClass}`


### PR DESCRIPTION
As a keybord  user I noticed the header isn't accessible through keybord controls, so i fixed it.

The `products` and `resources` header tabs were hover-only `div`s, so keyboard users skipped both dropdowns.

Triggers are now `<button>`s with `aria-expanded`. The menu opens on focus, closes on Escape or when focus leaves the tab, and Tab moves through the links inside. 

https://github.com/user-attachments/assets/62fee45d-d62b-4c32-84d8-5ccd30898224

