### PR TITLE
fix(deps): remove unused `better-sqlite3` peer dependency

### DIFF
--- a/.changeset/clean-hounds-shave.md
+++ b/.changeset/clean-hounds-shave.md
@@ -2,15 +2,4 @@
 "better-auth": patch
 ---
 
-fix(deps): remove the unused `better-sqlite3` peer and allow vitest 5
-
-`peerDependenciesMeta.optional` silences only a MISSING peer — npm still fails
-`ERESOLVE` on a version MISMATCH, so these two entries blocked installs for
-consumers who never import the relevant entry point.
-
-- `better-sqlite3` is not referenced anywhere in `packages/better-auth` (no
-  source import, not a devDependency); the peer is removed. It was the only
-  peer declaration of it in the repo — `cli` and `electron` take it as a
-  devDependency, which is unaffected.
-- `vitest` is genuinely imported by `src/test-utils/test-instance.ts`, so the
-  peer stays — its range now includes `^5.0.0`.
+Remove the unused optional `better-sqlite3` peer dependency to prevent installation conflicts.

--- a/.changeset/clean-hounds-shave.md
+++ b/.changeset/clean-hounds-shave.md
@@ -9,7 +9,8 @@ fix(deps): remove the unused `better-sqlite3` peer and allow vitest 5
 consumers who never import the relevant entry point.
 
 - `better-sqlite3` is not referenced anywhere in `packages/better-auth` (no
-  source import, not a devDependency); the peer is removed. The packages that
-  actually use it (`cli`, `drizzle-adapter`, `telemetry`) declare their own.
+  source import, not a devDependency); the peer is removed. It was the only
+  peer declaration of it in the repo — `cli` and `electron` take it as a
+  devDependency, which is unaffected.
 - `vitest` is genuinely imported by `src/test-utils/test-instance.ts`, so the
   peer stays — its range now includes `^5.0.0`.

--- a/.changeset/clean-hounds-shave.md
+++ b/.changeset/clean-hounds-shave.md
@@ -1,0 +1,15 @@
+---
+"better-auth": patch
+---
+
+fix(deps): remove the unused `better-sqlite3` peer and allow vitest 5
+
+`peerDependenciesMeta.optional` silences only a MISSING peer — npm still fails
+`ERESOLVE` on a version MISMATCH, so these two entries blocked installs for
+consumers who never import the relevant entry point.
+
+- `better-sqlite3` is not referenced anywhere in `packages/better-auth` (no
+  source import, not a devDependency); the peer is removed. The packages that
+  actually use it (`cli`, `drizzle-adapter`, `telemetry`) declare their own.
+- `vitest` is genuinely imported by `src/test-utils/test-instance.ts`, so the
+  peer stays — its range now includes `^5.0.0`.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -67,7 +67,7 @@
 		},
 		"packages/electron": {
 			"entry": ["src/index.ts!", "src/client.typecheck.ts"],
-			"project": ["src/**/*.ts!"]
+			"project": ["src/**/*.ts!", "test/**/*.ts"]
 		}
 	},
 	"vitest": {

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -523,7 +523,6 @@
     "@sveltejs/kit": "^2.0.0",
     "@tanstack/react-start": "^1.0.0",
     "@tanstack/solid-start": "^1.0.0",
-    "better-sqlite3": "^12.0.0",
     "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1",
     "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0",
     "mongodb": "^6.0.0 || ^7.0.0",
@@ -588,9 +587,6 @@
       "optional": true
     },
     "prisma": {
-      "optional": true
-    },
-    "better-sqlite3": {
       "optional": true
     },
     "vitest": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1036,9 +1036,6 @@ importers:
       better-call:
         specifier: 'catalog:'
         version: 1.4.0(zod@4.5.4)
-      better-sqlite3:
-        specifier: '>=12.10.0 <13'
-        version: 12.11.1
       defu:
         specifier: '>=6.1.5 <7'
         version: 6.1.7


### PR DESCRIPTION
Remove the optional `better-sqlite3` peer dependency, which causes installation conflicts when consumers use versions outside the declared range.

The peer was added when `better-auth/test` imported `better-sqlite3`. That import was replaced with `node:sqlite` in #7505, leaving the declaration unused. Support for user-provided SQLite database instances is unchanged.