### PR TITLE
ci(release): align v1.6 release configuration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -32,7 +32,7 @@
   "linked": [],
   "access": "public",
   "privatePackages": false,
-  "baseBranch": "main",
+  "baseBranch": "v1.6.x",
   "updateInternalDependencies": "patch",
   "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": [],

--- a/.github/workflows/release-notes-draft.yml
+++ b/.github/workflows/release-notes-draft.yml
@@ -10,6 +10,6 @@ jobs:
   draft:
     permissions:
       pull-requests: write
-    uses: better-auth/better-auth/.github/workflows/release-notes-draft.yml@0e02187ab45a903c66986fc5e28cddd37185147b
+    uses: better-auth/better-auth/.github/workflows/release-notes-draft.yml@9ca15f3726275f31d86cbd0a8cf21fea64441634
     secrets:
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: better-auth/better-auth/.github/workflows/release.yml@0e02187ab45a903c66986fc5e28cddd37185147b
+    uses: better-auth/better-auth/.github/workflows/release.yml@9ca15f3726275f31d86cbd0a8cf21fea64441634
     with:
       use_shared_tooling: true
     secrets:

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: better-auth/better-auth/.github/workflows/verify-changesets.yml@0e02187ab45a903c66986fc5e28cddd37185147b
+    uses: better-auth/better-auth/.github/workflows/verify-changesets.yml@9ca15f3726275f31d86cbd0a8cf21fea64441634


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the release configuration for the `v1.6.x` branch so changelogs, releases, and changeset checks run against the correct base branch and use the latest shared workflow versions.

<sup>Written for commit 7b77408dcf6bf1beaf0eaed358f21ce216b7e5a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

