### PR TITLE
docs: clarify Drizzle Relations v2 setup

### DIFF
--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -245,8 +245,8 @@ The `schemaName` option is also supported by the
 
 ## Drizzle Relations v2
 
-The current Drizzle adapter uses Drizzle Relations v1.
-To use Drizzle Relations v2, you need to use the `@better-auth/drizzle-adapter/relations-v2` adapter.
+The default Drizzle adapter uses Relations v1. For Drizzle Relations v2, use
+`@better-auth/drizzle-adapter/relations-v2`.
 
 Install the adapter:
 
@@ -254,18 +254,18 @@ Install the adapter:
 npm install @better-auth/drizzle-adapter
 ```
 
-Update your imports to use the relations-v2 adapter:
+Configure Better Auth with the v2 adapter and your auth schema:
 
 ```ts title="auth.ts"
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from '@better-auth/drizzle-adapter/relations-v2'; // [!code highlight]
-import { db } from './database.ts';
-import * as schema from './schema.ts';
+import { db } from './db.ts';
+import * as schema from './auth-schema.ts';
 
 export const auth = betterAuth({
 	database: drizzleAdapter(db, {
 		provider: 'sqlite', // or "pg" or "mysql"
-		schema,
+		schema, // [!code highlight]
 	}),
 	//... the rest of your config
 });
@@ -283,21 +283,15 @@ npx auth@latest generate
   The schema generator will output the new v2 format automatically.
 </Callout>
 
-The generated auth schema exports relations using `defineRelationsPart`, which is
-designed to be merged alongside your app's own `defineRelations`. Pass both to
-the drizzle instance — `schema` is no longer required since Drizzle v1 RC:
+Merge the generated auth relations after your app's relations when configuring Drizzle:
 
 ```ts title="db.ts"
 import { drizzle } from 'drizzle-orm/...';
-// generated relations from auth CLI (uses defineRelationsPart)
 import { authRelations } from './auth-schema.ts';
-// your app's own relations (uses defineRelations)
 import { relations } from './app-schema.ts';
 
 export const db = drizzle({
 	client,
-	// authRelations uses defineRelationsPart, // [!code highlight]
-	// so it must come after the main relations // [!code highlight]
 	relations: { ...relations, ...authRelations }, // [!code highlight]
 });
 ```

--- a/docs/content/docs/adapters/drizzle.mdx
+++ b/docs/content/docs/adapters/drizzle.mdx
@@ -283,10 +283,10 @@ npx auth@latest generate
   The schema generator will output the new v2 format automatically.
 </Callout>
 
-Merge the generated auth relations after your app's relations when configuring Drizzle:
+Merge the generated auth relations after your app's relations in your existing
+Drizzle configuration:
 
 ```ts title="db.ts"
-import { drizzle } from 'drizzle-orm/...';
 import { authRelations } from './auth-schema.ts';
 import { relations } from './app-schema.ts';
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies the Drizzle Relations v2 setup in the adapter docs so the migration steps are easier to follow.

- States explicitly that the default adapter uses Relations v1 and that v2 requires the `relations-v2` adapter.
- Removes the placeholder Drizzle driver import from the relations-merging example.
- Rewords the setup steps to show the v2 adapter and auth schema in the actual auth config, and to clarify how generated relations merge into the existing Drizzle configuration.

<sup>Written for commit aea062da755bc6960bb47ad196c7e2104e748657. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

