### PR TITLE
fix(db): use Kysely metadata for PostgreSQL schema introspection

### DIFF
--- a/.changeset/quiet-postgres-tables.md
+++ b/.changeset/quiet-postgres-tables.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Prevent PostgreSQL migrations from treating tables in other schemas or views in the active schema as Better Auth tables.

--- a/packages/better-auth/src/db/get-migration-schema.test.ts
+++ b/packages/better-auth/src/db/get-migration-schema.test.ts
@@ -35,10 +35,6 @@ describe.runIf(isPostgresAvailable)(
 		const customSchemaPool = new Pool({
 			connectionString: `${CONNECTION_STRING}?options=-c search_path=${customSchema}`,
 		});
-		const customSchemaKysely = new Kysely({
-			dialect: new PostgresDialect({ pool: customSchemaPool }),
-			plugins: [new CamelCasePlugin()],
-		});
 
 		beforeAll(async () => {
 			// Setup: Create custom schema and a table in public schema
@@ -94,6 +90,15 @@ describe.runIf(isPostgresAvailable)(
 		 * @see https://github.com/better-auth/better-auth/issues/7926
 		 */
 		it("should detect custom schema with CamelCasePlugin enabled", async () => {
+			const executedSql: string[] = [];
+			const customSchemaKysely = new Kysely({
+				dialect: new PostgresDialect({ pool: customSchemaPool }),
+				log(event) {
+					if (event.level === "query") executedSql.push(event.query.sql);
+				},
+				plugins: [new CamelCasePlugin()],
+			});
+
 			// Create a user table in the custom schema so it should be detected as existing
 			await customSchemaPool.query(`
 				CREATE TABLE IF NOT EXISTS ${customSchema}.user (
@@ -130,6 +135,9 @@ describe.runIf(isPostgresAvailable)(
 				// Other tables should still need to be created
 				const sessionTable = toBeCreated.find((t) => t.table === "session");
 				expect(sessionTable).toBeDefined();
+				expect(executedSql).not.toContainEqual(
+					expect.stringContaining("information_schema.tables"),
+				);
 			} finally {
 				// Cleanup: drop the user table so subsequent tests are not affected
 				await customSchemaPool.query(

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -621,22 +621,11 @@ export async function getMigrations(
 			`PostgreSQL migration: Using schema '${currentSchema}' (from search_path)`,
 		);
 
-		// Verify the schema exists
 		try {
-			const schemaCheck = await sql<{
-				schema_name?: string;
-				schemaName?: string;
-			}>`
-				SELECT schema_name
-				FROM information_schema.schemata
-				WHERE schema_name = ${currentSchema}
-			`.execute(db);
-
-			const schemaExists =
-				schemaCheck.rows[0]?.schema_name ?? schemaCheck.rows[0]?.schemaName;
-			if (!schemaExists) {
+			const schemas = await db.introspection.getSchemas();
+			if (!schemas.some(({ name }) => name === currentSchema)) {
 				logger.warn(
-					`Schema '${currentSchema}' does not exist. Tables will be inspected from available schemas. Consider creating the schema first or checking your database configuration.`,
+					`Schema '${currentSchema}' does not exist. Create it before running migrations or check your database configuration.`,
 				);
 			}
 		} catch (error) {
@@ -664,40 +653,14 @@ export async function getMigrations(
 		currentSchema,
 	);
 
-	// Filter introspected tables to the schema used by unqualified migrations.
 	let tableMetadata = allTableMetadata;
 	if (dbType === "postgres") {
-		// Get tables with their schema information
-		try {
-			const tablesInSchema = await sql<{
-				table_name?: string;
-				tableName?: string;
-			}>`
-				SELECT table_name
-				FROM information_schema.tables
-				WHERE table_schema = ${currentSchema}
-				AND table_type = 'BASE TABLE'
-			`.execute(db);
-
-			const tableNamesInSchema = new Set(
-				tablesInSchema.rows.map((row) => row.table_name ?? row.tableName),
-			);
-
-			// Filter to only tables that exist in the target schema
-			tableMetadata = allTableMetadata.filter(
-				(table) =>
-					table.schema === currentSchema && tableNamesInSchema.has(table.name),
-			);
-
-			logger.debug(
-				`Found ${tableMetadata.length} table(s) in schema '${currentSchema}': ${tableMetadata.map((t) => t.name).join(", ") || "(none)"}`,
-			);
-		} catch (error) {
-			logger.warn(
-				`Could not filter tables by schema. Using all discovered tables. Error: ${error instanceof Error ? error.message : String(error)}`,
-			);
-			// Fall back to using all tables if schema filtering fails
-		}
+		tableMetadata = allTableMetadata.filter(
+			(table) => table.schema === currentSchema && !table.isView,
+		);
+		logger.debug(
+			`Found ${tableMetadata.length} table(s) in schema '${currentSchema}': ${tableMetadata.map((table) => table.name).join(", ") || "(none)"}`,
+		);
 	} else if (dbType === "mssql") {
 		tableMetadata = allTableMetadata.filter(
 			(table) => table.schema === currentSchema,

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -655,8 +655,15 @@ export async function getMigrations(
 
 	let tableMetadata = allTableMetadata;
 	if (dbType === "postgres") {
+		/**
+		 * Kysely 0.28 does not expose `isForeign`, while 0.29 adds foreign table metadata.
+		 * @see https://github.com/kysely-org/kysely/pull/1494
+		 */
 		tableMetadata = allTableMetadata.filter(
-			(table) => table.schema === currentSchema && !table.isView,
+			(table) =>
+				table.schema === currentSchema &&
+				!table.isView &&
+				!("isForeign" in table && table.isForeign),
 		);
 		logger.debug(
 			`Found ${tableMetadata.length} table(s) in schema '${currentSchema}': ${tableMetadata.map((table) => table.name).join(", ") || "(none)"}`,


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PostgreSQL migrations so tables in other schemas, views, or foreign tables in the active schema are no longer treated as Better Auth tables.

**Bug Fixes**
- Replaces `information_schema` queries with Kysely's schema and table introspection.
- Filters discovered tables to the active schema and excludes views and foreign tables.
- Updates the schema existence warning to advise creating the schema first.
- Adds a test asserting no `information_schema.tables` queries are executed.

<sup>Written for commit a5c206595a2bf598eb62587661074901c33d4bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

