### PR TITLE
docs: fix foreign-key column type mismatch and index for MySQL snippets

### DIFF
--- a/docs/lib/copy-schema/adapter/drizzle.ts
+++ b/docs/lib/copy-schema/adapter/drizzle.ts
@@ -112,9 +112,10 @@ export const drizzleResolver = (options: DrizzleResolverOptions): Resolver => {
 				table.push(`\t${field.fieldName}: ${value},`);
 			}
 
-			const indexes = filterNonUniqueIndexes(ctx.schema).filter(
-				(field) => !field.references,
-			);
+			const indexes = filterNonUniqueIndexes(ctx.schema).filter((field) => {
+				if (provider === "mysql") return !field.references;
+				return true;
+			});
 			if (indexes.length > 0) {
 				table.push("}, (table) => [");
 				for (const field of indexes) {

--- a/docs/lib/copy-schema/adapter/drizzle.ts
+++ b/docs/lib/copy-schema/adapter/drizzle.ts
@@ -82,7 +82,9 @@ export const drizzleResolver = (options: DrizzleResolverOptions): Resolver => {
 							: `t.text("${fieldName}").primaryKey()`,
 					foreignKeyId: ctx.useNumberId
 						? `t.integer("${fieldName}")`
-						: `t.text("${fieldName}")`,
+						: provider === "mysql"
+							? `t.varchar("${fieldName}", { length: 36 })`
+							: `t.text("${fieldName}")`,
 					"number[]": `${number}.array()`,
 					"string[]": `t.text("${fieldName}").array()`,
 				};

--- a/docs/lib/copy-schema/adapter/drizzle.ts
+++ b/docs/lib/copy-schema/adapter/drizzle.ts
@@ -112,7 +112,9 @@ export const drizzleResolver = (options: DrizzleResolverOptions): Resolver => {
 				table.push(`\t${field.fieldName}: ${value},`);
 			}
 
-			const indexes = filterNonUniqueIndexes(ctx.schema);
+			const indexes = filterNonUniqueIndexes(ctx.schema).filter(
+				(field) => !field.references,
+			);
 			if (indexes.length > 0) {
 				table.push("}, (table) => [");
 				for (const field of indexes) {

--- a/docs/lib/copy-schema/dialects/mysql.ts
+++ b/docs/lib/copy-schema/dialects/mysql.ts
@@ -82,7 +82,7 @@ export const mysqlResolver = {
 			date: "timestamp(3)",
 			json: "json",
 			id: ctx.useNumberId ? "integer" : "varchar(36)",
-			foreignKeyId: ctx.useNumberId ? "integer" : "text",
+			foreignKeyId: ctx.useNumberId ? "integer" : "varchar(36)",
 		}));
 
 		const lines = [
@@ -115,6 +115,7 @@ export const mysqlResolver = {
 			lines.push(`);`);
 		}
 		for (const field of filterNonUniqueIndexes(ctx.schema)) {
+			if (field.references) continue;
 			lines.push(formatIndex(field, ctx.schema.modelName));
 		}
 		return lines.join("\n");

--- a/docs/lib/copy-schema/index.test.ts
+++ b/docs/lib/copy-schema/index.test.ts
@@ -81,3 +81,78 @@ describe("copySchema indexes", () => {
 		);
 	});
 });
+
+/**
+ * Foreign-key columns must use the same SQL type as the column they reference,
+ * otherwise MySQL/MSSQL reject the FK constraint (e.g. text cannot reference varchar).
+ */
+describe("copySchema foreign-key column types", () => {
+	const sessionSchema = {
+		modelName: "session",
+		fields: [
+			{ fieldName: "id", type: "string", required: true },
+			{
+				fieldName: "userId",
+				type: "string",
+				required: true,
+				index: true,
+				references: { model: "user", field: "id", onDelete: "cascade" },
+			},
+		],
+	} satisfies DBSchema;
+
+	it("matches the id column type for foreign keys in MySQL", () => {
+		const mysql = copySchema(sessionSchema, {
+			dialect: "mysql",
+			mode: "create",
+		}).result;
+
+		expect(mysql).toContain("`id` varchar(36)");
+		expect(mysql).toContain("`userId` varchar(36)");
+		expect(mysql).not.toContain("`userId` text");
+	});
+
+	it("matches the id column type for foreign keys in MSSQL", () => {
+		const mssql = copySchema(sessionSchema, {
+			dialect: "mssql",
+			mode: "create",
+		}).result;
+
+		expect(mssql).toContain("[id] varchar(36)");
+		expect(mssql).toContain("[userId] varchar(36)");
+	});
+
+	it("matches the id column type for foreign keys in PostgreSQL", () => {
+		const postgresql = copySchema(sessionSchema, {
+			dialect: "postgresql",
+			mode: "create",
+		}).result;
+
+		expect(postgresql).toContain('"id" text');
+		expect(postgresql).toContain('"userId" text');
+	});
+
+	it("matches the id column type for foreign keys in Drizzle (MySQL)", () => {
+		const drizzleMysql = copySchema(sessionSchema, {
+			dialect: drizzleResolver({ provider: "mysql" }),
+			mode: "create",
+		}).result;
+
+		expect(drizzleMysql).toContain(
+			't.varchar("id", { length: 36 }).primaryKey()',
+		);
+		expect(drizzleMysql).toContain('t.varchar("user_id", { length: 36 })');
+		expect(drizzleMysql).not.toContain('t.text("user_id")');
+	});
+
+	it("keeps foreign keys as text in Drizzle (pg, sqlite)", () => {
+		for (const provider of ["pg", "sqlite"] as const) {
+			const result = copySchema(sessionSchema, {
+				dialect: drizzleResolver({ provider }),
+				mode: "create",
+			}).result;
+
+			expect(result).toContain('t.text("user_id")');
+		}
+	});
+});


### PR DESCRIPTION

In [Database Core Schema](https://better-auth.com/docs/concepts/database#core-schema) the suggested MySQL is producing errors. Specifically:

- The `userId` foreign key of `session` & `account` tables does not match the `varchar(36)` type of their reference in the `user` table. 
- The `session` & `account` table attempt to create an index on the `userId` foreign key. Firstly, it assumes that the field is larger than it actually is (`CREATE INDEX session_userId_idx ON session (userId(191))`). Secondly, it is unnecessary as foreign keys are automatically indexed in MySQL.

This PR aligns the types the foreign key type for MySQL (both in the SQL and Drizzle tabs) and skips re-indexing foreign keys.

**BEFORE**:
<img width="1454" height="885" alt="image" src="https://github.com/user-attachments/assets/892f92fa-b519-4401-b080-4b468c1b874b" />

**AFTER**:
<img width="1460" height="778" alt="image" src="https://github.com/user-attachments/assets/268f37c1-c80b-488d-bd46-a8b0378fce9a" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MySQL schema snippets in the Database Core Schema docs so foreign-key columns match the type of the column they reference. `userId` columns in `session` and `account` are now `varchar(36)` instead of `text` in both the SQL and Drizzle tabs, snippet generation skips redundant indexes on foreign keys since MySQL auto-indexes them, and tests cover column types for MySQL, MSSQL, PostgreSQL, and Drizzle providers.

<sup>Written for commit 82be576dbacda9bb97b849f2e33f4fb42379fd30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

