### PR TITLE
ci(release): keep maintenance releases off latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,17 +117,20 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Determine npm dist-tag
-        id: npm-tag
+      - name: Resolve release channel
+        id: release-channel
         run: |
           REF="${GITHUB_REF_NAME}"
           if [[ "$REF" == "main" ]]; then
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            echo "publish_command=pnpm ci:release --tag latest" >> "$GITHUB_OUTPUT"
+            echo "github_latest=true" >> "$GITHUB_OUTPUT"
           elif [[ "$REF" =~ ^v([0-9]+)\.([0-9]+)\.x$ ]]; then
             TAG="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "publish_command=pnpm ci:release --tag $TAG" >> "$GITHUB_OUTPUT"
+            echo "github_latest=false" >> "$GITHUB_OUTPUT"
           elif [ "$REF" = "next" ]; then
-            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "publish_command=pnpm ci:release" >> "$GITHUB_OUTPUT"
+            echo "github_latest=false" >> "$GITHUB_OUTPUT"
           else
             echo "::error::Unsupported release branch ${REF}"
             exit 1
@@ -240,14 +243,13 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm ci:version
-          publish: pnpm ci:release
+          publish: ${{ steps.release-channel.outputs.publish_command }}
           title: "chore: release"
           commit: "chore: release"
           createGithubReleases: false
           prDraft: always
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_CONFIG_TAG: ${{ steps.npm-tag.outputs.tag }}
 
       - name: Rename release PR with version
         if: steps.changesets.outputs.pullRequestNumber
@@ -283,6 +285,7 @@ jobs:
           VERSION: ${{ steps.release-candidate.outputs.version }}
           RELEASE_COMMIT: ${{ steps.approved-notes.outputs.release_commit }}
           NOTES_FILE: ${{ steps.approved-notes.outputs.notes_path }}
+          GITHUB_LATEST: ${{ steps.release-channel.outputs.github_latest }}
         run: |
           if [ -z "$VERSION" ] || [ ! -s "$NOTES_FILE" ]; then
             echo "::error::Approved release notes are missing"
@@ -296,13 +299,16 @@ jobs:
           fi
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
-              --notes-file "$NOTES_FILE" $PRERELEASE_FLAG
+              --notes-file "$NOTES_FILE" \
+              --latest="$GITHUB_LATEST" \
+              $PRERELEASE_FLAG
             echo "Updated release ${TAG}"
           else
             gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
               --title "$TAG" \
               --notes-file "$NOTES_FILE" \
               --target "$RELEASE_COMMIT" \
+              --latest="$GITHUB_LATEST" \
               $PRERELEASE_FLAG
             echo "Created release ${TAG}"
           fi

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -457,9 +457,13 @@ describe("release notes command security", () => {
 	});
 
 	it("uses versioned maintenance branches", () => {
-		const npmTag = getStep(
+		const releaseChannel = getStep(
 			getJob(releaseWorkflow, "release"),
-			"Determine npm dist-tag",
+			"Resolve release channel",
+		);
+		const publish = getStep(
+			getJob(releaseWorkflow, "release"),
+			"Create Release Pull Request or Publish",
 		);
 		const authorize = getStep(
 			getJob(commandWorkflow, "generate"),
@@ -472,10 +476,18 @@ describe("release notes command security", () => {
 
 		expect(releaseWorkflow.content).toContain("'v*.*.x'");
 		expect(releaseWorkflow.content).not.toContain("release/**");
-		expect(npmTag.run).toContain("^v([0-9]+)\\.([0-9]+)\\.x$");
-		expect(npmTag.run).toContain(
+		expect(releaseChannel.run).toContain("^v([0-9]+)\\.([0-9]+)\\.x$");
+		expect(releaseChannel.run).toContain(
 			'TAG="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"',
 		);
+		expect(releaseChannel.run).toContain(
+			"publish_command=pnpm ci:release --tag $TAG",
+		);
+		expect(publish.with).toHaveProperty(
+			"publish",
+			expect.stringContaining("release-channel.outputs.publish_command"),
+		);
+		expect(publish.env).not.toHaveProperty("NPM_CONFIG_TAG");
 		expect(authorize.run).toContain("^v[0-9]+\\.[0-9]+\\.x$");
 		expect(prDetails.run).toContain('"$HEAD_REF" == v*.*.x');
 		expect(verifyChangesetsWorkflow.content).toContain("'v*.*.x'");
@@ -639,8 +651,13 @@ describe("release publication security", () => {
 			"RELEASE_COMMIT",
 			expect.stringContaining("approved-notes.outputs.release_commit"),
 		);
+		expect(createRelease.env).toHaveProperty(
+			"GITHUB_LATEST",
+			expect.stringContaining("release-channel.outputs.github_latest"),
+		);
 		expect(createRelease.run).toContain('gh release create "$TAG"');
 		expect(createRelease.run).toContain('--target "$RELEASE_COMMIT"');
+		expect(createRelease.run).toContain('--latest="$GITHUB_LATEST"');
 		expect(createRelease.run).not.toContain('COMMIT_SHA="${GITHUB_SHA}"');
 	});
 

--- a/packages/release-tooling/test/release-workflows.test.ts
+++ b/packages/release-tooling/test/release-workflows.test.ts
@@ -456,7 +456,7 @@ describe("release notes command security", () => {
 		);
 	});
 
-	it("uses versioned maintenance branches", () => {
+	it("selects release channels by branch", () => {
 		const releaseChannel = getStep(
 			getJob(releaseWorkflow, "release"),
 			"Resolve release channel",
@@ -465,6 +465,36 @@ describe("release notes command security", () => {
 			getJob(releaseWorkflow, "release"),
 			"Create Release Pull Request or Publish",
 		);
+		expect(releaseChannel.run).toContain(
+			[
+				'if [[ "$REF" == "main" ]]; then',
+				'  echo "publish_command=pnpm ci:release --tag latest" >> "$GITHUB_OUTPUT"',
+				'  echo "github_latest=true" >> "$GITHUB_OUTPUT"',
+			].join("\n"),
+		);
+		expect(releaseChannel.run).toContain(
+			[
+				'elif [[ "$REF" =~ ^v([0-9]+)\\.([0-9]+)\\.x$ ]]; then',
+				'  TAG="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"',
+				'  echo "publish_command=pnpm ci:release --tag $TAG" >> "$GITHUB_OUTPUT"',
+				'  echo "github_latest=false" >> "$GITHUB_OUTPUT"',
+			].join("\n"),
+		);
+		expect(releaseChannel.run).toContain(
+			[
+				'elif [ "$REF" = "next" ]; then',
+				'  echo "publish_command=pnpm ci:release" >> "$GITHUB_OUTPUT"',
+				'  echo "github_latest=false" >> "$GITHUB_OUTPUT"',
+			].join("\n"),
+		);
+		expect(publish.with).toHaveProperty(
+			"publish",
+			expect.stringContaining("release-channel.outputs.publish_command"),
+		);
+		expect(publish.env).not.toHaveProperty("NPM_CONFIG_TAG");
+	});
+
+	it("uses versioned maintenance branches", () => {
 		const authorize = getStep(
 			getJob(commandWorkflow, "generate"),
 			"Authorize command and resolve PR",
@@ -476,18 +506,6 @@ describe("release notes command security", () => {
 
 		expect(releaseWorkflow.content).toContain("'v*.*.x'");
 		expect(releaseWorkflow.content).not.toContain("release/**");
-		expect(releaseChannel.run).toContain("^v([0-9]+)\\.([0-9]+)\\.x$");
-		expect(releaseChannel.run).toContain(
-			'TAG="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"',
-		);
-		expect(releaseChannel.run).toContain(
-			"publish_command=pnpm ci:release --tag $TAG",
-		);
-		expect(publish.with).toHaveProperty(
-			"publish",
-			expect.stringContaining("release-channel.outputs.publish_command"),
-		);
-		expect(publish.env).not.toHaveProperty("NPM_CONFIG_TAG");
 		expect(authorize.run).toContain("^v[0-9]+\\.[0-9]+\\.x$");
 		expect(prDetails.run).toContain('"$HEAD_REF" == v*.*.x');
 		expect(verifyChangesetsWorkflow.content).toContain("'v*.*.x'");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the release workflow so maintenance and prerelease (`next`) releases no longer appear as the latest GitHub release. Previously every release was marked latest; now only `main` branch releases set GitHub's latest flag, while `v*.*.x` maintenance branches and `next` set `github_latest=false`. The npm dist-tag behavior is unchanged. Adds tests covering the new branch-to-channel mappings.

<sup>Written for commit e2caa4cf016f2177cb0ffbe4592b0d5f591b4cd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

