### PR TITLE
fix(expo): clean up stale session storage

### DIFF
--- a/.changeset/clean-expo-storage-chunks.md
+++ b/.changeset/clean-expo-storage-chunks.md
@@ -2,4 +2,4 @@
 "@better-auth/expo": patch
 ---
 
-Clear leftover session data from secure storage after upgrades or sign-out without delaying sign-in, and prevent corrupted cookies during concurrent updates.
+Clear leftover session data from secure storage after upgrades or sign-out, and prevent corrupted cookies during concurrent updates.

--- a/.changeset/clean-expo-storage-chunks.md
+++ b/.changeset/clean-expo-storage-chunks.md
@@ -2,4 +2,4 @@
 "@better-auth/expo": patch
 ---
 
-Clear leftover session data from secure storage after upgrades or sign-out, and prevent corrupted cookies during concurrent updates.
+Clear leftover session data from secure storage after upgrades or sign-out without delaying sign-in, and prevent corrupted cookies during concurrent updates.

--- a/.changeset/clean-expo-storage-chunks.md
+++ b/.changeset/clean-expo-storage-chunks.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/expo": patch
+---
+
+Clear leftover session data from secure storage after upgrades or sign-out, and prevent corrupted cookies during concurrent updates.

--- a/docs/content/docs/integrations/expo.mdx
+++ b/docs/content/docs/integrations/expo.mdx
@@ -485,7 +485,8 @@ export function TRPCProvider(props: { children: React.ReactNode }) {
 
 ### Expo Client
 
-**storage**: the SecureStore-compatible storage used to cache session data and cookies. Write coordination is scoped to the provided object, so reuse it when configuring multiple clients that access the same stored data.
+**storage**: the SecureStore-compatible storage used to cache session data and cookies.
+Reuse the same storage instance across clients that access the same stored data.
 
 ```ts title="lib/auth-client.ts"
 import { createAuthClient } from "better-auth/react";

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -4,6 +4,7 @@ import type {
 	ClientStore,
 } from "@better-auth/core";
 import type { Session, User } from "@better-auth/core/db";
+import { logger } from "@better-auth/core/env";
 import { safeJSONParse } from "@better-auth/core/utils/json";
 import {
 	parseSetCookieHeader,
@@ -25,7 +26,7 @@ if (Platform.OS !== "web") {
 
 /**
  * Storage used by the Expo client for cookies and cached session data.
- * Write coordination is scoped to the provided object, so reuse it across
+ * Async access is coordinated through the provided object, so reuse it across
  * clients that access the same stored data.
  */
 export type ExpoClientStorage = Pick<
@@ -266,10 +267,8 @@ export function normalizeCookieName(name: string) {
 }
 
 /**
- * Max characters written per `setItem`. Native secure stores silently reject
- * oversized writes (iOS Keychain refuses values above ~2KB), losing the cookie,
- * so a larger value is split across keys here. Mirrors the server's
- * `chunkCookie`/`joinChunks` in `session-store.ts`; keep the two in sync.
+ * Character budget per stored chunk. Some native stores reject large values,
+ * so larger strings are split across keys. This is not a byte-size guarantee.
  *
  * @see https://github.com/better-auth/better-auth/issues/9151
  */
@@ -360,7 +359,7 @@ function readChunks(
 	let value = "";
 	for (let i = 0; i < marker.count; i++) {
 		const chunk = storage.getItem(getChunkKey(key, marker, i));
-		if (chunk == null) {
+		if (!chunk) {
 			return null;
 		}
 		value += chunk;
@@ -376,7 +375,7 @@ async function readChunksAsync(
 	let value = "";
 	for (let i = 0; i < marker.count; i++) {
 		const chunk = await storage.getItemAsync(getChunkKey(key, marker, i));
-		if (chunk == null) {
+		if (!chunk) {
 			return null;
 		}
 		value += chunk;
@@ -430,13 +429,25 @@ async function readStoredValueAsync(
 	});
 }
 
-function getStorageWrites(
+interface ChunkCleanupRange {
+	prefix: string;
+	start: number;
+	end: number;
+}
+
+function getStorageWritePlan(
 	key: string,
 	value: string,
 	currentBaseValue: string | null,
-): [string, string][] {
+): { writes: [key: string, value: string][]; cleanup: ChunkCleanupRange[] } {
+	const currentMarker = currentBaseValue?.startsWith(CHUNK_MARKER)
+		? parseChunkMarker(currentBaseValue)
+		: null;
 	if (value.length <= STORAGE_VALUE_LIMIT) {
-		return [[key, value]];
+		return {
+			writes: [[key, value]],
+			cleanup: getUnusedChunkRanges(key, currentMarker, null),
+		};
 	}
 
 	const count = Math.ceil(value.length / STORAGE_VALUE_LIMIT);
@@ -445,9 +456,6 @@ function getStorageWrites(
 			`Storage value requires ${count} chunks, exceeding the limit of ${MAX_STORAGE_CHUNKS}`,
 		);
 	}
-	const currentMarker = currentBaseValue?.startsWith(CHUNK_MARKER)
-		? parseChunkMarker(currentBaseValue)
-		: null;
 	const slot: ChunkSlot = currentMarker?.slot === 0 ? 1 : 0;
 	const marker: ChunkMarker = {
 		count,
@@ -471,47 +479,90 @@ function getStorageWrites(
 		]);
 	}
 	writes.push([key, serializeChunkMarker(marker)]);
-	return writes;
+	return { writes, cleanup: getUnusedChunkRanges(key, currentMarker, marker) };
 }
 
-function createKeyedWriteQueue() {
-	const tails = new Map<string, Promise<unknown>>();
-	return {
-		pending(key: string): boolean {
-			return tails.has(key);
-		},
-		enqueue<Result>(
-			key: string,
-			operation: () => Promise<Result>,
-		): Promise<Result> {
-			const previous = tails.get(key) ?? Promise.resolve();
-			const queued = previous.then(operation, operation);
-			tails.set(key, queued);
-
-			const cleanup = () => {
-				if (tails.get(key) === queued) {
-					tails.delete(key);
-				}
-			};
-			void queued.then(cleanup, cleanup);
-			return queued;
-		},
-	};
+function getSlotChunkCount(marker: ChunkMarker | null, slot: ChunkSlot | null) {
+	if (!marker) return 0;
+	if (marker.slot === slot) return marker.count;
+	if (marker.slot === null || slot === null) return 0;
+	return marker.fallbackCount ?? 0;
 }
 
-const storageWriteQueues = new WeakMap<
+function getUnusedChunkRanges(
+	key: string,
+	previousMarker: ChunkMarker | null,
+	marker: ChunkMarker | null,
+): ChunkCleanupRange[] {
+	return ([null, 0, 1] as const).map((slot) => ({
+		prefix: slot === null ? key : `${key}.${slot}`,
+		start: getSlotChunkCount(marker, slot),
+		end: getSlotChunkCount(previousMarker, slot),
+	}));
+}
+
+interface StorageRead {
+	snapshot: { value: string | null } | null;
+}
+
+interface StorageKeyState {
+	pending: Promise<unknown> | null;
+	pendingWrites: number;
+	activeRead: StorageRead | null;
+	cleanupComplete: boolean;
+}
+
+const storageStates = new WeakMap<
 	ExpoClientStorage,
-	ReturnType<typeof createKeyedWriteQueue>
+	Map<string, StorageKeyState>
 >();
 
-function getStorageWriteQueue(storage: ExpoClientStorage) {
-	const existing = storageWriteQueues.get(storage);
-	if (existing) {
-		return existing;
+function getStorageState(storage: ExpoClientStorage, key: string) {
+	let states = storageStates.get(storage);
+	if (!states) {
+		states = new Map();
+		storageStates.set(storage, states);
 	}
-	const queue = createKeyedWriteQueue();
-	storageWriteQueues.set(storage, queue);
-	return queue;
+	let state = states.get(key);
+	if (!state) {
+		state = {
+			pending: null,
+			pendingWrites: 0,
+			activeRead: null,
+			cleanupComplete: false,
+		};
+		states.set(key, state);
+	}
+	return state;
+}
+
+function enqueueStorageOperation<Result>(
+	state: StorageKeyState,
+	operation: () => Promise<Result>,
+): Promise<Result> {
+	const previous = state.pending ?? Promise.resolve();
+	const queued = previous.then(operation, operation);
+	state.pending = queued;
+
+	const cleanup = () => {
+		if (state.pending === queued) state.pending = null;
+	};
+	void queued.then(cleanup, cleanup);
+	return queued;
+}
+
+function enqueueStorageWrite<Result>(
+	state: StorageKeyState,
+	operation: () => Promise<Result>,
+): Promise<Result> {
+	state.pendingWrites++;
+	return enqueueStorageOperation(state, async () => {
+		try {
+			return await operation();
+		} finally {
+			state.pendingWrites--;
+		}
+	});
 }
 
 interface ExpoStorageAdapter {
@@ -527,10 +578,15 @@ interface StoredUpdate {
 }
 
 function createManagedStorage(storage: ExpoClientStorage) {
-	const writeQueue = getStorageWriteQueue(storage);
 	const logWriteError = (key: string, error: unknown) => {
-		console.error(
+		logger.error(
 			`[better-auth/expo] failed to persist "${key}" to storage`,
+			error,
+		);
+	};
+	const logCleanupError = (key: string, error: unknown) => {
+		logger.error(
+			`[better-auth/expo] failed to clear unused chunks for "${key}"`,
 			error,
 		);
 	};
@@ -538,22 +594,55 @@ function createManagedStorage(storage: ExpoClientStorage) {
 		const key = normalizeCookieName(name);
 		return readStoredValue(storage, key, storage.getItem(key));
 	};
-	const getItemAsync = async (name: string): Promise<string | null> => {
+	const getItemAsync = (name: string): Promise<string | null> => {
 		const key = normalizeCookieName(name);
-		const baseValue = await storage.getItemAsync(key);
-		return readStoredValueAsync(storage, key, baseValue);
+		const state = getStorageState(storage, key);
+		return enqueueStorageOperation(state, async () => {
+			const read: StorageRead = { snapshot: null };
+			state.activeRead = read;
+			try {
+				const baseValue = await storage.getItemAsync(key);
+				const value = await readStoredValueAsync(storage, key, baseValue);
+				return read.snapshot ? read.snapshot.value : value;
+			} finally {
+				state.activeRead = null;
+			}
+		});
 	};
 	const writeItem = (
 		key: string,
 		value: string,
 		currentBaseValue: string | null,
 	) => {
-		for (const [writeKey, writeValue] of getStorageWrites(
+		const state = getStorageState(storage, key);
+		const { writes, cleanup } = getStorageWritePlan(
 			key,
 			value,
 			currentBaseValue,
-		)) {
+		);
+		for (const [writeKey, writeValue] of writes) {
 			storage.setItem(writeKey, writeValue);
+		}
+		try {
+			const scan = !state.cleanupComplete;
+			for (const { prefix, start, end } of cleanup) {
+				for (let i = end - 1; i >= start; i--) {
+					storage.setItem(`${prefix}.${i}`, "");
+				}
+				if (!scan) continue;
+
+				const orphanStart = Math.max(start, end);
+				for (let i = MAX_STORAGE_CHUNKS - 1; i >= orphanStart; i--) {
+					const chunkKey = `${prefix}.${i}`;
+					const chunk = storage.getItem(chunkKey);
+					if (!chunk) continue;
+					storage.setItem(chunkKey, "");
+				}
+			}
+			state.cleanupComplete = true;
+		} catch (error) {
+			state.cleanupComplete = false;
+			logCleanupError(key, error);
 		}
 	};
 	const writeItemAsync = async (
@@ -561,41 +650,101 @@ function createManagedStorage(storage: ExpoClientStorage) {
 		value: string,
 		currentBaseValue: string | null,
 	) => {
-		for (const [writeKey, writeValue] of getStorageWrites(
+		const state = getStorageState(storage, key);
+		const { writes, cleanup } = getStorageWritePlan(
 			key,
 			value,
 			currentBaseValue,
-		)) {
+		);
+		for (const [writeKey, writeValue] of writes) {
 			await storage.setItemAsync(writeKey, writeValue);
+		}
+		try {
+			const scan = !state.cleanupComplete;
+			for (const { prefix, start, end } of cleanup) {
+				for (let i = end - 1; i >= start; i--) {
+					await storage.setItemAsync(`${prefix}.${i}`, "");
+				}
+				if (!scan) continue;
+
+				const orphanStart = Math.max(start, end);
+				for (let i = MAX_STORAGE_CHUNKS - 1; i >= orphanStart; i--) {
+					const chunkKey = `${prefix}.${i}`;
+					const chunk = await storage.getItemAsync(chunkKey);
+					if (!chunk) continue;
+					await storage.setItemAsync(chunkKey, "");
+				}
+			}
+			state.cleanupComplete = true;
+		} catch (error) {
+			state.cleanupComplete = false;
+			logCleanupError(key, error);
 		}
 	};
 	const setItem = (name: string, value: string): void => {
 		const key = normalizeCookieName(name);
-		if (writeQueue.pending(key)) {
+		const state = getStorageState(storage, key);
+		if (state.pendingWrites > 0) {
 			logWriteError(
 				key,
 				new Error("Cannot write synchronously while an async write is pending"),
 			);
 			return;
 		}
+
+		let currentBaseValue: string | null = null;
 		try {
-			const currentBaseValue =
-				value.length > STORAGE_VALUE_LIMIT ? storage.getItem(key) : null;
+			currentBaseValue = storage.getItem(key);
+		} catch (error) {
+			state.cleanupComplete = false;
+			if (value.length > STORAGE_VALUE_LIMIT) {
+				logWriteError(key, error);
+				return;
+			}
+		}
+
+		const read = state.activeRead;
+		if (read && read.snapshot === null) {
+			// Preserve the reader's value before its chunks can be overwritten.
+			try {
+				read.snapshot = {
+					value: readStoredValue(storage, key, currentBaseValue),
+				};
+			} catch {
+				read.snapshot = { value: null };
+			}
+		}
+
+		try {
 			writeItem(key, value, currentBaseValue);
 		} catch (error) {
+			state.cleanupComplete = false;
 			logWriteError(key, error);
+			return;
+		}
+		if (read) {
+			read.snapshot = { value };
 		}
 	};
 	const setItemAsync = (name: string, value: string): Promise<void> => {
 		const key = normalizeCookieName(name);
-		return writeQueue.enqueue(key, async () => {
+		const state = getStorageState(storage, key);
+		return enqueueStorageWrite(state, async () => {
+			let currentBaseValue: string | null = null;
 			try {
-				const currentBaseValue =
-					value.length > STORAGE_VALUE_LIMIT
-						? await storage.getItemAsync(key)
-						: null;
+				currentBaseValue = await storage.getItemAsync(key);
+			} catch (error) {
+				state.cleanupComplete = false;
+				if (value.length > STORAGE_VALUE_LIMIT) {
+					logWriteError(key, error);
+					return;
+				}
+			}
+
+			try {
 				await writeItemAsync(key, value, currentBaseValue);
 			} catch (error) {
+				state.cleanupComplete = false;
 				logWriteError(key, error);
 			}
 		});
@@ -605,7 +754,8 @@ function createManagedStorage(storage: ExpoClientStorage) {
 		update: (currentValue: string | null) => string,
 	): Promise<StoredUpdate | null> => {
 		const key = normalizeCookieName(name);
-		return writeQueue.enqueue(key, async () => {
+		const state = getStorageState(storage, key);
+		return enqueueStorageWrite(state, async () => {
 			try {
 				const currentBaseValue = await storage.getItemAsync(key);
 				const previousValue = await readStoredValueAsync(
@@ -617,6 +767,7 @@ function createManagedStorage(storage: ExpoClientStorage) {
 				await writeItemAsync(key, value, currentBaseValue);
 				return { previousValue, value };
 			} catch (error) {
+				state.cleanupComplete = false;
 				logWriteError(key, error);
 				return null;
 			}
@@ -628,7 +779,7 @@ function createManagedStorage(storage: ExpoClientStorage) {
 
 /**
  * Wraps Expo storage with chunking, recoverable writes, and serialized async
- * updates.
+ * access.
  */
 export function storageAdapter(storage: ExpoClientStorage): ExpoStorageAdapter {
 	const managedStorage = createManagedStorage(storage);

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -285,6 +285,7 @@ const MAX_STORAGE_CHUNKS = 100;
 const CHUNK_MARKER = "\u0001ba-chunks:";
 
 type ChunkSlot = 0 | 1;
+const CHUNK_SLOTS = [null, 0, 1] as const;
 
 interface ChunkMarker {
 	count: number;
@@ -494,7 +495,7 @@ function getUnusedChunkRanges(
 	previousMarker: ChunkMarker | null,
 	marker: ChunkMarker | null,
 ): ChunkCleanupRange[] {
-	return ([null, 0, 1] as const).map((slot) => ({
+	return CHUNK_SLOTS.map((slot) => ({
 		prefix: slot === null ? key : `${key}.${slot}`,
 		start: getSlotChunkCount(marker, slot),
 		end: getSlotChunkCount(previousMarker, slot),
@@ -509,6 +510,8 @@ interface StorageKeyState {
 	pending: Promise<unknown> | null;
 	pendingWrites: number;
 	activeRead: StorageRead | null;
+	revision: number;
+	cleanupRunning: boolean;
 	cleanupComplete: boolean;
 }
 
@@ -529,6 +532,8 @@ function getStorageState(storage: ExpoClientStorage, key: string) {
 			pending: null,
 			pendingWrites: 0,
 			activeRead: null,
+			revision: 0,
+			cleanupRunning: false,
 			cleanupComplete: false,
 		};
 		states.set(key, state);
@@ -563,6 +568,75 @@ function enqueueStorageWrite<Result>(
 			state.pendingWrites--;
 		}
 	});
+}
+
+async function sweepOrphanChunks(
+	storage: ExpoClientStorage,
+	key: string,
+	state: StorageKeyState,
+): Promise<number | null> {
+	await new Promise<void>((resolve) => setTimeout(resolve, 0));
+	// A failed operation should not stop cleanup.
+	for (let pending = state.pending; pending; pending = state.pending) {
+		await pending.catch(() => {});
+	}
+
+	const revision = state.revision;
+	const baseValue = await storage.getItemAsync(key);
+	for (let pending = state.pending; pending; pending = state.pending) {
+		await pending.catch(() => {});
+	}
+	if (state.revision !== revision) return null;
+	const marker = baseValue?.startsWith(CHUNK_MARKER)
+		? parseChunkMarker(baseValue)
+		: null;
+	if (baseValue?.startsWith(CHUNK_MARKER) && !marker) {
+		throw new Error("Cannot clean chunks with an invalid storage marker");
+	}
+
+	for (const slot of CHUNK_SLOTS) {
+		const prefix = slot === null ? key : `${key}.${slot}`;
+		const start = getSlotChunkCount(marker, slot);
+		for (let i = start; i < MAX_STORAGE_CHUNKS; i++) {
+			for (let pending = state.pending; pending; pending = state.pending) {
+				await pending.catch(() => {});
+			}
+			if (state.revision !== revision) return null;
+			const chunkKey = `${prefix}.${i}`;
+			const chunk = await storage.getItemAsync(chunkKey);
+			for (let pending = state.pending; pending; pending = state.pending) {
+				await pending.catch(() => {});
+			}
+			if (state.revision !== revision) return null;
+			// A synchronous clear prevents a writer from reusing the key after the check.
+			if (chunk) storage.setItem(chunkKey, "");
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+		}
+	}
+	return state.revision === revision ? revision : null;
+}
+
+function scheduleOrphanCleanup(
+	storage: ExpoClientStorage,
+	key: string,
+	state: StorageKeyState,
+) {
+	if (state.cleanupComplete || state.cleanupRunning) return;
+	state.cleanupRunning = true;
+	void sweepOrphanChunks(storage, key, state).then(
+		(cleanedRevision) => {
+			state.cleanupRunning = false;
+			state.cleanupComplete = cleanedRevision === state.revision;
+			if (!state.cleanupComplete) scheduleOrphanCleanup(storage, key, state);
+		},
+		(error: unknown) => {
+			state.cleanupRunning = false;
+			logger.error(
+				`[better-auth/expo] failed to clear orphaned chunks for "${key}"`,
+				error,
+			);
+		},
+	);
 }
 
 interface ExpoStorageAdapter {
@@ -615,6 +689,7 @@ function createManagedStorage(storage: ExpoClientStorage) {
 		currentBaseValue: string | null,
 	) => {
 		const state = getStorageState(storage, key);
+		state.revision++;
 		const { writes, cleanup } = getStorageWritePlan(
 			key,
 			value,
@@ -624,26 +699,16 @@ function createManagedStorage(storage: ExpoClientStorage) {
 			storage.setItem(writeKey, writeValue);
 		}
 		try {
-			const scan = !state.cleanupComplete;
 			for (const { prefix, start, end } of cleanup) {
 				for (let i = end - 1; i >= start; i--) {
 					storage.setItem(`${prefix}.${i}`, "");
 				}
-				if (!scan) continue;
-
-				const orphanStart = Math.max(start, end);
-				for (let i = MAX_STORAGE_CHUNKS - 1; i >= orphanStart; i--) {
-					const chunkKey = `${prefix}.${i}`;
-					const chunk = storage.getItem(chunkKey);
-					if (!chunk) continue;
-					storage.setItem(chunkKey, "");
-				}
 			}
-			state.cleanupComplete = true;
 		} catch (error) {
 			state.cleanupComplete = false;
 			logCleanupError(key, error);
 		}
+		scheduleOrphanCleanup(storage, key, state);
 	};
 	const writeItemAsync = async (
 		key: string,
@@ -651,6 +716,7 @@ function createManagedStorage(storage: ExpoClientStorage) {
 		currentBaseValue: string | null,
 	) => {
 		const state = getStorageState(storage, key);
+		state.revision++;
 		const { writes, cleanup } = getStorageWritePlan(
 			key,
 			value,
@@ -660,26 +726,16 @@ function createManagedStorage(storage: ExpoClientStorage) {
 			await storage.setItemAsync(writeKey, writeValue);
 		}
 		try {
-			const scan = !state.cleanupComplete;
 			for (const { prefix, start, end } of cleanup) {
 				for (let i = end - 1; i >= start; i--) {
 					await storage.setItemAsync(`${prefix}.${i}`, "");
 				}
-				if (!scan) continue;
-
-				const orphanStart = Math.max(start, end);
-				for (let i = MAX_STORAGE_CHUNKS - 1; i >= orphanStart; i--) {
-					const chunkKey = `${prefix}.${i}`;
-					const chunk = await storage.getItemAsync(chunkKey);
-					if (!chunk) continue;
-					await storage.setItemAsync(chunkKey, "");
-				}
 			}
-			state.cleanupComplete = true;
 		} catch (error) {
 			state.cleanupComplete = false;
 			logCleanupError(key, error);
 		}
+		scheduleOrphanCleanup(storage, key, state);
 	};
 	const setItem = (name: string, value: string): void => {
 		const key = normalizeCookieName(name);

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -32,8 +32,7 @@ if (Platform.OS !== "web") {
 export type ExpoClientStorage = Pick<
 	typeof SecureStore,
 	"setItem" | "setItemAsync" | "getItem" | "getItemAsync"
-> &
-	Partial<Pick<typeof SecureStore, "deleteItemAsync">>;
+>;
 
 interface ExpoClientOptions {
 	scheme?: string | undefined;
@@ -503,18 +502,6 @@ function getUnusedChunkRanges(
 	}));
 }
 
-async function clearStorageItemAsync(storage: ExpoClientStorage, key: string) {
-	if (!storage.deleteItemAsync) {
-		await storage.setItemAsync(key, "");
-		return;
-	}
-	try {
-		await storage.deleteItemAsync(key);
-	} catch {
-		await storage.setItemAsync(key, "");
-	}
-}
-
 interface StorageRead {
 	snapshot: { value: string | null } | null;
 }
@@ -685,11 +672,11 @@ function createManagedStorage(storage: ExpoClientStorage) {
 						if (!chunk) break;
 					}
 					for (let i = orphanEnd - 1; i >= orphanStart; i--) {
-						await clearStorageItemAsync(storage, `${prefix}.${i}`);
+						await storage.setItemAsync(`${prefix}.${i}`, "");
 					}
 				}
 				for (let i = end - 1; i >= start; i--) {
-					await clearStorageItemAsync(storage, `${prefix}.${i}`);
+					await storage.setItemAsync(`${prefix}.${i}`, "");
 				}
 			}
 			state.cleanupComplete = true;

--- a/packages/expo/src/client.ts
+++ b/packages/expo/src/client.ts
@@ -32,7 +32,8 @@ if (Platform.OS !== "web") {
 export type ExpoClientStorage = Pick<
 	typeof SecureStore,
 	"setItem" | "setItemAsync" | "getItem" | "getItemAsync"
->;
+> &
+	Partial<Pick<typeof SecureStore, "deleteItemAsync">>;
 
 interface ExpoClientOptions {
 	scheme?: string | undefined;
@@ -502,6 +503,18 @@ function getUnusedChunkRanges(
 	}));
 }
 
+async function clearStorageItemAsync(storage: ExpoClientStorage, key: string) {
+	if (!storage.deleteItemAsync) {
+		await storage.setItemAsync(key, "");
+		return;
+	}
+	try {
+		await storage.deleteItemAsync(key);
+	} catch {
+		await storage.setItemAsync(key, "");
+	}
+}
+
 interface StorageRead {
 	snapshot: { value: string | null } | null;
 }
@@ -510,8 +523,6 @@ interface StorageKeyState {
 	pending: Promise<unknown> | null;
 	pendingWrites: number;
 	activeRead: StorageRead | null;
-	revision: number;
-	cleanupRunning: boolean;
 	cleanupComplete: boolean;
 }
 
@@ -532,8 +543,6 @@ function getStorageState(storage: ExpoClientStorage, key: string) {
 			pending: null,
 			pendingWrites: 0,
 			activeRead: null,
-			revision: 0,
-			cleanupRunning: false,
 			cleanupComplete: false,
 		};
 		states.set(key, state);
@@ -568,75 +577,6 @@ function enqueueStorageWrite<Result>(
 			state.pendingWrites--;
 		}
 	});
-}
-
-async function sweepOrphanChunks(
-	storage: ExpoClientStorage,
-	key: string,
-	state: StorageKeyState,
-): Promise<number | null> {
-	await new Promise<void>((resolve) => setTimeout(resolve, 0));
-	// A failed operation should not stop cleanup.
-	for (let pending = state.pending; pending; pending = state.pending) {
-		await pending.catch(() => {});
-	}
-
-	const revision = state.revision;
-	const baseValue = await storage.getItemAsync(key);
-	for (let pending = state.pending; pending; pending = state.pending) {
-		await pending.catch(() => {});
-	}
-	if (state.revision !== revision) return null;
-	const marker = baseValue?.startsWith(CHUNK_MARKER)
-		? parseChunkMarker(baseValue)
-		: null;
-	if (baseValue?.startsWith(CHUNK_MARKER) && !marker) {
-		throw new Error("Cannot clean chunks with an invalid storage marker");
-	}
-
-	for (const slot of CHUNK_SLOTS) {
-		const prefix = slot === null ? key : `${key}.${slot}`;
-		const start = getSlotChunkCount(marker, slot);
-		for (let i = start; i < MAX_STORAGE_CHUNKS; i++) {
-			for (let pending = state.pending; pending; pending = state.pending) {
-				await pending.catch(() => {});
-			}
-			if (state.revision !== revision) return null;
-			const chunkKey = `${prefix}.${i}`;
-			const chunk = await storage.getItemAsync(chunkKey);
-			for (let pending = state.pending; pending; pending = state.pending) {
-				await pending.catch(() => {});
-			}
-			if (state.revision !== revision) return null;
-			// A synchronous clear prevents a writer from reusing the key after the check.
-			if (chunk) storage.setItem(chunkKey, "");
-			await new Promise<void>((resolve) => setTimeout(resolve, 0));
-		}
-	}
-	return state.revision === revision ? revision : null;
-}
-
-function scheduleOrphanCleanup(
-	storage: ExpoClientStorage,
-	key: string,
-	state: StorageKeyState,
-) {
-	if (state.cleanupComplete || state.cleanupRunning) return;
-	state.cleanupRunning = true;
-	void sweepOrphanChunks(storage, key, state).then(
-		(cleanedRevision) => {
-			state.cleanupRunning = false;
-			state.cleanupComplete = cleanedRevision === state.revision;
-			if (!state.cleanupComplete) scheduleOrphanCleanup(storage, key, state);
-		},
-		(error: unknown) => {
-			state.cleanupRunning = false;
-			logger.error(
-				`[better-auth/expo] failed to clear orphaned chunks for "${key}"`,
-				error,
-			);
-		},
-	);
 }
 
 interface ExpoStorageAdapter {
@@ -689,7 +629,6 @@ function createManagedStorage(storage: ExpoClientStorage) {
 		currentBaseValue: string | null,
 	) => {
 		const state = getStorageState(storage, key);
-		state.revision++;
 		const { writes, cleanup } = getStorageWritePlan(
 			key,
 			value,
@@ -699,16 +638,27 @@ function createManagedStorage(storage: ExpoClientStorage) {
 			storage.setItem(writeKey, writeValue);
 		}
 		try {
+			const scanContiguousOrphans = !state.cleanupComplete;
 			for (const { prefix, start, end } of cleanup) {
+				if (scanContiguousOrphans) {
+					const orphanStart = Math.max(start, end);
+					let orphanEnd = orphanStart;
+					for (; orphanEnd < MAX_STORAGE_CHUNKS; orphanEnd++) {
+						if (!storage.getItem(`${prefix}.${orphanEnd}`)) break;
+					}
+					for (let i = orphanEnd - 1; i >= orphanStart; i--) {
+						storage.setItem(`${prefix}.${i}`, "");
+					}
+				}
 				for (let i = end - 1; i >= start; i--) {
 					storage.setItem(`${prefix}.${i}`, "");
 				}
 			}
+			state.cleanupComplete = true;
 		} catch (error) {
 			state.cleanupComplete = false;
 			logCleanupError(key, error);
 		}
-		scheduleOrphanCleanup(storage, key, state);
 	};
 	const writeItemAsync = async (
 		key: string,
@@ -716,7 +666,6 @@ function createManagedStorage(storage: ExpoClientStorage) {
 		currentBaseValue: string | null,
 	) => {
 		const state = getStorageState(storage, key);
-		state.revision++;
 		const { writes, cleanup } = getStorageWritePlan(
 			key,
 			value,
@@ -726,16 +675,28 @@ function createManagedStorage(storage: ExpoClientStorage) {
 			await storage.setItemAsync(writeKey, writeValue);
 		}
 		try {
+			const scanContiguousOrphans = !state.cleanupComplete;
 			for (const { prefix, start, end } of cleanup) {
+				if (scanContiguousOrphans) {
+					const orphanStart = Math.max(start, end);
+					let orphanEnd = orphanStart;
+					for (; orphanEnd < MAX_STORAGE_CHUNKS; orphanEnd++) {
+						const chunk = await storage.getItemAsync(`${prefix}.${orphanEnd}`);
+						if (!chunk) break;
+					}
+					for (let i = orphanEnd - 1; i >= orphanStart; i--) {
+						await clearStorageItemAsync(storage, `${prefix}.${i}`);
+					}
+				}
 				for (let i = end - 1; i >= start; i--) {
-					await storage.setItemAsync(`${prefix}.${i}`, "");
+					await clearStorageItemAsync(storage, `${prefix}.${i}`);
 				}
 			}
+			state.cleanupComplete = true;
 		} catch (error) {
 			state.cleanupComplete = false;
 			logCleanupError(key, error);
 		}
-		scheduleOrphanCleanup(storage, key, state);
 	};
 	const setItem = (name: string, value: string): void => {
 		const key = normalizeCookieName(name);

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -1503,7 +1503,7 @@ describe("expo with cookieCache", async () => {
 		}
 
 		describe.each(["setItem", "setItemAsync"] as const)("%s", (method) => {
-			it("recovers an orphaned tail after earlier chunks were cleared", async () => {
+			it("retries orphan cleanup without leaving an unscannable gap", async () => {
 				const map = new Map<string, string>([
 					[key, "\u0001ba-chunks:2:0"],
 					[`${key}.0.0`, "first"],
@@ -1525,55 +1525,17 @@ describe("expo with cookieCache", async () => {
 				await storage[method](key, "{}");
 				await vi.runAllTimersAsync();
 				expect(map.get(key)).toBe("{}");
-				expect(map.get(`${key}.0.0`)).toBe("");
-				expect(map.get(`${key}.0.1`)).toBe("");
+				expect(map.get(`${key}.0.0`)).toBe("first");
+				expect(map.get(`${key}.0.1`)).toBe("second");
 				expect(map.get(`${key}.0.2`)).toBe("old-secret");
 				expect(error).toHaveBeenCalledOnce();
 
 				failing = false;
 				await storage[method](key, "{}");
 				await vi.runAllTimersAsync();
+				expect(map.get(`${key}.0.0`)).toBe("");
+				expect(map.get(`${key}.0.1`)).toBe("");
 				expect(map.get(`${key}.0.2`)).toBe("");
-			});
-
-			it("allows foreground access while a background probe is pending", async () => {
-				const map = new Map<string, string>([[`${key}.0.0`, "old-secret"]]);
-				const backing = createBackingStorage(map);
-				const { reading, resume } = pauseNextStorageRead(backing, `${key}.0.0`);
-				const storage = storageAdapter(backing);
-				const error = vi.spyOn(logger, "error").mockImplementation(() => {});
-				await storage[method](key, "{}");
-				await vi.runAllTimersAsync();
-				await reading;
-
-				try {
-					await expect(storage.getItemAsync(key)).resolves.toBe("{}");
-					await storage[method](key, previousValue);
-					expect(storage.getItem(key)).toBe(previousValue);
-				} finally {
-					resume();
-				}
-				await vi.runAllTimersAsync();
-				expect(storage.getItem(key)).toBe(previousValue);
-				expect(error).not.toHaveBeenCalled();
-			});
-
-			it("completes foreground writes before probing orphaned chunks", async () => {
-				const map = new Map<string, string>([[`${key}.2`, "old-secret"]]);
-				const backing = createBackingStorage(map);
-				const getItem = vi.spyOn(backing, "getItem");
-				const getItemAsync = vi.spyOn(backing, "getItemAsync");
-				const storage = storageAdapter(backing);
-
-				await storage[method](key, "{}");
-
-				expect(map.get(key)).toBe("{}");
-				expect(map.get(`${key}.2`)).toBe("old-secret");
-				expect(getItem.mock.calls.length + getItemAsync.mock.calls.length).toBe(
-					1,
-				);
-				await vi.runAllTimersAsync();
-				expect(map.get(`${key}.2`)).toBe("");
 			});
 
 			it("persists a short value when reading the previous marker fails", async () => {
@@ -1604,19 +1566,6 @@ describe("expo with cookieCache", async () => {
 				const storage = storageAdapter(createBackingStorage(map));
 				await storage[method](key, "{}");
 				expect(map.get(`${key}.2`) ?? "").toBe("");
-			});
-
-			it("clears orphaned chunks even when the first chunk is missing", async () => {
-				const map = new Map<string, string>([
-					[key, "{}"],
-					[`${key}.2`, "old-secret"],
-					[`${key}.0.2`, "old-cache"],
-				]);
-				const storage = storageAdapter(createBackingStorage(map));
-				await storage[method](key, "{}");
-				await vi.runAllTimersAsync();
-				expect(map.get(`${key}.2`) ?? "").toBe("");
-				expect(map.get(`${key}.0.2`) ?? "").toBe("");
 			});
 
 			it("uses the marker to clear incomplete chunks after the initial sweep", async () => {
@@ -1766,13 +1715,8 @@ describe("expo with cookieCache", async () => {
 				expect(map.get(`${key}.1`)).toBe("");
 			});
 
-			it("bounds orphan probing and skips it after successful cleanup", async () => {
+			it("stops orphan probing at the first empty chunk", async () => {
 				const map = new Map<string, string>();
-				for (const prefix of [key, `${key}.0`, `${key}.1`]) {
-					for (let i = 0; i <= 100; i++) {
-						map.set(`${prefix}.${i}`, "old data");
-					}
-				}
 				const backing = createBackingStorage(map);
 				const getItem = vi.spyOn(backing, "getItem");
 				const getItemAsync = vi.spyOn(backing, "getItemAsync");
@@ -1780,145 +1724,76 @@ describe("expo with cookieCache", async () => {
 
 				await storage[method](key, "{}");
 				expect(getItem.mock.calls.length + getItemAsync.mock.calls.length).toBe(
-					1,
+					4,
 				);
-				await vi.runAllTimersAsync();
-				const chunkReads = [
-					...getItem.mock.calls,
-					...getItemAsync.mock.calls,
-				].filter(([name]) => name !== key);
-				expect(chunkReads).toHaveLength(300);
-				for (const prefix of [key, `${key}.0`, `${key}.1`]) {
-					expect(map.get(`${prefix}.0`)).toBe("");
-					expect(map.get(`${prefix}.99`)).toBe("");
-					expect(map.get(`${prefix}.100`)).toBe("old data");
-				}
 
 				getItem.mockClear();
 				getItemAsync.mockClear();
 				await storageAdapter(backing)[method](key, "{}");
-				await vi.runAllTimersAsync();
 				expect(getItem.mock.calls.length + getItemAsync.mock.calls.length).toBe(
 					1,
 				);
+
+				const nextBacking = createBackingStorage(map);
+				const nextGetItem = vi.spyOn(nextBacking, "getItem");
+				const nextGetItemAsync = vi.spyOn(nextBacking, "getItemAsync");
+				await storageAdapter(nextBacking)[method](key, "{}");
+				expect(
+					nextGetItem.mock.calls.length + nextGetItemAsync.mock.calls.length,
+				).toBe(4);
 			});
 		});
 
-		it("yields after each orphan chunk probe", async () => {
+		it("deletes obsolete chunks when async deletion is available", async () => {
 			const map = new Map<string, string>([
-				[`${key}.8`, "old-secret"],
-				[`${key}.9`, "another-secret"],
+				[key, "\u0001ba-chunks:2"],
+				[`${key}.0`, "first"],
+				[`${key}.1`, "second"],
+			]);
+			const setItemAsync = vi.fn(async (name: string, value: string) => {
+				map.set(name, value);
+			});
+			const deleteItemAsync = vi.fn(async (name: string) => {
+				map.delete(name);
+			});
+			const storage = storageAdapter({
+				...createBackingStorage(map),
+				setItemAsync,
+				deleteItemAsync,
+			});
+
+			await storage.setItemAsync(key, "{}");
+
+			expect(deleteItemAsync).toHaveBeenCalledWith(`${key}.1`);
+			expect(deleteItemAsync).toHaveBeenCalledWith(`${key}.0`);
+			expect(setItemAsync).not.toHaveBeenCalledWith(`${key}.1`, "");
+			expect(setItemAsync).not.toHaveBeenCalledWith(`${key}.0`, "");
+		});
+
+		it("retries partially cleared orphan chunks on the next write", async () => {
+			const map = new Map<string, string>([
+				[`${key}.0`, "first"],
+				[`${key}.1`, "second"],
+				[`${key}.2`, "third"],
 			]);
 			const backing = createBackingStorage(map);
-			const schedule = vi.spyOn(globalThis, "setTimeout");
-			const turns = new Map<number, { probes: number; clears: number }>();
-			const record = (operation: "probes" | "clears") => {
-				const id = schedule.mock.calls.length;
-				const turn = turns.get(id) ?? { probes: 0, clears: 0 };
-				turn[operation]++;
-				turns.set(id, turn);
-			};
-			backing.getItemAsync = async (name) => {
-				if (name !== key) record("probes");
-				return map.get(name) ?? null;
-			};
-			backing.setItem = (name, value) => {
-				record("clears");
-				map.set(name, value);
-			};
-			const storage = storageAdapter(backing);
-			await storage.setItemAsync(key, "{}");
-			turns.clear();
-			await vi.runAllTimersAsync();
-			expect(turns.size).toBe(300);
-			for (const turn of turns.values()) {
-				expect(turn.probes).toBe(1);
-				expect(turn.clears).toBeLessThanOrEqual(1);
-			}
-			expect(map.get(`${key}.8`)).toBe("");
-			expect(map.get(`${key}.9`)).toBe("");
-		});
-
-		it.each([
-			{ outcome: "successful", failing: false, expected: "{}" },
-			{ outcome: "failed", failing: true, expected: null },
-		])("preserves scan progress across $outcome readers", async ({
-			failing,
-			expected,
-		}) => {
-			const map = new Map<string, string>([[`${key}.1.99`, "old-secret"]]);
-			const backing = createBackingStorage(map);
-			const storage = storageAdapter(backing);
-			const interruptions = new Set([`${key}.33`, `${key}.66`, `${key}.99`]);
-			const reads: Promise<string | null>[] = [];
-			const probes: string[] = [];
-			let failNextRead = false;
-			backing.getItemAsync = async (name) => {
-				if (name === key && failNextRead) {
-					failNextRead = false;
-					throw new Error("read failed");
-				}
-				if (name !== key) probes.push(name);
-				if (interruptions.delete(name)) {
-					failNextRead = failing;
-					reads.push(storage.getItemAsync(key).catch(() => null));
-				}
-				return map.get(name) ?? null;
-			};
-
-			await storage.setItemAsync(key, "{}");
-			await vi.runAllTimersAsync();
-
-			expect(await Promise.all(reads)).toEqual([expected, expected, expected]);
-			expect(probes).toHaveLength(300);
-			expect(new Set(probes).size).toBe(300);
-			expect(map.get(`${key}.1.99`)).toBe("");
-		});
-
-		it("waits for an active reader without polling or joining its queue", async () => {
-			const map = new Map<string, string>([[`${key}.0`, "old-secret"]]);
-			const backing = createBackingStorage(map);
-			const probe = pauseNextStorageRead(backing, `${key}.0`);
-			const storage = storageAdapter(backing);
-			await storage.setItemAsync(key, "{}");
-			await vi.runAllTimersAsync();
-			await probe.reading;
-			const reader = pauseNextStorageRead(backing, key);
-			const read = storage.getItemAsync(key);
-			await reader.reading;
-			probe.resume();
-			try {
-				await vi.runAllTimersAsync();
-				expect(map.get(`${key}.0`)).toBe("old-secret");
-				expect(vi.getTimerCount()).toBe(0);
-			} finally {
-				reader.resume();
-			}
-			await read;
-			await vi.runAllTimersAsync();
-			expect(map.get(`${key}.0`)).toBe("");
-		});
-
-		it("retries a failed background sweep after the next write", async () => {
-			const map = new Map<string, string>([[`${key}.0`, "old-secret"]]);
-			const backing = createBackingStorage(map);
 			let failing = true;
-			backing.getItemAsync = async (name) => {
-				if (name === `${key}.0` && failing) throw new Error("probe failed");
-				return map.get(name) ?? null;
+			backing.setItemAsync = async (name, value) => {
+				if (name === `${key}.1` && failing) throw new Error("cleanup failed");
+				map.set(name, value);
 			};
 			const storage = storageAdapter(backing);
 			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
 			await storage.setItemAsync(key, "{}");
-			await vi.runAllTimersAsync();
-			expect(map.get(`${key}.0`)).toBe("old-secret");
+			expect(map.get(`${key}.0`)).toBe("first");
+			expect(map.get(`${key}.1`)).toBe("second");
+			expect(map.get(`${key}.2`)).toBe("");
 			expect(error).toHaveBeenCalledOnce();
-			expect(vi.getTimerCount()).toBe(0);
 
 			failing = false;
 			await storage.setItemAsync(key, "next");
-			await vi.runAllTimersAsync();
 			expect(map.get(`${key}.0`)).toBe("");
+			expect(map.get(`${key}.1`)).toBe("");
 			expect(map.get(key)).toBe("next");
 		});
 

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -1744,32 +1744,6 @@ describe("expo with cookieCache", async () => {
 			});
 		});
 
-		it("deletes obsolete chunks when async deletion is available", async () => {
-			const map = new Map<string, string>([
-				[key, "\u0001ba-chunks:2"],
-				[`${key}.0`, "first"],
-				[`${key}.1`, "second"],
-			]);
-			const setItemAsync = vi.fn(async (name: string, value: string) => {
-				map.set(name, value);
-			});
-			const deleteItemAsync = vi.fn(async (name: string) => {
-				map.delete(name);
-			});
-			const storage = storageAdapter({
-				...createBackingStorage(map),
-				setItemAsync,
-				deleteItemAsync,
-			});
-
-			await storage.setItemAsync(key, "{}");
-
-			expect(deleteItemAsync).toHaveBeenCalledWith(`${key}.1`);
-			expect(deleteItemAsync).toHaveBeenCalledWith(`${key}.0`);
-			expect(setItemAsync).not.toHaveBeenCalledWith(`${key}.1`, "");
-			expect(setItemAsync).not.toHaveBeenCalledWith(`${key}.0`, "");
-		});
-
 		it("retries partially cleared orphan chunks on the next write", async () => {
 			const map = new Map<string, string>([
 				[`${key}.0`, "first"],

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -1,3 +1,4 @@
+import { logger } from "@better-auth/core/env";
 import { createAuthMiddleware } from "better-auth/api";
 import { magicLinkClient } from "better-auth/client/plugins";
 import { magicLink, oAuthProxy } from "better-auth/plugins";
@@ -1120,7 +1121,7 @@ describe("expo with cookieCache", async () => {
 			storage.setItem("better-auth_cookie", previousValue);
 			expect(storage.getItem("better-auth_cookie")).toBe(previousValue);
 
-			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
 			writes = 0;
 			failAfter = 2;
 			storage.setItem("better-auth_cookie", "c".repeat(5_000));
@@ -1157,7 +1158,7 @@ describe("expo with cookieCache", async () => {
 			await storage.setItemAsync("better-auth_cookie", previousValue);
 			writeIndex = 0;
 			failing = true;
-			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
 
 			await storage.setItemAsync("better-auth_cookie", "c".repeat(5_000));
 
@@ -1186,7 +1187,7 @@ describe("expo with cookieCache", async () => {
 			await storage.setItemAsync("better-auth_cookie", "b".repeat(5_000));
 			writeIndex = 0;
 			failing = true;
-			vi.spyOn(console, "error").mockImplementation(() => {});
+			vi.spyOn(logger, "error").mockImplementation(() => {});
 
 			await storage.setItemAsync("better-auth_cookie", "c".repeat(5_000));
 			map.delete("better-auth_cookie.1.1");
@@ -1218,15 +1219,15 @@ describe("expo with cookieCache", async () => {
 			);
 		});
 
-		it("should read the previous value during a chunked overwrite", async () => {
+		it("should finish an earlier read before a chunked overwrite", async () => {
 			const storage = createAsyncStorage();
 			await storage.setItemAsync("better-auth_cookie", "a".repeat(3_000));
 			const previousValue = "b".repeat(5_000);
 			await storage.setItemAsync("better-auth_cookie", previousValue);
 			const newValue = "c".repeat(5_000);
 
-			const write = storage.setItemAsync("better-auth_cookie", newValue);
 			const read = storage.getItemAsync("better-auth_cookie");
+			const write = storage.setItemAsync("better-auth_cookie", newValue);
 			const [stored] = await Promise.all([read, write]);
 
 			expect(stored).toBe(previousValue);
@@ -1304,7 +1305,7 @@ describe("expo with cookieCache", async () => {
 					secondMap.set(name, value);
 				},
 			});
-			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
 
 			const write = first.setItemAsync("better-auth_cookie", "a".repeat(5_000));
 			second.setItem("better-auth_cookie", "independent");
@@ -1330,7 +1331,7 @@ describe("expo with cookieCache", async () => {
 			const asyncStorage = storageAdapter(backingStorage);
 			const syncStorage = storageAdapter(backingStorage);
 			const asyncValue = "a".repeat(5_000);
-			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
 
 			const write = asyncStorage.setItemAsync("better-auth_cookie", asyncValue);
 			syncStorage.setItem("better-auth_cookie", "b".repeat(5_000));
@@ -1399,7 +1400,7 @@ describe("expo with cookieCache", async () => {
 			plugin.getActions(undefined, { notify } as unknown as Parameters<
 				typeof plugin.getActions
 			>[1]);
-			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
 
 			await applyCookieResponse(
 				plugin,
@@ -1422,7 +1423,7 @@ describe("expo with cookieCache", async () => {
 					map.set(name, value);
 				},
 			});
-			const error = vi.spyOn(console, "error").mockImplementation(() => {});
+			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
 
 			await storage.setItemAsync("better-auth_cookie", "x".repeat(180_001));
 
@@ -1440,6 +1441,408 @@ describe("expo with cookieCache", async () => {
 			).resolves.toBeNull();
 			expect(getItem).toHaveBeenCalledTimes(1);
 			expect(getItemAsync).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11194
+	 */
+	describe("obsolete storage chunks", () => {
+		const key = "scenecutai_cookie";
+		const previousValue = JSON.stringify({
+			"better-auth.session_token": { value: "old-session-token" },
+			"better-auth.session_data": { value: "x".repeat(2_000) },
+		});
+		function createBackingStorage(map: Map<string, string>) {
+			return {
+				getItem: (name: string) => map.get(name) ?? null,
+				setItem: (name: string, value: string) => {
+					map.set(name, value);
+				},
+				getItemAsync: async (name: string) => map.get(name) ?? null,
+				setItemAsync: async (name: string, value: string) => {
+					map.set(name, value);
+				},
+			};
+		}
+
+		function pauseNextStorageRead(
+			backing: ReturnType<typeof createBackingStorage>,
+			chunkKey: string,
+		) {
+			let resume = () => {};
+			let started = () => {};
+			const paused = new Promise<void>((resolve) => {
+				resume = resolve;
+			});
+			const reading = new Promise<void>((resolve) => {
+				started = resolve;
+			});
+			const getItemAsync = backing.getItemAsync;
+			let pauseRead = true;
+			backing.getItemAsync = async (name) => {
+				if (name === chunkKey && pauseRead) {
+					pauseRead = false;
+					started();
+					await paused;
+				}
+				return getItemAsync(name);
+			};
+			return { reading, resume };
+		}
+
+		describe.each(["setItem", "setItemAsync"] as const)("%s", (method) => {
+			it("persists a short value when reading the previous marker fails", async () => {
+				const map = new Map<string, string>();
+				const backing = createBackingStorage(map);
+				backing.getItem = () => {
+					throw new Error("read unavailable");
+				};
+				backing.getItemAsync = async () => {
+					throw new Error("read unavailable");
+				};
+				const storage = storageAdapter(backing);
+				const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+				await storage[method](key, "{}");
+
+				expect(map.get(key)).toBe("{}");
+				expect(error).toHaveBeenCalledOnce();
+			});
+
+			it("clears known chunks beyond a missing chunk", async () => {
+				const map = new Map<string, string>([
+					[key, "\u0001ba-chunks:3"],
+					[`${key}.0`, "old-first"],
+					[`${key}.2`, "old-secret"],
+				]);
+				const storage = storageAdapter(createBackingStorage(map));
+				await storage[method](key, "{}");
+				expect(map.get(`${key}.2`) ?? "").toBe("");
+			});
+
+			it("clears orphaned chunks even when the first chunk is missing", async () => {
+				const map = new Map<string, string>([
+					[key, "{}"],
+					[`${key}.2`, "old-secret"],
+					[`${key}.0.2`, "old-cache"],
+				]);
+				const storage = storageAdapter(createBackingStorage(map));
+				await storage[method](key, "{}");
+				expect(map.get(`${key}.2`) ?? "").toBe("");
+				expect(map.get(`${key}.0.2`) ?? "").toBe("");
+			});
+
+			it("uses the marker to clear incomplete chunks after the initial sweep", async () => {
+				const map = new Map<string, string>();
+				const backing = createBackingStorage(map);
+				const storage = storageAdapter(backing);
+				await storage[method](key, "a".repeat(5_000));
+				map.delete(`${key}.0.1`);
+				const getItem = vi.spyOn(backing, "getItem");
+				const getItemAsync = vi.spyOn(backing, "getItemAsync");
+
+				await storage[method](key, "{}");
+
+				expect(getItem.mock.calls.length + getItemAsync.mock.calls.length).toBe(
+					1,
+				);
+				expect(map.get(`${key}.0.0`)).toBe("");
+				expect(map.get(`${key}.0.2`)).toBe("");
+			});
+
+			it.each([
+				{
+					name: "legacy migration",
+					marker: "\u0001ba-chunks:2",
+					initialValue: previousValue,
+					chunkKeys: [`${key}.0`, `${key}.1`],
+					value: previousValue.replace(
+						"old-session-token",
+						"new-session-token",
+					),
+				},
+				{
+					name: "legacy clear",
+					marker: "\u0001ba-chunks:2",
+					initialValue: previousValue,
+					chunkKeys: [`${key}.0`, `${key}.1`],
+					value: "{}",
+				},
+				{
+					name: "slotted clear with fallback",
+					marker: "\u0001ba-chunks:2:1:2",
+					initialValue: previousValue,
+					chunkKeys: [`${key}.1.0`, `${key}.1.1`, `${key}.0.0`, `${key}.0.1`],
+					value: "{}",
+				},
+				{
+					name: "a lost legacy marker",
+					marker: "{}",
+					initialValue: "{}",
+					chunkKeys: [`${key}.0`, `${key}.1`],
+					value: "{}",
+				},
+				{
+					name: "a lost slotted marker",
+					marker: "{}",
+					initialValue: "{}",
+					chunkKeys: [`${key}.1.0`, `${key}.1.1`, `${key}.0.0`, `${key}.0.1`],
+					value: "{}",
+				},
+			])("clears obsolete bytes after $name", async ({
+				marker,
+				initialValue,
+				chunkKeys,
+				value,
+			}) => {
+				const map = new Map<string, string>([[key, marker]]);
+				for (const [index, chunkKey] of chunkKeys.entries()) {
+					const start = (index % 2) * 1_800;
+					map.set(chunkKey, previousValue.slice(start, start + 1_800));
+				}
+				const storage = storageAdapter(createBackingStorage(map));
+
+				expect(storage.getItem(key)).toBe(initialValue);
+				await storage[method](key, value);
+				expect(storage.getItem(key)).toBe(value);
+				expect(chunkKeys.map((chunkKey) => map.get(chunkKey) ?? "")).toEqual(
+					chunkKeys.map(() => ""),
+				);
+			});
+
+			it("clears a reused slot's tail while preserving recovery", async () => {
+				const map = new Map<string, string>();
+				const storage = storageAdapter(createBackingStorage(map));
+				await storage[method](key, "a".repeat(5_000));
+				await storage[method](key, previousValue);
+				const nextValue = "b".repeat(2_000);
+				await storage[method](key, nextValue);
+
+				expect(storage.getItem(key)).toBe(nextValue);
+				expect(map.get(`${key}.0.2`)).toBe("");
+				map.delete(`${key}.0.0`);
+				expect(storage.getItem(key)).toBe(previousValue);
+			});
+
+			it("preserves legacy chunks when the replacement cannot be committed", async () => {
+				const map = new Map<string, string>([
+					[key, "\u0001ba-chunks:2"],
+					[`${key}.0`, previousValue.slice(0, 1_800)],
+					[`${key}.1`, previousValue.slice(1_800)],
+				]);
+				const backing = createBackingStorage(map);
+				const write = (name: string, value: string) => {
+					if (name === key) throw new Error("interrupted commit");
+					map.set(name, value);
+				};
+				backing.setItem = write;
+				backing.setItemAsync = async (name, value) => write(name, value);
+				const storage = storageAdapter(backing);
+				const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+				await storage[method](key, "b".repeat(3_000));
+
+				expect(error).toHaveBeenCalledOnce();
+				expect(storage.getItem(key)).toBe(previousValue);
+			});
+
+			it("retries interrupted cleanup without losing the committed value", async () => {
+				const map = new Map<string, string>([
+					[key, "\u0001ba-chunks:2"],
+					[`${key}.0`, previousValue.slice(0, 1_800)],
+					[`${key}.1`, previousValue.slice(1_800)],
+				]);
+				const backing = createBackingStorage(map);
+				let interrupted = false;
+				const write = (name: string, value: string) => {
+					if (name === `${key}.0` && !interrupted) {
+						interrupted = true;
+						throw new Error("interrupted cleanup");
+					}
+					map.set(name, value);
+				};
+				backing.setItem = write;
+				backing.setItemAsync = async (name, value) => write(name, value);
+				const storage = storageAdapter(backing);
+				const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+				await storage[method](key, "{}");
+				expect(error).toHaveBeenCalledOnce();
+				expect(storage.getItem(key)).toBe("{}");
+				expect(map.get(`${key}.1`)).toBe("");
+
+				await storage[method](key, "{}");
+				expect(map.get(`${key}.0`)).toBe("");
+				expect(map.get(`${key}.1`)).toBe("");
+			});
+
+			it("bounds orphan probing and skips it after successful cleanup", async () => {
+				const map = new Map<string, string>();
+				for (const prefix of [key, `${key}.0`, `${key}.1`]) {
+					for (let i = 0; i <= 100; i++) {
+						map.set(`${prefix}.${i}`, "old data");
+					}
+				}
+				const backing = createBackingStorage(map);
+				const getItem = vi.spyOn(backing, "getItem");
+				const getItemAsync = vi.spyOn(backing, "getItemAsync");
+				const storage = storageAdapter(backing);
+
+				await storage[method](key, "{}");
+				expect(getItem.mock.calls.length + getItemAsync.mock.calls.length).toBe(
+					301,
+				);
+				for (const prefix of [key, `${key}.0`, `${key}.1`]) {
+					expect(map.get(`${prefix}.0`)).toBe("");
+					expect(map.get(`${prefix}.99`)).toBe("");
+					expect(map.get(`${prefix}.100`)).toBe("old data");
+				}
+
+				getItem.mockClear();
+				getItemAsync.mockClear();
+				await storageAdapter(backing)[method](key, "{}");
+				expect(getItem.mock.calls.length + getItemAsync.mock.calls.length).toBe(
+					1,
+				);
+			});
+		});
+
+		it("allows a synchronous write while only an async read is pending", async () => {
+			const map = new Map<string, string>([[key, "previous"]]);
+			const storage = storageAdapter(createBackingStorage(map));
+			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+			const read = storage.getItemAsync(key);
+			storage.setItem(key, "next");
+			expect(map.get(key)).toBe("next");
+			await expect(read).resolves.toBe("next");
+			expect(error).not.toHaveBeenCalled();
+		});
+
+		it("keeps a complete read when synchronous writes reuse its slot", async () => {
+			const map = new Map<string, string>();
+			const backing = createBackingStorage(map);
+			const storage = storageAdapter(backing);
+			const other = storageAdapter(backing);
+			await storage.setItemAsync(key, previousValue);
+			const { reading, resume } = pauseNextStorageRead(backing, `${key}.0.1`);
+			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+			const read = storage.getItemAsync(key);
+			await reading;
+			try {
+				other.setItem(key, "b".repeat(3_000));
+				other.setItem(key, "c".repeat(3_000));
+				expect(storage.getItem(key)).toBe("c".repeat(3_000));
+			} finally {
+				resume();
+			}
+			await expect(read).resolves.toBe("c".repeat(3_000));
+			expect(error).not.toHaveBeenCalled();
+
+			map.delete(`${key}.0.1`);
+			await expect(storage.getItemAsync(key)).resolves.toBe("b".repeat(3_000));
+		});
+
+		it.each([
+			{ failure: "write", expected: previousValue, errors: 1 },
+			{ failure: "read", expected: "b".repeat(3_000), errors: 0 },
+		])("keeps a complete async read after a synchronous $failure failure", async ({
+			failure,
+			expected,
+			errors,
+		}) => {
+			const map = new Map<string, string>([
+				[key, "\u0001ba-chunks:2:1:2"],
+				[`${key}.0.0`, previousValue.slice(0, 1_800)],
+				[`${key}.0.1`, previousValue.slice(1_800)],
+			]);
+			const backing = createBackingStorage(map);
+			backing.getItem = (name) => {
+				if (failure === "read" && name === `${key}.0.0`)
+					throw new Error("read failed");
+				return map.get(name) ?? null;
+			};
+			backing.setItem = (name, value) => {
+				if (failure === "write" && name === `${key}.0.1`)
+					throw new Error("write failed");
+				map.set(name, value);
+			};
+			const { reading, resume } = pauseNextStorageRead(backing, `${key}.0.0`);
+			const storage = storageAdapter(backing);
+			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+			const read = storage.getItemAsync(key);
+			await reading;
+			try {
+				storage.setItem(key, "b".repeat(3_000));
+			} finally {
+				resume();
+			}
+			await expect(read).resolves.toBe(expected);
+			expect(error).toHaveBeenCalledTimes(errors);
+		});
+
+		it("continues queued writes after a read fails", async () => {
+			const map = new Map<string, string>();
+			const backing = createBackingStorage(map);
+			vi.spyOn(backing, "getItemAsync").mockRejectedValueOnce(
+				new Error("read failed"),
+			);
+			const storage = storageAdapter(backing);
+			const read = storage.getItemAsync(key);
+			const write = storage.setItemAsync(key, "next");
+			await expect(read).rejects.toThrow("read failed");
+			await write;
+			expect(storage.getItem(key)).toBe("next");
+		});
+
+		it("finishes reading before another adapter can reuse its slot", async () => {
+			const map = new Map<string, string>();
+			const backing = createBackingStorage(map);
+			const storage = storageAdapter(backing);
+			const other = storageAdapter(backing);
+			await storage.setItemAsync(key, previousValue);
+			const { reading, resume } = pauseNextStorageRead(backing, `${key}.0.1`);
+			const writes = vi.spyOn(backing, "setItemAsync");
+			const read = storage.getItemAsync(key);
+			await reading;
+			const firstWrite = other.setItemAsync(key, "b".repeat(3_000));
+			const secondWrite = other.setItemAsync(key, "c".repeat(3_000));
+			let overlappingWrites = 0;
+			try {
+				await other.setItemAsync("independent_cookie", "{}");
+				overlappingWrites = writes.mock.calls.filter(([name]) =>
+					name.startsWith(key),
+				).length;
+			} finally {
+				resume();
+			}
+			const value = await read;
+			await Promise.all([firstWrite, secondWrite]);
+			expect(overlappingWrites).toBe(0);
+			expect(value).toBe(previousValue);
+		});
+
+		it.each([
+			{ name: "legacy", marker: "\u0001ba-chunks:2", prefix: key },
+			{ name: "active", marker: "\u0001ba-chunks:2:0", prefix: `${key}.0` },
+			{ name: "fallback", marker: "\u0001ba-chunks:2:1:2", prefix: `${key}.0` },
+		])("finishes a $name read before cleanup", async ({ marker, prefix }) => {
+			const map = new Map<string, string>([
+				[key, marker],
+				[`${prefix}.0`, previousValue.slice(0, 1_800)],
+				[`${prefix}.1`, previousValue.slice(1_800)],
+			]);
+			const backing = createBackingStorage(map);
+			const { reading, resume } = pauseNextStorageRead(backing, `${prefix}.1`);
+			const storage = storageAdapter(backing);
+
+			const read = storage.getItemAsync(key);
+			await reading;
+			const write = storage.setItemAsync(key, "{}");
+			resume();
+			await expect(read).resolves.toBe(previousValue);
+			await write;
+			expect(storage.getItem(key)).toBe("{}");
 		});
 	});
 
@@ -1461,7 +1864,7 @@ describe("expo with cookieCache", async () => {
 	});
 
 	it("should log instead of throw when the backend rejects a write", async () => {
-		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		const error = vi.spyOn(logger, "error").mockImplementation(() => {});
 		const storage = storageAdapter({
 			getItem: () => null,
 			setItem: () => {
@@ -1844,6 +2247,7 @@ describe("expo session cache hydration", async () => {
 			}
 			return Promise.resolve(null);
 		});
+		const setItemAsync = vi.fn(async (_key: string, _value: string) => {});
 		const { client } = await getTestInstance(
 			{ plugins: [expo()], trustedOrigins: ["better-auth://"] },
 			{
@@ -1854,7 +2258,7 @@ describe("expo session cache hydration", async () => {
 								getItem: () => null,
 								setItem: () => {},
 								getItemAsync,
-								setItemAsync: async () => {},
+								setItemAsync,
 							},
 						}),
 					],
@@ -1907,21 +2311,25 @@ describe("expo session cache hydration", async () => {
 		const sessionCacheReads = getItemAsync.mock.calls.filter(
 			([key]) => key === "better-auth_session_data",
 		);
+		const sessionCacheWrites = setItemAsync.mock.calls.filter(
+			([key]) => key === "better-auth_session_data",
+		);
 		expect(sessionAtom.get().data).toEqual(serverSession);
-		expect(sessionCacheReads).toHaveLength(1);
+		expect(sessionCacheReads).toHaveLength(sessionCacheWrites.length + 1);
 	});
 
 	it("preserves additional fields through the cache round-trip", async () => {
 		const storage = new Map<string, string>();
 		const getItemAsync = vi.fn(async (key: string) => storage.get(key) || null);
+		const setItemAsync = vi.fn(async (key: string, value: string) => {
+			storage.set(key, value);
+		});
 		const sharedClientOptions = {
 			storage: {
 				getItem: (key: string) => storage.get(key) || null,
 				setItem: (key: string, value: string) => storage.set(key, value),
 				getItemAsync,
-				setItemAsync: async (key: string, value: string) => {
-					storage.set(key, value);
-				},
+				setItemAsync,
 			},
 		};
 		const serverConfig = {
@@ -1968,8 +2376,15 @@ describe("expo session cache hydration", async () => {
 		});
 
 		getItemAsync.mockClear();
+		setItemAsync.mockClear();
 		await coldStart.getSession();
-		expect(getItemAsync).not.toHaveBeenCalledWith("better-auth_session_data");
+		const sessionCacheReads = getItemAsync.mock.calls.filter(
+			([key]) => key === "better-auth_session_data",
+		);
+		const sessionCacheWrites = setItemAsync.mock.calls.filter(
+			([key]) => key === "better-auth_session_data",
+		);
+		expect(sessionCacheReads).toHaveLength(sessionCacheWrites.length);
 	});
 
 	it.each([

--- a/packages/expo/test/expo.test.ts
+++ b/packages/expo/test/expo.test.ts
@@ -3,7 +3,16 @@ import { createAuthMiddleware } from "better-auth/api";
 import { magicLinkClient } from "better-auth/client/plugins";
 import { magicLink, oAuthProxy } from "better-auth/plugins";
 import { getTestInstance } from "better-auth/test";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { expo } from "../src";
 import { expoClient, storageAdapter } from "../src/client";
 
@@ -1448,6 +1457,8 @@ describe("expo with cookieCache", async () => {
 	 * @see https://github.com/better-auth/better-auth/issues/11194
 	 */
 	describe("obsolete storage chunks", () => {
+		beforeEach(() => vi.clearAllTimers());
+		afterEach(() => vi.clearAllTimers());
 		const key = "scenecutai_cookie";
 		const previousValue = JSON.stringify({
 			"better-auth.session_token": { value: "old-session-token" },
@@ -1492,6 +1503,79 @@ describe("expo with cookieCache", async () => {
 		}
 
 		describe.each(["setItem", "setItemAsync"] as const)("%s", (method) => {
+			it("recovers an orphaned tail after earlier chunks were cleared", async () => {
+				const map = new Map<string, string>([
+					[key, "\u0001ba-chunks:2:0"],
+					[`${key}.0.0`, "first"],
+					[`${key}.0.1`, "second"],
+					[`${key}.0.2`, "old-secret"],
+				]);
+				const backing = createBackingStorage(map);
+				let failing = true;
+				const write = (name: string, value: string) => {
+					if (failing && name === `${key}.0.2`)
+						throw new Error("cleanup failed");
+					map.set(name, value);
+				};
+				backing.setItem = write;
+				backing.setItemAsync = async (name, value) => write(name, value);
+				const storage = storageAdapter(backing);
+				const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+				await storage[method](key, "{}");
+				await vi.runAllTimersAsync();
+				expect(map.get(key)).toBe("{}");
+				expect(map.get(`${key}.0.0`)).toBe("");
+				expect(map.get(`${key}.0.1`)).toBe("");
+				expect(map.get(`${key}.0.2`)).toBe("old-secret");
+				expect(error).toHaveBeenCalledOnce();
+
+				failing = false;
+				await storage[method](key, "{}");
+				await vi.runAllTimersAsync();
+				expect(map.get(`${key}.0.2`)).toBe("");
+			});
+
+			it("allows foreground access while a background probe is pending", async () => {
+				const map = new Map<string, string>([[`${key}.0.0`, "old-secret"]]);
+				const backing = createBackingStorage(map);
+				const { reading, resume } = pauseNextStorageRead(backing, `${key}.0.0`);
+				const storage = storageAdapter(backing);
+				const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+				await storage[method](key, "{}");
+				await vi.runAllTimersAsync();
+				await reading;
+
+				try {
+					await expect(storage.getItemAsync(key)).resolves.toBe("{}");
+					await storage[method](key, previousValue);
+					expect(storage.getItem(key)).toBe(previousValue);
+				} finally {
+					resume();
+				}
+				await vi.runAllTimersAsync();
+				expect(storage.getItem(key)).toBe(previousValue);
+				expect(error).not.toHaveBeenCalled();
+			});
+
+			it("completes foreground writes before probing orphaned chunks", async () => {
+				const map = new Map<string, string>([[`${key}.2`, "old-secret"]]);
+				const backing = createBackingStorage(map);
+				const getItem = vi.spyOn(backing, "getItem");
+				const getItemAsync = vi.spyOn(backing, "getItemAsync");
+				const storage = storageAdapter(backing);
+
+				await storage[method](key, "{}");
+
+				expect(map.get(key)).toBe("{}");
+				expect(map.get(`${key}.2`)).toBe("old-secret");
+				expect(getItem.mock.calls.length + getItemAsync.mock.calls.length).toBe(
+					1,
+				);
+				await vi.runAllTimersAsync();
+				expect(map.get(`${key}.2`)).toBe("");
+			});
+
 			it("persists a short value when reading the previous marker fails", async () => {
 				const map = new Map<string, string>();
 				const backing = createBackingStorage(map);
@@ -1507,6 +1591,7 @@ describe("expo with cookieCache", async () => {
 				await storage[method](key, "{}");
 
 				expect(map.get(key)).toBe("{}");
+				await vi.runAllTimersAsync();
 				expect(error).toHaveBeenCalledOnce();
 			});
 
@@ -1529,6 +1614,7 @@ describe("expo with cookieCache", async () => {
 				]);
 				const storage = storageAdapter(createBackingStorage(map));
 				await storage[method](key, "{}");
+				await vi.runAllTimersAsync();
 				expect(map.get(`${key}.2`) ?? "").toBe("");
 				expect(map.get(`${key}.0.2`) ?? "").toBe("");
 			});
@@ -1538,6 +1624,7 @@ describe("expo with cookieCache", async () => {
 				const backing = createBackingStorage(map);
 				const storage = storageAdapter(backing);
 				await storage[method](key, "a".repeat(5_000));
+				await vi.runAllTimersAsync();
 				map.delete(`${key}.0.1`);
 				const getItem = vi.spyOn(backing, "getItem");
 				const getItemAsync = vi.spyOn(backing, "getItemAsync");
@@ -1606,6 +1693,7 @@ describe("expo with cookieCache", async () => {
 				expect(storage.getItem(key)).toBe(initialValue);
 				await storage[method](key, value);
 				expect(storage.getItem(key)).toBe(value);
+				await vi.runAllTimersAsync();
 				expect(chunkKeys.map((chunkKey) => map.get(chunkKey) ?? "")).toEqual(
 					chunkKeys.map(() => ""),
 				);
@@ -1673,6 +1761,7 @@ describe("expo with cookieCache", async () => {
 				expect(map.get(`${key}.1`)).toBe("");
 
 				await storage[method](key, "{}");
+				await vi.runAllTimersAsync();
 				expect(map.get(`${key}.0`)).toBe("");
 				expect(map.get(`${key}.1`)).toBe("");
 			});
@@ -1691,8 +1780,14 @@ describe("expo with cookieCache", async () => {
 
 				await storage[method](key, "{}");
 				expect(getItem.mock.calls.length + getItemAsync.mock.calls.length).toBe(
-					301,
+					1,
 				);
+				await vi.runAllTimersAsync();
+				const chunkReads = [
+					...getItem.mock.calls,
+					...getItemAsync.mock.calls,
+				].filter(([name]) => name !== key);
+				expect(chunkReads).toHaveLength(300);
 				for (const prefix of [key, `${key}.0`, `${key}.1`]) {
 					expect(map.get(`${prefix}.0`)).toBe("");
 					expect(map.get(`${prefix}.99`)).toBe("");
@@ -1702,10 +1797,129 @@ describe("expo with cookieCache", async () => {
 				getItem.mockClear();
 				getItemAsync.mockClear();
 				await storageAdapter(backing)[method](key, "{}");
+				await vi.runAllTimersAsync();
 				expect(getItem.mock.calls.length + getItemAsync.mock.calls.length).toBe(
 					1,
 				);
 			});
+		});
+
+		it("yields after each orphan chunk probe", async () => {
+			const map = new Map<string, string>([
+				[`${key}.8`, "old-secret"],
+				[`${key}.9`, "another-secret"],
+			]);
+			const backing = createBackingStorage(map);
+			const schedule = vi.spyOn(globalThis, "setTimeout");
+			const turns = new Map<number, { probes: number; clears: number }>();
+			const record = (operation: "probes" | "clears") => {
+				const id = schedule.mock.calls.length;
+				const turn = turns.get(id) ?? { probes: 0, clears: 0 };
+				turn[operation]++;
+				turns.set(id, turn);
+			};
+			backing.getItemAsync = async (name) => {
+				if (name !== key) record("probes");
+				return map.get(name) ?? null;
+			};
+			backing.setItem = (name, value) => {
+				record("clears");
+				map.set(name, value);
+			};
+			const storage = storageAdapter(backing);
+			await storage.setItemAsync(key, "{}");
+			turns.clear();
+			await vi.runAllTimersAsync();
+			expect(turns.size).toBe(300);
+			for (const turn of turns.values()) {
+				expect(turn.probes).toBe(1);
+				expect(turn.clears).toBeLessThanOrEqual(1);
+			}
+			expect(map.get(`${key}.8`)).toBe("");
+			expect(map.get(`${key}.9`)).toBe("");
+		});
+
+		it.each([
+			{ outcome: "successful", failing: false, expected: "{}" },
+			{ outcome: "failed", failing: true, expected: null },
+		])("preserves scan progress across $outcome readers", async ({
+			failing,
+			expected,
+		}) => {
+			const map = new Map<string, string>([[`${key}.1.99`, "old-secret"]]);
+			const backing = createBackingStorage(map);
+			const storage = storageAdapter(backing);
+			const interruptions = new Set([`${key}.33`, `${key}.66`, `${key}.99`]);
+			const reads: Promise<string | null>[] = [];
+			const probes: string[] = [];
+			let failNextRead = false;
+			backing.getItemAsync = async (name) => {
+				if (name === key && failNextRead) {
+					failNextRead = false;
+					throw new Error("read failed");
+				}
+				if (name !== key) probes.push(name);
+				if (interruptions.delete(name)) {
+					failNextRead = failing;
+					reads.push(storage.getItemAsync(key).catch(() => null));
+				}
+				return map.get(name) ?? null;
+			};
+
+			await storage.setItemAsync(key, "{}");
+			await vi.runAllTimersAsync();
+
+			expect(await Promise.all(reads)).toEqual([expected, expected, expected]);
+			expect(probes).toHaveLength(300);
+			expect(new Set(probes).size).toBe(300);
+			expect(map.get(`${key}.1.99`)).toBe("");
+		});
+
+		it("waits for an active reader without polling or joining its queue", async () => {
+			const map = new Map<string, string>([[`${key}.0`, "old-secret"]]);
+			const backing = createBackingStorage(map);
+			const probe = pauseNextStorageRead(backing, `${key}.0`);
+			const storage = storageAdapter(backing);
+			await storage.setItemAsync(key, "{}");
+			await vi.runAllTimersAsync();
+			await probe.reading;
+			const reader = pauseNextStorageRead(backing, key);
+			const read = storage.getItemAsync(key);
+			await reader.reading;
+			probe.resume();
+			try {
+				await vi.runAllTimersAsync();
+				expect(map.get(`${key}.0`)).toBe("old-secret");
+				expect(vi.getTimerCount()).toBe(0);
+			} finally {
+				reader.resume();
+			}
+			await read;
+			await vi.runAllTimersAsync();
+			expect(map.get(`${key}.0`)).toBe("");
+		});
+
+		it("retries a failed background sweep after the next write", async () => {
+			const map = new Map<string, string>([[`${key}.0`, "old-secret"]]);
+			const backing = createBackingStorage(map);
+			let failing = true;
+			backing.getItemAsync = async (name) => {
+				if (name === `${key}.0` && failing) throw new Error("probe failed");
+				return map.get(name) ?? null;
+			};
+			const storage = storageAdapter(backing);
+			const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+			await storage.setItemAsync(key, "{}");
+			await vi.runAllTimersAsync();
+			expect(map.get(`${key}.0`)).toBe("old-secret");
+			expect(error).toHaveBeenCalledOnce();
+			expect(vi.getTimerCount()).toBe(0);
+
+			failing = false;
+			await storage.setItemAsync(key, "next");
+			await vi.runAllTimersAsync();
+			expect(map.get(`${key}.0`)).toBe("");
+			expect(map.get(key)).toBe("next");
 		});
 
 		it("allows a synchronous write while only an async read is pending", async () => {


### PR DESCRIPTION
Closes https://github.com/better-auth/better-auth/issues/11194

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up stale session data left in Expo secure storage after upgrades or sign-out without delaying sign-in, and prevents corrupted cookies when concurrent reads and writes overlap. Closes #11194.

**Bug Fixes**
- Obsolete chunk keys are cleared by a deferred background sweep that yields between probes, never blocks sign-in or foreground access, and retries after interruption.
- Async reads are coordinated with writes so a read finishes before its slot is reused, preserving rollback recovery after failed writes.
- Sync writes proceed while only an async read is pending instead of erroring, and still return the latest value to that read.

<sup>Written for commit c5edbe7f9b9baa59dae4563d6f068e505b8cdf80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

