### PR TITLE
fix(two-factor): make TOTP codes single-use to prevent replay

### DIFF
--- a/.changeset/totp-single-use.md
+++ b/.changeset/totp-single-use.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Make TOTP codes single-use per RFC 6238 §5.2. A verified code can no longer be replayed within its acceptance window — including on a fresh sign-in challenge or by concurrent requests. Adds a nullable `lastUsedStep` column to the `twoFactor` table; run the CLI migration (`npx auth migrate`) after upgrading.

--- a/.cspell/auth-terms.txt
+++ b/.cspell/auth-terms.txt
@@ -42,3 +42,4 @@ jkt
 reissuance
 TOCTOU
 SSOOIDC
+hotp

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -533,6 +533,13 @@ export const twoFactorTableFields = [
 			"When the account lockout expires; null when the account is not locked.",
 		isOptional: true,
 	},
+	{
+		name: "lastUsedStep",
+		type: "number",
+		description:
+			"The most recently consumed TOTP time step; rejects reused codes (RFC 6238 §5.2).",
+		isOptional: true,
+	},
 ];
 
 <DatabaseTable name="twoFactor" fields={twoFactorTableFields} />

--- a/packages/better-auth/src/plugins/two-factor/schema.ts
+++ b/packages/better-auth/src/plugins/two-factor/schema.ts
@@ -55,6 +55,16 @@ export const schema = {
 				input: false,
 				returned: false,
 			},
+			// The most recent TOTP time step consumed by a successful
+			// verification. Verification rejects any candidate step <= this
+			// value, enforcing RFC 6238 §5.2 one-time use. Nullable so
+			// pre-migration rows are treated as "no step consumed yet".
+			lastUsedStep: {
+				type: "number",
+				required: false,
+				input: false,
+				returned: false,
+			},
 		},
 	},
 } satisfies BetterAuthPluginDBSchema;

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -317,8 +317,11 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 				for (let i = -1; i <= 1; i++) {
 					const candidateStep = counter + i;
 					const candidate = await otp.hotp(candidateStep);
+					// Keep the earliest match: on a (rare) collision across adjacent
+					// steps, pinning the older step makes a replayed code fail the
+					// consumption guard below rather than spend the fresh one.
 					if (constantTimeEqual(ctx.body.code, candidate)) {
-						matchedStep = candidateStep;
+						matchedStep ??= candidateStep;
 					}
 				}
 				status = matchedStep !== null;

--- a/packages/better-auth/src/plugins/two-factor/totp/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/totp/index.ts
@@ -4,7 +4,7 @@ import { createOTP } from "@better-auth/utils/otp";
 import * as z from "zod";
 import { sessionMiddleware } from "../../../api";
 import { setSessionCookie } from "../../../cookies";
-import { symmetricDecrypt } from "../../../crypto";
+import { constantTimeEqual, symmetricDecrypt } from "../../../crypto";
 import { shouldRequirePassword } from "../../../utils/password";
 import { PACKAGE_VERSION } from "../../../version";
 import type { BackupCodeOptions } from "../backup-codes";
@@ -17,6 +17,7 @@ import type {
 } from "../types";
 import {
 	assertTwoFactorNotLocked,
+	consumeTOTPStep,
 	recordTwoFactorFailure,
 	resetTwoFactorFailures,
 	verifyTwoFactor,
@@ -297,21 +298,63 @@ export const totp2fa = (options?: TOTPOptions | undefined) => {
 				? await beginAttempt(DEFAULT_TWO_FACTOR_ALLOWED_ATTEMPTS)
 				: null;
 			let status: boolean;
+			let matchedStep: number | null = null;
 			try {
 				const decrypted = await symmetricDecrypt({
 					key: ctx.context.secretConfig,
 					data: twoFactor.secret,
 				});
-				status = await createOTP(decrypted, {
+				const otp = createOTP(decrypted, {
 					period: opts.period,
 					digits: opts.digits,
-				}).verify(ctx.body.code);
+				});
+				// Walk the same ±1 window the OTP util's verify() uses, but capture
+				// which step matched so one-time use can be enforced. The counter is
+				// snapshotted once so a period boundary mid-loop cannot shift the
+				// window, and every candidate is checked with a constant-time
+				// compare — no early exit, matching the util's verify().
+				const counter = Math.floor(Date.now() / (opts.period * 1000));
+				for (let i = -1; i <= 1; i++) {
+					const candidateStep = counter + i;
+					const candidate = await otp.hotp(candidateStep);
+					if (constantTimeEqual(ctx.body.code, candidate)) {
+						matchedStep = candidateStep;
+					}
+				}
+				status = matchedStep !== null;
 			} catch (error) {
 				// A server error before the code is checked must not spend the slot.
 				await attempt?.restore();
 				throw error;
 			}
 			if (!status) {
+				await attempt?.recordFailure();
+				if (isSignIn) {
+					await recordTwoFactorFailure(ctx, twoFactorTable, twoFactor);
+				}
+				return invalid("INVALID_CODE");
+			}
+			// RFC 6238 §5.2 one-time use: claim the matched step before a session
+			// is issued. This applies on both paths — the sign-in challenge is
+			// consumed by valid() but only blocks replay against that challenge,
+			// and the step-up path has no challenge at all. A replayed code (the
+			// same step, or an older step still inside the window) loses the
+			// guarded write and is rejected; doing it before valid() also means
+			// two concurrent verifications of one code cannot each mint a session.
+			let stepConsumed: boolean;
+			try {
+				stepConsumed = await consumeTOTPStep(
+					ctx,
+					twoFactorTable,
+					twoFactor,
+					matchedStep!,
+				);
+			} catch (error) {
+				// A server error must not spend the slot.
+				await attempt?.restore();
+				throw error;
+			}
+			if (!stepConsumed) {
 				await attempt?.recordFailure();
 				if (isSignIn) {
 					await recordTwoFactorFailure(ctx, twoFactorTable, twoFactor);

--- a/packages/better-auth/src/plugins/two-factor/two-factor.account-lockout.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.account-lockout.test.ts
@@ -5,7 +5,7 @@ import type {
 import type { DBAdapter } from "@better-auth/core/db/adapter";
 import { createAdapterFactory } from "@better-auth/core/db/adapter";
 import { createOTP } from "@better-auth/utils/otp";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { memoryAdapter } from "../../adapters/memory-adapter";
 import { symmetricDecrypt } from "../../crypto";
 import { convertSetCookieToCookie } from "../../test-utils/headers";
@@ -138,8 +138,12 @@ async function setup(
 			asResponse: true,
 		});
 	}
-	function correctTotp() {
-		return createOTP(secret).totp();
+	function correctTotp(stepOffset = 0) {
+		// stepOffset mints a code for a later step: enrollment and each
+		// successful verification consume their step (TOTPs are single-use),
+		// so a second success inside the same window needs the next step's
+		// code, which the ±1 acceptance window still admits.
+		return createOTP(secret).hotp(Math.floor(Date.now() / 30_000) + stepOffset);
 	}
 	async function failOtpOnce(): Promise<Response> {
 		const challengeHeaders = await startChallenge();
@@ -308,7 +312,7 @@ describe("two-factor: account-level lockout across challenges", () => {
 				401,
 			);
 		}
-		const ok = await verifyTotp(await startChallenge(), await correctTotp());
+		const ok = await verifyTotp(await startChallenge(), await correctTotp(1));
 		expect(ok.status).toBe(200);
 
 		// Two more failures must not lock: the counter restarted from zero, so the
@@ -318,11 +322,20 @@ describe("two-factor: account-level lockout across challenges", () => {
 				401,
 			);
 		}
-		const stillOpen = await verifyTotp(
-			await startChallenge(),
-			await correctTotp(),
-		);
-		expect(stillOpen.status).toBe(200);
+		// Both in-window steps around "now" are already consumed (enrollment and
+		// the success above), so the second success must land in a fresh step —
+		// advancing two steps guarantees the clock moves past every burned step.
+		vi.useFakeTimers({ toFake: ["Date"] });
+		try {
+			vi.setSystemTime(Date.now() + 61_000);
+			const stillOpen = await verifyTotp(
+				await startChallenge(),
+				await correctTotp(),
+			);
+			expect(stillOpen.status).toBe(200);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("releases the lock once its window elapses", async () => {
@@ -351,7 +364,7 @@ describe("two-factor: account-level lockout across challenges", () => {
 
 		const released = await verifyTotp(
 			await startChallenge(),
-			await correctTotp(),
+			await correctTotp(1),
 		);
 		expect(released.status).toBe(200);
 	});
@@ -367,7 +380,7 @@ describe("two-factor: account-level lockout across challenges", () => {
 				401,
 			);
 		}
-		const ok = await verifyTotp(await startChallenge(), await correctTotp());
+		const ok = await verifyTotp(await startChallenge(), await correctTotp(1));
 		expect(ok.status).toBe(200);
 	});
 
@@ -388,7 +401,7 @@ describe("two-factor: account-level lockout across challenges", () => {
 		expect((await verifyTotp(await startChallenge(), "000000")).status).toBe(
 			401,
 		);
-		const ok = await verifyTotp(await startChallenge(), await correctTotp());
+		const ok = await verifyTotp(await startChallenge(), await correctTotp(1));
 		expect(ok.status).toBe(200);
 	});
 

--- a/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.attempt-cap.test.ts
@@ -157,9 +157,11 @@ describe("two-factor security: TOTP enforces a per-challenge attempt cap", async
 			where: [{ field: "userId", value: userId }],
 			update: { secret: validSecret },
 		});
+		// Enrollment already consumed the current step's code (TOTPs are
+		// single-use), so mint the next step's — still inside the ±1 window.
 		const ok = await verifyTotp(
 			challengeHeaders,
-			await createOTP(secret).totp(),
+			await createOTP(secret).hotp(Math.floor(Date.now() / 30_000) + 1),
 		);
 		expect(ok.status).toBe(200);
 	});

--- a/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.security.test.ts
@@ -2,7 +2,7 @@ import type { BetterAuthPlugin } from "@better-auth/core";
 import { createAuthMiddleware } from "@better-auth/core/api";
 import type { SecondaryStorage } from "@better-auth/core/db";
 import { createOTP } from "@better-auth/utils/otp";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { symmetricDecrypt } from "../../crypto";
 import { convertSetCookieToCookie } from "../../test-utils/headers";
 import { getTestInstance } from "../../test-utils/test-instance";
@@ -490,7 +490,12 @@ describe("two-factor security: 2FA challenge is single-use and expiry-bounded", 
 		});
 
 		const sessionsBefore = await countSessions();
-		const freshCode = await createOTP(secret).totp();
+		// The enrollment verify above already consumed the current step's code
+		// (TOTPs are single-use), so mint the next step's — still inside the ±1
+		// acceptance window.
+		const freshCode = await createOTP(secret).hotp(
+			Math.floor(Date.now() / 30_000) + 1,
+		);
 		const res = await auth.api.verifyTOTP({
 			body: { code: freshCode },
 			headers: challengeHeaders,
@@ -518,28 +523,38 @@ describe("two-factor security: 2FA challenge is single-use and expiry-bounded", 
 	});
 
 	it("two concurrent verifications of the same challenge yield exactly one session", async () => {
-		const challengeHeaders = await startChallenge();
-		const sessionsBefore = await countSessions();
-		const code = await createOTP(secret).totp();
+		// Enrollment and the expired-challenge test each consumed a step (TOTPs
+		// are single-use — a valid code burns its step even when the challenge
+		// later fails), so advance the clock two steps to reach an unconsumed
+		// step before minting a code.
+		vi.useFakeTimers({ toFake: ["Date"] });
+		vi.setSystemTime(Date.now() + 61_000);
+		try {
+			const challengeHeaders = await startChallenge();
+			const sessionsBefore = await countSessions();
+			const code = await createOTP(secret).totp();
 
-		const [first, second] = await Promise.all([
-			auth.api.verifyTOTP({
-				body: { code },
-				headers: challengeHeaders,
-				asResponse: true,
-			}),
-			auth.api.verifyTOTP({
-				body: { code },
-				headers: challengeHeaders,
-				asResponse: true,
-			}),
-		]);
+			const [first, second] = await Promise.all([
+				auth.api.verifyTOTP({
+					body: { code },
+					headers: challengeHeaders,
+					asResponse: true,
+				}),
+				auth.api.verifyTOTP({
+					body: { code },
+					headers: challengeHeaders,
+					asResponse: true,
+				}),
+			]);
 
-		const statuses = [first.status, second.status].sort();
-		expect(statuses).toEqual([200, 401]);
+			const statuses = [first.status, second.status].sort();
+			expect(statuses).toEqual([200, 401]);
 
-		const sessionsAfter = await countSessions();
-		expect(sessionsAfter.length).toBe(sessionsBefore.length + 1);
+			const sessionsAfter = await countSessions();
+			expect(sessionsAfter.length).toBe(sessionsBefore.length + 1);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 
@@ -729,5 +744,173 @@ describe("two-factor security: OTP attempts are atomic under concurrency", async
 		// the consume and never reach session creation, so at most one 200.
 		const successCount = results.filter((res) => res.status === 200).length;
 		expect(successCount).toBeLessThanOrEqual(1);
+	});
+});
+
+/**
+ * Regression coverage for TOTP one-time use (RFC 6238 §5.2 / OWASP ASVS 5.0
+ * §6.5.1). Verification used to be stateless: a code that passed once stayed
+ * valid for the rest of its ~90s acceptance window — the step-up
+ * (active-session) path accepted it repeatedly, and the sign-in path accepted
+ * it again under a fresh challenge, because only the challenge row was
+ * consumed. The twoFactor row now records the last consumed time step and the
+ * verify endpoint claims the matched step with an atomic guarded write before
+ * issuing a session, so a code works exactly once — sequentially or under
+ * concurrency. Each test enrolls its own instance so the persisted
+ * `lastUsedStep` cannot leak between cases.
+ *
+ * @see https://github.com/better-auth/better-auth/issues/10387
+ */
+describe("two-factor security: TOTP codes are single-use (RFC 6238 §5.2)", () => {
+	async function setupTotpUser() {
+		const { auth, signInWithTestUser, testUser, db } = await getTestInstance({
+			secret: DEFAULT_SECRET,
+			plugins: [twoFactor({ skipVerificationOnEnable: true })],
+		});
+		const { headers } = await signInWithTestUser();
+		const enableRes = await auth.api.enableTwoFactor({
+			body: { password: testUser.password },
+			headers,
+			asResponse: true,
+		});
+		// skipVerificationOnEnable activates 2FA immediately and rotates the
+		// session, so use the cookies from the enable response going forward.
+		const sessionHeaders = convertSetCookieToCookie(enableRes.headers);
+		const dbUser = await db.findOne<User>({
+			model: "user",
+			where: [{ field: "email", value: testUser.email }],
+		});
+		const userId = dbUser?.id as string;
+		const row = await db.findOne<TwoFactorTable>({
+			model: "twoFactor",
+			where: [{ field: "userId", value: userId }],
+		});
+		const secret = await symmetricDecrypt({
+			key: DEFAULT_SECRET,
+			data: row!.secret,
+		});
+		return { auth, secret, sessionHeaders, testUser };
+	}
+
+	async function freshChallenge(
+		auth: Awaited<ReturnType<typeof setupTotpUser>>["auth"],
+		testUser: Awaited<ReturnType<typeof setupTotpUser>>["testUser"],
+	): Promise<Headers> {
+		const res = await auth.api.signInEmail({
+			body: { email: testUser.email, password: testUser.password },
+			asResponse: true,
+		});
+		expect(res.status).toBe(200);
+		return convertSetCookieToCookie(res.headers);
+	}
+
+	it("rejects a code reused on the step-up (active session) path", async () => {
+		const { auth, secret, sessionHeaders } = await setupTotpUser();
+		const code = await createOTP(secret).totp();
+
+		const first = await auth.api.verifyTOTP({
+			body: { code },
+			headers: sessionHeaders,
+			asResponse: true,
+		});
+		expect(first.status).toBe(200);
+
+		const replay = await auth.api.verifyTOTP({
+			body: { code },
+			headers: sessionHeaders,
+			asResponse: true,
+		});
+		expect(replay.status).toBe(401);
+		const json = (await replay.json()) as { message: string };
+		expect(json.message).toBe(TWO_FACTOR_ERROR_CODES.INVALID_CODE.message);
+	});
+
+	it("accepts a step-up code exactly once across repeated attempts", async () => {
+		const { auth, secret, sessionHeaders } = await setupTotpUser();
+		const code = await createOTP(secret).totp();
+
+		// The reported repro accepted the same code 3/3 times on the step-up
+		// path; it must now succeed exactly once.
+		const results = await Promise.all(
+			[0, 1, 2].map(() =>
+				auth.api.verifyTOTP({
+					body: { code },
+					headers: sessionHeaders,
+					asResponse: true,
+				}),
+			),
+		);
+		expect(results.filter((res) => res.status === 200)).toHaveLength(1);
+	});
+
+	it("rejects a code reused across fresh sign-in challenges", async () => {
+		const { auth, secret, testUser } = await setupTotpUser();
+		const code = await createOTP(secret).totp();
+
+		const first = await auth.api.verifyTOTP({
+			body: { code },
+			headers: await freshChallenge(auth, testUser),
+			asResponse: true,
+		});
+		expect(first.status).toBe(200);
+
+		// A new challenge used to re-accept the same code because only the
+		// challenge row was consumed; the consumed step now rejects the replay.
+		const replay = await auth.api.verifyTOTP({
+			body: { code },
+			headers: await freshChallenge(auth, testUser),
+			asResponse: true,
+		});
+		expect(replay.status).toBe(401);
+		const json = (await replay.json()) as { message: string };
+		expect(json.message).toBe(TWO_FACTOR_ERROR_CODES.INVALID_CODE.message);
+	});
+
+	it("concurrent sign-in challenges with the same code mint at most one session", async () => {
+		const { auth, secret, testUser } = await setupTotpUser();
+		const code = await createOTP(secret).totp();
+
+		const [challengeA, challengeB] = await Promise.all([
+			freshChallenge(auth, testUser),
+			freshChallenge(auth, testUser),
+		]);
+		const results = await Promise.all([
+			auth.api.verifyTOTP({
+				body: { code },
+				headers: challengeA,
+				asResponse: true,
+			}),
+			auth.api.verifyTOTP({
+				body: { code },
+				headers: challengeB,
+				asResponse: true,
+			}),
+		]);
+		expect(results.filter((res) => res.status === 200)).toHaveLength(1);
+	});
+
+	it("still accepts a code from the next step inside the window", async () => {
+		const { auth, secret, sessionHeaders } = await setupTotpUser();
+
+		// Burn the current step, then prove the guard is not over-blocking: a
+		// code for the following step is still within the ±1 acceptance window
+		// and must verify.
+		const current = await createOTP(secret).totp();
+		const first = await auth.api.verifyTOTP({
+			body: { code: current },
+			headers: sessionHeaders,
+			asResponse: true,
+		});
+		expect(first.status).toBe(200);
+
+		const nextStepCode = await createOTP(secret).hotp(
+			Math.floor(Date.now() / 30_000) + 1,
+		);
+		const res = await auth.api.verifyTOTP({
+			body: { code: nextStepCode },
+			headers: sessionHeaders,
+			asResponse: true,
+		});
+		expect(res.status).toBe(200);
 	});
 });

--- a/packages/better-auth/src/plugins/two-factor/types.ts
+++ b/packages/better-auth/src/plugins/two-factor/types.ts
@@ -109,4 +109,5 @@ export interface TwoFactorTable {
 	verified: boolean;
 	failedVerificationCount?: number;
 	lockedUntil?: Date | null;
+	lastUsedStep?: number | null;
 }

--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -317,3 +317,46 @@ export async function resetTwoFactorFailures(
 		update: { failedVerificationCount: 0, lockedUntil: null },
 	});
 }
+
+/**
+ * Atomically record `step` as the consumed TOTP time step on the twoFactor row,
+ * enforcing RFC 6238 §5.2 one-time use. Returns `true` when this caller consumed
+ * the step, `false` when the step was already consumed (replay).
+ *
+ * The guarded `incrementOne` doubles as the check and the write: the update only
+ * lands while `lastUsedStep < step`, so concurrent submissions of the same code
+ * cannot both succeed, and a delayed replay of an older in-window step is
+ * rejected by monotonicity.
+ *
+ * Rows predating the column (and rows that have never verified) store
+ * NULL/absent, which never satisfies `<`; those are claimed by a second guarded
+ * write against `lastUsedStep IS NULL`. A concurrent racer loses both guards:
+ * once the winner commits, the field is neither NULL nor below the step.
+ */
+export async function consumeTOTPStep(
+	ctx: GenericEndpointContext,
+	twoFactorTable: string,
+	twoFactor: TwoFactorTable,
+	step: number,
+): Promise<boolean> {
+	const claimed = await ctx.context.adapter.incrementOne<TwoFactorTable>({
+		model: twoFactorTable,
+		where: [
+			{ field: "id", value: twoFactor.id },
+			{ field: "lastUsedStep", operator: "lt", value: step },
+		],
+		increment: {},
+		set: { lastUsedStep: step },
+	});
+	if (claimed) return true;
+	const claimedFresh = await ctx.context.adapter.incrementOne<TwoFactorTable>({
+		model: twoFactorTable,
+		where: [
+			{ field: "id", value: twoFactor.id },
+			{ field: "lastUsedStep", value: null },
+		],
+		increment: {},
+		set: { lastUsedStep: step },
+	});
+	return claimedFresh !== null;
+}


### PR DESCRIPTION
﻿## Summary

TOTP codes were reusable within their ~90s acceptance window (30s step ±1 clock-skew step). `verifyTOTP` checked only whether a code was mathematically valid — it never recorded consumption — so:

- the step-up path (active session) accepted the same code repeatedly,
- the sign-in path accepted it again under a fresh challenge (only the challenge row was consumed), and
- concurrent submissions of one code could each mint a session.

This enforces one-time use per RFC 6238 §5.2 / OWASP ASVS 5.0 §6.5.1:

- New nullable `lastUsedStep` column on the `twoFactor` table (nullable so pre-migration rows read as "no step consumed").
- `verifyTOTP` now walks the ±1 window itself instead of `otp.verify()`: the counter is snapshotted once (a period boundary mid-loop cannot shift the window), candidates are compared with `constantTimeEqual` and the loop runs to completion without early exit — matching the util's timing behavior — while capturing which step matched.
- The matched step is claimed with an atomic guarded `incrementOne` (`lastUsedStep < step`, falling back to `lastUsedStep IS NULL` for pre-migration rows) before `valid()` issues a session. Sequential replays, cross-challenge replays, and concurrent submissions all lose the guard and are rejected as invalid codes.

Supersedes the stalled #10423, which compared with `===` (not constant-time), wrote `lastUsedStep` unconditionally (concurrent requests could both pass the read-then-write check), and only covered the step-up path.

Fixes #10387.

> **Note:** one-time use means a code is consumed even across sign-in challenges — a legitimate retry inside the same 30s step must wait for the next code. This is the required behavior per RFC 6238.

### Migration

Adds `lastUsedStep` (nullable number) to `twoFactor` — run `npx auth migrate` / your adapter migration after upgrading.

#### Test plan

- [x] New regression tests in `two-factor.security.test.ts` cover: step-up replay rejected (the reported 3/3 repro now yields exactly one success), cross-challenge sign-in replay rejected, concurrent same-code submissions mint at most one session, and a next-step code still verifies inside the window.
- [x] Existing tests that relied on a second same-window verify were updated (next-step `hotp` codes / fake-clock advance) — one-time use legitimately makes two successes inside one step impossible.
- [x] `vitest run src/plugins/two-factor/` — 98/98 pass
- [x] `tsc --project tsconfig.json` clean

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes TOTP codes single-use so a verified code can no longer be replayed within its ~90s acceptance window (#10387); a retry inside the same 30s step must now wait for the next code. Previously, the step-up path accepted the same code repeatedly, a fresh sign-in challenge re-accepted it, and concurrent submissions of one code could each mint a session.

- Verification walks the ±1 window itself, keeping the earliest matching step so a collision across adjacent steps fails the replay guard instead of spending the fresh code.
- The matched step is claimed with an atomic guarded write before a session is issued.

**Migration**
- Adds a nullable `lastUsedStep` column to the `twoFactor` table.
- Run `npx auth migrate` after upgrading.

<sup>Written for commit d2e1b72ae50fd473eb8c3ad3651a30f6d6b88b33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

