### PR TITLE
fix(client): coalesce $sessionSignal refetches

### DIFF
--- a/packages/better-auth/src/client/session-refresh.test.ts
+++ b/packages/better-auth/src/client/session-refresh.test.ts
@@ -221,6 +221,68 @@ describe("session-refresh", () => {
 		manager.cleanup();
 	});
 
+	it("should coalesce overlapping $sessionSignal bursts into a leading fetch plus one trailing fetch", async () => {
+		const sessionSignal = atom(false);
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const mockFetchSession = vi.fn(async () => {
+			await gate;
+		});
+
+		const manager = createSessionRefreshManager({
+			fetchSession: mockFetchSession,
+			sessionSignal,
+		});
+
+		manager.init();
+
+		// Burst of signals while the first fetch is still in flight.
+		for (let i = 0; i < 7; i++) {
+			sessionSignal.set(!sessionSignal.get());
+		}
+
+		expect(mockFetchSession).toHaveBeenCalledTimes(1);
+
+		release();
+		await vi.runAllTimersAsync();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// One leading fetch + one trailing fetch after the burst settles.
+		expect(mockFetchSession).toHaveBeenCalledTimes(2);
+
+		manager.cleanup();
+	});
+
+	it("should not start a second fetch for signals that arrive after cleanup of an in-flight coalesce", async () => {
+		const sessionSignal = atom(false);
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const mockFetchSession = vi.fn(async () => {
+			await gate;
+		});
+
+		const manager = createSessionRefreshManager({
+			fetchSession: mockFetchSession,
+			sessionSignal,
+		});
+
+		manager.init();
+		sessionSignal.set(!sessionSignal.get());
+		expect(mockFetchSession).toHaveBeenCalledTimes(1);
+
+		manager.cleanup();
+		sessionSignal.set(!sessionSignal.get());
+		release();
+		await vi.runAllTimersAsync();
+
+		expect(mockFetchSession).toHaveBeenCalledTimes(1);
+	});
+
 	it("should refetch on $sessionSignal even when offline", async () => {
 		const onlineManager = getGlobalOnlineManager();
 		onlineManager.setOnline(false);

--- a/packages/better-auth/src/client/session-refresh.test.ts
+++ b/packages/better-auth/src/client/session-refresh.test.ts
@@ -283,6 +283,53 @@ describe("session-refresh", () => {
 		expect(mockFetchSession).toHaveBeenCalledTimes(1);
 	});
 
+	it("should not resume a stale trailing coalesce after cleanup then init again", async () => {
+		const sessionSignal = atom(false);
+		let releaseFirst!: () => void;
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		let fetchCount = 0;
+		const mockFetchSession = vi.fn(async () => {
+			fetchCount += 1;
+			if (fetchCount === 1) {
+				await firstGate;
+			}
+		});
+
+		const manager = createSessionRefreshManager({
+			fetchSession: mockFetchSession,
+			sessionSignal,
+		});
+
+		manager.init();
+
+		// Leading fetch stays in-flight.
+		sessionSignal.set(!sessionSignal.get());
+		expect(mockFetchSession).toHaveBeenCalledTimes(1);
+
+		// Queue a trailing refetch in the old subscription closure.
+		sessionSignal.set(!sessionSignal.get());
+
+		// Clean up and init again before the old request settles.
+		manager.cleanup();
+		manager.init();
+
+		// New lifecycle starts its own fetch.
+		sessionSignal.set(!sessionSignal.get());
+		expect(mockFetchSession).toHaveBeenCalledTimes(2);
+
+		// Stale trailing work from the prior lifecycle must not resume.
+		releaseFirst();
+		await vi.runAllTimersAsync();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(mockFetchSession).toHaveBeenCalledTimes(2);
+
+		manager.cleanup();
+	});
+
 	it("should refetch on $sessionSignal even when offline", async () => {
 		const onlineManager = getGlobalOnlineManager();
 		onlineManager.setOnline(false);

--- a/packages/better-auth/src/client/session-refresh.ts
+++ b/packages/better-auth/src/client/session-refresh.ts
@@ -130,8 +130,33 @@ export function createSessionRefreshManager(opts: SessionRefreshOptions) {
 	};
 
 	const setupSignalSubscription = () => {
+		// Coalesce $sessionSignal bursts. fetchSession() cancels any in-flight
+		// /get-session, so calling it on every notify aborts work the server already
+		// finished. While a refetch is running, only remember that another signal
+		// arrived and run one trailing fetch after settle.
+		let signalFlight: Promise<void> | null = null;
+		let trailingSignal = false;
+
 		state.unsubscribeSignal = sessionSignal.listen(() => {
-			void fetchSession();
+			if (signalFlight) {
+				trailingSignal = true;
+				return;
+			}
+
+			const run = async () => {
+				do {
+					trailingSignal = false;
+					await fetchSession();
+					// Stop if the manager was cleaned up during the in-flight fetch.
+				} while (trailingSignal && state.isInitialized);
+			};
+
+			const flight = run().finally(() => {
+				if (signalFlight === flight) {
+					signalFlight = null;
+				}
+			});
+			signalFlight = flight;
 		});
 	};
 

--- a/packages/better-auth/src/client/session-refresh.ts
+++ b/packages/better-auth/src/client/session-refresh.ts
@@ -129,6 +129,9 @@ export function createSessionRefreshManager(opts: SessionRefreshOptions) {
 		});
 	};
 
+	// Bumped on init/cleanup so a stale coalesce closure cannot resume after a later init.
+	let initGeneration = 0;
+
 	const setupSignalSubscription = () => {
 		// Coalesce $sessionSignal bursts. fetchSession() cancels any in-flight
 		// /get-session, so calling it on every notify aborts work the server already
@@ -136,9 +139,10 @@ export function createSessionRefreshManager(opts: SessionRefreshOptions) {
 		// arrived and run one trailing fetch after settle.
 		let signalFlight: Promise<void> | null = null;
 		let trailingSignal = false;
+		const generation = initGeneration;
 
 		state.unsubscribeSignal = sessionSignal.listen(() => {
-			if (signalFlight) {
+			if (signalFlight !== null) {
 				trailingSignal = true;
 				return;
 			}
@@ -147,8 +151,14 @@ export function createSessionRefreshManager(opts: SessionRefreshOptions) {
 				do {
 					trailingSignal = false;
 					await fetchSession();
-					// Stop if the manager was cleaned up during the in-flight fetch.
-				} while (trailingSignal && state.isInitialized);
+					// Stop if cleaned up or initialized again during the in-flight fetch.
+					// Generation check blocks a stale trailing resume after a later init
+					// (shared state.isInitialized alone is not enough).
+				} while (
+					trailingSignal &&
+					state.isInitialized &&
+					generation === initGeneration
+				);
 			};
 
 			const flight = run().finally(() => {
@@ -162,6 +172,7 @@ export function createSessionRefreshManager(opts: SessionRefreshOptions) {
 
 	const init = () => {
 		if (state.isInitialized) return;
+		initGeneration += 1;
 		state.isInitialized = true;
 
 		setupPolling();
@@ -210,6 +221,9 @@ export function createSessionRefreshManager(opts: SessionRefreshOptions) {
 			state.cleanupOnlineSetup();
 			state.cleanupOnlineSetup = undefined;
 		}
+		// Invalidate pending trailing coalesce work from this lifecycle before
+		// flipping isInitialized, so a later init cannot resume it.
+		initGeneration += 1;
 		state.isInitialized = false;
 		state.lastSessionRequest = 0;
 	};


### PR DESCRIPTION
## Summary

Fixes #11160.

`$sessionSignal` was calling `fetchSession()` on every notify. Because `fetchSession()` cancels the in-flight `/get-session`, a burst of signals made the server do the work N times while the client kept at most one response.

This change coalesces overlapping signal notifications in `createSessionRefreshManager`:

1. The first signal starts a refetch.
2. Signals that arrive while that refetch is running only set a trailing flag.
3. After the in-flight refetch settles, at most one trailing refetch runs (and only if the manager is still initialized).

Focus / poll / storage paths are unchanged.

## Test plan

- [x] Added unit coverage for an overlapping 7-signal burst (1 leading + 1 trailing)
- [x] Added coverage that cleanup does not leave a dangling trailing fetch
- [ ] CI: existing `session-refresh` suite

Happy to adjust the coalescing shape if you would rather reuse the atom-level `flight` promise directly instead of doing this in the refresh manager.

Thanks for reviewing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces overlapping `$sessionSignal` notifications so a burst triggers one leading fetch and at most one trailing fetch, instead of calling `fetchSession()` on every notify and canceling the in-flight `/get-session`. Fixes #11160. An init-generation guard prevents a queued trailing fetch from a prior lifecycle from resuming after cleanup and re-init. Focus, poll, and storage paths are unchanged.

**Bug Fixes**
- Signals arriving while a refetch is running only set a trailing flag; the trailing fetch runs only if the manager is still initialized.
- Generation bump on cleanup and init invalidates stale trailing work so it cannot cancel a later lifecycle's in-flight `/get-session`.
- Added unit coverage for a 7-signal burst, cleanup not leaving a dangling trailing fetch, and stale trailing work not resuming after re-init.

<sup>Written for commit e476c60a766475b569a8de6bb37643f7643b1de2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

