### PR TITLE
fix(core): restore optional atomic adapter methods

### DIFF
--- a/.changeset/restore-custom-adapter-atomic-fallbacks.md
+++ b/.changeset/restore-custom-adapter-atomic-fallbacks.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/core": patch
+---
+
+Make `consumeOne` and `incrementOne` optional again for custom database adapters. Adapters without native implementations use conditional deletes and compare-and-swap updates, including guards for null counters and mapped IDs. Invalid affected-row counts, unsupported snapshots, and exhausted increment retries raise errors rather than report success.
+
+Fallbacks require atomic conditional writes and accurate affected-row counts. Built-in adapters continue using native operations. Custom secondary storage and rate-limit storage requirements are unchanged.

--- a/.changeset/restore-custom-adapter-atomic-fallbacks.md
+++ b/.changeset/restore-custom-adapter-atomic-fallbacks.md
@@ -2,6 +2,4 @@
 "@better-auth/core": patch
 ---
 
-Make `consumeOne` and `incrementOne` optional again for custom database adapters. Adapters without native implementations use conditional deletes and compare-and-swap updates, including guards for null counters and mapped IDs. Invalid affected-row counts, unsupported snapshots, and exhausted increment retries raise errors rather than report success.
-
-Fallbacks require atomic conditional writes and accurate affected-row counts. Built-in adapters continue using native operations. Custom secondary storage and rate-limit storage requirements are unchanged.
+Make `consumeOne` and `incrementOne` optional again for custom database adapters, using guarded fallbacks when native methods are absent. Fallbacks require atomic conditional writes and accurate affected-row counts. Fallback increments can fail when contention exhausts their retries.

--- a/docs/content/docs/guides/1-7-upgrade-guide.mdx
+++ b/docs/content/docs/guides/1-7-upgrade-guide.mdx
@@ -622,13 +622,13 @@ Two OAuth-provider behaviors read the incoming request origin. Behind a custom s
 
 ## Custom adapters and storage
 
-The atomic-state work introduces required methods. If you use only the built-in adapters and storage, you can skip this.
+The atomic-state work changes custom adapter and storage contracts. If you use only the built-in adapters and storage, you can skip this.
 
-### Database adapters must implement `incrementOne` and `consumeOne`
+### Database adapter atomic methods are optional again
 
-`incrementOne` updates one row's counter atomically and returns the row, or null when the guard did not match. `consumeOne` reads and deletes a row in one step for single-use credentials. Both are now required, and the old fallback is gone.
+1.7.0 through 1.7.2 required custom database adapters to implement `incrementOne` and `consumeOne`. They are optional again. Built-in adapters continue using their native implementations.
 
-**What to do:** implement both `incrementOne` and `consumeOne` in any custom adapter. A missing `consumeOne` throws at runtime. All built-in adapters already do.
+**What to do:** ensure your adapter provides atomic conditional writes and accurate affected-row counts. The factory fallbacks check the stored values before writing and reject unsafe snapshots or exhausted retries. See the [adapter guide](/docs/guides/create-a-db-adapter#consumeone-method) for the complete fallback requirements.
 
 ### Secondary storage must implement `increment` and `getAndDelete`
 

--- a/docs/content/docs/guides/create-a-db-adapter.mdx
+++ b/docs/content/docs/guides/create-a-db-adapter.mdx
@@ -272,7 +272,7 @@ consumeOne: async ({ model, where }) => {
 ```
 
 <Callout type="warn">
-  `consumeOne` is required. Better Auth does not provide a `findMany` plus `deleteMany` fallback because that shape cannot guarantee single-use semantics across adapters without a native atomic delete-and-return operation.
+  `consumeOne` is optional. Without it, Better Auth reads a candidate and conditionally deletes it only if its ID and stored values still match. It returns the candidate only when exactly one row was deleted.
 </Callout>
 
 ### `incrementOne` method
@@ -303,8 +303,12 @@ incrementOne: async ({ model, where, increment, set }) => {
 ```
 
 <Callout type="warn">
-  `incrementOne` is required. Better Auth uses it as a compare-and-swap primitive: the `where` clause is part of the guard, so concurrent requests cannot all update a stale snapshot.
+  `incrementOne` is optional. Without it, Better Auth reads a candidate and updates it only if its stored values still match. It retries a lost race up to five attempts, then throws on contention instead of silently dropping the increment. Null or absent counters start at zero and remain part of the write condition. An `undefined` value in `set` leaves the field unchanged, while `null` explicitly clears it.
 </Callout>
+
+Both fallbacks require `findOne` to return a complete, detached snapshot of the stored row with its mapped ID. `deleteMany` and `updateMany` must check all conditions and perform each row mutation atomically, with accurate numeric affected-row counts. Equality against `null` must also match an absent nullable field. Splitting the condition check and mutation into separate operations is not safe, even inside an application-level lock.
+
+Fallbacks validate and compare scalar values (strings, finite numbers, booleans, dates, and null). Implement the native methods for rows or assignments containing structured values, or for adapter-specific ID objects. Native methods are also preferable under contention or when database triggers change the returned values. The increment fallback returns the values it wrote without a second read that could observe another caller's update.
 
 ### `findOne` method
 

--- a/docs/content/docs/guides/create-a-db-adapter.mdx
+++ b/docs/content/docs/guides/create-a-db-adapter.mdx
@@ -272,7 +272,7 @@ consumeOne: async ({ model, where }) => {
 ```
 
 <Callout type="warn">
-  `consumeOne` is optional. Without it, Better Auth reads a candidate and conditionally deletes it only if its ID, original AND conditions, and comparable stored values still match. It returns the candidate only when exactly one row was deleted.
+  `consumeOne` is optional. Without it, Better Auth uses a conditional delete and returns the record only when exactly one row was deleted.
 </Callout>
 
 ### `incrementOne` method
@@ -284,7 +284,7 @@ parameters:
 * `model`: The model/table name to update.
 * `where`: The `where` clause that must still match for the increment to apply.
 * `increment`: Numeric deltas to apply, such as `{ count: 1 }` or `{ remaining: -1 }`.
-* `set`: Optional fields to set in the same atomic operation.
+* `set`: Optional fields to set in the same atomic operation. `undefined` leaves a field unchanged, while `null` clears it.
 
 **Returns** `Promise<T | null>`: the updated record, or `null` if no row matched. Implementations must update at most one matching row.
 
@@ -303,12 +303,12 @@ incrementOne: async ({ model, where, increment, set }) => {
 ```
 
 <Callout type="warn">
-  `incrementOne` is optional. Without it, Better Auth reads a candidate and updates it only if its stored values still match. It retries a lost race up to five attempts, then throws on contention instead of silently dropping the increment. Null or absent counters start at zero and remain part of the write condition. An `undefined` value in `set` leaves the field unchanged, while `null` explicitly clears it.
+  `incrementOne` is optional. Without it, Better Auth uses conditional updates with bounded retries. If retries are exhausted, the operation throws and the increment is not recorded. Use native increments for heavily contended counters and security controls such as failed-attempt limits.
 </Callout>
 
-Both fallbacks require `findOne` to return a complete, detached snapshot of the stored row with its mapped ID. `deleteMany` and `updateMany` must check all conditions and perform each row mutation atomically, with accurate numeric affected-row counts. Equality against `null` must also match an absent nullable field. Splitting the condition check and mutation into separate operations is not safe, even inside an application-level lock.
+Fallbacks reuse your adapter's CRUD methods. They need complete, stable row snapshots with mapped IDs, atomic conditional writes, and exact affected-row counts. Null comparisons must also match absent nullable fields.
 
-Fallbacks preserve returned objects and arrays and compare scalar values (strings, finite numbers, booleans, dates, and null). Object IDs use the adapter's existing ID input and output transformations. OR predicates on structured values still require native methods because the fallback cannot safely reconstruct their comparisons. Native methods are also preferable under contention or when database triggers change the returned values. The increment fallback returns the values it wrote without a second read that could observe another caller's update.
+Fallback counters must be finite numbers, with null or missing values starting at zero. Use native methods for `bigint` counters, OR predicates on structured values, or trigger-generated return values. Fields not updated by the increment fallback reflect the initial read.
 
 ### `findOne` method
 

--- a/docs/content/docs/guides/create-a-db-adapter.mdx
+++ b/docs/content/docs/guides/create-a-db-adapter.mdx
@@ -272,7 +272,7 @@ consumeOne: async ({ model, where }) => {
 ```
 
 <Callout type="warn">
-  `consumeOne` is optional. Without it, Better Auth reads a candidate and conditionally deletes it only if its ID and stored values still match. It returns the candidate only when exactly one row was deleted.
+  `consumeOne` is optional. Without it, Better Auth reads a candidate and conditionally deletes it only if its ID, original AND conditions, and comparable stored values still match. It returns the candidate only when exactly one row was deleted.
 </Callout>
 
 ### `incrementOne` method
@@ -308,7 +308,7 @@ incrementOne: async ({ model, where, increment, set }) => {
 
 Both fallbacks require `findOne` to return a complete, detached snapshot of the stored row with its mapped ID. `deleteMany` and `updateMany` must check all conditions and perform each row mutation atomically, with accurate numeric affected-row counts. Equality against `null` must also match an absent nullable field. Splitting the condition check and mutation into separate operations is not safe, even inside an application-level lock.
 
-Fallbacks validate and compare scalar values (strings, finite numbers, booleans, dates, and null). Implement the native methods for rows or assignments containing structured values, or for adapter-specific ID objects. Native methods are also preferable under contention or when database triggers change the returned values. The increment fallback returns the values it wrote without a second read that could observe another caller's update.
+Fallbacks preserve returned objects and arrays and compare scalar values (strings, finite numbers, booleans, dates, and null). Object IDs use the adapter's existing ID input and output transformations. OR predicates on structured values still require native methods because the fallback cannot safely reconstruct their comparisons. Native methods are also preferable under contention or when database triggers change the returned values. The increment fallback returns the values it wrote without a second read that could observe another caller's update.
 
 ### `findOne` method
 

--- a/packages/better-auth/src/plugins/two-factor/two-factor.account-lockout.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.account-lockout.test.ts
@@ -1,7 +1,12 @@
-import type { GenericEndpointContext } from "@better-auth/core";
+import type {
+	BetterAuthOptions,
+	GenericEndpointContext,
+} from "@better-auth/core";
 import type { DBAdapter } from "@better-auth/core/db/adapter";
+import { createAdapterFactory } from "@better-auth/core/db/adapter";
 import { createOTP } from "@better-auth/utils/otp";
 import { describe, expect, it } from "vitest";
+import { memoryAdapter } from "../../adapters/memory-adapter";
 import { symmetricDecrypt } from "../../crypto";
 import { convertSetCookieToCookie } from "../../test-utils/headers";
 import { getTestInstance } from "../../test-utils/test-instance";
@@ -18,11 +23,71 @@ import { recordTwoFactorFailure } from "./verify-two-factor";
  * successful verification.
  */
 
-async function setup(accountLockout?: TwoFactorOptions["accountLockout"]) {
+function createDbWithoutAtomicMethods() {
+	const database = memoryAdapter({
+		user: [],
+		session: [],
+		account: [],
+		verification: [],
+		twoFactor: [],
+	});
+	return (options: BetterAuthOptions) => {
+		const native = database(options);
+		return createAdapterFactory({
+			config: { adapterId: "legacy-memory" },
+			adapter: () => ({
+				create: ({ model, data }) =>
+					native.create({ model, data, forceAllowId: true }),
+				findOne: ({ model, where, select }) =>
+					native.findOne({ model, where, select }),
+				findMany: async <T>({
+					model,
+					where,
+					limit,
+					offset,
+					sortBy,
+					select,
+				}: Parameters<DBAdapter["findMany"]>[0]) =>
+					(await native.findMany({
+						model,
+						where,
+						limit,
+						offset,
+						sortBy,
+						select,
+					})) as T[],
+				update: ({ model, where, update }) =>
+					native.update({
+						model,
+						where,
+						update: update as Record<string, unknown>,
+					}),
+				updateMany: native.updateMany,
+				delete: native.delete,
+				deleteMany: native.deleteMany,
+				count: native.count,
+			}),
+		})(options);
+	};
+}
+
+async function setup(
+	accountLockout?: TwoFactorOptions["accountLockout"],
+	database?: BetterAuthOptions["database"],
+) {
+	let otp = "";
 	const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
 		secret: DEFAULT_SECRET,
+		...(database ? { database } : {}),
 		plugins: [
-			twoFactor({ accountLockout, otpOptions: { sendOTP: async () => {} } }),
+			twoFactor({
+				accountLockout,
+				otpOptions: {
+					sendOTP: async (data) => {
+						otp = data.otp;
+					},
+				},
+			}),
 		],
 	});
 	const { headers } = await signInWithTestUser();
@@ -96,10 +161,72 @@ async function setup(accountLockout?: TwoFactorOptions["accountLockout"]) {
 		verifyBackup,
 		correctTotp,
 		failOtpOnce,
+		getOtp: () => otp,
 	};
 }
 
 describe("two-factor: account-level lockout across challenges", () => {
+	/** @see https://cwe.mitre.org/data/definitions/307.html */
+	it("enforces account lockout through legacy adapter fallbacks", async () => {
+		const { startChallenge, verifyBackup, backupCodes } = await setup(
+			{ maxFailedAttempts: 3 },
+			createDbWithoutAtomicMethods(),
+		);
+		const challenges = await Promise.all(
+			Array.from({ length: 3 }, () => startChallenge()),
+		);
+		const failures = await Promise.all(
+			challenges.map((headers) => verifyBackup(headers, "0000-0000")),
+		);
+		expect(failures.map((response) => response.status)).toEqual([
+			401, 401, 401,
+		]);
+		expect(
+			(await verifyBackup(await startChallenge(), backupCodes[0]!)).status,
+		).toBe(429);
+	});
+	/** @see https://cwe.mitre.org/data/definitions/362.html */
+	it("consumes an email OTP once through legacy adapter fallbacks", async () => {
+		const { auth, startChallenge, getOtp } = await setup(
+			undefined,
+			createDbWithoutAtomicMethods(),
+		);
+		const headers = await startChallenge();
+		await auth.api.sendTwoFactorOTP({ body: {}, headers });
+		const code = getOtp();
+		expect(code).toMatch(/^\d{6}$/);
+		const responses = await Promise.all(
+			[0, 1].map(() =>
+				auth.api.verifyTwoFactorOTP({
+					body: { code },
+					headers,
+					asResponse: true,
+				}),
+			),
+		);
+		expect(
+			responses.filter((response) => response.status === 200),
+		).toHaveLength(1);
+		expect(
+			responses.filter(
+				(response) => response.status >= 400 && response.status < 500,
+			),
+		).toHaveLength(1);
+	});
+	/** @see https://cwe.mitre.org/data/definitions/362.html */
+	it("allows a backup code to be consumed once through legacy adapter fallbacks", async () => {
+		const { startChallenge, verifyBackup, backupCodes } = await setup(
+			undefined,
+			createDbWithoutAtomicMethods(),
+		);
+		const challenges = await Promise.all([startChallenge(), startChallenge()]);
+		const responses = await Promise.all(
+			challenges.map((headers) => verifyBackup(headers, backupCodes[0]!)),
+		);
+		expect(responses.map((response) => response.status).sort()).toEqual([
+			200, 409,
+		]);
+	});
 	it("locks the account after failures accumulate across separate challenges", async () => {
 		const { startChallenge, verifyTotp, correctTotp } = await setup({
 			maxFailedAttempts: 3,

--- a/packages/core/src/db/adapter/atomic-fallback.ts
+++ b/packages/core/src/db/adapter/atomic-fallback.ts
@@ -1,24 +1,21 @@
 import * as z from "zod";
 import { BetterAuthError } from "../../error";
-import type { CleanedWhere, CustomAdapter } from "./index";
+import type { CleanedWhere, CustomAdapter, Where } from "./index";
 
 const MAX_ATTEMPTS = 5;
 
 const scalar = z
 	.union([z.string(), z.number(), z.boolean(), z.date()])
 	.nullable();
-const rowSchema = z.record(z.string(), scalar.optional());
+const rowSchema = z.record(z.string(), z.unknown());
 const readSchema = rowSchema.nullable();
-const idSchema = z.union([z.string(), z.number()]);
-const setSchema = z
-	.record(z.string(), scalar.optional())
-	.transform((values) => {
-		const assignments: Record<string, z.output<typeof scalar>> = {};
-		for (const [field, value] of Object.entries(values)) {
-			if (value !== undefined) assignments[field] = value;
-		}
-		return assignments;
-	});
+const setSchema = z.record(z.string(), z.unknown()).transform((values) => {
+	const assignments: z.output<typeof rowSchema> = {};
+	for (const [field, value] of Object.entries(values)) {
+		if (value !== undefined) assignments[field] = value;
+	}
+	return assignments;
+});
 const mutationSchema = z.object({
 	increment: z.record(z.string(), z.number()),
 	set: setSchema.optional(),
@@ -27,139 +24,212 @@ const counterSchema = z.number().nullish();
 
 type StoredRow = z.output<typeof rowSchema>;
 
-type FallbackOptions = {
+type FallbackContext = {
 	adapter: CustomAdapter;
 	adapterId: string;
+	mapKeysTransformInput?: Record<string, string> | undefined;
+	mapKeysTransformOutput?: Record<string, string> | undefined;
+	getFieldName: (input: { model: string; field: string }) => string;
+	transformOutput: (
+		row: StoredRow,
+		model: string,
+		select: string[],
+		join: undefined,
+	) => Promise<{ id?: unknown } | null>;
+	transformWhereClause: (input: {
+		model: string;
+		where: Where[];
+		action: "consumeOne" | "incrementOne";
+	}) => CleanedWhere[];
+};
+
+type FallbackRequest = {
 	model: string;
-	idField: string;
+	logicalModel: string;
 	where: CleanedWhere[];
 };
 
-async function readRow({
-	adapter,
-	adapterId,
-	model,
-	where,
-	idField,
-}: FallbackOptions): Promise<StoredRow | null> {
-	const result = readSchema.safeParse(
-		await adapter.findOne<unknown>({ model, where }),
-	);
-	if (!result.success) {
-		throw new BetterAuthError(
-			`Adapter "${adapterId}" must return a scalar row snapshot or null. Implement native atomic methods for non-scalar values.`,
-		);
-	}
-	const row = result.data;
-	if (row === null) return null;
-	if (!idSchema.safeParse(row[idField]).success) {
-		throw new BetterAuthError(
-			`Adapter "${adapterId}" must return the row id for atomic fallbacks.`,
-		);
-	}
-	return row;
-}
-
-function snapshotGuard(
-	row: StoredRow,
-	fields: readonly string[],
-): CleanedWhere[] {
-	const keys = new Set([...Object.keys(row), ...fields]);
-	return Array.from(keys, (field) => ({
-		field,
-		value: row[field] ?? null,
-		operator: "eq",
-		connector: "AND",
-		mode: "sensitive",
-	}));
-}
-
-function changedOne(count: number, adapterId: string): boolean {
-	if (count !== 0 && count !== 1) {
-		throw new BetterAuthError(
-			`Adapter "${adapterId}" must return an affected row count of 0 or 1 from an atomic fallback.`,
-		);
-	}
-	return count === 1;
-}
-
-export async function consumeOneFallback(
-	options: FallbackOptions,
-): Promise<StoredRow | null> {
-	const { adapter, adapterId, model, where } = options;
-	const row = await readRow(options);
-	if (row === null) return null;
-	// Guard the selected snapshot with AND predicates, without widening an OR selector.
-	const guard = snapshotGuard(
-		row,
-		where.map(({ field }) => field),
-	);
-	const count = await adapter.deleteMany({ model, where: guard });
-	return changedOne(count, adapterId) ? row : null;
-}
-
-export async function incrementOneFallback(
-	options: FallbackOptions & {
-		increment: Record<string, number>;
-		set?: Record<string, unknown> | undefined;
-	},
-): Promise<StoredRow | null> {
-	const { adapter, adapterId, model, where } = options;
-	const mutation = mutationSchema.safeParse(options);
-	if (!mutation.success) {
-		throw new BetterAuthError(
-			`Adapter "${adapterId}" requires finite increments and scalar set values for the atomic fallback.`,
-		);
-	}
-	const { increment, set } = mutation.data;
-	const deltas = Object.entries(increment);
-	const fields = [
-		...where.map(({ field }) => field),
-		...Object.keys(increment),
-		...Object.keys(set ?? {}),
-	];
-	for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-		const row = await readRow(options);
-		if (row === null) return null;
-		const update: z.output<typeof setSchema> = { ...set };
-		for (const [field, delta] of deltas) {
-			const previous = counterSchema.safeParse(row[field]);
-			if (!previous.success) {
-				throw new BetterAuthError(
-					`Adapter "${adapterId}" must return finite numeric counter values or null for atomic increments.`,
-				);
-			}
-			const current = previous.data ?? 0;
-			const next = current + delta;
-			if (!Number.isFinite(next) || (delta !== 0 && next === current)) {
-				throw new BetterAuthError(
-					`Adapter "${adapterId}" cannot represent the requested counter increment safely.`,
-				);
-			}
-			update[field] = next;
+export function createAtomicFallbacks(context: FallbackContext) {
+	const { adapter, adapterId } = context;
+	const outputId =
+		Object.entries(context.mapKeysTransformOutput ?? {}).find(
+			([, field]) => field === "id",
+		)?.[0] ?? "id";
+	async function idWhere(
+		row: StoredRow,
+		model: string,
+		action: "consumeOne" | "incrementOne",
+	): Promise<CleanedWhere> {
+		const mappedId =
+			context.mapKeysTransformInput?.id ||
+			context.getFieldName({ model, field: "id" });
+		if (row[mappedId] === undefined || row[mappedId] === null) {
+			throw new BetterAuthError(
+				`Adapter "${context.adapterId}" must return the row id for atomic fallbacks.`,
+			);
 		}
-		// A no-op can finish at the read, including stores reporting changed rows.
-		if (
-			Object.entries(update).every(([field, value]) => {
-				const previous = row[field];
-				if (previous instanceof Date && value instanceof Date) {
-					return previous.getTime() === value.getTime();
-				}
-				return Object.is(previous, value);
-			})
-		)
-			return row;
-		const count = await adapter.updateMany({
+		const output = await context.transformOutput(
+			row,
 			model,
-			where: snapshotGuard(row, fields),
-			update,
-		});
-		if (changedOne(count, adapterId)) {
-			// A second read could observe another writer's result instead of ours.
-			return { ...row, ...update };
+			[outputId],
+			undefined,
+		);
+		const id = output?.id;
+		if (typeof id !== "string" && typeof id !== "number") {
+			throw new BetterAuthError(
+				`Adapter "${context.adapterId}" must expose a logical string or number id through its output transform.`,
+			);
 		}
+		const [condition] = context.transformWhereClause({
+			model,
+			where: [{ field: "id", value: id }],
+			action,
+		});
+		if (!condition)
+			throw new BetterAuthError(
+				"The atomic fallback id condition was transformed away.",
+			);
+		return condition;
 	}
-	throw new BetterAuthError(
-		`Adapter "${adapterId}" could not complete an atomic increment due to contention. Retry the operation or implement incrementOne natively.`,
-	);
+	async function readRow({
+		model,
+		where,
+	}: FallbackRequest): Promise<StoredRow | null> {
+		const result = readSchema.safeParse(
+			await adapter.findOne<unknown>({ model, where }),
+		);
+		if (!result.success) {
+			throw new BetterAuthError(
+				`Adapter "${adapterId}" must return a row snapshot or null.`,
+			);
+		}
+		return result.data;
+	}
+
+	async function snapshotGuard(
+		row: StoredRow,
+		fields: readonly string[],
+		request: FallbackRequest,
+		action: "consumeOne" | "incrementOne",
+	): Promise<CleanedWhere[]> {
+		const id = await idWhere(row, request.logicalModel, action);
+		const hasOr = request.where.some((clause) => clause.connector === "OR");
+		const guard: CleanedWhere[] = hasOr ? [id] : [...request.where, id];
+		const keys = new Set([...Object.keys(row), ...fields]);
+		for (const field of keys) {
+			if (field === id.field) continue;
+			const value = scalar.safeParse(row[field] ?? null);
+			if (!value.success) {
+				if (hasOr && request.where.some((clause) => clause.field === field)) {
+					throw new BetterAuthError(
+						`Adapter "${adapterId}" must implement native atomic methods for OR predicates on structured values.`,
+					);
+				}
+				continue;
+			}
+			guard.push({
+				field,
+				value: value.data,
+				operator: "eq",
+				connector: "AND",
+				mode: "sensitive",
+			});
+		}
+		return guard;
+	}
+
+	function changedOne(count: number): boolean {
+		if (count !== 0 && count !== 1) {
+			throw new BetterAuthError(
+				`Adapter "${adapterId}" must return an affected row count of 0 or 1 from an atomic fallback.`,
+			);
+		}
+		return count === 1;
+	}
+
+	async function consumeOne(
+		request: FallbackRequest,
+	): Promise<StoredRow | null> {
+		const { model, where } = request;
+		const row = await readRow(request);
+		if (row === null) return null;
+		// Guard the selected snapshot with AND predicates, without widening an OR selector.
+		const guard = await snapshotGuard(
+			row,
+			where.map(({ field }) => field),
+			request,
+			"consumeOne",
+		);
+		const count = await adapter.deleteMany({ model, where: guard });
+		return changedOne(count) ? row : null;
+	}
+
+	async function incrementOne(
+		request: FallbackRequest & {
+			increment: Record<string, number>;
+			set?: Record<string, unknown> | undefined;
+		},
+	): Promise<StoredRow | null> {
+		const { model, where } = request;
+		const mutation = mutationSchema.safeParse(request);
+		if (!mutation.success) {
+			throw new BetterAuthError(
+				`Adapter "${adapterId}" requires finite increments and a set object for the atomic fallback.`,
+			);
+		}
+		const { increment, set } = mutation.data;
+		const deltas = Object.entries(increment);
+		const fields = [
+			...where.map(({ field }) => field),
+			...Object.keys(increment),
+			...Object.keys(set ?? {}),
+		];
+		for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+			const row = await readRow(request);
+			if (row === null) return null;
+			const update: z.output<typeof setSchema> = { ...set };
+			for (const [field, delta] of deltas) {
+				const previous = counterSchema.safeParse(row[field]);
+				if (!previous.success) {
+					throw new BetterAuthError(
+						`Adapter "${adapterId}" must return finite numeric counter values or null for atomic increments.`,
+					);
+				}
+				const current = previous.data ?? 0;
+				const next = current + delta;
+				if (!Number.isFinite(next) || (delta !== 0 && next === current)) {
+					throw new BetterAuthError(
+						`Adapter "${adapterId}" cannot represent the requested counter increment safely.`,
+					);
+				}
+				update[field] = next;
+			}
+			const guard = await snapshotGuard(row, fields, request, "incrementOne");
+			// A no-op can finish at the read, including stores reporting changed rows.
+			if (
+				Object.entries(update).every(([field, value]) => {
+					const previous = row[field];
+					if (previous instanceof Date && value instanceof Date) {
+						return previous.getTime() === value.getTime();
+					}
+					return Object.is(previous, value);
+				})
+			)
+				return row;
+			const count = await adapter.updateMany({
+				model,
+				where: guard,
+				update,
+			});
+			if (changedOne(count)) {
+				// A second read could observe another writer's result instead of ours.
+				return { ...row, ...update };
+			}
+		}
+		throw new BetterAuthError(
+			`Adapter "${adapterId}" could not complete an atomic increment due to contention. Retry the operation or implement incrementOne natively.`,
+		);
+	}
+
+	return { consumeOne, incrementOne };
 }

--- a/packages/core/src/db/adapter/atomic-fallback.ts
+++ b/packages/core/src/db/adapter/atomic-fallback.ts
@@ -1,0 +1,165 @@
+import * as z from "zod";
+import { BetterAuthError } from "../../error";
+import type { CleanedWhere, CustomAdapter } from "./index";
+
+const MAX_ATTEMPTS = 5;
+
+const scalar = z
+	.union([z.string(), z.number(), z.boolean(), z.date()])
+	.nullable();
+const rowSchema = z.record(z.string(), scalar.optional());
+const readSchema = rowSchema.nullable();
+const idSchema = z.union([z.string(), z.number()]);
+const setSchema = z
+	.record(z.string(), scalar.optional())
+	.transform((values) => {
+		const assignments: Record<string, z.output<typeof scalar>> = {};
+		for (const [field, value] of Object.entries(values)) {
+			if (value !== undefined) assignments[field] = value;
+		}
+		return assignments;
+	});
+const mutationSchema = z.object({
+	increment: z.record(z.string(), z.number()),
+	set: setSchema.optional(),
+});
+const counterSchema = z.number().nullish();
+
+type StoredRow = z.output<typeof rowSchema>;
+
+type FallbackOptions = {
+	adapter: CustomAdapter;
+	adapterId: string;
+	model: string;
+	idField: string;
+	where: CleanedWhere[];
+};
+
+async function readRow({
+	adapter,
+	adapterId,
+	model,
+	where,
+	idField,
+}: FallbackOptions): Promise<StoredRow | null> {
+	const result = readSchema.safeParse(
+		await adapter.findOne<unknown>({ model, where }),
+	);
+	if (!result.success) {
+		throw new BetterAuthError(
+			`Adapter "${adapterId}" must return a scalar row snapshot or null. Implement native atomic methods for non-scalar values.`,
+		);
+	}
+	const row = result.data;
+	if (row === null) return null;
+	if (!idSchema.safeParse(row[idField]).success) {
+		throw new BetterAuthError(
+			`Adapter "${adapterId}" must return the row id for atomic fallbacks.`,
+		);
+	}
+	return row;
+}
+
+function snapshotGuard(
+	row: StoredRow,
+	fields: readonly string[],
+): CleanedWhere[] {
+	const keys = new Set([...Object.keys(row), ...fields]);
+	return Array.from(keys, (field) => ({
+		field,
+		value: row[field] ?? null,
+		operator: "eq",
+		connector: "AND",
+		mode: "sensitive",
+	}));
+}
+
+function changedOne(count: number, adapterId: string): boolean {
+	if (count !== 0 && count !== 1) {
+		throw new BetterAuthError(
+			`Adapter "${adapterId}" must return an affected row count of 0 or 1 from an atomic fallback.`,
+		);
+	}
+	return count === 1;
+}
+
+export async function consumeOneFallback(
+	options: FallbackOptions,
+): Promise<StoredRow | null> {
+	const { adapter, adapterId, model, where } = options;
+	const row = await readRow(options);
+	if (row === null) return null;
+	// Guard the selected snapshot with AND predicates, without widening an OR selector.
+	const guard = snapshotGuard(
+		row,
+		where.map(({ field }) => field),
+	);
+	const count = await adapter.deleteMany({ model, where: guard });
+	return changedOne(count, adapterId) ? row : null;
+}
+
+export async function incrementOneFallback(
+	options: FallbackOptions & {
+		increment: Record<string, number>;
+		set?: Record<string, unknown> | undefined;
+	},
+): Promise<StoredRow | null> {
+	const { adapter, adapterId, model, where } = options;
+	const mutation = mutationSchema.safeParse(options);
+	if (!mutation.success) {
+		throw new BetterAuthError(
+			`Adapter "${adapterId}" requires finite increments and scalar set values for the atomic fallback.`,
+		);
+	}
+	const { increment, set } = mutation.data;
+	const deltas = Object.entries(increment);
+	const fields = [
+		...where.map(({ field }) => field),
+		...Object.keys(increment),
+		...Object.keys(set ?? {}),
+	];
+	for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+		const row = await readRow(options);
+		if (row === null) return null;
+		const update: z.output<typeof setSchema> = { ...set };
+		for (const [field, delta] of deltas) {
+			const previous = counterSchema.safeParse(row[field]);
+			if (!previous.success) {
+				throw new BetterAuthError(
+					`Adapter "${adapterId}" must return finite numeric counter values or null for atomic increments.`,
+				);
+			}
+			const current = previous.data ?? 0;
+			const next = current + delta;
+			if (!Number.isFinite(next) || (delta !== 0 && next === current)) {
+				throw new BetterAuthError(
+					`Adapter "${adapterId}" cannot represent the requested counter increment safely.`,
+				);
+			}
+			update[field] = next;
+		}
+		// A no-op can finish at the read, including stores reporting changed rows.
+		if (
+			Object.entries(update).every(([field, value]) => {
+				const previous = row[field];
+				if (previous instanceof Date && value instanceof Date) {
+					return previous.getTime() === value.getTime();
+				}
+				return Object.is(previous, value);
+			})
+		)
+			return row;
+		const count = await adapter.updateMany({
+			model,
+			where: snapshotGuard(row, fields),
+			update,
+		});
+		if (changedOne(count, adapterId)) {
+			// A second read could observe another writer's result instead of ours.
+			return { ...row, ...update };
+		}
+	}
+	throw new BetterAuthError(
+		`Adapter "${adapterId}" could not complete an atomic increment due to contention. Retry the operation or implement incrementOne natively.`,
+	);
+}

--- a/packages/core/src/db/adapter/atomic-fallback.ts
+++ b/packages/core/src/db/adapter/atomic-fallback.ts
@@ -8,7 +8,7 @@ const scalar = z
 	.union([z.string(), z.number(), z.boolean(), z.date()])
 	.nullable();
 const rowSchema = z.record(z.string(), z.unknown());
-const readSchema = rowSchema.nullable();
+const readSchema = rowSchema.nullish();
 const setSchema = z.record(z.string(), z.unknown()).transform((values) => {
 	const assignments: z.output<typeof rowSchema> = {};
 	for (const [field, value] of Object.entries(values)) {
@@ -49,6 +49,8 @@ type FallbackRequest = {
 	where: CleanedWhere[];
 };
 
+// Read a snapshot, then conditionally mutate it. A write succeeds only when
+// an adapter checks and mutates atomically and reports exactly one affected row.
 export function createAtomicFallbacks(context: FallbackContext) {
 	const { adapter, adapterId } = context;
 	const outputId =
@@ -103,7 +105,7 @@ export function createAtomicFallbacks(context: FallbackContext) {
 				`Adapter "${adapterId}" must return a row snapshot or null.`,
 			);
 		}
-		return result.data;
+		return result.data ?? null;
 	}
 
 	async function snapshotGuard(
@@ -115,7 +117,7 @@ export function createAtomicFallbacks(context: FallbackContext) {
 		const id = await idWhere(row, request.logicalModel, action);
 		const hasOr = request.where.some((clause) => clause.connector === "OR");
 		const guard: CleanedWhere[] = hasOr ? [id] : [...request.where, id];
-		const keys = new Set([...Object.keys(row), ...fields]);
+		const keys = new Set(fields);
 		for (const field of keys) {
 			if (field === id.field) continue;
 			const value = scalar.safeParse(row[field] ?? null);
@@ -156,7 +158,7 @@ export function createAtomicFallbacks(context: FallbackContext) {
 		// Guard the selected snapshot with AND predicates, without widening an OR selector.
 		const guard = await snapshotGuard(
 			row,
-			where.map(({ field }) => field),
+			[...Object.keys(row), ...where.map(({ field }) => field)],
 			request,
 			"consumeOne",
 		);
@@ -174,7 +176,7 @@ export function createAtomicFallbacks(context: FallbackContext) {
 		const mutation = mutationSchema.safeParse(request);
 		if (!mutation.success) {
 			throw new BetterAuthError(
-				`Adapter "${adapterId}" requires finite increments and a set object for the atomic fallback.`,
+				"incrementOne requires finite increments and a set object for the atomic fallback.",
 			);
 		}
 		const { increment, set } = mutation.data;
@@ -205,7 +207,7 @@ export function createAtomicFallbacks(context: FallbackContext) {
 				update[field] = next;
 			}
 			const guard = await snapshotGuard(row, fields, request, "incrementOne");
-			// A no-op can finish at the read, including stores reporting changed rows.
+			// A no-op takes effect at the read. Stores counting changed rows would report zero.
 			if (
 				Object.entries(update).every(([field, value]) => {
 					const previous = row[field];

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -441,6 +441,36 @@ describe("legacy adapter atomic fallbacks", () => {
 			counter: 3,
 		});
 	});
+	it("uses stored counters even when output transformation is lossy", async ({
+		onTestFinished,
+	}) => {
+		const { raw, db } = setup(onTestFinished);
+		db.exec("UPDATE verification SET counter = 2");
+		const adapter = createAdapterFactory({
+			config: {
+				adapterId: "masked-counter",
+				mapKeysTransformInput: { id: "_id" },
+				mapKeysTransformOutput: { _id: "id" },
+				customTransformOutput: ({ field, data }) =>
+					field === "attempts" ? 0 : data,
+			},
+			adapter: () => raw,
+		})({
+			verification: {
+				additionalFields: {
+					attempts: { type: "number", required: false, fieldName: "counter" },
+				},
+			},
+		});
+		expect(await adapter.findOne(request)).toMatchObject({ attempts: 0 });
+		expect(
+			await adapter.incrementOne({ ...request, increment: { attempts: 1 } }),
+		).toMatchObject({ attempts: 0 });
+		expect(db.prepare("SELECT counter FROM verification").get()).toMatchObject({
+			counter: 3,
+		});
+	});
+
 	it("returns the row produced by its own update", async ({
 		onTestFinished,
 	}) => {
@@ -608,16 +638,24 @@ describe("legacy adapter atomic fallbacks", () => {
 			db.prepare("SELECT count(*) AS count FROM verification").get(),
 		).toMatchObject({ count: 1 });
 	});
-	it("requires a native method for non-scalar snapshots", async ({
+	it("allows unrelated structured data in returned rows", async ({
 		onTestFinished,
 	}) => {
 		const { raw, first, db } = setup(onTestFinished);
-		raw.findOne = async <T>() =>
-			({ _id: "a", identifier: "token", value: { secret: true } }) as T;
-		await expect(first.consumeOne(request)).rejects.toThrow(/non-scalar/);
+		const find = raw.findOne;
+		raw.findOne = async <T>(args: { where: CleanedWhere[] }) => {
+			const row = await find<Record<string, unknown>>(args);
+			return row
+				? ({ ...row, metadata: { locale: "en" }, tags: ["test"] } as T)
+				: null;
+		};
+		expect(await first.consumeOne(request)).toMatchObject({
+			id: "a",
+			value: "secret",
+		});
 		expect(
 			db.prepare("SELECT count(*) AS count FROM verification").get(),
-		).toMatchObject({ count: 1 });
+		).toMatchObject({ count: 0 });
 	});
 
 	it("rejects malformed reads instead of treating them as missing", async ({
@@ -630,23 +668,54 @@ describe("legacy adapter atomic fallbacks", () => {
 			db.prepare("SELECT count(*) AS count FROM verification").get(),
 		).toMatchObject({ count: 1 });
 	});
-	it("rejects non-scalar assignments without exposing their values", async ({
+	it("propagates write failures without reporting a successful increment", async ({
 		onTestFinished,
 	}) => {
-		const { first, db } = setup(onTestFinished);
-		const result = await first
-			.incrementOne({
-				...request,
-				increment: {},
-				set: { value: { secret: "must-not-leak" } },
-			})
-			.catch((error: unknown) => error);
-		expect(result).toBeInstanceOf(Error);
-		expect(String(result)).not.toContain("must-not-leak");
-		expect(db.prepare("SELECT value FROM verification").get()).toMatchObject({
+		const { first, raw, db } = setup(onTestFinished);
+		const failure = new Error("backend unavailable");
+		raw.updateMany = async () => {
+			throw failure;
+		};
+		await expect(
+			first.incrementOne({ ...request, increment: { attempts: 1 } }),
+		).rejects.toBe(failure);
+		expect(db.prepare("SELECT counter FROM verification").get()).toMatchObject({
+			counter: null,
+		});
+	});
+
+	it("uses adapter-owned transforms for object IDs", async () => {
+		const physicalId = { encoded: "a" };
+		const raw = createCustomAdapter({
+			consumeOne: undefined,
+			incrementOne: undefined,
+			findOne: async <T>() =>
+				({ _id: physicalId, identifier: "token", value: "secret" }) as T,
+			deleteMany: async ({ where }) => {
+				expect(where.find((clause) => clause.field === "_id")?.value).toBe(
+					physicalId,
+				);
+				return 1;
+			},
+		});
+		const adapter = createAdapterFactory({
+			config: {
+				adapterId: "object-id",
+				mapKeysTransformInput: { id: "_id" },
+				mapKeysTransformOutput: { _id: "id" },
+				customTransformInput: ({ field, data }) =>
+					field === "_id" ? physicalId : data,
+				customTransformOutput: ({ field, data }) =>
+					field === "id" ? "a" : data,
+			},
+			adapter: () => raw,
+		})({});
+		expect(await adapter.consumeOne(request)).toMatchObject({
+			id: "a",
 			value: "secret",
 		});
 	});
+
 	it("rejects increments that cannot change a large counter", async ({
 		onTestFinished,
 	}) => {

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -441,6 +441,33 @@ describe("legacy adapter atomic fallbacks", () => {
 			counter: 3,
 		});
 	});
+	it("increments despite unrelated concurrent writes", async ({
+		onTestFinished,
+	}) => {
+		const { db, raw, first } = setup(onTestFinished);
+		const update = raw.updateMany;
+		raw.updateMany = async (args) => {
+			db.exec("UPDATE verification SET value = value || '-changed'");
+			return update(args);
+		};
+		expect(
+			await first.incrementOne({ ...request, increment: { attempts: 1 } }),
+		).toMatchObject({ attempts: 1 });
+		expect(
+			db.prepare("SELECT counter, value FROM verification").get(),
+		).toMatchObject({ counter: 1, value: "secret-changed" });
+	});
+	it("treats an undefined legacy read as a missing row", async ({
+		onTestFinished,
+	}) => {
+		const { raw, first } = setup(onTestFinished);
+		// Legacy JavaScript adapters commonly return rows[0].
+		raw.findOne = async <T>() => undefined as T | null;
+		await expect(first.consumeOne(request)).resolves.toBeNull();
+		await expect(
+			first.incrementOne({ ...request, increment: { attempts: 1 } }),
+		).resolves.toBeNull();
+	});
 	it("uses stored counters even when output transformation is lossy", async ({
 		onTestFinished,
 	}) => {
@@ -541,6 +568,34 @@ describe("legacy adapter atomic fallbacks", () => {
 		await expect(
 			first.incrementOne({ ...request, increment: { attempts: 1 } }),
 		).rejects.toThrow(/affected/);
+	});
+	it("identifies invalid increment input before writing", async ({
+		onTestFinished,
+	}) => {
+		const { first, db } = setup(onTestFinished);
+		await expect(
+			first.incrementOne({ ...request, increment: { attempts: Number.NaN } }),
+		).rejects.toThrow(/^incrementOne requires finite increments/);
+		expect(db.prepare("SELECT counter FROM verification").get()).toMatchObject({
+			counter: null,
+		});
+	});
+	it("rejects bigint counters without coercion or writes", async ({
+		onTestFinished,
+	}) => {
+		const { raw, first, db } = setup(onTestFinished);
+		const read = raw.findOne;
+		raw.findOne = async <T>(args: { where: CleanedWhere[] }) =>
+			({
+				...(await read<Record<string, unknown>>(args)),
+				counter: 9007199254740993n,
+			}) as T;
+		await expect(
+			first.incrementOne({ ...request, increment: { attempts: 1 } }),
+		).rejects.toThrow(/finite numeric counter/);
+		expect(db.prepare("SELECT counter FROM verification").get()).toMatchObject({
+			counter: null,
+		});
 	});
 	it("rejects invalid counters before writing", async ({ onTestFinished }) => {
 		const { db, first } = setup(onTestFinished);

--- a/packages/core/src/db/adapter/factory.test.ts
+++ b/packages/core/src/db/adapter/factory.test.ts
@@ -1,3 +1,4 @@
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import type { BetterAuthOptions } from "../../types";
 import { createAdapterFactory } from "./factory";
@@ -209,37 +210,6 @@ describe("createAdapterFactory atomic primitives", () => {
 		).rejects.toThrow(/resolved to an empty update/);
 	});
 
-	it("throws a clear error when consumeOne is missing at runtime", async () => {
-		const adapter = createTestAdapter({
-			adapter: createCustomAdapter({
-				consumeOne: undefined as unknown as CustomAdapter["consumeOne"],
-			}),
-		});
-
-		await expect(
-			adapter.consumeOne({
-				model: "verification",
-				where: [{ field: "identifier", value: "token" }],
-			}),
-		).rejects.toThrow(/must implement consumeOne/);
-	});
-
-	it("throws a clear error when incrementOne is missing at runtime", async () => {
-		const adapter = createTestAdapter({
-			adapter: createCustomAdapter({
-				incrementOne: undefined as unknown as CustomAdapter["incrementOne"],
-			}),
-		});
-
-		await expect(
-			adapter.incrementOne({
-				model: "verification",
-				where: [{ field: "identifier", value: "token" }],
-				increment: { attempts: 1 },
-			}),
-		).rejects.toThrow(/must implement incrementOne/);
-	});
-
 	it("throws a clear error when updateMany does not return a finite count", async () => {
 		const adapter = createTestAdapter({
 			adapter: createCustomAdapter({
@@ -332,5 +302,424 @@ describe("createAdapterFactory where value coercion", () => {
 				},
 			],
 		]);
+	});
+});
+
+/**
+ * @see https://cwe.mitre.org/data/definitions/367.html
+ */
+describe("legacy adapter atomic fallbacks", () => {
+	function setup(
+		onTestFinished: (fn: () => void) => void,
+		disableTransformInput = false,
+	) {
+		const db = new DatabaseSync(":memory:");
+		onTestFinished(() => db.close());
+		db.exec(
+			"CREATE TABLE verification (_id TEXT PRIMARY KEY, identifier TEXT, value TEXT, counter REAL, updatedAt TEXT)",
+		);
+		db.exec(
+			"INSERT INTO verification VALUES ('a', 'token', 'secret', NULL, NULL)",
+		);
+		const quote = (name: string) => `"${name.replaceAll('"', '""')}"`;
+		function condition(where: CleanedWhere[]) {
+			return (
+				where
+					.map(({ field, value, operator, connector }, index) => {
+						if (operator !== "eq" && operator !== "gt")
+							throw new Error("Unsupported test predicate");
+						return `${index ? connector + " " : ""}${quote(field)} ${value === null ? "IS NULL" : operator === "gt" ? "> ?" : "= ?"}`;
+					})
+					.join(" ") || "1=1"
+			);
+		}
+		function values(where: CleanedWhere[]) {
+			return where
+				.filter(({ value }) => value !== null)
+				.map(({ value }) => {
+					if (typeof value !== "string" && typeof value !== "number")
+						throw new Error("Unsupported test value");
+					return value;
+				});
+		}
+		const raw = {
+			...createCustomAdapter(),
+			consumeOne: undefined,
+			incrementOne: undefined,
+			findOne: async <T>({ where }: { where: CleanedWhere[] }) =>
+				(db
+					.prepare(
+						`SELECT * FROM verification WHERE ${condition(where)} LIMIT 1`,
+					)
+					.get(...values(where)) ?? null) as T | null,
+			deleteMany: async ({ where }: { where: CleanedWhere[] }) =>
+				Number(
+					db
+						.prepare(`DELETE FROM verification WHERE ${condition(where)}`)
+						.run(...values(where)).changes,
+				),
+			updateMany: async ({
+				where,
+				update,
+			}: {
+				where: CleanedWhere[];
+				update: Record<string, unknown>;
+			}) => {
+				const entries = Object.entries(update);
+				const params = entries.map(([, value]) => {
+					if (
+						value === null ||
+						typeof value === "string" ||
+						typeof value === "number"
+					)
+						return value;
+					throw new Error("Unsupported test update");
+				});
+				return Number(
+					db
+						.prepare(
+							`UPDATE verification SET ${entries.map(([field]) => `${quote(field)} = ?`).join(", ")} WHERE ${condition(where)}`,
+						)
+						.run(...params, ...values(where)).changes,
+				);
+			},
+		};
+		const factory = createAdapterFactory({
+			config: {
+				adapterId: "legacy",
+				disableTransformInput,
+				mapKeysTransformInput: { id: "_id" },
+				mapKeysTransformOutput: { _id: "id" },
+			},
+			adapter: () => raw,
+		});
+		const options = {
+			verification: {
+				additionalFields: {
+					attempts: {
+						type: "number" as const,
+						required: false,
+						fieldName: "counter",
+					},
+				},
+			},
+		};
+		return { db, raw, first: factory(options), second: factory(options) };
+	}
+	const request = {
+		model: "verification",
+		where: [{ field: "identifier", value: "token" }],
+	};
+	it("lets only one independent adapter consume a credential", async ({
+		onTestFinished,
+	}) => {
+		const { db, first, second } = setup(onTestFinished);
+		const results = await Promise.all([
+			first.consumeOne(request),
+			second.consumeOne(request),
+		]);
+		expect(results.filter(Boolean)).toHaveLength(1);
+		expect(results.find(Boolean)).toMatchObject({ id: "a", value: "secret" });
+		expect(
+			db.prepare("SELECT count(*) AS count FROM verification").get(),
+		).toMatchObject({ count: 0 });
+	});
+	it("does not lose concurrent increments starting from null", async ({
+		onTestFinished,
+	}) => {
+		const { db, first, second } = setup(onTestFinished);
+		const results = await Promise.all(
+			[first, second, first].map((adapter) =>
+				adapter.incrementOne<{ attempts: number }>({
+					...request,
+					increment: { attempts: 1 },
+				}),
+			),
+		);
+		expect(results.map((row) => row?.attempts).sort()).toEqual([1, 2, 3]);
+		expect(db.prepare("SELECT counter FROM verification").get()).toMatchObject({
+			counter: 3,
+		});
+	});
+	it("returns the row produced by its own update", async ({
+		onTestFinished,
+	}) => {
+		const { db, raw, first } = setup(onTestFinished);
+		const update = raw.updateMany;
+		raw.updateMany = async (args) => {
+			const result = await update(args);
+			db.exec("UPDATE verification SET counter = 99");
+			return result;
+		};
+		expect(
+			await first.incrementOne({ ...request, increment: { attempts: 1 } }),
+		).toMatchObject({ attempts: 1 });
+	});
+	it("does not return a credential replaced between read and delete", async ({
+		onTestFinished,
+	}) => {
+		const { db, raw, first } = setup(onTestFinished);
+		const remove = raw.deleteMany;
+		raw.deleteMany = async (args) => {
+			db.exec("UPDATE verification SET value = 'replacement'");
+			return remove(args);
+		};
+		expect(await first.consumeOne(request)).toBeNull();
+		expect(db.prepare("SELECT value FROM verification").get()).toMatchObject({
+			value: "replacement",
+		});
+	});
+	it("keeps OR selectors from widening the guarded deletion", async ({
+		onTestFinished,
+	}) => {
+		const { db, first } = setup(onTestFinished);
+		db.exec(
+			"INSERT INTO verification VALUES ('b', 'other', 'other-secret', 0, NULL)",
+		);
+		await first.consumeOne({
+			model: "verification",
+			where: [
+				{ field: "identifier", value: "token" },
+				{ field: "identifier", value: "other", connector: "OR" },
+			],
+		});
+		expect(
+			db.prepare("SELECT count(*) AS count FROM verification").get(),
+		).toMatchObject({ count: 1 });
+	});
+	it("rejects contention exhaustion instead of reporting a missing row", async ({
+		onTestFinished,
+	}) => {
+		const { raw, first } = setup(onTestFinished);
+		raw.updateMany = async () => 0;
+		await expect(
+			first.incrementOne({ ...request, increment: { attempts: 1 } }),
+		).rejects.toThrow(/contention/);
+	});
+	it.for([
+		2,
+		-1,
+		0.5,
+		Number.NaN,
+	])("rejects invalid affected counts (%s)", async (count, {
+		onTestFinished,
+	}) => {
+		const { raw, first } = setup(onTestFinished);
+		raw.deleteMany = async () => count;
+		raw.updateMany = async () => count;
+		await expect(first.consumeOne(request)).rejects.toThrow(/affected/);
+		await expect(
+			first.incrementOne({ ...request, increment: { attempts: 1 } }),
+		).rejects.toThrow(/affected/);
+	});
+	it("rejects invalid counters before writing", async ({ onTestFinished }) => {
+		const { db, first } = setup(onTestFinished);
+		db.exec("UPDATE verification SET counter = 'invalid'");
+		await expect(
+			first.incrementOne({ ...request, increment: { attempts: 1 } }),
+		).rejects.toThrow(/counter/);
+		expect(db.prepare("SELECT counter FROM verification").get()).toMatchObject({
+			counter: "invalid",
+		});
+	});
+	it("handles an absent nullable counter with the null guard", async ({
+		onTestFinished,
+	}) => {
+		const { raw, first, second, db } = setup(onTestFinished);
+		const find = raw.findOne;
+		raw.findOne = async <T>(args: { where: CleanedWhere[] }) => {
+			const row = await find<Record<string, unknown>>(args);
+			if (row?.counter === null) {
+				const { counter: _counter, ...withoutCounter } = row;
+				return withoutCounter as T;
+			}
+			return row as T | null;
+		};
+		await Promise.all(
+			[first, second].map((adapter) =>
+				adapter.incrementOne({ ...request, increment: { attempts: 1 } }),
+			),
+		);
+		expect(db.prepare("SELECT counter FROM verification").get()).toMatchObject({
+			counter: 2,
+		});
+	});
+	it("honors a counter guard after losing a race", async ({
+		onTestFinished,
+	}) => {
+		const { db, first, second } = setup(onTestFinished);
+		db.exec("UPDATE verification SET counter = 1");
+		const guarded = {
+			model: "verification",
+			where: [{ field: "attempts", value: 0, operator: "gt" as const }],
+			increment: { attempts: -1 },
+		};
+		const results = await Promise.all([
+			first.incrementOne(guarded),
+			second.incrementOne(guarded),
+		]);
+		expect(results.filter(Boolean)).toHaveLength(1);
+		expect(db.prepare("SELECT counter FROM verification").get()).toMatchObject({
+			counter: 0,
+		});
+	});
+	it("completes a no-op without relying on changed-row counts", async ({
+		onTestFinished,
+	}) => {
+		const { db, raw, first } = setup(onTestFinished);
+		db.exec("UPDATE verification SET counter = 1");
+		raw.updateMany = async () => {
+			throw new Error("A no-op should not write");
+		};
+		expect(
+			await first.incrementOne({ ...request, increment: { attempts: 0 } }),
+		).toMatchObject({ attempts: 1 });
+	});
+	it("compares date values when a set-only update is a no-op", async ({
+		onTestFinished,
+	}) => {
+		const { raw, first } = setup(onTestFinished);
+		const find = raw.findOne;
+		const time = new Date("2026-01-01T00:00:00Z");
+		raw.findOne = async <T>(args: { where: CleanedWhere[] }) => {
+			const row = await find<Record<string, unknown>>(args);
+			return row ? ({ ...row, updatedAt: new Date(time) } as T) : null;
+		};
+		raw.updateMany = async () => {
+			throw new Error("A date no-op should not write");
+		};
+		expect(
+			await first.incrementOne({
+				...request,
+				increment: {},
+				set: { updatedAt: time },
+			}),
+		).toMatchObject({ updatedAt: time });
+	});
+
+	it("fails before writing when the row id is missing", async ({
+		onTestFinished,
+	}) => {
+		const { raw, first, db } = setup(onTestFinished);
+		raw.findOne = async <T>() =>
+			({ identifier: "token", value: "secret" }) as T;
+		await expect(first.consumeOne(request)).rejects.toThrow(/row id/);
+		expect(
+			db.prepare("SELECT count(*) AS count FROM verification").get(),
+		).toMatchObject({ count: 1 });
+	});
+	it("requires a native method for non-scalar snapshots", async ({
+		onTestFinished,
+	}) => {
+		const { raw, first, db } = setup(onTestFinished);
+		raw.findOne = async <T>() =>
+			({ _id: "a", identifier: "token", value: { secret: true } }) as T;
+		await expect(first.consumeOne(request)).rejects.toThrow(/non-scalar/);
+		expect(
+			db.prepare("SELECT count(*) AS count FROM verification").get(),
+		).toMatchObject({ count: 1 });
+	});
+
+	it("rejects malformed reads instead of treating them as missing", async ({
+		onTestFinished,
+	}) => {
+		const { raw, first, db } = setup(onTestFinished);
+		raw.findOne = async <T>() => false as T;
+		await expect(first.consumeOne(request)).rejects.toThrow(/snapshot or null/);
+		expect(
+			db.prepare("SELECT count(*) AS count FROM verification").get(),
+		).toMatchObject({ count: 1 });
+	});
+	it("rejects non-scalar assignments without exposing their values", async ({
+		onTestFinished,
+	}) => {
+		const { first, db } = setup(onTestFinished);
+		const result = await first
+			.incrementOne({
+				...request,
+				increment: {},
+				set: { value: { secret: "must-not-leak" } },
+			})
+			.catch((error: unknown) => error);
+		expect(result).toBeInstanceOf(Error);
+		expect(String(result)).not.toContain("must-not-leak");
+		expect(db.prepare("SELECT value FROM verification").get()).toMatchObject({
+			value: "secret",
+		});
+	});
+	it("rejects increments that cannot change a large counter", async ({
+		onTestFinished,
+	}) => {
+		const { first, db } = setup(onTestFinished);
+		db.prepare("UPDATE verification SET counter = ?").run(2 ** 53);
+		await expect(
+			first.incrementOne({ ...request, increment: { attempts: 1 } }),
+		).rejects.toThrow(/safely/);
+		expect(db.prepare("SELECT counter FROM verification").get()).toMatchObject({
+			counter: 2 ** 53,
+		});
+	});
+
+	it("omits undefined assignments even when input transformation is disabled", async ({
+		onTestFinished,
+	}) => {
+		const { first, raw, db } = setup(onTestFinished, true);
+		const write = raw.updateMany;
+		raw.updateMany = async (args) => {
+			expect(args.update).not.toHaveProperty("value");
+			return write(args);
+		};
+		expect(
+			await first.incrementOne({
+				...request,
+				increment: { attempts: 1 },
+				set: { value: undefined },
+			}),
+		).toMatchObject({ value: "secret", attempts: 1 });
+		expect(
+			db.prepare("SELECT value, counter FROM verification").get(),
+		).toMatchObject({ value: "secret", counter: 1 });
+	});
+	it("preserves explicit null assignments", async ({ onTestFinished }) => {
+		const { first, db } = setup(onTestFinished, true);
+		expect(
+			await first.incrementOne({
+				...request,
+				increment: {},
+				set: { value: null },
+			}),
+		).toMatchObject({ value: null });
+		expect(db.prepare("SELECT value FROM verification").get()).toMatchObject({
+			value: null,
+		});
+	});
+	it("treats undefined-only assignments as a no-op", async ({
+		onTestFinished,
+	}) => {
+		const { first, raw } = setup(onTestFinished, true);
+		raw.updateMany = async () => {
+			throw new Error("Undefined assignments must not write");
+		};
+		expect(
+			await first.incrementOne({
+				...request,
+				increment: {},
+				set: { value: undefined },
+			}),
+		).toMatchObject({ value: "secret" });
+	});
+
+	it("returns null when the selector does not match", async ({
+		onTestFinished,
+	}) => {
+		const { first } = setup(onTestFinished);
+		const missing = {
+			...request,
+			where: [{ field: "identifier", value: "missing" }],
+		};
+		expect(await first.consumeOne(missing)).toBeNull();
+		expect(
+			await first.incrementOne({ ...missing, increment: { attempts: 1 } }),
+		).toBeNull();
 	});
 });

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -8,6 +8,7 @@ import { BetterAuthError } from "../../error";
 import type { BetterAuthOptions } from "../../types";
 import { safeJSONParse } from "../../utils/json";
 import { getAuthTables } from "../get-tables";
+import { consumeOneFallback, incrementOneFallback } from "./atomic-fallback";
 import { initGetDefaultFieldName } from "./get-default-field-name";
 import { initGetDefaultModelName } from "./get-default-model-name";
 import { initGetFieldAttributes } from "./get-field-attributes";
@@ -1366,18 +1367,24 @@ export const createAdapterFactory =
 					{ model, where },
 				);
 
-				if (typeof adapterInstance.consumeOne !== "function") {
-					throw new BetterAuthError(
-						`Adapter "${config.adapterId}" must implement consumeOne for atomic single-use credential consumption.`,
-					);
-				}
 				const res = await withSpan(
 					`db consumeOne ${model}`,
 					{
 						[ATTR_DB_OPERATION_NAME]: "consumeOne",
 						[ATTR_DB_COLLECTION_NAME]: model,
 					},
-					() => adapterInstance.consumeOne<T>({ model, where }),
+					() =>
+						adapterInstance.consumeOne
+							? adapterInstance.consumeOne<T>({ model, where })
+							: consumeOneFallback({
+									adapter: adapterInstance,
+									adapterId: config.adapterId,
+									model,
+									where,
+									idField:
+										config.mapKeysTransformInput?.id ||
+										getFieldName({ model: unsafeModel, field: "id" }),
+								}),
 				);
 
 				debugLog(
@@ -1440,11 +1447,6 @@ export const createAdapterFactory =
 					{ model, where, increment: unsafeIncrement, set: unsafeSet },
 				);
 
-				if (typeof adapterInstance.incrementOne !== "function") {
-					throw new BetterAuthError(
-						`Adapter "${config.adapterId}" must implement incrementOne for atomic guarded counter updates.`,
-					);
-				}
 				const mappedKeys = config.mapKeysTransformInput ?? {};
 				const increment: Record<string, number> = {};
 				for (const [field, delta] of Object.entries(unsafeIncrement)) {
@@ -1473,12 +1475,24 @@ export const createAdapterFactory =
 						[ATTR_DB_COLLECTION_NAME]: model,
 					},
 					() =>
-						adapterInstance.incrementOne<T>({
-							model,
-							where,
-							increment,
-							set,
-						}),
+						adapterInstance.incrementOne
+							? adapterInstance.incrementOne<T>({
+									model,
+									where,
+									increment,
+									set,
+								})
+							: incrementOneFallback({
+									adapter: adapterInstance,
+									adapterId: config.adapterId,
+									model,
+									where,
+									increment,
+									set,
+									idField:
+										config.mapKeysTransformInput?.id ||
+										getFieldName({ model: unsafeModel, field: "id" }),
+								}),
 				);
 
 				debugLog(

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -8,7 +8,7 @@ import { BetterAuthError } from "../../error";
 import type { BetterAuthOptions } from "../../types";
 import { safeJSONParse } from "../../utils/json";
 import { getAuthTables } from "../get-tables";
-import { consumeOneFallback, incrementOneFallback } from "./atomic-fallback";
+import { createAtomicFallbacks } from "./atomic-fallback";
 import { initGetDefaultFieldName } from "./get-default-field-name";
 import { initGetDefaultModelName } from "./get-default-model-name";
 import { initGetFieldAttributes } from "./get-field-attributes";
@@ -842,6 +842,16 @@ export const createAdapterFactory =
 		});
 
 		let lazyLoadTransaction: DBAdapter<Options>["transaction"] | null = null;
+		const atomicFallbacks = createAtomicFallbacks({
+			adapter: adapterInstance,
+			adapterId: config.adapterId,
+			mapKeysTransformInput: config.mapKeysTransformInput,
+			mapKeysTransformOutput: config.mapKeysTransformOutput,
+			getFieldName,
+			transformOutput,
+			transformWhereClause,
+		});
+
 		const adapter: DBAdapter<Options> = {
 			transaction: async (cb) => {
 				if (!lazyLoadTransaction) {
@@ -1376,14 +1386,10 @@ export const createAdapterFactory =
 					() =>
 						adapterInstance.consumeOne
 							? adapterInstance.consumeOne<T>({ model, where })
-							: consumeOneFallback({
-									adapter: adapterInstance,
-									adapterId: config.adapterId,
+							: atomicFallbacks.consumeOne({
 									model,
+									logicalModel: unsafeModel,
 									where,
-									idField:
-										config.mapKeysTransformInput?.id ||
-										getFieldName({ model: unsafeModel, field: "id" }),
 								}),
 				);
 
@@ -1482,16 +1488,12 @@ export const createAdapterFactory =
 									increment,
 									set,
 								})
-							: incrementOneFallback({
-									adapter: adapterInstance,
-									adapterId: config.adapterId,
+							: atomicFallbacks.incrementOne({
 									model,
+									logicalModel: unsafeModel,
 									where,
 									increment,
 									set,
-									idField:
-										config.mapKeysTransformInput?.id ||
-										getFieldName({ model: unsafeModel, field: "id" }),
 								}),
 				);
 

--- a/packages/core/src/db/adapter/index.ts
+++ b/packages/core/src/db/adapter/index.ts
@@ -493,6 +493,8 @@ export type DBAdapter<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	 * Always defined on the factory-wrapped adapter. Without a native method,
 	 * the factory uses bounded compare-and-swap retries. Contention exhaustion
 	 * throws rather than returning null. Conditional writes must be atomic.
+	 * A no-op may return the read snapshot without writing. A non-null result
+	 * alone does not establish exclusive ownership of the row.
 	 */
 	incrementOne: <T>(data: {
 		model: string;

--- a/packages/core/src/db/adapter/index.ts
+++ b/packages/core/src/db/adapter/index.ts
@@ -466,9 +466,9 @@ export type DBAdapter<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	 * race-safe primitive for consuming single-use credentials
 	 * (verification tokens, authorization codes, one-time tokens).
 	 *
-	 * Always defined on the factory-wrapped adapter. The underlying
-	 * `CustomAdapter` must implement this natively; there is no portable
-	 * fallback that can guarantee cross-process single-use semantics.
+	 * Always defined on the factory-wrapped adapter. Without a native method,
+	 * the factory uses a snapshot-guarded delete and requires an exact affected
+	 * row count. The adapter must evaluate the condition and deletion atomically.
 	 */
 	consumeOne: <T>(data: { model: string; where: Where[] }) => Promise<T | null>;
 	/**
@@ -490,9 +490,9 @@ export type DBAdapter<Options extends BetterAuthOptions = BetterAuthOptions> = {
 	 * primitive for guarded counter updates (e.g. decrementing a remaining-uses
 	 * counter only while it is still positive).
 	 *
-	 * Always defined on the factory-wrapped adapter. The underlying
-	 * `CustomAdapter` must implement this natively; there is no portable
-	 * fallback that can guarantee guarded counter semantics across runtimes.
+	 * Always defined on the factory-wrapped adapter. Without a native method,
+	 * the factory uses bounded compare-and-swap retries. Contention exhaustion
+	 * throws rather than returning null. Conditional writes must be atomic.
 	 */
 	incrementOne: <T>(data: {
 		model: string;
@@ -587,19 +587,21 @@ export interface CustomAdapter {
 		where: CleanedWhere[];
 	}) => Promise<number>;
 	/**
-	 * Native atomic single-row consume.
+	 * Optional native atomic single-row consume.
+	 *
 	 * Implementing this method natively (e.g. `DELETE ... RETURNING *`,
 	 * `findOneAndDelete`, `OUTPUT deleted.*`) gives one round trip and the
 	 * strongest race-safety guarantee. Implementations must delete at most
 	 * one matching row.
 	 */
-	consumeOne: <T>(data: {
+	consumeOne?: <T>(data: {
 		model: string;
 		where: CleanedWhere[];
 	}) => Promise<T | null>;
 	/**
-	 * Native atomic guarded counter mutation. Applies
-	 * `field = field + delta` for each entry in `increment` (negative deltas
+	 * Optional native atomic guarded counter mutation.
+	 *
+	 * Applies `field = field + delta` for each entry in `increment` (negative deltas
 	 * decrement), with `where` acting as both selector and guard and `set`
 	 * assigning absolute values in the same operation. Returns the updated row,
 	 * or `null` when the guard matched no row.
@@ -608,7 +610,7 @@ export interface CustomAdapter {
 	 * RETURNING *`) gives one round trip and the strongest race-safety
 	 * guarantee.
 	 */
-	incrementOne: <T>(data: {
+	incrementOne?: <T>(data: {
 		model: string;
 		where: CleanedWhere[];
 		increment: Record<string, number>;


### PR DESCRIPTION
#10000 made `consumeOne` and `incrementOne` required in 1.7, breaking custom database adapters that relied on the compatibility fallbacks in 1.6.

This PR makes both methods optional again. Native implementations remain preferred. The fallbacks use guarded deletes and compare-and-swap updates, handle mapped IDs and nullable counters, and reject invalid affected-row counts or exhausted retries.

Returned objects and arrays are preserved, and IDs use the adapter’s existing transformations. Fallback safety depends on atomic conditional writes and accurate affected-row counts. OR predicates on structured values still require native implementations.

Replaces #11156


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `consumeOne` and `incrementOne` as optional methods for custom database adapters. Since 1.7.0 they were required and missing methods threw at runtime; the factory now falls back to snapshot-guarded conditional writes when they are absent, while built-in adapters keep their native implementations.

**Bug Fixes**
- The `consumeOne` fallback reads a candidate, conditionally deletes it with a full snapshot guard, and returns it only when exactly one row was deleted.
- The `incrementOne` fallback retries compare-and-swap updates up to five times, throws on contention, treats null or absent counters as zero, and completes no-ops without writing.
- Invalid affected-row counts, non-scalar snapshots, missing row IDs, and non-finite counters raise errors instead of reporting success; undefined reads are treated as missing rows.
- Tests now cover two-factor lockout, email OTP, and backup-code consumption through the legacy fallbacks.

**Migration**
- Fallbacks require atomic conditional writes and accurate numeric affected-row counts in `deleteMany` and `updateMany`; a separate check and mutation is unsafe even under a lock.
- Implement native methods for rows with structured values, adapter-specific ID objects, heavy contention, or security controls such as failed-attempt limits.

<sup>Written for commit cfb0e17fc209ce63bfa5ee80b94d923bb7fdc29f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



