### PR TITLE
fix(session): repopulate secondaryStorage after database fallback in findSession

### DIFF
--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -608,16 +608,24 @@ export const createInternalAdapter = (
 		} | null> => {
 			if (secondaryStorage) {
 				// Best-effort cache read: a secondary-storage outage must not 500
-				// the request when the database fallback is available - treat a
-				// failed read as a cache miss and fall through to the database.
-				// Without storeSessionInDatabase the miss path below still
-				// returns null, matching an ordinary cache miss.
+				// the request when the database fallback below can actually serve
+				// the session - treat a failed read as a cache miss and fall
+				// through. The fallback only runs with storeSessionInDatabase
+				// enabled and preserveSessionInDatabase off (preserve skips it
+				// entirely). In the secondary-storage-authoritative config there
+				// is no fallback, so a read failure must surface as an error,
+				// not a cache miss: returning null would treat a transient
+				// outage as an invalid session and log users out.
 				let sessionStringified: unknown = null;
 				try {
 					sessionStringified = await secondaryStorage.get(token);
 				} catch (error) {
+					const hasDatabaseFallback =
+						options.session?.storeSessionInDatabase === true &&
+						ctx.options.session?.preserveSessionInDatabase !== true;
+					if (!hasDatabaseFallback) throw error;
 					logger.error(
-						"[better-auth] secondary-storage session read failed; treating it as a cache miss",
+						"[better-auth] secondary-storage session read failed; falling back to the database",
 						error,
 					);
 				}

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -663,6 +663,48 @@ export const createInternalAdapter = (
 			if (!user) return null;
 			const parsedSession = parseSessionOutput(ctx.options, session);
 			const parsedUser = parseUserOutput(ctx.options, user);
+			if (secondaryStorage) {
+				// Cache-aside repair: the session was absent from secondary storage
+				// (TTL expiry, eviction, flush) but is still valid in the database.
+				// Repopulate the cache, including the active-sessions index, so that
+				// every subsequent request does not hit the primary database - and so
+				// that a later revoke-all still sweeps this token.
+				// Unreachable under preserveSessionInDatabase thanks to the early
+				// return above, so revoked rows cannot be resurrected here.
+				const now = Date.now();
+				const sessionTTL = getTTLSeconds(parsedSession.expiresAt, now);
+				if (sessionTTL > 0) {
+					const activeSessionsKey = `active-sessions-${parsedUser.id}`;
+					const currentList = await secondaryStorage.get(activeSessionsKey);
+					const list =
+						safeJSONParse<{ token: string; expiresAt: number }[]>(currentList) ||
+						[];
+					const filtered = list.filter(
+						(s) => s.expiresAt > now && s.token !== token,
+					);
+					filtered.push({
+						token,
+						expiresAt: parsedSession.expiresAt.getTime(),
+					});
+					filtered.sort((a, b) => a.expiresAt - b.expiresAt);
+					const furthestSessionTTL = getTTLSeconds(
+						filtered[filtered.length - 1]!.expiresAt,
+						now,
+					);
+					await Promise.all([
+						secondaryStorage.set(
+							token,
+							JSON.stringify({ session: parsedSession, user: parsedUser }),
+							sessionTTL,
+						),
+						secondaryStorage.set(
+							activeSessionsKey,
+							JSON.stringify(filtered),
+							furthestSessionTTL,
+						),
+					]);
+				}
+			}
 			return {
 				session: parsedSession,
 				user: parsedUser,

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -671,38 +671,54 @@ export const createInternalAdapter = (
 				// that a later revoke-all still sweeps this token.
 				// Unreachable under preserveSessionInDatabase thanks to the early
 				// return above, so revoked rows cannot be resurrected here.
-				const now = Date.now();
-				const sessionTTL = getTTLSeconds(parsedSession.expiresAt, now);
-				if (sessionTTL > 0) {
-					const activeSessionsKey = `active-sessions-${parsedUser.id}`;
-					const currentList = await secondaryStorage.get(activeSessionsKey);
-					const list =
-						safeJSONParse<{ token: string; expiresAt: number }[]>(currentList) ||
-						[];
-					const filtered = list.filter(
-						(s) => s.expiresAt > now && s.token !== token,
-					);
-					filtered.push({
-						token,
-						expiresAt: parsedSession.expiresAt.getTime(),
-					});
-					filtered.sort((a, b) => a.expiresAt - b.expiresAt);
-					const furthestSessionTTL = getTTLSeconds(
-						filtered[filtered.length - 1]!.expiresAt,
-						now,
-					);
-					await Promise.all([
-						secondaryStorage.set(
+				// Cache repair is best-effort: after the database has returned a
+				// valid session, a transient secondary-storage failure (e.g.
+				// Redis eviction plus a momentarily unreachable backend) must not
+				// turn /get-session into a 500 - the database result is
+				// authoritative (this matches the existing deferred-mirror
+				// handling below, which also has no ordering guard: see the
+				// known-limitation note for the revoke race).
+				try {
+					const now = Date.now();
+					const sessionTTL = getTTLSeconds(parsedSession.expiresAt, now);
+					if (sessionTTL > 0) {
+						const activeSessionsKey = `active-sessions-${parsedUser.id}`;
+						const currentList =
+							await secondaryStorage.get(activeSessionsKey);
+						const list =
+							safeJSONParse<{ token: string; expiresAt: number }[]>(
+								currentList,
+							) || [];
+						const filtered = list.filter(
+							(s) => s.expiresAt > now && s.token !== token,
+						);
+						filtered.push({
 							token,
-							JSON.stringify({ session: parsedSession, user: parsedUser }),
-							sessionTTL,
-						),
-						secondaryStorage.set(
-							activeSessionsKey,
-							JSON.stringify(filtered),
-							furthestSessionTTL,
-						),
-					]);
+							expiresAt: parsedSession.expiresAt.getTime(),
+						});
+						filtered.sort((a, b) => a.expiresAt - b.expiresAt);
+						const furthestSessionTTL = getTTLSeconds(
+							filtered[filtered.length - 1]!.expiresAt,
+							now,
+						);
+						await Promise.all([
+							secondaryStorage.set(
+								token,
+								JSON.stringify({ session: parsedSession, user: parsedUser }),
+								sessionTTL,
+							),
+							secondaryStorage.set(
+								activeSessionsKey,
+								JSON.stringify(filtered),
+								furthestSessionTTL,
+							),
+						]);
+					}
+				} catch (error) {
+					logger.error(
+						"[better-auth] secondary-storage session repair failed; serving the authoritative database session",
+						error,
+					);
 				}
 			}
 			return {

--- a/packages/better-auth/src/db/internal-adapter.ts
+++ b/packages/better-auth/src/db/internal-adapter.ts
@@ -607,7 +607,20 @@ export const createInternalAdapter = (
 			user: User & Record<string, any>;
 		} | null> => {
 			if (secondaryStorage) {
-				const sessionStringified = await secondaryStorage.get(token);
+				// Best-effort cache read: a secondary-storage outage must not 500
+				// the request when the database fallback is available - treat a
+				// failed read as a cache miss and fall through to the database.
+				// Without storeSessionInDatabase the miss path below still
+				// returns null, matching an ordinary cache miss.
+				let sessionStringified: unknown = null;
+				try {
+					sessionStringified = await secondaryStorage.get(token);
+				} catch (error) {
+					logger.error(
+						"[better-auth] secondary-storage session read failed; treating it as a cache miss",
+						error,
+					);
+				}
 				// When preserveSessionInDatabase is enabled, revoked sessions
 				// remain in the database for audit purposes. Skip the database
 				// fallback to prevent those revoked sessions from being restored.

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -35,22 +35,30 @@ function createStringSecondaryStorage(
 
 function createFlakySecondaryStorage(
 	inner: SecondaryStorage,
+	isOutage: () => boolean = () => true,
 ): SecondaryStorage {
-	// Wraps a working store but throws on every set/get at primary-Redis-outage
-	// level: used to prove cache-repair failures cannot break the session read.
+	// Wraps a working store but throws on every get/set while the outage flag
+	// holds, at primary-Redis-outage level: used to prove cache failures
+	// cannot break the session read. Tests sign in with the store healthy
+	// (session creation touches the cache synchronously), then flip the
+	// outage on before exercising the read path.
+	const guard = <T>(fn: () => T): T => {
+		if (isOutage()) throw new Error("redis: connection refused");
+		return fn();
+	};
 	return {
 		...inner,
-		get() {
-			throw new Error("redis: connection refused");
+		get(key) {
+			return guard(() => inner.get(key));
 		},
-		set() {
-			throw new Error("redis: connection refused");
+		set(key, value, ttl) {
+			return guard(() => inner.set(key, value, ttl));
 		},
-		getAndDelete() {
-			throw new Error("redis: connection refused");
+		getAndDelete(key) {
+			return guard(() => inner.getAndDelete(key));
 		},
-		increment() {
-			throw new Error("redis: connection refused");
+		increment(key, ttl) {
+			return guard(() => inner.increment(key, ttl));
 		},
 	};
 }
@@ -381,9 +389,11 @@ describe("secondary storage - storeSessionInDatabase", () => {
 describe("secondary storage - best-effort cache repair", () => {
 	it("a secondary-storage outage cannot turn the database fallback into a 500", async () => {
 		const store = new Map<string, string>();
+		let outage = false;
 		const { client, signInWithTestUser } = await getTestInstance({
 			secondaryStorage: createFlakySecondaryStorage(
 				createStringSecondaryStorage(store),
+				() => outage,
 			),
 			session: {
 				storeSessionInDatabase: true,
@@ -394,11 +404,15 @@ describe("secondary storage - best-effort cache repair", () => {
 			},
 		});
 
+		// Sign in against the healthy store: session creation mirrors into
+		// the cache synchronously, so it must run before the outage starts.
 		const { headers } = await signInWithTestUser();
 
-		// First read misses the (outage) cache and falls back to the database:
-		// this drives cache-aside repair - which now throws internally. The
-		// request must still return the authoritative database session.
+		// Redis "goes down": every cache operation now throws. The guarded
+		// initial read treats this as a miss and falls back to the database,
+		// and the cache-aside repair fails internally as well - the request
+		// must still return the authoritative database session.
+		outage = true;
 		const s1 = await client.getSession({ fetchOptions: { headers } });
 		expect(s1.error).toBeNull();
 		expect(s1.data).not.toBeNull();

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -202,6 +202,63 @@ describe("secondary storage - storeSessionInDatabase", () => {
 			const after = await client.getSession({ fetchOptions: { headers } });
 			expect(after.data).toBeNull();
 		});
+
+		it("repopulates secondary storage after a database fallback", async () => {
+			const { headers } = await signInWithTestUser();
+
+			const s1 = await client.getSession({ fetchOptions: { headers } });
+			expect(s1.data).not.toBeNull();
+			const token = s1.data!.session.token;
+			const userId = s1.data!.user.id;
+
+			expect(store.has(token)).toBe(true);
+
+			// Simulate a cache flush for this user: both the session entry and
+			// the active-sessions index are gone, the database row is still valid.
+			store.delete(token);
+			store.delete(`active-sessions-${userId}`);
+
+			const s2 = await client.getSession({ fetchOptions: { headers } });
+			expect(s2.data).not.toBeNull();
+			expect(s2.data!.session.token).toBe(token);
+
+			// The fallback repaired the cache: subsequent requests must not hit
+			// the primary database for this session anymore.
+			expect(store.has(token)).toBe(true);
+			const listRaw = store.get(`active-sessions-${userId}`);
+			expect(listRaw).toBeTruthy();
+			expect(JSON.parse(listRaw!)).toEqual([
+				{ token, expiresAt: s2.data!.session.expiresAt.getTime() },
+			]);
+
+			const s3 = await client.getSession({ fetchOptions: { headers } });
+			expect(s3.data).not.toBeNull();
+		});
+
+		it("revoke-all still sweeps a session repopulated by a database fallback", async () => {
+			const { headers } = await signInWithTestUser();
+
+			const s1 = await client.getSession({ fetchOptions: { headers } });
+			expect(s1.data).not.toBeNull();
+			const token = s1.data!.session.token;
+			const userId = s1.data!.user.id;
+
+			// Flush the cache, then let the database fallback repopulate it.
+			store.delete(token);
+			store.delete(`active-sessions-${userId}`);
+			const s2 = await client.getSession({ fetchOptions: { headers } });
+			expect(s2.data).not.toBeNull();
+			expect(store.has(token)).toBe(true);
+
+			const revokeAll = await client.revokeSessions({
+				fetchOptions: { headers },
+			});
+			expect(revokeAll.data?.status).toBe(true);
+
+			expect(store.has(token)).toBe(false);
+			const after = await client.getSession({ fetchOptions: { headers } });
+			expect(after.data).toBeNull();
+		});
 	});
 
 	describe("preserveSessionInDatabase: true", async () => {

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -418,6 +418,33 @@ describe("secondary storage - best-effort cache repair", () => {
 		expect(s1.data).not.toBeNull();
 		expect(s1.data!.session.token).toBeTruthy();
 	});
+
+	it("without storeSessionInDatabase, an outage surfaces as an error instead of a silent logout", async () => {
+		const store = new Map<string, string>();
+		let outage = false;
+		const { client, signInWithTestUser } = await getTestInstance({
+			secondaryStorage: createFlakySecondaryStorage(
+				createStringSecondaryStorage(store),
+				() => outage,
+			),
+			rateLimit: {
+				enabled: false,
+			},
+		});
+
+		// storeSessionInDatabase is disabled (the default), so secondary
+		// storage is the authoritative session store with no database
+		// fallback. Sign in against the healthy store first.
+		const { headers } = await signInWithTestUser();
+
+		// During an outage the read must fail loudly (request error, cookie
+		// intact) - a null here would clear a valid session on a transient
+		// blip and log the user out.
+		outage = true;
+		const s1 = await client.getSession({ fetchOptions: { headers } });
+		expect(s1.data).toBeNull();
+		expect(s1.error).not.toBeNull();
+	});
 });
 
 describe("secondary storage - deleteUser", () => {

--- a/packages/better-auth/src/db/secondary-storage.test.ts
+++ b/packages/better-auth/src/db/secondary-storage.test.ts
@@ -33,6 +33,28 @@ function createStringSecondaryStorage(
 	};
 }
 
+function createFlakySecondaryStorage(
+	inner: SecondaryStorage,
+): SecondaryStorage {
+	// Wraps a working store but throws on every set/get at primary-Redis-outage
+	// level: used to prove cache-repair failures cannot break the session read.
+	return {
+		...inner,
+		get() {
+			throw new Error("redis: connection refused");
+		},
+		set() {
+			throw new Error("redis: connection refused");
+		},
+		getAndDelete() {
+			throw new Error("redis: connection refused");
+		},
+		increment() {
+			throw new Error("redis: connection refused");
+		},
+	};
+}
+
 function createParsedSecondaryStorage(
 	store: Map<string, unknown>,
 ): SecondaryStorage {
@@ -353,6 +375,34 @@ describe("secondary storage - storeSessionInDatabase", () => {
 			await (await auth.$context).internalAdapter.deleteSession(token);
 			expect(deletedSessionIds).toHaveLength(1);
 		});
+	});
+});
+
+describe("secondary storage - best-effort cache repair", () => {
+	it("a secondary-storage outage cannot turn the database fallback into a 500", async () => {
+		const store = new Map<string, string>();
+		const { client, signInWithTestUser } = await getTestInstance({
+			secondaryStorage: createFlakySecondaryStorage(
+				createStringSecondaryStorage(store),
+			),
+			session: {
+				storeSessionInDatabase: true,
+				preserveSessionInDatabase: false,
+			},
+			rateLimit: {
+				enabled: false,
+			},
+		});
+
+		const { headers } = await signInWithTestUser();
+
+		// First read misses the (outage) cache and falls back to the database:
+		// this drives cache-aside repair - which now throws internally. The
+		// request must still return the authoritative database session.
+		const s1 = await client.getSession({ fetchOptions: { headers } });
+		expect(s1.error).toBeNull();
+		expect(s1.data).not.toBeNull();
+		expect(s1.data!.session.token).toBeTruthy();
 	});
 });
 


### PR DESCRIPTION
Fixes #11218.

When a session was missing from secondaryStorage (TTL expiry, eviction, flush) but still valid in the database, findSession's database fallback returned it without writing it back - so every subsequent request for that session kept hitting the primary database until the next login.

The fallback now repopulates secondaryStorage with the remaining TTL (same shape as createSession's mirror). It also restores the token in the active-sessions index: deleteUserSessions sweeps cached sessions through that index, so a write-back without it would have let a repopulated session survive revoke-all until cache expiry. The existing preserveSessionInDatabase early return is untouched, so revoked-and-preserved rows still can't be restored.

Tests: two cases in secondary-storage.test.ts - cache/index repair after a simulated flush, and revoke-all still sweeping a repopulated session. Both fail on main; the full file plus internal-adapter and session-api suites pass with the fix.

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11218. When a session is missing from secondary storage (TTL expiry, eviction, flush) but still valid in the database, `findSession` now writes it back with its remaining TTL and restores the active-sessions index entry, so repeat reads no longer hit the primary DB and revoke-all still sweeps the session.

- Cache reads and repair writes are best-effort when a database fallback exists: an outage is logged and treated as a cache miss, and repair failure serves the authoritative database session instead of failing the request.
- Without `storeSessionInDatabase`, a secondary-storage outage surfaces as a request error instead of being treated as an invalid session that could clear valid cookies.
- Known limitation: a concurrent revoke can race the write-back and leave the token accepted until its session TTL expires; fully closing that needs atomic cache+database coordination.
- `preserveSessionInDatabase` early return is unchanged, so revoked-and-preserved rows cannot be resurrected.

<sup>Written for commit f34ee67d46c2a18ebc12616f384011f3eaa753c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

**Follow-up (review feedback, 2026-09-09):**

- The database-fallback cache repair is now **best-effort**: the entire repair block is try/wrapped, so a secondary-storage failure (eviction + unreachable Redis) cannot reject out of `findSession` after the database has already returned the authoritative session - it logs the error and serves the DB result. Matching test: a throwing secondary storage cannot turn `/get-session` into a 500.
- **Known limitation (disclosed):** the repair has a residual check-then-act window against a *concurrent* revoke (revocation deletes the database row in flight while this repair repopulates the cache, in which case the token can remain accepted until its session TTL expires). Fully closing this requires atomic cache+database coordination (e.g. a Lua-scripted revoke on Redis, or versioned tokens) - deliberately not shipped as a re-read half-guard that narrows but does not close the race. Happy to pick that design up as a follow-up if wanted.
