### PR TITLE
fix(generic-oauth): support symmetric ID token verification

### DIFF
--- a/.changeset/generic-oauth-hs256-id-token.md
+++ b/.changeset/generic-oauth-hs256-id-token.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Verify generic-oauth discovery ID tokens signed with HS256, HS384, or HS512 using the configured client secret.

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -5170,6 +5170,7 @@ describe("oauth2", async () => {
 			let hs256Server: ReturnType<typeof createServer>;
 			let hs256Port: number;
 			let advertisedSigningAlgs: string[] | undefined = ["HS256"];
+			let jwksRequestCount = 0;
 
 			beforeAll(async () => {
 				hs256Server = createServer((req, res) => {
@@ -5193,6 +5194,7 @@ describe("oauth2", async () => {
 						return;
 					}
 					if (req.url === "/jwks") {
+						jwksRequestCount++;
 						res.setHeader("content-type", "application/json");
 						res.end(
 							JSON.stringify({
@@ -5217,6 +5219,7 @@ describe("oauth2", async () => {
 
 			afterEach(() => {
 				advertisedSigningAlgs = ["HS256"];
+				jwksRequestCount = 0;
 			});
 
 			afterAll(async () => {
@@ -5427,6 +5430,7 @@ describe("oauth2", async () => {
 					idToken: { token: tokenWithSecret },
 				});
 				expect(directSignIn.error).not.toBeNull();
+				expect(jwksRequestCount).toBe(0);
 			});
 
 			it("should reject an HS256 id_token when clientSecret is empty", async () => {
@@ -5455,6 +5459,7 @@ describe("oauth2", async () => {
 					idToken: { token: tokenWithSecret },
 				});
 				expect(directSignIn.error).not.toBeNull();
+				expect(jwksRequestCount).toBe(0);
 			});
 
 			it("should reject an HS256 id_token when discovery omits id_token_signing_alg_values_supported", async () => {

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -5162,6 +5162,241 @@ describe("oauth2", async () => {
 				);
 			}
 		});
+
+		/**
+		 * @see https://github.com/better-auth/better-auth/issues/11121
+		 */
+		describe("HS256 discovery verification", () => {
+			let hs256Server: ReturnType<typeof createServer>;
+			let hs256Port: number;
+			let advertisedSigningAlgs: string[] = ["HS256"];
+
+			beforeAll(async () => {
+				hs256Server = createServer((req, res) => {
+					if (req.url === "/.well-known/openid-configuration") {
+						res.setHeader("content-type", "application/json");
+						res.end(
+							JSON.stringify({
+								issuer: `http://localhost:${hs256Port}`,
+								authorization_endpoint: `http://localhost:${port}/authorize`,
+								token_endpoint: `http://localhost:${port}/token`,
+								userinfo_endpoint: `http://localhost:${port}/userinfo`,
+								jwks_uri: `http://localhost:${hs256Port}/jwks`,
+								id_token_signing_alg_values_supported: advertisedSigningAlgs,
+							}),
+						);
+						return;
+					}
+					if (req.url === "/jwks") {
+						res.setHeader("content-type", "application/json");
+						res.end(
+							JSON.stringify({
+								keys: [
+									{
+										kty: "oct",
+										kid: "hs256-key",
+										use: "sig",
+										alg: "HS256",
+									},
+								],
+							}),
+						);
+						return;
+					}
+					res.statusCode = 404;
+					res.end();
+				});
+				await new Promise<void>((resolve) => hs256Server.listen(0, resolve));
+				hs256Port = (hs256Server.address() as AddressInfo).port;
+			});
+
+			afterEach(() => {
+				advertisedSigningAlgs = ["HS256"];
+			});
+
+			afterAll(async () => {
+				await new Promise<void>((resolve, reject) =>
+					hs256Server.close((err) => (err ? reject(err) : resolve())),
+				);
+			});
+
+			async function createHs256Token(
+				signingSecret: string,
+				payloadOverrides?: Record<string, unknown>,
+				headerOverrides?: Record<string, unknown>,
+			) {
+				return new SignJWT({
+					email: "hs256@test.com",
+					email_verified: true,
+					name: "HS256 User",
+					...payloadOverrides,
+				})
+					.setProtectedHeader({
+						alg: "HS256",
+						kid: "hs256-key",
+						...headerOverrides,
+					})
+					.setSubject("hs256-user")
+					.setIssuer(`http://localhost:${hs256Port}`)
+					.setAudience(clientId)
+					.setIssuedAt()
+					.setExpirationTime("1h")
+					.sign(new TextEncoder().encode(signingSecret));
+			}
+
+			it("should verify an authentic HS256 id_token using clientSecret when discovery specifies jwks_uri", async () => {
+				let authNonce = "";
+				const { customFetchImpl, cookieSetter } = await getTestInstance({
+					plugins: [
+						genericOAuth({
+							config: [
+								{
+									providerId: "hs256-valid",
+									discoveryUrl: `http://localhost:${hs256Port}/.well-known/openid-configuration`,
+									clientId,
+									clientSecret,
+									pkce: true,
+									getToken: async () => ({
+										accessToken: "hs256-access-token",
+										idToken: await createHs256Token(clientSecret, {
+											nonce: authNonce,
+										}),
+										tokenType: "bearer",
+									}),
+								},
+							],
+						}),
+					],
+				});
+				const client = createAuthClient({
+					baseURL: "http://localhost:3000",
+					fetchOptions: { customFetchImpl },
+				});
+				const headers = new Headers();
+				const res = await client.signIn.social({
+					provider: "hs256-valid",
+					callbackURL: "http://localhost:3000/dashboard",
+					newUserCallbackURL: "http://localhost:3000/new_user",
+					fetchOptions: { onSuccess: cookieSetter(headers) },
+				});
+				authNonce =
+					new URL(res.data?.url || "").searchParams.get("nonce") || "";
+				const { callbackURL, headers: sessionHeaders } =
+					await simulateOAuthFlow(
+						res.data?.url || "",
+						headers,
+						customFetchImpl,
+					);
+				expect(callbackURL).toBe("http://localhost:3000/new_user");
+				const session = await client.getSession({
+					fetchOptions: { headers: sessionHeaders },
+				});
+				expect(session.data?.user.email).toBe("hs256@test.com");
+
+				const directToken = await createHs256Token(clientSecret);
+				const directSignIn = await client.signIn.social({
+					provider: "hs256-valid",
+					idToken: { token: directToken },
+				});
+				expect(directSignIn.error).toBeNull();
+				expect(directSignIn.data).toMatchObject({
+					token: expect.any(String),
+				});
+			});
+
+			it("should reject an HS256 id_token signed with an invalid clientSecret", async () => {
+				const invalidToken = await createHs256Token("wrong-secret");
+				const { customFetchImpl, cookieSetter } = await getTestInstance({
+					plugins: [
+						genericOAuth({
+							config: [
+								{
+									providerId: "hs256-wrong-secret",
+									discoveryUrl: `http://localhost:${hs256Port}/.well-known/openid-configuration`,
+									clientId,
+									clientSecret,
+									pkce: true,
+									getToken: async () => ({
+										accessToken: "hs256-access-token",
+										idToken: invalidToken,
+										tokenType: "bearer",
+									}),
+								},
+							],
+						}),
+					],
+				});
+				const client = createAuthClient({
+					baseURL: "http://localhost:3000",
+					fetchOptions: { customFetchImpl },
+				});
+				const headers = new Headers();
+				const res = await client.signIn.social({
+					provider: "hs256-wrong-secret",
+					callbackURL: "http://localhost:3000/dashboard",
+					fetchOptions: { onSuccess: cookieSetter(headers) },
+				});
+				const { callbackURL } = await simulateOAuthFlow(
+					res.data?.url || "",
+					headers,
+					customFetchImpl,
+				);
+				expect(callbackURL).toContain("?error=");
+
+				const directSignIn = await client.signIn.social({
+					provider: "hs256-wrong-secret",
+					idToken: { token: invalidToken },
+				});
+				expect(directSignIn.error).not.toBeNull();
+			});
+
+			it("should reject an HS256 id_token when discovery advertises only RS256", async () => {
+				advertisedSigningAlgs = ["RS256"];
+				const tokenWithSecret = await createHs256Token(clientSecret);
+				const { customFetchImpl, cookieSetter } = await getTestInstance({
+					plugins: [
+						genericOAuth({
+							config: [
+								{
+									providerId: "hs256-alg-restricted",
+									discoveryUrl: `http://localhost:${hs256Port}/.well-known/openid-configuration`,
+									clientId,
+									clientSecret,
+									pkce: true,
+									getToken: async () => ({
+										accessToken: "hs256-access-token",
+										idToken: tokenWithSecret,
+										tokenType: "bearer",
+									}),
+								},
+							],
+						}),
+					],
+				});
+				const client = createAuthClient({
+					baseURL: "http://localhost:3000",
+					fetchOptions: { customFetchImpl },
+				});
+				const headers = new Headers();
+				const res = await client.signIn.social({
+					provider: "hs256-alg-restricted",
+					callbackURL: "http://localhost:3000/dashboard",
+					fetchOptions: { onSuccess: cookieSetter(headers) },
+				});
+				const { callbackURL } = await simulateOAuthFlow(
+					res.data?.url || "",
+					headers,
+					customFetchImpl,
+				);
+				expect(callbackURL).toContain("?error=");
+
+				const directSignIn = await client.signIn.social({
+					provider: "hs256-alg-restricted",
+					idToken: { token: tokenWithSecret },
+				});
+				expect(directSignIn.error).not.toBeNull();
+			});
+		});
 	});
 
 	/**

--- a/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts
@@ -5169,7 +5169,7 @@ describe("oauth2", async () => {
 		describe("HS256 discovery verification", () => {
 			let hs256Server: ReturnType<typeof createServer>;
 			let hs256Port: number;
-			let advertisedSigningAlgs: string[] = ["HS256"];
+			let advertisedSigningAlgs: string[] | undefined = ["HS256"];
 
 			beforeAll(async () => {
 				hs256Server = createServer((req, res) => {
@@ -5182,7 +5182,12 @@ describe("oauth2", async () => {
 								token_endpoint: `http://localhost:${port}/token`,
 								userinfo_endpoint: `http://localhost:${port}/userinfo`,
 								jwks_uri: `http://localhost:${hs256Port}/jwks`,
-								id_token_signing_alg_values_supported: advertisedSigningAlgs,
+								...(advertisedSigningAlgs !== undefined
+									? {
+											id_token_signing_alg_values_supported:
+												advertisedSigningAlgs,
+										}
+									: {}),
 							}),
 						);
 						return;
@@ -5392,6 +5397,119 @@ describe("oauth2", async () => {
 
 				const directSignIn = await client.signIn.social({
 					provider: "hs256-alg-restricted",
+					idToken: { token: tokenWithSecret },
+				});
+				expect(directSignIn.error).not.toBeNull();
+			});
+
+			it("should reject an HS256 id_token when clientSecret is missing", async () => {
+				const tokenWithSecret = await createHs256Token("some-secret");
+				const { customFetchImpl } = await getTestInstance({
+					plugins: [
+						genericOAuth({
+							config: [
+								{
+									providerId: "hs256-missing-secret",
+									discoveryUrl: `http://localhost:${hs256Port}/.well-known/openid-configuration`,
+									clientId,
+									pkce: true,
+								},
+							],
+						}),
+					],
+				});
+				const client = createAuthClient({
+					baseURL: "http://localhost:3000",
+					fetchOptions: { customFetchImpl },
+				});
+				const directSignIn = await client.signIn.social({
+					provider: "hs256-missing-secret",
+					idToken: { token: tokenWithSecret },
+				});
+				expect(directSignIn.error).not.toBeNull();
+			});
+
+			it("should reject an HS256 id_token when clientSecret is empty", async () => {
+				const tokenWithSecret = await createHs256Token("some-secret");
+				const { customFetchImpl } = await getTestInstance({
+					plugins: [
+						genericOAuth({
+							config: [
+								{
+									providerId: "hs256-empty-secret",
+									discoveryUrl: `http://localhost:${hs256Port}/.well-known/openid-configuration`,
+									clientId,
+									clientSecret: "",
+									pkce: true,
+								},
+							],
+						}),
+					],
+				});
+				const client = createAuthClient({
+					baseURL: "http://localhost:3000",
+					fetchOptions: { customFetchImpl },
+				});
+				const directSignIn = await client.signIn.social({
+					provider: "hs256-empty-secret",
+					idToken: { token: tokenWithSecret },
+				});
+				expect(directSignIn.error).not.toBeNull();
+			});
+
+			it("should reject an HS256 id_token when discovery omits id_token_signing_alg_values_supported", async () => {
+				advertisedSigningAlgs = undefined;
+				const tokenWithSecret = await createHs256Token(clientSecret);
+				const { customFetchImpl } = await getTestInstance({
+					plugins: [
+						genericOAuth({
+							config: [
+								{
+									providerId: "hs256-omitted-metadata",
+									discoveryUrl: `http://localhost:${hs256Port}/.well-known/openid-configuration`,
+									clientId,
+									clientSecret,
+									pkce: true,
+								},
+							],
+						}),
+					],
+				});
+				const client = createAuthClient({
+					baseURL: "http://localhost:3000",
+					fetchOptions: { customFetchImpl },
+				});
+				const directSignIn = await client.signIn.social({
+					provider: "hs256-omitted-metadata",
+					idToken: { token: tokenWithSecret },
+				});
+				expect(directSignIn.error).not.toBeNull();
+			});
+
+			it("should reject an HS256 id_token when discovery provides an empty id_token_signing_alg_values_supported", async () => {
+				advertisedSigningAlgs = [];
+				const tokenWithSecret = await createHs256Token(clientSecret);
+				const { customFetchImpl } = await getTestInstance({
+					plugins: [
+						genericOAuth({
+							config: [
+								{
+									providerId: "hs256-empty-metadata",
+									discoveryUrl: `http://localhost:${hs256Port}/.well-known/openid-configuration`,
+									clientId,
+									clientSecret,
+									pkce: true,
+								},
+							],
+						}),
+					],
+				});
+				const client = createAuthClient({
+					baseURL: "http://localhost:3000",
+					fetchOptions: { customFetchImpl },
+				});
+				const directSignIn = await client.signIn.social({
+					provider: "hs256-empty-metadata",
 					idToken: { token: tokenWithSecret },
 				});
 				expect(directSignIn.error).not.toBeNull();

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -252,9 +252,16 @@ export const genericOAuth = <const ID extends string>(
 										protectedHeader.alg === "HS384" ||
 										protectedHeader.alg === "HS512"
 									) {
-										if (secretBytes) {
+										if (
+											secretBytes &&
+											Array.isArray(signingAlgs) &&
+											signingAlgs.includes(protectedHeader.alg)
+										) {
 											return secretBytes;
 										}
+										throw new Error(
+											`Provider "${c.providerId}": cannot verify ${protectedHeader.alg} id_token with discovery metadata`,
+										);
 									}
 									return remoteJWKS(protectedHeader, token);
 								},

--- a/packages/better-auth/src/plugins/generic-oauth/index.ts
+++ b/packages/better-auth/src/plugins/generic-oauth/index.ts
@@ -240,8 +240,24 @@ export const genericOAuth = <const ID extends string>(
 								);
 								continue;
 							}
+							const remoteJWKS = createRemoteJWKSet(jwksUrl);
+							const secretBytes =
+								typeof c.clientSecret === "string" && c.clientSecret.length > 0
+									? new TextEncoder().encode(c.clientSecret)
+									: null;
 							idTokenConfig = {
-								jwks: createRemoteJWKSet(jwksUrl),
+								jwks: async (protectedHeader, token) => {
+									if (
+										protectedHeader.alg === "HS256" ||
+										protectedHeader.alg === "HS384" ||
+										protectedHeader.alg === "HS512"
+									) {
+										if (secretBytes) {
+											return secretBytes;
+										}
+									}
+									return remoteJWKS(protectedHeader, token);
+								},
 								issuer: discovered.issuer,
 								audience: c.clientId,
 								algorithms: isOidc ? signingAlgs : undefined,


### PR DESCRIPTION
## Summary

When configuring an OIDC provider with `discoveryUrl`, genericOAuth currently binds ID-token verification strictly to `createRemoteJWKSet(jwksUrl)`. For identity providers that issue symmetrically signed ID tokens (e.g. `HS256`, `HS384`, `HS512`), verification unconditionally fails with `JWKSNoMatchingKey` because OIDC Discovery §3 specifies that symmetric keys must not be published in the public JWKS.

## Root Cause

`genericOAuth`'s discovery initialization unconditionally assigns `idTokenConfig.jwks = createRemoteJWKSet(jwksUrl)` whenever `discovered.jwks_uri` and `discovered.issuer` are present, without inspecting the token's algorithm header at verification time.

## Fix

- Wrap `remoteJWKS` in an algorithm-aware `JWTVerifyGetKey` resolver.
- For exact HMAC algorithms (`HS256`, `HS384`, `HS512`), verify using the pre-encoded bytes of the configured `clientSecret` per OIDC Core 1.0 §3.1.3.7.
- For asymmetric algorithms, continue delegating directly to `remoteJWKS`.
- Preserve all existing issuer, audience, nonce, and algorithm restriction checks.
- If `clientSecret` is absent or empty, HMAC verification safely fails closed.

## Tests

Added regression tests under `describe("HS256 discovery verification")` in `packages/better-auth/src/plugins/generic-oauth/generic-oauth.test.ts`:
- Validates authentic HS256 ID-token verification across both OAuth redirect flow (with nonce binding) and direct client sign-in.
- Validates rejection when signed with an incorrect secret.
- Validates algorithm enforcement (rejecting HS256 tokens when discovery specifies only `RS256`).
- Full generic-oauth suite passes (130/130).
- `pnpm typecheck` passes with 0 errors.

Closes #11121

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes generic OAuth ID token verification for providers that issue symmetric (HS256/HS384/HS512) tokens. Verification previously always used the remote JWKS, which per OIDC Discovery doesn't include symmetric keys, so these tokens failed with `JWKSNoMatchingKey`. Now HMAC tokens are verified against the pre-encoded `clientSecret`, but only when the token's algorithm is advertised in the discovery metadata; asymmetric tokens keep using the JWKS, and verification fails closed if `clientSecret` is missing or the algorithm isn't advertised.

**Tests**
- Added regression tests for valid HS256 tokens, invalid-secret rejection, missing/empty-secret rejection, and enforced algorithm restrictions from discovery, including confirmation that JWKS isn't requested when verification fails closed.

<sup>Written for commit be89cec645a967803a9ab2b36682f5e1a5333add. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

