### PR TITLE
fix(core): don't console.error the raw query error in handleFallbackJoin

### DIFF
--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -820,8 +820,8 @@ export const createAdapterFactory =
 				logger.error(`Failed to query fallback join for model ${modelName}:`, {
 					where,
 					limit: joinConfig.limit,
+					error,
 				});
-				console.error(error);
 				throw error;
 			}
 			return result;


### PR DESCRIPTION
### What

`handleFallbackJoin` catches a storage fault, logs it through `logger.error`, and then calls a bare `console.error(error)` before rethrowing. This moves the caught error into the `logger.error` call that is already there and drops the bare `console` call.

```diff
  } catch (error) {
      logger.error(`Failed to query fallback join for model ${modelName}:`, {
          where,
          limit: joinConfig.limit,
+         error,
      });
-     console.error(error);
      throw error;
  }
```

### Why

The error reaching this catch is normally a driver error. For Drizzle, `DrizzleQueryError`'s message is built unconditionally in `queryWithCache` as:

```
Failed query: <sql>
params: <params>
```

`handleFallbackJoin` is on well-travelled paths — `findSession` passes `join: { user: true }`, so it runs on **every session read**; `findOAuthUser` runs on the OAuth callback; `findUserByEmail` with `includeAccounts` runs on sign-in and password reset. So on a transient database fault, the bare `console.error` writes **query parameters** — a user id on the session leg, an email on a user lookup — straight to stderr, bypassing whatever `logger` the consumer configured.

That matters most on serverless hosts, where stderr *is* the log store and the lines are retained. A consumer who deliberately installs a `logger.log` handler to strip identifiers currently has no way to reach this one call site: it is not routed through the logger, and it is inside a closure the adapter option cannot wrap.

### Why this shape rather than deleting the line

The diagnostic is worth keeping — it is just going to the wrong place. Passing `error` as a structured field on the `logger.error` immediately above it preserves the information for anyone who wants it, routes it through the same logger as every other diagnostic in this file, and lets a consumer who sanitizes their logger actually get sanitization. No information is lost; only the bypass is.

### Notes

- No behaviour change beyond the log destination: the `throw error` below is untouched, so callers see exactly the same failure.
- Verified against `main` (`packages/core/src/db/adapter/factory.ts`), and the same block is present in the published `1.6.23` and `1.7.3` dists.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the fallback join error through the configured `logger.error` instead of a bare `console.error`, so driver error messages containing query parameters no longer bypass consumer log sanitization and write to stderr (which is the log store on serverless hosts).

- The error is passed as a structured field on the existing `logger.error` call, so no diagnostic information is lost.
- `handleFallbackJoin` runs on session reads, OAuth callbacks, and sign-in and password-reset lookups.
- The `throw error` below is untouched, so callers see the same failure.

<sup>Written for commit bc5882053080c66297a4f60c67253e20a498a649. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

