### PR TITLE
fix(core): include additionalFields in email callback user types

### DIFF
--- a/.changeset/soft-planets-listen.md
+++ b/.changeset/soft-planets-listen.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/core": patch
+---
+
+Expose `user.additionalFields` on the `user` param types of the `emailVerification`, `emailAndPassword`, `changeEmail`, and `deleteUser` callbacks. These callbacks receive the full user record from the database at runtime, but their types previously only included the base `User` fields.

--- a/packages/better-auth/src/types/types.test.ts
+++ b/packages/better-auth/src/types/types.test.ts
@@ -447,4 +447,36 @@ describe("any-poisoning guards", () => {
 		expectTypeOf<Codes>().not.toBeAny();
 		expectTypeOf<Codes>().toHaveProperty("SESSION_EXPIRED");
 	});
+
+	/**
+	 * Callbacks that receive the user from the database should expose
+	 * `user.additionalFields` on their param types, matching what the
+	 * callbacks get at runtime.
+	 * https://github.com/better-auth/better-auth/issues/11192
+	 */
+	it("email callbacks should expose additionalFields on the user param", async () => {
+		const { auth } = await getTestInstance({
+			user: {
+				additionalFields: {
+					locale: {
+						type: "string",
+						required: false,
+						defaultValue: "en",
+					},
+				},
+			},
+			emailVerification: {
+				sendVerificationEmail: async ({ user }) => {
+					expectTypeOf(user.locale).toBeAny();
+				},
+			},
+			emailAndPassword: {
+				enabled: true,
+				sendResetPassword: async ({ user }) => {
+					expectTypeOf(user.locale).toBeAny();
+				},
+			},
+		});
+		expectTypeOf<typeof auth.$Infer.Session.user>().toHaveProperty("locale");
+	});
 });

--- a/packages/core/src/types/init-options.ts
+++ b/packages/core/src/types/init-options.ts
@@ -708,7 +708,7 @@ export type BetterAuthOptions = {
 					 * @param token the token to send the verification email to
 					 */
 					data: {
-						user: User;
+						user: User & Record<string, any>;
 						url: string;
 						token: string;
 					},
@@ -750,7 +750,7 @@ export type BetterAuthOptions = {
 				 * @param request the request object
 				 */
 				beforeEmailVerification?: (
-					user: User,
+					user: User & Record<string, any>,
 					request?: Request,
 				) => Promise<void>;
 				/**
@@ -759,7 +759,7 @@ export type BetterAuthOptions = {
 				 * @param request the request object
 				 */
 				afterEmailVerification?: (
-					user: User,
+					user: User & Record<string, any>,
 					request?: Request,
 				) => Promise<void>;
 		  }
@@ -812,7 +812,11 @@ export type BetterAuthOptions = {
 					 * @param token the token to send to the user (could be used instead of sending the url
 					 * if you need to redirect the user to custom route)
 					 */
-					data: { user: User; url: string; token: string },
+					data: {
+						user: User & Record<string, any>;
+						url: string;
+						token: string;
+					},
 					/**
 					 * The request object
 					 */
@@ -829,7 +833,7 @@ export type BetterAuthOptions = {
 				 * when a user's password is changed successfully.
 				 */
 				onPasswordReset?: (
-					data: { user: User },
+					data: { user: User & Record<string, any> },
 					request?: Request,
 				) => Promise<void>;
 				/**
@@ -869,7 +873,7 @@ export type BetterAuthOptions = {
 					/**
 					 * @param user the existing user from the database
 					 */
-					data: { user: User },
+					data: { user: User & Record<string, any> },
 					request?: Request,
 				) => Promise<void>;
 				/**
@@ -969,7 +973,7 @@ export type BetterAuthOptions = {
 					 */
 					sendChangeEmailConfirmation?: (
 						data: {
-							user: User;
+							user: User & Record<string, any>;
 							newEmail: string;
 							url: string;
 							token: string;
@@ -999,7 +1003,7 @@ export type BetterAuthOptions = {
 					 */
 					sendDeleteAccountVerification?: (
 						data: {
-							user: User;
+							user: User & Record<string, any>;
 							url: string;
 							token: string;
 						},
@@ -1010,13 +1014,19 @@ export type BetterAuthOptions = {
 					 *
 					 * to interrupt with error you can throw `APIError`
 					 */
-					beforeDelete?: (user: User, request?: Request) => Promise<void>;
+					beforeDelete?: (
+						user: User & Record<string, any>,
+						request?: Request,
+					) => Promise<void>;
 					/**
 					 * A function that is called after a user is deleted.
 					 *
 					 * This is useful for cleaning up user data
 					 */
-					afterDelete?: (user: User, request?: Request) => Promise<void>;
+					afterDelete?: (
+						user: User & Record<string, any>,
+						request?: Request,
+					) => Promise<void>;
 					/**
 					 * The expiration time for the delete token.
 					 *


### PR DESCRIPTION
Fixes #11192

## What

Callbacks in the core options that receive the user record from the database were typed with the base `User`, so `user.additionalFields` did not appear on their param types even though the fields are present at runtime. This widens the `user` param to `User & Record<string, any>` for:

- `emailVerification.sendVerificationEmail`
- `emailVerification.beforeEmailVerification` / `afterEmailVerification`
- `emailAndPassword.sendResetPassword` / `onPasswordReset` / `onExistingUserSignUp`
- `changeEmail.sendChangeEmailConfirmation`
- `deleteUser.sendDeleteAccountVerification` / `beforeDelete` / `afterDelete`

## Why not the inferred type

`additionalFields` is declared inside the same options object as these callbacks, so TypeScript cannot thread the literal's inferred field types back into callbacks within that same expression. `$Infer.Session.user` works because it is evaluated on the returned auth instance, outside the options object. Widening with an index signature matches the existing pattern already used in this file (for example the session `version` callback) and unblocks property access for additional fields.

## Testing

- Added a type-level regression in `packages/better-auth/src/types/types.test.ts` that reads `data.user.locale` (an `additionalFields` entry) inside `sendVerificationEmail` and `sendResetPassword`. It fails without this change with `TS2339: Property 'locale' does not exist on type '{ ... }'` and passes with it.
- `pnpm typecheck` passes, and the `types.test.ts` + `email-verification.test.ts` suites pass (51 tests).
- Added a patch changeset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11192 so email, password, change-email, and delete-user callbacks now expose `user.additionalFields` on their typed params, matching the full user record they receive at runtime.

**Notes**
- TypeScript can't infer `additionalFields` into callbacks declared in the same options object, so params use `User & Record<string, any>`, matching the existing pattern in this file.
- Adds a type-level regression test that reads an `additionalFields` entry inside `sendVerificationEmail` and `sendResetPassword`; it fails without this change.
- Adds a patch changeset.

<sup>Written for commit 81e8712e54a6f9c39778222e11a7f08b418b9417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

