### PR TITLE
fix(expo): chunk storage values by byte size

### DIFF
--- a/.changeset/safe-expo-unicode-storage.md
+++ b/.changeset/safe-expo-unicode-storage.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/expo": patch
+---
+
+Store multibyte session data safely in Expo secure storage.

--- a/packages/expo/src/client-storage.ts
+++ b/packages/expo/src/client-storage.ts
@@ -25,13 +25,40 @@ export function normalizeCookieName(name: string) {
 }
 
 /**
- * Character budget per stored chunk. Some native stores reject large values,
- * so larger strings are split across keys. This is not a byte-size guarantee.
+ * UTF-8 byte budget per stored chunk. Some native stores reject large values,
+ * so larger strings are split across keys.
  *
  * @see https://github.com/better-auth/better-auth/issues/9151
  */
 const STORAGE_VALUE_LIMIT = 1800;
 const MAX_STORAGE_CHUNKS = 100;
+
+function getUtf8ByteLength(character: string) {
+	const codePoint = character.codePointAt(0) ?? 0;
+	if (codePoint <= 0x7f) return 1;
+	if (codePoint <= 0x7ff) return 2;
+	if (codePoint <= 0xffff) return 3;
+	return 4;
+}
+
+function splitStorageValue(value: string) {
+	const chunks: string[] = [];
+	let start = 0;
+	let end = 0;
+	let bytes = 0;
+	for (const character of value) {
+		const characterBytes = getUtf8ByteLength(character);
+		if (bytes + characterBytes > STORAGE_VALUE_LIMIT) {
+			chunks.push(value.slice(start, end));
+			start = end;
+			bytes = 0;
+		}
+		bytes += characterBytes;
+		end += character.length;
+	}
+	chunks.push(value.slice(start));
+	return chunks;
+}
 
 /**
  * Marks a base key whose value is split across multiple storage keys. Legacy
@@ -202,14 +229,15 @@ function getStorageWritePlan(
 	const currentMarker = currentBaseValue?.startsWith(CHUNK_MARKER)
 		? parseChunkMarker(currentBaseValue)
 		: null;
-	if (value.length <= STORAGE_VALUE_LIMIT) {
+	const chunks = splitStorageValue(value);
+	if (chunks.length === 1) {
 		return {
 			writes: [[key, value]],
 			cleanup: getUnusedChunkRanges(key, currentMarker, null),
 		};
 	}
 
-	const count = Math.ceil(value.length / STORAGE_VALUE_LIMIT);
+	const count = chunks.length;
 	if (count > MAX_STORAGE_CHUNKS) {
 		throw new Error(
 			`Storage value requires ${count} chunks, exceeding the limit of ${MAX_STORAGE_CHUNKS}`,
@@ -230,12 +258,8 @@ function getStorageWritePlan(
 			serializeChunkMarker({ ...currentMarker, fallbackCount: null }),
 		]);
 	}
-	for (let i = 0; i < count; i++) {
-		const start = i * STORAGE_VALUE_LIMIT;
-		writes.push([
-			getChunkKey(key, marker, i),
-			value.slice(start, start + STORAGE_VALUE_LIMIT),
-		]);
+	for (const [index, chunk] of chunks.entries()) {
+		writes.push([getChunkKey(key, marker, index), chunk]);
 	}
 	writes.push([key, serializeChunkMarker(marker)]);
 	return { writes, cleanup: getUnusedChunkRanges(key, currentMarker, marker) };

--- a/packages/expo/src/client-storage.ts
+++ b/packages/expo/src/client-storage.ts
@@ -484,7 +484,7 @@ export function createManagedStorage(storage: ExpoClientStorage) {
 			currentBaseValue = storage.getItem(key);
 		} catch (error) {
 			state.cleanupComplete = false;
-			if (value.length > STORAGE_VALUE_LIMIT) {
+			if (splitStorageValue(value).length > 1) {
 				logWriteError(key, error);
 				return;
 			}
@@ -522,7 +522,7 @@ export function createManagedStorage(storage: ExpoClientStorage) {
 				currentBaseValue = await storage.getItemAsync(key);
 			} catch (error) {
 				state.cleanupComplete = false;
-				if (value.length > STORAGE_VALUE_LIMIT) {
+				if (splitStorageValue(value).length > 1) {
 					logWriteError(key, error);
 					return;
 				}

--- a/packages/expo/test/client-storage.test.ts
+++ b/packages/expo/test/client-storage.test.ts
@@ -90,6 +90,29 @@ it("should round-trip a value larger than the per-write storage limit", async ()
 	expect(storedValue).toBe(large);
 });
 
+/**
+ * @see https://docs.expo.dev/versions/latest/sdk/securestore/#securestoresetitemasynckey-value-options
+ */
+it("should keep Unicode chunks within the storage byte limit", () => {
+	const map = new Map<string, string>();
+	const storage = storageAdapter({
+		getItem: (name) => map.get(name) ?? null,
+		setItem: (name, value) => map.set(name, value),
+		getItemAsync: async (name) => map.get(name) ?? null,
+		setItemAsync: async (name, value) => {
+			map.set(name, value);
+		},
+	});
+	const value = `${"x".repeat(1_799)}🔐${"🙂".repeat(1_000)}`;
+
+	storage.setItem("better-auth_cookie", value);
+
+	for (const chunk of map.values()) {
+		expect(new TextEncoder().encode(chunk).length).toBeLessThanOrEqual(1_800);
+	}
+	expect(storage.getItem("better-auth_cookie")).toBe(value);
+});
+
 it("should store a value within the limit under the base key unchanged", () => {
 	const map = new Map<string, string>();
 	const storage = storageAdapter({

--- a/packages/expo/test/client-storage.test.ts
+++ b/packages/expo/test/client-storage.test.ts
@@ -113,6 +113,31 @@ it("should keep Unicode chunks within the storage byte limit", () => {
 	expect(storage.getItem("better-auth_cookie")).toBe(value);
 });
 
+it.each([
+	"setItem",
+	"setItemAsync",
+] as const)("should stop %s when a multibyte value requires chunks and the base read fails", async (method) => {
+	const setItem = vi.fn();
+	const setItemAsync = vi.fn(async () => {});
+	const storage = storageAdapter({
+		getItem: () => {
+			throw new Error("read unavailable");
+		},
+		setItem,
+		getItemAsync: async () => {
+			throw new Error("read unavailable");
+		},
+		setItemAsync,
+	});
+	const error = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+	await storage[method]("better-auth_cookie", "한".repeat(700));
+
+	expect(setItem).not.toHaveBeenCalled();
+	expect(setItemAsync).not.toHaveBeenCalled();
+	expect(error).toHaveBeenCalledOnce();
+});
+
 it("should store a value within the limit under the base key unchanged", () => {
 	const map = new Map<string, string>();
 	const storage = storageAdapter({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Chunks Expo secure storage values by UTF-8 byte size so multibyte session data stays within the native byte limit. Previously values were split by character count, so strings with multibyte characters could create chunks exceeding the 1,800-byte limit.

<sup>Written for commit b5afffb4a4ff9403893ed7a9c7191817f11b01ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

