### PR TITLE
fix(one-tap): verify Google ID token nonce in callback

### DIFF
--- a/.changeset/tame-donuts-repeat.md
+++ b/.changeset/tame-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Verify the Google One Tap `nonce` option on the server. The `/one-tap/callback` endpoint now accepts an optional `nonce` and forwards it to `verifyGoogleIdToken`, so ID tokens minted with a nonce are bound to the sign-in attempt that requested them instead of remaining replayable.

--- a/docs/content/docs/plugins/one-tap.mdx
+++ b/docs/content/docs/plugins/one-tap.mdx
@@ -158,6 +158,18 @@ await authClient.oneTap({
 });
 ```
 
+#### Binding the ID Token with a Nonce
+
+Pass a unique `nonce` per sign-in attempt. It is forwarded to the Google One Tap API (which embeds it in the ID token) and then verified server-side against the token's `nonce` claim, so a captured token cannot be replayed without it:
+
+```ts
+import { authClient } from "@/lib/auth-client";
+
+await authClient.oneTap({
+  nonce: crypto.randomUUID()
+});
+```
+
 #### Handling Prompt Dismissals with Exponential Backoff
 
 If the user dismisses or skips the prompt, the plugin will retry showing the One Tap prompt using exponential backoff based on your configured promptOptions.

--- a/packages/better-auth/src/plugins/one-tap/client.ts
+++ b/packages/better-auth/src/plugins/one-tap/client.ts
@@ -259,7 +259,11 @@ export const oneTapClient = (options: GoogleOneTapOptions) => {
 						async function callback(idToken: string) {
 							const res = await $fetch("/one-tap/callback", {
 								method: "POST",
-								body: { idToken, callbackURL: opts?.callbackURL },
+								body: {
+									idToken,
+									callbackURL: opts?.callbackURL,
+									nonce: opts?.nonce,
+								},
 								...opts?.fetchOptions,
 								...fetchOptions,
 							});
@@ -314,7 +318,11 @@ export const oneTapClient = (options: GoogleOneTapOptions) => {
 					async function callback(idToken: string) {
 						const res = await $fetch("/one-tap/callback", {
 							method: "POST",
-							body: { idToken, callbackURL: opts?.callbackURL },
+							body: {
+								idToken,
+								callbackURL: opts?.callbackURL,
+								nonce: opts?.nonce,
+							},
 							...opts?.fetchOptions,
 							...fetchOptions,
 						});

--- a/packages/better-auth/src/plugins/one-tap/index.ts
+++ b/packages/better-auth/src/plugins/one-tap/index.ts
@@ -55,6 +55,19 @@ const oneTapCallbackBodySchema = z.object({
 			description: "URL to redirect to after a successful sign-in",
 		})
 		.optional(),
+	/**
+	 * The nonce the client passed to `google.accounts.id.initialize`. Google
+	 * embeds it in the ID token's `nonce` claim; forwarding it lets
+	 * `verifyGoogleIdToken` confirm the token was minted for this sign-in
+	 * attempt instead of replayed.
+	 */
+	nonce: z
+		.string()
+		.meta({
+			description:
+				"Nonce passed to the Google One Tap API, verified against the ID token's nonce claim",
+		})
+		.optional(),
 });
 
 export const oneTap = (options?: OneTapOptions | undefined) =>
@@ -99,7 +112,7 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 					},
 				},
 				async (ctx) => {
-					const { idToken } = ctx.body;
+					const { idToken, nonce } = ctx.body;
 					const googleProvider =
 						typeof ctx.context.options.socialProviders?.google === "function"
 							? await ctx.context.options.socialProviders?.google()
@@ -119,6 +132,7 @@ export const oneTap = (options?: OneTapOptions | undefined) =>
 					const payload = (await verifyGoogleIdToken({
 						token: idToken,
 						audience,
+						nonce,
 					})) as Partial<GoogleProfile> | null;
 					if (!payload) {
 						throw new APIError("BAD_REQUEST", {

--- a/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
+++ b/packages/better-auth/src/plugins/one-tap/one-tap.test.ts
@@ -820,3 +820,97 @@ describe("oneTapClient types", () => {
 		expectTypeOf(client.oneTap).toBeFunction();
 	});
 });
+
+/**
+ * @see https://github.com/better-auth/better-auth/issues/10926
+ */
+describe("one-tap nonce verification", async () => {
+	afterEach(() => {
+		Object.assign(verifiedPayload, defaultVerifiedPayload);
+		(verifiedPayload as Record<string, unknown>).nonce = undefined;
+	});
+
+	const googleProvider = {
+		clientId: "test-client",
+		clientSecret: "test-secret",
+		enabled: true,
+	};
+
+	it("accepts a token whose nonce claim matches the request nonce", async () => {
+		verifiedPayload.email = "one-tap-nonce-match@example.com";
+		verifiedPayload.sub = "one-tap-nonce-match-sub";
+		(verifiedPayload as Record<string, unknown>).nonce = "test-nonce";
+
+		const { client } = await getTestInstance({
+			socialProviders: { google: googleProvider },
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{ token?: string }>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token", nonce: "test-nonce" },
+		});
+
+		expect(res.error).toBeFalsy();
+		expect(res.data?.token).toBeTruthy();
+	});
+
+	it("rejects a token whose nonce claim does not match the request nonce", async () => {
+		verifiedPayload.email = "one-tap-nonce-mismatch@example.com";
+		verifiedPayload.sub = "one-tap-nonce-mismatch-sub";
+		(verifiedPayload as Record<string, unknown>).nonce = "expected-nonce";
+
+		const { client } = await getTestInstance({
+			socialProviders: { google: googleProvider },
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token", nonce: "wrong-nonce" },
+		});
+
+		expect(res.error?.status).toBe(400);
+	});
+
+	it("rejects a token with no nonce claim when the request sends one", async () => {
+		verifiedPayload.email = "one-tap-nonce-absent@example.com";
+		verifiedPayload.sub = "one-tap-nonce-absent-sub";
+
+		const { client } = await getTestInstance({
+			socialProviders: { google: googleProvider },
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{
+			data: unknown;
+			error: { status: number } | null;
+		}>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token", nonce: "test-nonce" },
+		});
+
+		expect(res.error?.status).toBe(400);
+	});
+
+	it("still accepts a token when no nonce is provided", async () => {
+		verifiedPayload.email = "one-tap-no-nonce@example.com";
+		verifiedPayload.sub = "one-tap-no-nonce-sub";
+
+		const { client } = await getTestInstance({
+			socialProviders: { google: googleProvider },
+			plugins: [oneTap()],
+		});
+
+		const res = await client.$fetch<{ token?: string }>("/one-tap/callback", {
+			method: "POST",
+			body: { idToken: "stub-id-token" },
+		});
+
+		expect(res.error).toBeFalsy();
+		expect(res.data?.token).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## Summary
- `/one-tap/callback` now accepts an optional `nonce` in the request body and forwards it to `verifyGoogleIdToken`, which compares it against the ID token's `nonce` claim
- `oneTapClient` now sends `opts.nonce` in the callback POST body (previously it only passed the nonce to `google.accounts.id.initialize`, so the server never verified it — a captured token stayed replayable for its lifetime)
- Documented the `nonce` option in the One Tap plugin docs

Closes #10926

#### Test plan
- [x] `pnpm vitest packages/better-auth/src/plugins/one-tap --run` — 27 tests pass, including 4 new nonce cases (matching nonce accepted; mismatched/missing claim rejected with 400; no nonce still accepted for backward compatibility)
- [x] `pnpm typecheck` passes
- [x] biome/format/spell hooks pass
- [x] Changeset added (`patch`)

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies the Google One Tap nonce on the server so a captured ID token can no longer be replayed for its lifetime. Closes #10926.

- `/one-tap/callback` now accepts an optional `nonce` in the request body and forwards it to `verifyGoogleIdToken`, which checks it against the token's `nonce` claim.
- `oneTapClient` now sends `opts.nonce` in the callback POST body; previously it only passed the nonce to `google.accounts.id.initialize`, so the server never verified it.
- Tokens with a mismatched or missing nonce claim are rejected with 400 when a nonce is provided; requests without a nonce still work for backward compatibility.
- Documents the `nonce` option in the One Tap plugin docs.

<sup>Written for commit 5395b4aed734392f9f039f345a9c71255ad0245d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

