### PR TITLE
fix(db): use reported MySQL index byte bounds

### DIFF
--- a/.changeset/mysql-index-byte-bounds.md
+++ b/.changeset/mysql-index-byte-bounds.md
@@ -1,0 +1,5 @@
+---
+"better-auth": patch
+---
+
+Use MySQL's reported byte lengths when validating indexes on existing string columns.

--- a/e2e/adapter/test/kysely-adapter/adapter.kysely.mysql.test.ts
+++ b/e2e/adapter/test/kysely-adapter/adapter.kysely.mysql.test.ts
@@ -25,10 +25,52 @@ const kyselyDB = new Kysely({
 	dialect: new MysqlDialect(mysqlDB),
 });
 
-const mysqlDisabledIndexTestSuite = createTestSuite(
+const mysqlMigrationIndexTestSuite = createTestSuite(
 	"mysql migration index introspection",
 	{},
 	() => ({
+		/**
+		 * @see https://dev.mysql.com/doc/refman/8.4/en/information-schema-columns-table.html
+		 */
+		"uses the column byte length when validating an index": async () => {
+			const tableName = "mysql_index_byte_length_subject";
+			const indexName = "mysql_byte_length_subject_idx";
+			const options = {
+				database: mysqlDB,
+				plugins: [
+					{
+						id: "mysql-index-byte-length",
+						schema: {
+							mysqlIndexByteLengthSubject: {
+								modelName: tableName,
+								fields: {
+									subject: { type: "string" },
+								},
+								indexes: [{ fields: ["subject"], name: indexName }],
+							},
+						},
+					} satisfies BetterAuthPlugin,
+				],
+			} satisfies BetterAuthOptions;
+
+			await mysqlDB.query(`
+				CREATE TABLE \`${tableName}\` (
+					\`id\` varchar(191) NOT NULL,
+					\`subject\` varchar(1000) CHARACTER SET latin1 NOT NULL,
+					PRIMARY KEY (\`id\`)
+				) ENGINE=InnoDB
+			`);
+			try {
+				const migrations = await getMigrations(options);
+				expect(await migrations.compileMigrations()).toContain(
+					`create index \`${indexName}\` on \`${tableName}\` (\`subject\`)`,
+				);
+				await migrations.runMigrations();
+			} finally {
+				await mysqlDB.query(`DROP TABLE \`${tableName}\``);
+			}
+		},
+
 		/**
 		 * @see https://dev.mysql.com/doc/refman/8.4/en/alter-table.html
 		 */
@@ -103,7 +145,7 @@ const { execute } = await testAdapter({
 		numberIdTestSuite(),
 		joinsTestSuite(),
 		uuidTestSuite(),
-		mysqlDisabledIndexTestSuite(),
+		mysqlMigrationIndexTestSuite(),
 		caseInsensitiveTestSuite({
 			disableTests: {
 				"findOne - eq with mode sensitive (default) should not match different case": true,

--- a/packages/better-auth/src/db/get-migration.ts
+++ b/packages/better-auth/src/db/get-migration.ts
@@ -399,7 +399,7 @@ async function getDatabaseColumnBounds(
 				SELECT
 					table_name AS tableName,
 					column_name AS columnName,
-					character_maximum_length * 4 AS maxIndexBytes
+					character_octet_length AS maxIndexBytes
 				FROM information_schema.columns
 				WHERE table_schema = DATABASE()
 			`.execute(db)


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MySQL index validation on existing string columns to use the database's reported byte length (`character_octet_length`) instead of assuming 4 bytes per character. This prevents false failures for charsets like `latin1`, where characters can be smaller than 4 bytes.

- Adds an e2e test that verifies index creation on a `varchar(1000) latin1` column.

<sup>Written for commit c42dcc76fd8d179ed3231b061ac26ae805f60b7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/better-auth/better-auth/pull/11272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

