### PR TITLE
docs(2fa): note that the TOTP URI carries the secret and the email

### DIFF
--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -262,6 +262,10 @@ After enabling 2FA, you can get the TOTP URI to display to the user. This URI is
   ```
 </APIMethod>
 
+<Callout type="warn">
+  Treat the TOTP URI as a secret. It contains the user's email and the shared secret used to generate TOTP codes. Render the QR code locally in the browser rather than sending the URI to a third-party QR service.
+</Callout>
+
 **Example: Using React**
 
 Once you have the TOTP URI, you can use it to generate a QR code for the user to scan with their authenticator app.
@@ -285,14 +289,6 @@ export default function UserCard({ password }: { password: string }){
    )
 }
 ```
-
-<Callout type="warn">
-  The TOTP URI contains the shared secret, and the account name inside it is the user's email, so both sit in the same string. Render the QR in the browser, as the example above does: handing the URI to a hosted QR image service puts the secret and the email in a query string bound for a third party, where they reach that service's access logs. TOTP secrets do not expire on their own, so anything that can read those logs can generate valid codes for as long as the enrollment lasts.
-</Callout>
-
-<Callout>
-  By default the issuer for TOTP is set to the app name provided in the auth config or if not provided it will be set to `Better Auth`. You can override this by passing `issuer` to the plugin config.
-</Callout>
 
 #### Verifying TOTP
 

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -286,6 +286,10 @@ export default function UserCard({ password }: { password: string }){
 }
 ```
 
+<Callout type="warn">
+  The TOTP URI contains the shared secret, and the account name inside it is the user's email, so both sit in the same string. Render the QR in the browser, as the example above does: handing the URI to a hosted QR image service puts the secret and the email in a query string bound for a third party, where they reach that service's access logs. TOTP secrets do not expire on their own, so anything that can read those logs can generate valid codes for as long as the enrollment lasts.
+</Callout>
+
 <Callout>
   By default the issuer for TOTP is set to the app name provided in the auth config or if not provided it will be set to `Better Auth`. You can override this by passing `issuer` to the plugin config.
 </Callout>


### PR DESCRIPTION
## What this is

A documentation clarification, not a vulnerability in Better Auth. The library already does the right thing: it mints the secret, builds the URI, and hands it back to the caller. That is inherent to TOTP enrollment, since the client has to receive the secret to show it to the user. Filing as a normal PR rather than through Security Advisories for that reason.

## Why

The 2FA page shows the safe pattern, `react-qr-code` rendered client side, but does not say that it *is* the safe pattern. Someone who would rather not add a QR dependency reaches for a hosted QR image service instead, and nothing on the page gives them a reason to hesitate.

The URI carries two things at once, which is what makes that a bad trade:

```
otpauth://totp/<issuer>:<user email>?secret=<shared secret>&issuer=<issuer>
```

The account name is the user's email, from `packages/better-auth/src/plugins/two-factor/index.ts:292`:

```ts
}).url(issuer || options?.issuer || ctx.context.appName, user.email);
```

So a hosted renderer receives the address and the seed in a single query string, and query strings are logged by default almost everywhere. TOTP secrets do not rotate or expire, and the app goes on reporting 2FA as enabled, so the account ends up quietly single-factor with nothing to signal it.

This is a well-travelled mistake rather than a hypothetical. `RobThree/TwoFactorAuth` shipped `api.qrserver.com` as its default QR provider (RobThree/TwoFactorAuth#104), and there is a documented case of TOTP secrets reaching Google through the Charts API the same way.

## The change

One `<Callout type="warn">` after the React example, using the same component and type already used five times on this page. No code changes, and no changeset, since it only touches `docs/`.

Targeting `main` as additive documentation and security-adjacent work. Happy to reword it, shorten it, or move it if you would rather it sat somewhere else on the page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a warning callout to the 2FA plugin docs explaining that the TOTP URI carries the shared secret and the user's email together, so the QR code should be rendered locally rather than sent to a hosted QR service. Removes the callout about the default TOTP issuer.

<sup>Written for commit c95560a19e001905d5c3f29b3b3a27e903f02548. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

