### PR TITLE
docs: update CLI references to `auth`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This is the Better Auth repository - a comprehensive authentication framework fo
 - Use `import type` for type-only imports
 - Use `node:` protocol for Node.js built-ins (e.g. `node:crypto`)
 - JSDoc comments for public APIs
+- The Better Auth CLI package was renamed from `@better-auth/cli` to `auth`. Use `npx auth@latest` in docs and user-facing messages, while preserving historical references in changelogs and explanations of the rename.
 - Plugins should be as independent as possible. When working on a plugin, prefer modifying the plugin over changing core.
 
 ### URL Composition

--- a/docs/content/docs/guides/1-7-upgrade-guide.mdx
+++ b/docs/content/docs/guides/1-7-upgrade-guide.mdx
@@ -137,7 +137,7 @@ Better Auth 1.7.0 through 1.7.2 added a required `issuer` column to the `account
         Regenerate instead of writing SQL. The generated `account` model drops both the field and the compound unique index, and your own tooling produces the migration.
 
         ```bash
-        npx @better-auth/cli@latest generate
+        npx auth@latest generate
         ```
       </Tab>
 

--- a/packages/better-auth/src/plugins/jwt/multi-alg.test.ts
+++ b/packages/better-auth/src/plugins/jwt/multi-alg.test.ts
@@ -435,7 +435,7 @@ describe("pinned-kid + signingAlgorithm against legacy null-alg rows", () => {
 
 /* -----------------------------------------------------------------------
  * jwks schema persistence (alg, crv) — tripwire for downstream consumers
- * that skipped `npx @better-auth/cli generate` after the schema bump.
+ * that skipped `npx auth generate` after the schema bump.
  * --------------------------------------------------------------------- */
 
 describe("jwks.alg / jwks.crv persistence after createJwk", () => {

--- a/packages/drizzle-adapter/src/relations-v2/index.ts
+++ b/packages/drizzle-adapter/src/relations-v2/index.ts
@@ -687,7 +687,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 				for (const key in values) {
 					if (!schema[key]) {
 						throw new BetterAuthError(
-							`The field "${key}" does not exist in the "${model}" Drizzle schema. Please update your drizzle schema or re-generate using "npx @better-auth/cli@latest generate".`,
+							`The field "${key}" does not exist in the "${model}" Drizzle schema. Please update your drizzle schema or re-generate using "npx auth@latest generate".`,
 						);
 					}
 				}
@@ -709,7 +709,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						const queryModel = getQueryModel(model);
 						if (!db.query || !queryModel) {
 							logger.error(
-								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx @better-auth/cli@latest generate".`,
+								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx auth@latest generate".`,
 							);
 							logger.info("Falling back to regular query");
 						} else {
@@ -797,7 +797,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 						const queryModel = getQueryModel(model);
 						if (!db.query || !queryModel) {
 							logger.error(
-								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx @better-auth/cli@latest generate".`,
+								`[# Drizzle Adapter]: The model "${model}" was not found in the query object. Please update your Drizzle schema to include relations or re-generate using "npx auth@latest generate".`,
 							);
 							logger.info("Falling back to regular query");
 						} else {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates user-facing CLI references from `@better-auth/cli` to the renamed `auth` package so commands like `npx auth@latest generate` appear consistently in docs and runtime error messages. Historical references in changelogs and rename explanations are preserved.

<sup>Written for commit 0f0a2cd7b1d406415716b543d952444f4bae9f84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

