### PR TITLE
test: adopt Vitest 5 features

### DIFF
--- a/packages/better-auth/src/client/client-declaration.test.ts
+++ b/packages/better-auth/src/client/client-declaration.test.ts
@@ -10,7 +10,7 @@ const execFileAsync = promisify(execFile);
 describe("client declaration emit", () => {
 	const createCompositeProject = (): { dir: string; cleanup: () => void } => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ba-client-dts-"));
-		const betterAuthDir = path.resolve(__dirname, "../..");
+		const betterAuthDir = path.resolve(import.meta.dirname, "../..");
 		const authPackageDir = path.join(dir, "packages/auth");
 		const webAppDir = path.join(dir, "apps/web");
 
@@ -155,7 +155,7 @@ authClient.useSession();
 
 		try {
 			const tscPath = path.resolve(
-				__dirname,
+				import.meta.dirname,
 				"../../../../node_modules/.bin/tsc",
 			);
 			const { stderr } = await execFileAsync(

--- a/packages/better-auth/src/plugins/organization/organization-client-declaration.test.ts
+++ b/packages/better-auth/src/plugins/organization/organization-client-declaration.test.ts
@@ -23,7 +23,7 @@ describe("organizationClient declaration emit with additionalFields", () => {
 	): { dir: string; cleanup: () => void } => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ba-ts2742-"));
 
-		const pkgDir = path.resolve(__dirname, "../../..");
+		const pkgDir = path.resolve(import.meta.dirname, "../../..");
 		const tsconfig = {
 			compilerOptions: {
 				target: "ES2020",
@@ -100,7 +100,7 @@ export const authClient = createAuthClient({
 
 			try {
 				const tscPath = path.resolve(
-					__dirname,
+					import.meta.dirname,
 					"../../../node_modules/.bin/tsc",
 				);
 				const { stderr } = await execAsync(
@@ -140,7 +140,7 @@ export const authClient = createAuthClient({
 
 			try {
 				const tscPath = path.resolve(
-					__dirname,
+					import.meta.dirname,
 					"../../../node_modules/.bin/tsc",
 				);
 				const { stderr } = await execAsync(

--- a/packages/better-auth/vitest.config.ts
+++ b/packages/better-auth/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject } from "vitest/config";
 
 export default defineProject({
 	test: {
+		fsModuleCache: true,
+		injectCjsGlobals: false,
 		testTimeout: 10_000,
 		execArgv: ["--expose-gc"],
 		// Exclude adapter tests by default - they are run separately via test:adapters

--- a/packages/core/src/social-providers/facebook.test.ts
+++ b/packages/core/src/social-providers/facebook.test.ts
@@ -42,26 +42,25 @@ function fbProfile(id: string, email = `${id}@example.com`) {
 	};
 }
 
-/**
- * Routes the two Graph calls (`debug_token` then `/me`) the access-token path
- * makes, based on the request URL.
- */
-function mockGraph(opts: {
+function mockGraphResponses(responses: {
 	debug?: ReturnType<typeof debugTokenResponse>;
 	me?: ReturnType<typeof profileResponse>;
 }) {
-	mockedBetterFetch.mockImplementation(((url: unknown) => {
-		const u = String(url);
-		if (u.includes("debug_token")) {
-			return Promise.resolve(
-				opts.debug ??
-					({ data: null, error: { message: "no debug mock" } } as any),
-			);
-		}
-		return Promise.resolve(
-			opts.me ?? ({ data: null, error: { message: "no /me mock" } } as any),
-		);
-	}) as unknown as typeof betterFetch);
+	const graphFetch = vi.when(mockedBetterFetch, { onUnmatched: "throw" });
+	if (responses.debug) {
+		graphFetch
+			.calledWith("https://graph.facebook.com/debug_token", expect.anything())
+			.thenResolve(responses.debug, { times: 1 });
+	}
+	if (responses.me) {
+		graphFetch
+			.calledWith(
+				"https://graph.facebook.com/me?fields=id,name,email,picture",
+				expect.anything(),
+			)
+			.thenResolve(responses.me, { times: 1 });
+	}
+	return graphFetch;
 }
 
 describe("facebook.getUserInfo (opaque access token)", () => {
@@ -70,7 +69,7 @@ describe("facebook.getUserInfo (opaque access token)", () => {
 	});
 
 	it("returns the profile for a token bound to the configured app", async () => {
-		mockGraph({
+		const graphFetch = mockGraphResponses({
 			debug: debugTokenResponse({
 				is_valid: true,
 				app_id: "fb-app",
@@ -84,6 +83,7 @@ describe("facebook.getUserInfo (opaque access token)", () => {
 		} as any);
 		expect(res?.user).not.toHaveProperty("id");
 		expect(res?.user.email).toBe("u1@example.com");
+		expect(graphFetch).toHaveBeenExhausted();
 		expect(typeof provider.accountSubject).toBe("function");
 		if (typeof provider.accountSubject !== "function" || !res) return;
 		expect(
@@ -95,23 +95,23 @@ describe("facebook.getUserInfo (opaque access token)", () => {
 	});
 
 	it("rejects a token issued to a different app (token substitution)", async () => {
-		mockGraph({
+		const graphFetch = mockGraphResponses({
 			debug: debugTokenResponse({
 				is_valid: true,
 				app_id: "someone-elses-app",
 				user_id: "other-user",
 			}),
-			me: profileResponse(fbProfile("other-user")),
 		});
 		const provider = facebook(options);
 		const res = await provider.getUserInfo({
 			accessToken: "foreign-app-token",
 		} as any);
 		expect(res).toBeNull();
+		expect(graphFetch).toHaveBeenExhausted();
 	});
 
 	it("rejects when the profile id does not match the validated token", async () => {
-		mockGraph({
+		const graphFetch = mockGraphResponses({
 			debug: debugTokenResponse({
 				is_valid: true,
 				app_id: "fb-app",
@@ -124,10 +124,10 @@ describe("facebook.getUserInfo (opaque access token)", () => {
 			accessToken: "opaque-access-token",
 		} as any);
 		expect(res).toBeNull();
+		expect(graphFetch).toHaveBeenExhausted();
 	});
 
 	it("rejects when no access token is supplied", async () => {
-		mockGraph({});
 		const provider = facebook(options);
 		const res = await provider.getUserInfo({} as any);
 		expect(res).toBeNull();

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineProject } from "vitest/config";
 export default defineProject({
 	test: {
 		clearMocks: true,
+		fsModuleCache: true,
+		injectCjsGlobals: false,
+		pool: "threads",
 		restoreMocks: true,
 	},
 });


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts Vitest 5 features in the test suite: replaces `__dirname` with `import.meta.dirname` to work with ESM, enables `fsModuleCache` and disables `injectCjsGlobals` in project configs, and sets `pool: "threads"` for `core` tests. Refactors Facebook provider tests to use `vi.when` with explicit call expectations, so tests now assert that all expected Graph API calls are made exactly once.

<sup>Written for commit e27a6baf88bdd3dcccf4ce52ca74acbdca703ef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

