### PR TITLE
docs: fix authClient import in Auth0 and Clerk migration guides

### DIFF
--- a/docs/content/docs/guides/auth0-migration-guide.mdx
+++ b/docs/content/docs/guides/auth0-migration-guide.mdx
@@ -640,7 +640,7 @@ Before starting the migration process, set up Better Auth in your project. Follo
     Now that the data is migrated, update your components to use Better Auth. Here's an example for the sign-in component:
 
     ```tsx title="components/auth/sign-in.tsx"
-    import { authClient } from "better-auth/client";
+    import { authClient } from "@/lib/auth-client";
 
     export const SignIn = () => {
       const handleSignIn = async () => {

--- a/docs/content/docs/guides/clerk-migration-guide.mdx
+++ b/docs/content/docs/guides/clerk-migration-guide.mdx
@@ -453,7 +453,7 @@ Before starting the migration process, set up Better Auth in your project. Follo
     Now that the data is migrated, you can start updating your components to use Better Auth. Here's an example for the sign-in component:
 
     ```tsx title="components/auth/sign-in.tsx"
-    import { authClient } from "better-auth/client";
+    import { authClient } from "@/lib/auth-client";
 
     export const SignIn = () => {
       const handleSignIn = async () => {


### PR DESCRIPTION
## Summary
- The sign-in component samples in the Auth0 and Clerk migration guides import `authClient` from `better-auth/client`, but no such export exists — the samples fail to compile
- Changed both to `import { authClient } from @/lib/auth-client`, matching the convention used by every other guide (next-auth, workos, browser-extension)

Closes #11045
Closes #10991

#### Test plan
- [x] Verified `better-auth/client` has no `authClient` export (only `createAuthClient`) — the samples previously could not compile
- [x] `@/lib/auth-client` is the established docs convention for the user-created client
- [x] No changeset needed — docs-only change

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `authClient` import in the Auth0 and Clerk migration guides so the sign-in component samples compile correctly.

The samples previously imported `authClient` from `better-auth/client`, which exports no such symbol. They now use `@/lib/auth-client`, the same convention used by every other guide. Closes #11045 and #10991.

<sup>Written for commit 97050ecb3c0877f759a3d4b3c19240d688683772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

