### PR TITLE
fix(generic-oauth): harden Auth0 domain normalization

### DIFF
--- a/.changeset/fix-auth0-domain-normalization.md
+++ b/.changeset/fix-auth0-domain-normalization.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Normalize Auth0 domains without a potentially slow trailing-slash regular expression.

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -2869,23 +2869,15 @@ describe("oauth2", async () => {
 			expect(auth0Config.getUserInfo).toBeUndefined();
 		});
 
-		it("should handle domain with protocol prefix", () => {
+		it.each([
+			["HTTP URL", "http://dev-xxx.eu.auth0.com"],
+			["HTTPS URL", "https://dev-xxx.eu.auth0.com"],
+			["trailing slashes", "https://dev-xxx.eu.auth0.com///"],
+		])("normalizes an Auth0 domain supplied as %s", (_case, domain) => {
 			const auth0Config = auth0({
 				clientId: "auth0-client-id",
 				clientSecret: "auth0-client-secret",
-				domain: "https://dev-xxx.eu.auth0.com",
-			});
-
-			expect(auth0Config.discoveryUrl).toBe(
-				"https://dev-xxx.eu.auth0.com/.well-known/openid-configuration",
-			);
-		});
-
-		it("normalizes a trailing slash in the domain", () => {
-			const auth0Config = auth0({
-				clientId: "auth0-client-id",
-				clientSecret: "auth0-client-secret",
-				domain: "https://dev-xxx.eu.auth0.com/",
+				domain,
 			});
 
 			expect(auth0Config.discoveryUrl).toBe(

--- a/packages/better-auth/src/plugins/generic-oauth/providers/auth0.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/providers/auth0.ts
@@ -33,8 +33,12 @@ export interface Auth0Options extends BaseOAuthProviderOptions {
 export function auth0(options: Auth0Options): GenericOAuthConfig<"auth0"> {
 	const defaultScopes = ["openid", "profile", "email"];
 
-	// Ensure domain doesn't have protocol prefix
-	const domain = options.domain.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+	const domainUrl =
+		options.domain.startsWith("http://") ||
+		options.domain.startsWith("https://")
+			? options.domain
+			: `https://${options.domain}`;
+	const domain = new URL(domainUrl).host;
 	const discoveryUrl = `https://${domain}/.well-known/openid-configuration`;
 
 	return {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens Auth0 domain normalization in the generic-oauth plugin so discovery URLs are built reliably across more input formats. The old regex-based cleanup is replaced with `URL` parsing, which now handles domains without a protocol, HTTP URLs, and multiple trailing slashes consistently; the resulting domain host is used to build the discovery URL as before.

<sup>Written for commit 395ee4343dcac415898a7045214a225e5e7ea0af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

