### PR TITLE
chore: bump `typesense-fumadocs-adapter`

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -106,7 +106,7 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "catalog:tailwind",
     "typesense": "^3.0.6",
-    "typesense-fumadocs-adapter": "^0.4.2",
+    "typesense-fumadocs-adapter": "^0.4.3",
     "unist-util-visit": "^5.1.0",
     "vaul": "^1.1.2",
     "zod": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,8 +438,8 @@ importers:
         specifier: ^3.0.6
         version: 3.0.6(@babel/runtime@7.29.2)
       typesense-fumadocs-adapter:
-        specifier: ^0.4.2
-        version: 0.4.2(d42a05bbb2fdcd75d75d256e426e7bd8)
+        specifier: ^0.4.3
+        version: 0.4.3(d42a05bbb2fdcd75d75d256e426e7bd8)
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -14769,8 +14769,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typesense-fumadocs-adapter@0.4.2:
-    resolution: {integrity: sha512-KmctDfcAdm7C+HS9zYNMYULuShZJDetKLO9mTyWw1EWGIjPjIRmnWyRsD41aErzEwDIN6TguUBjomp2Lx7klGg==}
+  typesense-fumadocs-adapter@0.4.3:
+    resolution: {integrity: sha512-ST0/j5AQDSPzaJ2OuLdRHuHOR+Prfomk//2NI57naQE3GKrFbDM5ZtXxGCxZCCFKcZcB1XJGoePIqHbgWD3xMg==}
     peerDependencies:
       fumadocs-core: ^16.0.0
       fumadocs-ui: ^16.0.0
@@ -32784,7 +32784,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  typesense-fumadocs-adapter@0.4.2(d42a05bbb2fdcd75d75d256e426e7bd8):
+  typesense-fumadocs-adapter@0.4.3(d42a05bbb2fdcd75d75d256e426e7bd8):
     dependencies:
       fumadocs-core: 16.12.0(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.3.4(@babel/core@8.0.1)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@25.9.4)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.5.4)
       fumadocs-ui: 16.12.0(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.12.0(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.21.0(react@19.2.7))(next@16.3.4(@babel/core@8.0.1)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@25.9.4)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.5.4))(next@16.3.4(@babel/core@8.0.1)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(@types/node@25.9.4)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)


### PR DESCRIPTION
Related to https://github.com/typesense/typesense-fumadocs-adapter/pull/5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `typesense-fumadocs-adapter` from 0.4.2 to 0.4.3 to pick up the latest upstream changes. No API changes or migration steps needed in our code.

<sup>Written for commit c0a7b343b1021f64ac88f378f4a76829d937d694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

