### PR TITLE
feat(instrumentation): add option to disable tracing

### DIFF
--- a/.changeset/quiet-traces-option.md
+++ b/.changeset/quiet-traces-option.md
@@ -1,0 +1,6 @@
+---
+"@better-auth/core": patch
+"better-auth": patch
+---
+
+Add `experimental.instrumentation.enabled` to disable Better Auth OpenTelemetry span creation per auth instance. Instrumentation remains enabled by default and independent of usage reporting.

--- a/docs/content/docs/reference/instrumentation.mdx
+++ b/docs/content/docs/reference/instrumentation.mdx
@@ -20,6 +20,24 @@ For setup instructions, see the official OpenTelemetry documentation:
 
 * **[Node.js getting started](https://opentelemetry.io/docs/languages/js/getting-started/nodejs/)** – Core setup for Node.js apps
 
+## Disable Instrumentation
+
+To prevent Better Auth from creating OpenTelemetry spans, set `experimental.instrumentation.enabled` to `false`:
+
+```ts
+import { betterAuth } from "better-auth";
+
+export const auth = betterAuth({
+  experimental: {
+    instrumentation: {
+      enabled: false,
+    },
+  },
+});
+```
+
+Instrumentation is enabled by default. Disabling it affects only this auth instance, leaving spans from your application and other libraries unchanged.
+
 ## Supported Spans
 
 The following spans are supported by Better Auth:

--- a/packages/better-auth/src/api/dispatch.ts
+++ b/packages/better-auth/src/api/dispatch.ts
@@ -8,7 +8,7 @@ import {
 	ATTR_HOOK_TYPE,
 	ATTR_HTTP_ROUTE,
 	ATTR_OPERATION_ID,
-	withSpan,
+	createWithSpan,
 } from "@better-auth/core/instrumentation";
 import type { Endpoint, EndpointContext, InputContext } from "better-call";
 import { kAPIErrorHeaderSymbol, toResponse } from "better-call";
@@ -140,6 +140,7 @@ async function runBeforeHooks(
 	endpoint: Endpoint,
 	operationId: string,
 ) {
+	const withSpan = createWithSpan(context.context.options);
 	let modifiedContext: Partial<InternalContext> = {};
 
 	for (const hook of hooks) {
@@ -224,6 +225,7 @@ async function runAfterHooks(
 	endpoint: Endpoint,
 	operationId: string,
 ) {
+	const withSpan = createWithSpan(context.context.options);
 	for (const hook of hooks) {
 		if (!hook.matcher(context as HookEndpointContext)) continue;
 
@@ -322,6 +324,7 @@ export async function dispatchAuthEndpoint(
 	endpoint: Endpoint,
 	input: DispatchContext,
 ): Promise<unknown> {
+	const withSpan = createWithSpan(input.context.options);
 	const operationId = input.operationId ?? getOperationId(endpoint);
 	const route = endpoint.path ?? "/:virtual";
 	const endpointMethod = endpoint.options?.method;

--- a/packages/better-auth/src/api/index.ts
+++ b/packages/better-auth/src/api/index.ts
@@ -11,7 +11,7 @@ import {
 	ATTR_HOOK_TYPE,
 	ATTR_HTTP_RESPONSE_STATUS_CODE,
 	ATTR_HTTP_ROUTE,
-	withSpan,
+	createWithSpan,
 } from "@better-auth/core/instrumentation";
 import { normalizePathname } from "@better-auth/core/utils/url";
 import type { Endpoint, Middleware } from "better-call";
@@ -174,6 +174,7 @@ export function getEndpoints<Option extends BetterAuthOptions>(
 	ctx: Awaitable<AuthContext>,
 	options: Option,
 ) {
+	const withSpan = createWithSpan(options);
 	const pluginEndpoints =
 		options.plugins?.reduce<Record<string, Endpoint>>((acc, plugin) => {
 			return {
@@ -274,6 +275,7 @@ export const router = <Option extends BetterAuthOptions>(
 	ctx: AuthContext,
 	options: Option,
 ) => {
+	const withSpan = createWithSpan(options);
 	const { api, middlewares } = getEndpoints(ctx, options);
 	const basePath = new URL(ctx.baseURL).pathname;
 

--- a/packages/better-auth/src/db/with-hooks.ts
+++ b/packages/better-auth/src/db/with-hooks.ts
@@ -10,7 +10,7 @@ import {
 	ATTR_CONTEXT,
 	ATTR_DB_COLLECTION_NAME,
 	ATTR_HOOK_TYPE,
-	withSpan,
+	createWithSpan,
 } from "@better-auth/core/instrumentation";
 
 export type DatabaseHooksEntry = {
@@ -25,6 +25,7 @@ export function getWithHooks(
 		hooks: DatabaseHooksEntry[];
 	},
 ) {
+	const withSpan = createWithSpan(ctx.options);
 	const hooksEntries = ctx.hooks;
 	async function createWithHooks<T extends Record<string, any>>(
 		data: T,

--- a/packages/better-auth/src/instrumentation.endpoint.test.ts
+++ b/packages/better-auth/src/instrumentation.endpoint.test.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthPlugin } from "@better-auth/core";
+import type { BetterAuthOptions, BetterAuthPlugin } from "@better-auth/core";
 import { createAuthEndpoint } from "@better-auth/core/api";
 import {
 	ATTR_CONTEXT,
@@ -31,7 +31,7 @@ let provider: NodeTracerProvider;
 
 const PLUGIN_ID = "test-plugin";
 
-async function createTestInstance() {
+async function createTestInstance(options: BetterAuthOptions = {}) {
 	const otelPlugin: BetterAuthPlugin = {
 		id: PLUGIN_ID,
 		endpoints: {
@@ -64,6 +64,7 @@ async function createTestInstance() {
 			after: createAuthMiddleware(async () => {}),
 		},
 		plugins: [otelPlugin],
+		...options,
 	});
 }
 
@@ -91,6 +92,62 @@ describe("endpoints instrumentation", () => {
 
 	beforeEach(() => {
 		exporter.reset();
+	});
+
+	it("disables instrumentation per instance while preserving application spans", async () => {
+		const enabled = await createTestInstance();
+		await enabled.client.getSession();
+		await waitForSpan((span) => span.name === "GET /get-session");
+		exporter.reset();
+		const getTracer = vi.spyOn(trace, "getTracer");
+		const disabled = await createTestInstance({
+			experimental: { instrumentation: { enabled: false } },
+			databaseHooks: {
+				user: {
+					create: {
+						before: async (data) => ({ data }),
+						after: async () => {},
+					},
+				},
+			},
+		});
+		const tracer = provider.getTracer("application");
+		await tracer.startActiveSpan("server request", async (span) => {
+			try {
+				const response = await disabled.client.signUp.email({
+					email: "disabled@example.com",
+					password: "password123456",
+					name: "Disabled tracing",
+				});
+				expect(response.error).toBeNull();
+				expect(
+					await disabled.auth.api.getSession({ headers: new Headers() }),
+				).toBeNull();
+				await disabled.auth.$context.then((ctx) =>
+					ctx.adapter.findMany({ model: "user" }),
+				);
+			} finally {
+				span.end();
+			}
+		});
+		expect(getTracer).not.toHaveBeenCalled();
+		getTracer.mockRestore();
+		await provider.forceFlush();
+		expect(exporter.getFinishedSpans().map((span) => span.name)).toEqual([
+			"server request",
+		]);
+
+		exporter.reset();
+		await Promise.all([
+			enabled.client.getSession(),
+			disabled.client.getSession(),
+		]);
+		await provider.forceFlush();
+		expect(
+			exporter
+				.getFinishedSpans()
+				.filter((span) => span.name === "GET /get-session"),
+		).toHaveLength(1);
 	});
 
 	it("emits a parent span for each endpoint", async () => {

--- a/packages/core/src/db/adapter/factory.ts
+++ b/packages/core/src/db/adapter/factory.ts
@@ -1,7 +1,7 @@
 import {
 	ATTR_DB_COLLECTION_NAME,
 	ATTR_DB_OPERATION_NAME,
-	withSpan,
+	createWithSpan,
 } from "@better-auth/core/instrumentation";
 import { createLogger, getColorDepth, TTY_COLORS } from "../../env";
 import { BetterAuthError } from "../../error";
@@ -58,6 +58,7 @@ export const createAdapterFactory =
 		config: cfg,
 	}: AdapterFactoryOptions): AdapterFactory<Options> =>
 	(options: Options): DBAdapter<Options> => {
+		const withSpan = createWithSpan(options);
 		const uniqueAdapterFactoryInstanceId = Math.random()
 			.toString(36)
 			.substring(2, 15);

--- a/packages/core/src/instrumentation/instrumentation.test.ts
+++ b/packages/core/src/instrumentation/instrumentation.test.ts
@@ -14,7 +14,7 @@ import {
 	it,
 	vi,
 } from "vitest";
-import { withSpan } from ".";
+import { createWithSpan, withSpan } from ".";
 import { getOpenTelemetryAPI } from "./api";
 import { ATTR_DB_COLLECTION_NAME, ATTR_DB_OPERATION_NAME } from "./attributes";
 
@@ -70,6 +70,42 @@ describe("instrumentation", () => {
 	beforeEach(() => {
 		exporter.reset();
 		vi.resetAllMocks();
+	});
+
+	it("enables instrumentation by default and when explicitly enabled", () => {
+		expect(createWithSpan({})).toBe(withSpan);
+		expect(createWithSpan({ experimental: { instrumentation: {} } })).toBe(
+			withSpan,
+		);
+		expect(
+			createWithSpan({
+				experimental: { instrumentation: { enabled: true } },
+			}),
+		).toBe(withSpan);
+	});
+
+	it("preserves return values and errors without accessing the tracer when disabled", async () => {
+		const run = createWithSpan({
+			experimental: { instrumentation: { enabled: false } },
+		});
+		const getTracer = vi.spyOn(getOpenTelemetryAPI().trace, "getTracer");
+		expect(run("sync", {}, () => 42)).toBe(42);
+		const promise = Promise.resolve(42);
+		expect(run("async", {}, () => promise)).toBe(promise);
+		const error = new Error("failure");
+		expect(() =>
+			run("sync error", {}, () => {
+				throw error;
+			}),
+		).toThrow(error);
+		await expect(
+			run("async error", {}, async () => {
+				throw error;
+			}),
+		).rejects.toBe(error);
+		expect(getTracer).not.toHaveBeenCalled();
+		expect(exporter.getFinishedSpans()).toEqual([]);
+		getTracer.mockRestore();
 	});
 
 	it("creates a span with name and attributes for sync function", async () => {

--- a/packages/core/src/instrumentation/noop.ts
+++ b/packages/core/src/instrumentation/noop.ts
@@ -72,3 +72,24 @@ function createNoopOpenTelemetryAPI(): OpenTelemetryAPI {
 
 export const noopOpenTelemetryAPI: OpenTelemetryAPI =
 	createNoopOpenTelemetryAPI();
+
+/**
+ * Executes a function without creating an OpenTelemetry span.
+ */
+export function noopWithSpan<T>(
+	name: string,
+	attributes: Record<string, string | number | boolean>,
+	fn: () => T,
+): T;
+export function noopWithSpan<T>(
+	name: string,
+	attributes: Record<string, string | number | boolean>,
+	fn: () => Promise<T>,
+): Promise<T>;
+export function noopWithSpan<T>(
+	_name: string,
+	_attributes: Record<string, string | number | boolean>,
+	fn: () => T | Promise<T>,
+): T | Promise<T> {
+	return fn();
+}

--- a/packages/core/src/instrumentation/pure.index.ts
+++ b/packages/core/src/instrumentation/pure.index.ts
@@ -9,23 +9,15 @@
  *
  * Public surface must stay identical to `./index` (enforced by `pure.test.ts`).
  */
+import type { BetterAuthOptions } from "../types";
+import { noopWithSpan as withSpan } from "./noop";
 
 export * from "./attributes";
+export { withSpan };
 
-export function withSpan<T>(
-	name: string,
-	attributes: Record<string, string | number | boolean>,
-	fn: () => T,
-): T;
-export function withSpan<T>(
-	name: string,
-	attributes: Record<string, string | number | boolean>,
-	fn: () => Promise<T>,
-): Promise<T>;
-export function withSpan<T>(
-	_name: string,
-	_attributes: Record<string, string | number | boolean>,
-	fn: () => T | Promise<T>,
-): T | Promise<T> {
-	return fn();
+/**
+ * Selects the span runner for an auth instance.
+ */
+export function createWithSpan(_options: BetterAuthOptions): typeof withSpan {
+	return withSpan;
 }

--- a/packages/core/src/instrumentation/pure.test.ts
+++ b/packages/core/src/instrumentation/pure.test.ts
@@ -1,6 +1,6 @@
 // cspell:ignore workerd
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { withSpan } from "./pure.index";
 
 type CorePackageJSON = {
@@ -42,9 +42,24 @@ describe("instrumentation (pure entry)", () => {
 		).rejects.toThrow("boom");
 	});
 
-	it("does not reference `@opentelemetry/api` at runtime", async () => {
-		const mod = await import("./pure.index");
-		expect(mod.withSpan.toString()).not.toContain("opentelemetry");
+	it("does not load `@opentelemetry/api` at runtime", async () => {
+		vi.resetModules();
+		const loadOpenTelemetry = vi.fn(() => {
+			throw new Error("OpenTelemetry is unavailable");
+		});
+		vi.doMock("@opentelemetry/api", loadOpenTelemetry);
+		try {
+			const mod = await import("./pure.index");
+			expect(mod.withSpan("pure", {}, () => 42)).toBe(42);
+			const run = mod.createWithSpan({
+				experimental: { instrumentation: { enabled: true } },
+			});
+			await expect(run("pure async", {}, async () => 42)).resolves.toBe(42);
+			expect(loadOpenTelemetry).not.toHaveBeenCalled();
+		} finally {
+			vi.doUnmock("@opentelemetry/api");
+			vi.resetModules();
+		}
 	});
 
 	it("does not export symbols beyond the public surface of ./index", async () => {

--- a/packages/core/src/instrumentation/tracer.ts
+++ b/packages/core/src/instrumentation/tracer.ts
@@ -1,6 +1,8 @@
 import type { Span } from "@opentelemetry/api";
+import type { BetterAuthOptions } from "../types";
 import { getOpenTelemetryAPI } from "./api";
 import { ATTR_HTTP_RESPONSE_STATUS_CODE } from "./attributes";
+import { noopWithSpan } from "./noop";
 
 const INSTRUMENTATION_SCOPE = "better-auth";
 const INSTRUMENTATION_VERSION = import.meta.env?.BETTER_AUTH_VERSION ?? "1.0.0";
@@ -92,4 +94,13 @@ export function withSpan<T>(
 			throw err;
 		}
 	});
+}
+
+/**
+ * Selects the span runner for an auth instance.
+ */
+export function createWithSpan(options: BetterAuthOptions): typeof withSpan {
+	return options.experimental?.instrumentation?.enabled === false
+		? noopWithSpan
+		: withSpan;
 }

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -1797,4 +1797,24 @@ export type BetterAuthOptions = {
 				debug?: boolean;
 		  }
 		| undefined;
+	/**
+	 * Experimental features.
+	 */
+	experimental?:
+		| {
+				/**
+				 * OpenTelemetry instrumentation configuration.
+				 */
+				instrumentation?:
+					| {
+							/**
+							 * Enable Better Auth spans. Does not affect usage reporting or application spans.
+							 *
+							 * @default true
+							 */
+							enabled?: boolean | undefined;
+					  }
+					| undefined;
+		  }
+		| undefined;
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an option to disable Better Auth's OpenTelemetry span creation per auth instance. Previously instrumentation was always enabled; now setting `experimental.instrumentation.enabled` to `false` skips span creation without affecting usage reporting or application spans.

**New Features**
- Introduces `experimental.instrumentation.enabled` to toggle Better Auth spans per auth instance, defaulting to `true`.
- Continues to support the pure entry point, which never loads `@opentelemetry/api` at runtime.

<sup>Written for commit aa11f55420681c931ea5239ca2b6df034f6f3e63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

