### PR TITLE
fix(oauth-provider): omit given_name and family_name when the user has no name

### DIFF
--- a/.changeset/oauth-provider-null-display-name.md
+++ b/.changeset/oauth-provider-null-display-name.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/oauth-provider": patch
+---
+
+Omit the `given_name` and `family_name` claims for users who have no name, instead of failing the request. Requesting the `profile` scope for such a user previously returned 500 from `/userinfo` and from the token endpoint when an ID token was issued.

--- a/packages/oauth-provider/src/standard-claims.test.ts
+++ b/packages/oauth-provider/src/standard-claims.test.ts
@@ -1,0 +1,68 @@
+import type { User } from "better-auth/types";
+import { describe, expect, it } from "vitest";
+import { STANDARD_CLAIMS } from "./standard-claims";
+
+/**
+ * Builds a user whose `name` is whatever the database actually holds. `name` is
+ * typed as a string, but the column is nullable in practice, so the cast is the
+ * point of these tests rather than a shortcut around the type.
+ */
+function userNamed(name: unknown): User {
+	return {
+		id: "user-id",
+		name,
+		email: "ada@example.com",
+		emailVerified: true,
+		image: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	} as unknown as User;
+}
+
+const givenName = (name: unknown) =>
+	STANDARD_CLAIMS.given_name.resolve(userNamed(name));
+const familyName = (name: unknown) =>
+	STANDARD_CLAIMS.family_name.resolve(userNamed(name));
+
+describe("STANDARD_CLAIMS", () => {
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11193
+	 */
+	describe("given_name and family_name", () => {
+		it("splits a two-part display name", () => {
+			expect(givenName("Ada Lovelace")).toBe("Ada");
+			expect(familyName("Ada Lovelace")).toBe("Lovelace");
+		});
+
+		it("treats every part but the last as the given name", () => {
+			expect(givenName("Ada King Lovelace")).toBe("Ada King");
+			expect(familyName("Ada King Lovelace")).toBe("Lovelace");
+		});
+
+		it("omits both claims for a single-word name", () => {
+			expect(givenName("Ada")).toBeUndefined();
+			expect(familyName("Ada")).toBeUndefined();
+		});
+
+		it("omits both claims when the name is null", () => {
+			expect(givenName(null)).toBeUndefined();
+			expect(familyName(null)).toBeUndefined();
+		});
+
+		it("omits both claims when the name is undefined", () => {
+			expect(givenName(undefined)).toBeUndefined();
+			expect(familyName(undefined)).toBeUndefined();
+		});
+
+		it("omits both claims for a blank name", () => {
+			expect(givenName("   ")).toBeUndefined();
+			expect(familyName("   ")).toBeUndefined();
+		});
+	});
+
+	describe("name", () => {
+		it("omits the claim when the name is null", () => {
+			expect(STANDARD_CLAIMS.name.resolve(userNamed(null))).toBeUndefined();
+		});
+	});
+});

--- a/packages/oauth-provider/src/standard-claims.ts
+++ b/packages/oauth-provider/src/standard-claims.ts
@@ -13,10 +13,19 @@ interface StandardClaimDefinition {
 	resolve: (user: User) => unknown;
 }
 
-function splitDisplayName(name: string): {
+/**
+ * Splits a display name into the `given_name` and `family_name` claims.
+ *
+ * `User["name"]` is typed as a string, but the stored value can be absent:
+ * providers may omit it, and rows can predate a name being required. The `name`
+ * claim below already resolves that away with `?? undefined`, so a missing name
+ * leaves these two claims unresolved rather than failing the whole response.
+ */
+function splitDisplayName(name: string | null | undefined): {
 	given?: string;
 	family?: string;
 } {
+	if (!name) return {};
 	const parts = name.split(" ").filter((part) => part !== "");
 	if (parts.length <= 1) return {};
 	return { given: parts.slice(0, -1).join(" "), family: parts.at(-1) };


### PR DESCRIPTION
Closes #11193

## The bug

`splitDisplayName` in `packages/oauth-provider/src/standard-claims.ts` takes a plain `string` and immediately calls `name.split(" ")`. Resolving `given_name` or `family_name` for a user whose stored `name` is null throws a `TypeError` out of the claim resolver, surfacing as **500 from `/userinfo`**, and from the token endpoint whenever an ID token is issued. Any client requesting the `profile` scope for such a user hits it.

## Why this is a contract violation, not just bad data

`userSchema` types `name` as `z.string()`, so the null does not come from the type contract. It comes from how this module already treats the value:

```ts
name:        { scope: "profile", resolve: (user) => user.name ?? undefined },              // guards
given_name:  { scope: "profile", resolve: (user) => splitDisplayName(user.name).given },   // throws
family_name: { scope: "profile", resolve: (user) => splitDisplayName(user.name).family },  // throws
```

`userNormalClaims` in `userinfo.ts` does the same for the subject (`sub: user.id ?? undefined`). So the module already treats these fields as runtime-nullable — three claims resolve a missing value to an absent claim, and two dereference it one line later. That inconsistency is the defect: a claim the provider cannot resolve should be omitted, not fail the entire response including the claims that did resolve.

## The change

`splitDisplayName` now accepts a nullish name and returns no claims for it. It is a module-private helper, so no exported type changes and `User["name"]` stays `z.string()` — the runtime guard is not being used to loosen the public type contract.

## Testing

New `packages/oauth-provider/src/standard-claims.test.ts` exercises the resolvers directly: two-part and multi-part names, single word, blank, `null`, and `undefined`. The `null` and `undefined` cases fail on `main` with the reported `TypeError` and pass with this change.

- `vitest packages/oauth-provider` — 42 files, 948 tests passing
- `pnpm typecheck` — passing

## AI assistance

Disclosed per CONTRIBUTING: this change was AI-assisted (Claude Code) — the investigation, patch and tests were produced with it. I have reviewed the full diff myself and verified it locally by running the commands above. Happy to discuss any of it in review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth provider so `given_name` and `family_name` claims are omitted for users with no name instead of failing the request. Previously, requesting the `profile` scope for such a user returned 500 from `/userinfo` and from the token endpoint when an ID token was issued.

- `splitDisplayName` now accepts a nullish name and returns no claims.
- Added tests covering two-part, multi-part, single-word, blank, `null`, and `undefined` names.

<sup>Written for commit 2a264c82bb7195598bbaa7bfbfe60bc16836556d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

