### PR TITLE
feat(test-utils): accept additional session fields in auth helpers

### DIFF
--- a/.changeset/test-utils-session-fields.md
+++ b/.changeset/test-utils-session-fields.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Allow `testUtils` auth helpers to accept additional session fields through the `session` option, including required fields without defaults and per-session overrides of configured defaults.

--- a/docs/content/docs/plugins/test-utils.mdx
+++ b/docs/content/docs/plugins/test-utils.mdx
@@ -156,6 +156,17 @@ const member = await test.addMember({
 
 Auth helpers create authenticated sessions for testing protected routes.
 
+All three helpers accept an optional `session` object with additional session fields. Use it to supply required fields without defaults or to override configured defaults for one session:
+
+```ts
+const { headers } = await test.login({
+    userId: user.id,
+    session: { providerToken: "test-token" }
+})
+```
+
+Configure these fields through `session.additionalFields` or a plugin's session schema. Standard session fields such as `id`, `userId`, `token`, and timestamps are ignored in this object; Better Auth continues to generate them. Omitting `session` preserves the default behavior.
+
 #### login
 
 Creates a session for a user and returns session details, headers, cookies, and token.

--- a/docs/content/docs/plugins/test-utils.mdx
+++ b/docs/content/docs/plugins/test-utils.mdx
@@ -156,16 +156,7 @@ const member = await test.addMember({
 
 Auth helpers create authenticated sessions for testing protected routes.
 
-All three helpers accept an optional `session` object with additional session fields. Use it to supply required fields without defaults or to override configured defaults for one session:
-
-```ts
-const { headers } = await test.login({
-    userId: user.id,
-    session: { providerToken: "test-token" }
-})
-```
-
-Configure these fields through `session.additionalFields` or a plugin's session schema. Standard session fields such as `id`, `userId`, `token`, and timestamps are ignored in this object; Better Auth continues to generate them. Omitting `session` preserves the default behavior.
+All three helpers accept an optional `session` object for fields configured through `session.additionalFields` or a plugin's session schema. Supplied values override defaults; omitted fields keep their defaults. Standard session fields such as `id`, `userId`, `token`, and timestamps are ignored.
 
 #### login
 
@@ -173,7 +164,8 @@ Creates a session for a user and returns session details, headers, cookies, and 
 
 ```ts
 const { session, user, headers, cookies, token } = await test.login({
-    userId: user.id
+    userId: user.id,
+    session: { providerToken: "test-token" } // optional additional fields
 })
 
 // session - The session object with userId, token, etc.

--- a/packages/better-auth/src/plugins/test-utils/auth-helpers.ts
+++ b/packages/better-auth/src/plugins/test-utils/auth-helpers.ts
@@ -1,9 +1,25 @@
 import type { AuthContext } from "@better-auth/core";
+import { sessionSchema } from "@better-auth/core/db";
 import { createCookieHeaders, createTestCookie } from "./cookie-builder";
-import type { LoginResult, TestCookie } from "./types";
+import type { LoginResult, TestAuthOptions, TestCookie } from "./types";
+
+function createSession(ctx: AuthContext, opts: TestAuthOptions) {
+	const additionalFields = Object.fromEntries(
+		Object.entries(opts.session ?? {}).filter(
+			([key]) => !Object.hasOwn(sessionSchema.shape, key),
+		),
+	);
+	// Override additional-field defaults without replacing generated session fields.
+	return ctx.internalAdapter.createSession(
+		opts.userId,
+		false,
+		additionalFields,
+		true,
+	);
+}
 
 export function createLogin(ctx: AuthContext) {
-	return async (opts: { userId: string }): Promise<LoginResult> => {
+	return async (opts: TestAuthOptions): Promise<LoginResult> => {
 		// Find the user first to avoid creating orphaned sessions
 		const user = await ctx.internalAdapter.findUserById(opts.userId);
 		if (!user) {
@@ -11,7 +27,7 @@ export function createLogin(ctx: AuthContext) {
 		}
 
 		// Create a session for the user
-		const session = await ctx.internalAdapter.createSession(opts.userId);
+		const session = await createSession(ctx, opts);
 
 		// Create headers with cookie
 		const headers = await createCookieHeaders(ctx, session.token);
@@ -30,18 +46,17 @@ export function createLogin(ctx: AuthContext) {
 }
 
 export function createGetAuthHeaders(ctx: AuthContext) {
-	return async (opts: { userId: string }): Promise<Headers> => {
-		const session = await ctx.internalAdapter.createSession(opts.userId);
+	return async (opts: TestAuthOptions): Promise<Headers> => {
+		const session = await createSession(ctx, opts);
 		return createCookieHeaders(ctx, session.token);
 	};
 }
 
 export function createGetCookies(ctx: AuthContext) {
-	return async (opts: {
-		userId: string;
-		domain?: string;
-	}): Promise<TestCookie[]> => {
-		const session = await ctx.internalAdapter.createSession(opts.userId);
+	return async (
+		opts: TestAuthOptions & { domain?: string },
+	): Promise<TestCookie[]> => {
+		const session = await createSession(ctx, opts);
 		return createTestCookie(ctx, session.token, opts.domain);
 	};
 }

--- a/packages/better-auth/src/plugins/test-utils/index.ts
+++ b/packages/better-auth/src/plugins/test-utils/index.ts
@@ -17,6 +17,7 @@ import type { TestHelpers, TestUtilsOptions } from "./types";
 
 export type {
 	LoginResult,
+	TestAuthOptions,
 	TestCookie,
 	TestHelpers,
 	TestUtilsOptions,

--- a/packages/better-auth/src/plugins/test-utils/test-utils.test.ts
+++ b/packages/better-auth/src/plugins/test-utils/test-utils.test.ts
@@ -199,7 +199,19 @@ describe("testUtils plugin", async () => {
 	describe("additional session fields", async () => {
 		const { auth } = await getTestInstance(
 			{
-				plugins: [testUtils()],
+				plugins: [
+					testUtils(),
+					{
+						id: "session-fixture",
+						schema: {
+							session: {
+								fields: {
+									pluginToken: { type: "string", required: true, input: false },
+								},
+							},
+						},
+					},
+				],
 				session: {
 					additionalFields: {
 						providerToken: { type: "string", required: true, input: false },
@@ -219,7 +231,11 @@ describe("testUtils plugin", async () => {
 			const user = await test.saveUser(test.createUser());
 			const options = {
 				userId: user.id,
-				session: { providerToken: `token-${helper}`, label: "" },
+				session: {
+					providerToken: `token-${helper}`,
+					pluginToken: `plugin-${helper}`,
+					label: "",
+				},
 			};
 			let headers: Headers;
 			if (helper === "login") {
@@ -252,6 +268,7 @@ describe("testUtils plugin", async () => {
 				userId: user.id,
 				session: {
 					providerToken: "fixture-token",
+					pluginToken: "plugin-token",
 					id: "supplied-id",
 					userId: "another-user",
 					token: "supplied-token",
@@ -265,6 +282,7 @@ describe("testUtils plugin", async () => {
 			expect(result.session).toMatchObject({
 				userId: user.id,
 				providerToken: "fixture-token",
+				pluginToken: "plugin-token",
 				label: "default",
 				ipAddress: "",
 				userAgent: "",

--- a/packages/better-auth/src/plugins/test-utils/test-utils.test.ts
+++ b/packages/better-auth/src/plugins/test-utils/test-utils.test.ts
@@ -245,11 +245,7 @@ describe("testUtils plugin", async () => {
 			} else if (helper === "getAuthHeaders") {
 				headers = await test.getAuthHeaders(options);
 			} else {
-				const cookies = await test.getCookies({
-					...options,
-					domain: "custom.example.com",
-				});
-				expect(cookies[0]?.domain).toBe("custom.example.com");
+				const cookies = await test.getCookies(options);
 				headers = new Headers({
 					cookie: cookies
 						.map(({ name, value }) => `${name}=${value}`)

--- a/packages/better-auth/src/plugins/test-utils/test-utils.test.ts
+++ b/packages/better-auth/src/plugins/test-utils/test-utils.test.ts
@@ -196,6 +196,90 @@ describe("testUtils plugin", async () => {
 		});
 	});
 
+	describe("additional session fields", async () => {
+		const { auth } = await getTestInstance(
+			{
+				plugins: [testUtils()],
+				session: {
+					additionalFields: {
+						providerToken: { type: "string", required: true, input: false },
+						label: { type: "string", defaultValue: "default" },
+					},
+				},
+			},
+			{ disableTestUser: true },
+		);
+		const test = (await auth.$context).test;
+
+		it.each([
+			"login",
+			"getAuthHeaders",
+			"getCookies",
+		] as const)("%s persists required fields and overrides defaults before authenticating", async (helper) => {
+			const user = await test.saveUser(test.createUser());
+			const options = {
+				userId: user.id,
+				session: { providerToken: `token-${helper}`, label: "" },
+			};
+			let headers: Headers;
+			if (helper === "login") {
+				const result = await test.login(options);
+				expect(result.session).toMatchObject(options.session);
+				headers = result.headers;
+			} else if (helper === "getAuthHeaders") {
+				headers = await test.getAuthHeaders(options);
+			} else {
+				const cookies = await test.getCookies({
+					...options,
+					domain: "custom.example.com",
+				});
+				expect(cookies[0]?.domain).toBe("custom.example.com");
+				headers = new Headers({
+					cookie: cookies
+						.map(({ name, value }) => `${name}=${value}`)
+						.join("; "),
+				});
+			}
+			const session = await auth.api.getSession({ headers });
+			expect(session?.user.id).toBe(user.id);
+			expect(session?.session).toMatchObject(options.session);
+			await test.deleteUser(user.id);
+		});
+
+		it("keeps defaults for omitted fields and generates standard session fields", async () => {
+			const user = await test.saveUser(test.createUser());
+			const result = await test.login({
+				userId: user.id,
+				session: {
+					providerToken: "fixture-token",
+					id: "supplied-id",
+					userId: "another-user",
+					token: "supplied-token",
+					expiresAt: new Date(0),
+					createdAt: new Date(0),
+					updatedAt: new Date(0),
+					ipAddress: "192.0.2.1",
+					userAgent: "supplied-agent",
+				},
+			});
+			expect(result.session).toMatchObject({
+				userId: user.id,
+				providerToken: "fixture-token",
+				label: "default",
+				ipAddress: "",
+				userAgent: "",
+			});
+			expect(result.session.id).not.toBe("supplied-id");
+			expect(result.token).not.toBe("supplied-token");
+			expect(result.session.expiresAt.getTime()).toBeGreaterThan(Date.now());
+			expect(result.session.createdAt.getTime()).toBeGreaterThan(0);
+			expect(result.session.updatedAt.getTime()).toBeGreaterThan(0);
+			const session = await auth.api.getSession({ headers: result.headers });
+			expect(session?.user.id).toBe(user.id);
+			await test.deleteUser(user.id);
+		});
+	});
+
 	describe("with organization plugin", async () => {
 		const { auth } = await getTestInstance({
 			plugins: [testUtils(), organization()],

--- a/packages/better-auth/src/plugins/test-utils/types.ts
+++ b/packages/better-auth/src/plugins/test-utils/types.ts
@@ -24,6 +24,13 @@ export interface LoginResult {
 	token: string;
 }
 
+/** Options for creating a session with the test auth helpers. */
+export interface TestAuthOptions {
+	userId: string;
+	/** Additional session fields. Standard session fields are ignored. */
+	session?: Record<string, unknown>;
+}
+
 export interface TestHelpers {
 	// Factories
 	createUser(overrides?: Partial<User> & Record<string, unknown>): User;
@@ -45,9 +52,11 @@ export interface TestHelpers {
 	deleteOrganization?(orgId: string): Promise<void>;
 
 	// Auth helpers
-	login(opts: { userId: string }): Promise<LoginResult>;
-	getAuthHeaders(opts: { userId: string }): Promise<Headers>;
-	getCookies(opts: { userId: string; domain?: string }): Promise<TestCookie[]>;
+	login(opts: TestAuthOptions): Promise<LoginResult>;
+	getAuthHeaders(opts: TestAuthOptions): Promise<Headers>;
+	getCookies(
+		opts: TestAuthOptions & { domain?: string },
+	): Promise<TestCookie[]>;
 
 	// OTP capture (when captureOTP: true)
 	getOTP?(identifier: string): string | undefined;


### PR DESCRIPTION
`testUtils` auth helpers cannot populate required session fields without defaults, so session creation fails with a database constraint error. This adds optional per-session values to `login`, `getAuthHeaders`, and `getCookies`:

```diff
 const { headers, cookies } = await test.login({
   userId: user.id,
+  session: { providerToken: "test-token" },
 })
```

Values are supplied before persistence and override field defaults. Better Auth continues to generate standard session fields such as the user ID and token.

[Repro](https://github.com/onmax/repros/tree/repro/better-auth-session-fixtures/better-auth-session-fixtures): 1.7.3 ignores the proposed option and fails with `NOT NULL constraint failed: session.providerToken`. The [patched fixture](https://github.com/onmax/repros/tree/repro/better-auth-session-fixtures/better-auth-session-fixtures-fix) runs the same verifier and successfully reads the field through an authenticated session lookup.
