### PR TITLE
Fix Drizzle Imports

### DIFF
--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.mixed-where.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.mixed-where.test.ts
@@ -9,7 +9,7 @@
 import type { User } from "@better-auth/core/db";
 import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import Database from "better-sqlite3";
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.plural-joins.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.plural-joins.test.ts
@@ -18,7 +18,7 @@
 import type { Session, User } from "@better-auth/core/db";
 import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import Database from "better-sqlite3";
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";

--- a/e2e/adapter/test/drizzle-adapter/adapter.drizzle.use-plural-joins-relationname.test.ts
+++ b/e2e/adapter/test/drizzle-adapter/adapter.drizzle.use-plural-joins-relationname.test.ts
@@ -7,7 +7,7 @@
 import type { Account, User } from "@better-auth/core/db";
 import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import Database from "better-sqlite3";
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";

--- a/packages/cli/test/__snapshots__/auth-schema-drizzle-use-plural.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-drizzle-use-plural.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import { pgTable, text, timestamp, boolean, index } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {

--- a/packages/cli/test/__snapshots__/auth-schema-mysql-enum.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql-enum.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import {
   mysqlTable,
   varchar,

--- a/packages/cli/test/__snapshots__/auth-schema-mysql-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql-number-id.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import {
   mysqlTable,
   varchar,

--- a/packages/cli/test/__snapshots__/auth-schema-mysql-passkey-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql-passkey-number-id.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import {
   mysqlTable,
   varchar,

--- a/packages/cli/test/__snapshots__/auth-schema-mysql-passkey.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql-passkey.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import {
   mysqlTable,
   varchar,

--- a/packages/cli/test/__snapshots__/auth-schema-mysql-uuid.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql-uuid.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import {
   mysqlTable,
   varchar,

--- a/packages/cli/test/__snapshots__/auth-schema-mysql.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-mysql.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import {
   mysqlTable,
   varchar,

--- a/packages/cli/test/__snapshots__/auth-schema-number-id.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-number-id.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import {
   pgTable,
   text,

--- a/packages/cli/test/__snapshots__/auth-schema-pg-enum.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-pg-enum.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import { pgTable, text, timestamp, boolean, index } from "drizzle-orm/pg-core";
 
 export const user = pgTable("user", {

--- a/packages/cli/test/__snapshots__/auth-schema-pg-passkey.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-pg-passkey.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import {
   pgTable,
   text,

--- a/packages/cli/test/__snapshots__/auth-schema-pg-with-schema-name.txt
+++ b/packages/cli/test/__snapshots__/auth-schema-pg-with-schema-name.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import {
   pgSchema,
   text,

--- a/packages/cli/test/__snapshots__/auth-schema.txt
+++ b/packages/cli/test/__snapshots__/auth-schema.txt
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import {
   pgTable,
   text,

--- a/packages/drizzle-adapter/src/schema-check.test.ts
+++ b/packages/drizzle-adapter/src/schema-check.test.ts
@@ -5,7 +5,7 @@ import {
 	SchemaMismatchError,
 	schemaCheckFor,
 } from "@better-auth/core/db/internal";
-import { relations } from "drizzle-orm";
+import { relations } from "drizzle-orm/_relations";
 import { pgTable, text } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 import { drizzleAdapter } from "./drizzle-adapter";


### PR DESCRIPTION
Just fixed drizzle import previously the import was this
```tsx
import { relations } from "drizzle-orm";
```
which was incorrect and I updated this to

```tsx
import { relations } from "drizzle-orm/_relations";
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `relations` import path from `drizzle-orm` to `drizzle-orm/_relations` across test files and CLI-generated schema snapshots. The previous import did not resolve correctly in all environments; the new path points to where Drizzle actually exports `relations`.

<sup>Written for commit 6c682d69137800633b51f2a46b953575a7c335c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

