### PR TITLE
fix(drizzle-adapter): defer relation metadata access

### DIFF
--- a/.changeset/lazy-drizzle-metadata.md
+++ b/.changeset/lazy-drizzle-metadata.md
@@ -1,0 +1,5 @@
+---
+"@better-auth/drizzle-adapter": patch
+---
+
+Defer Drizzle relation metadata access until a relational query runs, preserving lazy database initialization during application builds.

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -7,7 +7,9 @@ import {
 	timestamp,
 } from "drizzle-orm/pg-core";
 import { describe, expect, it, vi } from "vitest";
+import type { DB } from "./drizzle-adapter";
 import { drizzleAdapter } from "./drizzle-adapter";
+import { drizzleAdapter as drizzleRelationsV2Adapter } from "./relations-v2";
 
 describe("drizzle-adapter", () => {
 	it("should create drizzle adapter", () => {
@@ -21,6 +23,33 @@ describe("drizzle-adapter", () => {
 		};
 		const adapter = drizzleAdapter(db, config);
 		expect(adapter).toBeDefined();
+	});
+
+	/**
+	 * @see https://github.com/better-auth/better-auth/issues/11258
+	 */
+	describe("lazy database initialization", () => {
+		it.for([
+			{ relations: "Relations v1", createAdapter: drizzleAdapter },
+			{
+				relations: "Relations v2",
+				createAdapter: drizzleRelationsV2Adapter,
+			},
+		])("should not initialize a lazy database during $relations adapter construction", ({
+			createAdapter,
+		}) => {
+			const db = new Proxy({} as DB, {
+				get() {
+					throw new Error("DATABASE_URL is not set");
+				},
+			});
+
+			expect(() =>
+				createAdapter(db, { provider: "pg" })({
+					secret: "test-secret-that-is-at-least-32-chars-long!!",
+				}),
+			).not.toThrow();
+		});
 	});
 
 	it("should use unique column fallback for MySQL creates without an id", async () => {

--- a/packages/drizzle-adapter/src/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.test.ts
@@ -29,13 +29,22 @@ describe("drizzle-adapter", () => {
 	 * @see https://github.com/better-auth/better-auth/issues/11258
 	 */
 	describe("lazy database initialization", () => {
-		it.for([
-			{ relations: "Relations v1", createAdapter: drizzleAdapter },
+		const adapterFactories = [
+			{
+				relations: "Relations v1",
+				createAdapter: drizzleAdapter,
+				relationMetadata: { schema: {} },
+			},
 			{
 				relations: "Relations v2",
 				createAdapter: drizzleRelationsV2Adapter,
+				relationMetadata: { relations: {} },
 			},
-		])("should not initialize a lazy database during $relations adapter construction", ({
+		] as const;
+
+		it.for(
+			adapterFactories,
+		)("should not initialize a lazy database during $relations adapter construction", ({
 			createAdapter,
 		}) => {
 			const db = new Proxy({} as DB, {
@@ -49,6 +58,58 @@ describe("drizzle-adapter", () => {
 					secret: "test-secret-that-is-at-least-32-chars-long!!",
 				}),
 			).not.toThrow();
+		});
+
+		it.for(
+			adapterFactories,
+		)("should support a first $relations joined read inside a transaction", async ({
+			createAdapter,
+			relationMetadata,
+		}) => {
+			const findFirst = vi.fn().mockResolvedValue(null);
+			const transactionDatabase = new Proxy(
+				{
+					query: { user: { findFirst } },
+				} as DB,
+				{
+					get(target, property, receiver) {
+						if (property === "_") {
+							throw new Error("Transaction metadata should not be read");
+						}
+						return Reflect.get(target, property, receiver);
+					},
+				},
+			);
+			const database = {
+				_: relationMetadata,
+				transaction: (callback: (transactionDatabase: DB) => unknown) =>
+					callback(transactionDatabase),
+			} as DB;
+			const user = pgTable("user", { id: text("id") });
+			const adapter = createAdapter(database, {
+				provider: "pg",
+				schema: { user },
+				transaction: true,
+			})({
+				advanced: {
+					database: { joins: true, validateSchema: false },
+				},
+			});
+
+			if (!adapter.transaction) {
+				throw new Error("Transaction support should be enabled");
+			}
+
+			await expect(
+				adapter.transaction((transactionAdapter) =>
+					transactionAdapter.findOne({
+						model: "user",
+						where: [],
+						join: { session: true },
+					}),
+				),
+			).resolves.toBeNull();
+			expect(findFirst).toHaveBeenCalledOnce();
 		});
 	});
 

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -36,6 +36,7 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
+import type { RelationKeysByModel } from "./join-relation-key";
 import {
 	buildRelationKeysByModel,
 	getOneToOneRelationKey,
@@ -184,7 +185,7 @@ export interface DrizzleAdapterConfig {
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	let mysqlNoIdWarned = false;
-	const relationKeysByModel = buildRelationKeysByModel(db._?.schema);
+	let relationKeysByModel: RelationKeysByModel | undefined;
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({
@@ -803,7 +804,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const renamedJoinResults: { key: string; target: string }[] = [];
-							const relationKeys = relationKeysByModel.get(queryModel);
+							const relationKeys = (relationKeysByModel ??=
+								buildRelationKeysByModel(db._?.schema)).get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
 							for (const [joinModel, joinAttr] of joinEntries) {
@@ -890,7 +892,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const renamedJoinResults: { key: string; target: string }[] = [];
-							const relationKeys = relationKeysByModel.get(queryModel);
+							const relationKeys = (relationKeysByModel ??=
+								buildRelationKeysByModel(db._?.schema)).get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
 							for (const [joinModel, joinAttr] of joinEntries) {

--- a/packages/drizzle-adapter/src/drizzle-adapter.ts
+++ b/packages/drizzle-adapter/src/drizzle-adapter.ts
@@ -186,6 +186,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	let mysqlNoIdWarned = false;
 	let relationKeysByModel: RelationKeysByModel | undefined;
+	const getRelationKeysByModel = () =>
+		(relationKeysByModel ??= buildRelationKeysByModel(db._?.schema));
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({
@@ -804,8 +806,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const renamedJoinResults: { key: string; target: string }[] = [];
-							const relationKeys = (relationKeysByModel ??=
-								buildRelationKeysByModel(db._?.schema)).get(queryModel);
+							const relationKeys = getRelationKeysByModel().get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
 							for (const [joinModel, joinAttr] of joinEntries) {
@@ -892,8 +893,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const renamedJoinResults: { key: string; target: string }[] = [];
-							const relationKeys = (relationKeysByModel ??=
-								buildRelationKeysByModel(db._?.schema)).get(queryModel);
+							const relationKeys = getRelationKeysByModel().get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
 							for (const [joinModel, joinAttr] of joinEntries) {

--- a/packages/drizzle-adapter/src/relations-v2/index.ts
+++ b/packages/drizzle-adapter/src/relations-v2/index.ts
@@ -33,6 +33,7 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
+import type { RelationKeysByModel } from "../join-relation-key";
 import {
 	buildRelationKeysByModel,
 	getOneToOneRelationKey,
@@ -274,7 +275,7 @@ export interface DrizzleAdapterConfig {
 export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	let mysqlNoIdWarned = false;
-	const relationKeysByModel = buildRelationKeysByModel(db._?.relations);
+	let relationKeysByModel: RelationKeysByModel | undefined;
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({ getFieldName, getDefaultModelName, options, schema: baSchema }) => {
@@ -724,7 +725,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const renamedJoinResults: { key: string; target: string }[] = [];
-							const relationKeys = relationKeysByModel.get(queryModel);
+							const relationKeys = (relationKeysByModel ??=
+								buildRelationKeysByModel(db._?.relations)).get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
 							for (const [joinModel, joinAttr] of joinEntries) {
@@ -812,7 +814,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const renamedJoinResults: { key: string; target: string }[] = [];
-							const relationKeys = relationKeysByModel.get(queryModel);
+							const relationKeys = (relationKeysByModel ??=
+								buildRelationKeysByModel(db._?.relations)).get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
 							for (const [joinModel, joinAttr] of joinEntries) {

--- a/packages/drizzle-adapter/src/relations-v2/index.ts
+++ b/packages/drizzle-adapter/src/relations-v2/index.ts
@@ -276,6 +276,8 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 	let lazyOptions: BetterAuthOptions | null = null;
 	let mysqlNoIdWarned = false;
 	let relationKeysByModel: RelationKeysByModel | undefined;
+	const getRelationKeysByModel = () =>
+		(relationKeysByModel ??= buildRelationKeysByModel(db._?.relations));
 	const createCustomAdapter =
 		(db: DB, inTransaction = false): AdapterFactoryCustomizeAdapterCreator =>
 		({ getFieldName, getDefaultModelName, options, schema: baSchema }) => {
@@ -725,8 +727,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const renamedJoinResults: { key: string; target: string }[] = [];
-							const relationKeys = (relationKeysByModel ??=
-								buildRelationKeysByModel(db._?.relations)).get(queryModel);
+							const relationKeys = getRelationKeysByModel().get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
 							for (const [joinModel, joinAttr] of joinEntries) {
@@ -814,8 +815,7 @@ export const drizzleAdapter = (db: DB, config: DrizzleAdapterConfig) => {
 								| undefined;
 
 							const renamedJoinResults: { key: string; target: string }[] = [];
-							const relationKeys = (relationKeysByModel ??=
-								buildRelationKeysByModel(db._?.relations)).get(queryModel);
+							const relationKeys = getRelationKeysByModel().get(queryModel);
 							includes = {};
 							const joinEntries = Object.entries(join);
 							for (const [joinModel, joinAttr] of joinEntries) {


### PR DESCRIPTION
- Closes https://github.com/better-auth/better-auth/issues/11258

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deferring Drizzle relation metadata access in `@better-auth/drizzle-adapter` so creating the adapter no longer initializes lazy databases during application builds. Relation metadata is now built on the first relational query instead of at adapter construction.

**Bug Fixes**
- Applies to both the relations v1 and v2 adapter implementations.
- Adds regression tests covering adapter construction and the first joined read inside a transaction, using a database proxy that throws on any property access.

<sup>Written for commit ca980bc8e12487a26ea77af657b6461039716224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

