### PR TITLE
ci(docs): automate version source updates

### DIFF
--- a/.github/workflows/sync-version-docs.yml
+++ b/.github/workflows/sync-version-docs.yml
@@ -7,10 +7,11 @@ on:
     types:
       - completed
     branches:
-      # Match editBranch values with a pinned commitSha in `docs/lib/docs-version-sources.ts`.
+      # Match editBranch values with a pinned commitSha in `docs/lib/docs-version-sources.json`.
       - "v*.*.x"
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: sync-version-docs-${{ github.event.workflow_run.head_branch }}
@@ -20,25 +21,17 @@ jobs:
   sync:
     if: >
       github.repository_owner == 'better-auth' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.conclusion == 'success' &&
       vars.RELEASE_APP_ID != ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Generate App Token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
           persist-credentials: false
-          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -69,6 +62,16 @@ jobs:
             echo "relevant=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate App Token
+        id: app-token
+        if: steps.changes.outputs.relevant == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Create or update draft PR
         if: steps.changes.outputs.relevant == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
@@ -76,7 +79,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           base: main
           branch: docs-sync/${{ github.event.workflow_run.head_branch }}
-          add-paths: docs/lib/docs-version-sources.ts
+          add-paths: docs/lib/docs-version-sources.json
           commit-message: "docs: sync v${{ steps.update.outputs.release_line }} documentation"
           sign-commits: true
           title: "docs: sync v${{ steps.update.outputs.release_line }} documentation"

--- a/.github/workflows/sync-version-docs.yml
+++ b/.github/workflows/sync-version-docs.yml
@@ -1,28 +1,29 @@
 name: Sync Versioned Documentation
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
     branches:
       # Match editBranch values with a pinned commitSha in `docs/lib/docs-version-sources.ts`.
       - "v*.*.x"
-    paths:
-      - "docs/content/docs/**"
-      - "packages/better-auth/package.json"
 
 permissions: {}
 
 concurrency:
-  group: sync-version-docs-${{ github.ref_name }}
+  group: sync-version-docs-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:
   sync:
-    if: github.repository_owner == 'better-auth' && vars.RELEASE_APP_ID != ''
+    if: >
+      github.repository_owner == 'better-auth' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      vars.RELEASE_APP_ID != ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Generate App Token
         id: app-token
@@ -47,26 +48,43 @@ jobs:
       - name: Update documentation source
         id: update
         env:
-          SOURCE_BRANCH: ${{ github.ref_name }}
-          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: node docs/scripts/update-docs-version-source.ts "$SOURCE_BRANCH" "$SOURCE_SHA" >> "$GITHUB_OUTPUT"
 
-      - name: Create or update draft PR
+      - name: Check source changes
+        id: changes
         if: steps.update.outputs.changed == 'true'
+        env:
+          PREVIOUS_SHA: ${{ steps.update.outputs.previous_sha }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          git fetch --quiet --no-tags --depth=1 origin "$PREVIOUS_SHA" "$SOURCE_SHA"
+          CHANGED_FILES=$(git diff --name-only "$PREVIOUS_SHA" "$SOURCE_SHA" -- \
+            docs/content/docs \
+            packages/better-auth/package.json)
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update draft PR
+        if: steps.changes.outputs.relevant == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           base: main
-          branch: docs-sync/${{ github.ref_name }}
+          branch: docs-sync/${{ github.event.workflow_run.head_branch }}
           add-paths: docs/lib/docs-version-sources.ts
           commit-message: "docs: sync v${{ steps.update.outputs.release_line }} documentation"
           sign-commits: true
           title: "docs: sync v${{ steps.update.outputs.release_line }} documentation"
           draft: always-true
           body: |
-            Updates the v${{ steps.update.outputs.release_line }} documentation snapshot after changes landed on `${{ github.ref_name }}`.
+            Updates the v${{ steps.update.outputs.release_line }} documentation snapshot after changes landed on `${{ github.event.workflow_run.head_branch }}`.
 
-            - Source revision: [`${{ github.sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
-            - Compare: [Compare with the current snapshot](https://github.com/${{ github.repository }}/compare/${{ steps.update.outputs.previous_sha }}...${{ github.sha }})
+            - Source revision: [`${{ github.event.workflow_run.head_sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }})
+            - Compare: [Compare with the current snapshot](https://github.com/${{ github.repository }}/compare/${{ steps.update.outputs.previous_sha }}...${{ github.event.workflow_run.head_sha }})
 
             Review the source changes and documentation preview, then merge this PR when ready.

--- a/.github/workflows/sync-version-docs.yml
+++ b/.github/workflows/sync-version-docs.yml
@@ -1,0 +1,72 @@
+name: Sync Versioned Documentation
+
+on:
+  push:
+    branches:
+      # Match editBranch values with a pinned commitSha in `docs/lib/docs-version-sources.ts`.
+      - "v*.*.x"
+    paths:
+      - "docs/content/docs/**"
+      - "packages/better-auth/package.json"
+
+permissions: {}
+
+concurrency:
+  group: sync-version-docs-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    if: github.repository_owner == 'better-auth' && vars.RELEASE_APP_ID != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: main
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          package-manager-cache: false
+
+      - name: Update documentation source
+        id: update
+        env:
+          SOURCE_BRANCH: ${{ github.ref_name }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: node docs/scripts/update-docs-version-source.ts "$SOURCE_BRANCH" "$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update draft PR
+        if: steps.update.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          base: main
+          branch: docs-sync/${{ github.ref_name }}
+          add-paths: docs/lib/docs-version-sources.ts
+          commit-message: "docs: sync v${{ steps.update.outputs.release_line }} documentation"
+          sign-commits: true
+          title: "docs: sync v${{ steps.update.outputs.release_line }} documentation"
+          draft: always-true
+          body: |
+            Updates the v${{ steps.update.outputs.release_line }} documentation snapshot after changes landed on `${{ github.ref_name }}`.
+
+            - Source revision: [`${{ github.sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
+            - Compare: [Compare with the current snapshot](https://github.com/${{ github.repository }}/compare/${{ steps.update.outputs.previous_sha }}...${{ github.sha }})
+
+            Review the source changes and documentation preview, then merge this PR when ready.

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,6 +19,9 @@ rules:
       # slash commands. The pinned action retains a scoped token to push the
       # generated branch but does not execute checked-out repository code.
       - backport.yml
+      # Intentional: runs trusted code from main and validates the triggering
+      # branch and commit before creating a token. It never executes that revision.
+      - sync-version-docs.yml
   use-trusted-publishing:
     ignore:
       # Intentional: pkg.pr.new publishes ephemeral PR preview packages, not npm

--- a/docs/lib/docs-version-sources.json
+++ b/docs/lib/docs-version-sources.json
@@ -1,0 +1,12 @@
+{
+  "latest": {
+    "contentDirectory": "docs",
+    "editBranch": "main",
+    "commitSha": null
+  },
+  "1.6": {
+    "contentDirectory": "_generated/docs/v1-6",
+    "editBranch": "v1.6.x",
+    "commitSha": "886311168d86a75496f4e2bc339a6e5516a13d08"
+  }
+}

--- a/docs/lib/docs-version-sources.ts
+++ b/docs/lib/docs-version-sources.ts
@@ -1,3 +1,6 @@
+import docsVersionSourcesManifest from "./docs-version-sources.json" with {
+	type: "json",
+};
 import type { DocsVersionId } from "./docs-versions";
 
 export interface DocsVersionSource {
@@ -6,15 +9,7 @@ export interface DocsVersionSource {
 	commitSha: string | null;
 }
 
-export const docsVersionSources = {
-	latest: {
-		contentDirectory: "docs",
-		editBranch: "main",
-		commitSha: null,
-	},
-	"1.6": {
-		contentDirectory: "_generated/docs/v1-6",
-		editBranch: "v1.6.x",
-		commitSha: "886311168d86a75496f4e2bc339a6e5516a13d08",
-	},
-} as const satisfies Record<DocsVersionId, DocsVersionSource>;
+export const docsVersionSources = docsVersionSourcesManifest satisfies Record<
+	DocsVersionId,
+	DocsVersionSource
+>;

--- a/docs/scripts/update-docs-version-source.ts
+++ b/docs/scripts/update-docs-version-source.ts
@@ -35,18 +35,16 @@ export function updateDocsVersionSource(
 	const previousCommitSha = source.commitSha;
 	if (previousCommitSha === commitSha) return null;
 
-	const currentEntry = `\t\teditBranch: ${JSON.stringify(editBranch)},\n\t\tcommitSha: ${JSON.stringify(previousCommitSha)},`;
-	const nextEntry = `\t\teditBranch: ${JSON.stringify(editBranch)},\n\t\tcommitSha: ${JSON.stringify(commitSha)},`;
-	const entryIndex = content.indexOf(currentEntry);
-	if (
-		entryIndex === -1 ||
-		content.indexOf(currentEntry, entryIndex + currentEntry.length) !== -1
-	) {
-		throw new Error(`Expected one source entry for ${editBranch}`);
+	const assignment = new RegExp(
+		`(commitSha\\s*:\\s*)${JSON.stringify(previousCommitSha)}`,
+		"g",
+	);
+	if (content.match(assignment)?.length !== 1) {
+		throw new Error(`Expected one commitSha entry for ${editBranch}`);
 	}
 
 	return {
-		content: content.replace(currentEntry, nextEntry),
+		content: content.replace(assignment, `$1${JSON.stringify(commitSha)}`),
 		previousCommitSha,
 		releaseLine: version.releaseLine,
 	};

--- a/docs/scripts/update-docs-version-source.ts
+++ b/docs/scripts/update-docs-version-source.ts
@@ -1,21 +1,20 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { docsVersionSources } from "../lib/docs-version-sources.ts";
 import { docsVersions } from "../lib/docs-versions.ts";
 
 const commitShaPattern = /^[0-9a-f]{40}$/;
-const sourceFilePath = fileURLToPath(
-	new URL("../lib/docs-version-sources.ts", import.meta.url),
+const sourcesFilePath = fileURLToPath(
+	new URL("../lib/docs-version-sources.json", import.meta.url),
 );
 
-export interface DocsVersionSourceUpdate {
-	content: string;
+interface DocsVersionSourceUpdate {
+	serializedSources: string;
 	previousCommitSha: string;
 	releaseLine: string;
 }
 
-export function updateDocsVersionSource(
-	content: string,
+function getDocsVersionSourceUpdate(
 	editBranch: string,
 	commitSha: string,
 ): DocsVersionSourceUpdate | null {
@@ -35,16 +34,13 @@ export function updateDocsVersionSource(
 	const previousCommitSha = source.commitSha;
 	if (previousCommitSha === commitSha) return null;
 
-	const assignment = new RegExp(
-		`(commitSha\\s*:\\s*)${JSON.stringify(previousCommitSha)}`,
-		"g",
-	);
-	if (content.match(assignment)?.length !== 1) {
-		throw new Error(`Expected one commitSha entry for ${editBranch}`);
-	}
+	const updatedSources = {
+		...docsVersionSources,
+		[versionId]: { ...source, commitSha },
+	};
 
 	return {
-		content: content.replace(assignment, `$1${JSON.stringify(commitSha)}`),
+		serializedSources: `${JSON.stringify(updatedSources, null, 2)}\n`,
 		previousCommitSha,
 		releaseLine: version.releaseLine,
 	};
@@ -58,14 +54,13 @@ async function main() {
 		);
 	}
 
-	const content = await readFile(sourceFilePath, "utf8");
-	const update = updateDocsVersionSource(content, editBranch, commitSha);
+	const update = getDocsVersionSourceUpdate(editBranch, commitSha);
 	if (!update) {
 		console.log("changed=false");
 		return;
 	}
 
-	await writeFile(sourceFilePath, update.content);
+	await writeFile(sourcesFilePath, update.serializedSources);
 	console.log("changed=true");
 	console.log(`release_line=${update.releaseLine}`);
 	console.log(`previous_sha=${update.previousCommitSha}`);

--- a/docs/scripts/update-docs-version-source.ts
+++ b/docs/scripts/update-docs-version-source.ts
@@ -1,0 +1,78 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { docsVersionSources } from "../lib/docs-version-sources.ts";
+import { docsVersions } from "../lib/docs-versions.ts";
+
+const commitShaPattern = /^[0-9a-f]{40}$/;
+const sourceFilePath = fileURLToPath(
+	new URL("../lib/docs-version-sources.ts", import.meta.url),
+);
+
+export interface DocsVersionSourceUpdate {
+	content: string;
+	previousCommitSha: string;
+	releaseLine: string;
+}
+
+export function updateDocsVersionSource(
+	content: string,
+	editBranch: string,
+	commitSha: string,
+): DocsVersionSourceUpdate | null {
+	if (!commitShaPattern.test(commitSha)) {
+		throw new Error(`Invalid commit SHA: ${commitSha}`);
+	}
+
+	const entry = Object.entries(docsVersionSources).find(
+		([, source]) => source.editBranch === editBranch,
+	);
+	if (!entry || entry[1].commitSha === null) return null;
+
+	const [versionId, source] = entry;
+	const version = docsVersions.find((version) => version.id === versionId);
+	if (!version) throw new Error(`Missing docs version for ${versionId}`);
+
+	const previousCommitSha = source.commitSha;
+	if (previousCommitSha === commitSha) return null;
+
+	const currentEntry = `\t\teditBranch: ${JSON.stringify(editBranch)},\n\t\tcommitSha: ${JSON.stringify(previousCommitSha)},`;
+	const nextEntry = `\t\teditBranch: ${JSON.stringify(editBranch)},\n\t\tcommitSha: ${JSON.stringify(commitSha)},`;
+	const entryIndex = content.indexOf(currentEntry);
+	if (
+		entryIndex === -1 ||
+		content.indexOf(currentEntry, entryIndex + currentEntry.length) !== -1
+	) {
+		throw new Error(`Expected one source entry for ${editBranch}`);
+	}
+
+	return {
+		content: content.replace(currentEntry, nextEntry),
+		previousCommitSha,
+		releaseLine: version.releaseLine,
+	};
+}
+
+async function main() {
+	const [editBranch, commitSha] = process.argv.slice(2);
+	if (!editBranch || !commitSha) {
+		throw new Error(
+			"Usage: node update-docs-version-source.ts <branch> <commit-sha>",
+		);
+	}
+
+	const content = await readFile(sourceFilePath, "utf8");
+	const update = updateDocsVersionSource(content, editBranch, commitSha);
+	if (!update) {
+		console.log("changed=false");
+		return;
+	}
+
+	await writeFile(sourceFilePath, update.content);
+	console.log("changed=true");
+	console.log(`release_line=${update.releaseLine}`);
+	console.log(`previous_sha=${update.previousCommitSha}`);
+}
+
+if (import.meta.main) {
+	await main();
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automates the versioned documentation snapshot update so docs changes on `v*.*.x` branches open a draft PR against `main` with the new commit reference instead of being synced by hand. The workflow runs only after a successful Release workflow, opens a PR only when relevant docs files changed, and validates the triggering branch and commit before minting a token.

**Rollout**
- Requires `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`, and only runs for the `better-auth` repository owner.
- The zizmor config exempts this workflow as trusted code that runs from `main` and never executes the triggering revision.

<sup>Written for commit 63ec97473f647a23875755e272ecc8d4262c5e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

