### PR TITLE
ci(release): make release workflows reusable

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+paths:
+  .github/workflows/release.yml:
+    ignore:
+      # GitHub supports job.workflow_* for reusable workflow identity, but actionlint does not yet recognize these fields.
+      #
+      # GitHub: https://docs.github.com/actions/reference/workflows-and-actions/contexts#job-context
+      # actionlint: https://github.com/rhysd/actionlint/issues/705
+      - 'property "workflow_(repository|sha)" is not defined in object type'

--- a/.github/workflows/release-notes-draft.yml
+++ b/.github/workflows/release-notes-draft.yml
@@ -3,6 +3,7 @@ name: Release Notes Draft
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
+  workflow_call:
 
 permissions: {}
 

--- a/.github/workflows/release-notes-draft.yml
+++ b/.github/workflows/release-notes-draft.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
   workflow_call:
+    secrets:
+      RELEASE_APP_PRIVATE_KEY:
+        required: false
 
 permissions: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,13 +177,8 @@ jobs:
             exit 1
           fi
           COMMENTS=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" | jq -s 'add')
-          if [ -n "$RELEASE_APP_ID" ]; then
-            COMMENT=$(echo "$COMMENTS" | jq -c --arg app "$RELEASE_APP_ID" \
-              '[.[] | select((.performed_via_github_app.id | tostring) == $app) | select(.body | startswith("<!-- better-auth-release-notes:v1 -->"))] | sort_by(.updated_at) | last // empty')
-          else
-            COMMENT=$(echo "$COMMENTS" | jq -c \
-              '[.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- better-auth-release-notes:v1 -->"))] | sort_by(.updated_at) | last // empty')
-          fi
+          COMMENT=$(echo "$COMMENTS" | jq -c --arg app "$RELEASE_APP_ID" \
+            '[.[] | select((.performed_via_github_app.id | tostring) == $app) | select(.body | startswith("<!-- better-auth-release-notes:v1 -->"))] | sort_by(.updated_at) | last // empty')
           if [ -z "$COMMENT" ]; then
             {
               echo "### Approved release notes are missing"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      RELEASE_APP_PRIVATE_KEY:
+        required: false
   workflow_dispatch:
     inputs:
       snapshot:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
         type: boolean
     secrets:
       RELEASE_APP_PRIVATE_KEY:
-        required: false
+        required: true
   workflow_dispatch:
     inputs:
       snapshot:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,13 @@ on:
       - main
       - next
       - 'v*.*.x'
+  workflow_call:
+    inputs:
+      use_shared_tooling:
+        description: Use release tooling from the called workflow revision
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       snapshot:
@@ -56,6 +63,15 @@ jobs:
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
+      - name: Checkout shared release tooling
+        if: inputs.use_shared_tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: .release-tooling
+          persist-credentials: false
+
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -65,6 +81,31 @@ jobs:
           package-manager-cache: false
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Install shared release tooling
+        if: inputs.use_shared_tooling
+        run: pnpm --dir .release-tooling install --frozen-lockfile --filter @better-auth/release-tooling
+
+      - name: Resolve release tooling
+        env:
+          USE_SHARED_TOOLING: ${{ inputs.use_shared_tooling }}
+        run: |
+          if [ "$USE_SHARED_TOOLING" = "true" ]; then
+            echo "/.release-tooling/" >> .git/info/exclude
+            TOOLING_ROOT="$GITHUB_WORKSPACE/.release-tooling/packages/release-tooling"
+          else
+            TOOLING_ROOT="$GITHUB_WORKSPACE/packages/release-tooling"
+          fi
+
+          if [ ! -f "$TOOLING_ROOT/src/commands/release-notes.ts" ]; then
+            echo "::error::Release tooling is unavailable"
+            exit 1
+          fi
+
+          {
+            echo "RELEASE_NOTES_COMMAND=$TOOLING_ROOT/src/commands/release-notes.ts"
+            echo "RELEASE_NOTES_COMMENT_COMMAND=$TOOLING_ROOT/src/commands/release-notes-comment.ts"
+          } >> "$GITHUB_ENV"
 
       - name: Guard next branch pre-release state
         id: guard
@@ -97,7 +138,7 @@ jobs:
         id: release-candidate
         run: |
           CURRENT_VERSION=$(jq -r '.version' packages/better-auth/package.json)
-          pnpm --filter @better-auth/release-tooling release-notes candidate \
+          node "$RELEASE_NOTES_COMMAND" candidate \
             --version "$CURRENT_VERSION" \
             --branch "$GITHUB_SHA"
 
@@ -155,7 +196,7 @@ jobs:
           COMMENT_FILE="$RUNNER_TEMP/release-notes-comment.md"
           NOTES_FILE="$RUNNER_TEMP/release-notes-approved.md"
           echo "$COMMENT" | jq -r '.body' > "$COMMENT_FILE"
-          pnpm --filter @better-auth/release-tooling release-notes:comment extract \
+          node "$RELEASE_NOTES_COMMENT_COMMAND" extract \
             --version "$VERSION" \
             --head "$PR_HEAD_SHA" \
             --comment "$COMMENT_FILE" \
@@ -182,8 +223,8 @@ jobs:
       - name: Reject release commits with pending changesets
         if: steps.guard.outputs.skip != 'true' && steps.release-candidate.outputs.release == 'true'
         run: |
-          if pnpm --filter @better-auth/release-tooling release-notes \
-            check-changesets --branch "$GITHUB_SHA"; then
+          if node "$RELEASE_NOTES_COMMAND" check-changesets \
+            --branch "$GITHUB_SHA"; then
             exit 0
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,7 @@ jobs:
     timeout-minutes: 45
     environment: Release
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       id-token: write
     env:
       # The release bot's auto-commit must not be gated by the local pre-commit hooks.
@@ -53,7 +52,6 @@ jobs:
       - name: Generate App Token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        if: vars.RELEASE_APP_ID != ''
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -64,7 +62,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout shared release tooling
         if: inputs.use_shared_tooling
@@ -149,7 +147,7 @@ jobs:
         id: approved-notes
         if: steps.guard.outputs.skip != 'true' && steps.release-candidate.outputs.release == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.release-candidate.outputs.version }}
           VERSION_COMMIT: ${{ steps.release-candidate.outputs.version_commit }}
           RELEASE_APP_ID: ${{ vars.RELEASE_APP_ID }}
@@ -253,14 +251,14 @@ jobs:
           createGithubReleases: false
           prDraft: always
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_TAG: ${{ steps.npm-tag.outputs.tag }}
 
       - name: Rename release PR with version
         if: steps.changesets.outputs.pullRequestNumber
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
         run: |
           PR_DATA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName,headRefOid)
@@ -286,7 +284,7 @@ jobs:
       - name: Create GitHub Release
         if: steps.guard.outputs.skip != 'true' && steps.release-candidate.outputs.release == 'true' && steps.changesets.outputs.hasChangesets == 'false'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.release-candidate.outputs.version }}
           RELEASE_COMMIT: ${{ steps.approved-notes.outputs.release_commit }}
           NOTES_FILE: ${{ steps.approved-notes.outputs.notes_path }}
@@ -317,7 +315,7 @@ jobs:
       - name: Sync main to next via PR
         if: github.ref_name == 'main'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git fetch origin next || { echo "next branch does not exist, skipping"; exit 0; }
 

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -8,6 +8,7 @@ on:
       - next
       - 'v*.*.x'
   merge_group:
+  workflow_call:
 
 permissions: {}
 

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -703,7 +703,7 @@ describe("release publication security", () => {
 			"steps.app-token.outputs.token || secrets.GITHUB_TOKEN",
 		);
 		expect(approvedNotes.run).toContain("performed_via_github_app.id");
-		expect(approvedNotes.run).not.toContain('github-actions[bot]');
+		expect(approvedNotes.run).not.toContain("github-actions[bot]");
 	});
 
 	it("scopes the promotion App token to its required permissions", () => {

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -685,19 +685,22 @@ describe("release publication security", () => {
 		expect(promote.run).toContain("Do not manually mark it ready");
 	});
 
-	it("does not grant issue write access to the publisher", () => {
+	it("publishes only through the scoped release App", () => {
 		const release = getJob(releaseWorkflow, "release");
 		const token = getStep(release, "Generate App Token");
 
 		expect(release.permissions).toEqual({
-			contents: "write",
-			"pull-requests": "write",
+			contents: "read",
 			"id-token": "write",
 		});
+		expect(token.if).toBeUndefined();
 		expect(appTokenPermissions(token)).toEqual({
 			"permission-contents": "write",
 			"permission-pull-requests": "write",
 		});
+		expect(releaseWorkflow.content).not.toContain(
+			"steps.app-token.outputs.token || secrets.GITHUB_TOKEN",
+		);
 	});
 
 	it("scopes the promotion App token to its required permissions", () => {

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -688,6 +688,7 @@ describe("release publication security", () => {
 	it("publishes only through the scoped release App", () => {
 		const release = getJob(releaseWorkflow, "release");
 		const token = getStep(release, "Generate App Token");
+		const approvedNotes = getStep(release, "Resolve approved release notes");
 
 		expect(release.permissions).toEqual({
 			contents: "read",
@@ -701,6 +702,8 @@ describe("release publication security", () => {
 		expect(releaseWorkflow.content).not.toContain(
 			"steps.app-token.outputs.token || secrets.GITHUB_TOKEN",
 		);
+		expect(approvedNotes.run).toContain("performed_via_github_app.id");
+		expect(approvedNotes.run).not.toContain('github-actions[bot]');
 	});
 
 	it("scopes the promotion App token to its required permissions", () => {

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -16,6 +16,15 @@ const workflowValueSchema = z.union([
 	z.null(),
 ]);
 
+const workflowCallSchema = z.union([
+	z.null(),
+	z.looseObject({
+		secrets: z
+			.record(z.string(), z.looseObject({ required: z.boolean() }))
+			.optional(),
+	}),
+]);
+
 const workflowStepSchema = z.looseObject({
 	if: z.string().optional(),
 	name: z.string().optional(),
@@ -36,6 +45,11 @@ const workflowJobSchema = z.looseObject({
 });
 
 const workflowSchema = z.looseObject({
+	on: z
+		.looseObject({
+			workflow_call: workflowCallSchema.optional(),
+		})
+		.optional(),
 	concurrency: z
 		.looseObject({
 			group: z.string(),
@@ -501,13 +515,23 @@ describe("release notes command security", () => {
 });
 
 describe("release publication security", () => {
+	it("requires the release App key from reusable release callers", () => {
+		expect(releaseWorkflow.workflow.on?.workflow_call).toMatchObject({
+			secrets: {
+				RELEASE_APP_PRIVATE_KEY: {
+					required: true,
+				},
+			},
+		});
+	});
+
 	it("exposes release policy workflows to pinned maintenance callers", () => {
 		for (const file of [
 			releaseWorkflow,
 			draftWorkflow,
 			verifyChangesetsWorkflow,
 		]) {
-			expect(file.content).toContain("\n  workflow_call:");
+			expect(file.workflow.on?.workflow_call).not.toBeUndefined();
 		}
 	});
 

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -501,6 +501,34 @@ describe("release notes command security", () => {
 });
 
 describe("release publication security", () => {
+	it("exposes release policy workflows to pinned maintenance callers", () => {
+		for (const file of [
+			releaseWorkflow,
+			draftWorkflow,
+			verifyChangesetsWorkflow,
+		]) {
+			expect(file.content).toContain("\n  workflow_call:");
+		}
+	});
+
+	it("loads release tooling from the called workflow revision", () => {
+		const release = getJob(releaseWorkflow, "release");
+		const checkout = getStep(release, "Checkout shared release tooling");
+		const resolve = getStep(release, "Resolve release tooling");
+		const detect = getStep(release, "Detect release commit");
+
+		expect(checkout.if).toContain("inputs.use_shared_tooling");
+		expect(checkout.with).toMatchObject({
+			repository: "${{ job.workflow_repository }}",
+			ref: "${{ job.workflow_sha }}",
+			path: ".release-tooling",
+			"persist-credentials": false,
+		});
+		expect(resolve.run).toContain(".git/info/exclude");
+		expect(resolve.run).toContain("RELEASE_NOTES_COMMAND");
+		expect(detect.run).toContain('node "$RELEASE_NOTES_COMMAND" candidate');
+	});
+
 	it("rejects stale release merge groups before publication", () => {
 		const mergeGuard = getStep(
 			getJob(ciWorkflow, "lint"),
@@ -527,7 +555,7 @@ describe("release publication security", () => {
 		expect(approvalIndex).toBeGreaterThan(-1);
 		expect(publishIndex).toBeGreaterThan(approvalIndex);
 		expect(release.steps[approvalIndex]?.run).toContain(
-			"release-notes:comment extract",
+			'node "$RELEASE_NOTES_COMMENT_COMMAND" extract',
 		);
 	});
 
@@ -552,7 +580,7 @@ describe("release publication security", () => {
 			"Detect release commit",
 		);
 
-		expect(detect.run).toContain("release-notes candidate");
+		expect(detect.run).toContain('node "$RELEASE_NOTES_COMMAND" candidate');
 		expect(detect.run).toContain('--branch "$GITHUB_SHA"');
 		expect(detect.run).not.toContain("github.event.before");
 	});
@@ -608,7 +636,7 @@ describe("release publication security", () => {
 			"if",
 			expect.stringContaining("release-candidate.outputs.release == 'true'"),
 		);
-		expect(guard.run).toContain("check-changesets --branch");
+		expect(guard.run).toContain('"$RELEASE_NOTES_COMMAND" check-changesets');
 		expect(guard.run).toContain("GITHUB_STEP_SUMMARY");
 		expect(guard.run).toContain("Revert this release merge");
 		expect(guard.run).toContain("exit 1");


### PR DESCRIPTION
I'm doing this so we don't have to maintain the entire release workflow in each backport branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the release workflows reusable via `workflow_call` so backport branches can invoke them instead of maintaining their own copies. Adds a `use_shared_tooling` input that loads release tooling from the calling workflow's revision, switches release commands to run with `node` instead of `pnpm --filter`, and requires callers of `release.yml` to pass `RELEASE_APP_PRIVATE_KEY`.

The release job now always runs through the release App token and only accepts release notes authored by that App; `GITHUB_TOKEN` fallbacks and the `RELEASE_APP_ID` conditional are removed.

- Adds an `actionlint` override to ignore the `job.workflow_*` context, which actionlint does not recognize yet.

**Migration**
- Backport branches that want the shared tooling should call the workflows with `use_shared_tooling: true` and pass `RELEASE_APP_PRIVATE_KEY`.

<sup>Written for commit 9ebcad761d16fce03e8d0894e786b954a92b7f1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

