### PR TITLE
fix(github): align GithubProfile types with the GitHub API response

### DIFF
--- a/.changeset/github-profile-types.md
+++ b/.changeset/github-profile-types.md
@@ -1,0 +1,7 @@
+---
+"@better-auth/core": patch
+---
+
+Correct the `GithubProfile` interface to match GitHub's actual API response: `id` and the repo/gist/follower counters are `number`, optional profile fields (`name`, `company`, `blog`, `location`, `hireable`, `bio`, `twitter_username`, `gravatar_id`) allow `null`, and the authenticated-only fields (`private_gists`, `total_private_repos`, `owned_private_repos`, `disk_usage`, `collaborators`, `two_factor_authentication`, `plan`) are optional. Custom `getUserInfo` implementations can now return a real GitHub API response without a type assertion.
+
+Type-level breaking change: consumers that read `profile.id` or the counters as `string`, or access `plan` and the `private_*` fields unconditionally, will see type errors on upgrade. The previous types did not match GitHub's actual API — `id` was always a `number` at runtime — so no runtime behavior changes.

--- a/packages/core/src/social-providers/github.ts
+++ b/packages/core/src/social-providers/github.ts
@@ -10,10 +10,10 @@ import { authorizationCodeRequest } from "../oauth2/validate-authorization-code"
 
 export interface GithubProfile {
 	login: string;
-	id: string;
+	id: number;
 	node_id: string;
 	avatar_url: string;
-	gravatar_id: string;
+	gravatar_id: string | null;
 	url: string;
 	html_url: string;
 	followers_url: string;
@@ -27,31 +27,38 @@ export interface GithubProfile {
 	received_events_url: string;
 	type: string;
 	site_admin: boolean;
-	name: string;
-	company: string;
-	blog: string;
-	location: string;
+	name: string | null;
+	company: string | null;
+	blog: string | null;
+	location: string | null;
 	email: string | null;
-	hireable: boolean;
-	bio: string;
-	twitter_username: string;
-	public_repos: string;
-	public_gists: string;
-	followers: string;
-	following: string;
+	hireable: boolean | null;
+	bio: string | null;
+	twitter_username: string | null;
+	public_repos: number;
+	public_gists: number;
+	followers: number;
+	following: number;
 	created_at: string;
 	updated_at: string;
-	private_gists: string;
-	total_private_repos: string;
-	owned_private_repos: string;
-	disk_usage: string;
-	collaborators: string;
-	two_factor_authentication: boolean;
-	plan: {
+	/** Present only on the authenticated `GET /user` response. */
+	private_gists?: number;
+	/** Present only on the authenticated `GET /user` response. */
+	total_private_repos?: number;
+	/** Present only on the authenticated `GET /user` response. */
+	owned_private_repos?: number;
+	/** Present only on the authenticated `GET /user` response. */
+	disk_usage?: number;
+	/** Present only on the authenticated `GET /user` response. */
+	collaborators?: number;
+	/** Present only on the authenticated `GET /user` response. */
+	two_factor_authentication?: boolean;
+	/** Present only on the authenticated `GET /user` response. */
+	plan?: {
 		name: string;
-		space: string;
-		private_repos: string;
-		collaborators: string;
+		space: number;
+		private_repos: number;
+		collaborators: number;
 	};
 }
 

--- a/packages/core/src/social-providers/social-providers.test.ts
+++ b/packages/core/src/social-providers/social-providers.test.ts
@@ -13,6 +13,8 @@ import type {
 import { CLIENT_ASSERTION_TYPE } from "../oauth2";
 import { cognito } from "./cognito";
 import { discord } from "./discord";
+import type { GithubProfile } from "./github";
+import { github } from "./github";
 import { socialProviders } from "./index";
 import { microsoft } from "./microsoft-entra-id";
 import { roblox } from "./roblox";
@@ -453,5 +455,75 @@ describe("cognito provider", () => {
 		const provider = cognito(cognitoConfig);
 		const url = await provider.createAuthorizationURL(baseInput);
 		expect(url.searchParams.get("identity_provider")).toBeNull();
+	});
+});
+
+describe("github provider", () => {
+	/**
+	 * Matches the documented GET /users/{username} response: ids and counters
+	 * are numbers, and unset profile fields are null rather than empty strings.
+	 * Fields GitHub only returns on the authenticated GET /user response
+	 * (private_* counters, plan) are absent.
+	 */
+	const octocatProfile = {
+		login: "octocat",
+		id: 583231,
+		node_id: "MDQ6VXNlcjU4MzIzMQ==",
+		avatar_url: "https://avatars.githubusercontent.com/u/583231?v=4",
+		gravatar_id: "",
+		url: "https://api.github.com/users/octocat",
+		html_url: "https://github.com/octocat",
+		followers_url: "https://api.github.com/users/octocat/followers",
+		following_url:
+			"https://api.github.com/users/octocat/following{/other_user}",
+		gists_url: "https://api.github.com/users/octocat/gists{/gist_id}",
+		starred_url: "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+		subscriptions_url: "https://api.github.com/users/octocat/subscriptions",
+		organizations_url: "https://api.github.com/users/octocat/orgs",
+		repos_url: "https://api.github.com/users/octocat/repos",
+		events_url: "https://api.github.com/users/octocat/events{/privacy}",
+		received_events_url: "https://api.github.com/users/octocat/received_events",
+		type: "User",
+		site_admin: false,
+		name: "The Octocat",
+		company: "@github",
+		blog: "https://github.blog",
+		location: "San Francisco",
+		email: null,
+		hireable: null,
+		bio: null,
+		twitter_username: null,
+		public_repos: 8,
+		public_gists: 8,
+		followers: 23815,
+		following: 9,
+		created_at: "2011-01-25T18:44:36Z",
+		updated_at: "2026-01-01T00:00:00Z",
+	};
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11040
+	 */
+	it("accepts a real GitHub API user response as GithubProfile", () => {
+		const profile = octocatProfile satisfies GithubProfile;
+		expect(profile.id).toBe(583231);
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11040
+	 */
+	it("accepts a custom getUserInfo that returns the raw API response", () => {
+		const provider = github({
+			...credentials,
+			getUserInfo: async () => ({
+				user: {
+					name: octocatProfile.name ?? octocatProfile.login,
+					email: octocatProfile.email,
+					emailVerified: false,
+				},
+				data: octocatProfile,
+			}),
+		});
+		expect(provider.id).toBe("github");
 	});
 });


### PR DESCRIPTION
## Summary
- Rewrote `GithubProfile` to match GitHub's actual `GET /user` response schema: `id`, repo/gist/follower counters, and `plan.*` fields are `number`; `name`, `company`, `blog`, `location`, `hireable`, `bio`, `twitter_username`, `gravatar_id` allow `null`
- Marked the authenticated-only fields (`private_gists`, `total_private_repos`, `owned_private_repos`, `disk_usage`, `collaborators`, `two_factor_authentication`, `plan`) optional, so both `GET /user` and `GET /users/{username}` responses satisfy the interface
- Custom `getUserInfo` implementations can now return a real GitHub API response without a type assertion

No runtime change: `accountSubject` already supports `string | number`, and `resolveOAuthAccountKey` stringifies the resolved subject, so the stored `accountId` is identical.

Closes #11040

#### Test plan
- [x] `pnpm vitest packages/core/src/social-providers --run` — 125 tests pass, including 2 new cases asserting a real GitHub API response (octocat) satisfies `GithubProfile` and can be returned from a custom `getUserInfo`
- [x] `pnpm typecheck` passes
- [x] Changeset added (`patch`)

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `GithubProfile` with GitHub's actual `GET /user` and `GET /users/{username}` response schema so custom `getUserInfo` implementations can return a real API response without type assertions. Resolves #11040.

**Bug Fixes**
- `id`, the repo/gist/follower/following counters, and `plan` counters are now `number` instead of `string`.
- Optional profile fields (`name`, `company`, `blog`, `location`, `hireable`, `bio`, `twitter_username`, `gravatar_id`) now allow `null`.
- Authenticated-only fields (`private_gists`, `total_private_repos`, `owned_private_repos`, `disk_usage`, `collaborators`, `two_factor_authentication`, `plan`) are now optional, and tests cover both endpoint response shapes.
- Type-level breaking change: code reading these fields as `string` or accessing `plan`/`private_*` unconditionally will see type errors on upgrade.
- No runtime change: `accountSubject` already supports `string | number`, and the subject is stringified, so stored `accountId` values stay identical.

<sup>Written for commit d3c287b57dce1e571eabcf7082a072c1e65d59fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

