### PR TITLE
ci(backport): restore authenticated branch pushes

### DIFF
--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -68,6 +68,7 @@ GHEOF
 denoland
 zizmor
 zizmorcore
+artipacked
 IMDS
 WHATWG
 CIMD

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -85,7 +85,7 @@ jobs:
           experimental: '{"conflict_resolution": "draft_commit_conflicts"}'
 
       - name: Verify backport result
-        if: steps.backport.outputs.was_successful != 'true'
+        if: steps.backport.outputs.was_successful == 'false'
         run: |
           echo "::error::One or more backports failed"
           exit 1

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,15 +10,18 @@ permissions: {}
 
 concurrency:
   group: backport-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
 
 jobs:
   backport:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: >
       github.repository_owner == 'better-auth' && (
         (
           github.event_name == 'pull_request_target' &&
-          github.event.pull_request.merged
+          github.event.pull_request.merged &&
+          contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')
         ) || (
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
@@ -42,11 +45,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Check PR state and labels
         id: pr
@@ -63,14 +63,29 @@ jobs:
           HAS_LABEL=$(echo "$PR_DATA" | jq '[.labels[].name] | any(. == "backport-auto-merge")')
           echo "auto_merge=$HAS_LABEL" >> "$GITHUB_OUTPUT"
 
+      # Credentials stay available because backport-action pushes the generated branch.
+      # zizmor: ignore[artipacked]
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
       - name: Create backport PRs
+        id: backport
         uses: korthout/backport-action@66065406958f46e82238fd59546f5a99e69e22aa # v4.5.2
         with:
           github_token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           label_pattern: '^backport ([^ ]+)$'
           pull_title: '[backport ${target_branch}] ${pull_title}'
+          comment_style: summary
           copy_assignees: true
           add_author_as_reviewer: true
           auto_merge_enabled: ${{ steps.pr.outputs.auto_merge }}
           auto_merge_method: squash
           experimental: '{"conflict_resolution": "draft_commit_conflicts"}'
+
+      - name: Verify backport result
+        if: steps.backport.outputs.was_successful != 'true'
+        run: |
+          echo "::error::One or more backports failed"
+          exit 1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,8 +16,8 @@ rules:
       # labels can be applied to fork PRs.
       - auto-label.yml
       # Intentional: creates backports for already-merged PRs or maintainer
-      # slash commands. Checkout persists no credentials; the action receives
-      # an explicit token and does not execute fork PR code.
+      # slash commands. The pinned action retains a scoped token to push the
+      # generated branch but does not execute checked-out repository code.
       - backport.yml
   use-trusted-publishing:
     ignore:

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -93,6 +93,7 @@ const promoteWorkflow = readWorkflow("promote.yml");
 const releaseWorkflow = readWorkflow("release.yml");
 const autoChangesetWorkflow = readWorkflow("auto-changeset.yml");
 const verifyChangesetsWorkflow = readWorkflow("verify-changesets.yml");
+const backportWorkflow = readWorkflow("backport.yml");
 
 describe("release notes command security", () => {
 	it("bounds every privileged release job", () => {
@@ -102,6 +103,7 @@ describe("release notes command security", () => {
 			promoteWorkflow,
 			releaseWorkflow,
 			autoChangesetWorkflow,
+			backportWorkflow,
 		]) {
 			for (const job of Object.values(file.workflow.jobs)) {
 				expect(job["timeout-minutes"]).toBeGreaterThan(0);
@@ -666,6 +668,34 @@ describe("release publication security", () => {
 		);
 		expect(releaseWorkflow.content).not.toContain("AI_GATEWAY_API_KEY");
 		expect(releaseWorkflow.workflow.jobs).not.toHaveProperty("preview-notes");
+	});
+});
+
+describe("backport workflow", () => {
+	it("retains narrowly scoped credentials for the backport push", () => {
+		const backport = getJob(backportWorkflow, "backport");
+		const token = getStep(backport, "Generate App Token");
+		const checkout = backport.steps.find((step) =>
+			step.uses?.startsWith("actions/checkout@"),
+		);
+
+		expect(backport.permissions).toEqual({
+			contents: "write",
+			"pull-requests": "write",
+		});
+		expect(appTokenPermissions(token)).toEqual({
+			"permission-contents": "write",
+			"permission-pull-requests": "write",
+		});
+		expect(checkout?.with?.["persist-credentials"]).toBe(true);
+	});
+
+	it("fails when the action reports an unsuccessful target", () => {
+		const backport = getJob(backportWorkflow, "backport");
+		const verify = getStep(backport, "Verify backport result");
+
+		expect(verify.if).toContain("steps.backport.outputs.was_successful");
+		expect(verify.run).toContain("exit 1");
 	});
 });
 

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -694,7 +694,7 @@ describe("backport workflow", () => {
 		const backport = getJob(backportWorkflow, "backport");
 		const verify = getStep(backport, "Verify backport result");
 
-		expect(verify.if).toContain("steps.backport.outputs.was_successful");
+		expect(verify.if).toBe("steps.backport.outputs.was_successful == 'false'");
 		expect(verify.run).toContain("exit 1");
 	});
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores authenticated branch pushes in the backport workflow so backport PRs can be created again, and makes failure handling explicit so no-op runs don't fail the job.

- Backports trigger only for PRs labeled `backport <branch>`; the app token is scoped to write on contents and pull requests.
- Checkout persists credentials so the pinned action can push the branch, with a 10-minute job timeout.
- A new verify step fails the job only when the action reports an unsuccessful target, distinguishing no-op from actual failure.
- Adds tests covering the scoped permissions and the failure check.

<sup>Written for commit 77d18a40ddb365bf61dd0ef6951a73f7fda3a303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

