### PR TITLE
fix(demo): align better-fetch version

### DIFF
--- a/demo/nextjs/pnpm-lock.yaml
+++ b/demo/nextjs/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@better-fetch/fetch': 1.3.1
+  '@better-fetch/fetch': 1.3.2
   path-to-regexp@>=8: ^8.4.0
   fast-uri@<=3.1.3: '>=3.1.4 <4'
   hono: '>=4.12.27 <5'
@@ -315,8 +315,8 @@ packages:
   '@better-auth/utils@0.4.2':
     resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
 
-  '@better-fetch/fetch@1.3.1':
-    resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
+  '@better-fetch/fetch@1.3.2':
+    resolution: {integrity: sha512-Gs7n99b5tqUC6cQAPbV0uED3IraHB6xQbHLQ/C3l7ZFafHScOx9pQ+DYmP5blbLFShVWLqxNUlI9wi4xU/X+ow==}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -2432,7 +2432,7 @@ snapshots:
     dependencies:
       '@better-auth/core': link:../../packages/core
       '@better-auth/utils': 0.4.2
-      '@better-fetch/fetch': 1.3.1
+      '@better-fetch/fetch': 1.3.2
       better-auth: link:../../packages/better-auth
       better-call: 1.3.7(zod@4.5.4)
       jose: 6.2.2
@@ -2447,7 +2447,7 @@ snapshots:
     dependencies:
       '@noble/hashes': 2.2.0
 
-  '@better-fetch/fetch@1.3.1': {}
+  '@better-fetch/fetch@1.3.2': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -3711,7 +3711,7 @@ snapshots:
   better-call@1.3.7(zod@4.5.4):
     dependencies:
       '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.3.1
+      '@better-fetch/fetch': 1.3.2
       rou3: 0.7.12
       set-cookie-parser: 3.1.2
     optionalDependencies:

--- a/demo/nextjs/pnpm-workspace.yaml
+++ b/demo/nextjs/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ allowBuilds:
   sharp: true
 
 overrides:
-  '@better-fetch/fetch': 1.3.1
+  '@better-fetch/fetch': 1.3.2
   path-to-regexp@>=8: ^8.4.0
   fast-uri@<=3.1.3: '>=3.1.4 <4'
   hono: '>=4.12.27 <5'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the `@better-fetch/fetch` override in the Next.js demo from 1.3.1 to 1.3.2 so the demo aligns with the version used across the rest of the repo.

<sup>Written for commit e42f0b7294f6f7ced3dee93ef681fd4b3b546c93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

